### PR TITLE
fix(agent-pinning): avoid false failure toast after successful pin

### DIFF
--- a/src/renderer/components/chat/resourceList/AgentResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AgentResourceList.tsx
@@ -191,10 +191,16 @@ export function AgentResourceList({
 
       try {
         await toggleAgentPin(agentId)
-        await refetchAgents()
       } catch (err) {
         logger.error('Failed to toggle agent pin from classic-layout rail', { agentId, err })
         toast.error(t('common.error'))
+        return
+      }
+
+      try {
+        await refetchAgents()
+      } catch (err) {
+        logger.warn('Failed to refresh agents after toggling pin from classic-layout rail', { agentId, err })
       }
     },
     [isAgentPinActionDisabled, refetchAgents, t, toggleAgentPin]

--- a/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
@@ -4,6 +4,7 @@ import type { AgentSessionsSource, AssistantTopicsSource } from '@renderer/hooks
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ComponentProps, ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -23,7 +24,14 @@ const assistantDataMocks = vi.hoisted(() => ({
 
 const agentDataMocks = vi.hoisted(() => ({
   deleteAgent: vi.fn(),
-  refetchAgents: vi.fn()
+  refetchAgents: vi.fn(),
+  toggleAgentPin: vi.fn()
+}))
+
+const loggerMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn()
 }))
 
 const preferenceMocks = vi.hoisted(() => ({
@@ -88,11 +96,7 @@ vi.mock('@data/hooks/usePreference', () => ({
 
 vi.mock('@logger', () => ({
   loggerService: {
-    withContext: () => ({
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn()
-    })
+    withContext: () => loggerMocks
   }
 }))
 
@@ -252,7 +256,7 @@ vi.mock('@renderer/hooks/usePins', () => ({
     isMutating: false,
     isRefreshing: false,
     pinnedIds: [],
-    togglePin: vi.fn()
+    togglePin: agentDataMocks.toggleAgentPin
   })
 }))
 
@@ -363,6 +367,11 @@ describe('classic layout entity resource list actions', () => {
     agentDataMocks.deleteAgent.mockClear()
     agentDataMocks.refetchAgents.mockResolvedValue(undefined)
     agentDataMocks.refetchAgents.mockClear()
+    agentDataMocks.toggleAgentPin.mockResolvedValue(undefined)
+    agentDataMocks.toggleAgentPin.mockClear()
+    loggerMocks.error.mockClear()
+    loggerMocks.info.mockClear()
+    loggerMocks.warn.mockClear()
   })
 
   it('uses delete-assistant actions for the classic layout assistant context and more menus', async () => {
@@ -694,6 +703,57 @@ describe('classic layout entity resource list actions', () => {
     expect(onManageAssistants).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('resource-entity-rail')).toHaveAttribute('data-active-resource-menu', 'false')
     expect(screen.getByTestId('resource-entity-rail')).toHaveAttribute('data-selected-id', '')
+  })
+
+  it('does not report a pin failure when the post-success agent refresh fails', async () => {
+    const user = userEvent.setup()
+    const refreshError = new Error('transient refresh failure')
+    agentDataMocks.refetchAgents.mockRejectedValueOnce(refreshError)
+
+    render(
+      <AgentResourceList
+        activeAgentId="agent-1"
+        agentSessionsSource={createAgentSessionsSource()}
+        onSelectSession={vi.fn()}
+        onCreateSession={vi.fn()}
+        onShowMissingAgentSelection={vi.fn()}
+      />
+    )
+
+    await user.click(
+      within(screen.getByTestId('agent-1-context-menu')).getByRole('button', { name: 'agent.pin.title' })
+    )
+
+    await waitFor(() => expect(agentDataMocks.toggleAgentPin).toHaveBeenCalledWith('agent-1'))
+    await waitFor(() =>
+      expect(loggerMocks.warn).toHaveBeenCalledWith(
+        'Failed to refresh agents after toggling pin from classic-layout rail',
+        { agentId: 'agent-1', err: refreshError }
+      )
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('reports a pin failure and skips the agent refresh when the pin mutation fails', async () => {
+    const user = userEvent.setup()
+    agentDataMocks.toggleAgentPin.mockRejectedValueOnce(new Error('pin mutation failed'))
+
+    render(
+      <AgentResourceList
+        activeAgentId="agent-1"
+        agentSessionsSource={createAgentSessionsSource()}
+        onSelectSession={vi.fn()}
+        onCreateSession={vi.fn()}
+        onShowMissingAgentSelection={vi.fn()}
+      />
+    )
+
+    await user.click(
+      within(screen.getByTestId('agent-1-context-menu')).getByRole('button', { name: 'agent.pin.title' })
+    )
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('common.error'))
+    expect(agentDataMocks.refetchAgents).not.toHaveBeenCalled()
   })
 
   it('uses delete-agent actions for the classic layout agent context and more menus', async () => {

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1251,10 +1251,16 @@ const Sessions = ({
 
       try {
         await toggleAgentPin(agentId)
-        await refetchAgents()
       } catch (err) {
         logger.error('Failed to toggle agent pin from session group', { agentId, err })
         toast.error(t('common.error'))
+        return
+      }
+
+      try {
+        await refetchAgents()
+      } catch (err) {
+        logger.warn('Failed to refresh agents after toggling pin from session group', { agentId, err })
       }
     },
     [isAgentPinActionDisabled, refetchAgents, t, toggleAgentPin]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Pinning an agent and then encountering a transient agent-list refresh failure surfaced a generic failure toast, even though the pin mutation had already succeeded.

After this PR:

Pin mutation failures still surface an error, while post-success refresh failures are logged as warnings without incorrectly telling the user that pinning failed. Both classic-layout and session-group agent pin actions use this behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The mutation and the follow-up refresh have different failure semantics. Splitting their error handling preserves the real mutation error path while treating refresh as a best-effort synchronization step after success.

The following tradeoffs were made:

- A failed follow-up refresh is logged instead of shown to the user; the successful pin result is not rolled back.
- The duplicated handlers remain local to their components to keep this fix surgical and avoid introducing an abstraction for a small event flow.

The following alternatives were considered:

- Removing the follow-up refresh entirely was rejected because it still helps synchronize agent list data when available.
- Adding retry behavior was rejected because it would broaden this targeted UI feedback fix.

Links to places where the discussion took place: None.

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

- Regression coverage injects a successful pin mutation followed by a failed refresh and verifies that no error toast appears.
- A complementary case verifies that a real pin mutation failure still shows an error and skips the refresh.
- Validation completed: `pnpm lint` and `pnpm format`.
- Vitest and `pnpm build:check` were not run because verification is user-owned in this workspace.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an incorrect failure notification that could appear after successfully pinning an agent.
```
