### PR TITLE
test(job,stream-manager): remove wall-clock races from cancel and idle-timeout tests

### DIFF
--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -152,6 +152,32 @@ function createManager(config?: Partial<AiStreamManagerConfig>): ManagerInstance
   return new Ctor(config)
 }
 
+/**
+ * Fake *only* the timers the idle watchdog uses.
+ *
+ * `IdleTimeoutController` is a bare `setTimeout`, so this hands the watchdog to
+ * `vi.advanceTimersByTimeAsync` while leaving microtasks / `setImmediate` real —
+ * which is what `readUIMessageStream`'s accumulator needs (a blanket
+ * `useFakeTimers()` starves it). Lets the idle-timeout tests assert ordering
+ * instead of betting on wall-clock margins (#17703).
+ */
+function useWatchdogTimers(): void {
+  vi.useRealTimers()
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+}
+
+/**
+ * Spin the real microtask/macrotask queue until `predicate` holds, without
+ * touching the (faked) clock. Throws rather than hanging if it never does.
+ */
+async function flushUntil(predicate: () => boolean, maxTicks = 1000): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (predicate()) return
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+  throw new Error(`flushUntil: predicate never became true within ${maxTicks} ticks`)
+}
+
 function chunk(text: string): UIMessageChunk {
   return { type: 'text-delta', delta: text, id: 'p1' } as unknown as UIMessageChunk
 }
