### PR TITLE
fix(knowledge): use regional Jina reader for URL imports

### DIFF
--- a/src/main/features/knowledge/KnowledgeService.ts
+++ b/src/main/features/knowledge/KnowledgeService.ts
@@ -268,7 +268,7 @@ function scanConceptMatches(
 
 @Injectable('KnowledgeService')
 @ServicePhase(Phase.WhenReady)
-@DependsOn(['KnowledgeVectorStoreService', 'JobManager', 'FileProcessingService'])
+@DependsOn(['KnowledgeVectorStoreService', 'JobManager', 'FileProcessingService', 'WebSearchService'])
 export class KnowledgeService extends BaseService {
   private readonly knowledgeLockManager = new KnowledgeLockManager()
   private readonly workflowService = new KnowledgeWorkflowService(this.knowledgeLockManager)

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -385,7 +385,8 @@ describe('KnowledgeService', () => {
     expect(getDependencies(KnowledgeService)).toEqual([
       'KnowledgeVectorStoreService',
       'JobManager',
-      'FileProcessingService'
+      'FileProcessingService',
+      'WebSearchService'
     ])
   })
 

--- a/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
@@ -433,7 +433,8 @@ describe('index-documents job handler', () => {
       'kb-1',
       'https://example.com',
       '# Example page\n\nbody text',
-      expect.any(Set)
+      expect.any(Set),
+      'Example Page'
     )
     expect(knowledgeItemUpdateSnapshotRelativePathMock).toHaveBeenCalledWith('url-1', 'url', 'example-page.md')
     // The reader receives the item carrying the freshly captured snapshot path.
@@ -484,7 +485,7 @@ describe('index-documents job handler', () => {
   it('fails the index when a URL fetch returns empty markdown', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
     knowledgeItemGetByIdMock.mockReturnValue(createUrlItem('url-1'))
-    fetchKnowledgeWebPageMock.mockResolvedValueOnce('')
+    fetchKnowledgeWebPageMock.mockResolvedValueOnce({ title: 'Empty Page', markdown: '' })
 
     await expect(handler.execute(createCtx({ baseId: 'kb-1', itemId: 'url-1', parentJobId: null }))).rejects.toThrow(
       'empty markdown'

--- a/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
+++ b/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
@@ -360,7 +360,10 @@ beforeEach(() => {
   knowledgeItemGetItemsByBaseIdMock.mockReturnValue([])
   knowledgeItemSetSubtreeStatusMock.mockReturnValue([])
   knowledgeItemUpdateStatusMock.mockReturnValue(createNoteItem())
-  fetchKnowledgeWebPageMock.mockResolvedValue('# Example page\n\nbody text')
+  fetchKnowledgeWebPageMock.mockResolvedValue({
+    title: 'Example Page',
+    markdown: '# Example page\n\nbody text'
+  })
   captureUrlSnapshotFileMock.mockResolvedValue('example-page.md')
   captureNoteSnapshotFileMock.mockResolvedValue('note-snapshot.md')
   knowledgeItemUpdateSnapshotRelativePathMock.mockImplementation(

--- a/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
+++ b/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
@@ -178,10 +178,10 @@ async function readItemDocuments(
 
 type SnapshotCaptureSpec = {
   type: 'url' | 'note'
-  /** Produce the snapshot markdown OUTSIDE the base mutation lock; rejects empty input. */
-  produce: (signal: AbortSignal) => Promise<string>
-  /** Write the produced markdown to a base file under the lock, returning its relativePath. */
-  capture: (markdown: string, reservedPaths: Set<string>) => Promise<string>
+  /** Produce snapshot content OUTSIDE the base mutation lock; rejects empty input. */
+  produce: (signal: AbortSignal) => Promise<{ markdown: string; title?: string }>
+  /** Write the produced snapshot to a base file under the lock, returning its relativePath. */
+  capture: (snapshot: { markdown: string; title?: string }, reservedPaths: Set<string>) => Promise<string>
 }
 
 /**
@@ -198,13 +198,14 @@ function resolveSnapshotCaptureSpec(item: IndexableKnowledgeItem): SnapshotCaptu
     return {
       type: 'url',
       produce: async (signal) => {
-        const markdown = await fetchKnowledgeWebPage(url, signal)
-        if (!markdown) {
+        const page = await fetchKnowledgeWebPage(url, signal)
+        if (!page.markdown) {
           throw new Error(`Knowledge URL returned empty markdown: ${url}`)
         }
-        return markdown
+        return page
       },
-      capture: (markdown, reservedPaths) => captureUrlSnapshotFile(baseId, url, markdown, reservedPaths)
+      capture: ({ markdown, title }, reservedPaths) =>
+        captureUrlSnapshotFile(baseId, url, markdown, reservedPaths, title)
     }
   }
 
@@ -221,9 +222,9 @@ function resolveSnapshotCaptureSpec(item: IndexableKnowledgeItem): SnapshotCaptu
         if (content.trim() === '') {
           throw new Error(`Knowledge note has empty content: ${source}`)
         }
-        return content
+        return { markdown: content }
       },
-      capture: (markdown, reservedPaths) => captureNoteSnapshotFile(baseId, source, markdown, reservedPaths)
+      capture: ({ markdown }, reservedPaths) => captureNoteSnapshotFile(baseId, source, markdown, reservedPaths)
     }
   }
 
@@ -249,7 +250,7 @@ async function ensureSnapshot(
     return item
   }
 
-  const markdown = await spec.produce(ctx.signal)
+  const snapshot = await spec.produce(ctx.signal)
 
   return await knowledgeLockManager.withBaseMutationLock(ctx.input.baseId, async () => {
     const latest = knowledgeItemService.getById(ctx.input.itemId)
@@ -258,7 +259,7 @@ async function ensureSnapshot(
       return isIndexableKnowledgeItem(latest) ? latest : item
     }
     const reservedPaths = collectKnowledgeReservedRelativePaths(knowledgeItemService.getItemsByBaseId(ctx.input.baseId))
-    const relativePath = await spec.capture(markdown, reservedPaths)
+    const relativePath = await spec.capture(snapshot, reservedPaths)
     const updated = knowledgeItemService.updateSnapshotRelativePath(ctx.input.itemId, spec.type, relativePath)
     return isIndexableKnowledgeItem(updated) ? updated : item
   })

--- a/src/main/features/knowledge/utils/sources/__tests__/url.test.ts
+++ b/src/main/features/knowledge/utils/sources/__tests__/url.test.ts
@@ -22,14 +22,18 @@ vi.mock('@logger', () => ({
 
 const { fetchKnowledgeWebPage } = await import('../url')
 
-function fetchResponse(url: string, content: string) {
+function fetchResponse(url: string, content: string, title: string = url) {
   return {
     query: url,
     providerId: 'jina',
     capability: 'fetchUrls',
     inputs: [url],
-    results: [{ title: url, content, url, sourceInput: url }]
+    results: [{ title, content, url, sourceInput: url }]
   }
+}
+
+function fetchedPage(url: string, markdown: string, title: string = url) {
+  return { title, markdown }
 }
 
 function createDeferred<T>() {
@@ -51,13 +55,13 @@ describe('fetchKnowledgeWebPage', () => {
 
   it('fetches a page and returns markdown content', async () => {
     fetchUrlsUnprocessedMock.mockResolvedValue(
-      fetchResponse('https://example.com', '# Example Page\n\nHello knowledge')
+      fetchResponse('https://example.com', '# Example Page\n\nHello knowledge', 'Example Page')
     )
 
     const controller = new AbortController()
 
-    await expect(fetchKnowledgeWebPage('https://example.com', controller.signal)).resolves.toBe(
-      '# Example Page\n\nHello knowledge'
+    await expect(fetchKnowledgeWebPage('https://example.com', controller.signal)).resolves.toEqual(
+      fetchedPage('https://example.com', '# Example Page\n\nHello knowledge', 'Example Page')
     )
 
     expect(fetchUrlsUnprocessedMock).toHaveBeenCalledWith(
@@ -136,7 +140,13 @@ describe('fetchKnowledgeWebPage', () => {
     deferredResponses[3].resolve(fetchResponse('https://example.com/4', 'page 4'))
     deferredResponses[4].resolve(fetchResponse('https://example.com/5', 'page 5'))
 
-    await expect(Promise.all(requests)).resolves.toEqual(['page 1', 'page 2', 'page 3', 'page 4', 'page 5'])
+    await expect(Promise.all(requests)).resolves.toEqual([
+      fetchedPage('https://example.com/1', 'page 1'),
+      fetchedPage('https://example.com/2', 'page 2'),
+      fetchedPage('https://example.com/3', 'page 3'),
+      fetchedPage('https://example.com/4', 'page 4'),
+      fetchedPage('https://example.com/5', 'page 5')
+    ])
     expect(maxActiveFetches).toBeLessThanOrEqual(3)
   })
 
@@ -176,7 +186,11 @@ describe('fetchKnowledgeWebPage', () => {
     deferredResponses[1].resolve(fetchResponse('https://example.com/2', 'page 2'))
     deferredResponses[2].resolve(fetchResponse('https://example.com/3', 'page 3'))
 
-    await expect(Promise.all(activeRequests)).resolves.toEqual(['page 1', 'page 2', 'page 3'])
+    await expect(Promise.all(activeRequests)).resolves.toEqual([
+      fetchedPage('https://example.com/1', 'page 1'),
+      fetchedPage('https://example.com/2', 'page 2'),
+      fetchedPage('https://example.com/3', 'page 3')
+    ])
     expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(3)
     timeoutSpy.mockRestore()
   })

--- a/src/main/features/knowledge/utils/sources/__tests__/url.test.ts
+++ b/src/main/features/knowledge/utils/sources/__tests__/url.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const fetchMock = vi.hoisted(() => vi.fn())
+const fetchUrlsUnprocessedMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    WebSearchService: { fetchUrlsUnprocessed: fetchUrlsUnprocessedMock }
+  } as never)
+})
 
 vi.mock('@logger', () => ({
   loggerService: {
@@ -13,13 +20,17 @@ vi.mock('@logger', () => ({
   }
 }))
 
-vi.mock('electron', () => ({
-  net: {
-    fetch: fetchMock
-  }
-}))
-
 const { fetchKnowledgeWebPage } = await import('../url')
+
+function fetchResponse(url: string, content: string) {
+  return {
+    query: url,
+    providerId: 'jina',
+    capability: 'fetchUrls',
+    inputs: [url],
+    results: [{ title: url, content, url, sourceInput: url }]
+  }
+}
 
 function createDeferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void
@@ -35,11 +46,13 @@ function createDeferred<T>() {
 describe('fetchKnowledgeWebPage', () => {
   beforeEach(() => {
     vi.useRealTimers()
-    fetchMock.mockReset()
+    fetchUrlsUnprocessedMock.mockReset()
   })
 
   it('fetches a page and returns markdown content', async () => {
-    fetchMock.mockResolvedValue(new Response('# Example Page\n\nHello knowledge', { status: 200 }))
+    fetchUrlsUnprocessedMock.mockResolvedValue(
+      fetchResponse('https://example.com', '# Example Page\n\nHello knowledge')
+    )
 
     const controller = new AbortController()
 
@@ -47,15 +60,9 @@ describe('fetchKnowledgeWebPage', () => {
       '# Example Page\n\nHello knowledge'
     )
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://r.jina.ai/https://example.com',
-      expect.objectContaining({
-        signal: expect.any(AbortSignal),
-        headers: {
-          'X-Retain-Images': 'none',
-          'X-Return-Format': 'markdown'
-        }
-      })
+    expect(fetchUrlsUnprocessedMock).toHaveBeenCalledWith(
+      { providerId: 'jina', urls: ['https://example.com'] },
+      { signal: expect.any(AbortSignal) }
     )
   })
 
@@ -64,15 +71,13 @@ describe('fetchKnowledgeWebPage', () => {
     controller.abort(new Error('fetch aborted'))
 
     await expect(fetchKnowledgeWebPage('https://example.com', controller.signal)).rejects.toThrow('fetch aborted')
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchUrlsUnprocessedMock).not.toHaveBeenCalled()
   })
 
-  it('throws on non-ok upstream responses', async () => {
-    fetchMock.mockResolvedValue(new Response('nope', { status: 500 }))
+  it('propagates upstream fetch failures', async () => {
+    fetchUrlsUnprocessedMock.mockRejectedValue(new Error('Jina Reader fetch failed: HTTP 500'))
 
-    await expect(fetchKnowledgeWebPage('https://example.com')).rejects.toThrow(
-      'Failed to fetch knowledge web page https://example.com: HTTP 500'
-    )
+    await expect(fetchKnowledgeWebPage('https://example.com')).rejects.toThrow('Jina Reader fetch failed: HTTP 500')
   })
 
   it('rejects unsupported protocols before dispatching the request', async () => {
@@ -80,16 +85,16 @@ describe('fetchKnowledgeWebPage', () => {
       'Invalid knowledge url: file:///etc/passwd'
     )
 
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(fetchUrlsUnprocessedMock).not.toHaveBeenCalled()
   })
 
   it('limits concurrent upstream web fetches through a shared queue', async () => {
     let activeFetches = 0
     let maxActiveFetches = 0
-    const deferredResponses = Array.from({ length: 5 }, () => createDeferred<Response>())
+    const deferredResponses = Array.from({ length: 5 }, () => createDeferred<ReturnType<typeof fetchResponse>>())
     let fetchCallIndex = 0
 
-    fetchMock.mockImplementation(async () => {
+    fetchUrlsUnprocessedMock.mockImplementation(async () => {
       const deferred = deferredResponses[fetchCallIndex]
       fetchCallIndex += 1
       if (!deferred) {
@@ -115,21 +120,21 @@ describe('fetchKnowledgeWebPage', () => {
     ]
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(3)
       expect(activeFetches).toBe(3)
     })
 
-    deferredResponses[0].resolve(new Response('page 1', { status: 200 }))
+    deferredResponses[0].resolve(fetchResponse('https://example.com/1', 'page 1'))
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(4)
+      expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(4)
       expect(maxActiveFetches).toBeLessThanOrEqual(3)
     })
 
-    deferredResponses[1].resolve(new Response('page 2', { status: 200 }))
-    deferredResponses[2].resolve(new Response('page 3', { status: 200 }))
-    deferredResponses[3].resolve(new Response('page 4', { status: 200 }))
-    deferredResponses[4].resolve(new Response('page 5', { status: 200 }))
+    deferredResponses[1].resolve(fetchResponse('https://example.com/2', 'page 2'))
+    deferredResponses[2].resolve(fetchResponse('https://example.com/3', 'page 3'))
+    deferredResponses[3].resolve(fetchResponse('https://example.com/4', 'page 4'))
+    deferredResponses[4].resolve(fetchResponse('https://example.com/5', 'page 5'))
 
     await expect(Promise.all(requests)).resolves.toEqual(['page 1', 'page 2', 'page 3', 'page 4', 'page 5'])
     expect(maxActiveFetches).toBeLessThanOrEqual(3)
@@ -137,10 +142,10 @@ describe('fetchKnowledgeWebPage', () => {
 
   it('does not create the fetch timeout while a request is waiting in the queue', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
-    const deferredResponses = Array.from({ length: 4 }, () => createDeferred<Response>())
+    const deferredResponses = Array.from({ length: 4 }, () => createDeferred<ReturnType<typeof fetchResponse>>())
     let fetchCallIndex = 0
 
-    fetchMock.mockImplementation(async () => {
+    fetchUrlsUnprocessedMock.mockImplementation(async () => {
       const deferred = deferredResponses[fetchCallIndex]
       fetchCallIndex += 1
       if (!deferred) {
@@ -160,19 +165,19 @@ describe('fetchKnowledgeWebPage', () => {
     void queuedRequest.catch(() => undefined)
 
     await vi.waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(3)
     })
 
     expect(timeoutSpy).toHaveBeenCalledTimes(3)
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(3)
 
     queuedController.abort(new Error('queued abort'))
-    deferredResponses[0].resolve(new Response('page 1', { status: 200 }))
-    deferredResponses[1].resolve(new Response('page 2', { status: 200 }))
-    deferredResponses[2].resolve(new Response('page 3', { status: 200 }))
+    deferredResponses[0].resolve(fetchResponse('https://example.com/1', 'page 1'))
+    deferredResponses[1].resolve(fetchResponse('https://example.com/2', 'page 2'))
+    deferredResponses[2].resolve(fetchResponse('https://example.com/3', 'page 3'))
 
     await expect(Promise.all(activeRequests)).resolves.toEqual(['page 1', 'page 2', 'page 3'])
-    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchUrlsUnprocessedMock).toHaveBeenCalledTimes(3)
     timeoutSpy.mockRestore()
   })
 })

--- a/src/main/features/knowledge/utils/sources/__tests__/urlSnapshot.test.ts
+++ b/src/main/features/knowledge/utils/sources/__tests__/urlSnapshot.test.ts
@@ -79,6 +79,23 @@ describe('captureUrlSnapshotFile', () => {
     expect(stripOkfFrontmatter(written)).toBe(markdown)
   })
 
+  it('uses the fetched page title instead of markdown section links', async () => {
+    const markdown =
+      'Intro text\n\n## Install[\u200b](https://example.com/docs#install "Direct link to Install")\n\nbody'
+    const relativePath = await captureUrlSnapshotFile(
+      'kb-1',
+      'https://example.com/docs',
+      markdown,
+      new Set(),
+      'Example Documentation'
+    )
+
+    expect(relativePath).toBe('Example Documentation.md')
+    const written = writeFileIntoKnowledgeBaseAtMock.mock.calls[0][2] as string
+    expect(written).toContain('title: "Example Documentation"')
+    expect(stripOkfFrontmatter(written)).toBe(markdown)
+  })
+
   it('renames around an already-reserved snapshot name', async () => {
     const reserved = new Set<string>(['My Page.md'])
     const relativePath = await captureUrlSnapshotFile('kb-1', 'https://example.com/p', '# My Page\n\nbody', reserved)

--- a/src/main/features/knowledge/utils/sources/url.ts
+++ b/src/main/features/knowledge/utils/sources/url.ts
@@ -1,11 +1,10 @@
+import { application } from '@application'
 import { loggerService } from '@logger'
-import { net } from 'electron'
 import PQueue from 'p-queue'
 import { sanitizeUrl } from 'strict-url-sanitise'
 
 const logger = loggerService.withContext('KnowledgeWebSearch')
 const DEFAULT_FETCH_TIMEOUT_MS = 30000
-const JINA_READER_BASE_URL = 'https://r.jina.ai/'
 const KNOWLEDGE_WEB_FETCH_CONCURRENCY = 3
 const KNOWLEDGE_WEB_FETCH_INTERVAL_CAP = 10
 const KNOWLEDGE_WEB_FETCH_INTERVAL_MS = 60_000
@@ -40,13 +39,9 @@ export async function fetchKnowledgeWebPage(url: string, signal?: AbortSignal): 
         const timeoutSignal = AbortSignal.timeout(DEFAULT_FETCH_TIMEOUT_MS)
         const fetchSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
 
-        return await net.fetch(`${JINA_READER_BASE_URL}${safeUrl}`, {
-          signal: fetchSignal,
-          headers: {
-            'X-Retain-Images': 'none',
-            'X-Return-Format': 'markdown'
-          }
-        })
+        return await application
+          .get('WebSearchService')
+          .fetchUrlsUnprocessed({ providerId: 'jina', urls: [safeUrl] }, { signal: fetchSignal })
       },
       signal ? { signal } : undefined
     )
@@ -54,11 +49,12 @@ export async function fetchKnowledgeWebPage(url: string, signal?: AbortSignal): 
       throw new Error(`Knowledge web fetch queue returned no response for ${safeUrl}`)
     }
 
-    if (!response.ok) {
-      throw new Error(`Failed to fetch knowledge web page ${safeUrl}: HTTP ${response.status}`)
+    const result = response.results[0]
+    if (!result) {
+      throw new Error(`Knowledge web fetch returned no result for ${safeUrl}`)
     }
 
-    const markdown = (await response.text()).trim()
+    const markdown = result.content.trim()
 
     return markdown
   } catch (error) {

--- a/src/main/features/knowledge/utils/sources/url.ts
+++ b/src/main/features/knowledge/utils/sources/url.ts
@@ -15,6 +15,11 @@ const knowledgeWebFetchQueue = new PQueue({
   interval: KNOWLEDGE_WEB_FETCH_INTERVAL_MS
 })
 
+export interface KnowledgeWebPage {
+  title: string
+  markdown: string
+}
+
 export function sanitizeKnowledgeUrl(rawUrl: string): string {
   try {
     const sanitizedUrl = sanitizeUrl(rawUrl)
@@ -30,7 +35,7 @@ export function sanitizeKnowledgeUrl(rawUrl: string): string {
   }
 }
 
-export async function fetchKnowledgeWebPage(url: string, signal?: AbortSignal): Promise<string> {
+export async function fetchKnowledgeWebPage(url: string, signal?: AbortSignal): Promise<KnowledgeWebPage> {
   try {
     const safeUrl = sanitizeKnowledgeUrl(url)
 
@@ -54,9 +59,10 @@ export async function fetchKnowledgeWebPage(url: string, signal?: AbortSignal): 
       throw new Error(`Knowledge web fetch returned no result for ${safeUrl}`)
     }
 
-    const markdown = result.content.trim()
-
-    return markdown
+    return {
+      title: result.title.trim(),
+      markdown: result.content.trim()
+    }
   } catch (error) {
     const normalizedError = error instanceof Error ? error : new Error(String(error))
     logger.error(`Failed to load knowledge web page: ${url}`, normalizedError)

--- a/src/main/features/knowledge/utils/sources/urlSnapshot.ts
+++ b/src/main/features/knowledge/utils/sources/urlSnapshot.ts
@@ -7,13 +7,14 @@ const SNAPSHOT_TITLE_MAX = 80
 
 /**
  * Derive a human-readable file stem for a captured URL snapshot: the page's
- * first markdown heading (or first non-empty line), falling back to a slug of
- * the URL host and last path segment, and finally to `page`.
+ * fetched page title, then its first markdown heading (or first non-empty line),
+ * falling back to a slug of the URL host and last path segment, and finally to
+ * `page`.
  */
-export function deriveUrlSnapshotSlug(markdown: string, url: string): string {
-  const fromMarkdown = sanitizeFilename(firstHeadingOrLine(markdown).slice(0, SNAPSHOT_TITLE_MAX).trim())
-  if (fromMarkdown && fromMarkdown !== 'untitled') {
-    return fromMarkdown
+export function deriveUrlSnapshotSlug(markdown: string, url: string, pageTitle?: string): string {
+  const fromTitle = sanitizeFilename(preferredTitle(pageTitle, markdown))
+  if (fromTitle && fromTitle !== 'untitled') {
+    return fromTitle
   }
   const fromUrl = sanitizeFilename(urlStem(url).slice(0, SNAPSHOT_TITLE_MAX).trim())
   if (fromUrl && fromUrl !== 'untitled') {
@@ -23,17 +24,21 @@ export function deriveUrlSnapshotSlug(markdown: string, url: string): string {
 }
 
 /**
- * The page's display title for the OKF `title` field: the first markdown
- * heading (or non-empty line), unsanitized, capped at {@link SNAPSHOT_TITLE_MAX};
- * falls back to the URL host + last segment, then the raw URL. Unlike the slug
- * this keeps spaces/punctuation, since it is a frontmatter value, not a filename.
+ * The page's display title for the OKF `title` field: the fetched page title,
+ * falling back to the first markdown heading (or non-empty line), then the URL
+ * host + last segment and raw URL. Unlike the slug this keeps spaces/punctuation,
+ * since it is a frontmatter value, not a filename.
  */
-export function deriveUrlSnapshotTitle(markdown: string, url: string): string {
-  const fromMarkdown = firstHeadingOrLine(markdown).slice(0, SNAPSHOT_TITLE_MAX).trim()
-  if (fromMarkdown) {
-    return fromMarkdown
+export function deriveUrlSnapshotTitle(markdown: string, url: string, pageTitle?: string): string {
+  const fromTitle = preferredTitle(pageTitle, markdown)
+  if (fromTitle) {
+    return fromTitle
   }
   return urlStem(url).slice(0, SNAPSHOT_TITLE_MAX).trim() || url
+}
+
+function preferredTitle(pageTitle: string | undefined, markdown: string): string {
+  return (pageTitle?.trim() || firstHeadingOrLine(markdown)).slice(0, SNAPSHOT_TITLE_MAX).trim()
 }
 
 function firstHeadingOrLine(markdown: string): string {
@@ -60,22 +65,24 @@ function urlStem(url: string): string {
  * extension), without touching disk. The `fileText` is the markdown prefixed with
  * an OKF frontmatter block recording the source URL and title; reading for indexing
  * strips it back off. Shared by {@link captureUrlSnapshotFile} (native capture) and
- * the v1→v2 vector migrator so both produce byte-identical snapshots; the caller
+ * the v1→v2 vector migrator so both use the same snapshot format and fallback title
+ * rules. Native capture may additionally supply the fetched page title. The caller
  * supplies the `timestamp` (frontmatter-only, so it never affects a content hash).
  */
 export function buildUrlSnapshotFile(
   url: string,
   markdown: string,
-  timestamp: string
+  timestamp: string,
+  pageTitle?: string
 ): { slug: string; fileText: string } {
   const frontmatter = serializeOkfFrontmatter({
     type: 'URL',
-    title: deriveUrlSnapshotTitle(markdown, url),
+    title: deriveUrlSnapshotTitle(markdown, url, pageTitle),
     resource: url,
     timestamp
   })
   return {
-    slug: deriveUrlSnapshotSlug(markdown, url),
+    slug: deriveUrlSnapshotSlug(markdown, url, pageTitle),
     fileText: frontmatter + markdown
   }
 }
@@ -90,9 +97,10 @@ export async function captureUrlSnapshotFile(
   baseId: string,
   url: string,
   markdown: string,
-  reservedPaths: Set<string>
+  reservedPaths: Set<string>,
+  pageTitle?: string
 ): Promise<string> {
-  const { slug, fileText } = buildUrlSnapshotFile(url, markdown, new Date().toISOString())
+  const { slug, fileText } = buildUrlSnapshotFile(url, markdown, new Date().toISOString(), pageTitle)
   const relativePath = reserveImportedFileRelativePath(`${slug}.md`, false, reservedPaths)
   return await writeFileIntoKnowledgeBaseAt(baseId, relativePath, fileText)
 }

--- a/src/main/services/webSearch/WebSearchService.ts
+++ b/src/main/services/webSearch/WebSearchService.ts
@@ -28,6 +28,8 @@ type RunCapabilityRequest = {
   inputs: string[]
 }
 
+type PostProcessingMode = 'configured' | 'none'
+
 type PreparedWebSearchContext = {
   inputs: string[]
   runtimeConfig: WebSearchExecutionConfig
@@ -87,7 +89,8 @@ export class WebSearchService extends BaseService {
   private async buildFinalResponse(
     context: PreparedWebSearchContext,
     searchResults: PromiseSettledResult<WebSearchResponse>[],
-    httpOptions?: RequestInit
+    httpOptions: RequestInit | undefined,
+    postProcessingMode: PostProcessingMode
   ): Promise<WebSearchResponse> {
     const abortedSearch = searchResults.find(
       (item): item is PromiseRejectedResult => item.status === 'rejected' && isAbortError(item.reason)
@@ -126,6 +129,10 @@ export class WebSearchService extends BaseService {
       results: successfulSearches.flatMap((item) => item.value.results)
     }
 
+    if (postProcessingMode === 'none') {
+      return mergedResponse
+    }
+
     const filteredResponse = filterWebSearchResponseWithBlacklist(mergedResponse, context.runtimeConfig.excludeDomains)
     const postProcessed = await postProcessWebSearchResponse(filteredResponse, context.runtimeConfig)
 
@@ -133,13 +140,17 @@ export class WebSearchService extends BaseService {
   }
 
   @TraceMethod({ spanName: 'WebSearch', tag: 'WebSearch' })
-  private async runCapability(request: RunCapabilityRequest, httpOptions?: RequestInit): Promise<WebSearchResponse> {
+  private async runCapability(
+    request: RunCapabilityRequest,
+    httpOptions?: RequestInit,
+    postProcessingMode: PostProcessingMode = 'configured'
+  ): Promise<WebSearchResponse> {
     let context: PreparedWebSearchContext | undefined
 
     try {
       context = await this.prepareContext(request)
       const searchResults = await this.executeCapability(context, httpOptions)
-      return await this.buildFinalResponse(context, searchResults, httpOptions)
+      return await this.buildFinalResponse(context, searchResults, httpOptions, postProcessingMode)
     } catch (error) {
       if (!isAbortError(error) || !httpOptions?.signal?.aborted) {
         const normalizedError = error instanceof Error ? error : new Error(String(error))
@@ -171,6 +182,22 @@ export class WebSearchService extends BaseService {
         inputs: normalizeWebSearchUrls(request.urls)
       },
       httpOptions
+    )
+  }
+
+  /** Fetch provider-normalized content without Agent-facing blacklist or compression processing. */
+  async fetchUrlsUnprocessed(
+    request: WebSearchFetchUrlsRequest,
+    httpOptions?: RequestInit
+  ): Promise<WebSearchResponse> {
+    return this.runCapability(
+      {
+        providerId: request.providerId,
+        capability: 'fetchUrls',
+        inputs: normalizeWebSearchUrls(request.urls)
+      },
+      httpOptions,
+      'none'
     )
   }
 }

--- a/src/main/services/webSearch/__tests__/WebSearchService.test.ts
+++ b/src/main/services/webSearch/__tests__/WebSearchService.test.ts
@@ -379,6 +379,43 @@ describe('WebSearchService', () => {
     ])
   })
 
+  it('returns unprocessed fetch results without blacklist filtering or cutoff', async () => {
+    setWebSearchPreferences({
+      runtimeConfig: {
+        excludeDomains: ['https://blocked.example/*'],
+        compression: {
+          method: 'cutoff',
+          cutoffLimit: 5
+        }
+      }
+    })
+    createWebSearchProviderMock.mockReturnValue({
+      fetchUrls: vi.fn().mockResolvedValue(
+        response('jina', 'fetchUrls', 'https://blocked.example/post', [
+          {
+            title: 'Blocked',
+            content: 'complete knowledge content',
+            url: 'https://blocked.example/post'
+          }
+        ])
+      )
+    })
+
+    const result = await webSearchService.fetchUrlsUnprocessed({
+      providerId: 'jina',
+      urls: ['https://blocked.example/post']
+    })
+
+    expect(result.results).toEqual([
+      {
+        title: 'Blocked',
+        content: 'complete knowledge content',
+        url: 'https://blocked.example/post',
+        sourceInput: 'https://blocked.example/post'
+      }
+    ])
+  })
+
   it('uses the fetch URL default provider and validates URL inputs', async () => {
     const fetchUrls = vi.fn().mockImplementation((input: string) =>
       Promise.resolve(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Knowledge base URL capture called the anonymous global Jina Reader endpoint directly, which could return a Cloudflare HTTP 403 even when Agent web fetch succeeded through the regional endpoint.

After this PR: Knowledge base URL capture uses a main-process-only unprocessed WebSearchService path pinned to Jina, reuses regional routing and configured credentials, and preserves Jina's page title separately from the complete Markdown snapshot.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The new internal method bypasses Agent-facing domain filtering and token cutoff but keeps provider selection, validation, tracing, cancellation, and error handling centralized; snapshot naming prefers Jina's title and retains the existing Markdown/URL fallback.

The following alternatives were considered: Calling the existing processed `fetchUrls()` could silently blacklist or truncate indexed content, while retaining the direct Jina request would continue duplicating regional routing and authentication behavior.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with `pnpm lint`, 55 focused main-process tests, and a manual Hermes documentation import confirming successful capture and the correct page title. The full test suite and build check are delegated to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix knowledge base URL imports that could fail with HTTP 403 or use a Markdown section link as the captured title.
```
