### PR TITLE
fix(onboarding): skip redundant privacy agreement writes

### DIFF
--- a/src/renderer/windows/main/onboarding/OnboardingPage.tsx
+++ b/src/renderer/windows/main/onboarding/OnboardingPage.tsx
@@ -59,7 +59,7 @@ function OnboardingProviderSettings() {
 export default function OnboardingPage() {
   const { t } = useTranslation()
   const [language, setLanguage] = usePreference('app.language')
-  const [, updateOnboardingPreferences] = useMultiplePreferences(
+  const [{ policyVersion }, updateOnboardingPreferences] = useMultiplePreferences(
     ONBOARDING_PREFERENCE_KEYS,
     PESSIMISTIC_PREFERENCE_OPTIONS
   )
@@ -131,6 +131,10 @@ export default function OnboardingPage() {
   const persistPrivacyChoice = useCallback(async (): Promise<boolean> => {
     setIsUpdatingPrivacy(true)
     try {
+      if (privacyAccepted && policyVersion === LATEST_PRIVACY_POLICY_VERSION) {
+        return true
+      }
+
       await updateOnboardingPreferences(
         privacyAccepted
           ? { policyVersion: LATEST_PRIVACY_POLICY_VERSION }
@@ -143,7 +147,7 @@ export default function OnboardingPage() {
     } finally {
       setIsUpdatingPrivacy(false)
     }
-  }, [privacyAccepted, t, updateOnboardingPreferences])
+  }, [policyVersion, privacyAccepted, t, updateOnboardingPreferences])
 
   const updatePrivacyAcceptance = useCallback(
     async (accepted: boolean): Promise<boolean> => {

--- a/src/renderer/windows/main/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/src/renderer/windows/main/onboarding/__tests__/OnboardingPage.test.tsx
@@ -374,6 +374,30 @@ describe('OnboardingPage', () => {
     )
   })
 
+  it('does not rewrite an already-current privacy agreement before leaving onboarding', async () => {
+    const updatePreferences = vi.fn((updates: Record<string, unknown>) => {
+      if (updates.policyVersion !== undefined) {
+        return Promise.reject(new Error('privacy write unavailable'))
+      }
+      return Promise.resolve()
+    })
+    mockUseMultiplePreferences.mockReturnValueOnce([
+      {
+        providerSetupStatus: 'pending',
+        dataCollectionEnabled: true,
+        policyVersion: LATEST_PRIVACY_POLICY_VERSION
+      },
+      updatePreferences
+    ])
+    render(<OnboardingPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'onboarding.skip' }))
+
+    await waitFor(() => expect(updatePreferences).toHaveBeenCalledWith({ providerSetupStatus: 'skipped' }))
+    expect(updatePreferences).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
   it('shows the privacy control only on the welcome step', async () => {
     render(<OnboardingPage />)
 
@@ -531,7 +555,7 @@ describe('OnboardingPage', () => {
       {
         providerSetupStatus: 'pending',
         dataCollectionEnabled: true,
-        policyVersion: LATEST_PRIVACY_POLICY_VERSION
+        policyVersion: ''
       },
       updatePreferences
     ])
@@ -596,10 +620,9 @@ describe('OnboardingPage', () => {
     render(<OnboardingPage />)
 
     const loginButton = screen.getByRole('button', { name: 'onboarding.welcome.login_cherryin' })
-    fireEvent.click(loginButton)
+    await act(async () => fireEvent.click(loginButton))
 
     expect(loginButton).toBeDisabled()
-    await act(() => vi.advanceTimersByTimeAsync(10))
     expect(loginButton.querySelector('.lucide-log-in')).not.toBeInTheDocument()
 
     await act(() => vi.advanceTimersByTime(9_999))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Leaving onboarding always rewrote the privacy policy version, so a redundant write failure could block migrated users who had already accepted the current policy.

After this PR: Onboarding skips that no-op write when the accepted stored policy version is already current, while still persisting missing, stale, or declined choices.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17706

### Why we need it and why it was done in this way

The following tradeoffs were made: The guard is deliberately limited to an accepted, current policy version so real consent changes remain pessimistically persisted.

The following alternatives were considered: Ignoring all privacy write failures was rejected because it could allow onboarding to continue without saving a required choice.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17706

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- `pnpm lint` passed.
- The focused onboarding suite passed: 28/28 tests.
- The full `pnpm test` run was interrupted at approximately 83%; it had four high-concurrency failures, but no final failure summary was produced.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed onboarding blocking migrated users whose current privacy agreement was already saved.
```
