### PR TITLE
fix(agent-permission-mode): keep the mode warning out of single-line rows

### DIFF
--- a/src/renderer/components/PermissionModeOption.tsx
+++ b/src/renderer/components/PermissionModeOption.tsx
@@ -32,18 +32,21 @@ export function PermissionModeIcon({ mode, size = 18 }: { mode: PermissionMode; 
  * picking one hands the agent unattended file deletion and network access, so it needs
  * to read as dangerous at a glance rather than merely noteworthy.
  *
- * A mode's `warningKey` renders regardless of `withDescription`. The description says
- * what the mode does and can be dropped where space is tight; the warning is what the
- * user needs before choosing it, so dropping it would defeat the point.
+ * A mode's `warningKey` renders on its own line regardless of `withDescription`, since the
+ * warning is what the user needs before choosing the mode. Containers that can only render
+ * a single line (the composer quick panel row is a fixed 30px) pass `withWarning={false}`
+ * and place the caveat themselves.
  */
 export function PermissionModeOptionLabel({
   card,
   t,
-  withDescription = true
+  withDescription = true,
+  withWarning = true
 }: {
   card: PermissionModeCard
   t: TFunction
   withDescription?: boolean
+  withWarning?: boolean
 }) {
   return (
     <div className="flex flex-col gap-0.5">
@@ -55,7 +58,7 @@ export function PermissionModeOptionLabel({
           {t(card.descriptionKey, card.descriptionFallback)}
         </span>
       )}
-      {card.warningKey && (
+      {withWarning && card.warningKey && (
         <span className={cn('text-xs', card.dangerous ? 'text-destructive' : 'text-warning')}>
           {t(card.warningKey, card.warningFallback ?? '')}
         </span>

--- a/src/renderer/components/__tests__/PermissionModeOption.test.tsx
+++ b/src/renderer/components/__tests__/PermissionModeOption.test.tsx
@@ -44,6 +44,15 @@ describe('PermissionModeOptionLabel', () => {
     expect(screen.getByText('Needs a model that supports it.')).toBeInTheDocument()
   })
 
+  // Single-line containers (the composer quick panel row is a fixed 30px) opt out and
+  // render the caveat themselves; a stacked warning would overflow the row.
+  it('drops the warning line when the container cannot take a second line', () => {
+    render(<PermissionModeOptionLabel card={withWarning} t={t} withDescription={false} withWarning={false} />)
+
+    expect(screen.getByText('Approve for Me')).toBeInTheDocument()
+    expect(screen.queryByText('Needs a model that supports it.')).not.toBeInTheDocument()
+  })
+
   it('renders no warning line for a mode without one', () => {
     render(<PermissionModeOptionLabel card={withoutWarning} t={t} />)
 

--- a/src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx
+++ b/src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx
@@ -1,0 +1,52 @@
+import type { ComposerToolLauncher } from '@renderer/components/composer/toolLauncher'
+import { render, screen } from '@testing-library/react'
+import type { TFunction } from 'i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  registerLaunchers: vi.fn<(launchers: ComposerToolLauncher[]) => () => void>(() => () => undefined),
+  updateAgent: vi.fn()
+}))
+
+vi.mock('@renderer/hooks/agent/useAgent', () => ({
+  useAgent: () => ({ agent: { id: 'agent-1', configuration: { permission_mode: 'default' } } }),
+  useUpdateAgent: () => ({ updateAgent: mocks.updateAgent })
+}))
+
+import permissionModeTool from '../permissionModeTool'
+
+const t = ((key: string, fallback?: string) => fallback ?? key) as unknown as TFunction
+
+const renderRuntime = () => {
+  const Runtime = permissionModeTool.composer!.runtime!
+  const context = {
+    t,
+    launcher: { registerLaunchers: mocks.registerLaunchers },
+    session: { agentId: 'agent-1' }
+  }
+
+  render(<Runtime context={context as any} />)
+
+  const launchers = mocks.registerLaunchers.mock.calls.at(-1)?.[0] ?? []
+  return launchers[0]?.submenu ?? []
+}
+
+describe('permissionModeTool submenu', () => {
+  beforeEach(() => {
+    mocks.registerLaunchers.mockClear()
+  })
+
+  // The quick panel row is a fixed 30px single line: a stacked warning under the title
+  // overflows it and collides with the neighbouring rows.
+  it('keeps the caveat out of the label and shows it in the description column', () => {
+    const submenu = renderRuntime()
+    const auto = submenu.find((item) => item.id === 'permission-mode-auto')
+    expect(auto).toBeDefined()
+
+    render(<>{auto!.label}</>)
+    expect(screen.queryByText(/Needs a model/)).not.toBeInTheDocument()
+
+    render(<>{auto!.description}</>)
+    expect(screen.getByText(/Needs a model/)).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
@@ -38,7 +38,9 @@ const usePermissionModeToolController = (context: PermissionModeContext) => {
         kind: 'command' as const,
         sources: ['popover'] as const,
         order: 80 + index / 100,
-        label: <PermissionModeOptionLabel card={card} t={t} withDescription={false} />,
+        // The quick panel row is a fixed-height single line, so the label stays one line and
+        // the mode's caveat rides along in the description column instead of stacking below.
+        label: <PermissionModeOptionLabel card={card} t={t} withDescription={false} withWarning={false} />,
         // label/description are React nodes, which yield no searchable text — provide it explicitly.
         searchAliases: getQuickPanelSearchAliases(t, card.titleKey, [
           t(card.titleKey, card.titleFallback),
@@ -47,6 +49,12 @@ const usePermissionModeToolController = (context: PermissionModeContext) => {
         description: (
           <span className={card.dangerous ? 'text-destructive/80' : undefined}>
             {t(card.descriptionKey, card.descriptionFallback)}
+            {card.warningKey && (
+              <span className={card.dangerous ? undefined : 'text-warning'}>
+                {' · '}
+                {t(card.warningKey, card.warningFallback ?? '')}
+              </span>
+            )}
           </span>
         ),
         icon: <PermissionModeIcon mode={card.mode} />,

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelForms.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelForms.tsx
@@ -60,6 +60,7 @@ type ChannelFieldsFormProps = ChannelFormProps & {
 
 const ChannelPermissionMode: FC<ChannelFormProps> = ({ channel, onConfigChange }) => {
   const { t } = useTranslation()
+  const selectedCard = permissionModeCards.find((card) => card.mode === channel.permissionMode)
   return (
     <div className="flex flex-col gap-1">
       <Label className="text-xs">{t('agent.channels.security.permissionMode')}</Label>
@@ -71,7 +72,16 @@ const ChannelPermissionMode: FC<ChannelFormProps> = ({ channel, onConfigChange }
           })
         }>
         <SelectTrigger size="sm" className="w-full">
-          <SelectValue />
+          {/* Own children so the trigger stays one line: the items below can be two. */}
+          <SelectValue>
+            {selectedCard ? (
+              <span className={selectedCard.dangerous ? 'text-destructive' : undefined}>
+                {t(selectedCard.titleKey, selectedCard.titleFallback)}
+              </span>
+            ) : (
+              t('agent.channels.security.inheritFromAgent')
+            )}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={INHERIT_PERMISSION_MODE_VALUE}>{t('agent.channels.security.inheritFromAgent')}</SelectItem>


### PR DESCRIPTION
### What this PR does

Before this PR: the permission-mode warning added by #17690 rendered as a second line inside the label of every surface, including two that can only show one line — the composer quick panel row and the channel override select trigger. The quick panel row is a fixed `h-[30px]` with `whitespace-nowrap`, and the virtual list steps at 31px, so the extra line overflowed the row and collided with its neighbours.
<img width="1952" height="650" alt="img_v3_02144_9e6d9680-bc04-4881-9568-a5cd5f0cdebg" src="https://github.com/user-attachments/assets/af8a02f0-65f8-4fe6-9509-cebb552a5684" />



After this PR: the warning still renders wherever a second line exists (agent editor, channel override list items). Containers that cannot take one opt out via a new `withWarning` prop and place the caveat themselves.

<img width="816" height="253" alt="file-58aae54bf887fee94fbbe3f4295d3fa3" src="https://github.com/user-attachments/assets/9b3bb44f-281b-469c-9b08-37cd89bd6baa" />
<img width="495" height="263" alt="file-bd3c382a59f6b2886f7eb92461e47121" src="https://github.com/user-attachments/assets/942415f1-5f89-436c-a323-eddb5e468691" />


Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **An opt-out prop rather than reverting the warning.** #17690's reasoning holds: the caveat is what a user needs *before* picking `auto`, and the compact surfaces are exactly where the mode gets picked in a hurry. What did not hold is that a shared label component can decide to be two lines tall inside a container whose height is fixed. `withWarning` moves that decision to the container, which is the only place that knows.
- **In the quick panel the caveat rides in the description column, not the label.** That column already carries the mode description on the same row, so the caveat stays visible with no layout change. Long copy ellipsises there — the same degradation every other row in that panel already has — instead of breaking the row.
- **The channel override trigger gets its own children.** `<SelectValue />` mirrors the selected item's children into the trigger, so the warning turned a `size="sm"` trigger into two lines. `AgentEditDialog` already solved this by passing explicit single-line children to `SelectValue`; this copies that, rather than inventing a second mechanism.

The following alternatives were considered: letting the quick panel row grow (rejected — `QUICK_PANEL_ITEM_HEIGHT` feeds both the virtualiser's `estimateSize` and the panel height maths in `heights.ts`, and every other row in the panel is single-line by contract), and a warning icon with a tooltip in the row suffix (rejected — the suffix already carries the active checkmark, and an icon says less than the sentence does).


### Breaking changes

None. No behaviour, storage, or default changes — the permission modes and their copy are untouched.

### Special notes for your reviewer

The bug is visible in the composer permission-mode switcher: `auto` and `bypassPermissions` are the two modes with a `warningKey`, and both rows overlapped their neighbours.

New test: `src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx` — renders the composer runtime with a mocked launcher and asserts the registered `auto` submenu item keeps the caveat out of `label` and puts it in `description`. It fails on the current `main`. `PermissionModeOption.test.tsx` gains a `withWarning={false}` case; the existing case asserting the warning survives `withDescription={false}` is left as is, since that behaviour is unchanged.

Not verified by running the app — the fix is derived from the row's CSS contract (`QuickPanel/list.tsx:170`) and the fixed `QUICK_PANEL_ITEM_HEIGHT` used by the virtualiser.

`PermissionModeCard.unsupported` is still dead, as #17690 already noted. Left alone here too.

Verification: `pnpm build:check` exit 0 (1643 test files, 20132 tests passed, 66 skipped).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required — no stored state is involved
- [x] Documentation: A user-guide update was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed the agent permission-mode switcher in the composer, where the "Approve for Me" and "Full Access" model-support warnings overflowed their rows and overlapped neighbouring options. The same warning no longer pushes the channel permission-mode selector onto two lines.
```

## Summary by Sourcery

调整代理的权限模式（permission-mode）相关的 UI 展示，使警告文案在固定高度的单行行内不再溢出，同时在支持多行标签的地方仍能保持可见。

Bug 修复：
- 防止权限模式警告在编辑器快速面板（composer quick panel）中溢出并与其他行产生重叠。
- 确保频道权限模式选择器的触发元素保持单行显示，不再继承已选项目中的警告文案行。

增强功能：
- 为权限模式标签新增 `withWarning` 退选（opt-out）配置，使容器组件可以控制警告说明的具体渲染位置。

测试：
- 为 `PermissionModeOptionLabel` 和编辑器权限模式工具子菜单新增单元测试，用于验证警告内容在标签与描述之间的正确放置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust agent permission-mode UI surfaces so warning copy no longer overflows fixed-height single-line rows while remaining visible where multi-line labels are supported.

Bug Fixes:
- Prevent permission-mode warnings from overflowing and overlapping rows in the composer quick panel.
- Ensure the channel permission-mode selector trigger remains single-line and no longer inherits the warning line from the selected item.

Enhancements:
- Add a `withWarning` opt-out to permission mode labels so containers can control where the caveat is rendered.

Tests:
- Add unit tests for `PermissionModeOptionLabel` and the composer permission-mode tool submenu to confirm warning placement in labels versus descriptions.

</details>