### PR TITLE
feat: add MiniMax text-to-speech support

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -12814,6 +12814,78 @@
       }
     },
     {
+      "capabilities": ["audio-generation"],
+      "id": "speech-01-hd",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-01-hd",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-01-turbo",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-01-turbo",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-02-hd",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-02-hd",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-02-turbo",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-02-turbo",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-2-6-hd",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-2.6-hd",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-2-6-turbo",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-2.6-turbo",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-2-8-hd",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-2.8-hd",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
+      "capabilities": ["audio-generation"],
+      "id": "speech-2-8-turbo",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "speech-2.8-turbo",
+      "outputModalities": ["audio"],
+      "ownedBy": "minimax"
+    },
+    {
       "capabilities": ["function-call", "structured-output", "file-input"],
       "contextWindow": 256000,
       "family": "codestral",
@@ -22190,5 +22262,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "ea9e5ee3d7b53cc9"
+  "version": "dfe0effd1a6ef6d4"
 }

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -18437,6 +18437,50 @@
       "providerId": "minimax"
     },
     {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-01-hd",
+      "providerId": "minimax"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-01-turbo",
+      "providerId": "minimax"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-02-hd",
+      "providerId": "minimax"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-02-turbo",
+      "providerId": "minimax"
+    },
+    {
+      "apiModelId": "speech-2.6-hd",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-6-hd",
+      "providerId": "minimax"
+    },
+    {
+      "apiModelId": "speech-2.6-turbo",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-6-turbo",
+      "providerId": "minimax"
+    },
+    {
+      "apiModelId": "speech-2.8-hd",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-8-hd",
+      "providerId": "minimax"
+    },
+    {
+      "apiModelId": "speech-2.8-turbo",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-8-turbo",
+      "providerId": "minimax"
+    },
+    {
       "imageGeneration": {
         "modes": {
           "edit": {
@@ -18610,6 +18654,50 @@
         }
       },
       "modelId": "image-01-live",
+      "providerId": "minimax-global"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-01-hd",
+      "providerId": "minimax-global"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-01-turbo",
+      "providerId": "minimax-global"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-02-hd",
+      "providerId": "minimax-global"
+    },
+    {
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-02-turbo",
+      "providerId": "minimax-global"
+    },
+    {
+      "apiModelId": "speech-2.6-hd",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-6-hd",
+      "providerId": "minimax-global"
+    },
+    {
+      "apiModelId": "speech-2.6-turbo",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-6-turbo",
+      "providerId": "minimax-global"
+    },
+    {
+      "apiModelId": "speech-2.8-hd",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-8-hd",
+      "providerId": "minimax-global"
+    },
+    {
+      "apiModelId": "speech-2.8-turbo",
+      "endpointTypes": ["openai-text-to-speech"],
+      "modelId": "speech-2-8-turbo",
       "providerId": "minimax-global"
     },
     {
@@ -37615,5 +37703,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "b74c1401a7cf1e32"
+  "version": "95b4c7a613bdac19"
 }

--- a/packages/provider-registry/src/creators/minimax.ts
+++ b/packages/provider-registry/src/creators/minimax.ts
@@ -88,6 +88,62 @@ export default defineCreator({
           }
         }
       }
+    },
+    {
+      id: 'speech-2.8-hd',
+      name: 'speech-2.8-hd',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-2.8-turbo',
+      name: 'speech-2.8-turbo',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-2.6-hd',
+      name: 'speech-2.6-hd',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-2.6-turbo',
+      name: 'speech-2.6-turbo',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-02-hd',
+      name: 'speech-02-hd',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-02-turbo',
+      name: 'speech-02-turbo',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-01-hd',
+      name: 'speech-01-hd',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
+    },
+    {
+      id: 'speech-01-turbo',
+      name: 'speech-01-turbo',
+      capabilities: ['audio-generation'],
+      inputModalities: ['text'],
+      outputModalities: ['audio']
     }
   ]
 })

