### PR TITLE
fix(provider-registry): enable Gemma 4 thinking in Ollama

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -2789,11 +2789,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.15
+          "perMillionTokens": 0.13
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.6
+          "perMillionTokens": 0.52
         }
       }
     },
@@ -3461,35 +3461,6 @@
     {
       "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output", "file-input"],
       "contextWindow": 1000000,
-      "id": "claude-fable-5-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Fable 5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 25
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "medium", "high", "max"]
-          }
-        ],
-        "supportedEfforts": ["low", "medium", "high", "max"]
-      }
-    },
-    {
-      "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output", "file-input"],
-      "contextWindow": 1000000,
       "id": "claude-fable-latest",
       "inputModalities": ["text", "image"],
       "metadata": {},
@@ -3561,50 +3532,6 @@
             "kind": "budget",
             "max": 64000,
             "min": 1024
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 64000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 200000,
-      "id": "claude-haiku-4-5-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Haiku 4.5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 64000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
           }
         ],
         "supportedEfforts": ["none", "auto"],
@@ -3757,50 +3684,6 @@
         "web-search"
       ],
       "contextWindow": 200000,
-      "id": "claude-opus-4-1-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "Anthropic: Claude Opus 4.1 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 7.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 37.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 32000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 32000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 200000,
       "family": "claude-opus",
       "id": "claude-opus-4-5",
       "inputModalities": ["text", "image"],
@@ -3858,50 +3741,6 @@
         "file-input",
         "web-search"
       ],
-      "contextWindow": 200000,
-      "id": "claude-opus-4-5-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "Anthropic: Claude Opus 4.5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 12.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 64000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 64000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
       "contextWindow": 1000000,
       "family": "claude-opus",
       "id": "claude-opus-4-6",
@@ -3942,54 +3781,6 @@
             "kind": "budget",
             "max": 128000,
             "min": 1024
-          }
-        ],
-        "supportedEfforts": ["low", "medium", "high", "max", "none"],
-        "thinkingTokenLimits": {
-          "max": 128000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1000000,
-      "id": "claude-opus-4-6-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Opus 4.6 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 12.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "medium", "high", "max"]
-          },
-          {
-            "kind": "budget",
-            "max": 128000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
           }
         ],
         "supportedEfforts": ["low", "medium", "high", "max", "none"],
@@ -4122,54 +3913,6 @@
         "web-search"
       ],
       "contextWindow": 1000000,
-      "id": "claude-opus-4-7-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Opus 4.7 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 12.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "medium", "high", "max"]
-          },
-          {
-            "kind": "budget",
-            "max": 128000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["low", "medium", "high", "max", "none"],
-        "thinkingTokenLimits": {
-          "max": 128000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1000000,
       "id": "claude-opus-4-7-fast",
       "inputModalities": ["text", "image"],
       "metadata": {},
@@ -4255,45 +3998,6 @@
           }
         ],
         "supportedEfforts": ["low", "medium", "high", "xhigh", "max", "none"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1000000,
-      "id": "claude-opus-4-8-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Opus 4.8 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 12.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "medium", "high", "max"]
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["low", "medium", "high", "max", "none"]
       }
     },
     {
@@ -4566,50 +4270,6 @@
         "web-search"
       ],
       "contextWindow": 1000000,
-      "id": "claude-sonnet-4-5-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Sonnet 4.5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 7.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 64000,
-            "min": 1024
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 64000,
-          "min": 1024
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1000000,
       "family": "claude-sonnet",
       "id": "claude-sonnet-4-6",
       "inputModalities": ["text", "image"],
@@ -4698,38 +4358,6 @@
           }
         ],
         "supportedEfforts": ["low", "medium", "high", "xhigh", "max", "none"]