@@ -1484,10 +1510,7 @@ describe('AiStreamManager', () => {
 
   describe('idle timeout', () => {
     it('settles a timed-out execution as paused, not done', async () => {
-      // readUIMessageStream's accumulator needs real microtask/timer
-      // scheduling; fake timers starve it. The idle timer is a short real
-      // `setTimeout`, so a brief real wait lets it fire.
-      vi.useRealTimers()
+      useWatchdogTimers()
 
       const listener = new FakeListener('l:a')
       startSingle(mgr, {
@@ -1500,8 +1523,10 @@ describe('AiStreamManager', () => {
       })
       expect(mgr.inspect('a')!.status).toBe('pending')
 
-      // Let the idle timer fire and the abort propagate through the loop.
-      await new Promise((resolve) => setTimeout(resolve, 60))
+      // Drive the idle timer off the fake clock, then let the abort propagate
+      // through the loop on real microtasks.
+      await vi.advanceTimersByTimeAsync(10)
+      await flushUntil(() => listener.pausedResults.length > 0)
 
       // Terminal is paused (truncated reply persisted as paused), never a
       // success done.
@@ -1512,7 +1537,12 @@ describe('AiStreamManager', () => {
     })
 
     it('pauses the idle timer while a tool is awaiting approval — a long deliberation is not killed', async () => {
-      vi.useRealTimers()
+      // `IdleTimeoutController` is nothing but a `setTimeout`, so faking only
+      // setTimeout/clearTimeout puts the watchdog entirely under test control
+      // while `readUIMessageStream`'s accumulator keeps its real microtask /
+      // setImmediate scheduling. Without this the test was a race: the re-arm
+      // had to beat a 30ms wall clock (#17703).
+      useWatchdogTimers()
 
       const controlled = controlledStream()
       mockStreamText.mockImplementationOnce(async () => controlled.stream)
@@ -1531,15 +1561,21 @@ describe('AiStreamManager', () => {
       controlled.enqueue({ type: 'start' } as UIMessageChunk)
       controlled.enqueue({ type: 'tool-approval-request', toolCallId: 'tc-1', approvalId: 'a-1' } as UIMessageChunk)
 
-      // Wait well past the 30ms idle timeout — the approval re-arm uses the 2 h bound, so no abort.
-      await new Promise((resolve) => setTimeout(resolve, 90))
+      // Wait for the listener to have actually seen the approval chunk: that is
+      // the re-arm, and it is a state rather than an interval. The fake clock is
+      // frozen meanwhile, so the 30ms watchdog cannot fire behind our back.
+      await flushUntil(() => listener.chunks.length >= 2)
+
+      // Only now let the clock jump — 10s is 300x the idle timeout, and still
+      // far short of the 2h approval bound, so a live re-arm means no abort.
+      await vi.advanceTimersByTimeAsync(10_000)
 
       expect(listener.pausedResults).toHaveLength(0)
       expect(mgr.inspect('a')!.status).not.toBe('aborted')
     })
 
     it('still bounds an approval wait — an unresponsive renderer is aborted after the approval timeout', async () => {
-      vi.useRealTimers()
+      useWatchdogTimers()
       // Tight approval bound so the test doesn't wait 2 h; the normal idle timeout stays longer so it
       // can't be what fires.
       const boundedMgr = createManager({ approvalIdleTimeoutMs: 40 })
@@ -1558,8 +1594,13 @@ describe('AiStreamManager', () => {
       controlled.enqueue({ type: 'start' } as UIMessageChunk)
       controlled.enqueue({ type: 'tool-approval-request', toolCallId: 'tc-1', approvalId: 'a-1' } as UIMessageChunk)
 
+      // Wait for the approval chunk to land (the re-arm) before moving the clock —
+      // otherwise this only ever proves *some* timer fired, not the approval bound.
+      await flushUntil(() => listener.chunks.length >= 2)
+
       // No approval response ever arrives (window closed/crashed) → the approval bound fires.
-      await new Promise((resolve) => setTimeout(resolve, 120))
+      await vi.advanceTimersByTimeAsync(40)
+      await flushUntil(() => boundedMgr.inspect('a')!.status === 'aborted')
 
       expect(boundedMgr.inspect('a')!.status).toBe('aborted')
     })
@@ -1595,11 +1636,11 @@ describe('AiStreamManager', () => {
       controlled.enqueue({ type: 'finish' } as UIMessageChunk)
       controlled.close()
 
-      // Let the tee → accumulator → terminal chain drain on real timers.
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      // Let the tee → accumulator → terminal chain drain. Poll for the terminal
+      // rather than betting a fixed 50ms is enough on a loaded runner (#17703).
+      await vi.waitFor(() => expect(mgr.inspect('a')!.status).toBe('done'))
 
       const snap = mgr.inspect('a')!
-      expect(snap.status).toBe('done')
 
       // The terminal event received the same finalMessage that inspect()
       // now reports — proof that the accumulator wrote before the terminal
@@ -1671,9 +1712,8 @@ describe('AiStreamManager', () => {
           listeners: [listener]
         })
 
-        await new Promise((resolve) => setTimeout(resolve, 50))
+        await vi.waitFor(() => expect(listener.errorResults).toHaveLength(1))
 
-        expect(listener.errorResults).toHaveLength(1)
         expect(listener.errorResults[0].error).toMatchObject({ statusCode, isRetryable, message })
       }
     )
@@ -1724,10 +1764,9 @@ describe('AiStreamManager', () => {
       controlled.enqueue({ type: 'error', errorText: 'boom' } as UIMessageChunk)
       controlled.close()
 
-      // Let the tee → broadcast → terminal chain drain on real timers.
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      // Let the tee → broadcast → terminal chain drain.
+      await vi.waitFor(() => expect(listener.errorResults).toHaveLength(1))
 
-      expect(listener.errorResults).toHaveLength(1)
       // `errorFromStreamChunk('boom')` → { name: 'StreamError', message: 'boom', stack: null }.
       expect(listener.errorResults[0].error).toEqual({ name: 'StreamError', message: 'boom', stack: null })
       expect(listener.errorResults[0].status).toBe('error')
@@ -1788,10 +1827,9 @@ describe('AiStreamManager', () => {
       controlled.enqueue({ type: 'finish' } as UIMessageChunk)
       controlled.close()
 
-      await new Promise((resolve) => setTimeout(resolve, 50))
+      await vi.waitFor(() => expect(mgr.inspect('a')!.status).toBe('done'))
 
       const snap = mgr.inspect('a')!
-      expect(snap.status).toBe('done')
       // The accumulator did not halt — finalMessage landed with the appended
       // text AND the resolved tool output.
       const parts = (snap.executions[0].finalMessage?.parts ?? []) as Array<{

--- a/src/main/core/job/__tests__/JobManager.integration.test.ts
+++ b/src/main/core/job/__tests__/JobManager.integration.test.ts
@@ -53,6 +53,12 @@ interface SlowOutput {
   echoed: string
 }
 
+/**
+ * Set by a test that needs to know a slow handler is genuinely parked in its
+ * abortable await, instead of sleeping a fixed interval and hoping (#17703).
+ */
+let onSlowHandlerEntered: (() => void) | null = null
+
 function makeSlowHandler(recovery: 'abandon' | 'retry' | 'singleton'): JobHandler<SlowInput> {
   return {
     recovery,
@@ -71,6 +77,7 @@ function makeSlowHandler(recovery: 'abandon' | 'retry' | 'singleton'): JobHandle
           },
           { once: true }
         )
+        onSlowHandlerEntered?.()
       })
       return { echoed: `echo: ${ctx.input.message}` } satisfies SlowOutput
     }
@@ -676,6 +683,10 @@ describe('JobManager integration', () => {
         handlers: [['shutdown.slow', makeSlowHandler('retry') as JobHandler]]
       })
 
+      const entered = new Promise<void>((resolve) => {
+        onSlowHandlerEntered = resolve
+      })
+
       const handle = jobManager.enqueue(
         'shutdown.slow' as never,
         {
@@ -684,9 +695,11 @@ describe('JobManager integration', () => {
         } as never
       )
 
-      // Wait for dispatch + handler.execute to be inside its await.
+      // Wait for dispatch + handler.execute to be inside its await — the handler
+      // signals that itself, so _doStop() cannot race a fixed sleep.
       await drainAllQueues(jobManager)
-      await new Promise<void>((r) => setTimeout(r, 50))
+      await entered
+      onSlowHandlerEntered = null
 
       const stopPromise = jobManager._doStop()
       const settled = await handle.finished

--- a/src/main/core/job/__tests__/JobManager.smoke.test.ts
+++ b/src/main/core/job/__tests__/JobManager.smoke.test.ts
@@ -32,21 +32,46 @@ vi.mock('@application', async () => {
 
 interface EchoInput {
   message: string
-  /** Optional sleep before resolving, used to give cancel() time to abort mid-flight. */
+  /** Optional sleep before resolving, used to keep a job in flight for a while. */
   sleepMs?: number
+  /** Park until aborted instead of sleeping — see `echoEntered` below. */
+  hold?: boolean
 }
 
 interface EchoOutput {
   echoed: string
 }
 
-interface StubbornInput {
-  /** Sleep duration; set longer than `cancelTimeoutMs` to force the timeout path. */
-  sleepMs: number
-}
-
 let scheduler: SchedulerService
 let jobManager: JobManager
+
+interface Deferred {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+/**
+ * Test-controlled gates for the cancel tests (#17703).
+ *
+ * Both tests need to observe a handler that is *definitely* still in flight and
+ * has *definitely* not settled yet. Deriving that from wall-clock sleeps made
+ * the outcome a bet on how promptly a loaded runner schedules `cancel()`; these
+ * promises make it a state the test owns instead.
+ *
+ * - `*Entered` resolves when the handler has actually entered `execute`.
+ * - `stubbornGate` releases the stubborn handler's (abort-ignoring) wait.
+ */
+const echoEntered = deferred()
+const stubbornEntered = deferred()
+const stubbornGate = deferred()
 
 // PowerService stub: JobManager acquires a sleep-prevention hold per attempt and
 // releases it in the finally. Shared spies let the end-to-end test assert acquire/release.
@@ -62,21 +87,20 @@ function makeEchoHandler(): JobHandler<EchoInput> {
     defaultConcurrency: 2,
     async execute(ctx) {
       ctx.reportProgress(25, { stage: 'starting' })
-      const delay = ctx.input.sleepMs ?? 30
       await new Promise<void>((resolve, reject) => {
         if (ctx.signal.aborted) {
           reject(new Error('AbortError'))
           return
         }
-        const t = setTimeout(() => resolve(), delay)
-        ctx.signal.addEventListener(
-          'abort',
-          () => {
-            clearTimeout(t)
-            reject(new Error('AbortError'))
-          },
-          { once: true }
-        )
+        if (ctx.input.hold) {
+          // Park until aborted: the cancel test needs a handler that cannot
+          // settle on its own, so cancel() never races the sleep to finish.
+          echoEntered.resolve()
+        } else {
+          const t = setTimeout(() => resolve(), ctx.input.sleepMs ?? 30)
+          ctx.signal.addEventListener('abort', () => clearTimeout(t), { once: true })
+        }
+        ctx.signal.addEventListener('abort', () => reject(new Error('AbortError')), { once: true })
       })
       ctx.reportProgress(100, { stage: 'done' })
       return { echoed: `echo: ${ctx.input.message}` } satisfies EchoOutput
@@ -85,19 +109,21 @@ function makeEchoHandler(): JobHandler<EchoInput> {
 }
 
 /**
- * Handler that intentionally IGNORES `ctx.signal` until after the grace window,
- * forcing `cancel()` down its force-finalize-on-timeout branch. After the grace
- * window it honors the abort and throws, so the late settlement finalizes as
- * cancelled (matching a real handler that eventually reacts) rather than
+ * Handler that intentionally IGNORES `ctx.signal` until the test releases
+ * `stubbornGate`, forcing `cancel()` down its force-finalize-on-timeout branch:
+ * the grace window cannot expire early because the handler cannot settle early.
+ * Once released it honors the abort and throws, so the late settlement finalizes
+ * as cancelled (matching a real handler that eventually reacts) rather than
  * clobbering the row back to completed.
  */
-function makeStubbornHandler(): JobHandler<StubbornInput> {
+function makeStubbornHandler(): JobHandler<Record<string, never>> {
   return {
     recovery: 'abandon',
     cancelTimeoutMs: 200,
     defaultConcurrency: 2,
     async execute(ctx) {
-      await new Promise<void>((resolve) => setTimeout(resolve, ctx.input.sleepMs))
+      stubbornEntered.resolve()
+      await stubbornGate.promise
       if (ctx.signal.aborted) throw new Error('AbortError (late)')
       return { done: true }
     }
@@ -220,11 +246,12 @@ describe('JobManager smoke (dummy.echo)', () => {
   })
 
   it('cancels an in-flight job (handler observes abort → outcome cancelled)', async () => {
-    const handle = jobManager.enqueue('dummy.echo' as never, { message: 'long', sleepMs: 500 } as never)
+    const handle = jobManager.enqueue('dummy.echo' as never, { message: 'long', hold: true } as never)
     // Wait for dispatch tx to fully commit before launching the next write.
     await drainTrailingDispatch()
-    // Give the handler time to actually enter its abortable await.
-    await new Promise((r) => setTimeout(r, 50))
+    // The handler is parked on its abortable await and cannot complete on its
+    // own, so cancel() is guaranteed to land while the job is in flight.
+    await echoEntered.promise
 
     const result = await jobManager.cancel(handle.id, 'user requested')
     expect(result).toEqual({ outcome: 'cancelled' })
@@ -244,10 +271,11 @@ describe('JobManager smoke (dummy.echo)', () => {
   })
 
   it('reports timed-out when the handler ignores the abort past cancelTimeoutMs', async () => {
-    const handle = jobManager.enqueue('dummy.stubborn' as never, { sleepMs: 600 } as never)
+    const handle = jobManager.enqueue('dummy.stubborn' as never, {} as never)
     await drainTrailingDispatch()
-    // Give the handler time to enter its (un-abortable) sleep before cancelling.
-    await new Promise((r) => setTimeout(r, 50))
+    // The handler has entered its abort-ignoring wait and stays there until we
+    // release the gate, so the grace window is certain to expire.
+    await stubbornEntered.promise
     // Capture the executor settlement so we can await the late handler return and
     // not leak a trailing task into the next test.
     const executed = inFlightExecutedOf(handle.id)
@@ -258,6 +286,8 @@ describe('JobManager smoke (dummy.echo)', () => {
     const settled = await handle.finished
     expect(settled.status).toBe('cancelled')
 
+    // Let the stubborn handler return late; it observes the abort and throws.
+    stubbornGate.resolve()
     await executed
     await drainTrailingDispatch()
     // Even on the force-timeout terminal the hold is released once the late handler settles.


### PR DESCRIPTION
### What this PR does

Before this PR: three test suites asserted timing-sensitive behaviour by sleeping a fixed number of milliseconds and hoping the runner cooperated. Each one encoded a race window that a loaded CI host could lose.

After this PR: those tests wait on state they control — a promise the test resolves, a signal the handler emits, or a fake clock the test advances — so the assertions hold regardless of how promptly the process gets scheduled.

Three shapes were fixed:

1. **`JobManager.smoke.test.ts`** (the reported flake). `dummy.stubborn` slept 600ms against a 200ms `cancelTimeoutMs`, with `cancel()` issued after a 50ms wait — leaving 400ms of slack. Land `cancel()` later than that and the remaining sleep is shorter than the grace window, so the handler settles *inside* it and JobManager correctly reports `cancelled` instead of `timed-out`. The handler now blocks on a `stubbornGate` promise the test releases explicitly, and `dummy.echo` gains a `hold` input that parks until aborted. Both signal `*Entered` on reaching `execute`, replacing the "sleep 50ms and hope dispatch happened" waits.

2. **`AiStreamManager.test.ts`** — the same bug on a much tighter budget. With a 30ms idle timeout, the `tool-approval-request` chunk had to travel `startSingle` → stream pull → `onChunk` and re-arm the watchdog to the 2h approval bound *within 30ms*, or the idle timer fired first and aborted the execution. `IdleTimeoutController` is nothing but a `setTimeout`, so `useWatchdogTimers()` fakes only setTimeout/clearTimeout — the watchdog becomes test-driven while microtasks and `setImmediate` stay real (a blanket `useFakeTimers()` starves `readUIMessageStream`'s accumulator, which is why these tests used real timers at all). The three idle-timeout tests now wait for the re-arm as a *state*, then jump the clock 10s.

3. **Lower-risk cleanups.** Four `sleep(50)`-then-assert waits in the same file become `vi.waitFor` (already used elsewhere in that file); `JobManager.integration.test.ts`'s graceful-shutdown test uses the new `onSlowHandlerEntered` signal instead of a 50ms sleep.

Fixes #17703

### Why we need it and why it was done in this way

The property under test in each case is **ordering**, not timing: "the handler had not yet observed the abort", "the approval re-arm happened before the idle bound". Deriving that from wall-clock intervals makes the outcome a bet on scheduling. Making it a state the test owns removes the bet entirely.

The following tradeoffs were made:

- The issue offered a cheaper option — widen the margin (e.g. 3000ms vs 200ms). Rejected: it is still a wall-clock bet, just at longer odds, and it adds real seconds to the suite. These changes go the other way and remove ~1s of real sleeping.
- `useWatchdogTimers()` fakes a *subset* of timers, which is less obvious than `vi.useFakeTimers()`. Justified because the narrower fake is precisely what makes it work here, and the helper carries a comment explaining why.
- `flushUntil()` spins the real macrotask queue with a tick cap and throws on exhaustion rather than hanging, so a genuine regression surfaces as a clear error instead of a suite timeout.

The following alternatives were considered:

- Leaving the neighbouring `dummy.echo` cancel test alone (the issue notes it is not what fails today). Converted anyway: same shape, same file, and its failure mode — the job completing before `cancel()` lands — is the identical class of bug.
- Extracting a shared `deferred()` helper. Deliberately **not** done: the repo already has six independent copies of `createDeferred`, and consolidating them is a separate refactor with a scope far beyond this fix.

Links to places where the discussion took place: #17703 (the issue's own analysis identified the mechanism and both options; this PR implements option 2).

### Breaking changes

None. Test-only change — no production code was touched.

### Special notes for your reviewer

Both fixes were verified to still bite, not merely to pass:

- **JobManager**: injecting a 1s scheduling delay before `cancel()` — 2.5x past the old 400ms cliff — passes on the new shape. The old shape broke at 400ms, exactly as the issue predicted.
- **AiStreamManager**: shortening the approval bound below the 10s clock jump makes the re-arm test fail as it should, confirming the assertion is not vacuous.

Ran the affected files 5x consecutively (116 tests, green each time), plus the full `pnpm build:check` (1656 files / 20344 tests) and `pnpm test:lint` (0 errors).

Note the branch name on the remote is lowercase `eurfelux/...`; the local worktree had it recorded as `EurFelux/...` due to macOS case-insensitivity.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
