### PR TITLE
feat(resource-groups): add shared group creation dialog

### DIFF
--- a/src/renderer/components/CreateGroupDialog.tsx
+++ b/src/renderer/components/CreateGroupDialog.tsx
@@ -1,0 +1,124 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  FieldError,
+  Input
+} from '@cherrystudio/ui'
+import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
+import type { FormEvent } from 'react'
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export interface CreateGroupDialogProps {
+  open: boolean
+  onCreate: (name: string) => Promise<unknown>
+  onOpenChange: (open: boolean) => void
+  errorMessage?: string
+  isSubmitting?: boolean
+  namePlaceholder?: string
+  nameRequiredMessage?: string
+  submitLabel?: string
+  title?: string
+}
+
+export function CreateGroupDialog({
+  open,
+  onCreate,
+  onOpenChange,
+  errorMessage,
+  isSubmitting = false,
+  namePlaceholder,
+  nameRequiredMessage,
+  submitLabel,
+  title
+}: CreateGroupDialogProps) {
+  const { t } = useTranslation()
+  const [name, setName] = useState('')
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
+  const [isSubmittingInternally, setIsSubmittingInternally] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const submitting = isSubmitting || isSubmittingInternally
+
+  useEffect(() => {
+    if (open) return
+
+    setName('')
+    setHasAttemptedSubmit(false)
+    setIsSubmittingInternally(false)
+    setSubmitError(null)
+  }, [open])
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (submitting) return
+    onOpenChange(nextOpen)
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (submitting) return
+
+    const normalizedName = name.trim()
+    setHasAttemptedSubmit(true)
+    setSubmitError(null)
+    if (!normalizedName) return
+
+    setIsSubmittingInternally(true)
+    try {
+      await onCreate(normalizedName)
+      onOpenChange(false)
+    } catch (error) {
+      setSubmitError(formatErrorMessageWithPrefix(error, errorMessage ?? t('common.group.create_failed')))
+    } finally {
+      setIsSubmittingInternally(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent closeOnOverlayClick={false} size="sm">
+        <DialogHeader>
+          <DialogTitle>{title ?? t('common.group.create')}</DialogTitle>
+        </DialogHeader>
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          <div>
+            <Input
+              autoFocus
+              maxLength={64}
+              value={name}
+              aria-label={t('common.name')}
+              aria-invalid={hasAttemptedSubmit && !name.trim()}
+              placeholder={namePlaceholder ?? t('common.group.name_placeholder')}
+              disabled={submitting}
+              onChange={(event) => {
+                setName(event.target.value)
+                setHasAttemptedSubmit(false)
+                setSubmitError(null)
+              }}
+            />
+            {hasAttemptedSubmit && !name.trim() ? (
+              <div className="mt-2">
+                <FieldError>{nameRequiredMessage ?? t('common.group.name_required')}</FieldError>
+              </div>
+            ) : submitError ? (
+              <div className="mt-2">
+                <FieldError>{submitError}</FieldError>
+              </div>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" disabled={submitting} onClick={() => handleOpenChange(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" variant="emphasis" loading={submitting}>
+              {submitLabel ?? t('common.add')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/__tests__/CreateGroupDialog.test.tsx
+++ b/src/renderer/components/__tests__/CreateGroupDialog.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CreateGroupDialog } from '../CreateGroupDialog'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      (
+        ({
+          'common.add': 'Add',
+          'common.cancel': 'Cancel',
+          'common.group.create': 'New Group',
+          'common.group.create_failed': 'Failed to create group',
+          'common.group.name_placeholder': 'Enter group name...',
+          'common.group.name_required': 'Group name is required',
+          'common.name': 'Name'
+        }) as Record<string, string>
+      )[key] ?? key
+  })
+}))
+
+describe('CreateGroupDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('validates an empty group name', () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined)
+
+    render(<CreateGroupDialog open onCreate={onCreate} onOpenChange={vi.fn()} />)
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add' }))
+
+    expect(onCreate).not.toHaveBeenCalled()
+    expect(within(dialog).getByText('Group name is required')).toBeInTheDocument()
+  })
+
+  it('creates with a trimmed name and closes', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined)
+    const onOpenChange = vi.fn()
+
+    render(<CreateGroupDialog open onCreate={onCreate} onOpenChange={onOpenChange} />)
+
+    const dialog = screen.getByRole('dialog')
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: '  Research  ' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledWith('Research'))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps the dialog open and shows the mutation error', async () => {
+    const onCreate = vi.fn().mockRejectedValue(new Error('name conflict'))
+    const onOpenChange = vi.fn()
+
+    render(<CreateGroupDialog open onCreate={onCreate} onOpenChange={onOpenChange} />)
+
+    const dialog = screen.getByRole('dialog')
+    const input = within(dialog).getByLabelText('Name')
+    fireEvent.change(input, { target: { value: 'Research' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Add' }))
+
+    expect(await within(dialog).findByText('Failed to create group: name conflict')).toBeInTheDocument()
+    expect(input).toHaveValue('Research')
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/resourceCatalog/catalog/ResourceGrid.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceGrid.tsx
@@ -21,6 +21,7 @@ import {
   Skeleton
 } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { CreateGroupDialog } from '@renderer/components/CreateGroupDialog'
 import { SettingDescription, SettingDivider, SettingTitle } from '@renderer/components/SettingsPrimitives'
 import { useGroupMutations } from '@renderer/hooks/useGroups'
 import { toast } from '@renderer/services/toast'
@@ -221,10 +222,8 @@ export const ResourceGrid: FC<Props> = ({
   })
   const scrollRef = useRef<HTMLDivElement>(null)
   const columnCount = useGridColumnCount(scrollRef)
-  const [showAddGroup, setShowAddGroup] = useState(false)
   const [showAllGroups, setShowAllGroups] = useState(false)
-  const [newGroupName, setNewGroupName] = useState('')
-  const [addingGroup, setAddingGroup] = useState(false)
+  const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
   const [renamingGroup, setRenamingGroup] = useState<GroupItem | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const [renaming, setRenaming] = useState(false)
@@ -248,24 +247,19 @@ export const ResourceGrid: FC<Props> = ({
     }))
   }, [allGroups, groups, showAllGroups])
 