-      }
-    },
-    {
-      "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output", "file-input"],
-      "contextWindow": 1000000,
-      "id": "claude-sonnet-5-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "Anthropic: Claude Sonnet 5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "anthropic",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["low", "medium", "high", "max"]
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["low", "medium", "high", "max", "none"]
       }
     },
     {
@@ -5136,10 +4764,45 @@
         "controls": [
           {
             "kind": "effort",
-            "values": ["none", "minimal", "low", "medium", "high", "xhigh"]
+            "values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           }
         ],
-        "supportedEfforts": ["none", "minimal", "low", "medium", "high", "xhigh"]
+        "supportedEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "image-recognition", "audio-recognition", "file-input"],
+      "contextWindow": 1000000,
+      "family": "ling",
+      "id": "inkling-small",
+      "inputModalities": ["text", "image", "audio"],
+      "maxOutputTokens": 1000000,
+      "metadata": {},
+      "name": "Inkling Small",
+      "outputModalities": ["text"],
+      "ownedBy": "bailing",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.1
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
+        }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "supportedEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
       }
     },
     {
@@ -7747,6 +7410,35 @@
     {
       "capabilities": ["function-call", "reasoning", "structured-output"],
       "contextWindow": 1048576,
+      "id": "deepseek-v4-flash-latest",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "DeepSeek V4 Flash Latest",
+      "outputModalities": ["text"],
+      "ownedBy": "deepseek",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.09
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0.18
+        }
+      },
+      "reasoning": {
+        "controls": [
+          {
+            "kind": "effort",
+            "values": ["none", "high", "max"]
+          }
+        ],
+        "supportedEfforts": ["none", "high", "max"]
+      }
+    },
+    {
+      "capabilities": ["function-call", "reasoning", "structured-output"],
+      "contextWindow": 1048576,
       "family": "deepseek-thinking",
       "id": "deepseek-v4-pro",
       "inputModalities": ["text"],
@@ -8021,52 +7713,6 @@
       }
     },
     {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-2-5-flash-batch",
-      "inputModalities": ["image", "text", "audio", "video"],
-      "metadata": {},
-      "name": "Google: Gemini 2.5 Flash (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.15
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.25
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
       "capabilities": ["reasoning", "image-recognition", "image-generation", "file-input"],
       "contextWindow": 32768,
       "family": "gemini-flash",
@@ -8224,52 +7870,6 @@
       }
     },
     {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-2-5-flash-lite-batch",
-      "inputModalities": ["text", "image", "audio", "video"],
-      "metadata": {},
-      "name": "Google: Gemini 2.5 Flash Lite (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.049999999999999996
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.19999999999999998
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 512
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 512
-        }
-      }
-    },
-    {
       "capabilities": ["audio-generation"],
       "contextWindow": 8192,
       "family": "gemini-flash",
@@ -8344,48 +7944,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 10
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 32768,
-            "min": 128
-          }
-        ],
-        "thinkingTokenLimits": {
-          "max": 32768,
-          "min": 128
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-2-5-pro-batch",
-      "inputModalities": ["text", "image", "audio", "video"],
-      "metadata": {},
-      "name": "Google: Gemini 2.5 Pro (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.625
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 5
         }
       },
       "reasoning": {
@@ -8698,51 +8256,6 @@
         "function-call",
         "reasoning",
         "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-3-1-flash-lite-batch",
-      "inputModalities": ["text", "image", "video", "audio"],
-      "metadata": {},
-      "name": "Google: Gemini 3.1 Flash Lite (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.125
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.75
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
         "image-generation",
         "structured-output",
         "file-input"
@@ -8990,47 +8503,6 @@
         "file-input"
       ],
       "contextWindow": 1048576,
-      "id": "gemini-3-1-pro-preview-batch",
-      "inputModalities": ["audio", "image", "text", "video"],
-      "metadata": {},
-      "name": "Google: Gemini 3.1 Pro Preview (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 6
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 32768,
-            "min": 128
-          }
-        ],
-        "thinkingTokenLimits": {
-          "max": 32768,
-          "min": 128
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input"
-      ],
-      "contextWindow": 1048576,
       "family": "gemini-pro",
       "id": "gemini-3-1-pro-preview-customtools",
       "inputModalities": ["text", "image", "video", "audio"],
@@ -9137,52 +8609,6 @@
         "web-search"
       ],
       "contextWindow": 1048576,
-      "id": "gemini-3-5-flash-batch",
-      "inputModalities": ["text", "image", "video", "audio"],
-      "metadata": {},
-      "name": "Google: Gemini 3.5 Flash (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.75
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 4.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
       "family": "gemini-flash-lite",
       "id": "gemini-3-5-flash-lite",
       "inputModalities": ["text", "image", "video", "audio"],
