### PR TITLE
fix(copilot): preserve authorization headers

### DIFF
--- a/src/main/services/CopilotService.ts
+++ b/src/main/services/CopilotService.ts
@@ -90,7 +90,7 @@ class CopilotService {
    */
   private updateHeaders = (headers?: Record<string, string>): void => {
     if (headers && Object.keys(headers).length > 0) {
-      this.headers = { ...headers }
+      this.headers = { ...this.headers, ...headers }
     }
   }
 

--- a/src/main/services/__tests__/CopilotService.test.ts
+++ b/src/main/services/__tests__/CopilotService.test.ts
@@ -1,0 +1,40 @@
+import { net } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CopilotService from '../CopilotService'
+
+function jsonResponse(body: unknown): Awaited<ReturnType<typeof net.fetch>> {
+  return {
+    ok: true,
+    json: vi.fn().mockResolvedValue(body)
+  } as unknown as Awaited<ReturnType<typeof net.fetch>>
+}
+
+describe('CopilotService', () => {
+  beforeEach(() => {
+    vi.mocked(net.fetch).mockReset()
+  })
+
+  it('keeps required authorization headers when custom Copilot headers are provided', async () => {
+    vi.mocked(net.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        device_code: 'device-code',
+        user_code: 'user-code',
+        verification_uri: 'https://github.com/login/device'
+      })
+    )
+
+    await CopilotService.getAuthMessage({} as Electron.IpcMainInvokeEvent, { 'X-Custom': 'value' })
+
+    expect(net.fetch).toHaveBeenCalledWith(
+      'https://github.com/login/device/code',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Custom': 'value'
+        })
+      })
+    )
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

Custom GitHub Copilot headers replaced the service defaults. This could remove `Accept: application/json` from the device-code request, causing the response parsing to fail and preventing authorization.

After this PR:

Custom Copilot headers are merged with the existing service headers, so device-code authorization preserves its required defaults.

Fixes #17656

### Why we need it and why it was done in this way

The Copilot device flow requires JSON responses. Retaining the default headers keeps the authorization request valid while allowing users' custom headers to continue through the Copilot flow.

The following tradeoffs were made:

- Preserved the existing service state and added a one-line merge, limiting the change to the failing behavior.
- Added a focused main-process regression test that asserts custom headers do not remove the required authorization headers.

The following alternatives were considered:

- Ignore all custom headers for authorization requests. Rejected because those headers are part of the existing Copilot configuration and should remain available.

Links to places where the discussion took place: GitHub issue #17656.

### Breaking changes

None.

### Special notes for your reviewer

- Runtime verification passed in the v1 Electron app: `copilot.getAuthMessage` returned a device code when called with a custom header.
- The focused regression test passes.
- `pnpm lint`, typecheck, i18n, format, and OpenAPI checks pass.
- Full-suite and `pnpm build:check` test phases have unrelated Windows-environment failures: path-separator assertions and symlink creation blocked by `EPERM`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: I have left the code cleaner than I found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required; this restores existing authorization behavior.
- [x] Self-review: I have reviewed my own code and runtime behavior before requesting review from others

### Release note

```release-note
Fix GitHub Copilot device-code authorization when custom headers are configured.
```
