### PR TITLE
refactor(composer): lift agent path containment into renderer path utils

### DIFF
--- a/src/renderer/components/composer/tools/types.ts
+++ b/src/renderer/components/composer/tools/types.ts
@@ -3,6 +3,7 @@ import type { Assistant } from '@renderer/types/assistant'
 import { TopicType } from '@renderer/types/topic'
 import type { SlashCommand } from '@shared/ai/slashCommands'
 import type { Model } from '@shared/data/types/model'
+import type { AbsoluteFilePath } from '@shared/types/file'
 import type { TFunction } from 'i18next'
 import React from 'react'
 
@@ -61,7 +62,7 @@ export interface ToolContext {
     sessionId?: string
     agentType?: string
     tools?: Array<{ id: string; name: string; type: string; description?: string }>
-    accessiblePaths?: string[]
+    accessiblePaths?: readonly AbsoluteFilePath[]
     slashCommands?: SlashCommand[]
     /** Knowledge bases statically bound to the Agent. */
     knowledgeBaseIds?: readonly string[]

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -64,6 +64,7 @@ import type { FileUIPart } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import { getKnowledgeBaseIdsFromParts, withKnowledgeScopePart } from '@shared/data/types/uiParts'
 import type { OutputFor } from '@shared/ipc/types'
+import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
 import type { LocalSkill } from '@shared/types/skill'
 import { type CanonicalFilePath, canonicalizeFilePath, createFilePathHandle, toFileUrl } from '@shared/utils/file'
 import { Settings2, Terminal, ToolCase } from 'lucide-react'
@@ -131,7 +132,7 @@ const AGENT_MANAGED_TOKEN_KINDS_BEFORE_KNOWLEDGE_RESTORE = [
 ] as const satisfies readonly ComposerDraftToken['kind'][]
 const AGENT_SKILLS_LAUNCHER_ID = 'agent-skills'
 const AGENT_NEW_SESSION_TOOL_ID = 'composer:new-session'
-const EMPTY_ACCESSIBLE_PATHS: readonly string[] = []
+const EMPTY_ACCESSIBLE_PATHS: readonly AbsoluteFilePath[] = []
 const FILE_IPC_BATCH_SIZE = 500
 
 type AccessibleAttachment = {
@@ -185,9 +186,26 @@ const buildAccessiblePathFilePart = (
   )
 }
 
+/**
+ * `AgentWorkspacePathSchema` only guarantees a non-empty string, so the stored
+ * workspace path is asserted to be an absolute filesystem path here, before it
+ * reaches the path helpers. A malformed one yields no accessible paths, which
+ * degrades to inlining attachments instead of referencing them — still correct,
+ * just less efficient.
+ */
+const toAccessiblePaths = (workspacePath: string | undefined): AbsoluteFilePath[] => {
+  if (!workspacePath) return []
+  const parsed = AbsoluteFilePathSchema.safeParse(workspacePath)
+  if (!parsed.success) {
+    logger.warn('Ignoring agent workspace path that is not an absolute filesystem path', { path: workspacePath })
+    return []
+  }
+  return [parsed.data]
+}
+
 const buildAgentFilePartsForAttachments = async (
   attachments: ComposerAttachment[],
-  accessiblePaths: readonly string[]
+  accessiblePaths: readonly AbsoluteFilePath[]
 ): Promise<FileUIPart[]> => {
   const accessibleAttachments: AccessibleAttachment[] = []
   const internalizedAttachments: ComposerAttachment[] = []
@@ -393,7 +411,7 @@ const AgentComposerRoot = ({
   const sessionSlashCommands = useAgentSessionSlashCommands(sessionId)
   const sessionData = useMemo(() => {
     if (!session || !agent) return undefined
-    const accessiblePaths = session.workspace?.type === 'user' && session.workspace.path ? [session.workspace.path] : []
+    const accessiblePaths = toAccessiblePaths(session.workspace?.type === 'user' ? session.workspace.path : undefined)
     return {
       agentId,
       sessionId,

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2277,6 +2277,26 @@ describe('AgentComposer', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('ignores a workspace path that is not an absolute filesystem path', async () => {
+    mocks.sessionWorkspacePath = 'relative/workspace'
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const source = mocks.surfaceProps?.suggestionSources?.[0]
+    const items = await source?.items({ query: 'notes', editor: {} as any })
+
+    expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
+    expect(items).toEqual([expect.objectContaining({ id: 'agent-resource:no-paths' })])
+  })
+
   it('provides workspace file resources through the @ mention suggestion source', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -10,6 +10,7 @@ import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { FileUIPart } from '@shared/data/types/message'
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { IpcChannel } from '@shared/IpcChannel'
+import type { AbsoluteFilePath } from '@shared/types/file'
 import type { LocalSkill } from '@shared/types/skill'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { act, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react'
@@ -133,6 +134,9 @@ const createSerializedFolderToken = (folderPath: string): ComposerSerializedToke
   textOffset: 0
 })
 
+/** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
+const ps = (...values: string[]) => values as AbsoluteFilePath[]
+
 const renderAgentResourceMentionSource = (accessiblePaths: readonly string[] = ['/workspace']) =>
   renderHook(
     ({ paths }) =>
@@ -142,7 +146,7 @@ const renderAgentResourceMentionSource = (accessiblePaths: readonly string[] = [
         setFiles: mocks.setFiles,
         enabled: true
       }),
-    { initialProps: { paths: accessiblePaths } }
+    { initialProps: { paths: accessiblePaths as readonly AbsoluteFilePath[] } }
   )
 
 const requireFirstResourceMentionSource = (
@@ -2490,7 +2494,7 @@ describe('AgentComposer', () => {
     const staleSource = requireFirstResourceMentionSource(hook.result.current)
     const staleItemsPromise = staleSource.items({ query: '', editor: buildComposerEditorMock().editor })
 
-    hook.rerender({ paths: ['/workspace-2'] })
+    hook.rerender({ paths: ps('/workspace-2') })
     const currentSource = requireFirstResourceMentionSource(hook.result.current)
     await expect(currentSource.items({ query: '', editor: buildComposerEditorMock().editor })).resolves.toEqual([
       expect.objectContaining({ label: 'current', description: '/workspace-2/current' })

--- a/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
+++ b/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
@@ -1,99 +1,59 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { describe, expect, it } from 'vitest'
 
-async function loadAccessiblePath(platform: { isMac: boolean; isWin: boolean; isLinux: boolean }) {
-  vi.resetModules()
-  vi.doMock('@renderer/utils/platform', () => platform)
-  return import('../accessiblePath')
-}
+import { getAccessiblePathRelativePath, isPathWithinAccessiblePath } from '../accessiblePath'
 
-afterEach(() => {
-  vi.resetModules()
-  vi.clearAllMocks()
-})
+/** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
+const p = (value: string) => value as AbsoluteFilePath
+const ps = (...values: string[]) => values as AbsoluteFilePath[]
 
-describe('accessiblePath on a case-sensitive platform (linux)', () => {
-  const platform = { isMac: false, isWin: false, isLinux: true }
-
-  it('treats the base path itself and its descendants as within', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/workspace', ['/workspace'])).toBe(true)
-    expect(isPathWithinAccessiblePath('/workspace/docs/notes.md', ['/workspace'])).toBe(true)
+describe('accessiblePath', () => {
+  it('treats the base path itself and its descendants as within', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace'), ps('/workspace'))).toBe(true)
+    expect(isPathWithinAccessiblePath(p('/workspace/docs/notes.md'), ps('/workspace'))).toBe(true)
   })
 
-  it('rejects paths outside every accessible base', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/other/notes.md', ['/workspace'])).toBe(false)
-    expect(isPathWithinAccessiblePath('/workspace-2/notes.md', ['/workspace'])).toBe(false)
+  it('rejects paths outside every accessible base', () => {
+    expect(isPathWithinAccessiblePath(p('/other/notes.md'), ps('/workspace'))).toBe(false)
   })
 
-  it('resolves .. segments before comparing, closing the traversal gap', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/workspace/../outside/secret.txt', ['/workspace'])).toBe(false)
+  it('rejects a sibling directory that only shares a name prefix', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace-2/notes.md'), ps('/workspace'))).toBe(false)
   })
 
-  it('is case-sensitive', async () => {
-    const { getPathComparisonKey, isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/Workspace/notes.md', ['/workspace'])).toBe(false)
-    expect(getPathComparisonKey('/Workspace/docs')).not.toBe(getPathComparisonKey('/workspace/docs'))
+  it('resolves .. segments before comparing, closing the traversal gap', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace/../outside/secret.txt'), ps('/workspace'))).toBe(false)
   })
 
-  it('computes the relative path against the matching base', async () => {
-    const { getAccessiblePathRelativePath } = await loadAccessiblePath(platform)
-
-    expect(getAccessiblePathRelativePath('/workspace/docs/notes.md', ['/workspace'])).toBe('docs/notes.md')
+  it('is case-sensitive on every platform', () => {
+    expect(isPathWithinAccessiblePath(p('/Workspace/notes.md'), ps('/workspace'))).toBe(false)
+    expect(isPathWithinAccessiblePath(p('/Workspace/docs/notes.md'), ps('/workspace'))).toBe(false)
   })
 
-  it('returns the input unchanged when no base matches', async () => {
-    const { getAccessiblePathRelativePath } = await loadAccessiblePath(platform)
-
-    expect(getAccessiblePathRelativePath('/other/notes.md', ['/workspace'])).toBe('/other/notes.md')
+  it('accepts Windows drive-letter paths with backslashes or forward slashes', () => {
+    expect(isPathWithinAccessiblePath(p('C:/workspace/docs/notes.md'), ps('C:\\workspace'))).toBe(true)
+    expect(isPathWithinAccessiblePath(p('c:\\workspace\\docs\\notes.md'), ps('C:/workspace'))).toBe(true)
   })
 
-  it('matches against the POSIX filesystem root', async () => {
-    const { isPathWithinAccessiblePath, getAccessiblePathRelativePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/notes.md', ['/'])).toBe(true)
-    expect(getAccessiblePathRelativePath('/notes.md', ['/'])).toBe('notes.md')
+  it('matches against the POSIX filesystem root', () => {
+    expect(isPathWithinAccessiblePath(p('/notes.md'), ps('/'))).toBe(true)
+    expect(getAccessiblePathRelativePath(p('/notes.md'), ps('/'))).toBe('notes.md')
   })
 
-  it('rejects everything when there are no accessible paths', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/workspace/notes.md', [])).toBe(false)
-  })
-})
-
-describe('accessiblePath on a case-insensitive platform (macOS/Windows)', () => {
-  const platform = { isMac: true, isWin: false, isLinux: false }
-
-  it('matches regardless of case', async () => {
-    const { getPathComparisonKey, isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/Workspace/docs/notes.md', ['/workspace'])).toBe(true)
-    expect(getPathComparisonKey('/Workspace/Docs/./')).toBe(getPathComparisonKey('/workspace/docs'))
+  it('matches against a Windows drive root', () => {
+    expect(isPathWithinAccessiblePath(p('C:/notes.md'), ps('C:\\'))).toBe(true)
   })
 
-  it('accepts Windows drive-letter paths with backslashes or forward slashes', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('C:/workspace/docs/notes.md', ['C:\\workspace'])).toBe(true)
-    expect(isPathWithinAccessiblePath('c:\\workspace\\docs\\notes.md', ['C:/workspace'])).toBe(true)
+  it('rejects everything when there are no accessible paths', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace/notes.md'), ps())).toBe(false)
   })
 
-  it('rejects a sibling directory that only shares a name prefix', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('/workspace-2/notes.md', ['/workspace'])).toBe(false)
+  it('computes the relative path against the matching base', () => {
+    expect(getAccessiblePathRelativePath(p('/workspace/docs/notes.md'), ps('/workspace'))).toBe('docs/notes.md')
   })
 
-  it('matches against a Windows drive root', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('C:/notes.md', ['C:\\'])).toBe(true)
+  it('returns the input unchanged when no base matches', () => {
+    expect(getAccessiblePathRelativePath(p('/other/notes.md'), ps('/workspace'))).toBe('/other/notes.md')
   })
 })
 
@@ -102,25 +62,20 @@ describe('accessiblePath with un-canonicalizable input (UNC)', () => {
   // Containment is a predicate and must stay total: an un-canonicalizable path
   // is simply not provably inside anything. See
   // `docs/references/file/file-manager-architecture.md §1.2 "UNC paths"`.
-  const platform = { isMac: false, isWin: true, isLinux: false }
 
-  it('reports a UNC file path as not contained instead of throwing', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(() => isPathWithinAccessiblePath('\\\\server\\share\\notes.md', ['C:\\workspace'])).not.toThrow()
-    expect(isPathWithinAccessiblePath('\\\\server\\share\\notes.md', ['C:\\workspace'])).toBe(false)
+  it('reports a UNC file path as not contained instead of throwing', () => {
+    expect(() => isPathWithinAccessiblePath(p('\\\\server\\share\\notes.md'), ps('C:\\workspace'))).not.toThrow()
+    expect(isPathWithinAccessiblePath(p('\\\\server\\share\\notes.md'), ps('C:\\workspace'))).toBe(false)
   })
 
-  it('skips a UNC accessible base without discarding the usable ones', async () => {
-    const { isPathWithinAccessiblePath } = await loadAccessiblePath(platform)
-
-    expect(isPathWithinAccessiblePath('C:\\workspace\\notes.md', ['\\\\server\\share', 'C:\\workspace'])).toBe(true)
+  it('skips a UNC accessible base without discarding the usable ones', () => {
+    expect(isPathWithinAccessiblePath(p('C:\\workspace\\notes.md'), ps('\\\\server\\share', 'C:\\workspace'))).toBe(
+      true
+    )
   })
 
-  it('returns the path unchanged from getAccessiblePathRelativePath', async () => {
-    const { getAccessiblePathRelativePath } = await loadAccessiblePath(platform)
-
-    expect(getAccessiblePathRelativePath('\\\\server\\share\\notes.md', ['C:\\workspace'])).toBe(
+  it('returns the path unchanged from getAccessiblePathRelativePath', () => {
+    expect(getAccessiblePathRelativePath(p('\\\\server\\share\\notes.md'), ps('C:\\workspace'))).toBe(
       '\\\\server\\share\\notes.md'
     )
   })

--- a/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
+++ b/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
@@ -55,6 +55,19 @@ describe('accessiblePath', () => {
   it('returns the input unchanged when no base matches', () => {
     expect(getAccessiblePathRelativePath(p('/other/notes.md'), ps('/workspace'))).toBe('/other/notes.md')
   })
+
+  // A POSIX file named `a\b.txt` must not be mistaken for `b.txt` inside `a/`:
+  // that would classify an attachment as accessible and send a `file://`
+  // reference pointing at a different file.
+  it('does not treat a backslash in a POSIX filename as a directory separator', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace/a\\b.txt'), ps('/workspace/a'))).toBe(false)
+    expect(getAccessiblePathRelativePath(p('/workspace/a\\b.txt'), ps('/workspace/a'))).toBe('/workspace/a\\b.txt')
+  })
+
+  it('still resolves such a file against a base that genuinely contains it', () => {
+    expect(isPathWithinAccessiblePath(p('/workspace/a\\b.txt'), ps('/workspace'))).toBe(true)
+    expect(getAccessiblePathRelativePath(p('/workspace/a\\b.txt'), ps('/workspace'))).toBe('a\\b.txt')
+  })
 })
 
 describe('accessiblePath with un-canonicalizable input (UNC)', () => {

--- a/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
+++ b/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
@@ -1,7 +1,23 @@
 import type { AbsoluteFilePath } from '@shared/types/file'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getAccessiblePathRelativePath, isPathWithinAccessiblePath } from '../accessiblePath'
+
+/**
+ * `getPathComparisonKey` is the only export here that reads the platform, so it
+ * is the only one loaded through a module mock. The containment helpers are
+ * platform-independent and use the static import above.
+ */
+async function loadWithPlatform(platform: { isMac: boolean; isWin: boolean; isLinux: boolean }) {
+  vi.resetModules()
+  vi.doMock('@renderer/utils/platform', () => platform)
+  return import('../accessiblePath')
+}
+
+afterEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
 
 /** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
 const p = (value: string) => value as AbsoluteFilePath
@@ -91,5 +107,45 @@ describe('accessiblePath with un-canonicalizable input (UNC)', () => {
     expect(getAccessiblePathRelativePath(p('\\\\server\\share\\notes.md'), ps('C:\\workspace'))).toBe(
       '\\\\server\\share\\notes.md'
     )
+  })
+})
+
+describe('getPathComparisonKey', () => {
+  const LINUX = { isMac: false, isWin: false, isLinux: true }
+  const MACOS = { isMac: true, isWin: false, isLinux: false }
+
+  it('is case-sensitive on a case-sensitive platform', async () => {
+    const { getPathComparisonKey } = await loadWithPlatform(LINUX)
+
+    expect(getPathComparisonKey('/Workspace/docs')).not.toBe(getPathComparisonKey('/workspace/docs'))
+  })
+
+  it('folds case on a case-insensitive platform, after canonicalization', async () => {
+    const { getPathComparisonKey } = await loadWithPlatform(MACOS)
+
+    expect(getPathComparisonKey('/Workspace/Docs/./')).toBe(getPathComparisonKey('/workspace/docs'))
+  })
+
+  // The two below are what keying through `toPathKey` gains over an
+  // unconditional `\` → `/` fold: dedup must not merge paths that denote
+  // different files.
+
+  it('keeps a POSIX filename containing a backslash distinct from a nested path', async () => {
+    const { getPathComparisonKey } = await loadWithPlatform(LINUX)
+
+    expect(getPathComparisonKey('/workspace/a\\b.txt')).not.toBe(getPathComparisonKey('/workspace/a/b.txt'))
+  })
+
+  it('leaves an un-canonicalizable UNC path spelled as it came in', async () => {
+    const { getPathComparisonKey } = await loadWithPlatform(LINUX)
+
+    expect(getPathComparisonKey('\\\\server\\share\\a.txt')).toBe('\\\\server\\share\\a.txt')
+  })
+
+  it('falls back to the raw value for input that is not an absolute path', async () => {
+    const { getPathComparisonKey } = await loadWithPlatform(LINUX)
+
+    expect(getPathComparisonKey('')).toBe('')
+    expect(getPathComparisonKey('docs/notes.md')).toBe('docs/notes.md')
   })
 })

--- a/src/renderer/components/composer/variants/agent/accessiblePath.ts
+++ b/src/renderer/components/composer/variants/agent/accessiblePath.ts
@@ -1,12 +1,14 @@
-import { getRelativePath, isPathInside, isSamePath } from '@renderer/utils/path'
+import { getRelativePath, isPathInside, isSamePath, toPathKey } from '@renderer/utils/path'
+import { isMac, isWin } from '@renderer/utils/platform'
 import type { AbsoluteFilePath } from '@shared/types/file'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
 
 /**
  * Agent-specific policy over the generic renderer path primitives: match a path
  * against a list of accessible bases. Path semantics (canonicalization, strict
  * containment, un-canonicalizable input) live in `@renderer/utils/path`.
  *
- * Neither helper is an access-control gate — the authoritative one is main-side
+ * Nothing here is an access-control gate — the authoritative one is main-side
  * `WorkspaceFileGuard.resolveWorkspaceFile`.
  */
 
@@ -26,4 +28,38 @@ export const getAccessiblePathRelativePath = (
     if (relative !== null) return relative
   }
   return filePath
+}
+
+/**
+ * Case-folding matches the main-side `isPathInside` (`src/main/utils/file/path.ts`):
+ * case-insensitive on macOS/Windows (default APFS/NTFS), case-sensitive on Linux.
+ */
+const isCaseInsensitivePlatform = isMac || isWin
+
+/**
+ * A `Set`-able identity key for mention dedup — **deliberately looser than
+ * `isSamePath`**, and not interchangeable with it.
+ *
+ * Case-folding here is a UI heuristic, not an identity claim. It is a per-mount
+ * property that no string can decide, so the primitives in `@renderer/utils/path`
+ * refuse to guess. This consumer can afford the guess because both error
+ * directions are trivial: a folder that cannot be re-mentioned, or a duplicate
+ * token. The reference-vs-inline decision above cannot — a false "same" there
+ * sends the model a `file://` pointing at a different real file — which is why
+ * the fold lives at this call site instead of in the shared primitive.
+ *
+ * The two folder-token sources spell the same path differently
+ * (`listDirectoryEntries` inherits the workspace path's spelling, drag-and-drop
+ * carries the OS's), so a case mismatch is genuinely reachable.
+ *
+ * Keying through `toPathKey` rather than folding separators here is what keeps
+ * `/workspace/a\b.txt` — one POSIX file — from colliding with `/workspace/a/b.txt`.
+ * Input that is not an absolute path, or has no canonical form (UNC), keys on
+ * itself: unequal to everything but an identical spelling, which is the right
+ * answer for dedup.
+ */
+export const getPathComparisonKey = (value: string): string => {
+  const parsed = AbsoluteFilePathSchema.safeParse(value)
+  const key = (parsed.success ? toPathKey(parsed.data) : null) ?? value
+  return isCaseInsensitivePlatform ? key.toLowerCase() : key
 }

--- a/src/renderer/components/composer/variants/agent/accessiblePath.ts
+++ b/src/renderer/components/composer/variants/agent/accessiblePath.ts
@@ -2,6 +2,7 @@ import { getRelativePath, isPathInside, isSamePath, toPathKey } from '@renderer/
 import { isMac, isWin } from '@renderer/utils/platform'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 
 /**
  * Agent-specific policy over the generic renderer path primitives: match a path
@@ -18,11 +19,20 @@ export const isPathWithinAccessiblePath = (
   accessiblePaths: readonly AbsoluteFilePath[]
 ): boolean => accessiblePaths.some((base) => isSamePath(filePath, base) || isPathInside(filePath, base))
 
-/** `filePath` relative to the accessible base that contains it, or `filePath` unchanged if none matches. */
+/**
+ * `filePath` relative to the accessible base that contains it, or `filePath`
+ * unchanged if none matches.
+ *
+ * The return type is a union because the two branches return genuinely
+ * different things, and a caller that must tell them apart can now do so
+ * instead of inferring it from whether a leading `/` happens to be there.
+ * Today's caller wants neither — it renders the value — so the union costs it
+ * nothing.
+ */
 export const getAccessiblePathRelativePath = (
   filePath: AbsoluteFilePath,
   accessiblePaths: readonly AbsoluteFilePath[]
-): string => {
+): PosixRelativeFilePath | AbsoluteFilePath => {
   for (const base of accessiblePaths) {
     const relative = getRelativePath(base, filePath)
     if (relative !== null) return relative

--- a/src/renderer/components/composer/variants/agent/accessiblePath.ts
+++ b/src/renderer/components/composer/variants/agent/accessiblePath.ts
@@ -1,79 +1,29 @@
-// TODO(file-infra): Move the path-containment helpers below
-// (`isPathWithinAccessiblePath` / `getAccessiblePathRelativePath`) into a
-// renderer-safe, general-purpose `isPathInside` / `getRelativePath` in
-// `@shared/utils/file` once that infra exists — the main-side `isPathInside`
-// (`src/main/utils/file/path.ts`) can't be reused here because it depends on
-// `node:path`. Generalizing needs relative inputs and per-mount
-// case-insensitivity handling resolved first, so this module stays an
-// agent-local stopgap until then. (UNC is settled: not canonicalizable, hence
-// never contained — see `tryCanonicalize` below and
-// `docs/references/file/file-manager-architecture.md §1.2 "UNC paths"`.)
-import { isMac, isWin } from '@renderer/utils/platform'
-import { canonicalizeFilePath } from '@shared/utils/file'
+import { getRelativePath, isPathInside, isSamePath } from '@renderer/utils/path'
+import type { AbsoluteFilePath } from '@shared/types/file'
 
 /**
- * Case-folding matches the main-side `isPathInside` (`src/main/utils/file/path.ts`):
- * case-insensitive on macOS/Windows (default APFS/NTFS), case-sensitive on Linux.
+ * Agent-specific policy over the generic renderer path primitives: match a path
+ * against a list of accessible bases. Path semantics (canonicalization, strict
+ * containment, un-canonicalizable input) live in `@renderer/utils/path`.
+ *
+ * Neither helper is an access-control gate — the authoritative one is main-side
+ * `WorkspaceFileGuard.resolveWorkspaceFile`.
  */
-const isCaseInsensitivePlatform = isMac || isWin
 
-const toComparisonKey = (value: string) => (isCaseInsensitivePlatform ? value.toLowerCase() : value)
+/** True iff `filePath` is one of `accessiblePaths` or a descendant of one. */
+export const isPathWithinAccessiblePath = (
+  filePath: AbsoluteFilePath,
+  accessiblePaths: readonly AbsoluteFilePath[]
+): boolean => accessiblePaths.some((base) => isSamePath(filePath, base) || isPathInside(filePath, base))
 
-const normalizeSeparators = (value: string) => value.replace(/\\/g, '/')
-
-const withTrailingSlash = (value: string) => (value.endsWith('/') ? value : `${value}/`)
-
-/**
- * `canonicalizeFilePath` throws on input it cannot reduce to a byte-faithful
- * canonical form — today that is UNC (`\\server\share\…`), which is a valid
- * `AbsoluteFilePath` but has no defined canonical root here. Containment is a
- * predicate, not a parser: a path we cannot canonicalize is simply not
- * provably inside anything, so degrade to `null` rather than throwing out of
- * `isPathWithinAccessiblePath` and taking the caller down with it.
- */
-const tryCanonicalize = (value: string): string | null => {
-  try {
-    return canonicalizeFilePath(value)
-  } catch {
-    return null
+/** `filePath` relative to the accessible base that contains it, or `filePath` unchanged if none matches. */
+export const getAccessiblePathRelativePath = (
+  filePath: AbsoluteFilePath,
+  accessiblePaths: readonly AbsoluteFilePath[]
+): string => {
+  for (const base of accessiblePaths) {
+    const relative = getRelativePath(base, filePath)
+    if (relative !== null) return relative
   }
-}
-
-/** Canonical key for path identity, with a normalized fallback for unsupported UNC paths. */
-export const getPathComparisonKey = (value: string): string =>
-  toComparisonKey(normalizeSeparators(tryCanonicalize(value) ?? value))
-
-/** Canonicalized, `/`-separated form of an accessible base path, or null if the match fails. */
-const findAccessibleBasePath = (filePath: string, accessiblePaths: readonly string[]): string | null => {
-  const canonicalFilePath = tryCanonicalize(filePath)
-  if (canonicalFilePath === null) return null
-  const comparisonFilePath = toComparisonKey(normalizeSeparators(canonicalFilePath))
-
-  for (const basePath of accessiblePaths) {
-    const canonicalBasePath = tryCanonicalize(basePath)
-    if (canonicalBasePath === null) continue
-    const normalizedBasePath = normalizeSeparators(canonicalBasePath)
-    const comparisonBasePath = toComparisonKey(normalizedBasePath)
-    if (
-      comparisonFilePath === comparisonBasePath ||
-      comparisonFilePath.startsWith(toComparisonKey(withTrailingSlash(normalizedBasePath)))
-    ) {
-      return normalizedBasePath
-    }
-  }
-
-  return null
-}
-
-/** True iff `filePath` is `accessiblePaths[i]` itself or a descendant of it. */
-export const isPathWithinAccessiblePath = (filePath: string, accessiblePaths: readonly string[]): boolean =>
-  findAccessibleBasePath(filePath, accessiblePaths) !== null
-
-/** `filePath` relative to the accessible base path that contains it, or `filePath` unchanged if none matches. */
-export const getAccessiblePathRelativePath = (filePath: string, accessiblePaths: readonly string[]): string => {
-  const basePath = findAccessibleBasePath(filePath, accessiblePaths)
-  if (basePath === null) return filePath
-  // A non-null `basePath` proves `filePath` canonicalized above, so this
-  // cannot throw.
-  return normalizeSeparators(canonicalizeFilePath(filePath)).slice(withTrailingSlash(basePath).length)
+  return filePath
 }

--- a/src/renderer/components/composer/variants/agent/useAgentResourceMentionSource.tsx
+++ b/src/renderer/components/composer/variants/agent/useAgentResourceMentionSource.tsx
@@ -76,7 +76,7 @@ const createGroupHeaderItem = (id: string, label: string): ComposerSuggestionIte
 })
 
 interface AgentResourceMentionOptions {
-  accessiblePaths: readonly string[]
+  accessiblePaths: readonly AbsoluteFilePath[]
   files: ComposerAttachment[]
   setFiles: React.Dispatch<React.SetStateAction<ComposerAttachment[]>>
   /** Whether the agent session exposes any accessible workspace paths to mention. */

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -1,0 +1,119 @@
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { describe, expect, it } from 'vitest'
+
+import { getRelativePath, isPathInside, isSamePath } from '../path'
+
+/** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
+const p = (value: string) => value as AbsoluteFilePath
+
+describe('isSamePath', () => {
+  it('treats a path as the same as itself', () => {
+    expect(isSamePath(p('/workspace/notes.md'), p('/workspace/notes.md'))).toBe(true)
+  })
+
+  it('resolves . and .. segments before comparing', () => {
+    expect(isSamePath(p('/workspace/./docs/../notes.md'), p('/workspace/notes.md'))).toBe(true)
+  })
+
+  it('ignores a trailing separator', () => {
+    expect(isSamePath(p('/workspace/'), p('/workspace'))).toBe(true)
+  })
+
+  it('treats the POSIX root as the same as itself', () => {
+    expect(isSamePath(p('/'), p('/'))).toBe(true)
+  })
+
+  it('ignores Windows drive-letter case and separator style', () => {
+    expect(isSamePath(p('c:\\workspace\\notes.md'), p('C:/workspace/notes.md'))).toBe(true)
+  })
+
+  it('is case-sensitive on the path body', () => {
+    expect(isSamePath(p('/Workspace/notes.md'), p('/workspace/notes.md'))).toBe(false)
+  })
+
+  it('rejects different paths', () => {
+    expect(isSamePath(p('/workspace/a.md'), p('/workspace/b.md'))).toBe(false)
+  })
+
+  it('reports byte-identical UNC paths as not provably the same, rather than throwing', () => {
+    const unc = p('\\\\server\\share\\notes.md')
+
+    expect(() => isSamePath(unc, unc)).not.toThrow()
+    expect(isSamePath(unc, unc)).toBe(false)
+  })
+})
+
+describe('isPathInside', () => {
+  it('reports a descendant as inside', () => {
+    expect(isPathInside(p('/workspace/docs/notes.md'), p('/workspace'))).toBe(true)
+  })
+
+  it('is strict: a path is not inside itself', () => {
+    expect(isPathInside(p('/workspace'), p('/workspace'))).toBe(false)
+  })
+
+  it('rejects a sibling that only shares a name prefix', () => {
+    expect(isPathInside(p('/workspace-2/notes.md'), p('/workspace'))).toBe(false)
+  })
+
+  it('resolves .. before comparing, so a traversal escape is not inside', () => {
+    expect(isPathInside(p('/workspace/../outside/secret.txt'), p('/workspace'))).toBe(false)
+  })
+
+  it('reports a path as inside the POSIX root', () => {
+    expect(isPathInside(p('/notes.md'), p('/'))).toBe(true)
+  })
+
+  it('reports a path as inside its Windows drive root', () => {
+    expect(isPathInside(p('C:/notes.md'), p('C:\\'))).toBe(true)
+  })
+
+  it('matches across separator styles', () => {
+    expect(isPathInside(p('c:\\workspace\\docs\\notes.md'), p('C:/workspace'))).toBe(true)
+  })
+
+  it('reports an un-canonicalizable child as not inside, rather than throwing', () => {
+    expect(() => isPathInside(p('\\\\server\\share\\notes.md'), p('C:\\workspace'))).not.toThrow()
+    expect(isPathInside(p('\\\\server\\share\\notes.md'), p('C:\\workspace'))).toBe(false)
+  })
+
+  it('reports nothing as inside an un-canonicalizable parent, rather than throwing', () => {
+    expect(isPathInside(p('C:\\workspace\\notes.md'), p('\\\\server\\share'))).toBe(false)
+  })
+})
+
+describe('getRelativePath', () => {
+  it('returns the remainder for a descendant', () => {
+    expect(getRelativePath(p('/workspace'), p('/workspace/docs/notes.md'))).toBe('docs/notes.md')
+  })
+
+  it('returns an empty string for the base itself', () => {
+    expect(getRelativePath(p('/workspace'), p('/workspace'))).toBe('')
+  })
+
+  it('returns null for a path outside the base', () => {
+    expect(getRelativePath(p('/workspace'), p('/other/notes.md'))).toBe(null)
+  })
+
+  it('returns null for a sibling that only shares a name prefix', () => {
+    expect(getRelativePath(p('/workspace'), p('/workspace-2/notes.md'))).toBe(null)
+  })
+
+  it('computes against the POSIX root', () => {
+    expect(getRelativePath(p('/'), p('/notes.md'))).toBe('notes.md')
+  })
+
+  it('computes against a Windows drive root', () => {
+    expect(getRelativePath(p('C:\\'), p('C:/notes.md'))).toBe('notes.md')
+  })
+
+  it('returns a forward-slash relative path for Windows inputs', () => {
+    expect(getRelativePath(p('C:/workspace'), p('c:\\workspace\\docs\\notes.md'))).toBe('docs/notes.md')
+  })
+
+  it('returns null when either side is un-canonicalizable, rather than throwing', () => {
+    expect(() => getRelativePath(p('C:\\workspace'), p('\\\\server\\share\\notes.md'))).not.toThrow()
+    expect(getRelativePath(p('C:\\workspace'), p('\\\\server\\share\\notes.md'))).toBe(null)
+    expect(getRelativePath(p('\\\\server\\share'), p('C:\\workspace\\notes.md'))).toBe(null)
+  })
+})

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -117,3 +117,56 @@ describe('getRelativePath', () => {
     expect(getRelativePath(p('\\\\server\\share'), p('C:\\workspace\\notes.md'))).toBe(null)
   })
 })
+
+// On POSIX a backslash is an ordinary filename character, not a separator, so
+// `/workspace/a\b.txt` is ONE file named `a\b.txt` — not `b.txt` inside `a`.
+// `canonicalizeFilePath` already models this (its POSIX branch splits on `/`
+// only), and these primitives must not undo it.
+describe('POSIX paths containing a literal backslash', () => {
+  const backslashName = '/workspace/a\\b.txt'
+
+  it('does not treat a backslash in a filename as a separator', () => {
+    expect(isSamePath(p(backslashName), p('/workspace/a/b.txt'))).toBe(false)
+    expect(isPathInside(p(backslashName), p('/workspace/a'))).toBe(false)
+    expect(getRelativePath(p('/workspace/a'), p(backslashName))).toBe(null)
+  })
+
+  it('still matches such a path against itself', () => {
+    expect(isSamePath(p(backslashName), p(backslashName))).toBe(true)
+  })
+
+  it('still resolves genuine containment for such a path', () => {
+    expect(isPathInside(p(backslashName), p('/workspace'))).toBe(true)
+    expect(getRelativePath(p('/workspace'), p(backslashName))).toBe('a\\b.txt')
+  })
+
+  it('does not confuse a backslash name with a real directory of the same spelling', () => {
+    expect(isPathInside(p('/workspace/a/b.txt'), p('/workspace/a'))).toBe(true)
+    expect(isSamePath(p('/workspace/a/b.txt'), p(backslashName))).toBe(false)
+  })
+})
+
+// `//server/share` is the forward-slash spelling of UNC on Windows and is
+// implementation-defined on POSIX. `canonicalizeFilePath` collapses the leading
+// `//` to `/`, which would otherwise make it compare equal to an unrelated
+// POSIX path, so it gets the same verdict as `\\server\share`: not provable.
+describe('double-slash (forward-slash UNC) paths', () => {
+  it('is not the same as the single-slash path it collapses to', () => {
+    expect(isSamePath(p('//server/share/a.txt'), p('/server/share/a.txt'))).toBe(false)
+  })
+
+  it('is not provably the same as itself', () => {
+    expect(isSamePath(p('//server/share/a.txt'), p('//server/share/a.txt'))).toBe(false)
+  })
+
+  it('is not provably inside anything, on either side', () => {
+    expect(isPathInside(p('//server/share/a.txt'), p('//server/share'))).toBe(false)
+    expect(isPathInside(p('//server/share/a.txt'), p('/server'))).toBe(false)
+    expect(isPathInside(p('/server/share/a.txt'), p('//server/share'))).toBe(false)
+  })
+
+  it('yields no relative path, on either side', () => {
+    expect(getRelativePath(p('//server/share'), p('//server/share/a.txt'))).toBe(null)
+    expect(getRelativePath(p('/server/share'), p('//server/share/a.txt'))).toBe(null)
+  })
+})

--- a/src/renderer/utils/__tests__/path.test.ts
+++ b/src/renderer/utils/__tests__/path.test.ts
@@ -1,4 +1,5 @@
 import type { AbsoluteFilePath } from '@shared/types/file'
+import { PosixRelativeFilePathSchema } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
 import { getRelativePath, isPathInside, isSamePath } from '../path'
@@ -87,8 +88,11 @@ describe('getRelativePath', () => {
     expect(getRelativePath(p('/workspace'), p('/workspace/docs/notes.md'))).toBe('docs/notes.md')
   })
 
-  it('returns an empty string for the base itself', () => {
-    expect(getRelativePath(p('/workspace'), p('/workspace'))).toBe('')
+  // `.` denotes the base; the empty string is the ABSENCE of a path (`open("")`
+  // is ENOENT while `.` resolves), which is why `PosixRelativeFilePathSchema`
+  // rejects it. See its "`.` is a relative path; the empty string is not".
+  it('returns "." for the base itself', () => {
+    expect(getRelativePath(p('/workspace'), p('/workspace'))).toBe('.')
   })
 
   it('returns null for a path outside the base', () => {
@@ -115,6 +119,42 @@ describe('getRelativePath', () => {
     expect(() => getRelativePath(p('C:\\workspace'), p('\\\\server\\share\\notes.md'))).not.toThrow()
     expect(getRelativePath(p('C:\\workspace'), p('\\\\server\\share\\notes.md'))).toBe(null)
     expect(getRelativePath(p('\\\\server\\share'), p('C:\\workspace\\notes.md'))).toBe(null)
+  })
+})
+
+// `getRelativePath` asserts the `PosixRelativeFilePath` brand rather than
+// re-parsing, on the argument that its output cannot fail the schema: NUL is
+// already refused by `AbsoluteFilePathSchema`, canonicalization drops empty
+// segments, and neither branch can leave a `/` inside a segment. These cases
+// are that argument's guard — if a branch ever produces something the schema
+// refuses, the brand becomes a lie and one of these fails.
+describe('getRelativePath output satisfies PosixRelativeFilePathSchema', () => {
+  const parses = (value: string | null) => {
+    expect(value).not.toBeNull()
+    return PosixRelativeFilePathSchema.safeParse(value).success
+  }
+
+  it('holds for a nested POSIX descendant', () => {
+    expect(parses(getRelativePath(p('/workspace'), p('/workspace/docs/notes.md')))).toBe(true)
+  })
+
+  it('holds for the base itself', () => {
+    expect(parses(getRelativePath(p('/workspace'), p('/workspace')))).toBe(true)
+  })
+
+  it('holds for a Windows descendant, whose separators are folded to "/"', () => {
+    expect(parses(getRelativePath(p('C:/workspace'), p('c:\\workspace\\docs\\notes.md')))).toBe(true)
+  })
+
+  it('holds for a POSIX filename containing a backslash, which stays one segment', () => {
+    const relative = getRelativePath(p('/workspace'), p('/workspace/a\\b.txt'))
+    expect(parses(relative)).toBe(true)
+    expect(PosixRelativeFilePathSchema.parse(relative)).toBe('a\\b.txt')
+  })
+
+  it('holds against a filesystem root, where the base already ends in a separator', () => {
+    expect(parses(getRelativePath(p('/'), p('/notes.md')))).toBe(true)
+    expect(parses(getRelativePath(p('C:\\'), p('C:/notes.md')))).toBe(true)
   })
 })
 

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -1,4 +1,79 @@
 /**
+ * Pure-string path algebra for the renderer, which has no `node:path`.
+ *
+ * The comparison primitives below (`isSamePath` / `isPathInside` /
+ * `getRelativePath`) are **lexical**: they never consult the filesystem, so
+ * they are separator- and Windows-drive-case-insensitive and resolve `.`/`..`,
+ * but they are case-SENSITIVE on the path body and do not honour a
+ * case-insensitive mount. They are not a security or reachability primitive —
+ * when true on-disk identity matters, use the main-process `fs.realpath` gate
+ * (`WorkspaceFileGuard.resolveWorkspaceFile`) or `isSameFile`
+ * (`src/main/utils/file/fs.ts`) instead.
+ */
+
+import type { AbsoluteFilePath } from '@shared/types/file'
+import { canonicalizeFilePath } from '@shared/utils/file'
+
+/**
+ * Byte-faithful canonical, `/`-separated comparison form — or `null` when the
+ * path has no canonical form at all.
+ *
+ * The `\` → `/` fold is NOT redundant with `canonicalizeFilePath`, which
+ * normalizes Windows separators the other way (to `\`). It bridges that form to
+ * the `/` form used by the tree layer, `file://` URLs, and the relative paths
+ * returned below. Do not remove it. (See #17429 for the wider cleanup.)
+ *
+ * `canonicalizeFilePath` throws on input it cannot reduce — today that is UNC
+ * (`\\server\share\…`), a valid `AbsoluteFilePath` with no defined canonical
+ * root. These are predicates, not parsers: a path we cannot canonicalize is
+ * simply not provably the same as, or inside, anything. So degrade to `null`
+ * rather than throwing out of a predicate and taking the caller down with it.
+ */
+const toComparable = (path: AbsoluteFilePath): string | null => {
+  try {
+    return canonicalizeFilePath(path).replace(/\\/g, '/')
+  } catch {
+    return null
+  }
+}
+
+/** Appends a separator unless `path` is a root, which already ends with one. */
+const asPrefix = (path: string) => (path.endsWith('/') ? path : `${path}/`)
+
+/** True iff `a` and `b` denote the same path. Un-canonicalizable input → `false`. */
+export const isSamePath = (a: AbsoluteFilePath, b: AbsoluteFilePath): boolean => {
+  const left = toComparable(a)
+  return left !== null && left === toComparable(b)
+}
+
+/**
+ * True iff `child` is a **proper** descendant of `parent` — equal paths are
+ * `false`, matching the main-side `isPathInside` (`src/main/utils/file/path.ts`).
+ * For "at or under", write `isSamePath(a, b) || isPathInside(a, b)`.
+ * Un-canonicalizable input → `false`.
+ */
+export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath): boolean => {
+  const childPath = toComparable(child)
+  const parentPath = toComparable(parent)
+  if (childPath === null || parentPath === null || childPath === parentPath) return false
+  return childPath.startsWith(asPrefix(parentPath))
+}
+
+/**
+ * `to` relative to `from`, `/`-separated — or `null` if `to` is neither `from`
+ * itself nor a descendant of it. Equal paths give `''`. Never emits `../`
+ * climbs, and never returns an absolute path. Un-canonicalizable input → `null`.
+ */
+export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): string | null => {
+  const fromPath = toComparable(from)
+  const toPath = toComparable(to)
+  if (fromPath === null || toPath === null) return null
+  if (fromPath === toPath) return ''
+  const prefix = asPrefix(fromPath)
+  return toPath.startsWith(prefix) ? toPath.slice(prefix.length) : null
+}
+
+/**
  * Joins a base path and a relative segment with a single separator, tolerating both `/` and `\`
  * and a trailing separator on `base`. Leading separators on `rel` are stripped so the result stays
  * anchored to `base`.

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -3,9 +3,11 @@
  *
  * The comparison primitives below (`isSamePath` / `isPathInside` /
  * `getRelativePath`) are **lexical**: they never consult the filesystem, so
- * they are separator- and Windows-drive-case-insensitive and resolve `.`/`..`,
- * but they are case-SENSITIVE on the path body and do not honour a
- * case-insensitive mount. They are not a security or reachability primitive —
+ * they resolve `.`/`..`, ignore Windows drive-letter case, and treat `/` and `\`
+ * interchangeably **on Windows drive paths only** — on POSIX a backslash is an
+ * ordinary filename character and is preserved. They are case-SENSITIVE on the
+ * path body and do not honour a case-insensitive mount. They are not a security
+ * or reachability primitive —
  * when true on-disk identity matters, use the main-process `fs.realpath` gate
  * (`WorkspaceFileGuard.resolveWorkspaceFile`) or `isSameFile`
  * (`src/main/utils/file/fs.ts`) instead.
@@ -15,26 +17,53 @@ import type { AbsoluteFilePath } from '@shared/types/file'
 import { canonicalizeFilePath } from '@shared/utils/file'
 
 /**
- * Byte-faithful canonical, `/`-separated comparison form — or `null` when the
- * path has no canonical form at all.
+ * A Windows drive path (`C:\…` / `C:/…`) — the only shape in which a backslash
+ * is a separator. On POSIX a backslash is an ordinary filename character.
+ */
+const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
+
+/**
+ * Byte-faithful canonical comparison form — or `null` when the path has no
+ * canonical form we can trust.
  *
- * The `\` → `/` fold is NOT redundant with `canonicalizeFilePath`, which
- * normalizes Windows separators the other way (to `\`). It bridges that form to
- * the `/` form used by the tree layer, `file://` URLs, and the relative paths
- * returned below. Do not remove it. (See #17429 for the wider cleanup.)
+ * The `\` → `/` fold is applied to **Windows drive paths only**. It is not
+ * redundant with `canonicalizeFilePath`, which normalizes Windows separators the
+ * other way (to `\`); it bridges that form to the `/` form used by the tree
+ * layer, `file://` URLs, and the relative paths returned below. It must NOT be
+ * applied to POSIX paths: there a backslash is a legal filename character, so
+ * folding it would make `/workspace/a\b.txt` — one file named `a\b.txt` — compare
+ * equal to `/workspace/a/b.txt`, an entirely different file.
+ * `canonicalizeFilePath` already draws this distinction (its POSIX branch splits
+ * on `/` only); the job here is to preserve it, not undo it.
  *
- * `canonicalizeFilePath` throws on input it cannot reduce — today that is UNC
- * (`\\server\share\…`), a valid `AbsoluteFilePath` with no defined canonical
- * root. These are predicates, not parsers: a path we cannot canonicalize is
- * simply not provably the same as, or inside, anything. So degrade to `null`
- * rather than throwing out of a predicate and taking the caller down with it.
+ * Two shapes yield `null`, both meaning "not provably anything":
+ *
+ * - **UNC** (`\\server\share\…`) — a valid `AbsoluteFilePath` that
+ *   `canonicalizeFilePath` rejects outright, since `\\server\share` is an
+ *   indivisible root that `..` must not escape.
+ * - **Leading `//`** — the forward-slash spelling of UNC on Windows, and
+ *   implementation-defined on POSIX. `canonicalizeFilePath` collapses the
+ *   leading `//` to `/`, so `//server/share/a.txt` would otherwise compare equal
+ *   to the unrelated `/server/share/a.txt`. Checked here on the raw input,
+ *   because the canonical form no longer carries the distinction. (Collapsing it
+ *   inside `canonicalizeFilePath` is arguably the real defect, but that function
+ *   produces the persisted `file_entry.externalPath` key and changing its output
+ *   requires a paired migration — see its "Rule-evolution discipline". Tracked
+ *   in #17429.)
+ *
+ * These are predicates, not parsers: a path we cannot canonicalize is simply not
+ * provably the same as, or inside, anything. So degrade to `null` rather than
+ * throwing out of a predicate and taking the caller down with it.
  */
 const toComparable = (path: AbsoluteFilePath): string | null => {
+  if (path.startsWith('//')) return null
+  let canonical: string
   try {
-    return canonicalizeFilePath(path).replace(/\\/g, '/')
+    canonical = canonicalizeFilePath(path)
   } catch {
     return null
   }
+  return isWindowsDrivePath(canonical) ? canonical.replace(/\\/g, '/') : canonical
 }
 
 /** Appends a separator unless `path` is a root, which already ends with one. */
@@ -60,9 +89,12 @@ export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath):
 }
 
 /**
- * `to` relative to `from`, `/`-separated — or `null` if `to` is neither `from`
- * itself nor a descendant of it. Equal paths give `''`. Never emits `../`
- * climbs, and never returns an absolute path. Un-canonicalizable input → `null`.
+ * `to` relative to `from` — or `null` if `to` is neither `from` itself nor a
+ * descendant of it. Equal paths give `''`. Never emits `../` climbs, and never
+ * returns an absolute path. Un-canonicalizable input → `null`.
+ *
+ * Separators in the result follow the input: `/`-separated for Windows drive
+ * paths, and verbatim for POSIX, where a backslash belongs to the filename.
  */
 export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): string | null => {
   const fromPath = toComparable(from)

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -54,8 +54,13 @@ const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
  * These are predicates, not parsers: a path we cannot canonicalize is simply not
  * provably the same as, or inside, anything. So degrade to `null` rather than
  * throwing out of a predicate and taking the caller down with it.
+ *
+ * Exported because a consumer needing a `Set`/`Map` key, or a comparison looser
+ * than `isSamePath`, must reach the same form the primitives compare against —
+ * and hand-rolling it is exactly how the conditional fold above gets lost. A
+ * consumer that only asks "same?" or "inside?" should use those instead.
  */
-const toComparable = (path: AbsoluteFilePath): string | null => {
+export const toPathKey = (path: AbsoluteFilePath): string | null => {
   if (path.startsWith('//')) return null
   let canonical: string
   try {
@@ -71,8 +76,8 @@ const asPrefix = (path: string) => (path.endsWith('/') ? path : `${path}/`)
 
 /** True iff `a` and `b` denote the same path. Un-canonicalizable input → `false`. */
 export const isSamePath = (a: AbsoluteFilePath, b: AbsoluteFilePath): boolean => {
-  const left = toComparable(a)
-  return left !== null && left === toComparable(b)
+  const left = toPathKey(a)
+  return left !== null && left === toPathKey(b)
 }
 
 /**
@@ -82,8 +87,8 @@ export const isSamePath = (a: AbsoluteFilePath, b: AbsoluteFilePath): boolean =>
  * Un-canonicalizable input → `false`.
  */
 export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath): boolean => {
-  const childPath = toComparable(child)
-  const parentPath = toComparable(parent)
+  const childPath = toPathKey(child)
+  const parentPath = toPathKey(parent)
   if (childPath === null || parentPath === null || childPath === parentPath) return false
   return childPath.startsWith(asPrefix(parentPath))
 }
@@ -97,8 +102,8 @@ export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath):
  * paths, and verbatim for POSIX, where a backslash belongs to the filename.
  */
 export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): string | null => {
-  const fromPath = toComparable(from)
-  const toPath = toComparable(to)
+  const fromPath = toPathKey(from)
+  const toPath = toPathKey(to)
   if (fromPath === null || toPath === null) return null
   if (fromPath === toPath) return ''
   const prefix = asPrefix(fromPath)

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -14,7 +14,7 @@
  */
 
 import type { AbsoluteFilePath } from '@shared/types/file'
-import { canonicalizeFilePath } from '@shared/utils/file'
+import { canonicalizeFilePath, type PosixRelativeFilePath } from '@shared/utils/file'
 
 /**
  * A Windows drive path (`C:\…` / `C:/…`) — the only shape in which a backslash
@@ -95,19 +95,30 @@ export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath):
 
 /**
  * `to` relative to `from` — or `null` if `to` is neither `from` itself nor a
- * descendant of it. Equal paths give `''`. Never emits `../` climbs, and never
+ * descendant of it. Equal paths give `'.'`. Never emits `../` climbs, and never
  * returns an absolute path. Un-canonicalizable input → `null`.
  *
  * Separators in the result follow the input: `/`-separated for Windows drive
  * paths, and verbatim for POSIX, where a backslash belongs to the filename.
+ * That is why the result is branded POSIX on both branches — after the Windows
+ * fold, `/` is the only separator left under either reading, and the POSIX
+ * reading is the one that keeps a filename's backslash intact. It is the
+ * `/`-separated in-app form, not a claim about where the path came from.
+ *
+ * The brand is asserted, not re-parsed. `PosixRelativeFilePathSchema` refuses
+ * exactly: the empty string (hence `'.'` above, which also matches its reading
+ * that `''` is the absence of a path), NUL — already refused by
+ * `AbsoluteFilePathSchema` — a leading `/`, which slicing a proper prefix
+ * cannot leave behind, and an empty segment, which canonicalization drops. No
+ * branch can produce any of them; `path.test.ts` guards that claim per branch.
  */
-export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): string | null => {
+export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): PosixRelativeFilePath | null => {
   const fromPath = toPathKey(from)
   const toPath = toPathKey(to)
   if (fromPath === null || toPath === null) return null
-  if (fromPath === toPath) return ''
+  if (fromPath === toPath) return '.' as PosixRelativeFilePath
   const prefix = asPrefix(fromPath)
-  return toPath.startsWith(prefix) ? toPath.slice(prefix.length) : null
+  return toPath.startsWith(prefix) ? (toPath.slice(prefix.length) as PosixRelativeFilePath) : null
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR:

Path-containment logic lived inside agent scope. `src/renderer/components/composer/variants/agent/accessiblePath.ts` carried its own `isPathWithinAccessiblePath` / `getAccessiblePathRelativePath` plus private machinery (`findAccessibleBasePath`, `toComparisonKey`, `normalizeSeparators`, `withTrailingSlash`, `tryCanonicalize`) and a platform-derived case-folding flag. A `TODO(file-infra)` at the top of the file asked for exactly this generalization, blocked on "relative inputs and per-mount case-insensitivity handling". The renderer had no reusable `isPathInside` at all — the main-side one (`src/main/utils/file/path.ts`) depends on `node:path` and cannot be imported here.

After this PR:

`src/renderer/utils/path.ts` (which already held `joinPath`) gains three primitives, typed on the branded `AbsoluteFilePath` and built on `canonicalizeFilePath`:

- `isSamePath(a, b)`
- `isPathInside(child, parent)` — **strict**: a path is not inside itself
- `getRelativePath(from, to)` — the inverse of `joinPath`; `null` when not contained
- `toPathKey(path)` — the comparison form the three above share, for consumers that need a `Set`/`Map` key (see "Rebase" below)

`accessiblePath.ts` keeps only the agent-specific policy — iterate the accessible-base list, fall back to the input when nothing matches — and expresses "at or under" as `isSamePath || isPathInside`. The `TODO(file-infra)` is resolved and removed.

Relative results are typed on the brands upstream #18229 added:

- `getRelativePath: (from, to) => PosixRelativeFilePath | null`
- `getAccessiblePathRelativePath: (…) => PosixRelativeFilePath | AbsoluteFilePath`

Fixes #

### Why we need it and why it was done in this way

This is path logic, not agent logic. Keeping it in the composer/agent directory meant it could not be reused, and the renderer had no general containment primitive to reach for.

The following tradeoffs were made:

- **Renderer, not `@shared`.** These are pure functions that *could* run in either process, but `@shared` admits a module only if **both** main and renderer use it (`docs/references/shared-layer-architecture.md` §1.1, with an explicit "no speculative placement" rule). Main already has a more reliable `node:path`-based `isPathInside`; publishing a second pure-JS one into `@shared` would put **two** `isPathInside` in main's import surface — the exact ambiguity worth avoiding.
- **`isPathInside` is strict.** Equal paths are not "inside", matching the main-side helper of the same name so the name means one thing across the codebase. The legacy helper conflated "inside" with "at or under"; callers now compose the two explicitly.
- **Case-folding removed *from the primitives*.** (One consumer keeps it deliberately — see "Rebase" below.) The old helper case-folded on macOS/Windows. Both renderer consumers were traced end-to-end and neither is a security boundary: Consumer A (`useAgentResourceMentionSource`) only computes a display label for paths that are descendants by construction; Consumer B (`AgentComposer`) only chooses between sending a `file://` reference and inlining bytes, and the authoritative gate is main-side `WorkspaceFileGuard.resolveWorkspaceFile` (whose own JSDoc says it is "defense-in-depth … not a sandbox"). Both error directions are benign, and case-sensitive is the safer direction — fewer "inside" verdicts means more inlining, which always works.
- **Predicates, not parsers.** `canonicalizeFilePath` is not total over `AbsoluteFilePath` — it rejects UNC (`\\server\share\…`), which the brand accepts. Rather than propagating that throw, all three primitives degrade to `false` / `null` on input they cannot canonicalize. This lifts the `tryCanonicalize` precedent #16740 established in `accessiblePath.ts` up into the primitives, so every function stays total.
- **Parsing at the composer boundary.** `AgentWorkspacePathSchema` is still `z.string().min(1)` — a bare string never validated as an absolute path. Rather than widen that schema (a DataApi/entity/persistence change with existing rows), the workspace path is parsed with `AbsoluteFilePathSchema.safeParse` at the `AgentComposer` boundary; a malformed one logs and yields no accessible paths.

The following alternatives were considered:

- **A single helper with an `includeSelf` option** — rejected: it pushes two different semantics into one function. Absolute-path equality is just `isSamePath`, so `isPathInside` should stay strict.
- **A `caseSensitive` parameter or per-volume detection** — rejected: case sensitivity is per-mount, not per-platform (macOS is not always APFS), so a platform flag was already wrong. Detecting it properly needs the filesystem, which the renderer should not be doing; accuracy stays in the main-side realpath gate.
- **Branding `AgentWorkspacePathSchema` upstream** — the more correct fix, but it reaches the DataApi schema, the workspace entity, its persistence and every existing row. Left as separate work.

Links to places where the discussion took place: N/A

### Breaking changes

None user-facing.

One internal behavior change worth stating plainly: on macOS/Windows, accessible-path **containment** matching is now case-sensitive. In practice a mismatch means an attachment is inlined as base64 instead of being sent as a `file://` reference — it still sends and still works, just less efficiently. No path becomes unreachable.

Folder-mention **dedup** is unaffected: it keeps the platform case-fold (see "Rebase" above for why the two differ).

### Special notes for your reviewer

**Review round 1 fixed a real defect — `fix(path-utils)` (a01e2dfa4a).** Layered review found that `toComparable` folded `\` to `/` unconditionally. A backslash is only a separator on Windows drive paths; on POSIX it is an ordinary *filename* character, so `/workspace/a\b.txt` — one file named `a\b.txt` — compared equal to `/workspace/a/b.txt`, a different file. Independently reproduced against the real schema/helpers before fixing:

| Expression | Was | Now |
| --- | --- | --- |
| `isSamePath('/workspace/a\b.txt', '/workspace/a/b.txt')` | `true` | `false` |
| `isPathInside('/workspace/a\b.txt', '/workspace/a')` | `true` | `false` |
| `getRelativePath('/workspace/a', '/workspace/a\b.txt')` | `'b.txt'` | `null` |
| `isSamePath('//server/share/a.txt', '/server/share/a.txt')` | `true` | `false` |

Worth stating plainly: this was **worse than the benign failure modes the demand analysis above relies on**. It could make the accessible-attachment branch send a `file://` reference pointing at a *different real file* than the user attached — a wrong-file reference, not a fallback to inlining.

Note `canonicalizeFilePath` was never wrong here: its POSIX branch splits on `/` only and its Windows branch on `[/\]`. The unconditional fold undid that distinction downstream. The fix is in the primitives, not in the agent consumer: fold only when the canonical form is a Windows drive path, and treat a leading `//` as un-canonicalizable (checked on the raw input, since `canonicalizePosix` skips empty segments and the canonical form no longer carries the distinction).

**Two related defects are deliberately NOT fixed here** — both predate this PR, both live in `shared`, and this PR touches no `shared` file. Each is now filed on its own, because they need different fixes with different blast radii:
- **#18206** — `toFileUrl`/`fileUrlToPath` fold unconditionally too, so that path yields `file:///workspace/a/b.txt`. It is a cross-domain *codec*, judged by round-trip fidelity rather than normalization consistency, and its output reaches `<img src>` and gets cached.
- **#18207** — `canonicalizeFilePath` collapsing a leading `//` is arguably the root defect. Its output is the persisted `file_entry.externalPath` key, so changing it requires a paired re-canonicalization migration per its own "Rule-evolution discipline".
- **#17429** — the wider ad-hoc separator normalization, rewritten after this review into four classes (required / deliberately over-broad security checks / data-model convention / convenience), since a blanket migration would have broken the security-check class.

Worth noting for context: `src/renderer/utils/path.ts` as it stands in this PR is currently the **only** place in the codebase that folds separators conditionally and refuses a leading `//`.

**The case-folding removal is not observable in CI, and that is worth knowing when reading the test diff.** The renderer test environment reports neither macOS nor Windows, so the old `isMac || isWin` fold was already inert under test — which is exactly why the original suite needed a `vi.doMock('@renderer/utils/platform')` harness to reach its case-insensitive assertions. After removing that harness the rewritten suite passed against the *old* implementation too, i.e. it could not fail. A temporary test forcing `isMac: true` was used to observe the RED (`expected true to be false`) and then deleted once green, since with `accessiblePath.ts` no longer importing `platform`, mocking it was a no-op.

That harness is now back, and this time it is load-bearing: `getPathComparisonKey` (below) does read `platform`, so the mock is no longer a no-op. It is scoped to that one `describe` — the containment helpers stay on the static import, because mocking for them would again be a fake.

**Rebase onto #18342 and #18229.** Two upstream changes landed while this PR was open; both are absorbed here rather than worked around.

*#18342 (folder mentions)* added a fourth export to `accessiblePath.ts`, built on the three private helpers this PR deletes:

```ts
export const getPathComparisonKey = (value: string): string =>
  toComparisonKey(normalizeSeparators(tryCanonicalize(value) ?? value))
```

It re-introduced all three problems fixed above — platform case-folding, unconditional `\` → `/`, and UNC falling back to the raw value and then being folded anyway. **The function is kept; the fold is moved to where it is honest.** `toComparable` is now exported as `toPathKey`, and `getPathComparisonKey` is rebuilt on it with the platform case-fold retained *at that call site*.

The reason the fold may live there but not in the primitives is that the two consumers have opposite failure economics:

| Consumer | False "same" | False "different" | Needs |
| --- | --- | --- | --- |
| reference-vs-inline | **references the wrong file** | inlines instead | strict |
| folder-mention dedup | cannot re-mention a folder | duplicate token | loose is fine |

Case-insensitivity is a per-mount property no string can decide, so the primitives refuse to guess; a dedup key can afford the guess. Both upstream platform assertions pass unchanged, plus three cases upstream's version cannot satisfy: a POSIX backslash not colliding with a nested path, UNC keying on its own spelling, and non-absolute input keying on itself. `toPathKey` is exported rather than duplicated precisely because hand-rolling that form is how the conditional fold gets lost — which is what #18342 did.

*#18229* built the relative-path layer (`pathSpec.ts` + `PosixRelativeFilePath` / `WindowsRelativeFilePath`), so the two relativizing helpers no longer return a bare `string`. Both branches brand POSIX: after the Windows fold `/` is the only separator left under either reading, and the POSIX reading is the one that keeps a filename's backslash intact — the brand names the `/`-separated in-app form, not the path's origin. The brand is **asserted, not re-parsed**, on the argument that the schema's four rejections are all unreachable here; a `describe` in `path.test.ts` runs each branch through `safeParse` so that argument fails loudly if a branch drifts.

One behavior change: equal paths now give `'.'` rather than `''`, following #18229's reading that `''` is the *absence* of a path (`open("")` is `ENOENT`) rather than a second spelling of the base. The only consumer renders the value and cannot reach that branch — `listDirectoryEntries` returns entries under a base, never the base itself.

`getAccessiblePathRelativePath`'s union is the #18209 survey's §1 finding made explicit: that was always its return type, and nothing expressed it, so callers had to infer the branch from a leading slash.

Deliberately **not** done: rebuilding `toComparable` on `pathSpec` (its skeleton is `canonicalizeFilePath`, sole factory for `CanonicalFilePath` and owner of `..` resolution and UNC rejection — swapping in `pathSpec` would reimplement those and lose the latter; `pathSpec` is also not exported from the barrel), and tightening `joinPath`'s signature (it would pull in the four artifact-pane call sites). Upstream carries the matching debt: `AbsoluteFilePathSchema` still hand-rolls its POSIX/drive/UNC union, and `common.ts` records that it belongs in `pathSpec` but cannot move without a paired migration.

Two other notes:

- The cascade reached one file beyond the two consumers: `ToolContext['session'].accessiblePaths` (`composer/tools/types.ts`) was `string[]` and flows into `AgentComposer`'s `sessionData`, so it was retyped too.
- `useAgentResourceMentionSource.tsx:134` keeps its `entry.path.replace(/\\/g, '/')`. It looks redundant next to the new primitives but is not: it serves the two bare `===` path comparisons at `:151`/`:155`, and deleting it would silently break selection-highlight and dedup on Windows. Converting those to `isSamePath` is follow-up work, tracked in #17429 along with the ~26 other ad-hoc separator normalizations across the codebase and the brand-laundering they cause.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```