@@ -9218,52 +8644,6 @@
           }
         ],
         "supportedEfforts": ["minimal", "low", "medium", "high"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-3-5-flash-lite-batch",
-      "inputModalities": ["text", "image", "video", "audio"],
-      "metadata": {},
-      "name": "Google: Gemini 3.5 Flash Lite (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.15
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.25
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
         "thinkingTokenLimits": {
           "max": 24576,
           "min": 0
@@ -9337,51 +8717,6 @@
           }
         ],
         "supportedEfforts": ["minimal", "low", "medium", "high"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-3-6-flash-batch",
-      "inputModalities": ["text", "image", "video", "audio"],
-      "metadata": {},
-      "name": "Google: Gemini 3.6 Flash (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.75
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 3.75
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          },
-          {
-            "kind": "toggle"
-          }
-        ],
-        "supportedEfforts": ["none", "auto"],
         "thinkingTokenLimits": {
           "max": 24576,
           "min": 0
@@ -9464,53 +8799,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 3
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["minimal", "low", "medium", "high"]
-          },
-          {
-            "kind": "budget",
-            "max": 24576,
-            "min": 0
-          }
-        ],
-        "supportedEfforts": ["minimal", "low", "medium", "high"],
-        "thinkingTokenLimits": {
-          "max": 24576,
-          "min": 0
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "audio-recognition",
-        "video-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1048576,
-      "id": "gemini-3-flash-preview-batch",
-      "inputModalities": ["text", "image", "audio", "video"],
-      "metadata": {},
-      "name": "Google: Gemini 3 Flash Preview (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "google",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.25
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1.5
         }
       },
       "reasoning": {
@@ -10174,23 +9462,10 @@
       "reasoning": {
         "controls": [
           {
-            "kind": "effort",
-            "values": ["minimal", "high"]
-          },
-          {
             "kind": "toggle"
-          },
-          {
-            "kind": "budget",
-            "max": 30720,
-            "min": 1024
           }
         ],
-        "supportedEfforts": ["minimal", "high", "none"],
-        "thinkingTokenLimits": {
-          "max": 30720,
-          "min": 1024
-        }
+        "supportedEfforts": ["none", "auto"]
       }
     },
     {
@@ -10225,23 +9500,10 @@
       "reasoning": {
         "controls": [
           {
-            "kind": "effort",
-            "values": ["minimal", "high"]
-          },
-          {
             "kind": "toggle"
-          },
-          {
-            "kind": "budget",
-            "max": 30720,
-            "min": 1024
           }
         ],
-        "supportedEfforts": ["minimal", "high", "none"],
-        "thinkingTokenLimits": {
-          "max": 30720,
-          "min": 1024
-        }
+        "supportedEfforts": ["none", "auto"]
       }
     },
     {
@@ -12497,6 +11759,16 @@
       }
     },
     {
+      "capabilities": ["image-recognition", "video-generation", "file-input"],
+      "family": "minimax",
+      "id": "minimax-h3",
+      "inputModalities": ["text", "image"],
+      "metadata": {},
+      "name": "MiniMax H3",
+      "outputModalities": ["video"],
+      "ownedBy": "minimax"
+    },
+    {
       "capabilities": ["function-call", "reasoning"],
       "contextWindow": 1000000,
       "id": "minimax-m1",
@@ -12794,26 +12066,6 @@
       }
     },
     {
-      "capabilities": ["function-call", "reasoning", "image-recognition", "video-recognition", "structured-output"],
-      "contextWindow": 524288,
-      "id": "minimax-m3-batch",
-      "inputModalities": ["text", "image", "video"],
-      "metadata": {},
-      "name": "MiniMax: MiniMax M3 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "minimax",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.15
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.6
-        }
-      }
-    },
-    {
       "capabilities": ["function-call", "structured-output", "file-input"],
       "contextWindow": 256000,
       "family": "codestral",
@@ -12872,7 +12124,7 @@
       }
     },
     {
-      "capabilities": ["function-call", "structured-output", "file-input"],
+      "capabilities": ["function-call"],
       "contextWindow": 262144,
       "family": "devstral",
       "id": "devstral",
@@ -13651,11 +12903,11 @@
       }
     },
     {
-      "capabilities": ["function-call", "structured-output"],
+      "capabilities": ["function-call", "image-recognition", "structured-output"],
       "contextWindow": 131072,
       "family": "mistral-nemo",
       "id": "mistral-nemo",
-      "inputModalities": ["text"],
+      "inputModalities": ["text", "image"],
       "maxOutputTokens": 128000,
       "metadata": {},
       "name": "Mistral Nemo",
@@ -13800,11 +13052,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.09999999999999999
+          "perMillionTokens": 0.075
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.3
+          "perMillionTokens": 0.19999999999999998
         }
       }
     },
@@ -16147,62 +15399,6 @@
         "web-search"
       ],
       "contextWindow": 400000,
-      "id": "gpt-5-1-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.1 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.625
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high"]
-      }
-    },
-    {
-      "capabilities": ["function-call", "image-recognition", "structured-output", "file-input", "web-search"],
-      "contextWindow": 128000,
-      "id": "gpt-5-1-chat",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.1 Chat",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.25
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 10
-        }
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
       "family": "gpt",
       "id": "gpt-5-1-codex",
       "inputModalities": ["text", "image"],
@@ -16375,42 +15571,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 14
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high", "xhigh"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
-      "id": "gpt-5-2-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.2 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.875
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 7
         }
       },
       "reasoning": {
@@ -16744,42 +15904,6 @@
       }
     },
     {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1050000,
-      "id": "gpt-5-4-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.4 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.25
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 7.5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high", "xhigh"]
-      }
-    },
-    {
       "capabilities": ["reasoning", "image-recognition", "image-generation", "structured-output", "file-input"],
       "contextWindow": 272000,
       "id": "gpt-5-4-image-2",
@@ -16860,42 +15984,6 @@
         "web-search"
       ],
       "contextWindow": 400000,
-      "id": "gpt-5-4-mini-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.4 Mini (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.375
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2.25
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high", "xhigh"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
       "family": "gpt",
       "id": "gpt-5-4-nano",
       "inputModalities": ["text", "image"],
@@ -16916,42 +16004,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 1.25
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high", "xhigh"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
-      "id": "gpt-5-4-nano-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.4 Nano (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.09999999999999999
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.625
         }
       },
       "reasoning": {
@@ -17032,42 +16084,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 33
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["none", "low", "medium", "high", "xhigh"]
-          }
-        ],
-        "supportedEfforts": ["none", "low", "medium", "high", "xhigh"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 1050000,
-      "id": "gpt-5-5-batch",
-      "inputModalities": ["image", "text"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5.5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 2.5
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 15
         }
       },
       "reasoning": {
@@ -17419,42 +16435,6 @@
         "file-input",
         "web-search"
       ],
