### PR TITLE
chore: release v2.0.0-rc.4

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -155,92 +155,58 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.0-rc.3 - Agent Sessions, Migration Recovery & Accessibility
+    Cherry Studio 2.0.0-rc.4 - Providers, Files & Polish
 
     ✨ New Features
-    - [Agent] Agent sessions now render Workflow calls with a dedicated card, show live subagent and background-task progress with per-task stop, surface background agents' questions as persisted messages, keep context usage visible across idle disconnects, and recover automatically when a stored conversation can no longer be resumed.
-    - [Agent] Agents can now use the Claude Agent SDK's “Approve for Me” permission mode, where a model classifier approves routine tool calls and only asks you about risky ones. New agents use it by default instead of running every action unattended, and the permission modes have clearer names and descriptions.
-    - [Agent] Agent reasoning effort is now remembered and reused across chat, scheduled, and channel runs, with automatic adjustment when switching models.
-    - [Composer] Add model-aware reasoning controls and Fast mode for supported OpenAI Codex and Claude Code models.
-    - [Composer] Standalone pasted web links now appear as interactive tokens with a privacy-safe generic icon before send, site favicons in sent messages, open-on-click behavior, and hover-to-remove controls. Composer tokens now stay consistent across drafts, messages, queued follow-ups, and rich clipboard copy/paste.
-    - [Image Preview] Improved full-screen image previews with cursor-centered zoom, bounded panning, consistent transform controls, and grouped-image navigation.
-    - [API Gateway] The OpenAPI docs page now shows its descriptions in all 12 app languages, with a language switcher in the docs toolbar; endpoints are grouped by compatible API, and Scalar's third-party “Ask AI” is disabled.
-    - [Migration] Migration recovery now keeps errors visible for screenshots and groups “Save troubleshooting information”, “Use V2 without importing V1 data”, and “Continue using V1” under More options. Using V2 clears partial migration data before starting with defaults while preserving the original V1 data, and migration completion notices can be reviewed and copied from a dedicated dialog.
-    - [Agent] Assistant HTML artifacts now render inline at their original position in the conversation. A whole HTML page with scripts or external resources stays unloaded behind a compact artifact card until you select View webpage, then runs in an isolated immersive preview; HTML fragments embedded in prose render directly in a preview frame that cannot run scripts.
-    - [Resources] Adds a shared group creation dialog with quick creation and automatic selection in assistant editing.
+    - [Files] Files exclusively owned by deleted chats, topics, or paintings are now cleaned up automatically after a grace period instead of accumulating forever. Files you upload from the Files page are kept permanently; v1-migrated files are preserved unless they belonged to migrated chats or paintings.
+    - [Providers] Add AMD GPU Cloud as a built-in model provider and mini app, including Token Factory API key setup and source attribution.
+    - [Providers] Add official DeepSeek V4 Flash Responses API support while retaining Chat Completions fallback.
+    - [Providers] Provider request settings now allow changing the default chat endpoint.
+    - [Knowledge] Show live copy progress for folder imports and list folders before files in knowledge bases.
 
     🐛 Bug Fixes
