### PR TITLE
fix(system-ocr): prevent macOS image OCR crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -483,8 +483,8 @@
     "@napi-rs/canvas-linux-x64-musl": "0.1.97",
     "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
     "@napi-rs/canvas-win32-x64-msvc": "0.1.97",
-    "@napi-rs/system-ocr-darwin-arm64": "1.1.0",
-    "@napi-rs/system-ocr-darwin-x64": "1.1.0",
+    "@napi-rs/system-ocr-darwin-arm64": "1.0.2",
+    "@napi-rs/system-ocr-darwin-x64": "1.0.2",
     "@napi-rs/system-ocr-win32-arm64-msvc": "1.1.0",
     "@napi-rs/system-ocr-win32-x64-msvc": "1.1.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,8 @@ overrides:
   '@img/sharp-linux-x64': 0.34.5
   '@img/sharp-win32-x64': 0.34.5
   '@napi-rs/canvas': 0.1.97
+  '@napi-rs/system-ocr-darwin-arm64': 1.0.2
+  '@napi-rs/system-ocr-darwin-x64': 1.0.2
   '@ai-sdk/provider-utils': 4.0.40
   '@ai-sdk/anthropic': 3.0.87
 
@@ -1240,11 +1242,11 @@ importers:
         specifier: 0.1.97
         version: 0.1.97
       '@napi-rs/system-ocr-darwin-arm64':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.0.2
+        version: 1.0.2
       '@napi-rs/system-ocr-darwin-x64':
-        specifier: 1.1.0
-        version: 1.1.0
+        specifier: 1.0.2
+        version: 1.0.2
       '@napi-rs/system-ocr-win32-arm64-msvc':
         specifier: 1.1.0
         version: 1.1.0
@@ -3614,14 +3616,14 @@ packages:
     resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==}
     engines: {node: '>= 10'}
 
-  '@napi-rs/system-ocr-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-aZc7WKUxKCRD+HSOuAwWmxyjHgNuHoVBRF2UIq4fvWN5/xkdbl6NaiYdcIisILWbplwpGszRaKdOeQ8VJwOYDg==}
+  '@napi-rs/system-ocr-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-/9E1T4+Pzbk8eI1QC1a1wimj4wgweKn9NUGtmO9Vf0rDi1TxYaJsv6ioSzdmhlazkKxd27Brk5VfLfUg6Bha6A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@napi-rs/system-ocr-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-qcNDsBKQZSOH7dNardoqaiwq57pZKcwdoAaGiAa+ywks27yJYfYms18XoPY2FLlRTNs3odUypMQ+VQa0VY5n5w==}
+  '@napi-rs/system-ocr-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-z8FiuVjMEXrqU9O5tIWfLkNWzyx8moQZ/kgYo1jPvbiaC+bA0gBBo9X8C1dYrF7Q3nLug0zTU59FMAESXbhJpA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -16499,10 +16501,10 @@ snapshots:
       '@napi-rs/canvas-win32-arm64-msvc': 0.1.97
       '@napi-rs/canvas-win32-x64-msvc': 0.1.97
 
-  '@napi-rs/system-ocr-darwin-arm64@1.1.0':
+  '@napi-rs/system-ocr-darwin-arm64@1.0.2':
     optional: true
 
-  '@napi-rs/system-ocr-darwin-x64@1.1.0':
+  '@napi-rs/system-ocr-darwin-x64@1.0.2':
     optional: true
 
   '@napi-rs/system-ocr-win32-arm64-msvc@1.1.0':
@@ -16513,8 +16515,8 @@ snapshots:
 
   '@napi-rs/system-ocr@1.1.0(patch_hash=aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde)':
     optionalDependencies:
