### PR TITLE
fix(quick-assistant): stop settings preview from auto-reading clipboard

### DIFF
--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -221,7 +221,7 @@ const QuickAssistantSettings: FC = () => {
       )}
       {enableQuickAssistant && (
         <div className="mx-auto mt-5 h-115 w-full overflow-hidden rounded-[10px] border-[0.5px] border-border bg-background">
-          <HomeWindow draggable={false} />
+          <HomeWindow draggable={false} autoReadClipboard={false} />
         </div>
       )}
     </SettingsContentColumn>

--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -244,7 +244,7 @@ const QuickAssistantSettings: FC = () => {
       )}
       {enableQuickAssistant && (
         <div className="mx-auto mt-5 h-115 w-full overflow-hidden rounded-[10px] border-[0.5px] border-border bg-background">
-          <HomeWindow draggable={false} />
+          <HomeWindow draggable={false} autoReadClipboard={false} />
         </div>
       )}
     </SettingsContentColumn>

--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -78,7 +78,10 @@ export const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessa
   })
 }
 
-const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
+const HomeWindow: FC<{ draggable?: boolean; autoReadClipboard?: boolean }> = ({
+  draggable = true,
+  autoReadClipboard = true
+}) => {
   const [readClipboardAtStartup] = usePreference('feature.quick_assistant.read_clipboard_at_startup')
   const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
   const [windowStyle] = usePreference('ui.window_style')
@@ -290,8 +293,10 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   useIpcOn('quick_assistant.shown', onWindowShow)
 
   useEffect(() => {
-    void readClipboard()
-  }, [readClipboard])
+    // The embedded settings preview must not read on mount, or merely enabling
+    // the quick assistant would silently expose clipboard contents.
+    if (autoReadClipboard) void readClipboard()
+  }, [autoReadClipboard, readClipboard])
 
   const handleCloseWindow = useCallback(() => ipcApi.request('quick_assistant.hide'), [])
 

--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -75,7 +75,10 @@ const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] =>
   })
 }
 
