### PR TITLE
chore(build-toolchain): drop @electron-toolkit/tsconfig

### DIFF
--- a/.changeset/drop-electron-toolkit-tsconfig.md
+++ b/.changeset/drop-electron-toolkit-tsconfig.md
@@ -1,0 +1,4 @@
+---
+---
+
+No package release is required for dropping the @electron-toolkit/tsconfig dependency.

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@e965/xlsx": "^0.20.3",
     "@electron-toolkit/preload": "^3.0.0",
-    "@electron-toolkit/tsconfig": "^1.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@electron/notarize": "^2.5.0",
     "@electron/rebuild": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -210,7 +210,6 @@
     "@e965/xlsx": "^0.20.3",
     "@electron-toolkit/eslint-config-ts": "^3.0.0",
     "@electron-toolkit/preload": "^3.0.0",
-    "@electron-toolkit/tsconfig": "^1.0.1",
     "@electron-toolkit/utils": "^3.0.0",
     "@electron/asar": "3.4.1",
     "@electron/notarize": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,9 +311,6 @@ importers:
       '@electron-toolkit/preload':
         specifier: ^3.0.0
         version: 3.0.2(electron@41.8.0)
-      '@electron-toolkit/tsconfig':
-        specifier: ^1.0.1
-        version: 1.0.1(@types/node@24.10.4)
       '@electron-toolkit/utils':
         specifier: ^3.0.0
         version: 3.0.0(electron@41.8.0)
@@ -2460,11 +2457,6 @@ packages:
     resolution: {integrity: sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==}
     peerDependencies:
       electron: '>=13.0.0'
-
-  '@electron-toolkit/tsconfig@1.0.1':
-    resolution: {integrity: sha512-M0Mol3odspvtCuheyujLNAW7bXq7KFNYVMRtpjFa4ZfES4MuklXBC7Nli/omvc+PRKlrklgAGx3l4VakjNo8jg==}
-    peerDependencies:
-      '@types/node': '*'
 
   '@electron-toolkit/utils@3.0.0':
     resolution: {integrity: sha512-GaXHDhiT7KCvMJjXdp/QqpYinq69T/Pdl49Z1XLf8mKGf63dnsODMWyrmIjEQ0z/vG7dO8qF3fvmI6Eb2lUNZA==}
@@ -15064,10 +15056,6 @@ snapshots:
   '@electron-toolkit/preload@3.0.2(electron@41.8.0)':
     dependencies:
       electron: 41.8.0
-
-  '@electron-toolkit/tsconfig@1.0.1(@types/node@24.10.4)':
-    dependencies:
-      '@types/node': 24.10.4
 
   '@electron-toolkit/utils@3.0.0(electron@41.8.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,9 +387,6 @@ importers:
       '@electron-toolkit/preload':
         specifier: ^3.0.0
         version: 3.0.2(electron@41.8.0)
-      '@electron-toolkit/tsconfig':
-        specifier: ^1.0.1
-        version: 1.0.1(@types/node@24.10.4)
       '@electron-toolkit/utils':
         specifier: ^3.0.0
         version: 3.0.0(electron@41.8.0)
@@ -3938,11 +3935,6 @@ packages:
     resolution: {integrity: sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==}
     peerDependencies:
       electron: '>=13.0.0'
-
-  '@electron-toolkit/tsconfig@1.0.1':
-    resolution: {integrity: sha512-M0Mol3odspvtCuheyujLNAW7bXq7KFNYVMRtpjFa4ZfES4MuklXBC7Nli/omvc+PRKlrklgAGx3l4VakjNo8jg==}
-    peerDependencies:
-      '@types/node': '*'
 
   '@electron-toolkit/utils@3.0.0':
     resolution: {integrity: sha512-GaXHDhiT7KCvMJjXdp/QqpYinq69T/Pdl49Z1XLf8mKGf63dnsODMWyrmIjEQ0z/vG7dO8qF3fvmI6Eb2lUNZA==}
@@ -18926,10 +18918,6 @@ snapshots:
   '@electron-toolkit/preload@3.0.2(electron@41.8.0)':
     dependencies:
       electron: 41.8.0
-
-  '@electron-toolkit/tsconfig@1.0.1(@types/node@24.10.4)':
-    dependencies:
-      '@types/node': 24.10.4
 
   '@electron-toolkit/utils@3.0.0(electron@41.8.0)':
     dependencies:

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,10 +1,25 @@
 {
   "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "sourceMap": false,
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "composite": true,
+    "incremental": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "incremental": true,
-    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
     "paths": {
       "@application": ["./src/main/core/application/Application"],
       "@cherrystudio/provider-registry": ["./packages/provider-registry/src/index.ts"],
@@ -25,10 +40,8 @@
       "@test-mocks/*": ["./tests/__mocks__/*"]
     },
     "tsBuildInfoFile": ".tsbuildinfo/tsconfig.node.tsbuildinfo",
-    "types": ["electron-vite/node", "vitest/globals"],
-    "useDefineForClassFields": true
+    "types": ["electron-vite/node", "vitest/globals"]
   },
