### PR TITLE
fix(knowledge): require valid http(s) URL to add a link data source

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3018,6 +3018,7 @@
           "description": "Enter a webpage URL:",
           "help": "Page text will be fetched, chunked, and indexed automatically",
           "input_label": "Webpage URL",
+          "invalid": "Enter a valid URL starting with http:// or https://",
           "placeholder": "https://example.com",
           "title": "Import a single webpage"
         }

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3018,6 +3018,7 @@
           "description": "输入网页链接：",
           "help": "将自动抓取页面文本并分块索引",
           "input_label": "网页地址",
+          "invalid": "请输入以 http:// 或 https:// 开头的有效链接",
           "placeholder": "https://example.com",
           "title": "导入单个网页"
         }

--- a/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
+++ b/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
@@ -4,6 +4,7 @@ import { toast } from '@renderer/services/toast'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getFileExtension } from '@renderer/utils/file'
 import { resolveKnowledgeFileData, resolveKnowledgeFileMetadataEntryData } from '@renderer/utils/knowledgeFileEntry'
+import { isValidHttpUrl } from '@renderer/utils/url'
 import type { KnowledgeAddItemConflict, KnowledgeAddItemInput, KnowledgeItemType } from '@shared/data/types/knowledge'
 import { knowledgeSupportedFileExts } from '@shared/utils/file'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -39,18 +40,6 @@ const knowledgeSupportedFileExtSet = new Set<string>(knowledgeSupportedFileExts)
 const knowledgeFilePickerExtensions = knowledgeSupportedFileExts.map((ext) => ext.replace(/^\./, ''))
 
 const isSupportedKnowledgeFile = (fileName: string) => knowledgeSupportedFileExtSet.has(getFileExtension(fileName))