-      "contextWindow": 400000,
-      "id": "gpt-5-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5 (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.625
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 5
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["minimal", "low", "medium", "high"]
-          }
-        ],
-        "supportedEfforts": ["minimal", "low", "medium", "high"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
       "id": "gpt-5-chat",
       "metadata": {},
       "name": "GPT-5 Chat",
@@ -17613,42 +16593,6 @@
         "web-search"
       ],
       "contextWindow": 400000,
-      "id": "gpt-5-mini-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5 Mini (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.125
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 1
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["minimal", "low", "medium", "high"]
-          }
-        ],
-        "supportedEfforts": ["minimal", "low", "medium", "high"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
       "family": "gpt-nano",
       "id": "gpt-5-nano",
       "inputModalities": ["text", "image"],
@@ -17669,42 +16613,6 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 0.4
-        }
-      },
-      "reasoning": {
-        "controls": [
-          {
-            "kind": "effort",
-            "values": ["minimal", "low", "medium", "high"]
-          }
-        ],
-        "supportedEfforts": ["minimal", "low", "medium", "high"]
-      }
-    },
-    {
-      "capabilities": [
-        "function-call",
-        "reasoning",
-        "image-recognition",
-        "structured-output",
-        "file-input",
-        "web-search"
-      ],
-      "contextWindow": 400000,
-      "id": "gpt-5-nano-batch",
-      "inputModalities": ["text", "image"],
-      "metadata": {},
-      "name": "OpenAI: GPT-5 Nano (batch)",
-      "outputModalities": ["text"],
-      "ownedBy": "openai",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.024999999999999998
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.19999999999999998
         }
       },
       "reasoning": {
@@ -19170,11 +18078,11 @@
       }
     },
     {
-      "capabilities": ["function-call", "reasoning"],
+      "capabilities": ["function-call", "reasoning", "image-recognition"],
       "contextWindow": 262144,
       "family": "step",
       "id": "step-3-5-flash",
-      "inputModalities": ["text"],
+      "inputModalities": ["text", "image"],
       "maxOutputTokens": 262114,
       "metadata": {},
       "name": "Step 3.5 Flash",
@@ -19279,11 +18187,11 @@
       "ownedBy": "stepfun"
     },
     {
-      "capabilities": ["function-call", "reasoning", "structured-output"],
+      "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output"],
       "contextWindow": 256000,
       "family": "kat-coder",
       "id": "kat-coder-air-v2-5",
-      "inputModalities": ["text"],
+      "inputModalities": ["text", "image"],
       "maxOutputTokens": 80000,
       "metadata": {},
       "name": "Kat Coder Air V2.5",
@@ -19357,11 +18265,11 @@
       }
     },
     {
-      "capabilities": ["function-call", "reasoning", "structured-output"],
+      "capabilities": ["function-call", "reasoning", "image-recognition", "structured-output"],
       "contextWindow": 256000,
       "family": "kat-coder",
       "id": "kat-coder-pro-v2-5",
-      "inputModalities": ["text"],
+      "inputModalities": ["text", "image"],
       "maxOutputTokens": 80000,
       "metadata": {},
       "name": "Kat Coder Pro V2.5",
@@ -20023,6 +18931,16 @@
       "inputModalities": ["text"],
       "metadata": {},
       "name": "Veo 3.1",
+      "outputModalities": ["video"],
+      "ownedBy": "vercel"
+    },
+    {
+      "capabilities": ["video-generation"],
+      "family": "veo",
+      "id": "veo-3-1-lite-generate-001",
+      "inputModalities": ["text"],
+      "metadata": {},
+      "name": "Veo 3.1 Lite Generate",
       "outputModalities": ["video"],
       "ownedBy": "vercel"
     },
@@ -20961,11 +19879,11 @@
       "ownedBy": "xai"
     },
     {
-      "capabilities": ["image-recognition", "video-generation", "file-input"],
+      "capabilities": ["image-recognition", "audio-recognition", "video-generation", "file-input"],
       "contextWindow": 1024,
       "family": "grok",
       "id": "grok-imagine-video-1-5",
-      "inputModalities": ["text", "image"],
+      "inputModalities": ["text", "image", "audio"],
       "metadata": {},
       "name": "Grok Imagine Video 1.5",
       "outputModalities": ["video"],
@@ -22190,5 +21108,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "ea9e5ee3d7b53cc9"
+  "version": "720c311cd96313c4"
 }

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -12001,15 +12001,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.028
+          "perMillionTokens": 0.0028
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.138
+          "perMillionTokens": 0.14
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.275
+          "perMillionTokens": 0.28
         }
       },
       "providerId": "gateway"
@@ -13721,6 +13721,25 @@
         "output": {
           "currency": "USD",
           "perMillionTokens": 4.05
+        }
+      },
+      "providerId": "gateway"
+    },
+    {
+      "apiModelId": "thinkingmachines/inkling-small",
+      "modelId": "inkling-small",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.1
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.5
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.2
         }
       },
       "providerId": "gateway"