-    - [Channels] Restored Feishu QR registration after binding an agent, prevent channel dialogs from flashing while closing, and show QR login errors for Feishu and WeChat.
-    - [Windows] Fixed Cherry Studio failing to open when Windows cannot resolve a user system folder.
-    - [OpenClaw] The OpenClaw gateway launched by Cherry Studio no longer self-updates in the background and no longer shows its own “Update available” banner; opening the OpenClaw dashboard (or the S3 help and release-notes pages) in its own window no longer shows “app not found”.
-    - [Agent] Corrected the assistant tool-call limit UI to show the default 20-round cap and enforce the supported 1–100 range.
-    - [Accessibility] Added accessible names to the About page icon buttons (GitHub repository, logo, releases).
-    - [Accessibility] Added localized accessible names to the channel row's logs, edit, and delete icon buttons.
-    - [MCP] Fixed MCP package-registry option names not following the UI language (they stayed Chinese under an English interface).
-    - [Settings] Fixed the hardware acceleration restart confirmation showing “disable” wording when re-enabling hardware acceleration; the prompt now matches the toggle direction.
-    - [Agent] Improved agent artifact delivery: cards now appear after message playout, provide an explicit Open with menu, and correctly preview valid UTF-8 Markdown when a sampled multibyte character crosses the detection boundary.
-    - [Mini Apps] Added the missing Mini Apps show/hide translations.
-    - [Dialog] Fixed edit and search dialogs opening with an incorrect initial focus or selecting existing text unexpectedly.
-    - [Migration] Prevent Agents migration from running out of memory when importing large session histories.
-    - [Usage] Usage details now identify unattributed requests by their AI modality (language, embedding, image, or rerank).
-    - [macOS] Fixed crashes when System OCR processes some list-heavy images on macOS.
-    - [Knowledge] Knowledge base: clicking a plain note now opens its full original content in-app; viewing indexed chunks moved to the row's right-click menu, and the broken “preview original” action no longer shows for notes.
-    - [Knowledge] Used regional Jina reader for URL imports.
-    - [Knowledge] Used readable names for saved messages.
-    - [Knowledge] Hide injected knowledge prompts in the composer.
-    - [Paintings] Fixed horizontal rendering artifacts that could appear while dragging generated images in Paintings.
-    - [Selection Assistant] Fixed the opacity slider so dragging right increases opacity and left decreases it (previously reversed).
-    - [Notes] Fixed the note character count not updating after toolbar undo and redo actions.
-    - [Tools] Dropped the uri format that strict providers reject.
-    - [API Gateway] Fixed the OpenAPI docs page showing the Health check curl example as a bare relative path (`curl /health`); it now shows the full server address so the example can be copied and run directly.
-    - [Obsidian] Fixed Obsidian export incorrectly reporting success when the note title is empty; the export dialog now stays open on failure and the export button is disabled until a title is provided.
-    - [Accessibility] The Reset / Zoom Out / Zoom In buttons in Settings → Appearance → Page Zoom now expose accessible names (aria-label) and tooltips.
+    - [Chat] Fixed multi-model context selection so the indicator matches the branch used for subsequent messages, and selecting context no longer jumps the conversation to the latest message.
+    - [Paintings] Fixed the Paintings page opening the latest generated image instead of a fresh empty draft.
+    - [Agent] Claude Code Agent sessions no longer fail when SDK usage messages omit a model identifier.
+    - [Agent] Fixed the agent permission-mode switcher in the composer, where the "Approve for Me" and "Full Access" model-support warnings overflowed their rows and overlapped neighbouring options. The same warning no longer pushes the channel permission-mode selector onto two lines.
+    - [Agent] New agents now start in the "Ask Before Acting" permission mode instead of "Approve for Me". "Approve for Me" relies on model-side classification that not every model supports, so it is now an explicit choice and warns about model support when selected. Existing agents keep their current mode.
+    - [Agent] Fixed Agent v2 migration retries failing on stale Agent, workspace, or Claude Session cache targets.
+    - [Migration] Fixed model metadata (capabilities, context window, token limits) not being resolved from the provider registry after migrating from Cherry Studio v1 for models under user-defined custom providers.
+    - [Onboarding] Fixed onboarding blocking migrated users whose current privacy agreement was already saved.
+    - [Providers] Prevented API keys with non-ByteString characters from causing request encoding failures. Action required: replace any existing affected API key in provider settings.
+    - [Files] Agent file outputs now open in the appropriate Files pane view, with consistent previews and interactive HTML artifact support.
+    - [Mini Apps] Use a distinct grid icon for the mini-app launchpad action so it is easier to distinguish from the detached window always-on-top control.
 
-    ⚡ Performance
-    - [Agent] Improved Agent session startup performance, especially for configurations with many MCP servers and skills.
+    💄 Improvements
+    - [UI] Improved visual consistency and usability across settings, chat, Markdown, resource dialogs, and related navigation surfaces.
+    - [UI] Improved focus feedback so controls no longer draw an extra outer frame or change selector borders on pointer open.
+    - [Themes] Improved the consistency and readability of secondary text, links, focus outlines, selected borders, and feedback surfaces across light and dark themes.
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.0-rc.3 - 智能体会话、迁移恢复与无障碍优化
+    Cherry Studio 2.0.0-rc.4 - 服务商、文件与界面打磨
 
     ✨ 新功能
