### PR TITLE
fix(about-settings): add accessible labels to icon buttons

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5754,6 +5754,7 @@
         "button": "Releases",
         "title": "Release Notes"
       },
+      "repository": "GitHub Repository",
       "social": {
         "title": "Social Accounts"
       },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5754,6 +5754,7 @@
         "button": "查看",
         "title": "更新日志"
       },
+      "repository": "GitHub 仓库",
       "social": {
         "title": "社交账号"
       },

--- a/src/renderer/pages/settings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings.tsx
@@ -179,6 +179,7 @@ const AboutSettings: FC = () => {
           <span className="font-semibold text-[15px]">{t('settings.about.title')}</span>
           <button
             type="button"
+            aria-label={t('settings.about.repository')}
             onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
             className="inline-flex items-center justify-center rounded-md p-1 text-foreground transition-colors hover:bg-muted">
             <Github className="size-5" />
@@ -191,6 +192,7 @@ const AboutSettings: FC = () => {
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <button
               type="button"
+              aria-label="Cherry Studio"
               onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
               className="relative cursor-pointer">
               {appUpdateState.downloadProgress > 0 && (
@@ -213,6 +215,7 @@ const AboutSettings: FC = () => {
               <div className="text-foreground-secondary text-sm">{t('settings.about.description')}</div>
               <button
                 type="button"
+                aria-label={t('settings.about.releases.title')}
                 onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/releases')}
                 className="mt-1.5">
                 <Badge className="cursor-pointer rounded-md border-primary/20 bg-primary/10 px-1.5 py-0 text-[11px] text-primary leading-4 transition-colors hover:bg-primary/15">


### PR DESCRIPTION
## Summary

- add accessible names to the GitHub repository, Cherry Studio logo, and releases buttons on the About page
- add localized repository labels in English and Simplified Chinese
- keep the existing visual presentation and behavior unchanged

## Why

The icon-only controls were exposed as unnamed buttons in the macOS accessibility tree. Tooltip or visual content alone did not give these buttons reliable accessible names.

Original feedback: [Feishu record recvqKnE2ccysF](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvqKnE2ccysF), submitted by 金晨曦.

## Validation

- `tsgo --noEmit -p tsconfig.web.json --composite false`
- `oxlint --deny-warnings src/renderer/pages/settings/AboutSettings.tsx`
- `git diff --check upstream/main...HEAD`
