### PR TITLE
fix(code-cli): correct Windows launch quoting and batch env escaping

### DIFF
--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -7,6 +7,7 @@ import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecyc
 import { isMac, isWin } from '@main/core/platform'
 import { dedupePathSegments, mergeBinaryExecutionEnv } from '@main/utils/binaryEnv'
 import { getBundledGitDir } from '@main/utils/bundledGit'
+import { findExecutable } from '@main/utils/commandResolver'
 import { removeEnvProxy } from '@main/utils/processRunner'
 import { getRawShellEnv, getShellEnv } from '@main/utils/shellEnv'
 import { CODE_CLI_TOOL_PRESET_MAP } from '@shared/data/presets/codeCliTools'
@@ -452,46 +453,68 @@ export class CodeCliService extends BaseService {
     let terminalCommand: string
     let terminalArgs: string[]
 
-    // Build environment variable prefix (based on platform)
-    const buildEnvPrefix = (isWindows: boolean) => {
+    const logLaunchEnv = () => {
+      logger.info('Setting environment variables:', Object.keys(env))
+      logger.debug('Environment variable values:', sanitizeEnvForLogging(env))
+    }
+
+    /**
+     * One `set "KEY=value"` per line for the launcher .bat.
+     *
+     * Separate lines rather than one `&&` chain: a full Windows PATH plus the
+     * MISE_* block can exceed cmd.exe's ~8k per-line limit.
+     */
+    const buildWindowsEnvLines = (): string[] => {
+      if (Object.keys(env).length === 0) {
+        logger.info('No environment variables to set')
+        return []
+      }
+      logLaunchEnv()
+      return Object.entries(env).flatMap(([key, value]) => {
+        if (!isBatchQuotableEnvValue(value)) {
+          // Only a `"` or a newline can end the quoted value and turn the rest
+          // of the line into commands, and nothing Cherry sets here carries
+          // one. Drop it instead of inventing an escape cmd would not undo —
+          // the value still reaches the terminal through the spawn env.
+          logger.warn(`Skipping env var whose value cannot be quoted in the launch script: ${key}`)
+          return []
+        }
+        return [`set "${key}=${escapeBatchQuotedValue(value)}"`]
+      })
+    }
+
+    // Build the environment variable prefix for the POSIX shells (Windows
+    // assembles its own lines above).
+    const buildEnvPrefix = () => {
       if (Object.keys(env).length === 0) {
         logger.info('No environment variables to set')
         return ''
       }
 
-      logger.info('Setting environment variables:', Object.keys(env))
-      logger.debug('Environment variable values:', sanitizeEnvForLogging(env))
+      logLaunchEnv()
 
-      if (isWindows) {
-        // Windows uses set command
-        // Escape all cmd.exe metacharacters in env values to prevent command injection
-        return Object.entries(env)
-          .map(([key, value]) => `set "${key}=${escapeBatchText(value)}"`)
-          .join(' && ')
-      } else {
-        // Unix-like systems use export command
-        const validEntries = Object.entries(env).filter(([key, value]) => {
-          if (!key || key.trim() === '') {
-            return false
-          }
-          if (value === undefined || value === null) {
-            return false
-          }
-          return true
+      // Unix-like systems use export command
+      const validEntries = Object.entries(env).filter(([key, value]) => {
+        if (!key || key.trim() === '') {
+          return false
+        }
+        if (value === undefined || value === null) {
+          return false
+        }
+        return true
+      })
+
+      const envCommands = validEntries
+        .map(([key, value]) => {
+          const exportCmd = `export ${key}=${posixQuote(String(value))}`
+          logger.debug(`Setting env var: ${key}=<redacted>`)
+          return exportCmd
         })
-
-        const envCommands = validEntries
-          .map(([key, value]) => {
-            const exportCmd = `export ${key}=${posixQuote(String(value))}`
-            logger.debug(`Setting env var: ${key}=<redacted>`)
-            return exportCmd
-          })
-          .join(' && ')
-        const clearAmbientMise = usesCherryExecutionEnv
-          ? 'for _cherry_mise_key in $(env | sed -n \'s/^\\(MISE_[A-Za-z0-9_]*\\)=.*/\\1/p\'); do unset "$_cherry_mise_key"; done'
-          : ''
-        return [clearAmbientMise, envCommands].filter(Boolean).join(' && ')
-      }
+        .join(' && ')
+      const clearAmbientMise = usesCherryExecutionEnv
+        ? 'for _cherry_mise_key in $(env | sed -n \'s/^\\(MISE_[A-Za-z0-9_]*\\)=.*/\\1/p\'); do unset "$_cherry_mise_key"; done'
+        : ''
+      return [clearAmbientMise, envCommands].filter(Boolean).join(' && ')
     }
 
     const needsBatchCall = platform === 'win32' && ['.cmd', '.bat'].includes(path.extname(executablePath).toLowerCase())
@@ -553,7 +576,7 @@ export class CodeCliService extends BaseService {
     switch (platform) {
       case 'darwin': {
         // macOS - Support multiple terminals
-        const envPrefix = buildEnvPrefix(false)
+        const envPrefix = buildEnvPrefix()
 
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
 
@@ -572,8 +595,7 @@ export class CodeCliService extends BaseService {
       }
       case 'win32': {
         // Windows - Use temp bat file for debugging
-        const envPrefix = buildEnvPrefix(true)
-        const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
+        const envLines = buildWindowsEnvLines()
 
         // Create temp bat file for debugging and avoid complex command line escaping issues
         const tempDir = application.getPath('feature.cli.temp')
@@ -597,8 +619,8 @@ export class CodeCliService extends BaseService {
           `title ${cliTool} - Cherry Studio`,
           'echo ================================================',
           'echo Cherry Studio CLI Tool Launcher',
-          `echo Tool: ${CodeCliService.escapeBatchTextForEcho(cliTool)}`,
-          `echo Directory: ${CodeCliService.escapeBatchTextForEcho(directory)}`,
+          `echo Tool: ${escapeBatchUnquoted(cliTool)}`,
+          `echo Directory: ${escapeBatchUnquoted(directory)}`,
           `echo Time: ${new Date().toLocaleString()}`,
           'echo ================================================',
           '',
@@ -612,15 +634,16 @@ export class CodeCliService extends BaseService {
           ':: Clear screen before running CLI',
           'cls',
           '',
+          ...(envLines.length > 0 ? [':: Set environment variables', ...envLines, ''] : []),
           ':: Execute command',
-          command,
+          baseCommand,
           '',
           'goto :end',
           '',
           ':: Error handlers (using labels to ensure entire branch is conditional)',
           ':dir_missing',
           'echo ERROR: Directory does not exist',
-          `echo Target: ${CodeCliService.escapeBatchTextForEcho(directory)}`,
+          `echo Target: ${escapeBatchUnquoted(directory)}`,
           'pause',
           'exit /b 1',
           '',
@@ -698,7 +721,7 @@ export class CodeCliService extends BaseService {
       }
       case 'linux': {
         // Linux - Try to use common terminal emulators
-        const envPrefix = buildEnvPrefix(false)
+        const envPrefix = buildEnvPrefix()
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
 
         const linuxTerminals = ['gnome-terminal', 'konsole', 'deepin-terminal', 'xterm', 'x-terminal-emulator']
@@ -761,6 +784,26 @@ export class CodeCliService extends BaseService {
     if (platform === 'win32') appendBundledGitPathTail(processEnv)
     removeEnvProxy(processEnv)
 
+    // Windows launches the terminal executable directly rather than through a
+    // shell. With `shell: true` Node concatenates argv into one command line
+    // *without quoting* it (Node DEP0190), so a launcher path under
+    // `C:\Users\First Last\...` was split at the space and the terminal ran
+    // `C:\Users\First` instead. The shell was only carrying PATHEXT lookup —
+    // `wt` / `alacritty` / `wezterm` are passed without an extension — which
+    // findExecutable does explicitly, leaving Node to quote each argument.
+    if (platform === 'win32') {
+      const resolvedTerminal = findExecutable(terminalCommand, {
+        extensions: ['.exe', '.cmd', '.bat'],
+        env: processEnv
+      })
+      if (!resolvedTerminal) {
+        const message = `Terminal executable not found: ${terminalCommand}`
+        logger.error(message)
+        return { success: false, message }
+      }
+      terminalCommand = resolvedTerminal
+    }
+
     // Launch terminal process
     try {
       logger.info(`Launching terminal with command: ${terminalCommand}`)
@@ -773,7 +816,7 @@ export class CodeCliService extends BaseService {
         stdio: 'ignore',
         cwd: directory,
         env: processEnv,
-        shell: isWin
+        shell: false
       })
       // spawn() fails asynchronously (e.g. ENOENT when the fallback terminal is
       // missing); without a listener that becomes an uncaught exception after
@@ -798,31 +841,19 @@ export class CodeCliService extends BaseService {
       }
     }
   }
-
-  /**
-   * Escape text for safe use in batch echo statements
-   * Only handles critical issues: newlines and % characters
-   * Preserves command syntax (e.g., &&) - use for constructed command strings
-   * @param text - Raw text from command output or user input
-   * @returns Escaped text safe for batch echo statements
-   */
-  private static escapeBatchTextForEcho(text: string): string {
-    if (!text) return ''
-    return text
-      .replace(/%/g, '%%') // Escape % to avoid variable expansion
-      .replace(/\r\n/g, ' ') // Windows newline to space
-      .replace(/\n/g, ' ') // Unix newline to space
-  }
 }
 
 /**
- * Escape text for safe use in Windows batch files
- * Handles ALL cmd.exe metacharacters to prevent command injection
- * Use this for arbitrary untrusted input that may contain any characters
- * @param text - Raw text that may contain user input or error messages
- * @returns Fully escaped text safe for batch files
+ * Escape text embedded **unquoted** in a batch line — today only `echo`
+ * arguments. Carets escape the command metacharacters, which is what cmd.exe
+ * expects outside quotes: without it a directory named `Foo & Bar` makes the
+ * banner line run `Bar` as a command.
+ *
+ * Not interchangeable with `escapeBatchQuotedValue` — inside double quotes
+ * cmd.exe does not process carets, so this escaping would leak them into the
+ * value.
  */
-export function escapeBatchText(text: string): string {
+export function escapeBatchUnquoted(text: string): string {
   if (!text) return ''
   return text
     .replace(/\^/g, '^^') // Escape caret first (before other escapes)
@@ -831,7 +862,31 @@ export function escapeBatchText(text: string): string {
     .replace(/\|/g, '^|') // Escape | pipe
     .replace(/>/g, '^>') // Escape > output redirect
     .replace(/</g, '^<') // Escape < input redirect
-    .replace(/"/g, '""') // Escape double quotes to prevent echo injection
     .replace(/\r\n/g, ' ') // Windows newline to space
     .replace(/\n/g, ' ') // Unix newline to space
+}
+
+/**
+ * Escape a value for `set "KEY=<value>"` inside a batch file.
+ *
+ * Inside cmd.exe's double quotes `& | < >` are already literal and `^` is not
+ * an escape character, so caret-escaping them would leave the caret *in* the
+ * value — enough to break a PATH segment such as `C:\Dell & Co`. Only `%` has
+ * to be doubled, which the batch parser collapses back to one.
+ *
+ * Values that could break out of the quotes are rejected by
+ * `isBatchQuotableEnvValue`, never escaped.
+ */
+export function escapeBatchQuotedValue(value: string): string {
+  if (!value) return ''
+  return value.replace(/%/g, '%%')
+}
+
+/**
+ * Whether a value can be carried by `set "KEY=<value>"`. A `"` closes the
+ * quoted region and a newline ends the line, either of which would turn the
+ * remainder into commands.
+ */
+export function isBatchQuotableEnvValue(value: string): boolean {
+  return !/["\r\n]/.test(value)
 }

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -37,6 +37,11 @@ const bundledGitMock = vi.hoisted(() => ({
   getBundledGitPath: vi.fn(),
   getBundledGitDir: vi.fn()
 }))
+// Windows resolves the terminal executable itself instead of leaning on a
+// shell; default to echoing back a System32 path for whatever is asked.
+const commandResolverMock = vi.hoisted(() => ({
+  findExecutable: vi.fn((name: string): string | null => `C:\\Windows\\System32\\${name}.exe`)
+}))
 const childProcessMock = vi.hoisted(() => ({
   exec: vi.fn(),
   execFile: vi.fn(),
@@ -66,6 +71,10 @@ vi.mock('@main/utils/processRunner', () => ({
 vi.mock('@main/utils/shellEnv', () => ({
   getShellEnv: shellEnvMock.getShellEnv,
   getRawShellEnv: shellEnvMock.getRawShellEnv
+}))
+
+vi.mock('@main/utils/commandResolver', () => ({
+  findExecutable: commandResolverMock.findExecutable
 }))
 
 vi.mock('@main/utils/bundledGit', () => ({
@@ -664,9 +673,9 @@ describe('CodeCliService', () => {
 
         const launch = vi.mocked(spawn).mock.calls.at(-1)
         expect(launch).toBeDefined()
-        expect(launch![0]).toBe('cmd')
+        expect(launch![0]).toBe('C:\\Windows\\System32\\cmd.exe')
         expect(launch![1]).toEqual(['/c', batPath])
-        expect(launch![2]).toMatchObject({ shell: true, detached: true })
+        expect(launch![2]).toMatchObject({ detached: true })
       } finally {
         vi.useRealTimers()
       }
@@ -733,6 +742,85 @@ describe('CodeCliService', () => {
         // The user's own mise settings pass through untouched; Cherry's isolated
         // MISE_DATA_DIR must never redirect a system CLI's shims.
         expect(spawnEnv.MISE_DATA_DIR).toBe('C:\\Users\\me\\mise-data')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('keeps cmd metacharacters in a PATH segment out of the set lines', async () => {
+      // Regression: `set "Path=…"` quotes the value, and cmd.exe does not
+      // process carets inside quotes — caret-escaping `&` left the caret in
+      // PATH and killed the segment. A directory named `Dell & Co` is legal.
+      shellEnvMock.getRawShellEnv.mockResolvedValue({ Path: 'C:\\Dell & Co;C:\\Windows\\System32' })
+
+      vi.useFakeTimers()
+      try {
+        const fs = (await import('node:fs')).default
+        const { codeCliService } = await loadModules()
+
+        const result = await codeCliService.run({
+          mode: 'login-flow',
+          cliTool: CodeCli.CLAUDE_CODE,
+          directory: 'C:\\Users\\me\\proj'
+        })
+
+        expect(result.success).toBe(true)
+        const batContent = vi.mocked(fs.writeFileSync).mock.calls.at(-1)![1] as string
+        const pathLine = batContent.split('\r\n').find((line) => line.startsWith('set "Path='))
+        expect(pathLine).toBe('set "Path=/mock/binary-data/shims;C:\\Dell & Co;C:\\Windows\\System32"')
+        // One `set` per line: a full PATH plus the MISE_* block would otherwise
+        // risk cmd.exe's per-line length limit.
+        expect(batContent).not.toContain('" && set "')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('resolves the terminal executable so Node quotes a launcher path with spaces', async () => {
+      // Regression: `shell: true` makes Node concatenate argv without quoting
+      // (DEP0190), so a bat under `C:\Users\First Last\…` was split at the
+      // space. Resolving the terminal ourselves lets us spawn without a shell.
+      commandResolverMock.findExecutable.mockReturnValueOnce('C:\\Windows\\System32\\cmd.exe')
+
+      vi.useFakeTimers()
+      try {
+        const { spawn } = await import('child_process')
+        const { codeCliService } = await loadModules()
+
+        const result = await codeCliService.run({
+          mode: 'login-flow',
+          cliTool: CodeCli.CLAUDE_CODE,
+          directory: 'C:\\Users\\First Last\\proj'
+        })
+
+        expect(result.success).toBe(true)
+        const launch = vi.mocked(spawn).mock.calls.at(-1)!
+        expect(launch[0]).toBe('C:\\Windows\\System32\\cmd.exe')
+        expect(launch[2]).toMatchObject({ shell: false })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('reports a failure when the terminal executable cannot be resolved', async () => {
+      commandResolverMock.findExecutable.mockReturnValueOnce(null)
+
+      vi.useFakeTimers()
+      try {
+        const { spawn } = await import('child_process')
+        const { codeCliService } = await loadModules()
+
+        const result = await codeCliService.run({
+          mode: 'login-flow',
+          cliTool: CodeCli.CLAUDE_CODE,
+          directory: 'C:\\Users\\me\\proj'
+        })
+
+        expect(result).toMatchObject({
+          success: false,
+          message: expect.stringContaining('Terminal executable not found')
+        })
+        expect(spawn).not.toHaveBeenCalled()
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/services/codeCli/__tests__/codeCliService.helpers.test.ts
+++ b/src/main/services/codeCli/__tests__/codeCliService.helpers.test.ts
@@ -1,192 +1,222 @@
 import { describe, expect, it } from 'vitest'
 
-import { escapeBatchText } from '../CodeCliService'
+import { escapeBatchQuotedValue, escapeBatchUnquoted, isBatchQuotableEnvValue } from '../CodeCliService'
 import { sanitizeEnvForLogging } from '../envRedaction'
 
-describe('escapeBatchText', () => {
+describe('escapeBatchUnquoted', () => {
   it('preserves normal text without special characters', () => {
     const input = 'hello world'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('hello world')
   })
 
   it('converts Unix newlines to spaces', () => {
     const input = 'hello\nworld'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('hello world')
   })
 
   it('converts Windows newlines to spaces', () => {
     const input = 'hello\r\nworld'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('hello world')
   })
 
   it('escapes percent signs to prevent variable expansion', () => {
     const input = '100% complete'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('100%% complete')
   })
 
   it('handles multiple percent signs', () => {
     const input = 'user%username%path'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('user%%username%%path')
   })
 
   it('handles mixed newlines and percent signs', () => {
     const input = 'Resolving\ndependencies\n100% done'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('Resolving dependencies 100%% done')
   })
 
   it('returns empty string for empty input', () => {
     const input = ''
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('')
   })
 
   it('handles null-like values', () => {
     // @ts-expect-error - testing edge cases
-    expect(escapeBatchText(null)).toBe('')
+    expect(escapeBatchUnquoted(null)).toBe('')
     // @ts-expect-error - testing edge cases
-    expect(escapeBatchText(undefined)).toBe('')
+    expect(escapeBatchUnquoted(undefined)).toBe('')
   })
 
   it('handles whitespace-only input', () => {
-    expect(escapeBatchText('   ')).toBe('   ')
+    expect(escapeBatchUnquoted('   ')).toBe('   ')
   })
 
   it('handles npm error message with newlines', () => {
     const input = 'npm error code ECONNREFUSED\nResolving dependencies'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('npm error code ECONNREFUSED Resolving dependencies')
   })
 
   it('handles multiline error with percent in message', () => {
     const input = 'Error: 100% failed\nCheck %APPDATA%'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('Error: 100%% failed Check %%APPDATA%%')
   })
 
   // Chinese characters tests
   it('preserves Chinese characters in paths', () => {
     const input = 'C:\\用户\\张三\\文档'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('C:\\用户\\张三\\文档')
   })
 
   it('handles Chinese text with newlines', () => {
     const input = '安装路径：C:\\用户\\张三\n版本号：1.0'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('安装路径：C:\\用户\\张三 版本号：1.0')
   })
 
   it('handles Chinese text with percent signs', () => {
     const input = '进度：50%'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('进度：50%%')
   })
 
   // Path with spaces tests
   it('preserves spaces in paths', () => {
     const input = 'C:\\Program Files\\App'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('C:\\Program Files\\App')
   })
 
   it('handles paths with spaces and percent signs', () => {
     const input = 'C:\\Program Files\\50% off'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('C:\\Program Files\\50%% off')
   })
 
   // Real-world npm/bun error scenarios
   it('handles multiline npm error messages', () => {
     const input = 'npm WARN deprecated\nnpm ERR! code ENOENT'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('npm WARN deprecated npm ERR! code ENOENT')
   })
 
   it('handles multiline bun error messages', () => {
     const input = 'bun error\nResolving...'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('bun error Resolving...')
   })
 
   it('handles realistic npm update warning message', () => {
     const input = 'npm warn deprecated\nResolving dependency'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('npm warn deprecated Resolving dependency')
   })
 
   // Consecutive newlines test - each newline becomes a space
   it('converts each newline to a space (not collapsing)', () => {
     const input = 'line1\n\n\nline2'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('line1   line2')
   })
 
   // Mixed complex scenario
   it('handles complex Chinese path with spaces and newlines', () => {
     const input = 'C:\\Users\\张三\\My Documents\nVersion: 50%'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('C:\\Users\\张三\\My Documents Version: 50%%')
   })
 
   // Cmd metacharacter escaping tests (Review Bot concerns)
   it('escapes pipe character', () => {
     const input = 'error | pipe'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('error ^| pipe')
   })
 
   it('escapes output redirect character', () => {
     const input = 'error > file'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('error ^> file')
   })
 
   it('escapes input redirect character', () => {
     const input = 'error < file'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('error ^< file')
   })
 
   it('escapes caret character', () => {
     const input = 'path^file'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('path^^file')
   })
 
   it('escapes command separator ampersand', () => {
     const input = 'cmd1 & cmd2'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('cmd1 ^& cmd2')
   })
 
   it('escapes multiple cmd metacharacters', () => {
     const input = 'error & | > <'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('error ^& ^| ^> ^<')
-  })
-
-  it('escapes double quotes to prevent echo injection', () => {
-    const input = 'npm error "ECONNREFUSED"'
-    const result = escapeBatchText(input)
-    expect(result).toBe('npm error ""ECONNREFUSED""')
   })
 
   it('escapes real npm error with pipe character', () => {
     const input = 'npm ERR! command failed | npm ERR! path'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('npm ERR! command failed ^| npm ERR! path')
   })
 
   it('escapes bun error with redirect character', () => {
     const input = 'bun error > debug.log'
-    const result = escapeBatchText(input)
+    const result = escapeBatchUnquoted(input)
     expect(result).toBe('bun error ^> debug.log')
+  })
+})
+
+describe('escapeBatchQuotedValue', () => {
+  it('doubles percent signs so the batch parser yields one', () => {
+    expect(escapeBatchQuotedValue('C:\\Tools\\100% cli')).toBe('C:\\Tools\\100%% cli')
+  })
+
+  // Regression: cmd.exe does not process carets inside double quotes, so the
+  // generic (unquoted) escaping left a literal `^` in the value and broke the
+  // PATH segment it was meant to protect.
+  it('leaves cmd metacharacters untouched — inside quotes they are already literal', () => {
+    expect(escapeBatchQuotedValue('C:\\Dell & Co;C:\\a|b;C:\\c^d;C:\\e<f>g')).toBe(
+      'C:\\Dell & Co;C:\\a|b;C:\\c^d;C:\\e<f>g'
+    )
+  })
+
+  it('preserves spaces and non-ASCII path segments', () => {
+    expect(escapeBatchQuotedValue('C:\\用户\\张三\\Program Files')).toBe('C:\\用户\\张三\\Program Files')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(escapeBatchQuotedValue('')).toBe('')
+  })
+})
+
+describe('isBatchQuotableEnvValue', () => {
+  it('accepts values that cannot break out of the quoted set', () => {
+    expect(isBatchQuotableEnvValue('C:\\Dell & Co;C:\\Windows')).toBe(true)
+    expect(isBatchQuotableEnvValue('100% done')).toBe(true)
+  })
+
+  it('rejects values carrying a quote or a newline', () => {
+    expect(isBatchQuotableEnvValue('a"b')).toBe(false)
+    expect(isBatchQuotableEnvValue('a\nb')).toBe(false)
+    expect(isBatchQuotableEnvValue('a\r\nb')).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes part of #788 — see the scope note below.

## What

Make image input work for models that cannot see, and make Web single-chat attachments reach the model reliably.

Six commits, each independently reviewable:

1. **`1ed2a396` — three-state image capability.** `ProviderModel.Input` was a dead config field: nothing ever wrote it into `ai.Model`, so `SupportsImage()` always returned `true` and the read tool's Xberg fallback was unreachable code. It now flows `ProviderModel.Input → Snapshot.ModelInputs → ai.Model.Input`, and `SupportsImage()` is replaced by a three-valued `ImageCapability()` (`supported` / `unsupported` / `unknown`).

2. **`83befa9b` — vision service.** A new optional vision model plus `internal/vision`, which renders an image as text (transcription + a short scene description). It degrades vision model, then Xberg extraction, then error. Two callers share it: the `read` tool, and a new request-time materializer in the agent loop that rewrites inline images (channel photos, tool results) into text just before the request goes out.

3. **`9c0a9d49` — Web structured file parts.** The composer sends a `file` part instead of flattening the upload into a `[file: path]` line; the server resolves it through the session's authorized workspace access and attaches the image itself.

4. **`c7a4bc07` — the vision model is deployment-wide.** Commit 2 introduced it as a per-agent tier; this moves it to one admin setting. Reading an image is infrastructure, not personality — there is no reason for two agents in one deployment to transcribe the same screenshot differently, and a per-agent tier meant every newly created agent silently started blind.

5. **`652df8f1` — new custom models no longer declare `input: text`.** That default was inert when `input` was ignored; under three-state capability it means "cannot see", so every hand-added model would have declared itself image-blind.

6. **`1e826e15` — undeclared capability no longer fails open.** See below.

## Why

Image handling had two independent holes.

**Capability was never actually known.** Because `Input` never reached the runtime, every model was treated as vision-capable. Text-only models received inline base64 they could not read, and the fallback built for exactly that case never ran.

**Web uploads were a hint, not content.** An attachment became the text `[file: /path]`, so the model saw an image only if it decided to call `read` on that path. It frequently did not.

## How

**Capability.** The first version of this PR let `unknown` fail open, on the theory that most current models are multimodal. A live test killed that theory: the provider answered with an `[Unsupported Image]` placeholder, and the agent spent ten turns hand-parsing the PNG header in `bash` before loading the xberg skill on its own initiative. Providers do not report modalities through `ListModels`, so **undeclared is the common case, not the rare one**, and guessing "can see" is a wasted turn every time it is wrong.

So the ladder is explicit, and identical for an image the agent opens and an image the user uploads:

1. the answering model itself, if its `Input` declares `image`;
2. the vision model;
3. Xberg text extraction.

The runtime probe-and-retry design from #788 is still **not** implemented: it depends on high-confidence per-provider error classification, which is the most complex and least certain part of that proposal. Declaring `text, image` on a model is one field in the Provider UI and restores full fidelity.

**Where the vision model lives.** It is stored in the `app_setting` singleton that the embedding, runner, compaction and scheduler settings already use, so it needs no schema change; the unmerged `agent.model_vision` migration is dropped rather than paired with a revert, since the column never reached `main`. `Snapshot.ModelVision` stays and is filled from the global setting, which leaves tier resolution, `ResolveVisionModel` and `vision.NewFromSnapshot` untouched. A deployment-wide ref has no agent to infer a provider from, so the write path requires the `provider/model` form. The endpoint is `/api/vision-settings`, admin-only and bearer-denied, mirroring `/api/embedding-settings`.

**Vision service.** Renderings are memoized by image content (sha256) for the life of a runner, so an image recurring on every turn of a loop is described once; failures are cached too, since re-paying a 60s timeout each turn costs more than a stale failure. The decode budget (30 MiB input, 50 MP, inline ceiling) is shared by every path, so an oversized or hostile image cannot reach a decoder through any door. The system prompt states that text inside an image is data, never instructions.

**Materialization.** Runs only when the model's config explicitly says it cannot accept images. It copies on write and never touches persisted history, so switching to a vision model later still sees the original images. `supported` and `unknown` requests are untouched.

**Web file parts.** Resolution goes through `access.ReadWorkspacePath(Raw: true)`, the same authorized path the workspace endpoints use, so an attachment reference can only reach files the caller may already read. The `[file: path]` marker is still stored beside the image — the transcript renders attachments by parsing it — so live and reloaded messages look exactly as before. Uploads that cannot be read, are not images, or exceed the inline ceiling degrade to the marker alone rather than failing the send. The client's declared MIME is advisory; detection is from the bytes.

## Scope note on #788

The issue's situation analysis predates #786 and #789 and is partly stale; its group-message storage design also conflicts with what #789 actually merged. Details are in a separate comment on the issue. This PR implements the capability and image-understanding parts with the revisions above. Still open from #788, deliberately not in this PR:

- Web group chat still borrows the first member agent's temporary DM session for uploads, and the group send API still accepts only a string — so #789's `content_blocks` channel is a no-op for Web groups.
- History rendering of image blocks in the transcript (a separate vertical through the access layer, API spec, and frontend types). Display behavior is unchanged by this PR, so nothing regresses.

## Behavior change to note in the release

**This one needs to be prominent in the release notes.** `input` was previously ignored entirely, so every model received images inline. Now only a model whose `input` declares `image` does.

Every deployment that has not declared modalities — which, since `ListModels` does not report them, is most of them — will see multimodal models start receiving transcriptions instead of images until an admin sets **Input** to `text, image` on those models under Settings → Providers. That is the intended trade: a wasted turn against a blank placeholder costs more than a transcription, and the fix is one field.

Two things soften the edge: the substitution note tells the model what happened and why, and a vision model configured under Settings → Vision makes the fallback a real description rather than bare OCR.

## Testing

`mise run format && mise run build && mise run test` — all green, zero Go test failures.

New coverage:

- Three-state derivation, and a loop-level test asserting the vision flag the tools actually observe for each state (supported inlines; text-only and undeclared both render).
- Vision service: model path, model-fails-to-Xberg, no-model-straight-to-Xberg, both-fail-errors, budget rejection before any backend, memoization of successes and failures, nil-service fallback.
- Materializer: images survive only for a declared-`image` model, are rendered for text-only and undeclared ones, history slice not mutated in place, memo effective.
- Vision settings: load/save round-trip, unset means no model, trimmed refs, corrupt row surfaces an error, and the control-plane write rejects `gpt-4o` / `openai/` / `/gpt-4o` without persisting.
- Provider form defaults, in the frontend suite's first tests. `vp test` had a working runner but no test files and was wired into nothing, so `mise run test` now runs it after the Go suite.
- File parts: image inlined, MIME detected from bytes rather than the client's claim, non-image and unreadable and oversized uploads all keep the marker alone.

## Follow-ups (not blocking)

- A hook that swaps the model only overrides `Name`, not `Input`, so capability follows the original model's declaration.
- Provider `ListModels` does not report modalities, so `input` must be set by hand in the Provider UI. This is now load-bearing rather than cosmetic, and is the obvious next thing to fix — seeding `input` from a known-model catalogue would remove the manual step for common models.