--- a/packages/provider-registry/src/providers/minimax-global.ts
+++ b/packages/provider-registry/src/providers/minimax-global.ts
@@ -1,4 +1,4 @@
-import { minimaxImageOverrides } from './minimax'
+import { minimaxImageOverrides, minimaxSpeechOverrides } from './minimax'
 import { openaiCompatible } from './types'
 
 export default openaiCompatible({
@@ -13,5 +13,5 @@ export default openaiCompatible({
     official: 'https://platform.minimax.io/'
   },
   presetProviderId: 'minimax',
-  overrides: minimaxImageOverrides
+  overrides: [...minimaxImageOverrides, ...minimaxSpeechOverrides]
 })

--- a/packages/provider-registry/src/providers/minimax.ts
+++ b/packages/provider-registry/src/providers/minimax.ts
@@ -82,6 +82,17 @@ export const minimaxImageOverrides = [
   }
 ] satisfies NonNullable<Provider['overrides']>
 
+export const minimaxSpeechOverrides = [
+  { modelId: 'speech-2-8-hd', apiModelId: 'speech-2.8-hd', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-2-8-turbo', apiModelId: 'speech-2.8-turbo', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-2-6-hd', apiModelId: 'speech-2.6-hd', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-2-6-turbo', apiModelId: 'speech-2.6-turbo', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-02-hd', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-02-turbo', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-01-hd', endpointTypes: ['openai-text-to-speech'] },
+  { modelId: 'speech-01-turbo', endpointTypes: ['openai-text-to-speech'] }
+] satisfies NonNullable<Provider['overrides']>
+
 export default openaiCompatible({
   id: 'minimax',
   name: 'MiniMax',
@@ -96,5 +107,5 @@ export default openaiCompatible({
   apiFeatures: {
     arrayContent: false
   },
-  overrides: minimaxImageOverrides
+  overrides: [...minimaxImageOverrides, ...minimaxSpeechOverrides]
 })

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -897,6 +897,41 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       expect(config.providerId).toBe('openai-compatible')
     })
 
+    it.each([
+      ['minimax', undefined, 'https://api.minimaxi.com/v1'],
+      ['minimax-global', 'minimax', 'https://api.minimax.io/v1']
+    ])('routes %s TTS models through MiniMax config', async (id, presetProviderId, baseUrl) => {
+      const provider = makeProvider({
+        id,
+        presetProviderId,
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl,
+            adapterFamily: 'openai-compatible'
+          }
+        }
+      })
+      const model = makeModel({
+        providerId: id,
+        apiModelId: 'speech-2.8-hd',
+        capabilities: [MODEL_CAPABILITY.AUDIO_GENERATION],
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH]
+      })
+
+      const { config, credentialReceipt } = await resolveProviderAiSdkConfig(provider, model)
+      const settings = config.providerSettings as Record<string, unknown>
+
+      expect(config.providerId).toBe('minimax')
+      expect(settings.baseURL).toBe(baseUrl)
+      expect(settings.apiKey).toBe('sk-test-key')
+      expect(credentialReceipt).toEqual({
+        attribution: 'explicit',
+        id: 'test-key',
+        masked: 'sk-t****-key'
+      })
+    })
+
     it('routes Doubao IMAGE models through Doubao config (Ark protocol + the providerOptions key)', async () => {
       // Two things ride on this id. The generic OpenAICompatibleImageModel would POST
       // multipart /v1/images/edits once a reference image is attached — an endpoint Ark

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -248,6 +248,20 @@ export async function resolveProviderAiSdkConfig(
         }
       }))
     },
+    {
+      match: (p, id) =>
+        (id === 'openai-compatible' || id === 'minimax') &&
+        endpointType === ENDPOINT_TYPE.OPENAI_TEXT_TO_SPEECH &&
+        matchesPreset(p, 'minimax'),
+      build: withSelectedApiKey((ctx) => ({
+        providerId: 'minimax',
+        endpoint: ctx.endpoint,
+        providerSettings: {
+          ...ctx.baseConfig,
+          headers: { ...defaultAppHeaders(), ...getExtraHeaders(ctx.actualProvider) }
+        }
+      }))
+    },
     { match: (_, id) => id === 'bedrock', build: buildBedrockConfig },
     // `google-vertex-anthropic` (Vertex on an anthropic-messages endpoint) must route here
     // too — `buildVertexConfig` branches on `isAnthropic`. Otherwise it falls through to the

