### PR TITLE
fix(channels): add accessible labels to row actions

### DIFF
--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -367,12 +367,12 @@ const ChannelInstanceRow: FC<{
         </div>
       </div>
       <Tooltip title={t('agent.channels.logs')}>
-        <Button variant="ghost" size="icon-sm" onClick={onShowLogs}>
+        <Button variant="ghost" size="icon-sm" aria-label={t('agent.channels.logs')} onClick={onShowLogs}>
           <FileText className="size-4" />
         </Button>
       </Tooltip>
       <Tooltip title={t('common.edit')}>
-        <Button variant="ghost" size="icon-sm" onClick={onEdit}>
+        <Button variant="ghost" size="icon-sm" aria-label={t('common.edit')} onClick={onEdit}>
           <Pencil className="size-4" />
         </Button>
       </Tooltip>
@@ -381,6 +381,7 @@ const ChannelInstanceRow: FC<{
           variant="ghost"
           size="icon-sm"
           className="hover:text-destructive!"
+          aria-label={t('common.delete')}
           onClick={() => setDeleteConfirmOpen(true)}>
           <Trash2 className="size-4" />
         </Button>


### PR DESCRIPTION
## Summary

- add localized accessible names to the channel row's logs, edit, and delete icon buttons
- reuse the existing `agent.channels.logs`, `common.edit`, and `common.delete` translations
- keep the existing tooltips, visuals, and actions unchanged

## Why

The three icon-only channel actions relied on tooltips and were exposed as unnamed buttons in the macOS accessibility tree. Explicit `aria-label` values give assistive technology stable, localized names.

Original feedback: [Feishu record recvqKnDLefbAX](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvqKnDLefbAX), submitted by 金晨曦. The same symptom reported in `recvqyjXOInmpl` is covered by this fix.

## Validation

- `tsgo --noEmit -p tsconfig.web.json --composite false`
- `oxlint --deny-warnings src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx`
- `git diff --check upstream/main...HEAD`
