### PR TITLE
fix(obsidian-export): keep dialog open and report failure on empty title

### DIFF
--- a/src/renderer/components/ObsidianExportDialog.tsx
+++ b/src/renderer/components/ObsidianExportDialog.tsx
@@ -284,11 +284,14 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
       return
     }
     await navigator.clipboard.writeText(content)
-    void exportMarkdownToObsidian({
+    const success = await exportMarkdownToObsidian({
       ...state,
       folder: state.folder,
       vault: selectedVault
     })
+    if (!success) {
+      return
+    }
     setOpen(false)
     resolve(true)
   }
@@ -492,7 +495,10 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
           <Button type="button" variant="outline" onClick={handleCancel}>
             {i18n.t('common.cancel')}
           </Button>
-          <Button type="button" disabled={vaults.length === 0 || loading || !!error} onClick={handleOk}>
+          <Button
+            type="button"
+            disabled={vaults.length === 0 || loading || !!error || !state.title.trim()}
+            onClick={handleOk}>
             {i18n.t('chat.topics.export.obsidian_btn')}
           </Button>
         </DialogFooter>

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -767,10 +767,10 @@ export const exportMarkdownToYuque = async (title: string, content: string): Pro
  * @param attributes.folder 选择的文件夹路径或文件路径
  * @param attributes.vault 选择的Vault名称
  */
-export const exportMarkdownToObsidian = async (attributes: any): Promise<void> => {
+export const exportMarkdownToObsidian = async (attributes: any): Promise<boolean> => {
   if (getExportState()) {
     toast.warning(i18n.t('message.warn.export.exporting'))
-    return
+    return false
   }
 
   setExportingState(true)
@@ -783,12 +783,12 @@ export const exportMarkdownToObsidian = async (attributes: any): Promise<void> =
 
     if (!obsidianVault) {
       toast.error(i18n.t('chat.topics.export.obsidian_no_vault_selected'))
-      return
+      return false
     }
 
     if (!attributes.title) {
       toast.error(i18n.t('chat.topics.export.obsidian_title_required'))
-      return
+      return false
     }
 
     // 检查是否选择了.md文件
@@ -825,9 +825,11 @@ export const exportMarkdownToObsidian = async (attributes: any): Promise<void> =
 
     window.open(obsidianUrl)
     toast.success(i18n.t('chat.topics.export.obsidian_export_success'))
+    return true
   } catch (error) {
     logger.error('Failed to export to Obsidian:', error as Error)
     toast.error(i18n.t('chat.topics.export.obsidian_export_failed'))
+    return false
   } finally {
     setExportingState(false)
   }

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -121,6 +121,7 @@ import { processCitations } from '@renderer/utils/export'
 import { markdownToPlainText } from '@renderer/utils/markdown'
 
 import {
+  exportMarkdownToObsidian,
   exportTopicToNotes,
   messagesToMarkdown,
   messageToMarkdown,
@@ -611,6 +612,49 @@ describe('ExportService', () => {
       expect(toast.error).toHaveBeenCalledWith('message.error.notes.export')
 
       loggerErrorSpy.mockRestore()
+    })
+  })
+
+  describe('exportMarkdownToObsidian', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    it('returns false and toasts an error when the title is empty', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+      const result = await exportMarkdownToObsidian({ vault: 'MyVault', title: '' })
+
+      expect(result).toBe(false)
+      expect(toast.error).toHaveBeenCalledWith('chat.topics.export.obsidian_title_required')
+      expect(openSpy).not.toHaveBeenCalled()
+
+      openSpy.mockRestore()
+    })
+
+    it('returns false and toasts an error when no vault is selected', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+      const result = await exportMarkdownToObsidian({ vault: '', title: 'Note' })
+
+      expect(result).toBe(false)
+      expect(toast.error).toHaveBeenCalledWith('chat.topics.export.obsidian_no_vault_selected')
+      expect(openSpy).not.toHaveBeenCalled()
+
+      openSpy.mockRestore()
+    })
+
+    it('returns true and opens Obsidian when the export succeeds', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+      const result = await exportMarkdownToObsidian({ vault: 'MyVault', title: 'Note' })
+
+      expect(result).toBe(true)
+      expect(openSpy).toHaveBeenCalledTimes(1)
+      expect(openSpy.mock.calls[0][0]).toContain('obsidian://new')
+      expect(toast.success).toHaveBeenCalledWith('chat.topics.export.obsidian_export_success')
+
+      openSpy.mockRestore()
     })
   })
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Exporting a chat/topic/message to Obsidian with an empty **title** showed an error toast ("The title cannot be empty") but the dialog **still closed and reported success**. Root cause: `exportMarkdownToObsidian` returned `Promise<void>`, so the caller couldn't distinguish success from failure; the dialog fired it with `void exportMarkdownToObsidian(...)` and then unconditionally called `resolve(true)` + closed.

After this PR:

- `exportMarkdownToObsidian` now returns `Promise<boolean>` — `false` on the no-vault / empty-title early returns and in the `catch`, `true` only on genuine success.
- `ObsidianExportDialog` `await`s the result and returns early on failure, so the dialog **stays open and does not report success**.
- The export button is **disabled while the title is empty**, preventing the confusing state up front.
- Added tests covering the boolean return (empty title → false, no vault → false, success → true).

No user-facing strings were added or changed (existing i18n keys are reused).

**Original feedback (traceability):** 用户「Octor」(Cherry Studio Agent): Obsidian 标题为空时，导出报错但弹窗仍关闭并返回成功 ｜ 源记录(dev表 recvqD1h5Df7JX): https://mcnnox2fhjfq.feishu.cn/record/XdUQrxA6IetoJRcbvq4cp0wenBb

### Why we need it and why it was done in this way

The dialog reporting success on a failed export is misleading — users believe the note was created when it was not. Returning a boolean from the exporter is the minimal change that lets the dialog react to the actual outcome; disabling the button on an empty title also prevents the invalid attempt entirely.

The following tradeoffs were made:

- Kept the change surgical: only the exporter's return type, the dialog's `handleOk` await, and the button's `disabled` condition changed.

The following alternatives were considered:

- Only disabling the button (without awaiting the result) — rejected because it would leave the other failure paths (no vault / thrown error) still able to close-and-report-success.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified locally: `pnpm typecheck:web` (pass), `oxlint` on the changed files (0 warnings/0 errors), and `pnpm vitest run src/renderer/services/__tests__/ExportService.test.ts` (32 passed). Also driven end-to-end against a dev build (CDP): empty title → export button disabled; filling a title re-enables it; the pre-fix build reproduced the bug (dialog closed while an error toast showed).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Obsidian export incorrectly reporting success when the note title is empty; the export dialog now stays open on failure and the export button is disabled until a title is provided.
```