-  "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   "include": [
     "electron.vite.config.*",
     "scripts",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,10 +1,25 @@
 {
   "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "sourceMap": false,
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "composite": true,
+    "incremental": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "incremental": true,
-    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
     "paths": {
       "@application": ["./src/main/core/application/Application"],
       "@cherrystudio/provider-registry": ["./packages/provider-registry/src/index.ts"],
@@ -24,10 +39,8 @@
       "@test-mocks/*": ["./tests/__mocks__/*"]
     },
     "tsBuildInfoFile": ".tsbuildinfo/tsconfig.node.tsbuildinfo",
-    "types": ["electron-vite/node", "vitest/globals"],
-    "useDefineForClassFields": true
+    "types": ["electron-vite/node", "vitest/globals"]
   },
-  "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
   "include": [
     "electron.vite.config.*",
     "scripts",

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,11 +1,26 @@
 {
   "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "sourceMap": false,
+    "strict": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
     "composite": true,
+    "incremental": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "incremental": true,
-    "jsx": "react-jsx",
-    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
     "paths": {
       "@cherrystudio/ai-core": ["./packages/aiCore/src/index.ts"],
       "@cherrystudio/ai-core/*": ["./packages/aiCore/src/*"],
@@ -24,11 +39,9 @@
       "@shared/*": ["./src/shared/*"],
       "@test-mocks/*": ["./tests/__mocks__/*"]
     },
-    "tsBuildInfoFile": ".tsbuildinfo/tsconfig.web.tsbuildinfo",
-    "useDefineForClassFields": true
+    "tsBuildInfoFile": ".tsbuildinfo/tsconfig.web.tsbuildinfo"
   },
   "exclude": ["packages/aiCore/src/**/__tests__/**"],
-  "extends": "@electron-toolkit/tsconfig/tsconfig.web.json",
   "include": [
     "local/src/renderer/**/*",
     "src/renderer/**/*",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!-- Thanks for sending a pull request! -->

> ### 🚨 Branch strategy — read before opening this PR
>
> This active-development toolchain change targets the preceding Vite 8 branch and ultimately `main`.

### What this PR does

Before this PR:

`tsconfig.node.json` and `tsconfig.web.json` extended `@electron-toolkit/tsconfig`. That base config sets `moduleResolution: "node"` (conflicting with this stack's bundler/TS7 direction) and `noImplicitAny: false` alongside `strict: true`. Both project configs already re-declared `moduleResolution: "bundler"`, so the base's `"node"` was silently masked rather than removed.

After this PR:

The `@electron-toolkit/tsconfig` dependency is removed. Both project configs inline the compiler options they were inheriting and are now self-contained: `moduleResolution: "bundler"` is the only declared value (no masked `"node"`), and there is no hidden base layer. Type-check behavior is otherwise unchanged.

<!-- No linked issue. -->

### Why we need it and why it was done in this way

The base config introduced two footguns that were invisible at the call site: a `moduleResolution: "node"` that only worked because both configs happened to override it, and `noImplicitAny: false` masking `strict`. Inlining the options makes the real configuration explicit and removes the `"node"` value entirely, so the resolution mode can no longer regress if an override is dropped.

The following tradeoffs were made:

- `noImplicitAny: false` is kept explicit rather than dropped. Enabling it (via `strict`) surfaces ~277 implicit-any errors across main + renderer; fixing those is out of scope for a dependency-removal layer and is left for a dedicated follow-up. Keeping it explicit preserves current type-check behavior exactly.
- The inlined options mirror the previous effective configuration (base + per-config overrides), so no type-check result changes in this PR.

The following alternatives were considered:

- Keeping `@electron-toolkit/tsconfig` was rejected because it hides the resolution mode and the `noImplicitAny` opt-out behind an external base.
- Flipping `noImplicitAny` in the same layer was rejected because ~277 pre-existing implicit-any sites would turn a config cleanup into a broad code change.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/17719#pullrequestreview-4838129638

### Breaking changes

No user-facing API, IPC, or data-structure changes. Internal type-check configuration only; `pnpm typecheck:node` and `pnpm typecheck:web` pass unchanged.

### Special notes for your reviewer

This is layer 7 of the toolchain stack and is based on `toolchain/vite-8`. Validation: both project type-checks pass with `tsc@7.0.2` (0 errors) before and after; `pnpm install --frozen-lockfile` passes with `@electron-toolkit/tsconfig` fully removed from `package.json` and the lockfile; the inlined configs are Oxfmt-clean.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The inlined type-check configuration preserves the previous effective behavior
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present or not required. This is intentionally unchecked because the change is internal tooling only.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
