### PR TITLE
fix(mcp): repair stale auto-install package args

### DIFF
--- a/src/renderer/src/store/__tests__/migrate.test.ts
+++ b/src/renderer/src/store/__tests__/migrate.test.ts
@@ -1,3 +1,4 @@
+import { BuiltinMCPServerNames, MCP_AUTO_INSTALL_ARGS } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
 import migrate from '../migrate'
@@ -39,6 +40,88 @@ describe('store migrations', () => {
       const migrated: any = await migrate(state as any, 207)
 
       expect(migrated.llm.providers[0].anthropicApiHost).toBe('https://custom.example.com')
+    })
+  })
+
+  describe('migration 209: mcp-auto-install package repair', () => {
+    it('replaces only the stale package name while preserving command and extra args', async () => {
+      const state = {
+        mcp: {
+          servers: [
+            {
+              id: 'mcp-auto-install',
+              name: BuiltinMCPServerNames.mcpAutoInstall,
+              command: 'bun',
+              args: ['x', BuiltinMCPServerNames.mcpAutoInstall, 'connect', '--json'],
+              isActive: false
+            }
+          ]
+        },
+        _persist: { version: 208, rehydrated: false }
+      }
+
+      const migrated: any = await migrate(state as any, 209)
+
+      expect(migrated.mcp.servers[0].command).toBe('bun')
+      expect(migrated.mcp.servers[0].args).toEqual(['x', '@mcpmarket/mcp-auto-install', 'connect', '--json'])
+    })
+
+    it('preserves custom command and additional user flags', async () => {
+      const state = {
+        mcp: {
+          servers: [
+            {
+              id: 'mcp-auto-install',
+              name: BuiltinMCPServerNames.mcpAutoInstall,
+              command: '/usr/local/bin/npx',
+              args: [
+                '--registry',
+                'https://custom.registry.com',
+                BuiltinMCPServerNames.mcpAutoInstall,
+                'connect',
+                '--json',
+                '--verbose'
+              ],
+              isActive: false
+            }
+          ]
+        },
+        _persist: { version: 208, rehydrated: false }
+      }
+
+      const migrated: any = await migrate(state as any, 209)
+
+      expect(migrated.mcp.servers[0].command).toBe('/usr/local/bin/npx')
+      expect(migrated.mcp.servers[0].args).toEqual([
+        '--registry',
+        'https://custom.registry.com',
+        '@mcpmarket/mcp-auto-install',
+        'connect',
+        '--json',
+        '--verbose'
+      ])
+    })
+
+    it('leaves correctly configured auto-install servers unchanged', async () => {
+      const state = {
+        mcp: {
+          servers: [
+            {
+              id: 'mcp-auto-install',
+              name: BuiltinMCPServerNames.mcpAutoInstall,
+              command: 'npx',
+              args: [...MCP_AUTO_INSTALL_ARGS],
+              isActive: false
+            }
+          ]
+        },
+        _persist: { version: 208, rehydrated: false }
+      }
+
+      const migrated: any = await migrate(state as any, 209)
+
+      expect(migrated.mcp.servers[0].command).toBe('npx')
+      expect(migrated.mcp.servers[0].args).toEqual(MCP_AUTO_INSTALL_ARGS)
     })
   })
 })

--- a/src/renderer/src/store/__tests__/migrate.test.ts
+++ b/src/renderer/src/store/__tests__/migrate.test.ts
@@ -1,7 +1,10 @@
-import { BuiltinMCPServerNames, MCP_AUTO_INSTALL_ARGS } from '@renderer/types'
+import { MCP_AUTO_INSTALL_ARGS } from '@renderer/types'
 import { describe, expect, it } from 'vitest'
 
 import migrate from '../migrate'
