### PR TITLE
test(file-processing): wait for async model overrides

### DIFF
--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
@@ -732,18 +732,22 @@ describe('processing settings pages', () => {
 
     const { rerender } = render(<OcrSettings />)
 
-    expect(
-      await screen.findByRole('button', {
-        name: 'settings.tool.file_processing.processors.paddleocr.fields.parse_model'
-      })
-    ).toHaveTextContent('PP-OCRv5')
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'settings.tool.file_processing.processors.paddleocr.fields.parse_model'
+        })
+      ).toHaveTextContent('PP-OCRv5')
+    })
 
     rerender(<DocumentProcessingSettings />)
-    expect(
-      await screen.findByRole('button', {
-        name: 'settings.tool.file_processing.processors.paddleocr.fields.parse_model'
-      })
-    ).toHaveTextContent('PP-StructureV3')
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'settings.tool.file_processing.processors.paddleocr.fields.parse_model'
+        })
+      ).toHaveTextContent('PP-StructureV3')
+    })
   })
 
   it('shows only OCR-safe model options for PaddleOCR image_to_text', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The PaddleOCR feature-override test asserted model text as soon as the model button appeared. Because the processor list loads asynchronously, the button could briefly contain the previous processor's `pipeline` model and fail the renderer test shard.

After this PR:

The test waits for both OCR and document model buttons to display their final override values before asserting.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The processor list is populated by an asynchronous IPC request, and the panel synchronizes its selected entry in an effect. Waiting for the user-visible model text removes the race while preserving the existing production-like async boundary.

The following tradeoffs were made:

`waitFor` may retry the semantic query briefly, but it targets the final observable state and keeps the test independent of effect timing.

The following alternatives were considered:

Using `findByRole` alone was insufficient because the accessible name is available during the transient render. Reintroducing processor-selection clicks would add unnecessary interaction and hide the default-processor path covered by the test.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/30789460250

### Breaking changes

<!-- optional -->

None. This is a test-only change.

### Special notes for your reviewer

Validation completed: `pnpm lint` and `pnpm format`. Lint passed with 40 pre-existing warnings. Vitest and `pnpm build:check` were not run per local verification policy; the PR CI will exercise the affected renderer shard.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the release note requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
