### PR TITLE
fix(paintings): prevent image drag artifacts

### DIFF
--- a/src/renderer/pages/paintings/components/Artboard.tsx
+++ b/src/renderer/pages/paintings/components/Artboard.tsx
@@ -521,7 +521,9 @@ const Artboard: FC<ArtboardProps> = ({ painting, isLoading, imageCover }) => {
                 alt=""
                 data-testid="artboard-image-transform"
                 className={`max-h-full min-h-0 max-w-full select-none rounded-md object-contain ${
-                  isDraggingImage ? 'cursor-grabbing transition-none' : 'cursor-grab transition-transform duration-150'
+                  isDraggingImage
+                    ? 'cursor-grabbing transition-none will-change-transform'
+                    : 'cursor-grab transition-transform duration-150'
                 }`}
                 draggable={false}
                 onLoad={onDisplayedImageLoad}

--- a/src/renderer/pages/paintings/components/__tests__/Artboard.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/Artboard.test.tsx
@@ -646,6 +646,18 @@ describe('Artboard', () => {
     expect(transformTarget.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
   })
 
+  it('promotes the image to a compositor layer only while dragging', () => {
+    render(<Artboard painting={makePainting()} isLoading={false} />)
+
+    const image = document.querySelector('img') as HTMLImageElement
+
+    firePointer(image, 'pointerdown', { button: 0, clientX: 10, clientY: 10, pointerId: 1 })
+    expect(image).toHaveClass('will-change-transform')
+
+    firePointer(image, 'pointerup', { clientX: 10, clientY: 10, pointerId: 1 })
+    expect(image).not.toHaveClass('will-change-transform')
+  })
+
   it('disables zoom controls at image scale boundaries', () => {
     render(<Artboard painting={makePainting()} isLoading={false} />)
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Dragging a generated image in the Paintings artboard could leave repeated horizontal edge trails across the canvas.

After this PR:

The image is promoted to its own compositor layer while a pointer drag is active, preventing stale pixels from being left behind. The compositor hint is removed when the drag ends.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

Moving the transform from the artboard layout wrapper to the image exposed a Chromium repaint artifact during high-frequency pointer movement. Applying `will-change: transform` only for the active drag gives Chromium a stable compositor layer without permanently retaining a large image texture.

The following tradeoffs were made:

- The image temporarily consumes an additional compositor layer while it is being dragged.
- The hint is removed on pointer up or cancel to avoid ongoing GPU memory use.

The following alternatives were considered:

- Keeping `will-change: transform` enabled permanently, which would retain compositor resources while idle.
- Switching to a permanent 3D transform, which has the same persistent compositing cost.
- Replacing React state updates with imperative animation-frame updates, which is significantly more code for a rendering-layer issue.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm lint` passed. It reported 40 pre-existing warnings outside the changed files.
- Tests and interactive UI verification were not run at the submitter's request.
- A regression assertion verifies that the compositor hint is present only during an active drag.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix horizontal rendering artifacts that could appear while dragging generated images in Paintings.
```
