### PR TITLE
fix(ui-checkbox): show minus icon for indeterminate state

### DIFF
--- a/packages/ui/src/components/primitives/checkbox.tsx
+++ b/packages/ui/src/components/primitives/checkbox.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@cherrystudio/ui/lib/utils'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { CheckIcon } from 'lucide-react'
+import { CheckIcon, MinusIcon } from 'lucide-react'
 import * as React from 'react'
 
 export type CheckedState = CheckboxPrimitive.CheckedState
@@ -58,7 +58,11 @@ function Checkbox({
       className={cn(checkboxVariants({ size }), className)}
       {...props}>
       <CheckboxPrimitive.Indicator data-slot="checkbox-indicator" className="grid place-content-center transition-none">
-        <CheckIcon strokeWidth={2.5} className={cn(checkboxIconVariants({ size }), 'text-current')} />
+        {props.checked === 'indeterminate' ? (
+          <MinusIcon strokeWidth={2.5} className={cn(checkboxIconVariants({ size }), 'text-current')} />
+        ) : (
+          <CheckIcon strokeWidth={2.5} className={cn(checkboxIconVariants({ size }), 'text-current')} />
+        )}
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )


### PR DESCRIPTION
### What this PR does

Before this PR:

The shared `Checkbox` primitive (`packages/ui`) always rendered `CheckIcon` inside `CheckboxPrimitive.Indicator`. Radix shows the Indicator for **both** the `checked` and `indeterminate` states, so an indeterminate (partially-selected) checkbox looked identical to a fully-checked one. This was visible on the Files page: selecting a single row made the toolbar "select all" / header checkbox show a full check instead of a partial-selection state.

After this PR:

The Indicator renders `MinusIcon` (a dash) when `checked === 'indeterminate'`, and `CheckIcon` otherwise — so the indeterminate state is now visually distinct across the whole app.

Fixes # N/A (internal tracking — see original feedback below)

### Why we need it and why it was done in this way

The page-level logic (e.g. `FilesPage` `visibleSelectionState`) already returns `'indeterminate'` correctly; the defect was purely in the shared primitive, so the fix belongs there and benefits every consumer of the `Checkbox`.

The following tradeoffs were made:
- Fixed the shared primitive rather than adding a per-page workaround, since the bug affects all indeterminate checkboxes. This is the correct general fix and is low-risk (icon selection only).

The following alternatives were considered:
- Handling it at each call site (rejected — duplicative and leaves the primitive wrong for other consumers).

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Original feedback (traceability): 用户「张晨杰」(Cherry Studio Agent)：文件列表仅选中一张图片时"全选"复选框错误显示为已勾选 ｜ 源记录(dev表 recvqysNZMfhh2)：https://mcnnox2fhjfq.feishu.cn/record/VnvxrqnbYemhLjcVfITcFLWDn3d

Verified in the running app (Files page, 3 images, 1 selected): header checkbox `data-state=indeterminate` now renders `lucide-minus` (dash); before the fix it rendered `lucide-check` (full check). `pnpm type:check` and ESLint on the changed file both pass.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the checkbox indeterminate (partial-selection) state showing a full check mark instead of a dash — e.g. the Files page "select all" checkbox when only some rows are selected.
```