--- a/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
+++ b/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { MinimaxImageModel } from '../minimax/minimaxImageModel'
 import { createMinimaxProvider } from '../minimax/minimaxProvider'
+import { MinimaxSpeechModel } from '../minimax/minimaxSpeechModel'
 
 describe('createMinimaxProvider', () => {
-  it('uses OpenAI-compatible chat + embedding and the MiniMax image model', () => {
+  it('uses OpenAI-compatible chat + embedding and the MiniMax media models', () => {
     const provider = createMinimaxProvider({
       apiKey: 'sk-test',
       baseURL: 'https://api.minimax.io/v1',
@@ -15,6 +16,7 @@ describe('createMinimaxProvider', () => {
     expect(provider.embeddingModel('embedding-model').provider).toBe('minimax.embedding')
     expect(provider.imageModel('image-01')).toBeInstanceOf(MinimaxImageModel)
     expect(provider.imageModel('image-01-live')).toBeInstanceOf(MinimaxImageModel)
+    expect(provider.speechModel('speech-2.8-hd')).toBeInstanceOf(MinimaxSpeechModel)
   })
 
   it('posts the complete text-to-image request and parses URL output', async () => {
@@ -127,5 +129,74 @@ describe('createMinimaxProvider', () => {
       expect.objectContaining({ method: 'POST' })
     )
     expect(result.images).toEqual([image])
+  })
+
+  it('posts MiniMax speech fields to the global endpoint and decodes hex audio', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: { audio: '000102ff', status: 2 }, base_resp: { status_code: 0 } }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200
+      })
+    )
+    const provider = createMinimaxProvider({ apiKey: 'sk-test', baseURL: 'https://api.minimax.io/v1', fetch })
+
+    const result = await provider.speechModel('speech-2.8-hd').doGenerate({
+      text: 'Hello from MiniMax',
+      voice: 'male-qn-qingse',
+      outputFormat: 'wav',
+      speed: 1.2,
+      language: 'English',
+      instructions: 'Speak clearly',
+      providerOptions: {
+        minimax: {
+          voice_setting: { emotion: 'happy' },
+          audio_setting: { sample_rate: 32000 },
+          pronunciation_dict: { tone: ['Hello/(hello)'] },
+          voice_modify: { pitch: 1 },
+          subtitle_enable: true
+        }
+      }
+    })
+
+    expect(fetch).toHaveBeenCalledWith('https://api.minimax.io/v1/t2a_v2', expect.objectContaining({ method: 'POST' }))
+    const sent = JSON.parse((fetch.mock.calls[0][1] as RequestInit).body as string)
+    expect(sent).toEqual({
+      model: 'speech-2.8-hd',
+      text: 'Hello from MiniMax',
+      stream: false,
+      language_boost: 'English',
+      output_format: 'hex',
+      voice_setting: { emotion: 'happy', voice_id: 'male-qn-qingse', speed: 1.2 },
+      audio_setting: { sample_rate: 32000, format: 'wav' },
+      pronunciation_dict: { tone: ['Hello/(hello)'] },
+      voice_modify: { pitch: 1 },
+      subtitle_enable: true
+    })
+    expect(Array.from(result.audio as Uint8Array)).toEqual([0, 1, 2, 255])
+    expect(result.warnings).toEqual([
+      {
+        type: 'unsupported',
+        feature: 'instructions',
+        details: 'MiniMax speech does not expose an instructions request field.'
+      }
+    ])
+  })
+
+  it('uses the China speech endpoint and surfaces MiniMax API errors', async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ base_resp: { status_code: 1004, status_msg: 'invalid voice' } }), {
+        headers: { 'content-type': 'application/json' },
+        status: 200
+      })
+    )
+    const provider = createMinimaxProvider({ apiKey: 'sk-test', baseURL: 'https://api.minimaxi.com/v1', fetch })
+
+    await expect(
+      provider.speechModel('speech-02-hd').doGenerate({ text: 'Hello from China', voice: 'male-qn-qingse' })
+    ).rejects.toMatchObject({ message: 'invalid voice' })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.minimaxi.com/v1/t2a_v2',
+      expect.objectContaining({ method: 'POST' })
+    )
   })
 })

