### PR TITLE
feat(provider-settings): allow changing the default endpoint

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderCustomHeaderDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderCustomHeaderDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  Badge,
   Button,
   InputGroup,
   InputGroupInput,
@@ -63,6 +64,16 @@ const ENDPOINT_TYPE_LABEL_KEYS: Partial<Record<EndpointType, string>> = {
 const IMAGE_ENDPOINT_TYPES = new Set<EndpointType>([
   ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION,
   ENDPOINT_TYPE.OPENAI_IMAGE_EDIT
+])
+
+const DEFAULT_CHAT_ENDPOINT_TYPES = new Set<EndpointType>([
+  ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  ENDPOINT_TYPE.OPENAI_RESPONSES,
+  ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+  ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+  ENDPOINT_TYPE.OLLAMA_CHAT,
+  ENDPOINT_TYPE.OLLAMA_GENERATE,
+  ENDPOINT_TYPE.OPENAI_TEXT_COMPLETIONS
 ])
 
 function newRow(partial?: Partial<Pick<HeaderRow, 'key' | 'value'>>): HeaderRow {
@@ -193,6 +204,7 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
 
   const [rows, setRows] = useState<HeaderRow[]>([])
   const [endpointDrafts, setEndpointDrafts] = useState<Record<string, EndpointDraft>>({})
+  const [defaultChatEndpoint, setDefaultChatEndpoint] = useState<EndpointType>(primaryEndpoint)
   const [imageEndpointDraft, setImageEndpointDraft] = useState<ProviderImageEndpointDraft>(() =>
     readProviderImageEndpointDraft(undefined)
   )
@@ -220,6 +232,7 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
       }
     }
     setEndpointDrafts(drafts)
+    setDefaultChatEndpoint(primaryEndpoint)
     setImageEndpointDraft(readProviderImageEndpointDraft(provider?.endpointConfigs))
     setInvalidImageEndpointField(null)
     setVisibleEndpointTypes(endpointTypes)
@@ -227,7 +240,7 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
     setRows(headersObjectToRows(sourceHeaders))
     setJsonDraft(JSON.stringify(sourceHeaders, null, 2))
     setHeadersUiMode('list')
