### PR TITLE
fix(system-settings): show direction-aware hardware acceleration restart prompt

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -6595,7 +6595,8 @@
     },
     "hardware_acceleration": {
       "confirm": {
-        "content": "Disabling hardware acceleration requires restarting the app to take effect. Do you want to restart now?",
+        "content_disable": "Disabling hardware acceleration requires restarting the app to take effect. Do you want to restart now?",
+        "content_enable": "Enabling hardware acceleration requires restarting the app to take effect. Do you want to restart now?",
         "title": "Restart Required"
       },
       "title": "Disable Hardware Acceleration"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -6595,7 +6595,8 @@
     },
     "hardware_acceleration": {
       "confirm": {
-        "content": "禁用硬件加速需要重启应用才能生效，是否现在重启？",
+        "content_disable": "禁用硬件加速需要重启应用才能生效，是否现在重启？",
+        "content_enable": "启用硬件加速需要重启应用才能生效，是否现在重启？",
         "title": "需要重启应用"
       },
       "title": "禁用硬件加速"

--- a/src/renderer/pages/settings/SystemSettings/SystemSettings.tsx
+++ b/src/renderer/pages/settings/SystemSettings/SystemSettings.tsx
@@ -88,7 +88,9 @@ const SystemSettings: FC = () => {
   const handleHardwareAccelerationChange = async (checked: boolean) => {
     const confirmed = await popup.confirm({
       title: t('settings.hardware_acceleration.confirm.title'),
-      content: t('settings.hardware_acceleration.confirm.content'),
+      content: checked
+        ? t('settings.hardware_acceleration.confirm.content_disable')
+        : t('settings.hardware_acceleration.confirm.content_enable'),
       okText: t('common.confirm'),
       cancelText: t('common.cancel'),
       centered: true


### PR DESCRIPTION
### What this PR does

Before this PR:

The "restart required" confirmation shown when toggling **Disable Hardware Acceleration** always used the *disable* copy (`settings.hardware_acceleration.confirm.content`, zh-cn: "禁用硬件加速…"), regardless of toggle direction. So when a user turned the switch **off** to re-enable hardware acceleration, the dialog still read "禁用硬件加速 / Disabling hardware acceleration…", contradicting the action.

After this PR:

The confirmation copy is chosen by the switch direction:
- turning the switch **on** (disabling HW accel) → `content_disable` ("禁用硬件加速…" / "Disabling hardware acceleration…")
- turning the switch **off** (enabling HW accel) → `content_enable` ("启用硬件加速…" / "Enabling hardware acceleration…")

Added the matching i18n keys (`content_enable` / `content_disable`) to `en-us` and `zh-cn`.

Fixes #

### Why we need it and why it was done in this way

The single fixed copy could not describe both toggle directions. Splitting into two direction-specific keys and selecting on the existing `checked` argument is the minimal fix (~7 lines) and keeps the copy accurate in both languages.

The following tradeoffs were made: none of note — no logic/state change, only the confirmation string.

The following alternatives were considered: a generic wording ("This change requires a restart"); rejected to preserve the explicit enable/disable phrasing users expect.

### Breaking changes

None.

### Special notes for your reviewer

Verified in a running dev build (both languages × both directions) — the dialog text now matches the action in all four cases.

**Original feedback (source):** 用户「Octor」(Cherry Studio Agent)：启用硬件加速时，确认框仍说"禁用硬件加速" ｜ 源记录: https://mcnnox2fhjfq.feishu.cn/record/E82trbgssej9uccES0jcpi69nqh

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the hardware acceleration restart confirmation showing "disable" wording when re-enabling hardware acceleration; the prompt now matches the toggle direction.
```
