### PR TITLE
chore: release v2.0.0-rc.3

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -154,50 +154,92 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.0-rc.2 - Model Routing, Clear Context & v2 Stabilization
+    Cherry Studio 2.0.0-rc.3 - Agent Sessions, Migration Recovery & Accessibility
 
     ✨ New Features
-    - [Knowledge] Added a Select All control when importing notes into a knowledge base.
-    - [Claude Code] Claude Code provider now offers Claude Opus 5 and Claude Sonnet 5, plus 1M-context variants of Opus 4.6/4.7/4.8/5 and Sonnet 4.6.
-    - [Chat] Home Chat can now start a fresh model context without creating a new conversation. Use Cmd/Ctrl+K or the input QuickPanel; the optional eraser button remains hidden by default and can be enabled from toolbar customization.
+    - [Agent] Agent sessions now render Workflow calls with a dedicated card, show live subagent and background-task progress with per-task stop, surface background agents' questions as persisted messages, keep context usage visible across idle disconnects, and recover automatically when a stored conversation can no longer be resumed.
+    - [Agent] Agents can now use the Claude Agent SDK's “Approve for Me” permission mode, where a model classifier approves routine tool calls and only asks you about risky ones. New agents use it by default instead of running every action unattended, and the permission modes have clearer names and descriptions.
+    - [Agent] Agent reasoning effort is now remembered and reused across chat, scheduled, and channel runs, with automatic adjustment when switching models.
+    - [Composer] Add model-aware reasoning controls and Fast mode for supported OpenAI Codex and Claude Code models.
+    - [Composer] Standalone pasted web links now appear as interactive tokens with a privacy-safe generic icon before send, site favicons in sent messages, open-on-click behavior, and hover-to-remove controls. Composer tokens now stay consistent across drafts, messages, queued follow-ups, and rich clipboard copy/paste.
+    - [Image Preview] Improved full-screen image previews with cursor-centered zoom, bounded panning, consistent transform controls, and grouped-image navigation.
+    - [API Gateway] The OpenAPI docs page now shows its descriptions in all 12 app languages, with a language switcher in the docs toolbar; endpoints are grouped by compatible API, and Scalar's third-party “Ask AI” is disabled.
+    - [Migration] Migration recovery now keeps errors visible for screenshots and groups “Save troubleshooting information”, “Use V2 without importing V1 data”, and “Continue using V1” under More options. Using V2 clears partial migration data before starting with defaults while preserving the original V1 data, and migration completion notices can be reviewed and copied from a dedicated dialog.
+    - [Agent] Assistant HTML artifacts now render inline at their original position in the conversation. A whole HTML page with scripts or external resources stays unloaded behind a compact artifact card until you select View webpage, then runs in an isolated immersive preview; HTML fragments embedded in prose render directly in a preview frame that cannot run scripts.
+    - [Resources] Adds a shared group creation dialog with quick creation and automatic selection in assistant editing.
 
     🐛 Bug Fixes