-  const handleAddGroup = async () => {
-    const trimmed = newGroupName.trim()
-    if (!trimmed || addingGroup) return
-    setAddingGroup(true)
-    try {
-      await onAddGroup(trimmed)
-      setNewGroupName('')
-      setShowAddGroup(false)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : t('library.group_sync_failed')
-      toast.error(message)
-      logger.error('Failed to create assistant group', error instanceof Error ? error : new Error(String(error)), {
-        name: trimmed
-      })
-    } finally {
-      setAddingGroup(false)
-    }
-  }
+  const handleAddGroup = useCallback(
+    async (name: string) => {
+      try {
+        await onAddGroup(name)
+      } catch (error) {
+        logger.error('Failed to create assistant group', error instanceof Error ? error : new Error(String(error)), {
+          name
+        })
+        throw error
+      }
+    },
+    [onAddGroup]
+  )
 
   const handleOpenRenameGroup = useCallback((group: GroupItem) => {
     setRenamingGroup(group)
@@ -446,47 +440,20 @@ export const ResourceGrid: FC<Props> = ({
                 </Button>
               )}
 
-              {showAddGroup ? (
-                <div className="flex shrink-0 items-center gap-1">
-                  <Input
-                    autoFocus
-                    maxLength={64}
-                    value={newGroupName}
-                    onChange={(e) => setNewGroupName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') void handleAddGroup()
-                      if (e.key === 'Escape') {
-                        setShowAddGroup(false)
-                        setNewGroupName('')
-                      }
-                    }}
-                    onBlur={() => {
-                      if (!newGroupName.trim() && !addingGroup) setShowAddGroup(false)
-                    }}
-                    disabled={addingGroup}
-                    placeholder={t('library.toolbar.add_group_placeholder')}
-                    className="h-6 w-20 rounded-full border-input bg-background px-2 text-xs placeholder:text-foreground-muted"
-                  />
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => void handleAddGroup()}
-                    disabled={addingGroup || !newGroupName.trim()}
-                    className="size-6 text-foreground-muted hover:text-foreground">
-                    <Plus size={12} />
-                  </Button>
-                </div>
-              ) : (
-                <Button
-                  variant="ghost"
-                  onClick={() => setShowAddGroup(true)}
-                  className="flex h-6 min-h-0 shrink-0 items-center gap-1 rounded-full border border-border-muted border-dashed px-2 text-foreground-muted text-xs shadow-none hover:border-border-hover hover:bg-accent hover:text-foreground">
-                  <Plus size={11} /> {t('library.toolbar.group_button')}
-                </Button>
-              )}
+              <Button
+                variant="ghost"
+                onClick={() => setCreateGroupDialogOpen(true)}
+                className="flex h-6 min-h-0 shrink-0 items-center gap-1 rounded-full border border-border-muted border-dashed px-2 text-foreground-muted text-xs shadow-none hover:border-border-hover hover:bg-accent hover:text-foreground">
+                <Plus size={11} /> {t('library.toolbar.group_button')}
+              </Button>
             </div>
           </div>
         )}