-  }, [open, sourceHeaders, endpointTypes, provider?.endpointConfigs])
+  }, [open, sourceHeaders, endpointTypes, primaryEndpoint, provider?.endpointConfigs])
 
   const syncListToJson = useCallback(() => {
     setJsonDraft(JSON.stringify(rowsToHeadersObject(rows), null, 2))
@@ -258,18 +271,18 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
   const handleSave = useCallback(async () => {
     if (!provider) return
 
-    // Validate the primary baseUrl — non-empty + URL-shape, unless this is
-    // Vertex (whose primary endpoint is account-managed, no URL needed).
-    const primaryDraft = trim(endpointDrafts[primaryEndpoint]?.baseUrl ?? '')
-    const isVertex = provider.authType === 'iam-gcp'
-    if (!isVertex && (!primaryDraft || !validateApiHost(primaryDraft))) {
+    // Validate the selected default baseUrl — non-empty + URL-shape, unless
+    // this is Vertex (whose text endpoints are account-managed).
+    const defaultEndpointDraft = trim(endpointDrafts[defaultChatEndpoint]?.baseUrl ?? '')
+    const isAccountManagedProvider = provider.authType === 'iam-gcp'
+    if (!isAccountManagedProvider && (!defaultEndpointDraft || !validateApiHost(defaultEndpointDraft))) {
       toast.error(t('settings.provider.api_host_no_valid'))
       return
     }
 
     // Secondary endpoints are optional, but a non-empty one must still be a
     // valid URL — otherwise it surfaces as an opaque chat-traffic failure later.
-    if (findInvalidSecondaryEndpointUrl(endpointDrafts, primaryEndpoint)) {
+    if (findInvalidSecondaryEndpointUrl(endpointDrafts, defaultChatEndpoint)) {
       toast.error(t('settings.provider.api_host_no_valid'))
       return
     }
@@ -283,7 +296,8 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
 
     const textEndpointConfigs = mergeEndpointConfigs(provider.endpointConfigs, endpointDrafts)
     const nextEndpointConfigs = mergeProviderImageEndpointDraft(textEndpointConfigs, imageEndpointDraft)
-    const previousPrimaryBaseUrl = trim(provider.endpointConfigs?.[primaryEndpoint]?.baseUrl ?? '')
+    const previousDefaultBaseUrl = trim(provider.endpointConfigs?.[primaryEndpoint]?.baseUrl ?? '')
+    const defaultEndpointChanged = defaultChatEndpoint !== primaryEndpoint
 
     let parsedHeaders: Record<string, string>
     if (headersUiMode === 'json') {
@@ -300,6 +314,7 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
     try {
       await updateProvider({
         endpointConfigs: nextEndpointConfigs,
+        defaultChatEndpoint,
         providerSettings: { ...provider.settings, extraHeaders: parsedHeaders }
       })
     } catch (error) {
@@ -310,15 +325,20 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
       return
     }
 
-    if (primaryDraft !== previousPrimaryBaseUrl) {
-      syncProviderModels().catch((error) => {
-        logger.error('Background model sync after baseUrl change failed', error as Error, { providerId })
+    if (defaultEndpointChanged || defaultEndpointDraft !== previousDefaultBaseUrl) {
+      syncProviderModels({
+        ...provider,
+        endpointConfigs: nextEndpointConfigs,
+        defaultChatEndpoint
+      }).catch((error) => {
+        logger.error('Background model sync after endpoint change failed', error as Error, { providerId })
       })
     }
 
     toast.success(t('message.save.success.title'))
     onClose()
   }, [
+    defaultChatEndpoint,
     endpointDrafts,
     headersUiMode,
     imageEndpointDraft,
@@ -368,15 +388,38 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
       footer={footer}>
       <div className={customHeaderDrawerClasses.bodyScroll}>
         {visibleEndpointTypes.map((type, index) => {
-          const isPrimary = index === 0
+          const isInitialPrimary = index === 0
+          const isDefault = type === defaultChatEndpoint
           const labelKey = ENDPOINT_TYPE_LABEL_KEYS[type]
-          const label = isPrimary ? t('settings.provider.api_host') : labelKey ? t(labelKey) : type
+          const label = labelKey ? t(labelKey) : isInitialPrimary ? t('settings.provider.api_host') : type
           const inputId = `provider-request-config-endpoint-${type}`
+          const isConfiguredDefaultCandidate =
+            type === primaryEndpoint ||
+            Object.prototype.hasOwnProperty.call(provider?.endpointConfigs ?? {}, type) ||
+            Boolean(trim(endpointDrafts[type]?.baseUrl ?? ''))
           return (
             <div key={type} className="space-y-1.5">
-              <Label className="text-muted-foreground text-xs" htmlFor={inputId}>
-                {label}
-              </Label>
+              <div className="flex min-h-5 items-center gap-2">
+                <Label className="text-[13px] text-foreground" htmlFor={inputId}>
+                  {label}
+                </Label>
+                {isDefault ? (
+                  <Badge
+                    variant="secondary"
+                    className="h-5 border-0 px-1.5 py-0 font-normal text-foreground-tertiary text-xs">
+                    {t('settings.provider.create_custom.endpoint_fields.default_chat')}
+                  </Badge>
+                ) : DEFAULT_CHAT_ENDPOINT_TYPES.has(type) && isConfiguredDefaultCandidate ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="before:-top-5 relative h-5 min-h-0 rounded-full px-2 text-xs transition-transform before:absolute before:inset-x-0 before:bottom-0 before:content-[''] active:scale-[0.96]"
+                    onClick={() => setDefaultChatEndpoint(type)}>
+                    {t('settings.provider.create_custom.endpoint_fields.set_default_chat')}
+                  </Button>
+                ) : null}
+              </div>
               <InputGroup className={fieldClasses.inputGroup}>
                 <InputGroupInput
                   id={inputId}
@@ -392,7 +435,7 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
                   autoComplete="off"
                 />
               </InputGroup>
-              {isPrimary && (
+              {isDefault && (
                 <p className="wrap-break-word text-muted-foreground text-xs leading-relaxed">
                   {t('settings.provider.api_host_drawer_hint')}
                 </p>

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderCustomHeaderDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderCustomHeaderDrawer.test.tsx
@@ -1,0 +1,124 @@
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useProviderMock = vi.fn()
+const updateProviderMock = vi.fn()
+const syncProviderModelsMock = vi.fn()
+
+vi.mock('@cherrystudio/ui', () => {
+  const React = require('react')
+
+  return {
+    Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+    Button: ({ children, onClick, ...props }: any) =>
+      React.createElement('button', { ...props, onClick, type: props.type ?? 'button' }, children),
+    InputGroup: ({ children, ...props }: any) => React.createElement('div', props, children),
+    InputGroupInput: (props: any) => React.createElement('input', props),
+    Label: ({ children, ...props }: any) => React.createElement('label', props, children),
+    MenuItem: ({ label, onClick }: any) => React.createElement('button', { onClick, type: 'button' }, label),
+    MenuList: ({ children }: any) => React.createElement('div', null, children),
+    Popover: ({ children }: any) => React.createElement('div', null, children),
+    PopoverContent: ({ children }: any) => React.createElement('div', null, children),
+    PopoverTrigger: ({ children }: any) => children,
+    Tooltip: ({ children }: any) => children
+  }
+})
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProvider: (...args: any[]) => useProviderMock(...args)
+}))
+
+vi.mock('../../components/ProviderImageEndpointFields', () => ({
+  ProviderImageEndpointFields: () => null
+}))
+
+vi.mock('../../hooks/useProviderModelSync', () => ({
+  useProviderModelSync: () => ({ syncProviderModels: syncProviderModelsMock })
+}))
+
+vi.mock('../../primitives/ProviderActions', () => ({
+  default: ({ children }: any) => <div>{children}</div>
+}))
+
+vi.mock('../../primitives/ProviderSettingsDrawer', () => ({
+  default: ({ children, footer, open, title }: any) =>
+    open ? (
+      <div role="dialog" aria-label={title}>
+        {children}
+        {footer}
+      </div>
+    ) : null
+}))
+
+vi.mock('../../primitives/ProviderSettingsPrimitives', () => ({
+  customHeaderDrawerClasses: {
+    addRowButton: '',
+    bodyScroll: '',
+    headerList: '',
+    headerRow: '',
+    removeIconButton: ''
+  },
+  drawerClasses: { footer: '' },
+  fieldClasses: { iconButton: '', input: '', inputGroup: '' }
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+import ProviderCustomHeaderDrawer from '../ProviderCustomHeaderDrawer'
+
+describe('ProviderCustomHeaderDrawer', () => {
+  const provider = {
+    id: 'custom-provider',
+    name: 'Custom Provider',
+    authType: 'api-key',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://openai.example.com' },
+      [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { baseUrl: 'https://anthropic.example.com' }
+    },
+    settings: {}
+  } as any
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateProviderMock.mockResolvedValue(undefined)
+    syncProviderModelsMock.mockResolvedValue([])
+    useProviderMock.mockReturnValue({ provider, updateProvider: updateProviderMock })
+  })
+
+  it('persists a configured endpoint as the provider default', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<ProviderCustomHeaderDrawer providerId={provider.id} open onClose={onClose} />)
+
+    expect(screen.getByText('settings.provider.create_custom.endpoint_fields.default_chat')).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'settings.provider.create_custom.endpoint_fields.set_default_chat'
+      })
+    )
+    await user.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(updateProviderMock).toHaveBeenCalledWith({
+        endpointConfigs: provider.endpointConfigs,
+        defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+        providerSettings: { extraHeaders: {} }
+      })
+    })
+    expect(syncProviderModelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpointConfigs: provider.endpointConfigs,
+        defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES
+      })
+    )
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/pages/settings/ProviderSettings/hooks/__tests__/useProviderModelSync.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/__tests__/useProviderModelSync.test.tsx
@@ -132,4 +132,22 @@ describe('useProviderModelSync', () => {
       }
     ])
   })
+
+  it('uses an endpoint provider override when settings changed before the hook rerenders', async () => {
+    const currentProvider = { id: 'new-api', defaultChatEndpoint: 'openai-chat-completions' }
+    const updatedProvider = { id: 'new-api', defaultChatEndpoint: 'anthropic-messages' }
+    const model = { id: 'new-api:model-alpha', providerId: 'new-api', name: 'Alpha' }
+    useProviderMock.mockReturnValue({ provider: currentProvider })
+    fetchResolvedProviderModelsMock.mockResolvedValue([model])
+    resolveCreateModelEndpointTypesMock.mockReturnValue(['anthropic-messages'])
+    createModelsMock.mockResolvedValue([{ id: 'new-api:model-alpha' }])
+
+    const { result } = renderHook(() => useProviderModelSync('new-api', { existingModels: [] }))
+
+    await act(async () => {
+      await result.current.syncProviderModels(updatedProvider as any)
+    })
+
+    expect(resolveCreateModelEndpointTypesMock).toHaveBeenCalledWith(updatedProvider, model)
+  })
 })

--- a/src/renderer/pages/settings/ProviderSettings/hooks/useProviderModelSync.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/useProviderModelSync.ts
@@ -28,80 +28,83 @@ export function useProviderModelSync(providerId: string, options: UseProviderMod
   const { provider } = useProvider(providerId)
   const { createModels, isCreating } = useModelMutations()
 
-  const syncProviderModels = useCallback(async (): Promise<Model[]> => {
-    logger.info('Checking provider models before sync', {
-      providerId,
-      localModelCount: models.length
-    })
-
-    // `useModels` returns a readonly SWR slice — copy into a mutable array so
-    // the function's `Promise<Model[]>` return type is satisfied without
-    // pushing `readonly` all the way through the public API.
-    const latestModels: Model[] =
-      models.length > 0
-        ? [...models]
-        : await dataApiService.get('/models', {
-            query: { providerId }
-          })
-
-    if (latestModels.length > 0) {
-      logger.info('Skipping provider model creation because models already exist', {
+  const syncProviderModels = useCallback(
+    async (endpointProvider = provider) => {
+      logger.info('Checking provider models before sync', {
         providerId,
-        modelCount: latestModels.length
+        localModelCount: models.length
       })
-      return latestModels
-    }
 
-    logger.info('Fetching remote provider models for sync', {
-      providerId
-    })
-    const resolvedModels = await fetchResolvedProviderModels(providerId)
-    if (resolvedModels.length === 0) {
-      logger.info('No remote provider models were resolved for sync', {
+      // `useModels` returns a readonly SWR slice — copy into a mutable array so
+      // the function's `Promise<Model[]>` return type is satisfied without
+      // pushing `readonly` all the way through the public API.
+      const latestModels: Model[] =
+        models.length > 0
+          ? [...models]
+          : await dataApiService.get('/models', {
+              query: { providerId }
+            })
+
+      if (latestModels.length > 0) {
+        logger.info('Skipping provider model creation because models already exist', {
+          providerId,
+          modelCount: latestModels.length
+        })
+        return latestModels
+      }
+
+      logger.info('Fetching remote provider models for sync', {
         providerId
       })
-      return []
-    }
+      const resolvedModels = await fetchResolvedProviderModels(providerId)
+      if (resolvedModels.length === 0) {
+        logger.info('No remote provider models were resolved for sync', {
+          providerId
+        })
+        return []
+      }
 
-    logger.info('Resolved remote provider models for sync', {
-      providerId,
-      resolvedModelCount: resolvedModels.length
-    })
-
-    const existingModelIds = new Set<UniqueModelId>(latestModels.map((model) => model.id))
-    const payload = resolvedModels
-      .filter((model) => !existingModelIds.has(model.id))
-      .map((model) => toCreateModelDto(providerId, model, resolveCreateModelEndpointTypes(provider, model)))
-
-    if (payload.length === 0) {
-      logger.info('Skipping provider model creation because resolved models are already present', {
+      logger.info('Resolved remote provider models for sync', {
         providerId,
         resolvedModelCount: resolvedModels.length
       })
-      return latestModels
-    }
 
-    const chunks = chunkArray(payload, MODELS_BATCH_MAX_ITEMS)
-    const createdModels: Model[] = []
+      const existingModelIds = new Set<UniqueModelId>(latestModels.map((model) => model.id))
+      const payload = resolvedModels
+        .filter((model) => !existingModelIds.has(model.id))
+        .map((model) => toCreateModelDto(providerId, model, resolveCreateModelEndpointTypes(endpointProvider, model)))
 
-    logger.info('Creating provider models from resolved remote list', {
-      providerId,
-      createCount: payload.length,
-      chunkCount: chunks.length
-    })
+      if (payload.length === 0) {
+        logger.info('Skipping provider model creation because resolved models are already present', {
+          providerId,
+          resolvedModelCount: resolvedModels.length
+        })
+        return latestModels
+      }
 
-    for (const chunk of chunks) {
-      const created = await createModels(chunk)
-      createdModels.push(...created)
-    }
+      const chunks = chunkArray(payload, MODELS_BATCH_MAX_ITEMS)
+      const createdModels: Model[] = []
 
-    logger.info('Completed provider model sync', {
-      providerId,
-      createdModelCount: createdModels.length
-    })
+      logger.info('Creating provider models from resolved remote list', {
+        providerId,
+        createCount: payload.length,
+        chunkCount: chunks.length
+      })
 
-    return [...latestModels, ...createdModels]
-  }, [createModels, models, provider, providerId])
+      for (const chunk of chunks) {
+        const created = await createModels(chunk)
+        createdModels.push(...created)
+      }
+
+      logger.info('Completed provider model sync', {
+        providerId,
+        createdModelCount: createdModels.length
+      })
+
+      return [...latestModels, ...createdModels]
+    },
+    [createModels, models, provider, providerId]
+  )
 
   return {
     syncProviderModels,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: The request configuration drawer could edit endpoint URLs but could not change the provider's default chat endpoint.

After this PR: Configured chat endpoints can be selected as default; saves persist the choice and model synchronization uses the updated provider snapshot.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Selection is limited to configured text endpoints so an empty default URL cannot be saved.

The following alternatives were considered: Reusing the full provider editor was rejected to keep the change local to request configuration while matching its existing endpoint UI.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with `pnpm lint`, 6 targeted renderer tests, and an Electron UI persistence check; `pnpm build:check` was skipped as requested, and the full test run exposed an unrelated `HomePage.test.tsx` failure before the remaining run was stopped.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Provider request settings now allow changing the default chat endpoint.
```
