### PR TITLE
fix(model-list): group flat model IDs by family

### DIFF
--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -73,6 +73,34 @@ function makeGeminiProvider() {
   })
 }
 
+describe('listModels — default grouping', () => {
+  it.each(['7f8b0f84-36d1-45ec-9f49-0bfb535ab38d', 'opencode'])(
+    'derives model-family groups instead of using provider id %s',
+    async (providerId) => {
+      aiSdkGetFromApiMock.mockResolvedValue({
+        value: {
+          data: [
+            { id: 'deepseek-v4-pro', owned_by: providerId },
+            { id: 'glm-5.2', owned_by: providerId },
+            { id: 'grok-4.5', owned_by: providerId }
+          ]
+        }
+      })
+      const provider = makeProvider({
+        id: providerId,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://models.example.com/v1' }
+        }
+      })
+
+      const models = await listModels(provider)
+
+      expect(models.map((model) => model.group)).toEqual(['deepseek', 'glm', 'grok'])
+      expect(models.map((model) => model.group)).not.toContain(providerId)
+    }
+  )
+})
+
 describe('listModels — geminiFetcher API key transport', () => {
   it('passes the API key via the x-goog-api-key header, never the ?key= query (REGRESSION)', async () => {
     const provider = makeGeminiProvider()

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -24,6 +24,7 @@ import {
 } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { formatApiHost, withoutTrailingSlash } from '@shared/utils/api'
+import { deriveModelGroupName } from '@shared/utils/model'
 import {
   isAIGatewayProvider,
   isGeminiProvider,
@@ -131,8 +132,7 @@ async function getFromApi<T>({
 /** Build default headers with rotated API key */
 
 function defaultGroup(modelId: string, providerId: string): string {
-  const parts = modelId.split('/')
-  return parts.length > 1 ? parts[0] : providerId
+  return deriveModelGroupName(modelId) ?? providerId
 }
 
 /** Build a partial v2 Model from API response */

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/modelListDerivedState.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/modelListDerivedState.test.ts
@@ -87,6 +87,35 @@ describe('modelListDerivedState', () => {
     expect(Object.keys(groupModels(groupedModels as any))).toEqual(['deepseek', 'openai'])
   })
 
+  it('repairs legacy provider-id groups while preserving explicit user groups', () => {
+    const groupedModels = [
+      {
+        id: 'opencode::deepseek-v4-pro',
+        apiModelId: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        providerId: 'opencode',
+        group: 'opencode',
+        capabilities: [],
+        isEnabled: true
+      },
+      {
+        id: 'opencode::gpt-5.6-sol',
+        apiModelId: 'gpt-5.6-sol',
+        name: 'GPT 5.6 Sol',
+        providerId: 'opencode',
+        group: 'Featured',
+        capabilities: [],
+        isEnabled: true
+      }
+    ]
+
+    const groups = groupModels(groupedModels as any, false, { preferModelGroup: true })
+
+    expect(groups.deepseek.map((model) => model.id)).toEqual(['opencode::deepseek-v4-pro'])
+    expect(groups.Featured.map((model) => model.id)).toEqual(['opencode::gpt-5.6-sol'])
+    expect(groups.opencode).toBeUndefined()
+  })
+
   it('applies search text and capability filters together', () => {
     expect(applyModelFilters(models as any, 'alpha', 'all').map((model) => model.id)).toEqual([
       'openai::reasoning-free',

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/modelListDerivedState.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/modelListDerivedState.ts
@@ -2,6 +2,7 @@ import type { ModelWithStatus } from '@renderer/pages/settings/ProviderSettings/
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, parseUniqueModelId } from '@shared/data/types/model'
 import {
+  deriveModelGroupName,
   isEmbeddingModel,
   isGenerateAudioModel,
   isGenerateImageModel,
@@ -59,13 +60,7 @@ type CalculateModelListDerivedStateInput = {
 
 function getModelIdGroupName(model: Model): string | undefined {
   const modelId = model.apiModelId ?? parseUniqueModelId(model.id).modelId
-  const pathParts = modelId.split('/')
-  if (pathParts.length > 1) {
-    return pathParts[0]
-  }
-
-  const familyName = modelId.split('-')[0]?.trim()
-  return familyName !== modelId ? familyName : undefined
+  return deriveModelGroupName(modelId)
 }
 
 export const groupModels = (
@@ -74,8 +69,11 @@ export const groupModels = (
   options: GroupModelsOptions = {}
 ): ModelGroups => {
   const grouped = models.reduce<ModelGroups>((acc, model) => {
-    const preferredGroup = options.preferModelGroup ? model.group : getModelIdGroupName(model)
-    const fallbackGroup = options.preferModelGroup ? getModelIdGroupName(model) : model.group
+    const inferredGroup = getModelIdGroupName(model)
+    const hasLegacyProviderGroup = inferredGroup !== undefined && model.group?.trim() === model.providerId
+    const shouldPreferStoredGroup = options.preferModelGroup && !hasLegacyProviderGroup
+    const preferredGroup = shouldPreferStoredGroup ? model.group : inferredGroup
+    const fallbackGroup = shouldPreferStoredGroup ? inferredGroup : model.group
     const groupName = normalizeModelGroupName(preferredGroup, fallbackGroup ?? model.providerId)
     if (!acc[groupName]) {
       acc[groupName] = []

--- a/src/shared/utils/__tests__/model.test.ts
+++ b/src/shared/utils/__tests__/model.test.ts
@@ -1,6 +1,7 @@
 import { CHERRYAI_DEFAULT_MODEL_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { ENDPOINT_TYPE, type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import {
+  deriveModelGroupName,
   isAudioModel,
   isEmbeddingModel,
   isFunctionCallingModel,
@@ -29,6 +30,19 @@ const createModel = (capabilities: Model['capabilities'] = []): Model => ({
 })
 
 describe('shared model capability helpers', () => {
+  describe('deriveModelGroupName', () => {
+    it.each([
+      ['openai/gpt-4o', 'openai'],
+      ['deepseek-v4-pro', 'deepseek'],
+      ['gpt-5.6-sol', 'gpt'],
+      ['codex-auto-review', 'codex'],
+      ['hy3', undefined],
+      ['  ', undefined]
+    ])('derives %s as %s', (modelId, expected) => {
+      expect(deriveModelGroupName(modelId)).toBe(expected)
+    })
+  })
+
   it('reads capability state from v2 Model.capabilities', () => {
     const model = createModel([
       MODEL_CAPABILITY.REASONING,

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -392,6 +392,23 @@ export const getLowerBaseModelName = (id: string, delimiter: string = '/'): stri
   return baseModelName
 }
 
+/**
+ * Derive the model-list group from an API model ID.
+ *
+ * Provider-prefixed IDs use the provider segment (`openai/gpt-4o` → `openai`);
+ * flat IDs use their family prefix (`deepseek-v4-pro` → `deepseek`).
+ */
+export function deriveModelGroupName(modelId: string): string | undefined {
+  const normalizedId = modelId.trim()
+  const pathParts = normalizedId.split('/')
+  if (pathParts.length > 1) {
+    return pathParts[0]?.trim() || undefined
+  }
+
+  const familyName = normalizedId.split('-')[0]?.trim()
+  return familyName && familyName !== normalizedId ? familyName : undefined
+}
+
 export const groupQwenModels = <T extends Pick<Model, 'id'> & Partial<Pick<Model, 'group'>>>(
   models: T[]
 ): Record<string, T[]> => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Providers returning flat model IDs grouped fetched and persisted models under the provider ID, such as `opencode` or a custom provider UUID.

After this PR: Flat IDs are grouped by model family, legacy provider-ID groups are repaired when rendered, and explicit custom groups remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17576

### Why we need it and why it was done in this way

The following tradeoffs were made: Shared family inference in the fetch and renderer paths; provider fallback for IDs without an inferable family

The following alternatives were considered: Database migration; avoided because render-time compatibility does not rewrite user-defined groups

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17576

### Breaking changes

None

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation: 62 focused Vitest cases, `pnpm lint`, `pnpm format`, and a tracked Electron OpenCode pull/add/remove flow; full `pnpm test` and `pnpm build:check` not run

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed incorrect model grouping for providers that return flat model IDs.
```