+        <CreateGroupDialog
+          open={createGroupDialogOpen}
+          onCreate={handleAddGroup}
+          onOpenChange={setCreateGroupDialogOpen}
+        />
         <Dialog
           open={Boolean(renamingGroup)}
           onOpenChange={(open) => {

--- a/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
@@ -25,6 +25,11 @@ vi.mock('react-i18next', () => ({
           'assistants.groups.delete': '删除分组',
           'assistants.groups.deleteConfirm': '确定要删除这个分组吗？',
           'common.delete': '删除',
+          'common.group.create': '新建分组',
+          'common.group.create_failed': '创建分组失败',
+          'common.group.name_placeholder': '请输入分组名称...',
+          'common.group.name_required': '请输入分组名称',
+          'common.name': '名称',
           'common.rename': '重命名',
           'common.save': '保存',
           'chat.add.assistant.title': '添加助手',
@@ -173,6 +178,7 @@ vi.mock('@cherrystudio/ui', async () => {
         {description && <div>{description}</div>}
       </div>
     ),
+    FieldError: ({ children }: { children?: ReactNode }) => <div role="alert">{children}</div>,
     Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) => (open ? <>{children}</> : null),
     DialogContent: ({ children }: { children?: ReactNode }) => <div role="dialog">{children}</div>,
     DialogDescription: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -274,6 +280,7 @@ vi.mock('@cherrystudio/ui', async () => {
       )
     },
     Input: (props: ComponentProps<'input'> & { className?: string }) => <input {...props} />,
+    Label: ({ children, ...props }: ComponentProps<'label'>) => <label {...props}>{children}</label>,
     MenuDivider: () => <div data-testid="menu-divider" />,
     MenuList: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
     MenuItem: ({
@@ -685,17 +692,18 @@ describe('ResourceGrid group toolbar management', () => {
     expect(onGroupFilter).toHaveBeenCalledWith(null)
   })
 
-  it('keeps the add-group editor open and clears pending state when creation fails', async () => {
+  it('keeps the shared create-group dialog open when creation fails', async () => {
     const user = userEvent.setup()
     const onAddGroup = vi.fn().mockRejectedValueOnce(new Error('create failed'))
 
     renderResourceGrid({ onAddGroup })
 
     await user.click(screen.getByRole('button', { name: '分组' }))
-    const input = screen.getByPlaceholderText('library.toolbar.add_group_placeholder')
-    await user.type(input, 'work{Enter}')
+    const input = screen.getByPlaceholderText('请输入分组名称...')
+    await user.type(input, 'work')
+    await user.click(screen.getByRole('button', { name: 'common.add' }))
 
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('create failed'))
+    expect(await screen.findByText('创建分组失败: create failed')).toBeInTheDocument()
     expect(input).toBeInTheDocument()
     expect(input).toHaveValue('work')
     await waitFor(() => expect(input).not.toBeDisabled())

--- a/src/renderer/components/resourceCatalog/dialogs/components/GroupSelector.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/GroupSelector.tsx
@@ -81,7 +81,8 @@ export const GroupSelector: FC<Props> = ({
             onCreateGroup?.()
             return
           }
-          onChange(decodeGroupSelectValue(selectedValue))
+          const groupId = decodeGroupSelectValue(selectedValue)
+          if (groupId !== null) onChange(groupId)
         }}>
         <SelectTrigger
           size="sm"

--- a/src/renderer/components/resourceCatalog/dialogs/components/GroupSelector.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/GroupSelector.tsx
@@ -1,7 +1,15 @@
-import { Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@cherrystudio/ui'
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
+} from '@cherrystudio/ui'
 import { cn } from '@renderer/utils/style'
 import type { Group } from '@shared/data/types/group'
-import { X } from 'lucide-react'
+import { Plus, X } from 'lucide-react'
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,9 +22,11 @@ interface Props {
   error?: Error
   disabled?: boolean
   portalContainer?: HTMLElement | null
+  onCreateGroup?: () => void
 }
 
 const GROUP_SELECT_VALUE_PREFIX = 'group:'
+const CREATE_GROUP_SELECT_VALUE = 'action:create-group'
 
 function encodeGroupSelectValue(groupId: string) {
   return `${GROUP_SELECT_VALUE_PREFIX}${groupId}`
@@ -27,19 +37,32 @@ function decodeGroupSelectValue(value: string) {
   return value.slice(GROUP_SELECT_VALUE_PREFIX.length)
 }
 
-export const GroupSelector: FC<Props> = ({ value, onChange, groups, isLoading, error, disabled, portalContainer }) => {
+export const GroupSelector: FC<Props> = ({
+  value,
+  onChange,
+  groups,
+  isLoading,
+  error,
+  disabled,
+  portalContainer,
+  onCreateGroup
+}) => {
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
 
   const hasGroupOptions = groups.length > 0
   const isUnavailable = Boolean(isLoading || error)
-  const canOpen = hasGroupOptions && !isUnavailable
+  const canOpen = !disabled && !isUnavailable && (hasGroupOptions || Boolean(onCreateGroup))
   const selectOpen = canOpen && open
   const placeholder = isLoading
     ? t('common.loading')
     : error
       ? t('library.group_sync_failed')
-      : t(hasGroupOptions ? 'library.config.basic.group_placeholder' : 'library.config.basic.group_empty')
+      : t(
+          hasGroupOptions || onCreateGroup
+            ? 'library.config.basic.group_placeholder'
+            : 'library.config.basic.group_empty'
+        )
 
   useEffect(() => {
     if (!canOpen) setOpen(false)
@@ -48,11 +71,18 @@ export const GroupSelector: FC<Props> = ({ value, onChange, groups, isLoading, e
   return (
     <div className="group/group-select relative flex w-full min-w-0 items-center">
       <Select
-        disabled={disabled || isUnavailable}
+        disabled={!canOpen}
         open={selectOpen}
         value={!isUnavailable && value ? encodeGroupSelectValue(value) : ''}
         onOpenChange={(nextOpen) => setOpen(canOpen && nextOpen)}
-        onValueChange={(selectedValue) => onChange(decodeGroupSelectValue(selectedValue))}>
+        onValueChange={(selectedValue) => {
+          if (selectedValue === CREATE_GROUP_SELECT_VALUE) {
+            setOpen(false)
+            onCreateGroup?.()
+            return
+          }
+          onChange(decodeGroupSelectValue(selectedValue))
+        }}>
         <SelectTrigger
           size="sm"
           className={cn(
@@ -69,6 +99,13 @@ export const GroupSelector: FC<Props> = ({ value, onChange, groups, isLoading, e
               {group.name}
             </SelectItem>
           ))}
+          {onCreateGroup && hasGroupOptions ? <SelectSeparator /> : null}
+          {onCreateGroup ? (
+            <SelectItem value={CREATE_GROUP_SELECT_VALUE}>
+              <Plus />
+              {t('common.group.create')}
+            </SelectItem>
+          ) : null}
         </SelectContent>
       </Select>
       {value && !disabled && !isUnavailable ? (

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/GroupSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/GroupSelector.test.tsx
@@ -53,6 +53,7 @@ vi.mock('@cherrystudio/ui', () => ({
     <SelectContext value={{ open, disabled, onOpenChange, onValueChange }}>
       <div data-testid="select-root" data-open={String(open)}>
         {children}
+        <button type="button" data-testid="select-unknown-value" onClick={() => onValueChange?.('')} />
       </div>
     </SelectContext>
   ),
@@ -136,8 +137,9 @@ describe('GroupSelector', () => {
 
   it('offers group creation even when no groups exist', () => {
     const onCreateGroup = vi.fn()
+    const onChange = vi.fn()
 
-    render(<GroupSelector value={null} onChange={vi.fn()} groups={[]} onCreateGroup={onCreateGroup} />)
+    render(<GroupSelector value={null} onChange={onChange} groups={[]} onCreateGroup={onCreateGroup} />)
 
     const trigger = screen.getByRole('button', { name: 'Group' })
     expect(trigger).toHaveTextContent('Select group')
@@ -146,6 +148,17 @@ describe('GroupSelector', () => {
     fireEvent.click(screen.getByRole('option', { name: 'New Group' }))
 
     expect(onCreateGroup).toHaveBeenCalledTimes(1)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('ignores values that are neither a group nor the create action', () => {
+    const onChange = vi.fn()
+
+    render(<GroupSelector value={groups[0].id} onChange={onChange} groups={groups} />)
+
+    fireEvent.click(screen.getByTestId('select-unknown-value'))
+
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('closes the open select when it loses all group options', () => {

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/GroupSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/GroupSelector.test.tsx
@@ -16,7 +16,8 @@ vi.mock('react-i18next', () => ({
         'library.config.basic.group_placeholder': 'Select group',
         'library.group_sync_failed': 'Failed to sync groups',
         'common.loading': 'Loading...',
-        'common.clear': 'Clear'
+        'common.clear': 'Clear',
+        'common.group.create': 'New Group'
       })[key] ?? key
   })
 }))
@@ -25,6 +26,7 @@ type SelectContextValue = {
   open: boolean
   disabled: boolean
   onOpenChange?: (open: boolean) => void
+  onValueChange?: (value: string) => void
 }
 
 const SelectContext = createContext<SelectContextValue>({ open: false, disabled: false })
@@ -39,14 +41,16 @@ vi.mock('@cherrystudio/ui', () => ({
     children,
     open = false,
     disabled = false,
-    onOpenChange
+    onOpenChange,
+    onValueChange
   }: {
     children?: ReactNode
     open?: boolean
     disabled?: boolean
     onOpenChange?: (open: boolean) => void
+    onValueChange?: (value: string) => void
   }) => (
-    <SelectContext value={{ open, disabled, onOpenChange }}>
+    <SelectContext value={{ open, disabled, onOpenChange, onValueChange }}>
       <div data-testid="select-root" data-open={String(open)}>
         {children}
       </div>
@@ -60,7 +64,15 @@ vi.mock('@cherrystudio/ui', () => ({
     const { open } = use(SelectContext)
     return open ? createPortal(<div {...props}>{children}</div>, portalContainer ?? document.body) : null
   },
-  SelectItem: ({ children }: { children?: ReactNode }) => <div role="option">{children}</div>,
+  SelectItem: ({ children, value }: { children?: ReactNode; value: string }) => {
+    const { onValueChange } = use(SelectContext)
+    return (
+      <button type="button" role="option" onClick={() => onValueChange?.(value)}>
+        {children}
+      </button>
+    )
+  },
+  SelectSeparator: () => <hr />,
   SelectTrigger: ({ children, ...props }: { children?: ReactNode }) => {
     const { open, disabled, onOpenChange } = use(SelectContext)
     return (
@@ -120,6 +132,20 @@ describe('GroupSelector', () => {
     } finally {
       portalContainer.remove()
     }
+  })
+
+  it('offers group creation even when no groups exist', () => {
+    const onCreateGroup = vi.fn()
+
+    render(<GroupSelector value={null} onChange={vi.fn()} groups={[]} onCreateGroup={onCreateGroup} />)
+
+    const trigger = screen.getByRole('button', { name: 'Group' })
+    expect(trigger).toHaveTextContent('Select group')
+
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole('option', { name: 'New Group' }))
+
+    expect(onCreateGroup).toHaveBeenCalledTimes(1)
   })
 
   it('closes the open select when it loses all group options', () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -18,10 +18,11 @@ import {
   Textarea
 } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { CreateGroupDialog } from '@renderer/components/CreateGroupDialog'
 import PromptEditorField from '@renderer/components/PromptEditorField'
 import { useAssistantMutationsById } from '@renderer/hooks/resourceCatalog'
 import { useCloseBeforeAction } from '@renderer/hooks/useCloseBeforeAction'
-import { useGroups } from '@renderer/hooks/useGroups'
+import { useGroupMutations, useGroups } from '@renderer/hooks/useGroups'
 import { usePromptProcessor } from '@renderer/hooks/usePromptProcessor'
 import { MCP_MODE_OPTIONS, RESOURCE_PROMPT_POLISH_SYSTEM_PROMPT } from '@renderer/utils/resourceCatalog'
 import {
@@ -184,12 +185,14 @@ function AssistantEditDialogContent({
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState(initialTab ?? 'basic')
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
+  const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
   const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAssistant(resource))
   const defaultValues = useMemo(() => defaultValuesForAssistant(resource), [resource])
   const form = useForm<AssistantEditFormValues>({ defaultValues })
   const values = form.watch()
   const { groups, isLoading: isGroupsLoading, error: groupsError } = useGroups('assistant')
+  const { createGroup } = useGroupMutations('assistant')
   const { updateAssistant } = useAssistantMutationsById(resource.id)
   const saveIntent = useMemo(() => {
     const baseline = initialAssistantFormState(resource)
@@ -220,12 +223,17 @@ function AssistantEditDialogContent({
   useEffect(() => {
     const justOpened = open && !wasOpenRef.current
     wasOpenRef.current = open
+    if (!open) {
+      setCreateGroupDialogOpen(false)
+      return
+    }
     if (!justOpened) return
 
     form.reset(defaultValues)
     form.clearErrors()
     setActiveTab(initialTab ?? 'basic')
     setEmojiPickerOpen(false)
+    setCreateGroupDialogOpen(false)
     setModelLabels(modelLabelsForAssistant(resource))
     // A fresh open is a fresh editing session — a stale failure from a prior
     // session (this instance can outlive one close, see the exit-animation
@@ -286,6 +294,23 @@ function AssistantEditDialogContent({
   // Route the settings-navigate close through handleOpenChange so it flushes too.
   const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
 
+  const handleCreateGroup = async (name: string) => {
+    try {
+      const group = await createGroup(name)
+      form.setValue('groupId', group.id, { shouldDirty: true, shouldTouch: true })
+    } catch (error) {
+      logger.error(
+        'Failed to create assistant group from edit dialog',
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          assistantId: resource.id,
+          name
+        }
+      )
+      throw error
+    }
+  }
+
   return (
     <EditDialogShell
       activeTab={activeTab}
@@ -311,6 +336,7 @@ function AssistantEditDialogContent({
             groupsError={groupsError}
             emojiPickerOpen={emojiPickerOpen}
             setEmojiPickerOpen={setEmojiPickerOpen}
+            onCreateGroup={() => setCreateGroupDialogOpen(true)}
             onSettingsNavigate={closeBeforeAction}
           />
         </TabsContent>
@@ -340,6 +366,11 @@ function AssistantEditDialogContent({
         <TabsContent value="advanced" forceMount hidden={activeTab !== 'advanced'} className="m-0">
           <AssistantAdvancedFields form={form} portalContainer={dialogContentElement} />
         </TabsContent>
+        <CreateGroupDialog
+          open={createGroupDialogOpen}
+          onCreate={handleCreateGroup}
+          onOpenChange={setCreateGroupDialogOpen}
+        />
       </>
     </EditDialogShell>
   )
@@ -356,6 +387,7 @@ function AssistantBasicFields({
   groupsError,
   emojiPickerOpen,
   setEmojiPickerOpen,
+  onCreateGroup,
   onSettingsNavigate
 }: {
   form: UseFormReturn<AssistantEditFormValues>
@@ -368,6 +400,7 @@ function AssistantBasicFields({
   groupsError: ReturnType<typeof useGroups>['error']
   emojiPickerOpen: boolean
   setEmojiPickerOpen: (open: boolean) => void
+  onCreateGroup: () => void
   onSettingsNavigate?: (navigate: () => void) => void
 }) {
   const { t } = useTranslation()
@@ -429,6 +462,7 @@ function AssistantBasicFields({
                 isLoading={groupsLoading}
                 error={groupsError}
                 portalContainer={portalContainer}
+                onCreateGroup={onCreateGroup}
               />
               <FormMessage />
             </FormItem>

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1,7 +1,7 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import type { Assistant } from '@shared/data/types/assistant'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import type * as ReactI18next from 'react-i18next'
@@ -11,6 +11,7 @@ import { EDIT_DIALOG_PROMPT_MAX_HEIGHT, EDIT_DIALOG_PROMPT_MIN_HEIGHT } from '..
 
 const {
   agentTools,
+  createGroupMock,
   fetchGenerateMock,
   installedSkillsState,
   ipcRequestMock,
@@ -51,6 +52,7 @@ const {
     { id: 'WebSearch', name: 'WebSearch', description: 'Search web', origin: 'builtin', approval: 'prompt' },
     { id: 'Write', name: 'Write', description: 'Write files', origin: 'builtin', approval: 'prompt' }
   ],
+  createGroupMock: vi.fn(),
   fetchGenerateMock: vi.fn(),
   installedSkillsState: {
     current: {
@@ -236,6 +238,9 @@ vi.mock('@renderer/hooks/useGroups', () => ({
         updatedAt: '2024-01-01T00:00:00.000Z'
       }
     ]
+  }),
+  useGroupMutations: () => ({
+    createGroup: createGroupMock
   })
 }))
 
@@ -294,6 +299,7 @@ vi.mock('react-i18next', async (importOriginal) => {
           'agent.settings.tooling.permissionMode.plan.title': 'Plan Mode',
           'agent.settings.skills.addMore': 'Manage Skills',
           'common.avatar': 'Avatar',
+          'common.add': 'Add',
           'common.cancel': 'Cancel',
           'common.clear': 'Clear',
           'common.close': 'Close',
@@ -301,6 +307,10 @@ vi.mock('react-i18next', async (importOriginal) => {
           'common.description': 'Description',
           'common.edit': 'Edit',
           'common.help': 'Help',
+          'common.group.create': 'New Group',
+          'common.group.create_failed': 'Failed to create group',
+          'common.group.name_placeholder': 'Enter group name...',
+          'common.group.name_required': 'Group name is required',
           'common.loading': 'Loading',
           'common.model': 'Model',
           'common.name': 'Name',
@@ -591,6 +601,14 @@ beforeEach(() => {
     return { trigger: vi.fn(), isLoading: false, error: undefined }
   })
   updateAssistantMock.mockResolvedValue({ ...ASSISTANT, name: 'Updated Assistant' })
+  createGroupMock.mockResolvedValue({
+    id: 'group-created',
+    entityType: 'assistant',
+    name: 'created',
+    orderKey: 'a2',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z'
+  })
   updateAgentMock.mockResolvedValue({ ...AGENT, instructions: 'Updated instructions' })
   fetchGenerateMock.mockResolvedValue('Generated prompt')
   knowledgeBasesState.current = [
@@ -723,6 +741,26 @@ describe('edit dialogs', () => {
     )
   })
 
+  it('creates and selects an assistant group from the group field', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
+
+    openGroupSelect()
+    fireEvent.click(await screen.findByRole('option', { name: 'New Group' }))
+
+    const createDialog = screen.getByRole('dialog', { name: 'New Group' })
+    fireEvent.change(within(createDialog).getByLabelText('Name'), { target: { value: '  created  ' } })
+    fireEvent.click(within(createDialog).getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(createGroupMock).toHaveBeenCalledWith('created'))
+    await waitFor(() =>
+      expect(updateAssistantMock).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          groupId: 'group-created'
+        })
+      })
+    )
+  })
+
   it('clears the assistant group from the single-select group field', async () => {
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
@@ -738,13 +776,13 @@ describe('edit dialogs', () => {
     )
   })
 
-  it('limits assistant group editing to existing groups', async () => {
+  it('keeps assistant grouping single-select while exposing the shared create action', async () => {
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     openGroupSelect()
     expect(screen.queryByPlaceholderText('Search groups')).not.toBeInTheDocument()
     expect(screen.queryByRole('option', { name: 'No group' })).not.toBeInTheDocument()
-    expect(screen.queryByText('new-group')).not.toBeInTheDocument()
+    expect(await screen.findByRole('option', { name: 'New Group' })).toBeInTheDocument()
   })
 
   it('closes the group selector without closing the assistant edit dialog when clicking elsewhere inside it', async () => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -101,6 +101,9 @@ vi.mock('@renderer/hooks/useGroups', () => ({
       }
     ],
     isLoading: false
+  }),
+  useGroupMutations: () => ({
+    createGroup: vi.fn()
   })
 }))
 

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2301,6 +2301,12 @@
     "generate_random_seed": "Generate random seed",
     "get_embedding_dimension": "Get embedding dimension",
     "go_to_settings": "Go to settings",
+    "group": {
+      "create": "New Group",
+      "create_failed": "Failed to create group",
+      "name_placeholder": "Enter group name...",
+      "name_required": "Group name is required"
+    },
     "help": "Help",
     "html_preview": "HTML Preview",
     "i_know": "I know",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2301,6 +2301,12 @@
     "generate_random_seed": "生成随机种子",
     "get_embedding_dimension": "获取嵌入维度",
     "go_to_settings": "前往设置",
+    "group": {
+      "create": "新建分组",
+      "create_failed": "创建分组失败",
+      "name_placeholder": "请输入分组名称...",
+      "name_required": "请输入分组名称"
+    },
     "help": "帮助",
     "html_preview": "HTML 预览",
     "i_know": "我知道了",

--- a/src/renderer/pages/knowledge/components/CreateKnowledgeGroupDialog.tsx
+++ b/src/renderer/pages/knowledge/components/CreateKnowledgeGroupDialog.tsx
@@ -1,6 +1,5 @@
+import { CreateGroupDialog } from '@renderer/components/CreateGroupDialog'
 import { useTranslation } from 'react-i18next'
-
-import KnowledgeEntityNameDialog from './KnowledgeEntityNameDialog'
 
 interface CreateKnowledgeGroupDialogProps {
   open: boolean
@@ -18,16 +17,15 @@ const CreateKnowledgeGroupDialog = ({
   const { t } = useTranslation()
 
   return (
-    <KnowledgeEntityNameDialog
+    <CreateGroupDialog
       open={open}
       title={t('knowledge.groups.add')}
       submitLabel={t('common.add')}
-      initialName=""
       isSubmitting={isSubmitting}
-      submitErrorMessage={t('knowledge.groups.error.failed_to_create')}
+      errorMessage={t('knowledge.groups.error.failed_to_create')}
       namePlaceholder={t('knowledge.groups.name_placeholder')}
       nameRequiredMessage={t('knowledge.groups.name_required')}
-      onSubmit={onSubmit}
+      onCreate={onSubmit}
       onOpenChange={onOpenChange}
     />
   )

--- a/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeGroupDialog.test.tsx
+++ b/src/renderer/pages/knowledge/components/__tests__/CreateKnowledgeGroupDialog.test.tsx
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import CreateKnowledgeGroupDialog from '../CreateKnowledgeGroupDialog'
 
-const mockKnowledgeEntityNameDialog = vi.fn()
+const mockCreateGroupDialog = vi.fn()
 
-vi.mock('../KnowledgeEntityNameDialog', () => ({
-  default: (props: unknown) => {
-    mockKnowledgeEntityNameDialog(props)
+vi.mock('@renderer/components/CreateGroupDialog', () => ({
+  CreateGroupDialog: (props: unknown) => {
+    mockCreateGroupDialog(props)
     return null
   }
 }))
@@ -32,22 +32,21 @@ describe('CreateKnowledgeGroupDialog', () => {
     vi.clearAllMocks()
   })
 
-  it('passes the explicit create-group props into KnowledgeEntityNameDialog', () => {
+  it('passes the knowledge-specific copy into the shared create-group dialog', () => {
     const onSubmit = vi.fn().mockResolvedValue(undefined)
     const onOpenChange = vi.fn()
 
     render(<CreateKnowledgeGroupDialog open isSubmitting={false} onSubmit={onSubmit} onOpenChange={onOpenChange} />)
 
-    expect(mockKnowledgeEntityNameDialog).toHaveBeenCalledWith({
+    expect(mockCreateGroupDialog).toHaveBeenCalledWith({
       open: true,
       title: '新建分组',
       submitLabel: '添加',
-      initialName: '',
       isSubmitting: false,
-      submitErrorMessage: '分组创建失败',
+      errorMessage: '分组创建失败',
       namePlaceholder: '输入分组名称...',
       nameRequiredMessage: '分组名称为必填项',
-      onSubmit,
+      onCreate: onSubmit,
       onOpenChange
     })
   })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Assistant edit dialogs could only select existing groups, while group creation used separate UI patterns across the resource catalog and knowledge base.

After this PR:

A shared single-field group creation dialog is available across the project. Assistant edit dialogs can create a group directly from the group selector, automatically select it, and expose it globally through the existing `/groups` cache refresh.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The shared dialog keeps group creation behavior, validation, loading state, error handling, sizing, and action hierarchy consistent while leaving entity-specific mutations with each caller. This preserves the existing DataApi ownership and global cache invalidation behavior.

The following tradeoffs were made:

- The dialog accepts an async creation callback instead of owning a group entity type, so callers remain responsible for selecting or moving the newly created entity.
- The assistant selector exposes creation as a reserved action item while preserving the existing single-select behavior.

The following alternatives were considered:

- A global imperative dialog service was avoided because the existing controlled-dialog pattern is sufficient and easier to compose inside nested edit flows.
- Keeping the resource catalog's inline group-name editor was rejected because it would preserve inconsistent creation UX.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

The shared dialog uses `DialogContent size="sm"` as required for single-field dialogs. `pnpm lint` passed, including type checking, i18n validation, and formatting. Automated tests were added but not executed locally under the workspace verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Adds a shared group creation dialog with quick creation and automatic selection in assistant editing.
```