@@ -22114,26 +22133,6 @@
       }
     },
     {
-      "apiModelId": "anthropic/claude-fable-5:batch",
-      "modelId": "claude-fable-5-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "high",
-                "kind": "effort",
-                "values": ["max", "xhigh", "high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "high",
-            "supportedEfforts": ["max", "xhigh", "high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "~anthropic/claude-fable-latest",
       "modelId": "claude-fable-latest",
       "pricing": {
@@ -22192,18 +22191,6 @@
           "perMillionTokens": 5
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "anthropic/claude-haiku-4.5:batch",
-      "modelId": "claude-haiku-4-5-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -22304,18 +22291,6 @@
       }
     },
     {
-      "apiModelId": "anthropic/claude-opus-4.1:batch",
-      "modelId": "claude-opus-4-1-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "anthropic/claude-opus-4.5",
       "modelId": "claude-opus-4-5",
       "pricing": {
@@ -22336,18 +22311,6 @@
           "perMillionTokens": 25
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "anthropic/claude-opus-4.5:batch",
-      "modelId": "claude-opus-4-5-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -22396,26 +22359,6 @@
       }
     },
     {
-      "apiModelId": "anthropic/claude-opus-4.6:batch",
-      "modelId": "claude-opus-4-6-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "high",
-                "kind": "effort",
-                "values": ["max", "high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "high",
-            "supportedEfforts": ["max", "high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "anthropic/claude-opus-4.7",
       "modelId": "claude-opus-4-7",
       "pricing": {
@@ -22436,26 +22379,6 @@
           "perMillionTokens": 25
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "high",
-                "kind": "effort",
-                "values": ["max", "xhigh", "high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "high",
-            "supportedEfforts": ["max", "xhigh", "high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "anthropic/claude-opus-4.7:batch",
-      "modelId": "claude-opus-4-7-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -22532,26 +22455,6 @@
           "perMillionTokens": 25
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "high",
-                "kind": "effort",
-                "values": ["max", "xhigh", "high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "high",
-            "supportedEfforts": ["max", "xhigh", "high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "anthropic/claude-opus-4.8:batch",
-      "modelId": "claude-opus-4-8-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -22782,18 +22685,6 @@
       }
     },
     {
-      "apiModelId": "anthropic/claude-sonnet-4.5:batch",
-      "modelId": "claude-sonnet-4-5-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "anthropic/claude-sonnet-4.6",
       "modelId": "claude-sonnet-4-6",
       "pricing": {
@@ -22852,26 +22743,6 @@
           "perMillionTokens": 10
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "high",
-                "kind": "effort",
-                "values": ["max", "xhigh", "high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "high",
-            "supportedEfforts": ["max", "xhigh", "high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "anthropic/claude-sonnet-5:batch",
-      "modelId": "claude-sonnet-5-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -23260,11 +23131,31 @@
               {
                 "default": "high",
                 "kind": "effort",
-                "values": ["xhigh", "high"]
+                "values": ["max", "high", "low"]
               }
             ],
             "defaultEffort": "high",
-            "supportedEfforts": ["xhigh", "high"]
+            "supportedEfforts": ["max", "high", "low"]
+          }
+        }
+      }
+    },
+    {
+      "apiModelId": "~deepseek/deepseek-v4-flash-latest",
+      "modelId": "deepseek-v4-flash-latest",
+      "providerId": "openrouter",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "support": {
+            "controls": [
+              {
+                "default": "high",
+                "kind": "effort",
+                "values": ["max", "high", "low"]
+              }
+            ],
+            "defaultEffort": "high",
+            "supportedEfforts": ["max", "high", "low"]
           }
         }
       }
@@ -23302,25 +23193,6 @@
           }
         }
       }
-    },
-    {
-      "apiModelId": "mistralai/devstral-2512",
-      "modelId": "devstral",
-      "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.04
-        },
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.4
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 2
-        }
-      },
-      "providerId": "openrouter"
     },
     {
       "apiModelId": "cognitivecomputations/dolphin-mistral-24b-venice-edition",
@@ -23673,18 +23545,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-2.5-flash:batch",
-      "modelId": "gemini-2-5-flash-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-2.5-flash-image",
       "capabilities": {
         "add": ["image-generation"]
@@ -23777,18 +23637,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-2.5-flash-lite:batch",
-      "modelId": "gemini-2-5-flash-lite-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-2.5-pro",
       "modelId": "gemini-2-5-pro",
       "pricing": {
@@ -23809,18 +23657,6 @@
           "perMillionTokens": 10
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "google/gemini-2.5-pro:batch",
-      "modelId": "gemini-2-5-pro-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -24143,26 +23979,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-3.1-flash-lite:batch",
-      "modelId": "gemini-3-1-flash-lite-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "minimal",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "minimal",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-3.1-flash-lite-image",
       "capabilities": {
         "add": ["image-generation"]
@@ -24346,26 +24162,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-3.1-pro-preview:batch",
-      "modelId": "gemini-3-1-pro-preview-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-3.1-pro-preview-customtools",
       "modelId": "gemini-3-1-pro-preview-customtools",
       "pricing": {
@@ -24442,26 +24238,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-3.5-flash:batch",
-      "modelId": "gemini-3-5-flash-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-3.5-flash-lite",
       "modelId": "gemini-3-5-flash-lite",
       "pricing": {
@@ -24482,26 +24258,6 @@
           "perMillionTokens": 2.5
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "minimal",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "minimal",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "google/gemini-3.5-flash-lite:batch",
-      "modelId": "gemini-3-5-flash-lite-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -24558,26 +24314,6 @@
       }
     },
     {
-      "apiModelId": "google/gemini-3.6-flash:batch",
-      "modelId": "gemini-3-6-flash-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "google/gemini-3-flash-preview",
       "modelId": "gemini-3-flash-preview",
       "pricing": {
@@ -24598,26 +24334,6 @@
           "perMillionTokens": 3
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "google/gemini-3-flash-preview:batch",
-      "modelId": "gemini-3-flash-preview-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -25262,15 +24978,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.1794
+          "perMillionTokens": 0.208
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.966
+          "perMillionTokens": 1.12
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3.036
+          "perMillionTokens": 3.52
         }
       },
       "providerId": "openrouter",
@@ -25606,45 +25322,6 @@
       }
     },
     {
-      "apiModelId": "openai/gpt-5.1:batch",
-      "modelId": "gpt-5-1-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "none",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "none",
-            "supportedEfforts": ["high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "openai/gpt-5.1-chat",
-      "modelId": "gpt-5-1-chat",
-      "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.13
-        },
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 1.25
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 10
-        }
-      },
-      "providerId": "openrouter"
-    },
-    {
       "apiModelId": "openai/gpt-5.1-codex",
       "modelId": "gpt-5-1-codex",
       "pricing": {
@@ -25763,26 +25440,6 @@
           "perMillionTokens": 14
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["xhigh", "high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["xhigh", "high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "openai/gpt-5.2:batch",
-      "modelId": "gpt-5-2-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -25971,26 +25628,6 @@
       }
     },
     {
-      "apiModelId": "openai/gpt-5.4:batch",
-      "modelId": "gpt-5-4-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["xhigh", "high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["xhigh", "high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "openai/gpt-5.4-image-2",
       "capabilities": {
         "add": ["image-generation"]
@@ -26106,26 +25743,6 @@
       }
     },
     {
-      "apiModelId": "openai/gpt-5.4-mini:batch",
-      "modelId": "gpt-5-4-mini-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["xhigh", "high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["xhigh", "high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "openai/gpt-5.4-nano",
       "modelId": "gpt-5-4-nano",
       "pricing": {
@@ -26142,26 +25759,6 @@
           "perMillionTokens": 1.25
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["xhigh", "high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["xhigh", "high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "openai/gpt-5.4-nano:batch",
-      "modelId": "gpt-5-4-nano-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -26226,26 +25823,6 @@
           "perMillionTokens": 30
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["xhigh", "high", "medium", "low", "none"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["xhigh", "high", "medium", "low", "none"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "openai/gpt-5.5:batch",
-      "modelId": "gpt-5-5-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -26522,26 +26099,6 @@
       }
     },
     {
-      "apiModelId": "openai/gpt-5:batch",
-      "modelId": "gpt-5-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "openai/gpt-5-image",
       "capabilities": {
         "add": ["image-generation"]
@@ -26722,26 +26279,6 @@
       }
     },
     {
-      "apiModelId": "openai/gpt-5-mini:batch",
-      "modelId": "gpt-5-mini-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "openai/gpt-5-nano",
       "modelId": "gpt-5-nano",
       "pricing": {
@@ -26758,26 +26295,6 @@
           "perMillionTokens": 0.4
         }
       },
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": [
-              {
-                "default": "medium",
-                "kind": "effort",
-                "values": ["high", "medium", "low", "minimal"]
-              }
-            ],
-            "defaultEffort": "medium",
-            "supportedEfforts": ["high", "medium", "low", "minimal"]
-          }
-        }
-      }
-    },
-    {
-      "apiModelId": "openai/gpt-5-nano:batch",
-      "modelId": "gpt-5-nano-batch",
       "providerId": "openrouter",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -27160,17 +26677,13 @@
       "apiModelId": "openai/gpt-oss-20b",
       "modelId": "gpt-oss-20b",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.03
-        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 0.03
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.13
+          "perMillionTokens": 0.14
         }
       },
       "providerId": "openrouter",
