### PR TITLE
fix(appearance-settings): add aria-labels and tooltips to page-zoom buttons

### DIFF
--- a/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
@@ -376,17 +376,35 @@ const AppearanceSettings: FC = () => {
           <SettingRowTitle>{t('settings.zoom.title')}</SettingRowTitle>
           <ZoomButtonGroup>
             {!isDefaultZoom && (
-              <Button onClick={() => handleZoomFactor(0, true)} variant="ghost" size="icon">
-                <ResetIcon size="14" />
-              </Button>
+              <Tooltip content={t('preview.reset')} delay={800}>
+                <Button
+                  onClick={() => handleZoomFactor(0, true)}
+                  variant="ghost"
+                  size="icon"
+                  aria-label={t('preview.reset')}>
+                  <ResetIcon size="14" />
+                </Button>
+              </Tooltip>
             )}
-            <Button onClick={() => handleZoomFactor(-0.1)} variant="ghost" size="icon">
-              <Minus size="14" />
-            </Button>
+            <Tooltip content={t('preview.zoom_out')} delay={800}>
+              <Button
+                onClick={() => handleZoomFactor(-0.1)}
+                variant="ghost"
+                size="icon"
+                aria-label={t('preview.zoom_out')}>
+                <Minus size="14" />
+              </Button>
+            </Tooltip>
             <ZoomValue>{Math.round(currentZoom * 100)}%</ZoomValue>
-            <Button onClick={() => handleZoomFactor(0.1)} variant="ghost" size="icon">
-              <Plus size="14" />
-            </Button>
+            <Tooltip content={t('preview.zoom_in')} delay={800}>
+              <Button
+                onClick={() => handleZoomFactor(0.1)}
+                variant="ghost"
+                size="icon"
+                aria-label={t('preview.zoom_in')}>
+                <Plus size="14" />
+              </Button>
+            </Tooltip>
           </ZoomButtonGroup>
         </SettingRow>
         <SettingDivider />


### PR DESCRIPTION
### What this PR does

Before this PR:

The three icon buttons in **Settings → Appearance → Page Zoom** (reset, zoom-out, zoom-in) had no text, `aria-label`, `title` or tooltip. Their Lucide SVG icons are `aria-hidden`, so screen readers announced an **empty accessible name** and keyboard users got no affordance hint. There is no visual/pixel change — this is purely an accessibility (a11y) gap.

After this PR:

Each button is wrapped in a `<Tooltip content={...} delay={800}>` and given a matching `aria-label`, mirroring the existing `DocumentPreviewToolbar` pattern:

- reset button → `preview.reset` ("Reset")
- zoom-out (Minus) → `preview.zoom_out` ("Zoom Out")
- zoom-in (Plus) → `preview.zoom_in` ("Zoom In")

Reuses the already-present `preview.*` i18n keys — **no new i18n keys** added. Only `AppearanceSettings.tsx` is touched.

Fixes #

### Why we need it and why it was done in this way

Icon-only buttons must expose an accessible name; without one, assistive-tech users cannot tell the buttons apart. Wrapping in `Tooltip` + `aria-label` also gives sighted keyboard/mouse users a hover hint, matching how the same zoom controls are already labelled in `DocumentPreviewToolbar`.

The following tradeoffs were made: reused the existing `preview.reset` / `preview.zoom_in` / `preview.zoom_out` keys rather than introducing settings-scoped keys, to stay consistent with the toolbar and avoid duplicate strings.

The following alternatives were considered: a bare `aria-label` without a `Tooltip` (rejected — loses the visible hint for sighted keyboard users and diverges from the toolbar pattern).

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- No visual/pixel change — the reset button still only renders when zoom ≠ 100%.
- Verified at runtime (Settings → Appearance): reset → accessible name "Reset" (+ tooltip), zoom-out → "Zoom Out", zoom-in → "Zoom In".
- Gates: `pnpm lint` (oxlint 0/0, eslint, typecheck, i18n, format) and `pnpm typecheck:web` pass. Full `pnpm test`: only unrelated `FileManager.integration.test.ts` flakes on cross-file harness leak in the parallel run; it passes 26/26 in isolation.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix: the Reset / Zoom Out / Zoom In buttons in Settings → Appearance → Page Zoom now expose accessible names (aria-label) and tooltips, so screen-reader and keyboard users can identify them.
```