-    - [Chat] Fixed chat message toolbar icon buttons (edit, copy, regenerate, delete, save to notes) missing accessible names, so screen readers and keyboard users can now identify them.
-    - [Models] Fixed incorrect model grouping for providers that return flat model IDs.
-    - [Agent] Editing an assistant or agent now keeps the edit dialog open after each automatic save.
-    - [Chat] Fixed message-list flickering and ghosting when reversing direction while dragging the scrollbar thumb.
-    - [MCP] MCP JSON import now supports configurations containing multiple servers.
-    - [Agent] Changing the app language now updates existing agent sessions on their next turn instead of retaining the previous response-language instruction.
-    - [Chat] Fixed drag selection so messages leave the multi-select set when the selection box shrinks.
-    - [Agent] Fixed OpenCode Go and other mixed-endpoint providers returning a 400 error in new Agent Sessions by routing each model through its declared protocol.
-    - [Chat] Conversations and agent sessions without a valid owner are now consistently labeled Unlinked Assistant or Unlinked Agent while preserving their titles.
-    - [MCP] Fixed MCP server environment variables and headers remaining configured after all entries are cleared.
-    - [Notes] Opening an existing note no longer steals focus or jumps the caret to the end of the document; only new (empty) notes automatically focus the editor.
-    - [Migration] Migrated Agent tasks now preserve managed workspace files and relocate available Claude session caches while surfacing unavailable resume data through the normal runtime error.
-    - [Migration] Fixed model endpoint routing after migrating from Cherry Studio v1, including NewAPI-compatible providers.
-    - [Data] Existing v1 clear-context boundaries are preserved during migration when they have not already been discarded by an earlier v2 preview migration.
+    - [Channels] Restored Feishu QR registration after binding an agent, prevent channel dialogs from flashing while closing, and show QR login errors for Feishu and WeChat.
+    - [Windows] Fixed Cherry Studio failing to open when Windows cannot resolve a user system folder.
+    - [OpenClaw] The OpenClaw gateway launched by Cherry Studio no longer self-updates in the background and no longer shows its own “Update available” banner; opening the OpenClaw dashboard (or the S3 help and release-notes pages) in its own window no longer shows “app not found”.
+    - [Agent] Corrected the assistant tool-call limit UI to show the default 20-round cap and enforce the supported 1–100 range.
+    - [Accessibility] Added accessible names to the About page icon buttons (GitHub repository, logo, releases).
+    - [Accessibility] Added localized accessible names to the channel row's logs, edit, and delete icon buttons.
+    - [MCP] Fixed MCP package-registry option names not following the UI language (they stayed Chinese under an English interface).
+    - [Settings] Fixed the hardware acceleration restart confirmation showing “disable” wording when re-enabling hardware acceleration; the prompt now matches the toggle direction.
+    - [Agent] Improved agent artifact delivery: cards now appear after message playout, provide an explicit Open with menu, and correctly preview valid UTF-8 Markdown when a sampled multibyte character crosses the detection boundary.
+    - [Mini Apps] Added the missing Mini Apps show/hide translations.
+    - [Dialog] Fixed edit and search dialogs opening with an incorrect initial focus or selecting existing text unexpectedly.
+    - [Migration] Prevent Agents migration from running out of memory when importing large session histories.
+    - [Usage] Usage details now identify unattributed requests by their AI modality (language, embedding, image, or rerank).
+    - [macOS] Fixed crashes when System OCR processes some list-heavy images on macOS.
+    - [Knowledge] Knowledge base: clicking a plain note now opens its full original content in-app; viewing indexed chunks moved to the row's right-click menu, and the broken “preview original” action no longer shows for notes.
+    - [Knowledge] Used regional Jina reader for URL imports.
+    - [Knowledge] Used readable names for saved messages.
+    - [Knowledge] Hide injected knowledge prompts in the composer.
+    - [Paintings] Fixed horizontal rendering artifacts that could appear while dragging generated images in Paintings.
+    - [Selection Assistant] Fixed the opacity slider so dragging right increases opacity and left decreases it (previously reversed).
+    - [Notes] Fixed the note character count not updating after toolbar undo and redo actions.
+    - [Tools] Dropped the uri format that strict providers reject.
+    - [API Gateway] Fixed the OpenAPI docs page showing the Health check curl example as a bare relative path (`curl /health`); it now shows the full server address so the example can be copied and run directly.
+    - [Obsidian] Fixed Obsidian export incorrectly reporting success when the note title is empty; the export dialog now stays open on failure and the export button is disabled until a title is provided.
+    - [Accessibility] The Reset / Zoom Out / Zoom In buttons in Settings → Appearance → Page Zoom now expose accessible names (aria-label) and tooltips.
+
+    ⚡ Performance
+    - [Agent] Improved Agent session startup performance, especially for configurations with many MCP servers and skills.
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.0-rc.2 - 模型路由、清除上下文与 v2 稳定化
+    Cherry Studio 2.0.0-rc.3 - 智能体会话、迁移恢复与无障碍优化
 
     ✨ 新功能