@@ -27727,6 +27240,40 @@
       }
     },
     {
+      "apiModelId": "thinkingmachines/inkling-small",
+      "modelId": "inkling-small",
+      "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.116
+        },
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0.58
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 1.44
+        }
+      },
+      "providerId": "openrouter",
+      "reasoningContracts": {
+        "openai-chat-completions": {
+          "support": {
+            "controls": [
+              {
+                "default": "high",
+                "kind": "effort",
+                "values": ["max", "high", "medium", "low", "minimal", "none"]
+              }
+            ],
+            "defaultEffort": "high",
+            "supportedEfforts": ["max", "high", "medium", "low", "minimal", "none"]
+          }
+        }
+      }
+    },
+    {
       "apiModelId": "ai21/jamba-large-1.7",
       "modelId": "jamba-large-1-7",
       "pricing": {
@@ -27857,15 +27404,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.16
+          "perMillionTokens": 0.0992
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.95
+          "perMillionTokens": 0.589
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 4
+          "perMillionTokens": 2.48
         }
       },
       "providerId": "openrouter",
@@ -28848,18 +28395,6 @@
       }
     },
     {
-      "apiModelId": "minimax/minimax-m3:batch",
-      "modelId": "minimax-m3-batch",
-      "providerId": "openrouter",
-      "reasoningContracts": {
-        "openai-chat-completions": {
-          "support": {
-            "controls": []
-          }
-        }
-      }
-    },
-    {
       "apiModelId": "mistralai/ministral-14b-2512",
       "modelId": "ministral-14b",
       "pricing": {
@@ -29105,17 +28640,13 @@
       "apiModelId": "mistralai/mistral-small-3.2-24b-instruct",
       "modelId": "mistral-small-3-2-24b-instruct",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.01
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.1
+          "perMillionTokens": 0.075
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.3
+          "perMillionTokens": 0.2
         }
       },
       "providerId": "openrouter"