+
+const LEGACY_MCP_AUTO_INSTALL_PACKAGE = '@cherry/mcp-auto-install'
+const CURRENT_MCP_AUTO_INSTALL_PACKAGE = '@mcpmarket/mcp-auto-install'
 
 describe('store migrations', () => {
   describe('migration 207: StepFun Anthropic-compatible host backfill', () => {
@@ -50,9 +53,9 @@ describe('store migrations', () => {
           servers: [
             {
               id: 'mcp-auto-install',
-              name: BuiltinMCPServerNames.mcpAutoInstall,
+              name: LEGACY_MCP_AUTO_INSTALL_PACKAGE,
               command: 'bun',
-              args: ['x', BuiltinMCPServerNames.mcpAutoInstall, 'connect', '--json'],
+              args: ['x', LEGACY_MCP_AUTO_INSTALL_PACKAGE, 'connect', '--json'],
               isActive: false
             }
           ]
@@ -63,7 +66,7 @@ describe('store migrations', () => {
       const migrated: any = await migrate(state as any, 209)
 
       expect(migrated.mcp.servers[0].command).toBe('bun')
-      expect(migrated.mcp.servers[0].args).toEqual(['x', '@mcpmarket/mcp-auto-install', 'connect', '--json'])
+      expect(migrated.mcp.servers[0].args).toEqual(['x', CURRENT_MCP_AUTO_INSTALL_PACKAGE, 'connect', '--json'])
     })
 
     it('preserves custom command and additional user flags', async () => {
@@ -72,12 +75,12 @@ describe('store migrations', () => {
           servers: [
             {
               id: 'mcp-auto-install',
-              name: BuiltinMCPServerNames.mcpAutoInstall,
+              name: LEGACY_MCP_AUTO_INSTALL_PACKAGE,
               command: '/usr/local/bin/npx',
               args: [
                 '--registry',
                 'https://custom.registry.com',
-                BuiltinMCPServerNames.mcpAutoInstall,
+                LEGACY_MCP_AUTO_INSTALL_PACKAGE,
                 'connect',
                 '--json',
                 '--verbose'
@@ -95,7 +98,7 @@ describe('store migrations', () => {
       expect(migrated.mcp.servers[0].args).toEqual([
         '--registry',
         'https://custom.registry.com',
-        '@mcpmarket/mcp-auto-install',
+        CURRENT_MCP_AUTO_INSTALL_PACKAGE,
         'connect',
         '--json',
         '--verbose'
@@ -108,7 +111,7 @@ describe('store migrations', () => {
           servers: [
             {
               id: 'mcp-auto-install',
-              name: BuiltinMCPServerNames.mcpAutoInstall,
+              name: LEGACY_MCP_AUTO_INSTALL_PACKAGE,
               command: 'npx',
               args: [...MCP_AUTO_INSTALL_ARGS],
               isActive: false

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -86,7 +86,7 @@ const persistedReducer = persistReducer(
   {
     key: 'cherry-studio',
     storage,
-    version: 208,
+    version: 209,
     blacklist: ['runtime', 'messages', 'messageBlocks', 'tabs', 'toolPermissions'],
     migrate
   },

--- a/src/renderer/src/store/mcp.ts
+++ b/src/renderer/src/store/mcp.ts
@@ -16,7 +16,13 @@
  */
 import { loggerService } from '@logger'
 import { createSlice, nanoid, type PayloadAction } from '@reduxjs/toolkit'
-import { type BuiltinMCPServer, BuiltinMCPServerNames, type MCPConfig, type MCPServer } from '@renderer/types'
+import {
+  type BuiltinMCPServer,
+  BuiltinMCPServerNames,
+  MCP_AUTO_INSTALL_ARGS,
+  type MCPConfig,
+  type MCPServer
+} from '@renderer/types'
 
 const logger = loggerService.withContext('Store:MCP')
 const filesystemManualApprovalTools = ['write', 'edit', 'delete'] as const
@@ -126,7 +132,7 @@ export const builtinMCPServers: BuiltinMCPServer[] = [
     reference: 'https://docs.cherry-ai.com/advanced-basic/mcp/auto-install',
     type: 'inMemory',
     command: 'npx',
-    args: ['-y', '@mcpmarket/mcp-auto-install', 'connect', '--json'],
+    args: MCP_AUTO_INSTALL_ARGS,
     isActive: false,
     provider: 'CherryAI',
     installSource: 'builtin',

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -42,7 +42,13 @@ import type {
   TranslateLanguageCode,
   WebSearchProvider
 } from '@renderer/types'
-import { isBuiltinMCPServer, isSystemProvider, SystemProviderIds } from '@renderer/types'
+import {
+  BuiltinMCPServerNames,
+  isBuiltinMCPServer,
+  isSystemProvider,
+  MCP_AUTO_INSTALL_ARGS,
+  SystemProviderIds
+} from '@renderer/types'
 import { getDefaultGroupName, getLeadingEmoji, runAsyncFunction, uuid } from '@renderer/utils'
 import {
   isSupportArrayContentProvider,
@@ -3445,6 +3451,26 @@ const migrateConfig = {
       return state
     } catch (error) {
       logger.error('migrate 208 error', error as Error)
+      return state
+    }
+  },
+  '209': (state: RootState) => {
+    try {
+      state.mcp?.servers?.forEach((server) => {
+        if (
+          server.name === BuiltinMCPServerNames.mcpAutoInstall &&
+          server.args?.includes(BuiltinMCPServerNames.mcpAutoInstall)
+        ) {
+          server.args = server.args.map((arg) =>
+            arg === BuiltinMCPServerNames.mcpAutoInstall ? MCP_AUTO_INSTALL_ARGS[1] : arg
+          )
+        }
+      })
+
+      logger.info('migrate 209 success')
+      return state
+    } catch (error) {
+      logger.error('migrate 209 error', error as Error)
       return state
     }
   }

--- a/src/renderer/src/store/migrate.ts
+++ b/src/renderer/src/store/migrate.ts
@@ -42,13 +42,7 @@ import type {
   TranslateLanguageCode,
   WebSearchProvider
 } from '@renderer/types'
-import {
-  BuiltinMCPServerNames,
-  isBuiltinMCPServer,
-  isSystemProvider,
-  MCP_AUTO_INSTALL_ARGS,
-  SystemProviderIds
-} from '@renderer/types'
+import { isBuiltinMCPServer, isSystemProvider, SystemProviderIds } from '@renderer/types'
 import { getDefaultGroupName, getLeadingEmoji, runAsyncFunction, uuid } from '@renderer/utils'
 import {
   isSupportArrayContentProvider,
@@ -3456,13 +3450,14 @@ const migrateConfig = {
   },
   '209': (state: RootState) => {
     try {
+      // Historical migration: use literals so future changes to builtin definitions
+      // do not affect repair of stale installations.
+      const LEGACY_MCP_AUTO_INSTALL_PACKAGE = '@cherry/mcp-auto-install'
+      const CURRENT_MCP_AUTO_INSTALL_PACKAGE = '@mcpmarket/mcp-auto-install'
       state.mcp?.servers?.forEach((server) => {
-        if (
-          server.name === BuiltinMCPServerNames.mcpAutoInstall &&
-          server.args?.includes(BuiltinMCPServerNames.mcpAutoInstall)
-        ) {
+        if (server.name === LEGACY_MCP_AUTO_INSTALL_PACKAGE && server.args?.includes(LEGACY_MCP_AUTO_INSTALL_PACKAGE)) {
           server.args = server.args.map((arg) =>
-            arg === BuiltinMCPServerNames.mcpAutoInstall ? MCP_AUTO_INSTALL_ARGS[1] : arg
+            arg === LEGACY_MCP_AUTO_INSTALL_PACKAGE ? CURRENT_MCP_AUTO_INSTALL_PACKAGE : arg
           )
         }
       })

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -873,6 +873,7 @@ export const BuiltinMCPServerNames = {
 } as const
 
 export type BuiltinMCPServerName = (typeof BuiltinMCPServerNames)[keyof typeof BuiltinMCPServerNames]
+export const MCP_AUTO_INSTALL_ARGS = ['-y', '@mcpmarket/mcp-auto-install', 'connect', '--json']
 
 export const BuiltinMCPServerNamesArray = Object.values(BuiltinMCPServerNames)
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Existing v1 installations could retain an `mcp-auto-install` configuration whose command arguments referenced the removed `@cherry/mcp-auto-install` npm package, causing the built-in MCP to disconnect.

After this PR:

Migration 209 repairs stale configurations to launch the published `@mcpmarket/mcp-auto-install` package through the standard `npx -y ... connect --json` command. New defaults use the same centralized argument definition.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17688

### Why we need it and why it was done in this way

The following tradeoffs were made:

The migration changes only auto-install entries containing the removed package, preserves already-correct configurations, and keeps the existing v1 server identity for compatibility. The published package remains an external stdio server because it installs and connects to user-selected MCP packages.

The following alternatives were considered:

Publishing a new `@cherry/mcp-auto-install` package would preserve the broken package contract and add an unnecessary package-maintenance burden. Converting the service to in-memory transport would require bundling functionality that is intentionally provided by the published package.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17688

### Breaking changes

None.

### Special notes for your reviewer

The issue-specific MCP store and migration tests pass (7/7). `pnpm lint`, typecheck, i18n validation, formatting, `openapi:check`, and `pnpm test:lint` pass. The full `pnpm test` and `pnpm build:check` suites still report unrelated pre-existing Windows path/symlink failures in CherryClaw workspace-memory tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Existing v1 installations now automatically repair stale mcp-auto-install configurations so the built-in MCP launches the published package.
```

