### PR TITLE
fix(knowledge): use readable names for saved messages

### DIFF
--- a/src/renderer/components/SaveToKnowledgePopup.tsx
+++ b/src/renderer/components/SaveToKnowledgePopup.tsx
@@ -15,6 +15,7 @@ import { loggerService } from '@logger'
 import CustomTag from '@renderer/components/tags/CustomTag'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
 import { useAddKnowledgeItems } from '@renderer/hooks/useKnowledgeItems'
+import { getMessageTitle } from '@renderer/services/ExportService'
 import {
   analyzeMessagesContent,
   analyzeTopicContent,
@@ -108,7 +109,7 @@ interface SaveResult {
 
 type Props = ShowParams & PopupInjectedProps<SaveResult | null>
 
-const getNoteSource = (source: ContentSource, fallbackConversationTitle: string, sourceTitle?: string) => {
+const getNoteSource = async (source: ContentSource, fallbackConversationTitle: string, sourceTitle?: string) => {
   const trimmedSourceTitle = sourceTitle?.trim()
 
   if (trimmedSourceTitle) {
@@ -127,7 +128,7 @@ const getNoteSource = (source: ContentSource, fallbackConversationTitle: string,
     return source.data.title.trim() || fallbackConversationTitle
   }
 
-  return source.data.id
+  return getMessageTitle(source.data)
 }
 
 const PopupContainer: React.FC<Props> = ({ dialogTitle, source, sourceTitle, open, resolve }) => {
@@ -306,7 +307,7 @@ const PopupContainer: React.FC<Props> = ({ dialogTitle, source, sourceTitle, ope
       }
 
       const items: KnowledgeAddItemInput[] = []
-      const noteSource = getNoteSource(source, t('chat.save.topic.knowledge.source_fallback'), sourceTitle)
+      const noteSource = await getNoteSource(source, t('chat.save.topic.knowledge.source_fallback'), sourceTitle)
 
       if (isNoteMode) {
         const note = source.data

--- a/src/renderer/components/__tests__/SaveToKnowledgePopup.test.tsx
+++ b/src/renderer/components/__tests__/SaveToKnowledgePopup.test.tsx
@@ -10,6 +10,7 @@ import type React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  getMessageTitle: vi.fn(),
   processMessageContent: vi.fn(),
   submitKnowledgeItems: vi.fn()
 }))
@@ -26,6 +27,10 @@ vi.mock('@renderer/hooks/useKnowledgeItems', () => ({
   useAddKnowledgeItems: vi.fn()
 }))
 
+vi.mock('@renderer/services/ExportService', () => ({
+  getMessageTitle: mocks.getMessageTitle
+}))
+
 vi.mock('@renderer/utils/knowledge', () => ({
   CONTENT_TYPES: {
     TEXT: 'text',
@@ -39,7 +44,7 @@ vi.mock('@renderer/utils/knowledge', () => ({
     IMAGES: 'images'
   },
   analyzeMessageContent: (message: MessageExportView & { testFiles?: FileMetadata[] }) => ({
-    text: 0,
+    text: message.parts.some((part) => part.type === 'text') ? 1 : 0,
     code: 0,
     thinking: 0,
     images: 0,
@@ -182,6 +187,7 @@ describe('SaveToKnowledgePopup', () => {
       text: '',
       files: message.testFiles ?? []
     }))
+    mocks.getMessageTitle.mockResolvedValue('All tools are working')
     ;(useKnowledgeBases as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       bases: [{ id: 'base-1', name: 'Knowledge Base', status: 'completed' }]
     })
@@ -266,6 +272,38 @@ describe('SaveToKnowledgePopup', () => {
       }
     ])
     await expect(promise).resolves.toEqual({ success: true, savedCount: 1 })
+  })
+
+  it('uses the readable message title as the note source', async () => {
+    const message = {
+      ...createMessageWithFiles([]),
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'All tools are working' }]
+    } as MessageExportView
+    mocks.processMessageContent.mockReturnValue({ text: 'All tools are working', files: [] })
+
+    render(<PopupHost />)
+    let promise!: ReturnType<typeof SaveToKnowledgePopup.showForMessage>
+    act(() => {
+      promise = SaveToKnowledgePopup.showForMessage(message)
+    })
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'common.save' })).not.toBeDisabled())
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+      await promise
+    })
+
+    expect(mocks.getMessageTitle).toHaveBeenCalledWith(message)
+    expect(mocks.submitKnowledgeItems).toHaveBeenCalledWith([
+      {
+        type: 'note',
+        data: {
+          source: 'All tools are working',
+          content: 'All tools are working'
+        }
+      }
+    ])
   })
 
   it('saves resolvable files and warns about failed files', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Saving a single assistant or agent message to a knowledge base used its opaque message ID as the note source name.

After this PR: Single-message saves reuse the existing readable message-title generator, with regression coverage for the submitted source name.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: When quick-model title naming is enabled, saving waits for the same asynchronous title generation already used by other message exports.

The following alternatives were considered: Deriving another title inside the knowledge popup or using a topic/session name was rejected because it would duplicate policy or may be unavailable for a single message.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Existing knowledge entries are not renamed; the fix applies to future saves. Focused regression test, `pnpm lint`, and `pnpm format` passed; the full test run was stopped at the requester's direction.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Saved assistant and agent messages now use readable knowledge base names instead of message IDs.
```