@@ -29917,11 +29448,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.3
+          "perMillionTokens": 0.23
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 3
+          "perMillionTokens": 2.3
         }
       },
       "providerId": "openrouter",
@@ -30686,11 +30217,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.15
+          "perMillionTokens": 0.13
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.6
+          "perMillionTokens": 0.52
         }
       },
       "providerId": "openrouter"
@@ -34334,6 +33865,10 @@
       "apiModelId": "zai-org/GLM-5",
       "modelId": "glm-5",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.2
+        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 0.95
@@ -34412,6 +33947,10 @@
       "apiModelId": "zai-org/GLM-5.1",
       "modelId": "glm-5-1",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.26
+        },
         "cacheWrite": {
           "currency": "USD",
           "perMillionTokens": 0
@@ -34494,6 +34033,10 @@
       "apiModelId": "zai-org/GLM-5.2",
       "modelId": "glm-5-2",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.26
+        },
         "cacheWrite": {
           "currency": "USD",
           "perMillionTokens": 0
@@ -34576,6 +34119,10 @@
       "apiModelId": "zai-org/GLM-5V-Turbo",
       "modelId": "glm-5v-turbo",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.24
+        },
         "cacheWrite": {
           "currency": "USD",
           "perMillionTokens": 0
@@ -34785,6 +34332,10 @@
       "apiModelId": "moonshotai/Kimi-K2.5",
       "modelId": "kimi-k2-5",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.07
+        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 0.45
@@ -34835,6 +34386,10 @@
       "apiModelId": "MiniMaxAI/MiniMax-M2.5",
       "modelId": "minimax-m2-5",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.03
+        },
         "input": {
           "currency": "USD",
           "perMillionTokens": 0.3
@@ -37615,5 +37170,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "b74c1401a7cf1e32"
+  "version": "4908e2f1a5633f0d"
 }

--- a/packages/provider-registry/src/__tests__/reasoningControls.test.ts
+++ b/packages/provider-registry/src/__tests__/reasoningControls.test.ts
@@ -107,7 +107,8 @@ describe('inferReasoningControls (ingest-time heuristics)', () => {
       ]
     ],
     ['glm-4.6', [{ kind: 'toggle' }]],
-    ['gemma-4-27b-it', [{ kind: 'effort', values: ['minimal', 'high'] }]],
+    ['gemma4:31b', [{ kind: 'toggle' }]],
+    ['gemma-4-31b-it', [{ kind: 'toggle' }]],
     ['mistral-small-2603', [{ kind: 'effort', values: ['none', 'high'] }]],
     // provider-namespaced ids are normalized before matching
     ['deepseek/deepseek-v4', [{ kind: 'effort', values: ['none', 'high', 'max'] }]],