-    - [智能体] 智能体会话现以专属卡片渲染 Workflow 调用，实时展示子智能体与后台任务进度并支持逐任务停止，将后台智能体的提问作为持久化消息呈现，在空闲断连时仍保留上下文用量，并在已存储对话无法恢复时自动重置。
-    - [智能体] 智能体现可使用 Claude Agent SDK 的”为我审批”权限模式：由模型分类器自动批准常规工具调用，仅就有风险的操作征求你的确认。新建智能体默认使用该模式，且各权限模式有了更清晰的名称与说明。
-    - [智能体] 智能体的推理强度现可在聊天、定时与频道运行间记忆复用，切换模型时自动调整。
-    - [输入框] 为支持的 OpenAI Codex 与 Claude Code 模型新增模型感知的推理控件与快速模式。
-    - [输入框] 粘贴的独立网页链接现以交互式令牌呈现：发送前显示隐私安全的通用图标，发送后展示站点 favicon，点击即可打开，悬停可移除。输入框令牌在草稿、消息、排队后续问题以及富文本剪贴板复制/粘贴间保持一致。
-    - [图片预览] 改进全屏图片预览：支持以光标为中心的缩放、受限平移、统一的变换控件，以及分组图片导航。
-    - [API 网关] OpenAPI 文档页现以全部 12 种应用语言显示描述，文档工具栏新增语言切换器；端点按兼容的 API 分组，并禁用 Scalar 第三方”Ask AI”。
-    - [迁移] 迁移恢复现保留错误信息便于截图，并在”更多选项”下归类”保存故障排查信息”、”使用 V2 但不导入 V1 数据”、”继续使用 V1”。选择使用 V2 将以默认值启动前清除部分迁移数据，但保留原始 V1 数据；迁移完成通知可在专属对话框中查看与复制。
-    - [智能体] 助手 HTML 工件现以内联方式渲染在对话原始位置。包含脚本或外部资源的完整 HTML 页面在点击”查看网页”前以紧凑工件卡片加载，随后在隔离的沉浸式预览中运行；嵌入正文中的 HTML 片段在不可执行脚本的预览框架中直接渲染。
-    - [资源] 新增共享分组创建对话框，可快速创建并在助手编辑中自动选中。
+    - [文件] 已删除对话、话题或绘画面板专属的文件现会在宽限期后自动清理，而非永久堆积。从”文件”页上传的文件将永久保留；从 v1 迁移过来的文件除非属于已迁移的对话或绘画面板，否则也会保留。
+    - [服务商] 新增 AMD GPU Cloud 作为内置模型服务商与小程序，包含 Token Factory API 密钥设置与来源标注。
+    - [服务商] 新增 DeepSeek V4 Flash Responses API 官方支持，并保留 Chat Completions 作为回退。
+    - [服务商] 服务商请求设置现允许更改默认聊天端点。
+    - [知识库] 文件夹导入现显示实时复制进度，并在知识库中将文件夹排在文件之前。
 
     🐛 问题修复
