### PR TITLE
feat(knowledge): add select all to note import

### DIFF
--- a/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
+++ b/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
@@ -82,6 +82,11 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
     )
   }, [])
 
+  const handleNoteSelectionChange = useCallback((notes: NoteItem[]) => {
+    setSubmitErrorMessage('')
+    setSelectedNotes(notes)
+  }, [])
+
   const canSubmit = useMemo(() => {
     if (!selectedBaseId) {
       return false
@@ -314,6 +319,7 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
                 selectedNotes={selectedNotes}
                 urlValue={urlValue}
                 onNoteToggle={handleNoteToggle}
+                onNoteSelectionChange={handleNoteSelectionChange}
                 onUrlValueChange={(value) => {
                   setSubmitErrorMessage('')
                   setUrlValue(value)

--- a/src/renderer/pages/knowledge/components/__tests__/AddKnowledgeItemDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/AddKnowledgeItemDialog.test.tsx
@@ -173,6 +173,7 @@ vi.mock('react-i18next', () => {
       'common.cancel': '取消',
       'common.close': '关闭',
       'common.delete': '删除',
+      'common.select_all': '全选',
       'knowledge.data_source.add_dialog.conflict_dialog.title': '存在同名数据源',
       'knowledge.data_source.add_dialog.conflict_dialog.description': `有 ${options?.count ?? 0} 个数据源与知识库中已存在的项目同名，请选择处理方式。`,
       'knowledge.data_source.add_dialog.conflict_dialog.keep_all': '全部保留',
@@ -395,10 +396,33 @@ describe('AddKnowledgeItemDialog', () => {
       expect(screen.getByText('Ideas')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: '添加' })).toBeDisabled()
 
-      fireEvent.click(screen.getAllByRole('checkbox')[0])
+      fireEvent.click(screen.getByRole('checkbox', { name: /Meeting notes/ }))
 
       expect(screen.getByText('已选 1 个笔记')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: '添加' })).toBeEnabled()
+    })
+
+    it('selects and deselects every note from the list header', () => {
+      setPendingAddSource('note')
+      mockProjectNotesTree.mockReturnValue([
+        createNoteNode('Meeting notes', '/notes/Meeting notes.md'),
+        createNoteNode('Ideas', '/notes/Ideas.md')
+      ])
+      render(<AddKnowledgeItemDialog open onOpenChange={vi.fn()} />)
+
+      const selectAll = screen.getByRole('checkbox', { name: '全选' })
+      fireEvent.click(selectAll)
+
+      expect(screen.getByText('已选 2 个笔记')).toBeInTheDocument()
+      expect(screen.getByRole('checkbox', { name: /Meeting notes/ })).toBeChecked()
+      expect(screen.getByRole('checkbox', { name: /Ideas/ })).toBeChecked()
+
+      fireEvent.click(selectAll)
+
+      expect(screen.queryByText('已选 2 个笔记')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '添加' })).toBeDisabled()
+      expect(screen.getByRole('checkbox', { name: /Meeting notes/ })).not.toBeChecked()
+      expect(screen.getByRole('checkbox', { name: /Ideas/ })).not.toBeChecked()
     })
 
     it('submits note source body through the generic hook', async () => {
@@ -407,7 +431,7 @@ describe('AddKnowledgeItemDialog', () => {
       mockReadExternal.mockResolvedValueOnce('# Meeting\n\nbody')
       render(<AddKnowledgeItemDialog open onOpenChange={vi.fn()} />)
 
-      fireEvent.click(screen.getByRole('checkbox'))
+      fireEvent.click(screen.getByRole('checkbox', { name: /Meeting notes/ }))
       fireEvent.click(screen.getByRole('button', { name: '添加' }))
 
       await waitFor(() => {
@@ -426,7 +450,7 @@ describe('AddKnowledgeItemDialog', () => {
       mockProjectNotesTree.mockReturnValue(notes)
       render(<AddKnowledgeItemDialog open onOpenChange={vi.fn()} />)
 
-      screen.getAllByRole('checkbox').forEach((checkbox) => fireEvent.click(checkbox))
+      fireEvent.click(screen.getByRole('checkbox', { name: '全选' }))
       fireEvent.click(screen.getByRole('button', { name: '添加' }))
 
       const alert = await screen.findByRole('alert')
@@ -450,7 +474,7 @@ describe('AddKnowledgeItemDialog', () => {
       mockReadExternal.mockRejectedValueOnce(new Error('ENOENT'))
       render(<AddKnowledgeItemDialog open onOpenChange={vi.fn()} />)
 
-      fireEvent.click(screen.getByRole('checkbox'))
+      fireEvent.click(screen.getByRole('checkbox', { name: /Meeting notes/ }))
       fireEvent.click(screen.getByRole('button', { name: '添加' }))
 
       const alert = await screen.findByRole('alert')

--- a/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogSourceTabs.tsx
+++ b/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/AddKnowledgeItemDialogSourceTabs.tsx
@@ -9,6 +9,7 @@ interface AddKnowledgeItemDialogSourceTabsProps {
   selectedNotes: NoteItem[]
   urlValue: string
   onNoteToggle: (note: NoteItem) => void
+  onNoteSelectionChange: (notes: NoteItem[]) => void
   onUrlValueChange: (value: string) => void
 }
 
@@ -17,13 +18,20 @@ const AddKnowledgeItemDialogSourceTabs = ({
   selectedNotes,
   urlValue,
   onNoteToggle,
+  onNoteSelectionChange,
   onUrlValueChange
 }: AddKnowledgeItemDialogSourceTabsProps) => {
   // `file` / `directory` use the OS picker directly and never reach this panel.
   const renderSourceContent = (source: KnowledgeItemType) => {
     switch (source) {
       case 'note':
-        return <NoteSourceContent selectedNotes={selectedNotes} onToggle={onNoteToggle} />
+        return (
+          <NoteSourceContent
+            selectedNotes={selectedNotes}
+            onToggle={onNoteToggle}
+            onSelectionChange={onNoteSelectionChange}
+          />
+        )
       case 'url':
         return <UrlSourceContent value={urlValue} onValueChange={onUrlValueChange} />
       default:

--- a/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/sources/NoteSourceContent.tsx
+++ b/src/renderer/pages/knowledge/components/addKnowledgeItemDialog/sources/NoteSourceContent.tsx
@@ -12,6 +12,7 @@ import type { NoteItem } from '../types'
 interface NoteSourceContentProps {
   selectedNotes: NoteItem[]
   onToggle: (note: NoteItem) => void
+  onSelectionChange: (notes: NoteItem[]) => void
 }
 
 /** Flatten the notes tree to its markdown files; folders only carry structure here. */
@@ -27,7 +28,7 @@ function collectNoteFiles(nodes: NotesTreeNode[]): NotesTreeNode[] {
   return files
 }
 
-const NoteSourceContent = ({ selectedNotes, onToggle }: NoteSourceContentProps) => {
+const NoteSourceContent = ({ selectedNotes, onToggle, onSelectionChange }: NoteSourceContentProps) => {
   const { t } = useTranslation()
   const { notesPath } = useNotesSettings()
   const { root, isLoading, error } = useDirectoryTree(notesPath || undefined)
@@ -40,6 +41,8 @@ const NoteSourceContent = ({ selectedNotes, onToggle }: NoteSourceContentProps) 
   }, [root, notesPath])
 
   const selectedPaths = useMemo(() => new Set(selectedNotes.map((note) => note.externalPath)), [selectedNotes])
+  const allNotesSelected = noteFiles.every((note) => selectedPaths.has(note.externalPath))
+  const someNotesSelected = noteFiles.some((note) => selectedPaths.has(note.externalPath))
 
   const renderBody = () => {
     if (isLoading) {
@@ -109,9 +112,28 @@ const NoteSourceContent = ({ selectedNotes, onToggle }: NoteSourceContentProps) 
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3">
-      <p className="text-foreground-muted text-xs leading-4">
-        {t('knowledge.data_source.add_dialog.note.description')}
-      </p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-foreground-muted text-xs leading-4">
+          {t('knowledge.data_source.add_dialog.note.description')}
+        </p>
+        {noteFiles.length > 0 && (
+          <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-foreground text-xs leading-4">
+            <Checkbox
+              size="sm"
+              checked={allNotesSelected ? true : someNotesSelected ? 'indeterminate' : false}
+              onCheckedChange={(checked) =>
+                onSelectionChange(
+                  checked === true
+                    ? noteFiles.map((note) => ({ name: note.name, externalPath: note.externalPath }))
+                    : []
+                )
+              }
+              aria-label={t('common.select_all')}
+            />
+            <span>{t('common.select_all')}</span>
+          </label>
+        )}
+      </div>
       {renderBody()}
     </div>
   )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The note source picker required users to select every flattened note individually.

After this PR:

The picker shows a Select All checkbox in the header. It selects or clears every note and displays an indeterminate state when only some notes are selected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The flattened note list can contain many entries, so selecting each row individually is unnecessarily repetitive. The bulk action updates the same parent-owned selection array used by individual rows, keeping one source of truth.

The following tradeoffs were made:

The control selects every visible note even when the result exceeds the existing 20-source submission limit. The existing validation remains responsible for showing the limit error, preserving current behavior.

The following alternatives were considered:

Calling the row toggle once per note was considered, but replacing the selection array once avoids repeated state updates and stale transitions.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Targeted renderer tests pass (22/22), and `pnpm lint` passes with 40 pre-existing warnings. The full test suite and `build:check` were not run at the contributor's request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) — N/A, no refactor
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. No guide update is required for this discoverable picker control.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added a Select All control when importing notes into a knowledge base.
```