--- a/packages/provider-registry/src/creators/google.ts
+++ b/packages/provider-registry/src/creators/google.ts
@@ -7,7 +7,7 @@ export default defineCreator({
   fetchModels: googleModels(),
   modelsDevProviders: ['google', 'google-vertex'],
   reasoningFamilies: [
-    { pattern: '^gemma-?4', effort: ['minimal', 'high'] },
+    { pattern: '^gemma-?4', toggle: true },
     {
       pattern: '^gemini-3(?:\\.\\d+)?-flash|^gemini-3\\.1-flash-lite|^gemini-flash-latest',
       effort: ['minimal', 'low', 'medium', 'high']
@@ -26,9 +26,6 @@ export default defineCreator({
     { pattern: 'gemini-pro-latest$', budget: { min: 128, max: 32768 }, template: true },
     { pattern: 'gemini-.*-flash.*$', budget: { min: 0, max: 24576 }, template: true },
     { pattern: 'gemini-.*-pro.*$', budget: { min: 128, max: 32768 }, template: true },
-    { pattern: 'gemma-?4[:-]?e[24]b', budget: { min: 1024, max: 8192 }, template: true },
-    { pattern: 'gemma-?4[:-]?26b', budget: { min: 1024, max: 30720 }, template: true },
-    { pattern: 'gemma-?4[:-]?31b', budget: { min: 1024, max: 30720 }, template: true },
     // Membership profiles (no knobs): reasoning SKUs beyond the knob rules above.
     { pattern: '^gemini.*thinking' },
     { pattern: 'gemini-3(?:[.-]\\d+)?-pro-image' },

--- a/packages/provider-registry/src/patterns/reasoning-families.gen.ts
+++ b/packages/provider-registry/src/patterns/reasoning-families.gen.ts
@@ -133,7 +133,7 @@ export const REASONING_FAMILY_RULES: readonly ReasoningFamilyRule[] = [
   { pattern: 'deepseek-v(?:[4-9]\\d*|[1-9]\\d{1,})(?:\\.\\d+)?(?:-[\\w]+)*(?=$|[:/])' },
   { pattern: 'deepseek-v3\\.2-speciale' },
   // google
-  { pattern: '^gemma-?4', effort: ['minimal', 'high'] },
+  { pattern: '^gemma-?4', toggle: true },
   {
     pattern: '^gemini-3(?:\\.\\d+)?-flash|^gemini-3\\.1-flash-lite|^gemini-flash-latest',
     effort: ['minimal', 'low', 'medium', 'high']
@@ -148,9 +148,6 @@ export const REASONING_FAMILY_RULES: readonly ReasoningFamilyRule[] = [
   { pattern: 'gemini-pro-latest$', budget: { min: 128, max: 32768 }, template: true },
   { pattern: 'gemini-.*-flash.*$', budget: { min: 0, max: 24576 }, template: true },
   { pattern: 'gemini-.*-pro.*$', budget: { min: 128, max: 32768 }, template: true },
-  { pattern: 'gemma-?4[:-]?e[24]b', budget: { min: 1024, max: 8192 }, template: true },
-  { pattern: 'gemma-?4[:-]?26b', budget: { min: 1024, max: 30720 }, template: true },
-  { pattern: 'gemma-?4[:-]?31b', budget: { min: 1024, max: 30720 }, template: true },
   { pattern: '^gemini.*thinking' },
   { pattern: 'gemini-3(?:[.-]\\d+)?-pro-image' },
   { pattern: '^gemini-3(?:[.-]\\d+)?-flash-tts' },

--- a/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
+++ b/src/main/ai/utils/__tests__/reasoningSerializers.test.ts
@@ -1,4 +1,8 @@
-import type { ReasoningWireProfile } from '@cherrystudio/provider-registry'
+import {
+  inferReasoningControls,
+  REASONING_FORMAT_PROFILES,
+  type ReasoningWireProfile
+} from '@cherrystudio/provider-registry'
 import { describe, expect, it } from 'vitest'
 
 import { makeModel } from '../../__tests__/fixtures'
@@ -61,5 +65,21 @@ describe('resolveReasoningInvocation budget constraints', () => {
     const invocation = resolveReasoningInvocation({ selection: 'auto', model: toggleModel, profile })
 
     expect(encodeReasoningInvocation(invocation)).toEqual({ chat_template_kwargs: { thinking_mode: 'adaptive' } })
+  })
+
+  it('encodes Gemma 4 thinking control as Ollama booleans', () => {
+    const controls = inferReasoningControls('gemma4:31b')
+    expect(controls).toEqual([{ kind: 'toggle' }])
+
+    const gemma4 = makeModel({
+      reasoning: { controls, selectableEfforts: ['none', 'auto'] }
+    })
+    const profile = REASONING_FORMAT_PROFILES.ollama.wire
+
+    const enabled = resolveReasoningInvocation({ selection: 'auto', model: gemma4, profile })
+    const disabled = resolveReasoningInvocation({ selection: 'none', model: gemma4, profile })
+
+    expect(encodeReasoningInvocation(enabled)).toEqual({ think: true })
+    expect(encodeReasoningInvocation(disabled)).toEqual({ think: false })
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Gemma 4 was modeled with synthetic effort and budget controls, so Ollama requests could keep sending `think: false` even when thinking was selected.

After this PR: Gemma 4 exposes a binary thinking toggle and Ollama serializes enabled/disabled selections as `think: true`/`think: false`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: unsupported Gemma 4 effort and token-budget controls were removed in favor of the documented on/off capability.

The following alternatives were considered: an Ollama-only serializer special case, rejected because the model capability itself is binary across documented runtimes.

Links to places where the discussion took place: [Ollama Gemma 4](https://ollama.com/library/gemma4), [Google Gemma thinking](https://ai.google.dev/gemma/docs/capabilities/thinking), [Ollama thinking API](https://docs.ollama.com/capabilities/thinking)

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The provider-registry generator refreshed the checked-in model catalogs, including current upstream catalog drift; `pnpm build:check` passed with 1,654 test files and 20,301 tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Gemma 4 thinking controls so Ollama can correctly enable and disable reasoning.
```