-    - [知识库] 在向知识库导入笔记时新增“全选”控件。
-    - [Claude Code] Claude Code 服务商现已提供 Claude Opus 5 与 Claude Sonnet 5，以及 Opus 4.6/4.7/4.8/5 和 Sonnet 4.6 的 1M 上下文变体。
-    - [聊天] 主聊天现可在不新建对话的情况下开启全新的模型上下文。使用 Cmd/Ctrl+K 或输入框快捷面板；可选的橡皮擦按钮默认隐藏，可在工具栏自定义中开启。
+    - [智能体] 智能体会话现以专属卡片渲染 Workflow 调用，实时展示子智能体与后台任务进度并支持逐任务停止，将后台智能体的提问作为持久化消息呈现，在空闲断连时仍保留上下文用量，并在已存储对话无法恢复时自动重置。
+    - [智能体] 智能体现可使用 Claude Agent SDK 的”为我审批”权限模式：由模型分类器自动批准常规工具调用，仅就有风险的操作征求你的确认。新建智能体默认使用该模式，且各权限模式有了更清晰的名称与说明。
+    - [智能体] 智能体的推理强度现可在聊天、定时与频道运行间记忆复用，切换模型时自动调整。
+    - [输入框] 为支持的 OpenAI Codex 与 Claude Code 模型新增模型感知的推理控件与快速模式。
+    - [输入框] 粘贴的独立网页链接现以交互式令牌呈现：发送前显示隐私安全的通用图标，发送后展示站点 favicon，点击即可打开，悬停可移除。输入框令牌在草稿、消息、排队后续问题以及富文本剪贴板复制/粘贴间保持一致。
+    - [图片预览] 改进全屏图片预览：支持以光标为中心的缩放、受限平移、统一的变换控件，以及分组图片导航。
+    - [API 网关] OpenAPI 文档页现以全部 12 种应用语言显示描述，文档工具栏新增语言切换器；端点按兼容的 API 分组，并禁用 Scalar 第三方”Ask AI”。
+    - [迁移] 迁移恢复现保留错误信息便于截图，并在”更多选项”下归类”保存故障排查信息”、”使用 V2 但不导入 V1 数据”、”继续使用 V1”。选择使用 V2 将以默认值启动前清除部分迁移数据，但保留原始 V1 数据；迁移完成通知可在专属对话框中查看与复制。
+    - [智能体] 助手 HTML 工件现以内联方式渲染在对话原始位置。包含脚本或外部资源的完整 HTML 页面在点击”查看网页”前以紧凑工件卡片加载，随后在隔离的沉浸式预览中运行；嵌入正文中的 HTML 片段在不可执行脚本的预览框架中直接渲染。
+    - [资源] 新增共享分组创建对话框，可快速创建并在助手编辑中自动选中。
 
     🐛 问题修复