-    - [频道] 恢复了绑定智能体后的飞书二维码注册流程，防止频道对话框关闭时闪烁，并显示飞书与微信的二维码登录错误。
-    - [Windows] 修复了当 Windows 无法解析用户系统文件夹时 Cherry Studio 无法启动的问题。
-    - [OpenClaw] 由 Cherry Studio 启动的 OpenClaw 网关不再在后台自更新，也不再显示自身的”有更新可用”横幅；将 OpenClaw 仪表板（或 S3 帮助与发布说明页面）拖出为独立窗口不再提示”app not found”。
-    - [智能体] 修正了助手工具调用次数限制的界面，显示默认 20 轮上限，并强制限制在 1–100 范围内。
-    - [无障碍] 为”关于”页面的图标按钮（GitHub 仓库、Logo、发布版本）添加无障碍名称。
-    - [无障碍] 为频道行的日志、编辑、删除图标按钮添加本地化的无障碍名称。
-    - [MCP] 修复了 MCP 注册表选项名称不跟随界面语言（英文界面下仍显示中文）的问题。
-    - [设置] 修复了重新开启硬件加速时重启确认提示仍显示”关闭”措辞的问题；提示现与开关方向一致。
-    - [智能体] 改进智能体工件交付：卡片现于消息播放后出现，提供显式的”打开方式”菜单，并在多字节字符跨越检测边界时正确预览有效的 UTF-8 Markdown。
-    - [小程序] 补齐了小程序显示/隐藏的缺失翻译。
-    - [对话框] 修复了编辑与搜索对话框打开时初始焦点不正确或意外选中文本的问题。
-    - [迁移] 防止 Agents 迁移在导入大量会话历史时内存溢出。
-    - [用量] 用量详情现按 AI 模态（语言、嵌入、图像或重排）标识未归属请求。
-    - [macOS] 修复了系统 OCR 在 macOS 上处理部分列表密集图片时崩溃的问题。
-    - [知识库] 知识库：单击普通笔记现可在应用内查看其完整原始内容；查看已索引片段移至行右键菜单，且笔记不再显示失效的”预览原文”操作。
-    - [知识库] URL 导入改用区域化的 Jina reader。
-    - [知识库] 为保存的消息使用可读名称。
-    - [知识库] 在输入框中隐藏注入的知识库提示。
-    - [绘画面板] 修复了在 Paintings 中拖动生成图片时可能出现横向渲染瑕疵的问题。
-    - [选择助手] 修正了不透明度滑块方向：向右拖动增加不透明度，向左减少（此前反向）。
-    - [笔记] 修复了工具栏撤销/重做后笔记字符数不更新的问题。
-    - [工具] 移除了严格服务商拒绝的 uri 格式。
-    - [API 网关] 修复了 OpenAPI 文档页将健康检查 curl 示例显示为相对路径（`curl /health`）的问题；现显示完整服务器地址，可直接复制运行。
-    - [Obsidian] 修复了笔记标题为空时 Obsidian 导出仍误报成功的问题；导出对话框现于失败时保持打开，且在提供标题前禁用导出按钮。
-    - [无障碍] 设置 → 外观 → 页面缩放中的”重置/缩小/放大”按钮现提供无障碍名称（aria-label）与工具提示。
+    - [聊天] 修复多模型上下文选择：指示器现与后续消息所用分支一致，选择上下文不再让对话跳转到最新消息。
+    - [绘画面板] 修复绘画面板打开时显示最近生成图片而非空白草稿的问题。
+    - [智能体] Claude Code 智能体会话在 SDK 用量消息缺少模型标识时不再失败。
+    - [智能体] 修复输入框中智能体权限模式切换器的”为我审批”与”完全访问”模型支持警告溢出行、与相邻选项重叠的问题；该警告也不再使频道权限模式选择器折成两行。
+    - [智能体] 新建智能体现以”操作前询问”权限模式启动，而非”为我审批”。”为我审批”依赖并非所有模型都支持的模型端分类，因此现为显式选择，并在选中时提示模型支持情况。已有智能体保持当前模式不变。
+    - [智能体] 修复智能体 v2 迁移在遇到陈旧的智能体、工作区或 Claude Session 缓存目标时重试失败的问题。
+    - [迁移] 修复从 Cherry Studio v1 迁移后，用户自定义服务商下模型的元数据（能力、上下文窗口、token 上限）无法从服务商注册表解析的问题。
+    - [引导] 修复引导流程卡住已保存过隐私协议的迁移用户的问题。
+    - [服务商] 阻止包含非 ByteString 字符的 API 密钥导致请求编码失败。需要操作：在服务商设置中替换任何已存在的受影响 API 密钥。
+    - [文件] 智能体文件输出现可在相应的”文件”窗格视图中打开，预览一致并支持交互式 HTML 工件。
+    - [小程序] 为小程序启动台操作使用独立的网格图标，使其更易与分离窗口的置顶控件区分。
 
-    ⚡ 性能优化
-    - [智能体] 提升智能体会话启动性能，尤其是配置了较多 MCP 服务器与技能时。
+    💄 改进
+    - [界面] 改进设置、聊天、Markdown、资源对话框及相关导航界面的视觉一致性与可用性。
+    - [界面] 改进焦点反馈，控件不再在指针打开时绘制多余外框或更改选择器边框。
+    - [主题] 改进亮色与暗色主题下辅助文本、链接、焦点轮廓、选中边框与反馈界面的一致性与可读性。
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.0-rc.3",
+  "version": "2.0.0-rc.4",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- The latest release is `v2.0.0-rc.3`; `package.json` and `electron-builder.yml` carry the rc.3 release notes.

After this PR:

- Bumps the version to `2.0.0-rc.4`.
- Replaces the release notes in `electron-builder.yml` with bilingual (English + Simplified Chinese) notes covering all user-facing changes since `v2.0.0-rc.3`.

This is a release-prep PR. It only touches `package.json` (version field) and `electron-builder.yml` (release notes block).

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The release notes are assembled from the `release-note` blocks of every commit since `v2.0.0-rc.3`. Internal-only commits (CI/stylesheet refactors, test convergence, dead-code removal, file-IPC audit) are excluded per the `prepare-release` skill rules because their release-note blocks say `NONE`.
- The `feat(chat-greeting)` commit (#17408) was reverted by `c4bcfab385` in this same range, so the greeting feature is not in the release and was excluded from the notes.
- The PR follows the standard release workflow: branch `release/v2.0.0-rc.4` → `main`, which triggers `release.yml` (macOS/Windows/Linux builds + draft GitHub Release) and `ci.yml` (lint/typecheck/tests).

The following alternatives were considered:

- Bundling extra code changes into the release commit — rejected to keep the release commit reviewable on its own.

Links to places where the discussion took place: N/A

### Breaking changes

None. This is a version bump and release-notes update only.

### Special notes for your reviewer

Review checklist:

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] CI passes
- [ ] Merge to trigger release build