-
-// The `url` source persists a real data source the moment it's added, so a bad value creates a
-// broken item that only fails asynchronously (e.g. "Invalid knowledge url: abc"). Gate submission
-// on a parseable http(s) URL instead of any non-empty text.
-const isValidHttpUrl = (value: string): boolean => {
-  try {
-    const { protocol } = new URL(value)
-    return protocol === 'http:' || protocol === 'https:'
-  } catch {
-    return false
-  }
-}
 
 const resolveFileEntryDataFromFile = (file: File) => {
   const filePath = window.api.file.getPathForFile(file)
@@ -105,6 +94,9 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
     }
 
     switch (activeSource) {
+      // The `url` source persists a real data source the moment it's added, so a bad value creates a
+      // broken item that only fails asynchronously (e.g. "Invalid knowledge url: abc"). Gate
+      // submission on a parseable http(s) URL instead of any non-empty text.
       case 'url':
         return isValidHttpUrl(urlValue.trim())
       case 'note':

--- a/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
+++ b/src/renderer/pages/knowledge/components/AddKnowledgeItemDialog.tsx
@@ -40,6 +40,18 @@ const knowledgeFilePickerExtensions = knowledgeSupportedFileExts.map((ext) => ex
 
 const isSupportedKnowledgeFile = (fileName: string) => knowledgeSupportedFileExtSet.has(getFileExtension(fileName))
 
+// The `url` source persists a real data source the moment it's added, so a bad value creates a
+// broken item that only fails asynchronously (e.g. "Invalid knowledge url: abc"). Gate submission
+// on a parseable http(s) URL instead of any non-empty text.
+const isValidHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 const resolveFileEntryDataFromFile = (file: File) => {
   const filePath = window.api.file.getPathForFile(file)
 
@@ -94,13 +106,26 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
 
     switch (activeSource) {
       case 'url':
-        return urlValue.trim().length > 0
+        return isValidHttpUrl(urlValue.trim())
       case 'note':
         return selectedNotes.length > 0
       default:
         return false
     }
   }, [activeSource, selectedBaseId, selectedNotes.length, urlValue])
+
+  // Warn once the field holds text that isn't a valid http(s) URL; stays quiet while empty so the
+  // hint reads as guidance for a bad entry rather than a nag on the pristine input.
+  const urlHint = useMemo(() => {
+    if (activeSource !== 'url') {
+      return ''
+    }
+    const value = urlValue.trim()
+    if (value.length === 0 || isValidHttpUrl(value)) {
+      return ''
+    }
+    return t('knowledge.data_source.add_dialog.url.invalid')
+  }, [activeSource, t, urlValue])
 
   const buildPanelSubmitItems = useCallback(async (): Promise<KnowledgeAddItemInput[]> => {
     if (activeSource === 'url') {
@@ -329,7 +354,7 @@ const AddKnowledgeItemDialog = ({ open, onOpenChange }: AddKnowledgeItemDialogPr
             <AddKnowledgeItemDialogFooter
               activeSource={activeSource}
               canSubmit={canSubmit}
-              errorMessage={submitErrorMessage}
+              errorMessage={submitErrorMessage || urlHint}
               isSubmitting={isSubmitting}
               selectedNoteCount={selectedNotes.length}
               onSubmit={handleSubmit}

--- a/src/renderer/utils/__tests__/url.test.ts
+++ b/src/renderer/utils/__tests__/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isValidProxyUrl } from '../url'
+import { isValidHttpUrl, isValidProxyUrl } from '../url'
 
 describe('isValidProxyUrl', () => {
   it('should return true for string containing "://"', () => {
@@ -19,5 +19,22 @@ describe('isValidProxyUrl', () => {
 
   it('should return true for only "://"', () => {
     expect(isValidProxyUrl('://')).toBe(true)
+  })
+})
+
+describe('isValidHttpUrl', () => {
+  it('should return true for http and https urls', () => {
+    expect(isValidHttpUrl('http://example.com')).toBe(true)
+    expect(isValidHttpUrl('https://example.com/path?q=1')).toBe(true)
+  })
+
+  it('should return false for non-http(s) schemes', () => {
+    expect(isValidHttpUrl('ftp://example.com')).toBe(false)
+    expect(isValidHttpUrl('file:///tmp/foo')).toBe(false)
+  })
+
+  it('should return false for unparseable text', () => {
+    expect(isValidHttpUrl('abc')).toBe(false)
+    expect(isValidHttpUrl('')).toBe(false)
   })
 })

--- a/src/renderer/utils/url.ts
+++ b/src/renderer/utils/url.ts
@@ -14,3 +14,17 @@ export function getUrlOriginOrFallback(url: string): string {
 export const isValidProxyUrl = (url: string): boolean => {
   return url.includes('://')
 }
+
+/**
+ * 检查字符串是否是可解析的 http(s) URL。
+ * @param {string} value URL 字符串
+ * @returns {boolean} 是否是有效的 http/https URL
+ */
+export const isValidHttpUrl = (value: string): boolean => {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
### What this PR does

Before this PR:
In a knowledge base, adding a **link** (URL) data source only checked that the input was non-empty. Typing arbitrary text such as `abc` still kept the **Add** button enabled; clicking it persisted a real data source that entered "processing" and then asynchronously flipped to an error (`Invalid knowledge url: abc`), leaving a broken entry the user had to delete by hand.

After this PR:
Submission is gated on a parseable `http(s)` URL. Invalid input keeps **Add** disabled and shows an inline hint (`Enter a valid URL starting with http:// or https://`); a valid `http`/`https` URL re-enables the button and clears the hint. No broken data source can be created.

Original feedback (traceability):
用户「金晨曦」(Codex Computer Use 实测)：知识库链接数据源不校验 URL，任意文本也会创建持久记录 ｜ 源记录(dev 表 recvqyk0J6Lk97)：https://mcnnox2fhjfq.feishu.cn/record/Ib7xrzunPexBcucf6wCckbz2nth

Fixes #

### Why we need it and why it was done in this way

The root cause is in `AddKnowledgeItemDialog.tsx`: `canSubmit`'s `url` branch returned `urlValue.trim().length > 0`, so any non-empty string was submittable. The fix validates the value with a small `isValidHttpUrl()` helper (`new URL()` + `http:`/`https:` protocol check) and surfaces an inline hint for invalid non-empty input.

The following tradeoffs were made:
- Used the native `URL` constructor rather than a regex — it correctly rejects non-URL text and non-`http(s)` schemes without maintaining a pattern.
- Reused the footer's existing inline error slot for the hint (quiet while the field is empty) instead of adding new UI.

The following alternatives were considered:
- Validating only at submit time (toast on failure) — rejected; disabling the button gives immediate, clearer feedback and prevents the accidental persist.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Scope is intentionally minimal: one component plus two i18n strings (`knowledge.data_source.add_dialog.url.invalid` in `en-us` / `zh-cn`). Verified locally: `pnpm typecheck:web`, `oxlint` on the changed file (0/0), and `pnpm i18n:check` all pass. Behavior was exercised end-to-end in a dev build (invalid `abc` → Add disabled + hint; valid URL → Add enabled).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed knowledge base link data source not validating the URL: invalid text no longer enables "Add" or creates a broken data source; only valid http(s) URLs are accepted.
```
