### PR TITLE
feat(image-preview): add save-as actions

### DIFF
--- a/src/renderer/components/ImageViewer.tsx
+++ b/src/renderer/components/ImageViewer.tsx
@@ -7,9 +7,10 @@ import {
 import { loggerService } from '@logger'
 import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/components/command'
 import { toast } from '@renderer/services/toast'
-import { copyImageToClipboard } from '@renderer/utils/image'
+import { removeSpecialCharactersForFileName } from '@renderer/utils/file'
+import { blobToDataUrl, convertImageToPng, copyImageToClipboard, getImageBlobFromSource } from '@renderer/utils/image'
 import { cn } from '@renderer/utils/style'
-import { CopyIcon } from 'lucide-react'
+import { CopyIcon, SaveIcon } from 'lucide-react'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -31,6 +32,22 @@ export interface ImageViewerProps extends Omit<React.ImgHTMLAttributes<HTMLImage
 const getPreviewIndex = (items: ImagePreviewItem[], src: string, fallbackIndex = 0) => {
   const matchedIndex = items.findIndex((item) => item.src === src)
   return matchedIndex >= 0 ? matchedIndex : fallbackIndex
+}
+
+const getImageSaveName = (item: ImagePreviewItem) => {
+  let name = item.alt?.trim()
+
+  if (!name && /^(?:file|https?):/.test(item.src)) {
+    try {
+      const pathname = decodeURIComponent(new URL(item.src).pathname)
+      name = pathname.slice(pathname.lastIndexOf('/') + 1)
+    } catch {
+      // Fall back to the generic image name below.
+    }
+  }
+
+  const nameWithoutImageExtension = name?.replace(/\.(?:avif|bmp|gif|heic|jpe?g|png|svg|webp)$/i, '')
+  return removeSpecialCharactersForFileName(nameWithoutImageExtension || '') || 'image'
 }
 
 const ImageViewer: React.FC<ImageViewerProps> = ({
@@ -110,6 +127,34 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     [t]
   )
 
+  const handleSaveImage = React.useCallback(
+    async (item: ImagePreviewItem) => {
+      try {
+        const blob = await getImageBlobFromSource(item.src)
+        const pngBlob = await convertImageToPng(blob)
+        const saved = await window.api.file.saveImage(getImageSaveName(item), await blobToDataUrl(pngBlob))
+        if (saved) {
+          toast.success(t('common.saved'))
+        }
+      } catch (error) {
+        const err = error as Error
+        logger.error(`Failed to save image: ${err.message}`, { stack: err.stack })
+        toast.error(t('common.save_failed'))
+      }
+    },
+    [t]
+  )
+
+  const saveAction = React.useMemo<ImagePreviewAction>(
+    () => ({
+      icon: <SaveIcon className="size-3.5" />,
+      id: 'save-as',
+      label: t('preview.save_as'),
+      onSelect: handleSaveImage
+    }),
+    [handleSaveImage, t]
+  )
+
   const builtInActions = React.useMemo<ImagePreviewAction[]>(
     () => [
       {
@@ -118,6 +163,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         label: t('preview.copy.image'),
         onSelect: handleCopyImage
       },
+      saveAction,
       {
         icon: <CopyIcon className="size-3.5" />,
         id: 'copy-src',
@@ -125,12 +171,16 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
         onSelect: handleCopySource
       }
     ],
-    [handleCopyImage, handleCopySource, t]
+    [handleCopyImage, handleCopySource, saveAction, t]
   )
 
   const contextActions = React.useMemo(
     () => [...builtInActions, ...(previewConfig?.actions ?? [])],
     [builtInActions, previewConfig?.actions]
+  )
+  const toolbarActions = React.useMemo(
+    () => [saveAction, ...(previewConfig?.toolbarActions ?? [])],
+    [previewConfig?.toolbarActions, saveAction]
   )
   const displayItem = items.find((item) => item.src === src) ?? {
     alt: typeof alt === 'string' ? alt : undefined,
@@ -212,7 +262,7 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
           onActiveIndexChange={setActiveIndex}
           onOpenChange={setOpen}
           open={open}
-          toolbarActions={previewConfig?.toolbarActions}
+          toolbarActions={toolbarActions}
         />
       )}
     </>

--- a/src/renderer/components/__tests__/ImageViewer.test.tsx
+++ b/src/renderer/components/__tests__/ImageViewer.test.tsx
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
   clipboard: {
     write: vi.fn(),
     writeText: vi.fn()
-  }
+  },
+  saveImage: vi.fn()
 }))
 
 vi.mock('react-i18next', () => ({
@@ -37,21 +38,23 @@ describe('ImageViewer', () => {
       blob: async () => new Blob(['remote'], { type: 'image/webp' })
     })
     mocks.fsRead.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    mocks.saveImage.mockResolvedValue(true)
 
     Object.assign(window, {
-      api: { fs: { read: mocks.fsRead } }
+      api: { file: { saveImage: mocks.saveImage }, fs: { read: mocks.fsRead } }
     })
     Object.assign(navigator, { clipboard: mocks.clipboard })
     vi.stubGlobal('ClipboardItem', MockClipboardItem)
     vi.stubGlobal('fetch', mocks.fetch)
   })
 
-  it('opens the shared preview dialog when clicked', () => {
+  it('opens the shared preview dialog with the save-as toolbar action', () => {
     render(<ImageViewer src="https://example.com/image.png" alt="Example image" />)
 
     fireEvent.click(screen.getByRole('img', { name: 'Example image' }))
 
     expect(screen.getByTestId('image-preview-dialog')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'preview.save_as' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'preview.copy.image' })).not.toBeInTheDocument()
   })
 
@@ -85,6 +88,18 @@ describe('ImageViewer', () => {
       expect(mocks.clipboard.write).toHaveBeenCalledWith([expect.any(MockClipboardItem)])
     })
     expect(toast.success).toHaveBeenCalledWith('message.copy.success')
+  })
+
+  it('saves image data from the context menu with the existing file save flow', async () => {
+    render(<ImageViewer src="data:image/png;base64,aGVsbG8=" alt="Example image" />)
+
+    fireEvent.contextMenu(screen.getByRole('img', { name: 'Example image' }))
+    fireEvent.click(screen.getByRole('button', { name: 'preview.save_as' }))
+
+    await waitFor(() => {
+      expect(mocks.saveImage).toHaveBeenCalledWith('Example image', 'data:image/png;base64,aGVsbG8=')
+    })
+    expect(toast.success).toHaveBeenCalledWith('common.saved')
   })
 
   it('does not expose a download action in the preview toolbar or context menu', () => {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5146,6 +5146,7 @@
     "reset": "Reset",
     "rotate_left": "Rotate Left",
     "rotate_right": "Rotate Right",
+    "save_as": "Save As",
     "source": "View Source Code",
     "zoom_in": "Zoom In",
     "zoom_out": "Zoom Out"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5146,6 +5146,7 @@
     "reset": "重置",
     "rotate_left": "向左旋转",
     "rotate_right": "向右旋转",
+    "save_as": "另存为",
     "source": "查看源代码",
     "zoom_in": "放大",
     "zoom_out": "缩小"

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -20,7 +20,7 @@ const loadHtmlToImage = () => {
   return htmlToImagePromise
 }
 
-function blobToDataUrl(blob: Blob): Promise<string> {
+export function blobToDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
     reader.onloadend = () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Image context menus only supported copying the rendered image or its source, and the shared image preview toolbar only exposed transform controls.

After this PR:

Image context menus and the shared image preview toolbar expose a localized **Save As** action. The action resolves local, data, blob, and remote image sources, normalizes them to PNG, derives a safe default filename, and delegates to the existing native file save flow.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Users need a direct way to save images from assistant conversations without copying them through the clipboard. Reusing `window.api.file.saveImage` preserves the existing native save dialog, managed-storage checks, and file-writing behavior.

The following tradeoffs were made:

- Saved images are normalized to PNG to match the existing save API and file filter.
- Remote images must be fetched before the native save dialog is opened.
- Canceling the native dialog remains a silent no-op, matching the existing API contract.

The following alternatives were considered:

- The browser-style download helper was not used because it bypasses the project's native file save flow and its storage protections.
- Separate save handlers for the context menu and preview toolbar were avoided; both surfaces share one action.

Links to places where the discussion took place: None.

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Validation completed: `pnpm lint`, `pnpm format`, TypeScript checks, i18n checks, and `git diff --check`.
- `pnpm test`, `pnpm build:check`, and manual UI verification were not run per the repository's user-owned verification rule.
- A user-guide update is not required for this discoverable context-menu and preview-toolbar action.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Add Save As actions to image context menus and the shared image preview toolbar.
```
