### PR TITLE
fix(api-gateway): render absolute OpenAPI server URL for curl examples

### DIFF
--- a/src/main/features/apiGateway/app.ts
+++ b/src/main/features/apiGateway/app.ts
@@ -46,14 +46,26 @@ const v1Routes = new Elysia({ prefix: '/v1' })
   .use(modelsRoutes)
   .use(knowledgeRoutes)
 
+/** Where the gateway listens; used to render an absolute OpenAPI server URL. */
+interface BuildAppOptions {
+  host?: string
+  port?: number
+}
+
 /**
  * Build the Elysia application (Node adapter). Assembles CORS, OpenAPI docs,
  * request logging + `X-Request-ID`, error handling, public info routes, and the
  * protected API route plugins.
  *
+ * `host`/`port` default to the `feature.api_gateway.*` preference defaults so the
+ * integration tests can call `buildApp()` with no arguments; `server.ts` passes
+ * the live preference values. They populate the OpenAPI `servers` URL so Scalar
+ * renders copyable absolute curl examples (e.g. `curl http://127.0.0.1:23333/health`)
+ * instead of relative paths.
+ *
  * Exported for both the runtime server (`server.ts`) and the integration tests.
  */
-export function buildApp() {
+export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions = {}) {
   const app = new Elysia({ adapter: node() })
     .use(
       cors({
@@ -80,7 +92,10 @@ export function buildApp() {
             version: '1.0.0',
             description:
               'OpenAI- and Anthropic-compatible HTTP API for Cherry Studio, plus Cherry-specific endpoints (models, knowledge bases)'
-          }
+          },
+          // Absolute base URL so Scalar renders copyable curl examples with the
+          // full address instead of relative paths (e.g. `curl /health`).
+          servers: [{ url: `http://${host}:${port}` }]
         }
       })
     )

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -86,6 +86,17 @@ describe('API gateway routes (integration)', () => {
       expect(body.name).toBe('Cherry Studio API')
       expect(body.endpoints).toBeDefined()
     })
+
+    it('OpenAPI spec advertises an absolute server URL from host/port', async () => {
+      // Scalar renders curl examples against `servers[0].url`; an absolute URL
+      // keeps the health-check example copyable (`curl http://.../health`)
+      // instead of a bare relative path (`curl /health`).
+      const { body } = await read(await get(app, '/openapi/json', {}))
+      expect(body.servers).toEqual([{ url: 'http://127.0.0.1:23333' }])
+
+      const custom = await read(await get(buildApp({ host: '0.0.0.0', port: 8080 }), '/openapi/json', {}))
+      expect(custom.body.servers).toEqual([{ url: 'http://0.0.0.0:8080' }])
+    })
   })
 
   describe('auth', () => {

--- a/src/main/features/apiGateway/server.ts
+++ b/src/main/features/apiGateway/server.ts
@@ -42,7 +42,7 @@ export class ApiGateway {
     const port = preferenceService.get('feature.api_gateway.port')
     const host = preferenceService.get('feature.api_gateway.host')
 
-    const app = buildApp()
+    const app = buildApp({ host, port })
     this.app = app
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
### What this PR does

Before this PR:

The API Gateway's OpenAPI documentation (rendered by Scalar at `/openapi`) declared no `servers` in its `openapi()` configuration. As a result Scalar rendered the request/curl examples against a relative path — the Health check example showed as `curl /health`, with no host or port, so users could not copy-paste and run it directly.

After this PR:

`buildApp` now accepts the gateway's `host`/`port` and sets `documentation.servers` to `http://<host>:<port>`, so Scalar renders copyable absolute examples (e.g. `curl http://127.0.0.1:23333/health`). `server.ts` passes the live `feature.api_gateway.host` / `feature.api_gateway.port` preference values; the params default to those same preference defaults (`127.0.0.1` / `23333`) so the integration tests keep calling `buildApp()` with no arguments.
### Why we need it and why it was done in this way

The root cause is purely the missing `servers` field — Scalar falls back to relative paths when it is absent. The host/port are already read from the preference service in `ApiGateway.start()`, so threading them into `buildApp` is the smallest change that makes the docs reflect the address the server actually listens on (including a user-customized host/port), rather than hardcoding a URL.

The following tradeoffs were made:

- Params default to the preference defaults so no existing caller (tests) breaks and there is a single source of truth for the fallback.

The following alternatives were considered:

- Hardcoding `http://127.0.0.1:23333` in the openapi config — rejected because it would be wrong whenever the user changes `feature.api_gateway.host`/`port`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Backend-only change with **no visual/UI change** to the app itself — the only user-visible effect is that the auto-generated OpenAPI docs page now shows a complete, copyable curl command instead of a relative path.

Verified end-to-end by driving the real Elysia app via `app.handle(new Request('/openapi/json'))` and asserting the emitted spec's `servers`:
- default: `[{ "url": "http://127.0.0.1:23333" }]`
- custom host/port: `[{ "url": "http://0.0.0.0:8080" }]`

A regression test covering both was added to the integration suite.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed the API Gateway's OpenAPI docs page showing the Health check curl example as a bare relative path (`curl /health`); it now shows the full server address (e.g. `curl http://127.0.0.1:23333/health`) so the example can be copied and run directly.
```