-const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
+const HomeWindow: FC<{ draggable?: boolean; autoReadClipboard?: boolean }> = ({
+  draggable = true,
+  autoReadClipboard = true
+}) => {
   const [readClipboardAtStartup] = usePreference('feature.quick_assistant.read_clipboard_at_startup')
   const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
   const [windowStyle] = usePreference('ui.window_style')
@@ -286,8 +289,11 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   useIpcOn('quick_assistant.shown', onWindowShow)
 
   useEffect(() => {
-    void readClipboard()
-  }, [readClipboard])
+    // Real mini window reads on mount; the embedded settings preview must not,
+    // or merely enabling the quick assistant would silently expose clipboard
+    // contents. Reading on a genuine `quick_assistant.shown` is unaffected.
+    if (autoReadClipboard) void readClipboard()
+  }, [autoReadClipboard, readClipboard])
 
   const handleCloseWindow = useCallback(() => ipcApi.request('quick_assistant.hide'), [])
 

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom/vitest'
 
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -16,6 +16,7 @@ type TestModel = {
 
 const state = vi.hoisted(() => ({
   quickAssistantId: '',
+  readClipboardAtStartup: false,
   defaultModel: {
     id: 'cherryai::qwen',
     modelId: 'qwen',
@@ -60,7 +61,7 @@ vi.mock('@ai-sdk/react', () => ({
 vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
     const values: Record<string, unknown> = {
-      'feature.quick_assistant.read_clipboard_at_startup': false,
+      'feature.quick_assistant.read_clipboard_at_startup': state.readClipboardAtStartup,
       'feature.quick_assistant.assistant_id': state.quickAssistantId,
       'app.language': 'en-US',
       'ui.window_style': 'default'
@@ -222,6 +223,7 @@ describe('HomeWindow', () => {
       providerId: 'anthropic',
       group: 'Anthropic'
     }
+    state.readClipboardAtStartup = false
     state.sendMessage.mockClear()
     state.stopChat.mockClear()
     state.setMessages.mockClear()
@@ -259,5 +261,37 @@ describe('HomeWindow', () => {
 
     expect(screen.getByTestId('quick-input')).toHaveValue('hello')
     expect(screen.queryByTestId('clipboard-preview')).not.toBeInTheDocument()
+  })
+
+  describe('clipboard read on mount', () => {
+    let readText: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      state.readClipboardAtStartup = true
+      readText = vi.fn().mockResolvedValue('secret-token')
+      // jsdom ships no navigator.clipboard, so define it before the window mounts.
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { readText },
+        configurable: true,
+        writable: true
+      })
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    })
+
+    it('reads the clipboard on mount for the real window', async () => {
+      render(<HomeWindow />)
+
+      await waitFor(() => expect(readText).toHaveBeenCalled())
+      expect(await screen.findByTestId('clipboard-preview')).toHaveTextContent('secret-token')
+    })
+
+    it('does not read the clipboard on mount for the settings preview', async () => {
+      render(<HomeWindow draggable={false} autoReadClipboard={false} />)
+
+      // Give any stray mount effect a chance to fire before asserting.
+      await Promise.resolve()
+      expect(readText).not.toHaveBeenCalled()
+      expect(screen.queryByTestId('clipboard-preview')).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
@@ -1,11 +1,12 @@
 import '@testing-library/jest-dom/vitest'
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({
   quickAssistantId: '',
+  readClipboardAtStartup: false,
   defaultModel: {
     id: 'cherryai::qwen',
     modelId: 'qwen',
@@ -43,7 +44,7 @@ vi.mock('@ai-sdk/react', () => ({
 vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
     const values: Record<string, unknown> = {
-      'feature.quick_assistant.read_clipboard_at_startup': false,
+      'feature.quick_assistant.read_clipboard_at_startup': state.readClipboardAtStartup,
       'feature.quick_assistant.assistant_id': state.quickAssistantId,
       'app.language': 'en-US',
       'ui.window_style': 'default'
@@ -144,6 +145,7 @@ vi.mock('../../translate/TranslateWindow', () => ({
 describe('HomeWindow', () => {
   beforeEach(() => {
     state.quickAssistantId = ''
+    state.readClipboardAtStartup = false
     state.sendMessage.mockClear()
     state.stopChat.mockClear()
     state.setMessages.mockClear()
@@ -165,5 +167,37 @@ describe('HomeWindow', () => {
 
     expect(screen.getByTestId('quick-input')).toHaveValue('hello')
     expect(screen.queryByTestId('clipboard-preview')).not.toBeInTheDocument()
+  })
+
+  describe('clipboard read on mount', () => {
+    let readText: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      state.readClipboardAtStartup = true
+      readText = vi.fn().mockResolvedValue('secret-token')
+      // jsdom ships no navigator.clipboard, so define it before the window mounts.
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { readText },
+        configurable: true,
+        writable: true
+      })
+      vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    })
+
+    it('reads the clipboard on mount for the real window', async () => {
+      render(<HomeWindow />)
+
+      await waitFor(() => expect(readText).toHaveBeenCalled())
+      expect(await screen.findByTestId('clipboard-preview')).toHaveTextContent('secret-token')
+    })
+
+    it('does not read the clipboard on mount for the settings preview', async () => {
+      render(<HomeWindow draggable={false} autoReadClipboard={false} />)
+
+      // Give any stray mount effect a chance to fire before asserting.
+      await Promise.resolve()
+      expect(readText).not.toHaveBeenCalled()
+      expect(screen.queryByTestId('clipboard-preview')).not.toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

Enabling the Quick Assistant from **Settings → Quick Assistant** immediately reads the system clipboard and pre-fills its content into the assistant input — before the user has clicked the tray icon, pressed the shortcut, or otherwise launched the assistant. The settings page embeds a live `<HomeWindow>` preview, and `HomeWindow` reads the clipboard on mount whenever `read_clipboard_at_startup` (default `true`) is on and the window has focus. Since the settings window holds focus, merely toggling the feature on silently surfaces whatever is on the clipboard — potentially a token, password, or other sensitive text.

After this PR:

The embedded settings preview no longer reads the clipboard on mount. A new `autoReadClipboard` prop (default `true`) gates the mount-time read; `QuickAssistantSettings` passes `autoReadClipboard={false}` for the preview. The real Quick Assistant mini window is unaffected — it still reads the clipboard on a genuine `quick_assistant.shown` IPC event when the user actually opens it.

Fixes # N/A — reported via internal V2 preview bug-bash (no public issue).

### Why we need it and why it was done in this way

The auto-fill is intended for the real mini window when the user deliberately opens it. The settings preview reuses the same `HomeWindow` component purely for visual preview, so it should not trigger the clipboard side effect.

An explicit `autoReadClipboard` prop is clearer than overloading the existing `draggable` flag (which happens to already distinguish preview from real window), and it keeps the two concerns — drag region vs. clipboard side effect — independent.

The following alternatives were considered:
- Reusing `draggable` as the gate: rejected — couples two unrelated behaviors and reads as an accidental side effect.

### Breaking changes

None. The only user-visible change is that the settings preview's input starts empty instead of pre-filled — no layout or styling change. The real Quick Assistant's clipboard behavior is unchanged.

### Special notes for your reviewer

Reported via V2 preview bug-bash (Codex Computer Use test run, macOS). Repro: disable Quick Assistant → copy any text → Settings → Quick Assistant → toggle "Enable Quick Assistant" on → the preview previously expanded with the clipboard text already filled in; now it stays empty.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix a privacy issue where enabling the Quick Assistant in Settings would immediately read the clipboard and pre-fill its contents into the embedded preview before the assistant was actually opened.
```
