### PR TITLE
fix(resource-catalog): keep edit dialogs open after auto-save

### DIFF
--- a/src/renderer/components/chat/resourceList/AgentResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AgentResourceList.tsx
@@ -334,7 +334,6 @@ export function AgentResourceList({
         onOpenChange={(open) => {
           if (!open) setEditDialogTarget(null)
         }}
-        onSaved={refetchAgents}
       />
     </>
   )

--- a/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
@@ -518,7 +518,6 @@ export function AssistantResourceList({
         onOpenChange={(open) => {
           if (!open) setEditDialogTarget(null)
         }}
-        onSaved={refreshAssistants}
       />
     </>
   )

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCatalogDialogs.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCatalogDialogs.tsx
@@ -1,6 +1,6 @@
 import { ResourceCreateWizard } from '@renderer/components/resourceCatalog/dialogs/create'
 import { SkillDetailDialog } from '@renderer/components/resourceCatalog/dialogs/detail'
-import { AgentEditDialog, AssistantEditDialog } from '@renderer/components/resourceCatalog/dialogs/edit'
+import { ResourceEditDialogHost } from '@renderer/components/resourceCatalog/dialogs/edit'
 import { ImportAssistantDialog } from '@renderer/components/resourceCatalog/dialogs/import'
 import {
   ImportSkillDialog,
@@ -64,24 +64,12 @@ export function ResourceCatalogDialogs({
         onOpenChange={dialogs.handleCreateDialogOpenChange}
         onSubmit={dialogs.handleSubmitCreateResource}
       />
-      {dialogs.editDialog?.kind === 'assistant' ? (
-        <AssistantEditDialog
-          open={dialogs.editDialogOpen}
-          resource={dialogs.editDialog.resource}
-          modelFilter={isSelectableAssistantModel}
-          onOpenChange={dialogs.handleEditDialogOpenChange}
-          onSaved={dialogs.handleEditSaved}
-        />
-      ) : null}
-      {dialogs.editDialog?.kind === 'agent' ? (
-        <AgentEditDialog
-          open={dialogs.editDialogOpen}
-          resource={dialogs.editDialog.resource}
-          modelFilter={agentModelFilter}
-          onOpenChange={dialogs.handleEditDialogOpenChange}
-          onSaved={dialogs.handleEditSaved}
-        />
-      ) : null}
+      <ResourceEditDialogHost
+        target={dialogs.editDialogTarget}
+        onOpenChange={(open) => {
+          if (!open) dialogs.setEditDialogTarget(null)
+        }}
+      />
     </>
   )
 }

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCatalogView.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCatalogView.tsx
@@ -45,8 +45,7 @@ export function ResourceCatalogView({
       (resourceType === 'skill' && dialogs.systemSkillOpen) ||
       dialogs.createDialogOpen ||
       dialogs.createDialogKind ||
-      dialogs.editDialogOpen ||
-      dialogs.editDialog
+      dialogs.editDialogTarget
   )
   const [dialogsActivated, setDialogsActivated] = useState(hasActiveDialog)
 

--- a/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceCatalogView.test.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceCatalogView.test.tsx
@@ -73,8 +73,7 @@ vi.mock('@renderer/components/resourceCatalog/dialogs/detail', () => {
 vi.mock('@renderer/components/resourceCatalog/dialogs/edit', () => {
   dialogImplementationsLoadedMock('edit')
   return {
-    AgentEditDialog: () => null,
-    AssistantEditDialog: () => null
+    ResourceEditDialogHost: () => null
   }
 })
 vi.mock('@renderer/components/resourceCatalog/dialogs/import', () => {
@@ -150,16 +149,14 @@ function createController(resourceError?: Error) {
       createDialogOpen: false,
       creatingResource: false,
       deleteConfirm: null,
-      editDialog: null,
-      editDialogOpen: false,
+      editDialogTarget: null,
       handleCreateDialogOpenChange: vi.fn(),
-      handleEditDialogOpenChange: vi.fn(),
-      handleEditSaved: vi.fn(),
       handleSubmitCreateResource: vi.fn(),
       selectedSkill: null,
       setAssistantImportOpen: vi.fn(),
       setAssistantLibraryOpen: vi.fn(),
       setDeleteConfirm: vi.fn(),
+      setEditDialogTarget: vi.fn(),
       setSelectedSkill: vi.fn(),
       setSkillImportOpen: vi.fn(),
       setSkillMarketplaceOpen: vi.fn(),

--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -52,10 +52,9 @@ const logger = loggerService.withContext('EditDialogShared')
 export type ModelLabelKey = 'modelId' | 'planModelId' | 'smallModelId'
 export type ModelLabels = Record<ModelLabelKey, string | null>
 
-export type EditDialogBaseProps<TResource> = {
+export type EditDialogBaseProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSaved: (resource: TResource) => Promise<void> | void
   modelFilter?: (model: Model) => boolean
   /** Leaf tab id to open on first render (e.g. `tools.mcp`, `tools.skills`); falls back to `basic`. */
   initialTab?: string

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -65,7 +65,7 @@ import {
 import { McpServerCatalogGrid } from '../components/McpServerCatalogGrid'
 import { PromptPolishActions } from '../components/PromptPolishActions'
 
-export type AgentEditDialogProps = EditDialogBaseProps<AgentDetail> & {
+export type AgentEditDialogProps = EditDialogBaseProps & {
   resource: AgentDetail | null
 }
 
@@ -193,14 +193,7 @@ function createAgentPatcher(form: UseFormReturn<AgentEditFormValues>, resource: 
   }
 }
 
-export function AgentEditDialog({
-  resource,
-  open,
-  onOpenChange,
-  onSaved,
-  modelFilter,
-  initialTab
-}: AgentEditDialogProps) {
+export function AgentEditDialog({ resource, open, onOpenChange, modelFilter, initialTab }: AgentEditDialogProps) {
   if (!resource) return null
 
   return (
@@ -208,7 +201,6 @@ export function AgentEditDialog({
       resource={resource}
       open={open}
       onOpenChange={onOpenChange}
-      onSaved={onSaved}
       modelFilter={modelFilter}
       initialTab={initialTab}
     />
@@ -219,10 +211,9 @@ function AgentEditDialogContent({
   resource,
   open,
   onOpenChange,
-  onSaved,
   modelFilter,
   initialTab
-}: EditDialogBaseProps<AgentDetail> & { resource: AgentDetail }) {
+}: EditDialogBaseProps & { resource: AgentDetail }) {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState(initialTab ?? 'basic')
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
@@ -335,20 +326,12 @@ function AgentEditDialogContent({
     form.clearErrors('root')
     saveFailedRef.current = false
 
-    let updated: Awaited<ReturnType<typeof updateAgent>>
     try {
-      updated = await updateAgent(pending.payload)
+      await updateAgent(pending.payload)
     } catch (error) {
       logger.error('Failed to auto-save agent edit dialog', error as Error, { agentId: resource.id })
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
       saveFailedRef.current = true
-      return
-    }
-
-    try {
-      await onSaved(updated)
-    } catch (error) {
-      logger.warn('Failed to run agent edit dialog post-save callback', { error, agentId: resource.id })
     }
   }
 

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -58,7 +58,7 @@ import { PromptPolishActions } from '../components/PromptPolishActions'
 
 export type AssistantEditDialogResource = Parameters<typeof initialAssistantFormState>[0]
 
-export type AssistantEditDialogProps = EditDialogBaseProps<AssistantEditDialogResource> & {
+export type AssistantEditDialogProps = EditDialogBaseProps & {
   resource: AssistantEditDialogResource | null
 }
 
@@ -158,7 +158,6 @@ export function AssistantEditDialog({
   resource,
   open,
   onOpenChange,
-  onSaved,
   modelFilter,
   initialTab
 }: AssistantEditDialogProps) {
@@ -169,7 +168,6 @@ export function AssistantEditDialog({
       resource={resource}
       open={open}
       onOpenChange={onOpenChange}
-      onSaved={onSaved}
       modelFilter={modelFilter}
       initialTab={initialTab}
     />
@@ -180,10 +178,9 @@ function AssistantEditDialogContent({
   resource,
   open,
   onOpenChange,
-  onSaved,
   modelFilter,
   initialTab
-}: EditDialogBaseProps<AssistantEditDialogResource> & { resource: AssistantEditDialogResource }) {
+}: EditDialogBaseProps & { resource: AssistantEditDialogResource }) {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState(initialTab ?? 'basic')
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
@@ -249,20 +246,12 @@ function AssistantEditDialogContent({
     form.clearErrors('root')
     failedSaveKeyRef.current = null
 
-    let updated: Awaited<ReturnType<typeof updateAssistant>>
     try {
-      updated = await updateAssistant(pending.payload)
+      await updateAssistant(pending.payload)
     } catch (error) {
       logger.error('Failed to auto-save assistant edit dialog', error as Error, { assistantId: resource.id })
       failedSaveKeyRef.current = attemptedKey
       form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
-      return
-    }
-
-    try {
-      await onSaved(updated)
-    } catch (error) {
-      logger.warn('Failed to run assistant edit dialog post-save callback', { error, assistantId: resource.id })
     }
   }
 

--- a/src/renderer/components/resourceCatalog/dialogs/edit/ResourceEditDialogEventHost.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/ResourceEditDialogEventHost.tsx
@@ -1,7 +1,6 @@
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import type { ResourceEditDialogTarget } from '@renderer/types/resourceCatalog'
 import React, { useCallback, useEffect, useState } from 'react'
-
-import type { ResourceEditDialogTarget } from './ResourceEditDialogHost'
 
 // Lazy so the edit dialog (and its heavy form deps) stay out of the composer bundle until requested.
 const ResourceEditDialogHost = React.lazy(() =>

--- a/src/renderer/components/resourceCatalog/dialogs/edit/ResourceEditDialogHost.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/ResourceEditDialogHost.tsx
@@ -4,6 +4,7 @@ import { useAgent } from '@renderer/hooks/agent/useAgent'
 import { useAgentModelFilter } from '@renderer/hooks/agent/useAgentModelFilter'
 import { useAssistantApiById } from '@renderer/hooks/useAssistant'
 import { toast } from '@renderer/services/toast'
+import type { ResourceEditDialogTarget } from '@renderer/types/resourceCatalog'
 import { isSelectableAssistantModel } from '@renderer/utils/resourceCatalog'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -11,20 +12,14 @@ import { useTranslation } from 'react-i18next'
 import { AgentEditDialog } from './AgentEditDialog'
 import { AssistantEditDialog } from './AssistantEditDialog'
 
-export type ResourceEditDialogTarget = ({ kind: 'assistant'; id: string } | { kind: 'agent'; id: string }) & {
-  /** Leaf tab id to open the dialog on (e.g. `tools.mcp`, `tools.skills`). */
-  initialTab?: string
-}
-
 type ResourceEditDialogHostProps = {
   target: ResourceEditDialogTarget | null
   onOpenChange: (open: boolean) => void
-  onSaved?: (target: ResourceEditDialogTarget) => Promise<unknown> | void
 }
 
 const logger = loggerService.withContext('ResourceEditDialogHost')
 
-export function ResourceEditDialogHost({ target, onOpenChange, onSaved }: ResourceEditDialogHostProps) {
+export function ResourceEditDialogHost({ target, onOpenChange }: ResourceEditDialogHostProps) {
   const [open, setOpen] = useState(target !== null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -63,11 +58,11 @@ export function ResourceEditDialogHost({ target, onOpenChange, onSaved }: Resour
   )
 
   if (target?.kind === 'assistant') {
-    return <AssistantEditDialogHost target={target} open={open} onOpenChange={handleOpenChange} onSaved={onSaved} />
+    return <AssistantEditDialogHost target={target} open={open} onOpenChange={handleOpenChange} />
   }
 
   if (target?.kind === 'agent') {
-    return <AgentEditDialogHost target={target} open={open} onOpenChange={handleOpenChange} onSaved={onSaved} />
+    return <AgentEditDialogHost target={target} open={open} onOpenChange={handleOpenChange} />
   }
 
   return null
@@ -76,14 +71,13 @@ export function ResourceEditDialogHost({ target, onOpenChange, onSaved }: Resour
 function AssistantEditDialogHost({
   target,
   open,
-  onOpenChange,
-  onSaved
+  onOpenChange
 }: ResourceEditDialogHostProps & {
   target: Extract<ResourceEditDialogTarget, { kind: 'assistant' }>
   open: boolean
 }) {
   const { t } = useTranslation()
-  const { assistant, error, refetch } = useAssistantApiById(target.id)
+  const { assistant, error } = useAssistantApiById(target.id)
 
   useEffect(() => {
     if (!error) return
@@ -92,22 +86,11 @@ function AssistantEditDialogHost({
     toast.error(t('common.error'))
   }, [error, t, target.id])
 
-  const handleSaved = useCallback(async () => {
-    try {
-      await refetch()
-      await onSaved?.(target)
-    } catch (error) {
-      logger.warn('Failed to refresh assistant after edit dialog save', { error, id: target.id })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [onSaved, refetch, t, target])
-
   return (
     <AssistantEditDialog
       open={open}
       resource={assistant ?? null}
       onOpenChange={onOpenChange}
-      onSaved={handleSaved}
       modelFilter={isSelectableAssistantModel}
       initialTab={target.initialTab}
     />
@@ -117,15 +100,14 @@ function AssistantEditDialogHost({
 function AgentEditDialogHost({
   target,
   open,
-  onOpenChange,
-  onSaved
+  onOpenChange
 }: ResourceEditDialogHostProps & {
   target: Extract<ResourceEditDialogTarget, { kind: 'agent' }>
   open: boolean
 }) {
   const { t } = useTranslation()
   const modelFilter = useAgentModelFilter('claude-code')
-  const { agent, error, revalidate } = useAgent(target.id)
+  const { agent, error } = useAgent(target.id)
 
   useEffect(() => {
     if (!error) return
@@ -134,22 +116,11 @@ function AgentEditDialogHost({
     toast.error(t('common.error'))
   }, [error, t, target.id])
 
-  const handleSaved = useCallback(async () => {
-    try {
-      await revalidate()
-      await onSaved?.(target)
-    } catch (error) {
-      logger.warn('Failed to refresh agent after edit dialog save', { error, id: target.id })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [onSaved, revalidate, t, target])
-
   return (
     <AgentEditDialog
       open={open}
       resource={agent ?? null}
       onOpenChange={onOpenChange}
-      onSaved={handleSaved}
       modelFilter={modelFilter}
       initialTab={target.initialTab}
     />

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -669,8 +669,7 @@ function mockDeferredAnimationFrames() {
 
 describe('edit dialogs', () => {
   it('submits assistant name, description, and model changes as a PATCH', async () => {
-    const onSaved = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={onSaved} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Assistant' } })
     fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Updated assistant description' } })
@@ -688,11 +687,10 @@ describe('edit dialogs', () => {
         })
       })
     )
-    await waitFor(() => expect(onSaved).toHaveBeenCalled())
   })
 
   it('shows the clear model affordance beside the chevron and clears the selected model', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     const modelTrigger = screen.getByRole('button', { name: 'Model' })
     const clearButton = screen.getByRole('button', { name: 'Model Clear' })
@@ -712,7 +710,7 @@ describe('edit dialogs', () => {
   })
 
   it('submits assistant group changes directly', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     openGroupSelect()
     fireEvent.click(await screen.findByRole('option', { name: 'personal' }))
@@ -726,7 +724,7 @@ describe('edit dialogs', () => {
   })
 
   it('clears the assistant group from the single-select group field', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     const clearButton = screen.getByRole('button', { name: 'Group Clear' })
     expect(clearButton).toHaveClass('focus-visible:pointer-events-auto', 'focus-visible:opacity-100')
@@ -741,7 +739,7 @@ describe('edit dialogs', () => {
   })
 
   it('limits assistant group editing to existing groups', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     openGroupSelect()
     expect(screen.queryByPlaceholderText('Search groups')).not.toBeInTheDocument()
@@ -751,7 +749,7 @@ describe('edit dialogs', () => {
 
   it('closes the group selector without closing the assistant edit dialog when clicking elsewhere inside it', async () => {
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     openGroupSelect()
     await screen.findByRole('option', { name: 'personal' })
@@ -763,7 +761,7 @@ describe('edit dialogs', () => {
   })
 
   it('submits agent instructions and model changes as a PATCH', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     selectTab('Prompt')
     await expectVariablesHelpOnOpen()
@@ -793,7 +791,7 @@ describe('edit dialogs', () => {
 
   it('polishes agent instructions and auto-saves the polished value', async () => {
     fetchGenerateMock.mockResolvedValue('Polished agent instructions')
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     selectTab('Prompt')
     fireEvent.click(screen.getByRole('button', { name: 'Polish prompt' }))
@@ -814,7 +812,7 @@ describe('edit dialogs', () => {
 
   it('generates agent instructions from the agent name when instructions are blank', async () => {
     fetchGenerateMock.mockResolvedValue('Generated agent instructions')
-    render(<AgentEditDialog open resource={{ ...AGENT, instructions: '' }} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={{ ...AGENT, instructions: '' }} onOpenChange={vi.fn()} />)
 
     selectTab('Prompt')
     expect(screen.getByTestId('prompt-preview-reset-key')).toHaveTextContent('0')
@@ -838,7 +836,7 @@ describe('edit dialogs', () => {
   it('allows closing and tab navigation while an agent prompt action is in flight', async () => {
     fetchGenerateMock.mockReturnValueOnce(new Promise<string>(() => undefined))
     const onOpenChange = vi.fn()
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
 
     selectTab('Prompt')
     fireEvent.click(screen.getByRole('button', { name: 'Polish prompt' }))
@@ -874,7 +872,7 @@ describe('edit dialogs', () => {
       return { data: { items: [] }, isLoading: false }
     })
 
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     selectTab('MCP')
 
@@ -887,7 +885,7 @@ describe('edit dialogs', () => {
   })
 
   it('submits assistant knowledge, MCP, and model parameter changes', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     expect(screen.queryByRole('button', { name: 'Tools' })).not.toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'MCP' })).toBeInTheDocument()
@@ -933,7 +931,7 @@ describe('edit dialogs', () => {
 
   it('polishes and restores assistant prompts through the shared action', async () => {
     fetchGenerateMock.mockResolvedValueOnce('Polished assistant prompt')
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     selectTab('Prompt')
     await expectVariablesHelpOnOpen()
@@ -957,9 +955,7 @@ describe('edit dialogs', () => {
   })
 
   it('generates an assistant prompt from its name when the prompt is blank', async () => {
-    render(
-      <AssistantEditDialog open resource={{ ...ASSISTANT, prompt: '' }} onOpenChange={vi.fn()} onSaved={vi.fn()} />
-    )
+    render(<AssistantEditDialog open resource={{ ...ASSISTANT, prompt: '' }} onOpenChange={vi.fn()} />)
 
     selectTab('Prompt')
     const generateButton = screen.getByRole('button', { name: 'Generate prompt' })
@@ -980,7 +976,7 @@ describe('edit dialogs', () => {
   it('allows closing and tab navigation while an assistant prompt action is in flight', async () => {
     fetchGenerateMock.mockReturnValueOnce(new Promise<string>(() => undefined))
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     selectTab('Prompt')
     fireEvent.click(screen.getByRole('button', { name: 'Polish prompt' }))
@@ -992,7 +988,7 @@ describe('edit dialogs', () => {
   })
 
   it('submits agent permission defaults and advanced changes', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     expect(screen.queryByRole('tab', { name: 'Permission' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('combobox', { name: 'Permission mode' }))
@@ -1020,7 +1016,7 @@ describe('edit dialogs', () => {
   })
 
   it('shows agent tool categories directly in the left tab list', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     expect(screen.queryByRole('button', { name: 'Tools' })).not.toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: 'Tools' })).not.toBeInTheDocument()
@@ -1040,20 +1036,13 @@ describe('edit dialogs', () => {
 
   it('removes deleted knowledge bases from an open agent form', async () => {
     const boundAgent = { ...AGENT, knowledgeBaseIds: ['kb-1'] }
-    const { rerender } = render(<AgentEditDialog open resource={boundAgent} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    const { rerender } = render(<AgentEditDialog open resource={boundAgent} onOpenChange={vi.fn()} />)
 
     selectTab('Built-in tools')
     expect(screen.getByText('Knowledge Search')).toBeInTheDocument()
 
     knowledgeBasesState.current = []
-    rerender(
-      <AgentEditDialog
-        open
-        resource={{ ...boundAgent, knowledgeBaseIds: [] }}
-        onOpenChange={vi.fn()}
-        onSaved={vi.fn()}
-      />
-    )
+    rerender(<AgentEditDialog open resource={{ ...boundAgent, knowledgeBaseIds: [] }} onOpenChange={vi.fn()} />)
 
     await waitFor(() => expect(screen.queryByText('Knowledge Search')).not.toBeInTheDocument())
     expect(updateAgentMock).not.toHaveBeenCalled()
@@ -1068,7 +1057,7 @@ describe('edit dialogs', () => {
         })
     )
     const boundAgent = { ...AGENT, knowledgeBaseIds: ['kb-1'] }
-    const props = { open: true, onOpenChange: vi.fn(), onSaved: vi.fn(), initialTab: 'tools.knowledge' }
+    const props = { open: true, onOpenChange: vi.fn(), initialTab: 'tools.knowledge' }
     const { rerender } = render(<AgentEditDialog {...props} resource={boundAgent} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove knowledge base' }))
@@ -1090,7 +1079,7 @@ describe('edit dialogs', () => {
   })
 
   it('opens the agent edit dialog directly on the requested initial tab', () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} initialTab="tools.skills" />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} initialTab="tools.skills" />)
 
     expect(screen.getByRole('tab', { name: '技能' })).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByText('Skill One')).toBeInTheDocument()
@@ -1098,7 +1087,7 @@ describe('edit dialogs', () => {
 
   it('opens Skill settings in an app tab without closing the agent edit dialog', () => {
     const onOpenChange = vi.fn()
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
 
     selectTab('技能')
 
@@ -1115,7 +1104,7 @@ describe('edit dialogs', () => {
   })
 
   it('reuses the shared skill catalog in the agent edit dialog', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} initialTab="tools.skills" />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} initialTab="tools.skills" />)
 
     await waitFor(() =>
       expect(skillCatalogPickerMock).toHaveBeenLastCalledWith(
@@ -1137,9 +1126,8 @@ describe('edit dialogs', () => {
       refreshing: true
     }
     const onOpenChange = vi.fn()
-    const onSaved = vi.fn()
     const { rerender } = render(
-      <AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={onSaved} initialTab="tools.skills" />
+      <AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} initialTab="tools.skills" />
     )
 
     expect(screen.getByText('Skill One')).toBeInTheDocument()
@@ -1150,9 +1138,7 @@ describe('edit dialogs', () => {
       skills: installedSkillsState.current.skills.map((skill) => ({ ...skill, isEnabled: true })),
       refreshing: false
     }
-    rerender(
-      <AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={onSaved} initialTab="tools.skills" />
-    )
+    rerender(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} initialTab="tools.skills" />)
 
     await waitFor(() => {
       expect(screen.getByRole('switch', { name: 'Skill One' })).toBeChecked()
@@ -1172,15 +1158,13 @@ describe('edit dialogs', () => {
   })
 
   it('opens the assistant edit dialog directly on the requested initial tab', () => {
-    render(
-      <AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} initialTab="tools.mcp" />
-    )
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} initialTab="tools.mcp" />)
 
     expect(screen.getByRole('tab', { name: 'MCP' })).toHaveAttribute('aria-selected', 'true')
   })
 
   it('auto-saves agent skill toggles after a debounce', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     selectTab('技能')
 
@@ -1199,7 +1183,7 @@ describe('edit dialogs', () => {
 
   it('uses the same MCP server list presentation in assistant and agent editing', async () => {
     const onAssistantOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onAssistantOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onAssistantOpenChange} />)
 
     selectTab('MCP')
     fireEvent.click(screen.getByRole('combobox', { name: 'MCP Mode' }))
@@ -1216,7 +1200,7 @@ describe('edit dialogs', () => {
     openSettingsTabMock.mockClear()
     const onAgentOpenChange = vi.fn()
 
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={onAgentOpenChange} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onAgentOpenChange} />)
 
     selectTab('MCP')
 
@@ -1238,7 +1222,7 @@ describe('edit dialogs', () => {
         if (!nextOpen) setTarget(null)
       }
 
-      return <AssistantEditDialog open={open} resource={target} onOpenChange={handleOpenChange} onSaved={vi.fn()} />
+      return <AssistantEditDialog open={open} resource={target} onOpenChange={handleOpenChange} />
     }
 
     render(<Host />)
@@ -1269,7 +1253,7 @@ describe('edit dialogs', () => {
         if (!nextOpen) setTarget(null)
       }
 
-      return <AgentEditDialog open={open} resource={target} onOpenChange={handleOpenChange} onSaved={vi.fn()} />
+      return <AgentEditDialog open={open} resource={target} onOpenChange={handleOpenChange} />
     }
 
     render(<Host />)
@@ -1291,7 +1275,7 @@ describe('edit dialogs', () => {
   })
 
   it('keeps popover content inside the dialog container', async () => {
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     const dialog = screen.getByRole('dialog')
     fireEvent.click(screen.getByLabelText('Pick avatar'))
@@ -1300,7 +1284,7 @@ describe('edit dialogs', () => {
   })
 
   it('keeps edited values while switching tabs before save', async () => {
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Draft Agent' } })
     selectTab('Prompt')
@@ -1312,7 +1296,7 @@ describe('edit dialogs', () => {
   it('keeps the dialog open and shows an error when save fails', async () => {
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Broken Assistant' } })
     expect(await screen.findByText('Save failed')).toBeInTheDocument()
@@ -1320,20 +1304,20 @@ describe('edit dialogs', () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
 
-  it('does not show a save error when the post-save callback fails', async () => {
+  it('keeps the dialog open after a successful auto-save', async () => {
     const onOpenChange = vi.fn()
-    const onSaved = vi.fn().mockRejectedValue(new Error('Refresh failed'))
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={onSaved} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Saved Assistant' } })
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
-    await waitFor(() => expect(onSaved).toHaveBeenCalled())
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
     expect(screen.queryByText('Save failed')).not.toBeInTheDocument()
   })
 
   it('flushes a pending change and closes when the dialog is closed', async () => {
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Updated Assistant' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
@@ -1355,7 +1339,7 @@ describe('edit dialogs', () => {
           resolveFirstSave = () => resolve({ ...ASSISTANT, name: 'First Edit' })
         })
     )
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     const nameInput = screen.getByLabelText('Name')
     fireEvent.change(nameInput, { target: { value: 'First Edit' } })
@@ -1380,7 +1364,7 @@ describe('edit dialogs', () => {
   it('keeps the dialog open with a visible error when the save on close fails', async () => {
     updateAssistantMock.mockRejectedValue(new Error('Network down'))
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
@@ -1398,7 +1382,7 @@ describe('edit dialogs', () => {
   it('retries saving when the form changes after a failed close', async () => {
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     const nameInput = screen.getByLabelText('Name')
     fireEvent.change(nameInput, { target: { value: 'First Closing Edit' } })
@@ -1424,9 +1408,7 @@ describe('edit dialogs', () => {
     // `rerender` rather than a fresh `render`.
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
-    const { rerender } = render(
-      <AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />
-    )
+    const { rerender } = render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Repro Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
@@ -1435,8 +1417,8 @@ describe('edit dialogs', () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
 
     // Discard-close, then reopen on the same instance before it unmounts.
-    rerender(<AssistantEditDialog open={false} resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
-    rerender(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    rerender(<AssistantEditDialog open={false} resource={ASSISTANT} onOpenChange={onOpenChange} />)
+    rerender(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     // Make the exact same edit again — this reproduces the identical changeKey as the
     // failed attempt above. Without clearing failedSaveKeyRef on reopen, the stale key
@@ -1464,7 +1446,7 @@ describe('edit dialogs', () => {
         })
     )
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Mid Save' } })
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
@@ -1483,7 +1465,7 @@ describe('edit dialogs', () => {
   it('keeps the agent dialog open with a visible error when the save on close fails', async () => {
     updateAgentMock.mockRejectedValue(new Error('Network down'))
     const onOpenChange = vi.fn()
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} onSaved={vi.fn()} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Agent' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/ResourceEditDialogHost.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/ResourceEditDialogHost.test.tsx
@@ -1,15 +1,11 @@
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import { act, fireEvent, render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ResourceEditDialogHost } from '../ResourceEditDialogHost'
 
 const mocks = vi.hoisted(() => ({
-  assistantRefetch: vi.fn(),
-  agentRevalidate: vi.fn(),
   onOpenChange: vi.fn(),
-  onSaved: vi.fn(),
   useAgent: vi.fn(),
   useAssistantApiById: vi.fn()
 }))
@@ -45,19 +41,14 @@ vi.mock('../AssistantEditDialog', () => ({
   AssistantEditDialog: ({
     open,
     onOpenChange,
-    onSaved,
     resource
   }: {
     open: boolean
     onOpenChange: (open: boolean) => void
-    onSaved: () => Promise<void>
     resource: { id: string } | null
   }) =>
     resource ? (
       <div data-testid="assistant-edit-dialog" data-open={open}>
-        <button type="button" onClick={() => void onSaved()}>
-          save
-        </button>
         <button type="button" onClick={() => onOpenChange(false)}>
           close
         </button>
@@ -69,19 +60,14 @@ vi.mock('../AgentEditDialog', () => ({
   AgentEditDialog: ({
     open,
     onOpenChange,
-    onSaved,
     resource
   }: {
     open: boolean
     onOpenChange: (open: boolean) => void
-    onSaved: () => Promise<void>
     resource: { id: string } | null
   }) =>
     resource ? (
       <div data-testid="agent-edit-dialog" data-open={open}>
-        <button type="button" onClick={() => void onSaved()}>
-          save
-        </button>
         <button type="button" onClick={() => onOpenChange(false)}>
           close
         </button>
@@ -95,97 +81,33 @@ describe('ResourceEditDialogHost', () => {
   })
 
   beforeEach(() => {
-    mocks.assistantRefetch.mockReset()
-    mocks.assistantRefetch.mockResolvedValue(undefined)
-    mocks.agentRevalidate.mockReset()
-    mocks.agentRevalidate.mockResolvedValue(undefined)
     mocks.onOpenChange.mockReset()
-    mocks.onSaved.mockReset()
-    mocks.onSaved.mockResolvedValue(undefined)
     mocks.useAssistantApiById.mockReset()
     mocks.useAssistantApiById.mockReturnValue({
       assistant: { id: 'assistant-1' },
-      error: undefined,
-      refetch: mocks.assistantRefetch
+      error: undefined
     })
     mocks.useAgent.mockReset()
     mocks.useAgent.mockReturnValue({
       agent: { id: 'agent-1' },
-      error: undefined,
-      revalidate: mocks.agentRevalidate
+      error: undefined
     })
   })
 
-  it('loads and saves an assistant edit target', async () => {
-    const user = userEvent.setup()
-
+  it('loads an assistant edit target by key', () => {
     render(
-      <ResourceEditDialogHost
-        target={{ kind: 'assistant', id: 'assistant-1' }}
-        onOpenChange={mocks.onOpenChange}
-        onSaved={mocks.onSaved}
-      />
+      <ResourceEditDialogHost target={{ kind: 'assistant', id: 'assistant-1' }} onOpenChange={mocks.onOpenChange} />
     )
 
     expect(mocks.useAssistantApiById).toHaveBeenCalledWith('assistant-1')
-    await user.click(screen.getByRole('button', { name: 'save' }))
-
-    expect(mocks.assistantRefetch).toHaveBeenCalledTimes(1)
-    expect(mocks.onSaved).toHaveBeenCalledWith({ kind: 'assistant', id: 'assistant-1' })
+    expect(screen.getByTestId('assistant-edit-dialog')).toHaveAttribute('data-open', 'true')
   })
 
-  it('keeps assistant post-save refresh failures inside the host', async () => {
-    const user = userEvent.setup()
-    mocks.assistantRefetch.mockRejectedValueOnce(new Error('Refresh failed'))
-
-    render(
-      <ResourceEditDialogHost
-        target={{ kind: 'assistant', id: 'assistant-1' }}
-        onOpenChange={mocks.onOpenChange}
-        onSaved={mocks.onSaved}
-      />
-    )
-
-    await expect(user.click(screen.getByRole('button', { name: 'save' }))).resolves.toBeUndefined()
-
-    expect(mocks.assistantRefetch).toHaveBeenCalledTimes(1)
-    expect(mocks.onSaved).not.toHaveBeenCalled()
-  })
-
-  it('loads and saves an agent edit target', async () => {
-    const user = userEvent.setup()
-
-    render(
-      <ResourceEditDialogHost
-        target={{ kind: 'agent', id: 'agent-1' }}
-        onOpenChange={mocks.onOpenChange}
-        onSaved={mocks.onSaved}
-      />
-    )
+  it('loads an agent edit target by key', () => {
+    render(<ResourceEditDialogHost target={{ kind: 'agent', id: 'agent-1' }} onOpenChange={mocks.onOpenChange} />)
 
     expect(mocks.useAgent).toHaveBeenCalledWith('agent-1')
-    await user.click(screen.getByRole('button', { name: 'save' }))
-
-    expect(mocks.agentRevalidate).toHaveBeenCalledTimes(1)
-    expect(mocks.onSaved).toHaveBeenCalledWith({ kind: 'agent', id: 'agent-1' })
-  })
-
-  it('keeps agent post-save refresh failures inside the host', async () => {
-    const user = userEvent.setup()
-    mocks.agentRevalidate.mockRejectedValueOnce(new Error('Refresh failed'))
-
-    render(
-      <ResourceEditDialogHost
-        target={{ kind: 'agent', id: 'agent-1' }}
-        onOpenChange={mocks.onOpenChange}
-        onSaved={mocks.onSaved}
-      />
-    )
-
-    await expect(user.click(screen.getByRole('button', { name: 'save' }))).resolves.toBeUndefined()
-
-    expect(mocks.agentRevalidate).toHaveBeenCalledTimes(1)
-    expect(mocks.onSaved).not.toHaveBeenCalled()
+    expect(screen.getByTestId('agent-edit-dialog')).toHaveAttribute('data-open', 'true')
   })
 
   it('keeps the target mounted until the shared unmount delay expires', async () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/index.ts
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/index.ts
@@ -1,9 +1,4 @@
-export { AgentEditDialog, type AgentEditDialogProps } from './AgentEditDialog'
-export {
-  AssistantEditDialog,
-  type AssistantEditDialogProps,
-  type AssistantEditDialogResource
-} from './AssistantEditDialog'
 export { default as PromptEditDialog } from './PromptEditDialog'
 export { openResourceEditDialog, ResourceEditDialogEventHost } from './ResourceEditDialogEventHost'
-export { ResourceEditDialogHost, type ResourceEditDialogTarget } from './ResourceEditDialogHost'
+export { ResourceEditDialogHost } from './ResourceEditDialogHost'
+export type { ResourceEditDialogTarget } from '@renderer/types/resourceCatalog'

--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -9,7 +9,7 @@ import { useAgentModelFilter } from '@renderer/hooks/agent/useAgentModelFilter'
 import { useAgentMutations } from '@renderer/hooks/resourceCatalog'
 import { usePins } from '@renderer/hooks/usePins'
 import { toast } from '@renderer/services/toast'
-import type { AgentDetail } from '@renderer/types/resourceCatalog'
+import type { AgentDetail, ResourceEditDialogTarget } from '@renderer/types/resourceCatalog'
 import { getAgentAvatarFromConfiguration, getAgentDescriptionForDisplay } from '@renderer/utils/agent'
 import { buildCreateAgentCommand } from '@renderer/utils/resourceCatalog'
 import { AGENTS_MAX_LIMIT } from '@shared/data/api/schemas/agents'
@@ -19,9 +19,9 @@ import { useTranslation } from 'react-i18next'
 import { ResourceSelectorShell, type ResourceSelectorShellItem } from './ResourceSelectorShell'
 
 const logger = loggerService.withContext('AgentSelector')
-const AgentEditDialog = lazy(() =>
+const ResourceEditDialogHost = lazy(() =>
   import('@renderer/components/resourceCatalog/dialogs/edit').then((module) => ({
-    default: module.AgentEditDialog
+    default: module.ResourceEditDialogHost
   }))
 )
 
@@ -71,8 +71,7 @@ export function AgentSelector(props: AgentSelectorProps) {
   const modelFilter = useAgentModelFilter('claude-code')
   const [internalOpen, setInternalOpen] = useState(false)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  const [editDialogOpen, setEditDialogOpen] = useState(false)
-  const [editingAgent, setEditingAgent] = useState<AgentDetail | null>(null)
+  const [editDialogTarget, setEditDialogTarget] = useState<ResourceEditDialogTarget | null>(null)
   const selectorOpen = open ?? internalOpen
   const handleSelectorOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -126,20 +125,16 @@ export function AgentSelector(props: AgentSelectorProps) {
 
   const handleEditItem = useCallback(
     (item: AgentSelectorItem) => {
-      const agent = data?.items.find((candidate) => candidate.id === item.id)
-      if (!agent) return
-
-      setEditingAgent(agent)
-      setEditDialogOpen(true)
+      if (!data?.items.some((candidate) => candidate.id === item.id)) return
+      setEditDialogTarget({ kind: 'agent', id: item.id })
     },
     [data?.items]
   )
 
   const handleEditDialogOpenChange = useCallback(
     (nextOpen: boolean) => {
-      setEditDialogOpen(nextOpen)
       if (!nextOpen) {
-        setEditingAgent(null)
+        setEditDialogTarget(null)
         onDialogCloseAutoFocus?.()
       }
     },
@@ -193,17 +188,6 @@ export function AgentSelector(props: AgentSelectorProps) {
     [autoSelectOnCreate, createAgent, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  const handleEditSaved = useCallback(async () => {
-    setEditDialogOpen(false)
-    setEditingAgent(null)
-    try {
-      await refetch()
-    } catch (error) {
-      logger.warn('Failed to refresh agents after selector edit', { error })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [refetch, t])
-
   const createDialog = (
     <ResourceCreateWizard
       kind="agent"
@@ -215,18 +199,11 @@ export function AgentSelector(props: AgentSelectorProps) {
     />
   )
 
-  const editDialog =
-    editDialogOpen || editingAgent ? (
-      <Suspense fallback={null}>
-        <AgentEditDialog
-          open={editDialogOpen}
-          resource={editingAgent}
-          onOpenChange={handleEditDialogOpenChange}
-          onSaved={handleEditSaved}
-          modelFilter={modelFilter}
-        />
-      </Suspense>
-    ) : null
+  const editDialog = editDialogTarget ? (
+    <Suspense fallback={null}>
+      <ResourceEditDialogHost target={editDialogTarget} onOpenChange={handleEditDialogOpenChange} />
+    </Suspense>
+  ) : null
 
   const shared = {
     trigger,

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -1,4 +1,3 @@
-import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import { loggerService } from '@logger'
 import {
   ResourceCreateWizard,
@@ -9,9 +8,10 @@ import { useMutation, useQuery } from '@renderer/data/hooks/useDataApi'
 import { useGroups } from '@renderer/hooks/useGroups'
 import { usePins } from '@renderer/hooks/usePins'
 import { toast } from '@renderer/services/toast'
+import type { ResourceEditDialogTarget } from '@renderer/types/resourceCatalog'
 import { buildCreateAssistantDto, isSelectableAssistantModel } from '@renderer/utils/resourceCatalog'
 import type { Assistant } from '@shared/data/types/assistant'
-import { lazy, type ReactElement, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, type ReactElement, Suspense, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -21,9 +21,9 @@ import {
 } from './ResourceSelectorShell'
 
 const logger = loggerService.withContext('AssistantSelector')
-const AssistantEditDialog = lazy(() =>
+const ResourceEditDialogHost = lazy(() =>
   import('@renderer/components/resourceCatalog/dialogs/edit').then((module) => ({
-    default: module.AssistantEditDialog
+    default: module.ResourceEditDialogHost
   }))
 )
 
@@ -97,9 +97,7 @@ export function AssistantSelector(props: AssistantSelectorProps) {
   const { t } = useTranslation()
   const [internalOpen, setInternalOpen] = useState(false)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  const [editDialogOpen, setEditDialogOpen] = useState(false)
-  const [editingAssistant, setEditingAssistant] = useState<Assistant | null>(null)
-  const editDialogCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [editDialogTarget, setEditDialogTarget] = useState<ResourceEditDialogTarget | null>(null)
   const selectorOpen = open ?? internalOpen
   const handleSelectorOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -164,49 +162,22 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     [isPinActionDisabled, togglePin, t]
   )
 
-  const clearEditDialogCloseTimer = useCallback(() => {
-    if (editDialogCloseTimerRef.current === null) return
-
-    clearTimeout(editDialogCloseTimerRef.current)
-    editDialogCloseTimerRef.current = null
-  }, [])
-
-  useEffect(() => clearEditDialogCloseTimer, [clearEditDialogCloseTimer])
-
-  const scheduleEditDialogClose = useCallback(() => {
-    setEditDialogOpen(false)
-    if (editDialogCloseTimerRef.current !== null) return
-
-    editDialogCloseTimerRef.current = setTimeout(() => {
-      editDialogCloseTimerRef.current = null
-      setEditingAssistant(null)
-      onDialogCloseAutoFocus?.()
-    }, DIALOG_UNMOUNT_DELAY_MS)
-  }, [onDialogCloseAutoFocus])
-
   const handleEditItem = useCallback(
     (item: AssistantSelectorItem) => {
-      const assistant = data?.items.find((candidate) => candidate.id === item.id)
-      if (!assistant) return
-
-      clearEditDialogCloseTimer()
-      setEditingAssistant(assistant)
-      setEditDialogOpen(true)
+      if (!data?.items.some((candidate) => candidate.id === item.id)) return
+      setEditDialogTarget({ kind: 'assistant', id: item.id })
     },
-    [clearEditDialogCloseTimer, data?.items]
+    [data?.items]
   )
 
   const handleEditDialogOpenChange = useCallback(
     (nextOpen: boolean) => {
-      if (nextOpen) {
-        clearEditDialogCloseTimer()
-        setEditDialogOpen(true)
-        return
+      if (!nextOpen) {
+        setEditDialogTarget(null)
+        onDialogCloseAutoFocus?.()
       }
-
-      scheduleEditDialogClose()
     },
-    [clearEditDialogCloseTimer, scheduleEditDialogClose]
+    [onDialogCloseAutoFocus]
   )
 
   const handleCreateDialogOpenChange = useCallback(
@@ -258,16 +229,6 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     [autoSelectOnCreate, createAssistant, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  const handleEditSaved = useCallback(async () => {
-    scheduleEditDialogClose()
-    try {
-      await refetch()
-    } catch (error) {
-      logger.warn('Failed to refresh assistants after selector edit', { error })
-      toast.error(t('selector.edit_dialog.refresh_failed'))
-    }
-  }, [refetch, scheduleEditDialogClose, t])
-
   const createDialog = (
     <ResourceCreateWizard
       kind="assistant"
@@ -279,18 +240,11 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     />
   )
 
-  const editDialog =
-    editDialogOpen || editingAssistant ? (
-      <Suspense fallback={null}>
-        <AssistantEditDialog
-          open={editDialogOpen}
-          resource={editingAssistant}
-          onOpenChange={handleEditDialogOpenChange}
-          onSaved={handleEditSaved}
-          modelFilter={isSelectableAssistantModel}
-        />
-      </Suspense>
-    ) : null
+  const editDialog = editDialogTarget ? (
+    <Suspense fallback={null}>
+      <ResourceEditDialogHost target={editDialogTarget} onOpenChange={handleEditDialogOpenChange} />
+    </Suspense>
+  ) : null
 
   const shared = {
     trigger,

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -1,7 +1,8 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
+import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import type * as ModelSelectorModule from '@renderer/components/ModelSelector'
 import type * as UseModelModule from '@renderer/hooks/useModel'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -261,13 +262,16 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  useQueryMock.mockReturnValue({
-    data: AGENTS_RESPONSE,
-    isLoading: false,
-    isRefreshing: false,
-    error: undefined,
-    refetch: refetchAgentsMock,
-    mutate: vi.fn()
+  useQueryMock.mockImplementation((path: string) => {
+    const data = path === '/agents/:agentId' ? AGENTS_RESPONSE.items[0] : AGENTS_RESPONSE
+    return {
+      data,
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      refetch: refetchAgentsMock,
+      mutate: vi.fn()
+    }
   })
   useMutationMock.mockImplementation((method: string, path: string) => {
     if (method === 'PATCH' && path.startsWith('/agents/')) {
@@ -312,6 +316,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
+  vi.useRealTimers()
 })
 
 function renderSelector(onChange = vi.fn()) {
@@ -553,7 +558,7 @@ describe('AgentSelector', () => {
     await waitFor(() => expect(screen.getByPlaceholderText('Search agents')).toBeInTheDocument())
   })
 
-  it('keeps the selector closed after editing an agent from a row action', async () => {
+  it('keeps the selector closed and the edit dialog open after auto-saving an agent', async () => {
     renderSelector()
     openPopover()
 
@@ -564,8 +569,8 @@ describe('AgentSelector', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Agent' } })
 
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
-    await waitFor(() => expect(refetchAgentsMock).toHaveBeenCalledTimes(1))
     expect(screen.queryByPlaceholderText('Search agents')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Edit Agent' })).toBeInTheDocument()
   })
 
   it('calls the dialog-close autofocus callback when the edit dialog closes', async () => {
@@ -582,8 +587,11 @@ describe('AgentSelector', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Edit agent' })[0])
     expect(await screen.findByRole('heading', { name: 'Edit Agent' }, { timeout: 5000 })).toBeInTheDocument()
+    vi.useFakeTimers()
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
+    expect(onDialogCloseAutoFocus).not.toHaveBeenCalled()
+    await act(() => vi.advanceTimersByTime(DIALOG_UNMOUNT_DELAY_MS))
     expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
   })
   it('calls the dialog-close autofocus callback once when saving the edit dialog', async () => {
@@ -604,8 +612,7 @@ describe('AgentSelector', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
-    await waitFor(() => expect(refetchAgentsMock).toHaveBeenCalledTimes(1))
-    expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
 
   it('does not show the empty state while the agents query is loading', () => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -274,13 +274,16 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  useQueryMock.mockReturnValue({
-    data: ASSISTANTS_RESPONSE,
-    isLoading: false,
-    isRefreshing: false,
-    error: undefined,
-    refetch: refetchAssistantsMock,
-    mutate: vi.fn()
+  useQueryMock.mockImplementation((path: string) => {
+    const data = path === '/assistants/:id' ? ASSISTANTS_RESPONSE.items[0] : ASSISTANTS_RESPONSE
+    return {
+      data,
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      refetch: refetchAssistantsMock,
+      mutate: vi.fn()
+    }
   })
   useMutationMock.mockImplementation((method: string, path: string) => {
     if (method === 'PATCH' && path.startsWith('/assistants/')) {
@@ -482,7 +485,7 @@ describe('AssistantSelector', () => {
     expect(onChange).toHaveBeenCalledWith('created-assistant')
   })
 
-  it('keeps the selector closed after editing an assistant from a row action', async () => {
+  it('keeps the selector closed and the edit dialog open after auto-saving an assistant', async () => {
     renderSelector()
     openPopover()
 
@@ -493,8 +496,8 @@ describe('AssistantSelector', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed Assistant' } })
 
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
-    await waitFor(() => expect(refetchAssistantsMock).toHaveBeenCalledTimes(1))
     expect(screen.queryByPlaceholderText('Search assistants')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Edit Assistant' })).toBeInTheDocument()
   })
 
   it('restores focus after the edit dialog close animation completes', async () => {
@@ -541,7 +544,6 @@ describe('AssistantSelector', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalled())
-    await waitFor(() => expect(refetchAssistantsMock).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(onDialogCloseAutoFocus).toHaveBeenCalledTimes(1))
   })
 

--- a/src/renderer/hooks/resourceCatalog/__tests__/useResourceCatalogController.test.tsx
+++ b/src/renderer/hooks/resourceCatalog/__tests__/useResourceCatalogController.test.tsx
@@ -178,6 +178,20 @@ describe('useResourceCatalogController', () => {
     expect(controllerMocks.refetch).not.toHaveBeenCalled()
   })
 
+  it('stores only the resource key when opening the edit dialog', () => {
+    controllerMocks.resourceLibraryState.resources = [assistantResource]
+    const { result } = renderHook(() => useResourceCatalogController('assistant'))
+
+    act(() => {
+      result.current.gridProps.onEdit(assistantResource)
+    })
+
+    expect(result.current.dialogs.editDialogTarget).toEqual({
+      kind: 'assistant',
+      id: 'assistant-to-duplicate'
+    })
+  })
+
   it('reports assistant export failures without throwing', async () => {
     controllerMocks.saveFile.mockRejectedValueOnce(new Error('export failed'))
     const { result } = renderHook(() => useResourceCatalogController('assistant'))

--- a/src/renderer/hooks/resourceCatalog/useResourceCatalogController.ts
+++ b/src/renderer/hooks/resourceCatalog/useResourceCatalogController.ts
@@ -1,16 +1,15 @@
 import { useGroupMutations, useGroups } from '@renderer/hooks/useGroups'
 import { toast } from '@renderer/services/toast'
 import type {
-  AgentDetail,
   GroupItem,
   ResourceCreateValues,
+  ResourceEditDialogTarget,
   ResourceItem,
   ResourceType
 } from '@renderer/types/resourceCatalog'
 import { serializeAssistantForExport } from '@renderer/utils/assistantTransfer'
 import { buildCreateAgentCommand, buildCreateAssistantDto } from '@renderer/utils/resourceCatalog'
 import type { InstalledSkill } from '@shared/data/types/agent'
-import type { Assistant } from '@shared/data/types/assistant'
 import type { Group } from '@shared/data/types/group'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -19,12 +18,10 @@ import { useAgentMutations } from './agentAdapter'
 import { useAssistantMutations } from './assistantAdapter'
 import { useResourceLibrary } from './useResourceLibrary'
 
-type EditDialogState = { kind: 'assistant'; resource: Assistant } | { kind: 'agent'; resource: AgentDetail }
-
 type ResourceCreateWizardKind = 'assistant' | 'agent'
 type ResourceCatalogControllerType = Extract<ResourceType, 'assistant' | 'agent' | 'skill'>
 
-const DIALOG_EXIT_ANIMATION_MS = 200
+const CREATE_DIALOG_EXIT_ANIMATION_MS = 200
 
 /**
  * Build the top-bar chip list.
@@ -54,8 +51,7 @@ export function useResourceCatalogController(resourceType: ResourceCatalogContro
   const [deleteConfirm, setDeleteConfirm] = useState<ResourceItem | null>(null)
   const [createDialogKind, setCreateDialogKind] = useState<ResourceCreateWizardKind | null>(null)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
-  const [editDialog, setEditDialog] = useState<EditDialogState | null>(null)
-  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [editDialogTarget, setEditDialogTarget] = useState<ResourceEditDialogTarget | null>(null)
   const [creatingResource, setCreatingResource] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<InstalledSkill | null>(null)
   const [assistantImportOpen, setAssistantImportOpen] = useState(false)
@@ -97,24 +93,15 @@ export function useResourceCatalogController(resourceType: ResourceCatalogContro
   useEffect(() => {
     if (createDialogOpen || !createDialogKind) return
 
-    const timeoutId = window.setTimeout(() => setCreateDialogKind(null), DIALOG_EXIT_ANIMATION_MS)
+    const timeoutId = window.setTimeout(() => setCreateDialogKind(null), CREATE_DIALOG_EXIT_ANIMATION_MS)
     return () => window.clearTimeout(timeoutId)
   }, [createDialogKind, createDialogOpen])
 
-  useEffect(() => {
-    if (editDialogOpen || !editDialog) return
-
-    const timeoutId = window.setTimeout(() => setEditDialog(null), DIALOG_EXIT_ANIMATION_MS)
-    return () => window.clearTimeout(timeoutId)
-  }, [editDialog, editDialogOpen])
-
   const handleOpenResource = useCallback((resource: ResourceItem) => {
     if (resource.type === 'assistant') {
-      setEditDialog({ kind: 'assistant', resource: resource.raw })
-      setEditDialogOpen(true)
+      setEditDialogTarget({ kind: 'assistant', id: resource.id })
     } else if (resource.type === 'agent') {
-      setEditDialog({ kind: 'agent', resource: resource.raw })
-      setEditDialogOpen(true)
+      setEditDialogTarget({ kind: 'agent', id: resource.id })
     } else if (resource.type === 'skill') {
       setSelectedSkill(resource.raw)
     }
@@ -195,14 +182,6 @@ export function useResourceCatalogController(resourceType: ResourceCatalogContro
     [createAgent, createAssistant, createDialogKind, creatingResource, refetch]
   )
 
-  const handleEditDialogOpenChange = useCallback((open: boolean) => {
-    setEditDialogOpen(open)
-  }, [])
-
-  const handleEditSaved = useCallback(() => {
-    refetch()
-  }, [refetch])
-
   return {
     resourceError,
     refetch,
@@ -238,8 +217,7 @@ export function useResourceCatalogController(resourceType: ResourceCatalogContro
       createDialogOpen,
       creatingResource,
       deleteConfirm,
-      editDialog,
-      editDialogOpen,
+      editDialogTarget,
       selectedSkill,
       skillImportOpen,
       skillMarketplaceOpen,
@@ -247,13 +225,12 @@ export function useResourceCatalogController(resourceType: ResourceCatalogContro
       setAssistantImportOpen,
       setAssistantLibraryOpen,
       setDeleteConfirm,
+      setEditDialogTarget,
       setSelectedSkill,
       setSkillImportOpen,
       setSkillMarketplaceOpen,
       setSystemSkillOpen,
       handleCreateDialogOpenChange,
-      handleEditDialogOpenChange,
-      handleEditSaved,
       handleSubmitCreateResource
     }
   }

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1881,7 +1881,6 @@ const Sessions = ({
         onOpenChange={(open) => {
           if (!open) setEditDialogTarget(null)
         }}
-        onSaved={refetchAgents}
       />
       {imageCaptureTargets.map(({ requestId, target: session }) => {
         const activeAgent = session.agentId ? agentById.get(session.agentId) : undefined

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -1391,7 +1391,6 @@ export function Topics({
             onOpenChange={(open) => {
               if (!open) setEditDialogTarget(null)
             }}
-            onSaved={refreshAssistants}
           />
         </Suspense>
       ) : null}

--- a/src/renderer/types/resourceCatalog.ts
+++ b/src/renderer/types/resourceCatalog.ts
@@ -7,6 +7,11 @@ import type { Prompt } from '@shared/data/types/prompt'
 
 export type ResourceType = 'agent' | 'assistant' | 'skill' | 'prompt'
 
+export type ResourceEditDialogTarget = ({ kind: 'assistant'; id: string } | { kind: 'agent'; id: string }) & {
+  /** Leaf tab id to open the dialog on (e.g. `tools.mcp`, `tools.skills`). */
+  initialTab?: string
+}
+
 /** Validated values shared by every Assistant / Agent creation entry point. */
 export type ResourceCreateValues = {
   avatar: string


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Assistant and agent edit dialogs used submission-style `onSaved` callbacks after each auto-save. Callers duplicated resource snapshots, open state, refetching, and close behavior, causing a successful field update to close the dialog.

After this PR:

Edit entry points pass only a `{ kind, id }` target to a shared host. The host resolves the latest resource, mutations own cache invalidation, and auto-save updates no longer close the dialog. The dialog closes only through an explicit close action.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The resource key is the stable identity the upstream UI actually owns. Resolving the current resource inside `ResourceEditDialogHost` removes stale snapshots and gives every edit entry point one lifecycle. Existing mutation refresh rules already invalidate assistant/agent list and detail queries, so an additional post-save callback is unnecessary.

The following tradeoffs were made:

- React Hook Form remains inside the leaf dialogs for local draft state, validation, diffing, and debounced auto-save.
- The shared host owns the close animation delay so callers do not need parallel open/resource state.

The following alternatives were considered:

- Keeping `onSaved` and patching each caller to avoid closing was rejected because it would preserve duplicated refetch and lifecycle responsibilities.
- Passing complete resource snapshots upstream was rejected because they become stale after mutation-driven cache refreshes.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- `pnpm lint` passes, including typecheck, i18n validation, and formatting.
- The command reports 40 pre-existing repository warnings and 0 errors.
- Automated tests and interactive UI verification were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Editing an assistant or agent now keeps the edit dialog open after each automatic save.
```