-    - [聊天] 修复了聊天消息工具栏图标按钮（编辑、复制、重新生成、删除、保存到笔记）缺少无障碍名称的问题，屏幕阅读器与键盘用户现可识别它们。
-    - [模型] 修复了返回扁平模型 ID 的服务商的模型分组错误。
-    - [智能体] 编辑助手或智能体时，每次自动保存后编辑对话框现保持打开。
-    - [聊天] 修复了反向拖动滚动条滑块时消息列表的闪烁与残影问题。
-    - [MCP] MCP JSON 导入现支持包含多个服务器的配置。
-    - [智能体] 更改应用语言后，已有智能体会话在下一轮对话中随即更新，不再沿用旧的回复语言指令。
-    - [聊天] 修复了拖选：当选择框缩小时，消息会移出多选集合。
-    - [智能体] 修复了 OpenCode Go 等混合端点服务商在新智能体会话中返回 400 错误的问题，现按各模型声明的协议进行路由。
-    - [聊天] 没有有效属主的对话与智能体会话现统一标记为“未关联助手”或“未关联智能体”，并保留标题。
-    - [MCP] 修复了 MCP 服务器环境变量与请求头在所有条目清空后仍保留配置的问题。
-    - [笔记] 打开已有笔记不再抢占焦点或将光标跳到文档末尾；仅新建（空白）笔记会自动聚焦编辑器。
-    - [迁移] 迁移后的智能体任务现保留受管工作区文件，并迁移可用的 Claude 会话缓存，不可用的恢复数据通过常规运行时错误展示。
-    - [迁移] 修复了从 Cherry Studio v1 迁移后的模型端点路由，含 NewAPI 兼容服务商。
-    - [数据] 既有 v1 的清除上下文边界在迁移时被保留（未被早期 v2 预览迁移丢弃的情况下）。
+    - [频道] 恢复了绑定智能体后的飞书二维码注册流程，防止频道对话框关闭时闪烁，并显示飞书与微信的二维码登录错误。
+    - [Windows] 修复了当 Windows 无法解析用户系统文件夹时 Cherry Studio 无法启动的问题。
+    - [OpenClaw] 由 Cherry Studio 启动的 OpenClaw 网关不再在后台自更新，也不再显示自身的”有更新可用”横幅；将 OpenClaw 仪表板（或 S3 帮助与发布说明页面）拖出为独立窗口不再提示”app not found”。
+    - [智能体] 修正了助手工具调用次数限制的界面，显示默认 20 轮上限，并强制限制在 1–100 范围内。
+    - [无障碍] 为”关于”页面的图标按钮（GitHub 仓库、Logo、发布版本）添加无障碍名称。
+    - [无障碍] 为频道行的日志、编辑、删除图标按钮添加本地化的无障碍名称。
+    - [MCP] 修复了 MCP 注册表选项名称不跟随界面语言（英文界面下仍显示中文）的问题。
+    - [设置] 修复了重新开启硬件加速时重启确认提示仍显示”关闭”措辞的问题；提示现与开关方向一致。
+    - [智能体] 改进智能体工件交付：卡片现于消息播放后出现，提供显式的”打开方式”菜单，并在多字节字符跨越检测边界时正确预览有效的 UTF-8 Markdown。
+    - [小程序] 补齐了小程序显示/隐藏的缺失翻译。
+    - [对话框] 修复了编辑与搜索对话框打开时初始焦点不正确或意外选中文本的问题。
+    - [迁移] 防止 Agents 迁移在导入大量会话历史时内存溢出。
+    - [用量] 用量详情现按 AI 模态（语言、嵌入、图像或重排）标识未归属请求。
+    - [macOS] 修复了系统 OCR 在 macOS 上处理部分列表密集图片时崩溃的问题。
+    - [知识库] 知识库：单击普通笔记现可在应用内查看其完整原始内容；查看已索引片段移至行右键菜单，且笔记不再显示失效的”预览原文”操作。
+    - [知识库] URL 导入改用区域化的 Jina reader。
+    - [知识库] 为保存的消息使用可读名称。
+    - [知识库] 在输入框中隐藏注入的知识库提示。
+    - [绘画面板] 修复了在 Paintings 中拖动生成图片时可能出现横向渲染瑕疵的问题。
+    - [选择助手] 修正了不透明度滑块方向：向右拖动增加不透明度，向左减少（此前反向）。
+    - [笔记] 修复了工具栏撤销/重做后笔记字符数不更新的问题。
+    - [工具] 移除了严格服务商拒绝的 uri 格式。
+    - [API 网关] 修复了 OpenAPI 文档页将健康检查 curl 示例显示为相对路径（`curl /health`）的问题；现显示完整服务器地址，可直接复制运行。
+    - [Obsidian] 修复了笔记标题为空时 Obsidian 导出仍误报成功的问题；导出对话框现于失败时保持打开，且在提供标题前禁用导出按钮。
+    - [无障碍] 设置 → 外观 → 页面缩放中的”重置/缩小/放大”按钮现提供无障碍名称（aria-label）与工具提示。
+
+    ⚡ 性能优化
+    - [智能体] 提升智能体会话启动性能，尤其是配置了较多 MCP 服务器与技能时。
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0-rc.3",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
### What this PR does

Before this PR:

- The latest release is `v2.0.0-rc.2`; `package.json` and `electron-builder.yml` carry the rc.2 release notes.

After this PR:

- Bumps the version to `2.0.0-rc.3`.
- Replaces the release notes in `electron-builder.yml` with bilingual (English + Simplified Chinese) notes covering all user-facing changes since `v2.0.0-rc.2`.

This is a release-prep PR. It only touches `package.json` (version field) and `electron-builder.yml` (release notes block).

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The release notes are assembled from the `release-note` blocks of every commit since `v2.0.0-rc.2`. Internal-only commits (daily i18n sync, docs-only `docs(testing)`, and the `chore(codeowners)` housekeeping) are excluded per the `prepare-release` skill rules.
- Commits without a `release-note` block are summarized from their conventional-commit title.
- The PR follows the standard release workflow: branch `release/v2.0.0-rc.3` → `main`, which triggers `release.yml` (macOS/Windows/Linux builds + draft GitHub Release) and `ci.yml` (lint/typecheck/tests).