--- a/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
+++ b/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
@@ -145,10 +145,12 @@ describe('createMinimaxProvider', () => {
       voice: 'male-qn-qingse',
       outputFormat: 'wav',
       speed: 1.2,
-      language: 'English',
+      language: 'en',
       instructions: 'Speak clearly',
       providerOptions: {
         minimax: {
+          stream: true,
+          language_boost: 'English',
           voice_setting: { emotion: 'happy' },
           audio_setting: { sample_rate: 32000 },
           pronunciation_dict: { tone: ['Hello/(hello)'] },
@@ -174,6 +176,16 @@ describe('createMinimaxProvider', () => {
     })
     expect(Array.from(result.audio as Uint8Array)).toEqual([0, 1, 2, 255])
     expect(result.warnings).toEqual([
+      {
+        type: 'unsupported',
+        feature: 'providerOptions.minimax.stream',
+        details: 'MiniMax speech streaming is not supported by the SpeechModelV3 response contract.'
+      },
+      {
+        type: 'unsupported',
+        feature: 'language',
+        details: 'Use providerOptions.minimax.language_boost for MiniMax language selection.'
+      },
       {
         type: 'unsupported',
         feature: 'instructions',

--- a/src/main/ai/provider/custom/minimax/minimaxProvider.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxProvider.ts
@@ -1,9 +1,10 @@
 import { OpenAICompatibleChatLanguageModel, OpenAICompatibleEmbeddingModel } from '@ai-sdk/openai-compatible'
-import type { EmbeddingModelV3, ImageModelV3, LanguageModelV3, ProviderV3 } from '@ai-sdk/provider'
+import type { EmbeddingModelV3, ImageModelV3, LanguageModelV3, ProviderV3, SpeechModelV3 } from '@ai-sdk/provider'
 import type { FetchFunction } from '@ai-sdk/provider-utils'
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils'
 
 import { MinimaxImageModel } from './minimaxImageModel'
+import { MinimaxSpeechModel } from './minimaxSpeechModel'
 
 export const MINIMAX_PROVIDER_NAME = 'minimax' as const
 
@@ -22,6 +23,7 @@ export interface MinimaxProvider extends ProviderV3 {
   embeddingModel(modelId: string): EmbeddingModelV3
   textEmbeddingModel(modelId: string): EmbeddingModelV3
   imageModel(modelId: string): ImageModelV3
+  speechModel(modelId: string): SpeechModelV3
 }
 
 export function createMinimaxProvider(settings: MinimaxProviderSettings = {}): MinimaxProvider {
@@ -62,6 +64,13 @@ export function createMinimaxProvider(settings: MinimaxProviderSettings = {}): M
   provider.imageModel = (modelId: string) =>
     new MinimaxImageModel(modelId, {
       provider: `${MINIMAX_PROVIDER_NAME}.image`,
+      url,
+      headers,
+      fetch: customFetch
+    })
+  provider.speechModel = (modelId: string) =>
+    new MinimaxSpeechModel(modelId, {
+      provider: `${MINIMAX_PROVIDER_NAME}.speech`,
       url,
       headers,
       fetch: customFetch

--- a/src/main/ai/provider/custom/minimax/minimaxSpeechModel.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxSpeechModel.ts
@@ -1,0 +1,202 @@
+import { APICallError, type SharedV3Warning, type SpeechModelV3, type SpeechModelV3CallOptions } from '@ai-sdk/provider'
+import { combineHeaders, type FetchFunction, removeUndefinedEntries } from '@ai-sdk/provider-utils'
+
+export interface MinimaxSpeechModelConfig {
+  provider: string
+  url: (options: { modelId: string; path: string }) => string
+  headers: () => Record<string, string | undefined>
+  fetch?: FetchFunction
+  _internal?: {
+    currentDate?: () => Date
+  }
+}
+
+interface MinimaxSpeechResponse {
+  data?: {
+    audio?: string
+    status?: number
+  }
+  base_resp?: {
+    status_code?: number
+    status_msg?: string
+  }
+}
+
+const AUDIO_FORMATS = ['mp3', 'wav', 'flac', 'pcm'] as const
+
+function responseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+  return headers
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? { ...(value as Record<string, unknown>) } : {}
+}
+
+function decodeHexAudio(value: string): Uint8Array {
+  const hex = value.trim()
+  if (hex.length % 2 !== 0 || /[^0-9a-f]/i.test(hex)) {
+    throw new Error('MiniMax returned invalid hex audio data')
+  }
+
+  const audio = new Uint8Array(hex.length / 2)
+  for (let index = 0; index < audio.length; index += 1) {
+    audio[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16)
+  }
+  return audio
+}
+
+export class MinimaxSpeechModel implements SpeechModelV3 {
+  readonly specificationVersion = 'v3'
+
+  get provider(): string {
+    return this.config.provider
+  }
+
+  constructor(
+    readonly modelId: string,
+    private readonly config: MinimaxSpeechModelConfig
+  ) {}
+
+  async doGenerate(options: SpeechModelV3CallOptions): Promise<Awaited<ReturnType<SpeechModelV3['doGenerate']>>> {
+    const currentDate = this.config._internal?.currentDate?.() ?? new Date()
+    const { text, voice, outputFormat, instructions, speed, language, providerOptions, headers, abortSignal } = options
+    const bag = asRecord(providerOptions?.minimax ?? providerOptions?.['minimax-global'])
+    const warnings: SharedV3Warning[] = []
+
+    const body: Record<string, unknown> = {
+      model: this.modelId,
+      text,
+      stream: typeof bag.stream === 'boolean' ? bag.stream : false,
+      output_format: 'hex'
+    }
+
+    const languageBoost = language ?? bag.language_boost
+    if (languageBoost !== undefined && languageBoost !== null) body.language_boost = languageBoost
+
+    for (const key of ['pronunciation_dict', 'voice_modify', 'subtitle_enable'] as const) {
+      if (bag[key] !== undefined && bag[key] !== null) body[key] = bag[key]
+    }
+
+    const voiceSetting = asRecord(bag.voice_setting)
+    if (voice !== undefined) voiceSetting.voice_id = voice
+    if (speed !== undefined) voiceSetting.speed = speed
+    if (Object.keys(voiceSetting).length > 0) body.voice_setting = voiceSetting
+
+    const audioSetting = asRecord(bag.audio_setting)
+    if (outputFormat !== undefined) {
+      if ((AUDIO_FORMATS as readonly string[]).includes(outputFormat)) {
+        audioSetting.format = outputFormat
+      } else {
+        warnings.push({
+          type: 'unsupported',
+          feature: 'outputFormat',
+          details: `Unsupported MiniMax audio format: ${outputFormat}.`
+        })
+      }
+    }
+    if (Object.keys(audioSetting).length > 0) body.audio_setting = audioSetting
+
+    if (instructions !== undefined) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'instructions',
+        details: 'MiniMax speech does not expose an instructions request field.'
+      })
+    }
+
+    const url = this.config.url({ path: '/t2a_v2', modelId: this.modelId })
+    const fetchFn = this.config.fetch ?? globalThis.fetch
+    const response = await fetchFn(url, {
+      method: 'POST',
+      headers: removeUndefinedEntries(
+        combineHeaders(this.config.headers(), headers, { 'Content-Type': 'application/json' })
+      ),
+      body: JSON.stringify(body),
+      signal: abortSignal
+    })
+    const headersRecord = responseHeaders(response)
+    const responseBody = await response.text()
+
+    if (!response.ok) {
+      throw new APICallError({
+        message: responseBody || response.statusText,
+        url,
+        requestBodyValues: body,
+        statusCode: response.status,
+        responseHeaders: headersRecord,
+        responseBody
+      })
+    }
+
+    let parsed: MinimaxSpeechResponse
+    try {
+      parsed = JSON.parse(responseBody) as MinimaxSpeechResponse
+    } catch (cause) {
+      throw new APICallError({
+        message: 'Invalid JSON response from MiniMax',
+        cause,
+        url,
+        requestBodyValues: body,
+        statusCode: response.status,
+        responseHeaders: headersRecord,
+        responseBody
+      })
+    }
+
+    const statusCode = parsed.base_resp?.status_code
+    if (statusCode !== undefined && statusCode !== 0) {
+      throw new APICallError({
+        message: parsed.base_resp?.status_msg || `MiniMax error ${statusCode}`,
+        url,
+        requestBodyValues: body,
+        statusCode: response.status,
+        responseHeaders: headersRecord,
+        responseBody
+      })
+    }
+
+    if (typeof parsed.data?.audio !== 'string') {
+      throw new APICallError({
+        message: 'MiniMax response did not include audio data',
+        url,
+        requestBodyValues: body,
+        statusCode: response.status,
+        responseHeaders: headersRecord,
+        responseBody
+      })
+    }
+
+    let audio: Uint8Array
+    try {
+      audio = decodeHexAudio(parsed.data.audio)
+    } catch (cause) {
+      throw new APICallError({
+        message: 'Invalid hex audio response from MiniMax',
+        cause,
+        url,
+        requestBodyValues: body,
+        statusCode: response.status,
+        responseHeaders: headersRecord,
+        responseBody
+      })
+    }
+
+    return {
+      audio,
+      warnings,
+      request: {
+        body: JSON.stringify(body)
+      },
+      response: {
+        timestamp: currentDate,
+        modelId: this.modelId,
+        headers: headersRecord,
+        body: parsed
+      }
+    }
+  }
+}

--- a/src/main/ai/provider/custom/minimax/minimaxSpeechModel.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxSpeechModel.ts
@@ -70,11 +70,27 @@ export class MinimaxSpeechModel implements SpeechModelV3 {
     const body: Record<string, unknown> = {
       model: this.modelId,
       text,
-      stream: typeof bag.stream === 'boolean' ? bag.stream : false,
+      stream: false,
       output_format: 'hex'
     }
 
-    const languageBoost = language ?? bag.language_boost
+    if (bag.stream === true) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'providerOptions.minimax.stream',
+        details: 'MiniMax speech streaming is not supported by the SpeechModelV3 response contract.'
+      })
+    }
+
+    if (language !== undefined) {
+      warnings.push({
+        type: 'unsupported',
+        feature: 'language',
+        details: 'Use providerOptions.minimax.language_boost for MiniMax language selection.'
+      })
+    }
+
+    const languageBoost = bag.language_boost
     if (languageBoost !== undefined && languageBoost !== null) body.language_boost = languageBoost
 
     for (const key of ['pronunciation_dict', 'voice_modify', 'subtitle_enable'] as const) {


### PR DESCRIPTION
Reason: Add native MiniMax text-to-speech support for the synchronous t2a_v2 API and current speech model catalog.

## Changes

- add a SpeechModelV3 adapter for MiniMax voice, language, speed, audio, pronunciation, voice modification, and subtitle settings
- decode hex audio responses and surface MiniMax API errors
- register eight speech models for the global and China endpoints
- route MiniMax text-to-speech models through the custom provider and add focused coverage

## Checks

- `pnpm exec vitest run --project main src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts src/main/ai/provider/__tests__/config.test.ts`
- `pnpm test:provider-registry`
- `pnpm run typecheck:node`
- `pnpm exec biome format <changed files>`
- `pnpm exec oxlint --deny-warnings <changed TypeScript files>`
- `pnpm exec eslint <changed TypeScript files>`
- `git diff --check`
