### PR TITLE
fix(mini-apps): add show and hide translations

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -6996,6 +6996,7 @@
         "display": "Display management",
         "preferences": "Preferences"
       },
+      "hide_app": "Hide {{name}}",
       "open_link_external": {
         "description": "Opens new-window links in your default browser",
         "title": "Open new-window links in browser"
@@ -7008,6 +7009,7 @@
         "title": "Mini Program filter"
       },
       "reset_tooltip": "Reset to default",
+      "show_app": "Show {{name}}",
       "title": "Mini Apps Settings",
       "visible": "Visible Mini Apps"
     },

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -6996,6 +6996,7 @@
         "display": "显示管理",
         "preferences": "使用偏好"
       },
+      "hide_app": "隐藏 {{name}}",
       "open_link_external": {
         "description": "新窗口链接用系统默认浏览器打开",
         "title": "在浏览器中打开新窗口链接"
@@ -7008,6 +7009,7 @@
         "title": "小程序区域筛选"
       },
       "reset_tooltip": "重置为默认值",
+      "show_app": "显示 {{name}}",
       "title": "小程序设置",
       "visible": "显示的小程序"
     },


### PR DESCRIPTION
## Summary

- add the missing `settings.miniApps.hide_app` and `settings.miniApps.show_app` translations
- provide English and Simplified Chinese labels with the existing `{{name}}` interpolation
- keep the Mini Apps settings UI and behavior unchanged

## Why

The Mini Apps visibility controls already referenced these keys for their accessible labels, but the keys were absent from the `settings.miniApps` locale section. The i18n fallback therefore exposed raw translation keys instead of readable labels.

Original feedback: [Feishu record recvqKnElgwhe4](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvqKnElgwhe4), submitted by 金晨曦.

## Validation

- `tsgo --noEmit -p tsconfig.web.json --composite false`
- `oxlint --deny-warnings src/renderer/pages/miniApps/MiniAppSettings/MiniAppListColumn.tsx`
- `dotenv -e .env -- tsx scripts/check-i18n.ts`
- `git diff --check upstream/main...HEAD`
