### PR TITLE
fix(model-parameters): drop stop sequences for models that reject the stop param

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -283,6 +283,16 @@ describe('applyCallOverrides', () => {
     expect(result.standardParams.topK).toBe(40)
   })
 
+  it('drops stopSequences for GPT-5 family models via filterStandardParams', () => {
+    const result = applyCallOverrides(
+      base(),
+      { stopSequences: ['</block>'], maxOutputTokens: 2112 },
+      makeModel({ id: 'cherryin::openai/gpt-5.6-luna', providerId: 'cherryin' })
+    )
+    expect(result.standardParams.maxOutputTokens).toBe(2112)
+    expect(result.standardParams).not.toHaveProperty('stopSequences')
+  })
+
   it('merges providerOptions per provider without clobbering other providers', () => {
     const result = applyCallOverrides(
       { standardParams: {}, providerOptions: { openai: { reasoningEffort: 'low' } } },

--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -135,6 +135,27 @@ describe('filterStandardParams', () => {
     const input = { topK: 40 }
     expect(filterStandardParams(input, makeModel())).toBe(input)
   })
+
+  it('drops stopSequences for GPT-5 family models (provider-prefixed api model id)', () => {
+    // Regression: the Claude Agent SDK auto-mode classifier sends `stop_sequences`;
+    // GPT-5 family chat/completions rejects `stop` with 400 invalid_request.
+    const model = makeModel({ id: 'cherryin::openai/gpt-5.6-luna', providerId: 'cherryin' })
+    expect(filterStandardParams({ stopSequences: ['</block>'], temperature: 0.2 }, model)).toEqual({
+      temperature: 0.2
+    })
+  })
+
+  it('drops stopSequences for o-series reasoning models', () => {
+    const model = makeModel({ id: 'openai::o3-mini' })
+    expect(filterStandardParams({ stopSequences: ['STOP'] }, model)).toEqual({})
+  })
+
+  it('keeps stopSequences for models that support them', () => {
+    const input = { stopSequences: ['</block>'] }
+    expect(filterStandardParams(input, makeModel({ id: 'anthropic::claude-haiku-4-5', providerId: 'anthropic' }))).toBe(
+      input
+    )
+  })
 })
 
 describe('getMaxTokens', () => {

--- a/src/main/ai/utils/modelParameters.ts
+++ b/src/main/ai/utils/modelParameters.ts
@@ -17,6 +17,7 @@ import {
   isMaxTemperatureOneModel,
   isSupportedFlexServiceTier,
   isSupportedThinkingTokenClaudeModel,
+  isSupportStopSequencesModel,
   isSupportTemperatureModel,
   isSupportTopPModel,
   isTemperatureTopPMutuallyExclusiveModel
@@ -125,6 +126,12 @@ export function filterStandardParams(
   if (isClaude47SeriesModel(model) && 'topK' in standardParams) {
     const { topK, ...rest } = standardParams
     logger.info(`Model ${model.id} rejects sampling parameters, dropping topK=${topK} from custom params`)
+    return rest
+  }
+
+  if ('stopSequences' in standardParams && !isSupportStopSequencesModel(model)) {
+    const { stopSequences, ...rest } = standardParams
+    logger.info(`Model ${model.id} does not support stop sequences, dropping ${JSON.stringify(stopSequences)}`)
     return rest
   }
 

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -241,6 +241,16 @@ export const isGPT52SeriesModel = (model: Model): boolean =>
 /** GPT-5 family models support verbosity */
 export const isSupportVerbosityModel = isGPT5FamilyModel
 
+/**
+ * OpenAI reasoning models (o-series and the GPT-5 family) reject the `stop`
+ * parameter on Chat Completions with `invalid_request` — stop sequences must
+ * be dropped for them, not forwarded.
+ */
+export const isSupportStopSequencesModel = (model: Model): boolean => {
+  const id = getLowerBaseModelName(getRawModelId(model))
+  return !(/^o[134](?:-|$)/.test(id) || isGPT5FamilyModel(model))
+}
+
 /** Check if model supports flex service tier */
 export const isSupportFlexServiceTierModel = (model: Model): boolean => {
   const id = getLowerBaseModelName(getRawModelId(model))


### PR DESCRIPTION
### What this PR does

Before this PR:

When an agent runs in the `auto` permission mode (#17584), the Claude Agent SDK's safety classifier issues its review request with `stop_sequences: ["</block>"]`. The API gateway forwards that as the Chat Completions `stop` parameter. OpenAI reasoning-family models (o-series, GPT-5 family) reject `stop` with `400 invalid_request`, so for an agent whose classifier model resolves to such a model (e.g. `cherryin:openai/gpt-5.6-luna`), **every classifier call fails deterministically**. The SDK fails closed and denies every gated tool call as `Classifier unavailable` — Bash becomes unusable in `auto` mode.

After this PR:

- New shared predicate `isSupportStopSequencesModel` identifies the model families that reject `stop` (o-series, GPT-5 family).
- `filterStandardParams` — the existing model-capability gate on the `callOverrides` path (already dropping `topK` for Gemini 3.x / Claude 4.7) — now also drops `stopSequences` for those families, with an info log.
- The classifier request goes through, `auto` mode works on these models. Verified live: the previously failing `Bash` review on `cherryin:openai/gpt-5.6-luna` now executes; the gateway logs `does not support stop sequences, dropping ["</block>"]` and no further 400s occur.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The drop applies to the whole GPT-5 family, including chat variants that might accept `stop`. Being over-broad is benign (stop sequences are a best-effort truncation hint; the caller still parses the full output), while being under-broad reproduces the catastrophic failure (all tool calls fail closed). One simple predicate beats a per-SKU matrix.
- Detection is by model-family name pattern rather than the data-driven `parameterSupport` schema: gateway-routed models (provider-prefixed api model ids) have no registry `parameterSupport` data, and extending the DB schema for one boolean is not warranted by this fix.

The following alternatives were considered:

- Stripping in the gateway's `AnthropicMessageConverter` / `proxyStream` — rejected: `filterStandardParams` is the established single gate for model-capability parameter dropping and covers every AI SDK caller, not just one inbound format.
- Fixing at the provider/gateway relay (cherryin) — out of our control, and other OpenAI-compatible endpoints share the behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None. Only affected requests are those carrying `stopSequences` to o-series / GPT-5 family models, which previously always failed with 400.

### Special notes for your reviewer

The failure was reproduced from the app logs: 9 identical `400 invalid_request` responses from `POST /v1/chat/completions` with `stop: ["</block>"]`, while identical-model requests without `stop` succeed. Regression tests pin the exact real-world model id (`cherryin::openai/gpt-5.6-luna`) at both the `filterStandardParams` and `applyCallOverrides` levels.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the auto permission mode denying all tool calls ("Classifier unavailable") when the agent's classifier model is an OpenAI reasoning-family model (o-series / GPT-5): stop sequences these models reject are no longer forwarded.
```
