### PR TITLE
fix(message-menu-bar): add aria-labels to default toolbar icon buttons

### DIFF
--- a/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBarToolbarRenderers.tsx
@@ -76,9 +76,11 @@ const ActionButtonWithConfirm = ({
   tooltip?: ReactNode | false
 }) => {
   const disabled = !action.availability.enabled
+  const label = typeof action.label === 'string' ? action.label : undefined
   const button = (
     <MessageActionButton
       className="message-action-button"
+      aria-label={label}
       onClick={(e) => {
         e.stopPropagation()
         if (!action.confirm) {
@@ -102,6 +104,7 @@ const ActionButtonWithConfirm = ({
       {(open) => (
         <MessageActionButton
           className="message-action-button"
+          aria-label={label}
           onClick={(e) => {
             e.stopPropagation()
             open()


### PR DESCRIPTION
### What this PR does

Before this PR:

Several icon-only buttons in the chat message action toolbar had a visual `Tooltip` but **no `aria-label`**. The affected buttons are the ones rendered by the default toolbar renderer (`ActionButtonWithConfirm`): user-message **Edit**, **Copy**, **Delete**, and assistant-message **Copy**, **Regenerate**, **Save to Notes**, **Delete**. In the macOS accessibility tree (and to screen readers / keyboard users) they surfaced as unnamed "button", so they were impossible to distinguish or operate non-visually.

After this PR:

`ActionButtonWithConfirm` now passes `aria-label={label}` to both `MessageActionButton`s it renders (the plain button and the confirm-dialog trigger), using the same string-guarded `label = typeof action.label === 'string' ? action.label : undefined` pattern the other specialized renderers (`renderModelPickerToolbarAction`, `renderTranslateToolbarAction`, `renderMoreMenuToolbarAction`) already use. `action.label` is the already-resolved i18n string, so no new i18n keys are needed.

**No visual change** — this only adds accessibility metadata; pixels are identical.


### Why we need it and why it was done in this way

The specialized toolbar renderers already exposed accessible names via `aria-label={label}`; only the default/confirm renderer was missing it, leaving the most common actions (edit/copy/regenerate/delete) unnamed. The fix reuses the exact existing pattern rather than introducing anything new, keeping the change to 3 lines.

The following tradeoffs were made: none — minimal, pattern-consistent change.

The following alternatives were considered: deriving the name from the icon or tooltip node, rejected because `action.label` already holds the resolved localized string.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified at runtime via CDP: after sending a message, the CDP Accessibility (AX) tree reports a computed accessible name for all 10 message-toolbar buttons (`role=button`, name sourced from the `aria-label` attribute): Copy / Edit / Delete (user message) and Copy / Regenerate / Switch model answer / Translate / Save to Notes / Delete / More actions (assistant message). Before the fix, the default-renderer buttons had a `null` accessible name.

Gates: `pnpm typecheck:web`, `pnpm i18n:check`, and the `messages/frame` Vitest suite (62 tests) all pass; `oxlint` clean on the changed file.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix chat message toolbar icon buttons (edit, copy, regenerate, delete, save to notes) missing accessible names, so screen readers and keyboard users can now identify them.
```