Included commits (since `v2.0.0-rc.3`):

- refactor(ui): polish settings, chat, and resource interfaces (#17710)
- fix(ui): keep focus feedback within control bounds (#17436)
- fix(onboarding): skip redundant privacy agreement writes (#17708)
- feat(file-manager): policy-based file entry GC with cleanup_policy and scan reaper (#16727)
- fix(provider-settings): reject invalid API key characters (#17678)
- fix(paintings): open on an empty page (#17660)
- fix(data-migration): match global model metadata for custom providers (#17692)
- fix(agent-runtime): handle missing Claude invocation models (#17670)
- fix(agent-permission-mode): keep the mode warning out of single-line rows (#17698)
- feat(provider-registry): support DeepSeek V4 Flash Responses API (#17694)
- fix(chat): sync multi-model context selection (#17371)
- fix(agent-migration): reset stale filesystem targets (#17687)
- fix: distinguish mini app launchpad icon from window pin (#17683)
- feat(knowledge): show folder import copy progress (#17655)
- fix(agent-permission-mode): stop defaulting new agents to auto (#17690)
- feat(provider): add Radeon Cloud integration (#16622)
- feat(provider-settings): allow changing the default endpoint (#17691)
- refactor(design-tokens): converge semantic color contract (#17535)
- fix(file-preview): unify file and artifact preview routing (#17646)

Excluded per release-notes policy: `refactor(ci)` (#17710 CSS workflow), `refactor(styles)` (CSS var tests), the `feat(chat-greeting)` revert (#17408, reverted in-range), `test(job,stream-manager)`, `refactor(file-ipc)`, `feat(file-manager)` dedup (#17210, NONE), `feat(file-preview)` range reads (#17153, NONE), `test(renderer)` convergence (#17671, #17676), `feat(chat-citations)` (#17590, NONE), `chore(renderer)` v1 residue (#17686), `feat(file-ipc)` chunk reads (#17152, NONE).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Cherry Studio 2.0.0-rc.4 - Providers, Files & Polish

✨ New Features
- [Files] Files exclusively owned by deleted chats, topics, or paintings are now cleaned up automatically after a grace period instead of accumulating forever. Files you upload from the Files page are kept permanently; v1-migrated files are preserved unless they belonged to migrated chats or paintings.
- [Providers] Add AMD GPU Cloud as a built-in model provider and mini app, including Token Factory API key setup and source attribution.
- [Providers] Add official DeepSeek V4 Flash Responses API support while retaining Chat Completions fallback.
- [Providers] Provider request settings now allow changing the default chat endpoint.
- [Knowledge] Show live copy progress for folder imports and list folders before files in knowledge bases.

🐛 Bug Fixes
- [Chat] Fixed multi-model context selection so the indicator matches the branch used for subsequent messages, and selecting context no longer jumps the conversation to the latest message.
- [Paintings] Fixed the Paintings page opening the latest generated image instead of a fresh empty draft.
- [Agent] Claude Code Agent sessions no longer fail when SDK usage messages omit a model identifier.
- [Agent] Fixed the agent permission-mode switcher in the composer, where the "Approve for Me" and "Full Access" model-support warnings overflowed their rows and overlapped neighbouring options. The same warning no longer pushes the channel permission-mode selector onto two lines.
- [Agent] New agents now start in the "Ask Before Acting" permission mode instead of "Approve for Me". "Approve for Me" relies on model-side classification that not every model supports, so it is now an explicit choice and warns about model support when selected. Existing agents keep their current mode.
- [Agent] Fixed Agent v2 migration retries failing on stale Agent, workspace, or Claude Session cache targets.
- [Migration] Fixed model metadata (capabilities, context window, token limits) not being resolved from the provider registry after migrating from Cherry Studio v1 for models under user-defined custom providers.
- [Onboarding] Fixed onboarding blocking migrated users whose current privacy agreement was already saved.
- [Providers] Prevented API keys with non-ByteString characters from causing request encoding failures. action required: replace any existing affected API key in provider settings.
- [Files] Agent file outputs now open in the appropriate Files pane view, with consistent previews and interactive HTML artifact support.
- [Mini Apps] Use a distinct grid icon for the mini-app launchpad action so it is easier to distinguish from the detached window always-on-top control.

💄 Improvements
- [UI] Improved visual consistency and usability across settings, chat, Markdown, resource dialogs, and related navigation surfaces.
- [UI] Improved focus feedback so controls no longer draw an extra outer frame or change selector borders on pointer open.
- [Themes] Improved the consistency and readability of secondary text, links, focus outlines, selected borders, and feedback surfaces across light and dark themes.
```