-      '@napi-rs/system-ocr-darwin-arm64': 1.1.0
-      '@napi-rs/system-ocr-darwin-x64': 1.1.0
+      '@napi-rs/system-ocr-darwin-arm64': 1.0.2
+      '@napi-rs/system-ocr-darwin-x64': 1.0.2
       '@napi-rs/system-ocr-win32-arm64-msvc': 1.1.0
       '@napi-rs/system-ocr-win32-x64-msvc': 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,12 @@ overrides:
   '@img/sharp-linux-x64': '0.34.5'
   '@img/sharp-win32-x64': '0.34.5'
   '@napi-rs/canvas': '0.1.97'
+  # system-ocr 1.1.0's macOS 26 structured-document sidecar can recurse
+  # indefinitely through Vision list containers. Keep the 1.1.0 wrapper and
+  # Windows bindings, but use the legacy Accurate macOS implementation until
+  # upstream adds cycle/depth guards.
+  '@napi-rs/system-ocr-darwin-arm64': '1.0.2'
+  '@napi-rs/system-ocr-darwin-x64': '1.0.2'
   '@ai-sdk/provider-utils': '4.0.40'
   # Pin to the version our patch (patches/@ai-sdk__anthropic.patch) targets so every
   # instance — including the copies pulled transitively by @ai-sdk/amazon-bedrock and

--- a/scripts/__tests__/before-pack.test.ts
+++ b/scripts/__tests__/before-pack.test.ts
@@ -4,13 +4,18 @@
  * stopped materialising both CPU architectures for the host OS — the packaging bug that
  * shipped a macOS x64 build without `@img/sharp-darwin-x64`.
  */
+import { readFileSync } from 'node:fs'
+
 import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 
 // CJS build script — vitest interops the module.exports fine.
 import { assertPrebuiltPackages } from '../before-pack'
 
 const hostPlatform = process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'win32' : 'linux'
 const foreignPlatform = hostPlatform === 'darwin' ? 'win32' : 'darwin'
+const legacyMacOcrVersion = '1.0.2'
+const macOcrPackages = ['@napi-rs/system-ocr-darwin-arm64', '@napi-rs/system-ocr-darwin-x64']
 
 describe('assertPrebuiltPackages', () => {
   it.each(['arm64', 'x64'])('passes for the host platform on %s', (arch) => {
@@ -23,5 +28,19 @@ describe('assertPrebuiltPackages', () => {
     expect(() => assertPrebuiltPackages(foreignPlatform, 'x64')).toThrow(
       /Missing prebuilt packages for .+-x64: .*@img\/sharp-/
     )
+  })
+
+  it('pins macOS system OCR to the legacy Accurate implementation', () => {
+    const packageManifest = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      optionalDependencies: Record<string, string>
+    }
+    const workspaceConfig = parse(readFileSync('pnpm-workspace.yaml', 'utf8')) as {
+      overrides: Record<string, string>
+    }
+
+    for (const packageName of macOcrPackages) {
+      expect(packageManifest.optionalDependencies[packageName]).toBe(legacyMacOcrVersion)
+      expect(workspaceConfig.overrides[packageName]).toBe(legacyMacOcrVersion)
+    }
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: On macOS 26, System OCR could crash the entire app when Apple Vision returned recursive list containers for some images.

After this PR: The JavaScript wrapper and Windows bindings remain on 1.1.0, while the macOS arm64/x64 bindings are pinned to 1.0.2 to retain Apple Vision Accurate OCR without the structured-document recursion path.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: temporary macOS native-binding pin until upstream adds cycle/depth guards

The following alternatives were considered: Fast mode rejected due to unusable Chinese recognition; switching OCR engines rejected because System OCR must remain selected

Links to places where the discussion took place: https://github.com/Brooooooklyn/system-ocr/blob/v1.1.0/src/macos/recognize_documents.swift#L400-L420

### Breaking changes

<!-- optional -->

None

### Special notes for your reviewer

<!-- optional -->

- Reported image on macOS 26: native exit 132 before; exit 0 with Chinese OCR text after
- Focused tests: 6/6 passed
- `pnpm format`: passed
- `pnpm lint`: passed with 0 errors and 40 pre-existing warnings
- Full `pnpm test` and `pnpm build:check`: not run

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix crashes when System OCR processes some list-heavy images on macOS.
```