The following alternatives were considered:

- Bundling extra code changes into the release commit — rejected to keep the release commit reviewable on its own.

Links to places where the discussion took place: N/A

### Breaking changes

None. This is a version bump and release-notes update only.

### Special notes for your reviewer

Review checklist:

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

Included commits (since `v2.0.0-rc.2`):

- feat(agent-session): surface workflow and background task progress (#17440)
- feat(agent-permission-mode): support the SDK auto mode and collapse the enum copies (#17584)
- fix(channel-settings): restore QR registration flows (#17635)
- fix(preboot): prevent silent Windows startup failures (#17665)
- fix(openclaw): stop the gateway from updating itself, fix detached dashboard (#17634)
- fix(assistant-settings): clarify tool call round limit (#17596)
- fix(about-settings): add accessible labels to icon buttons (#17662)
- fix(channels): add accessible labels to row actions (#17664)
- feat(image-preview): improve full-screen viewing interactions (#17643)
- fix(mcp-settings): i18n registry option names (#17619)
- fix(system-settings): show direction-aware hardware acceleration restart prompt (#17621)
- feat(api-gateway): localize the OpenAPI docs and add a language switcher (#17399)
- fix(agent-artifacts): stabilize delivery cards and previews (#17291)
- fix(mini-apps): add show and hide translations (#17663)
- feat(composer): add interactive link tokens (#17616)
- feat(composer): add provider-aware speed controls (#17530)
- feat(data-migration): improve migration failure recovery (#17593)
- feat(agent-reasoning): persist reasoning effort (#17586)
- feat(html-artifact): restore isolated inline HTML previews (#17323)
- fix(dialog): avoid selecting first input on open (#17631)
- fix(agents-migration): prevent OOM on large session histories (#17579)
- fix(ai-usage): show modality for unattributed entries (#17592)
- fix(system-ocr): prevent macOS image OCR crashes (#17657)
- fix(knowledge): use regional Jina reader for URL imports (#17653)
- fix(paintings): prevent image drag artifacts (#17641)
- fix(selection-assistant): correct opacity slider drag direction (#17623)
- fix(notes): sync character count after undo and redo (#17638)
- perf(agent-runtime): reduce Agent session startup latency (#17615)
- fix(builtin-tools): drop the uri format that strict providers reject (#17633)
- fix(knowledge): view a note's original content on primary click (#17624)
- fix(api-gateway): render absolute OpenAPI server URL for curl examples (#17608)
- fix(obsidian-export): keep dialog open and report failure on empty title (#17625)
- fix(knowledge): use readable names for saved messages (#17630)
- fix(composer): hide injected knowledge prompts (#17613)
- feat(resource-groups): add shared group creation dialog (#17611)
- fix(appearance-settings): add aria-labels and tooltips to page-zoom buttons (#17606)

Excluded per release-notes policy: daily auto i18n sync (#17666), `docs(testing)` (NONE), and `chore(codeowners)` (internal housekeeping).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Cherry Studio 2.0.0-rc.3 - Agent Sessions, Migration Recovery & Accessibility

✨ New Features
- [Agent] Agent sessions now render Workflow calls with a dedicated card, show live subagent and background-task progress with per-task stop, surface background agents' questions as persisted messages, keep context usage visible across idle disconnects, and recover automatically when a stored conversation can no longer be resumed.
- [Agent] Agents can now use the Claude Agent SDK's "Approve for Me" permission mode, where a model classifier approves routine tool calls and only asks you about risky ones. New agents use it by default instead of running every action unattended, and the permission modes have clearer names and descriptions.
- [Agent] Agent reasoning effort is now remembered and reused across chat, scheduled, and channel runs, with automatic adjustment when switching models.
- [Composer] Add model-aware reasoning controls and Fast mode for supported OpenAI Codex and Claude Code models.
- [Composer] Standalone pasted web links now appear as interactive tokens with a privacy-safe generic icon before send, site favicons in sent messages, open-on-click behavior, and hover-to-remove controls. Composer tokens now stay consistent across drafts, messages, queued follow-ups, and rich clipboard copy/paste.
- [Image Preview] Improved full-screen image previews with cursor-centered zoom, bounded panning, consistent transform controls, and grouped-image navigation.
- [API Gateway] The OpenAPI docs page now shows its descriptions in all 12 app languages, with a language switcher in the docs toolbar; endpoints are grouped by compatible API, and Scalar's third-party "Ask AI" is disabled.
- [Migration] Migration recovery now keeps errors visible for screenshots and groups "Save troubleshooting information", "Use V2 without importing V1 data", and "Continue using V1" under More options. Using V2 clears partial migration data before starting with defaults while preserving the original V1 data, and migration completion notices can be reviewed and copied from a dedicated dialog.
- [Agent] Assistant HTML artifacts now render inline at their original position in the conversation. A whole HTML page with scripts or external resources stays unloaded behind a compact artifact card until you select View webpage, then runs in an isolated immersive preview; HTML fragments embedded in prose render directly in a preview frame that cannot run scripts.
- [Resources] Adds a shared group creation dialog with quick creation and automatic selection in assistant editing.

🐛 Bug Fixes
- [Channels] Restored Feishu QR registration after binding an agent, prevent channel dialogs from flashing while closing, and show QR login errors for Feishu and WeChat.
- [Windows] Fixed Cherry Studio failing to open when Windows cannot resolve a user system folder.
- [OpenClaw] The OpenClaw gateway launched by Cherry Studio no longer self-updates in the background and no longer shows its own "Update available" banner; opening the OpenClaw dashboard (or the S3 help and release-notes pages) in its own window no longer shows "app not found".
- [Agent] Corrected the assistant tool-call limit UI to show the default 20-round cap and enforce the supported 1–100 range.
- [Accessibility] Added accessible names to the About page icon buttons (GitHub repository, logo, releases).
- [Accessibility] Added localized accessible names to the channel row's logs, edit, and delete icon buttons.
- [MCP] Fixed MCP package-registry option names not following the UI language (they stayed Chinese under an English interface).
- [Settings] Fixed the hardware acceleration restart confirmation showing "disable" wording when re-enabling hardware acceleration; the prompt now matches the toggle direction.
- [Agent] Improved agent artifact delivery: cards now appear after message playout, provide an explicit Open with menu, and correctly preview valid UTF-8 Markdown when a sampled multibyte character crosses the detection boundary.
- [Mini Apps] Added the missing Mini Apps show/hide translations.
- [Dialog] Fixed edit and search dialogs opening with an incorrect initial focus or selecting existing text unexpectedly.
- [Migration] Prevent Agents migration from running out of memory when importing large session histories.
- [Usage] Usage details now identify unattributed requests by their AI modality (language, embedding, image, or rerank).
- [macOS] Fixed crashes when System OCR processes some list-heavy images on macOS.
- [Knowledge] Knowledge base: clicking a plain note now opens its full original content in-app; viewing indexed chunks moved to the row's right-click menu, and the broken "preview original" action no longer shows for notes.
- [Knowledge] Used regional Jina reader for URL imports.
- [Knowledge] Used readable names for saved messages.
- [Knowledge] Hide injected knowledge prompts in the composer.
- [Paintings] Fixed horizontal rendering artifacts that could appear while dragging generated images in Paintings.
- [Selection Assistant] Fixed the opacity slider so dragging right increases opacity and left decreases it (previously reversed).
- [Notes] Fixed the note character count not updating after toolbar undo and redo actions.
- [Tools] Dropped the uri format that strict providers reject.
- [API Gateway] Fixed the OpenAPI docs page showing the Health check curl example as a bare relative path (`curl /health`); it now shows the full server address so the example can be copied and run directly.
- [Obsidian] Fixed Obsidian export incorrectly reporting success when the note title is empty; the export dialog now stays open on failure and the export button is disabled until a title is provided.
- [Accessibility] The Reset / Zoom Out / Zoom In buttons in Settings → Appearance → Page Zoom now expose accessible names (aria-label) and tooltips.

⚡ Performance
- [Agent] Improved Agent session startup performance, especially for configurations with many MCP servers and skills.
```
