### PR TITLE
fix(composer): hide injected knowledge prompts

### DIFF
--- a/src/renderer/components/composer/QueuedFollowupsDock.tsx
+++ b/src/renderer/components/composer/QueuedFollowupsDock.tsx
@@ -8,6 +8,7 @@ import { ComposerToken } from '@renderer/components/composer/tokenView'
 import { ArrowUp, GripVertical, Pause, Pencil, Play, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { excludeComposerDraftTokens } from './composerDraft'
 import type { FollowupQueueItem } from './useFollowupQueue'
 
 interface QueuedFollowupsDockProps {
@@ -61,6 +62,10 @@ function QueuedFollowupRow({
   onRemove: (id: string) => void
 }) {
   const { t } = useTranslation()
+  const previewText = item.draft
+    ? excludeComposerDraftTokens(item.draft, (token) => token.kind === 'knowledge').text
+    : item.payload.text
+
   return (
     <div className="group flex items-center gap-1.5 rounded-[12px] bg-muted/40 px-2 py-1.5">
       <span
@@ -70,7 +75,7 @@ function QueuedFollowupRow({
         <GripVertical className="size-4" />
       </span>
       <div className="min-w-0 flex-1">
-        <span className="line-clamp-2 text-foreground text-sm">{item.draft?.text ?? item.payload.text}</span>
+        <span className="line-clamp-2 text-foreground text-sm">{previewText}</span>
         <DraftTokenChips item={item} />
       </div>
       <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">

--- a/src/renderer/components/composer/__tests__/QueuedFollowupsDock.test.tsx
+++ b/src/renderer/components/composer/__tests__/QueuedFollowupsDock.test.tsx
@@ -24,6 +24,26 @@ const items = [
   { id: '2', draft: { text: 'second', tokens: [] }, payload: { text: 'second', userMessageParts: [] } }
 ] as any
 
+const knowledgePrompt = 'The user attached knowledge base "Notes" (id: kb-1) — use that id with the kb_* tools.'
+
+const knowledgeItem = {
+  id: 'knowledge',
+  draft: {
+    text: `${knowledgePrompt} what is in it?`,
+    tokens: [
+      {
+        id: 'knowledge:kb-1',
+        kind: 'knowledge',
+        label: 'Notes',
+        promptText: knowledgePrompt,
+        index: 0,
+        textOffset: 0
+      }
+    ]
+  },
+  payload: { text: `${knowledgePrompt} what is in it?`, userMessageParts: [] }
+} as any
+
 describe('QueuedFollowupsDock', () => {
   it('renders queued items with token chips and fires the per-item + pause callbacks', () => {
     const onSteer = vi.fn()
@@ -78,5 +98,24 @@ describe('QueuedFollowupsDock', () => {
       />
     )
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('hides a knowledge token prompt while keeping the user text and chip', () => {
+    const { container } = render(
+      <QueuedFollowupsDock
+        items={[knowledgeItem]}
+        paused={false}
+        onTogglePause={vi.fn()}
+        onSteer={vi.fn()}
+        onEdit={vi.fn()}
+        onRemove={vi.fn()}
+        onReorder={vi.fn()}
+      />
+    )
+
+    expect(container).toHaveTextContent('what is in it?')
+    expect(container.querySelector('[data-composer-token-kind="knowledge"]')).toHaveTextContent('Notes')
+    expect(container).not.toHaveTextContent(knowledgePrompt)
+    expect(container).not.toHaveTextContent('kb-1')
   })
 })

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -81,8 +81,7 @@ import {
 import {
   type AgentComposerDraftCache,
   getAgentDraftCacheKey,
-  getCacheableDraftTokens,
-  getCachedKnowledgeBases,
+  getAgentManagedDraftTokens,
   getCachedSkillTokens,
   getSkillFromCachedToken,
   readAgentDraftCache,
@@ -341,19 +340,13 @@ const AgentComposerRoot = ({
   const initialState = useMemo(
     () => ({
       mentionedModels: [],
-      // Seeded synchronously, like files: the cached draft restores its knowledge chips, and the
-      // surface's managed-token sync strips any chip the selection does not already contain.
-      selectedKnowledgeBases: getCachedKnowledgeBases(readAgentDraftCache(getAgentDraftCacheKey(agentId))),
+      selectedKnowledgeBases: [],
       files: [] as ComposerAttachment[],
       isExpanded: false,
       couldAddImageFile: false,
       extensions: [] as string[]
     }),
-    // `sessionId` is load-bearing despite not appearing above: the provider below is keyed by agent +
-    // session and seeds this object once per mount, so it must be re-read in the same render that
-    // changes the key — otherwise the remounted provider replays the previous session's selection.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agentId, sessionId]
+    []
   )
 
   if (!session) return null
@@ -737,7 +730,7 @@ const AgentComposerInner = ({
   const inputHistoryToolsRef = useRef<InputHistoryToolSnapshot | null>(null)
   const applyHistoryDraft = useCallback(
     (historyDraft: ComposerSerializedDraft, options: { source: 'history' | 'draft' }) => {
-      const nextDraftTokens = getCacheableDraftTokens(historyDraft.tokens)
+      const nextDraftTokens = getAgentManagedDraftTokens(historyDraft.tokens)
       const persistDraft = options.source === 'draft'
       actionsRef.current.replaceDraft(historyDraft)
       setText(historyDraft.text, { persist: false })
@@ -1001,7 +994,7 @@ const AgentComposerInner = ({
   const reconcileTokens = useComposerTokenReconcile({ scope, model, session: toolsSession })
   const handleTokensChange = useCallback(
     (draftTokens: readonly ComposerSerializedToken[]) => {
-      const nextDraftTokens = getCacheableDraftTokens(draftTokens)
+      const nextDraftTokens = getAgentManagedDraftTokens(draftTokens)
       setDraftTokens(nextDraftTokens)
       draftTokensRef.current = nextDraftTokens
       writeAgentDraftCache(draftCacheKey, textRef.current, nextDraftTokens)
@@ -1133,7 +1126,7 @@ const AgentComposerInner = ({
   // skill subset and managed file/knowledge/skill state before dropping it from the queue.
   const restoreFollowupDraft = useCallback(
     (item: FollowupQueueItem) => {
-      const nextDraftTokens = getCacheableDraftTokens(item.draft.tokens)
+      const nextDraftTokens = getAgentManagedDraftTokens(item.draft.tokens)
       resetHistoryIndex()
       inputHistoryToolsRef.current = null
       actionsRef.current.replaceDraft(item.draft)

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -715,12 +715,12 @@ const AgentComposerInner = ({
   }, [model])
 
   const setText = useCallback(
-    (nextText: string, options: { persist?: boolean } = {}) => {
+    (nextText: string, options: { persist?: boolean; tokens?: readonly ComposerSerializedToken[] } = {}) => {
       clearTimeoutTimer('agentComposerSendMessage')
       textRef.current = nextText
       setTextState(nextText)
       if (options.persist ?? true) {
-        writeAgentDraftCache(draftCacheKey, nextText, draftTokensRef.current)
+        writeAgentDraftCache(draftCacheKey, nextText, options.tokens ?? draftTokensRef.current)
       }
     },
     [clearTimeoutTimer, draftCacheKey]
@@ -769,9 +769,11 @@ const AgentComposerInner = ({
     (nextText: string) => {
       resetHistoryIndex()
       inputHistoryToolsRef.current = null
-      setText(nextText)
+      // Controlled token sync updates text without firing onTokensChange, so this editor-originated
+      // path must persist the live token snapshot rather than the potentially stale draftTokensRef.
+      setText(nextText, { tokens: actionsRef.current.getDraft().tokens })
     },
-    [resetHistoryIndex, setText]
+    [actionsRef, resetHistoryIndex, setText]
   )
   const handleInputHistoryNavigate = useCallback(
     (direction: InputHistoryDirection) => navigateHistory(direction, actionsRef.current.getDraft()),

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2609,15 +2609,17 @@ describe('AgentComposer', () => {
     ])
   })
 
-  it('restores a cached knowledge chip together with the selection its prompt text needs', () => {
-    // The cached text carries the sentence the chip contributed. The pick has to come back with it —
-    // seeded synchronously from the token payload — or the surface's managed-token sync drops the chip
-    // as unselected and the sentence survives as prose claiming a base that nothing scopes.
+  it('drops a cached knowledge chip together with its prompt text', () => {
     mocks.knowledgeBases = [knowledgeBaseOne]
     const cachedToken = knowledgeBaseToken(knowledgeBaseOne)
     vi.mocked(cacheService.getCasual).mockReturnValue({
       text: 'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.',
-      tokens: [cachedToken]
+      tokens: [
+        {
+          ...cachedToken,
+          promptText: 'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
+        }
+      ]
     })
 
     render(
@@ -2630,16 +2632,15 @@ describe('AgentComposer', () => {
       />
     )
 
-    expect(mocks.surfaceProps?.draftTokens).toEqual([cachedToken])
-    expect(mocks.selectedKnowledgeBases).toEqual([knowledgeBaseOne])
-    expect(mocks.surfaceProps?.tokens).toContainEqual(
+    expect(mocks.surfaceProps?.text).toBe('')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([])
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    expect(mocks.surfaceProps?.tokens).not.toContainEqual(
       expect.objectContaining({ id: `knowledge:${knowledgeBaseOne.id}`, kind: 'knowledge' })
     )
   })
 
-  it('persists a knowledge chip into the agent draft cache alongside its sentence', () => {
-    // The write side of the round-trip: the text handed to the cache already contains the sentence the
-    // chip contributed, so persisting the text while dropping the token is what strands it as prose.
+  it('excludes a knowledge chip and its prompt text from the agent draft cache', () => {
     mocks.knowledgeBases = [knowledgeBaseOne]
 
     render(
@@ -2652,19 +2653,87 @@ describe('AgentComposer', () => {
       />
     )
 
-    const cachedToken = knowledgeBaseToken(knowledgeBaseOne)
+    const promptText = 'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
+    const cachedToken = { ...knowledgeBaseToken(knowledgeBaseOne), promptText }
     act(() => {
+      mocks.surfaceProps?.onTextChange(`${promptText} keep this`)
       mocks.surfaceProps?.onTokensChange?.([cachedToken])
     })
 
     expect(cacheService.setCasual).toHaveBeenLastCalledWith(
       'agent-session-draft-agent-1',
-      expect.objectContaining({ tokens: [cachedToken] }),
+      { text: 'keep this', tokens: [] },
       expect.any(Number)
     )
   })
 
-  it('drops a cached knowledge pick the agent no longer configures', () => {
+  it('clears knowledge state on a same-agent session switch while preserving text and skills', async () => {
+    let cachedDraft: unknown = ''
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key === 'agent-session-draft-agent-1' ? cachedDraft : ''
+    )
+    vi.mocked(cacheService.setCasual).mockImplementation((key: string, value: unknown) => {
+      if (key === 'agent-session-draft-agent-1') cachedDraft = value
+    })
+    mocks.knowledgeBases = [knowledgeBaseOne]
+    mocks.agentKnowledgeBaseIds = [knowledgeBaseOne.id]
+    mocks.availableSkills = [pdfSkill]
+
+    const view = render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    void act(() => mocks.setSelectedKnowledgeBases([knowledgeBaseOne]))
+    view.rerender(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const knowledgePrompt =
+      'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
+    const text = `${knowledgePrompt} ${pdfSkillToken.promptText} keep this`
+    act(() => {
+      mocks.surfaceProps?.onTextChange(text)
+      mocks.surfaceProps?.onTokensChange?.([
+        { ...knowledgeBaseToken(knowledgeBaseOne), promptText: knowledgePrompt },
+        {
+          ...pdfSkillToken,
+          index: 1,
+          textOffset: knowledgePrompt.length + 1
+        }
+      ])
+    })
+
+    view.rerender(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-2"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe(`${pdfSkillToken.promptText} keep this`))
+    expect(mocks.surfaceProps?.draftTokens).toEqual([{ ...pdfSkillToken, index: 0, textOffset: 0 }])
+    expect(mocks.selectedKnowledgeBases).toEqual([])
+    expect(mocks.surfaceProps?.tokens).not.toContainEqual(
+      expect.objectContaining({ id: `knowledge:${knowledgeBaseOne.id}`, kind: 'knowledge' })
+    )
+  })
+
+  it('does not restore a cached knowledge pick', () => {
     mocks.knowledgeBases = [knowledgeBaseOne, knowledgeBaseTwo]
     mocks.agentKnowledgeBaseIds = [knowledgeBaseTwo.id]
     vi.mocked(cacheService.getCasual).mockReturnValue({

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2703,16 +2703,19 @@ describe('AgentComposer', () => {
     const knowledgePrompt =
       'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
     const text = `${knowledgePrompt} ${pdfSkillToken.promptText} keep this`
-    act(() => {
-      mocks.surfaceProps?.onTextChange(text)
-      mocks.surfaceProps?.onTokensChange?.([
+    mocks.getDraft.mockReturnValue({
+      text,
+      tokens: [
         { ...knowledgeBaseToken(knowledgeBaseOne), promptText: knowledgePrompt },
         {
           ...pdfSkillToken,
           index: 1,
           textOffset: knowledgePrompt.length + 1
         }
-      ])
+      ]
+    })
+    act(() => {
+      mocks.surfaceProps?.onTextChange(text)
     })
 
     view.rerender(

--- a/src/renderer/components/composer/variants/__tests__/agentDraftCache.test.ts
+++ b/src/renderer/components/composer/variants/__tests__/agentDraftCache.test.ts
@@ -1,11 +1,10 @@
 import { cacheService } from '@data/CacheService'
-import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerSerializedToken } from '../../tokens'
 import {
   getAgentDraftCacheKey,
-  getCachedKnowledgeBases,
+  getCacheableAgentDraft,
   getCachedSkillTokens,
   readAgentDraftCache,
   writeAgentDraftCache
@@ -18,7 +17,7 @@ vi.mock('@data/CacheService', () => ({
   }
 }))
 
-const base = { id: 'kb-1', name: 'Notes' } as KnowledgeBase
+const base = { id: 'kb-1', name: 'Notes' }
 
 const skillToken: ComposerSerializedToken = {
   id: 'skill:review',
@@ -54,41 +53,50 @@ describe('agentDraftCache', () => {
     vi.mocked(cacheService.setCasual).mockReset()
   })
 
-  it('round-trips knowledge tokens so their prompt text keeps its chip', () => {
-    // Dropping the token while persisting the text would strand the sentence as chip-less prose that
-    // tells the model a base is attached while the send path scopes nothing.
-    writeAgentDraftCache(getAgentDraftCacheKey('agent-1'), 'text', [skillToken, knowledgeToken, fileToken])
+  it('drops a knowledge token together with its prompt while preserving and rebasing a skill token', () => {
+    const knowledgeFirst = { ...knowledgeToken, index: 0, textOffset: 0 }
+    const skillAfterKnowledge = {
+      ...skillToken,
+      index: 1,
+      textOffset: knowledgeToken.promptText!.length + 1
+    }
+    const text = `${knowledgeToken.promptText} ${skillToken.promptText} keep this`
 
-    const written = vi.mocked(cacheService.setCasual).mock.calls[0][1]
-    expect(written).toEqual({ text: 'text', tokens: [skillToken, knowledgeToken] })
-
-    vi.mocked(cacheService.getCasual).mockReturnValue(written)
-    expect(readAgentDraftCache(getAgentDraftCacheKey('agent-1')).tokens).toEqual([skillToken, knowledgeToken])
+    expect(getCacheableAgentDraft({ text, tokens: [knowledgeFirst, skillAfterKnowledge, fileToken] })).toEqual({
+      text: `${skillToken.promptText} keep this`,
+      tokens: [{ ...skillToken, index: 0, textOffset: 0 }]
+    })
   })
 
-  it('rebuilds the knowledge selection from the cached token payload', () => {
-    // Read synchronously at mount, so it must not depend on the knowledge-base query having resolved.
-    const text = `prefix ${knowledgeToken.promptText}`
+  it('excises knowledge tokens on both cache writes and reads', () => {
+    const text = `${knowledgeToken.promptText} keep this`
+    const token = { ...knowledgeToken, index: 0, textOffset: 0 }
+
+    writeAgentDraftCache(getAgentDraftCacheKey('agent-1'), text, [token, skillToken])
+
+    expect(cacheService.setCasual).toHaveBeenCalledWith(
+      'agent-session-draft-agent-1',
+      { text: 'keep this', tokens: [{ ...skillToken, index: 0, textOffset: 0 }] },
+      expect.any(Number)
+    )
+
+    vi.mocked(cacheService.getCasual).mockReturnValue({ text, tokens: [token, skillToken] })
+    expect(readAgentDraftCache(getAgentDraftCacheKey('agent-1'))).toEqual({
+      text: 'keep this',
+      tokens: [{ ...skillToken, index: 0, textOffset: 0 }]
+    })
+  })
+
+  it('collapses a knowledge-only draft to empty', () => {
     expect(
-      getCachedKnowledgeBases({ text, tokens: [skillToken, { ...knowledgeToken, textOffset: 7 }, fileToken] })
-    ).toEqual([base])
-  })
-
-  it('ignores a knowledge token whose sentence is no longer at its offset', () => {
-    // A managed-token strip suppresses onTokensChange but still fires onTextChange, so the cache can
-    // hold a token naming a chip whose sentence is already gone. Re-seeding from it would resurrect a
-    // pick the user watched disappear.
-    expect(getCachedKnowledgeBases({ text: 'the sentence was edited away', tokens: [knowledgeToken] })).toEqual([])
+      getCacheableAgentDraft({
+        text: `${knowledgeToken.promptText} `,
+        tokens: [{ ...knowledgeToken, index: 0, textOffset: 0 }]
+      })
+    ).toEqual({ text: '', tokens: [] })
   })
 
   it('keeps the skill subset separate from the persisted token set', () => {
     expect(getCachedSkillTokens([skillToken, knowledgeToken])).toEqual([skillToken])
-  })
-
-  it('ignores a knowledge token whose payload is not a knowledge base', () => {
-    const text = `prefix ${knowledgeToken.promptText}`
-    expect(getCachedKnowledgeBases({ text, tokens: [{ ...knowledgeToken, textOffset: 7, payload: 'nope' }] })).toEqual(
-      []
-    )
   })
 })

--- a/src/renderer/components/composer/variants/agent/agentDraftCache.ts
+++ b/src/renderer/components/composer/variants/agent/agentDraftCache.ts
@@ -1,8 +1,8 @@
 import { cacheService } from '@data/CacheService'
-import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { LocalSkill } from '@shared/types/skill'
 
-import type { ComposerSerializedToken } from '../../tokens'
+import { excludeComposerDraftTokens } from '../../composerDraft'
+import type { ComposerSerializedDraft, ComposerSerializedToken } from '../../tokens'
 
 const DRAFT_CACHE_TTL = 24 * 60 * 60 * 1000
 
@@ -44,39 +44,21 @@ export function getCachedSkillTokens(tokens: readonly ComposerSerializedToken[])
   return tokens.filter((token) => token.kind === 'skill')
 }
 
-function isKnowledgeBase(value: unknown): value is KnowledgeBase {
-  return isRecord(value) && typeof value.id === 'string' && typeof value.name === 'string'
-}
-
 /**
- * Rebuilds the knowledge selection a cached draft's chips stand for, mirroring
- * `getSkillFromCachedToken`. Read synchronously at mount rather than mapped through the
- * knowledge-base query, so the pick exists before the surface's managed-token sync would strip a
- * restored chip as unselected.
- *
- * A token whose sentence is no longer at its recorded offset is stale and must not seed anything: a
- * managed-token strip suppresses `onTokensChange` but still fires `onTextChange`, so the draft can be
- * persisted with the sentence already gone while the token list still names the chip. Re-seeding from
- * that would resurrect a pick the user watched disappear, and `createComposerDocumentContent` refuses
- * to rebuild the chip at the stale offset anyway, so the sentence would land wherever the caret is.
+ * Token kinds retained in the live Agent composer draft. Knowledge remains here so the current
+ * session can serialize and edit its chip; the persistence boundary below removes it.
  */
-export function getCachedKnowledgeBases(draft: AgentComposerDraftCache): KnowledgeBase[] {
-  return draft.tokens.flatMap((token) =>
-    token.kind === 'knowledge' &&
-    isKnowledgeBase(token.payload) &&
-    (!token.promptText || draft.text.startsWith(token.promptText, token.textOffset))
-      ? [token.payload]
-      : []
-  )
-}
-
-/**
- * The token kinds that ride the cached draft. Both fold a `promptText` into the draft text, so
- * persisting the text while dropping the token would strand that sentence as chip-less prose —
- * for a knowledge pick, prose telling the model a base is attached that nothing scopes.
- */
-export function getCacheableDraftTokens(tokens: readonly ComposerSerializedToken[]) {
+export function getAgentManagedDraftTokens(tokens: readonly ComposerSerializedToken[]) {
   return tokens.filter((token) => token.kind === 'skill' || token.kind === 'knowledge')
+}
+
+/** Knowledge selection is session-scoped, while this cache is agent-scoped. */
+export function getCacheableAgentDraft(draft: ComposerSerializedDraft): AgentComposerDraftCache {
+  const withoutKnowledge = excludeComposerDraftTokens(draft, (token) => token.kind === 'knowledge')
+  return {
+    text: withoutKnowledge.text,
+    tokens: getCachedSkillTokens(withoutKnowledge.tokens)
+  }
 }
 
 export function readAgentDraftCache(cacheKey: string): AgentComposerDraftCache {
@@ -86,19 +68,10 @@ export function readAgentDraftCache(cacheKey: string): AgentComposerDraftCache {
     return { text: '', tokens: [] }
   }
 
-  return {
-    text: cached.text,
-    tokens: getCacheableDraftTokens(cached.tokens)
-  }
+  return getCacheableAgentDraft({ text: cached.text, tokens: cached.tokens })
 }
 
 export function writeAgentDraftCache(cacheKey: string, text: string, tokens: readonly ComposerSerializedToken[]) {
-  cacheService.setCasual<AgentComposerDraftCache>(
-    cacheKey,
-    {
-      text,
-      tokens: getCacheableDraftTokens(tokens)
-    },
-    DRAFT_CACHE_TTL
-  )
+  const cacheableDraft = getCacheableAgentDraft({ text, tokens: [...tokens] })
+  cacheService.setCasual<AgentComposerDraftCache>(cacheKey, cacheableDraft, DRAFT_CACHE_TTL)
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Queued follow-ups displayed the internal knowledge-base prompt, and Agent drafts could leave that prompt behind after switching sessions.

After this PR:

Queued follow-ups show only the user-authored text and knowledge chip. Agent draft persistence removes session-scoped knowledge tokens together with their prompt text while retaining ordinary text and skill tokens.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Knowledge tokens serialize model-facing instructions into the draft text. UI previews and agent-scoped persistence must derive a user-visible copy instead of exposing or replaying those instructions outside their session scope.

The following tradeoffs were made:

Knowledge-base selection is no longer restored from the agent-scoped draft cache across sessions. Ordinary draft text and skill tokens remain agent-scoped.

The following alternatives were considered:

Keying Agent drafts by both agent and session was considered, but rejected to keep knowledge selection behavior consistent with Chat Composer and avoid persisting session-scoped selection.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The full local test suite was not run by request. Focused renderer tests, lint, formatting, type checking, i18n checks, and the strict lint gate passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed internal knowledge-base prompts appearing in queued messages and Agent drafts after switching sessions.
```
