### PR TITLE
feat(settings): open settings as an immersive application surface

### DIFF
--- a/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
+++ b/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
@@ -2296,9 +2296,9 @@ describe('GlobalSearchPanel', () => {
     mocks.recentItems = [
       {
         kind: 'route',
-        url: '/app/settings',
-        title: 'Settings',
-        icon: 'settings',
+        url: '/app/knowledge',
+        title: 'Knowledge',
+        icon: 'knowledge',
         lastAccessTime: 20
       }
     ]
@@ -2311,19 +2311,18 @@ describe('GlobalSearchPanel', () => {
     expect(mocks.recentItems).toEqual([
       {
         kind: 'route',
-        url: '/app/settings',
-        title: 'Settings',
-        icon: 'settings',
+        url: '/app/knowledge',
+        title: 'Knowledge',
+        icon: 'knowledge',
         lastAccessTime: 20
       }
     ])
   })
 
-  it('cleans legacy assistant library route recents on open', async () => {
-    const user = userEvent.setup()
+  it('cleans legacy and immersive-only route recents on open', async () => {
     const settingsRecent = {
       kind: 'route' as const,
-      url: '/app/settings',
+      url: '/settings/provider',
       title: 'Settings',
       icon: 'settings',
       lastAccessTime: 20
@@ -2342,18 +2341,12 @@ describe('GlobalSearchPanel', () => {
     render(<GlobalSearchPanel onClose={mocks.onClose} />)
 
     expect(screen.queryByRole('option', { name: /Library/ })).not.toBeInTheDocument()
-    const settingsOption = screen.getByRole('option', { name: /Settings/ })
+    expect(screen.queryByRole('option', { name: /Settings/ })).not.toBeInTheDocument()
     await waitFor(() => {
-      expect(mocks.recentItems).toEqual([settingsRecent])
+      expect(mocks.recentItems).toEqual([])
     })
 
-    await user.click(settingsOption)
-
-    expect(mocks.openTab).toHaveBeenCalledWith('/app/settings', { title: 'Settings', icon: 'settings' })
-    expect(mocks.openTab).not.toHaveBeenCalledWith(
-      '/app/library?resourceType=assistant',
-      expect.objectContaining({ title: 'Library' })
-    )
+    expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
   it('only refreshes up to the display limit items ordered by lastAccessTime', async () => {

--- a/src/renderer/components/GlobalSearch/__tests__/globalSearchGroups.test.ts
+++ b/src/renderer/components/GlobalSearch/__tests__/globalSearchGroups.test.ts
@@ -79,7 +79,7 @@ describe('globalSearchGroups', () => {
     expect(changed[0]).toEqual(expect.objectContaining({ kind: 'topic', topicId: 'topic-1', lastAccessTime: 30 }))
   })
 
-  it('filters legacy assistant library route recents', () => {
+  it('filters legacy and immersive-only route recents', () => {
     const entries = [
       {
         kind: 'route' as const,
@@ -92,17 +92,16 @@ describe('globalSearchGroups', () => {
         url: '/app/settings',
         title: 'Settings',
         lastAccessTime: 20
+      },
+      {
+        kind: 'route' as const,
+        url: '/settings/provider?id=openai',
+        title: 'Provider Settings',
+        lastAccessTime: 10
       }
     ]
 
-    expect(sanitizeGlobalSearchRecentEntries(entries)).toEqual([
-      {
-        kind: 'route',
-        url: '/app/settings',
-        title: 'Settings',
-        lastAccessTime: 20
-      }
-    ])
+    expect(sanitizeGlobalSearchRecentEntries(entries)).toEqual([])
     expect(
       upsertGlobalSearchRecentEntry(entries, {
         kind: 'route',
@@ -110,14 +109,7 @@ describe('globalSearchGroups', () => {
         title: 'Library',
         lastAccessTime: 40
       })
-    ).toEqual([
-      {
-        kind: 'route',
-        url: '/app/settings',
-        title: 'Settings',
-        lastAccessTime: 20
-      }
-    ])
+    ).toEqual([])
     expect(
       getDisplayGlobalSearchRecentEntries([
         ...entries,
@@ -129,12 +121,6 @@ describe('globalSearchGroups', () => {
         }
       ])
     ).toEqual([
-      {
-        kind: 'route',
-        url: '/app/settings',
-        title: 'Settings',
-        lastAccessTime: 20
-      },
       {
         kind: 'topic',
         topicId: 'topic-1',

--- a/src/renderer/components/GlobalSearch/globalSearchGroups.ts
+++ b/src/renderer/components/GlobalSearch/globalSearchGroups.ts
@@ -9,6 +9,7 @@ import type {
   TopicMessageContentSearchItem
 } from '@shared/data/api/schemas/search'
 import type { GlobalSearchRecentEntry, Tab } from '@shared/data/cache/cacheValueTypes'
+import { isSettingsPath } from '@shared/data/types/settingsPath'
 import dayjs from 'dayjs'
 
 export const GLOBAL_SEARCH_RECENT_ITEM_LIMIT = 20
@@ -145,7 +146,10 @@ function getRoutePathname(url: string) {
 }
 
 function isLegacyRouteRecentEntry(entry: GlobalSearchRecentEntry) {
-  return entry.kind === 'route' && LEGACY_ROUTE_PATHS.has(getRoutePathname(entry.url))
+  if (entry.kind !== 'route') return false
+
+  const pathname = getRoutePathname(entry.url)
+  return LEGACY_ROUTE_PATHS.has(pathname) || pathname === '/app/settings' || isSettingsPath(pathname)
 }
 
 export function sanitizeGlobalSearchRecentEntries(

--- a/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
@@ -3,6 +3,7 @@ import { cn } from '@cherrystudio/ui/lib/utils'
 import { loggerService } from '@logger'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { getHttpMessageLabelKey, getProviderLabelKey } from '@renderer/i18n/label'
+import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import type { SerializedError } from '@renderer/types/error'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { classifyError } from '@renderer/utils/errorClassifier'
@@ -51,7 +52,18 @@ const ErrorMessage: React.FC<{ error: Props['error'] }> = ({ error }) => {
           i18nKey={i18nKey}
           values={{ provider: t(getProviderLabelKey(providerId)) }}
           components={{
-            provider: <Link style={{ color: 'var(--link)' }} to="/settings/provider" search={{ id: providerId }} />
+            provider: (
+              <Link
+                style={{ color: 'var(--link)' }}
+                to="/settings/provider"
+                search={{ id: providerId }}
+                onClick={(event) => {
+                  event.preventDefault()
+                  event.stopPropagation()
+                  openSettingsTab('/settings/provider', { id: providerId })
+                }}
+              />
+            )
           }}
         />
       )

--- a/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/ErrorBlock.test.tsx
@@ -6,7 +6,8 @@ import type { MessageListActions, MessageListItem } from '../../types'
 
 const mocks = vi.hoisted(() => ({
   actions: {} as MessageListActions,
-  i18nKeys: new Set<string>()
+  i18nKeys: new Set<string>(),
+  openSettingsTab: vi.fn()
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
@@ -30,12 +31,33 @@ vi.mock('@renderer/i18n/label', () => ({
   getProviderLabelKey: (providerId: string) => providerId
 }))
 
+vi.mock('@renderer/services/mainWindowNavigation', () => ({
+  openSettingsTab: mocks.openSettingsTab
+}))
+
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a>
+  Link: ({ children, to, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  )
 }))
 
 vi.mock('react-i18next', () => ({
-  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  Trans: ({
+    components,
+    i18nKey
+  }: {
+    components?: Record<string, React.ReactElement<React.AnchorHTMLAttributes<HTMLAnchorElement>>>
+    i18nKey: string
+  }) =>
+    components?.provider ? (
+      <a href="/settings/provider" onClick={components.provider.props.onClick}>
+        provider
+      </a>
+    ) : (
+      <>{i18nKey}</>
+    ),
   useTranslation: () => ({
     t: (key: string) => key,
     i18n: {
@@ -209,5 +231,23 @@ describe('ErrorBlock', () => {
         language: 'en'
       })
     )
+  })
+
+  it('opens an inline provider link in immersive Settings', () => {
+    mocks.i18nKeys.add('error.api_key')
+    const openErrorDetail = vi.fn()
+    mocks.actions = { openErrorDetail }
+    render(
+      <ErrorBlock
+        partId="message-1-part-0"
+        error={{ name: 'AuthError', message: 'Unauthorized', stack: null, providerId: 'open ai', i18nKey: 'api_key' }}
+        message={message}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'provider' }))
+
+    expect(mocks.openSettingsTab).toHaveBeenCalledWith('/settings/provider', { id: 'open ai' })
+    expect(openErrorDetail).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/chat/messages/hooks/__tests__/useMessageErrorActions.test.tsx
+++ b/src/renderer/components/chat/messages/hooks/__tests__/useMessageErrorActions.test.tsx
@@ -6,7 +6,9 @@ import type { MessageListItem } from '../../types'
 const mocks = vi.hoisted(() => ({
   cache: new Map<string, unknown>(),
   classifyErrorByAI: vi.fn(),
-  showErrorDetailPopup: vi.fn()
+  showErrorDetailPopup: vi.fn(),
+  navigate: vi.fn(),
+  openSettingsTab: vi.fn()
 }))
 
 vi.mock('@data/CacheService', () => ({
@@ -28,8 +30,12 @@ vi.mock('@renderer/components/ErrorDetailModal', () => ({
   showErrorDetailPopup: mocks.showErrorDetailPopup
 }))
 
+vi.mock('@renderer/services/mainWindowNavigation', () => ({
+  openSettingsTab: mocks.openSettingsTab
+}))
+
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn()
+  useNavigate: () => mocks.navigate
 }))
 
 const { cacheService } = await import('@data/CacheService')
@@ -86,5 +92,23 @@ describe('useMessageErrorActions', () => {
         onDiagnosisComplete: persistDiagnosis
       })
     )
+  })
+
+  it('opens Settings targets outside the current message-list router', () => {
+    const { result } = renderHook(() => useMessageErrorActions())
+
+    void result.current.navigateErrorTarget?.('/settings/provider?id=openai')
+
+    expect(mocks.openSettingsTab).toHaveBeenCalledWith('/settings/provider?id=openai')
+    expect(mocks.navigate).not.toHaveBeenCalled()
+  })
+
+  it('keeps non-Settings error targets inside the current router', () => {
+    const { result } = renderHook(() => useMessageErrorActions())
+
+    void result.current.navigateErrorTarget?.('/app/knowledge')
+
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/app/knowledge' })
+    expect(mocks.openSettingsTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/chat/messages/hooks/useMessageErrorActions.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageErrorActions.ts
@@ -1,7 +1,9 @@
 import { cacheService } from '@data/CacheService'
 import type { MessageListActions } from '@renderer/components/chat/messages/types'
 import { showErrorDetailPopup } from '@renderer/components/ErrorDetailModal'
+import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import { classifyErrorByAI } from '@renderer/utils/errorDiagnosis'
+import { isSettingsPath } from '@shared/data/types/settingsPath'
 import { useNavigate } from '@tanstack/react-router'
 import { useCallback, useMemo } from 'react'
 
@@ -52,6 +54,10 @@ export function useMessageErrorActions(options: MessageErrorActionOptions = {}):
 
   const navigateErrorTarget = useCallback<NonNullable<MessageListActions['navigateErrorTarget']>>(
     (target) => {
+      if (isSettingsPath(target)) {
+        openSettingsTab(target)
+        return
+      }
       void navigate({ to: target })
     },
     [navigate]

--- a/src/renderer/components/composer/tools/components/WebSearchButton.tsx
+++ b/src/renderer/components/composer/tools/components/WebSearchButton.tsx
@@ -7,13 +7,13 @@ import type { ToolLauncherApi } from '@renderer/components/composer/tools/types'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { useWebSearchProviders } from '@renderer/hooks/useWebSearch'
+import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import { getEffectiveMcpMode } from '@renderer/utils/mcpMode'
 import { getWebSearchProviderLogo } from '@renderer/utils/webSearchProviderMeta'
 import { isWebSearchProviderReady } from '@shared/data/presets/webSearchProviders'
 import { resolveWebToolRoutes, type WebToolUnavailableReason } from '@shared/utils/provider'
-import { useNavigate } from '@tanstack/react-router'
 import { Globe } from 'lucide-react'
 import type { FC, MouseEventHandler } from 'react'
 import { memo, useCallback, useEffect, useMemo } from 'react'
@@ -34,7 +34,6 @@ const REASON_MESSAGE_KEYS: Partial<Record<WebToolUnavailableReason, string>> = {
 
 const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const { assistant, model, updateAssistant } = useAssistant(assistantId)
   const { provider: modelProvider } = useProvider(model?.providerId ?? '')
   const { defaultFetchUrlsProvider, defaultSearchKeywordsProvider } = useWebSearchProviders()
@@ -97,7 +96,7 @@ const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
         if (!confirmed) return
 
         navigatedAway = true
-        await navigate({ to: '/settings/websearch' })
+        openSettingsTab('/settings/websearch')
         return
       }
 
@@ -107,7 +106,7 @@ const useWebSearchToolController = ({ assistantId, launcher }: Props) => {
 
       void updateAssistant({ settings: { enableWebSearch: true } })
     },
-    [assistant, disabledReason, enableWebSearch, navigate, t, updateAssistant, model, searchUnavailableReason]
+    [assistant, disabledReason, enableWebSearch, t, updateAssistant, model, searchUnavailableReason]
   )
 
   const ariaLabel = enableWebSearch ? t('common.close') : t('chat.input.web_search.label')

--- a/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/WebSearchButton.test.tsx
@@ -13,7 +13,7 @@ import WebSearchButton from '../WebSearchButton'
 
 const mocks = vi.hoisted(() => ({
   updateAssistant: vi.fn(),
-  navigate: vi.fn(),
+  openSettingsTab: vi.fn(),
   assistant: undefined as any,
   model: undefined as Model | undefined,
   provider: undefined as any
@@ -31,8 +31,8 @@ vi.mock('react-i18next', async (importOriginal) => {
   }
 })
 
-vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => mocks.navigate
+vi.mock('@renderer/services/mainWindowNavigation', () => ({
+  openSettingsTab: mocks.openSettingsTab
 }))
 
 vi.mock('@renderer/components/ActionIconButton', () => ({
@@ -189,7 +189,7 @@ describe('WebSearchButton', () => {
     fireEvent.click(button)
 
     const confirmOptions = vi.mocked(popup.confirm).mock.calls[0][0]
-    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith({ to: '/settings/websearch' }))
+    await waitFor(() => expect(mocks.openSettingsTab).toHaveBeenCalledWith('/settings/websearch'))
     confirmOptions.focusOnClose?.()
 
     expect(button).not.toHaveFocus()

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -67,15 +67,13 @@ function ImmersiveSettingsShell({
         'flex h-screen w-screen flex-col overflow-hidden text-foreground',
         isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
       )}>
-      {/* Two deliberate offsets keep Back on the traffic lights' line:
-          - the divider is an overlay, not a border, so it does not shrink the content box;
-          - macOS draws the lights from `trafficLightPosition` y=16 (windowRegistry) at ~13.5px, so
-            their centre sits ~0.75px below the centre of the 44px chrome. `pt-[1.5px]` moves the
-            row's centre down by exactly that much. Fullscreen hides the lights, so it drops out. */}
+      {/* macOS draws the lights from `trafficLightPosition` y=16 (windowRegistry) at ~13.5px, so
+          their centre sits ~0.75px below the centre of the 44px chrome. `pt-[1.5px]` moves the
+          row's centre down by exactly that much. Fullscreen hides the lights, so it drops out. */}
       <header
         data-testid="settings-title-bar"
         className={cn(
-          "relative flex h-[var(--app-top-chrome-height)] shrink-0 items-center [-webkit-app-region:drag] after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-[0.5px] after:bg-border after:content-['']",
+          'relative flex h-[var(--app-top-chrome-height)] shrink-0 items-center [-webkit-app-region:drag]',
           isMac && !isFullscreen && 'pt-[1.5px]'
         )}>
         {isMac && !isFullscreen && (
@@ -92,7 +90,7 @@ function ImmersiveSettingsShell({
             variant="ghost"
             aria-label={t('common.back')}
             onClick={onBack}
-            className="h-8 text-foreground text-sm dark:text-foreground">
+            className="h-7 min-h-7 gap-1 px-1.5 text-foreground text-sm dark:text-foreground">
             <ArrowLeft size={16} />
             <span>{t('common.back')}</span>
           </Button>
@@ -101,11 +99,13 @@ function ImmersiveSettingsShell({
           <WindowControls />
         </div>
       </header>
-      <main className="relative min-h-0 flex-1 overflow-hidden bg-background">
-        <ResourceViewSourceProvider>
-          <TabRouter tab={settingsTab} isActive onUrlChange={onUrlChange} />
-        </ResourceViewSourceProvider>
-      </main>
+      <div className="flex min-h-0 flex-1 flex-col px-2 pb-2">
+        <main className="relative min-h-0 flex-1 overflow-hidden rounded-[12px] border-[0.5px] border-border bg-background">
+          <ResourceViewSourceProvider>
+            <TabRouter tab={settingsTab} isActive onUrlChange={onUrlChange} />
+          </ResourceViewSourceProvider>
+        </main>
+      </div>
     </section>
   )
 }

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@cherrystudio/ui'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { useTabs } from '@renderer/hooks/tab'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
@@ -6,15 +7,108 @@ import { isMac } from '@renderer/utils/platform'
 import { getDefaultRouteTitle, isPageTitledRoute } from '@renderer/utils/routeTitle'
 import { cn } from '@renderer/utils/style'
 import { clearTabInstanceMetadata } from '@renderer/utils/tabInstanceMetadata'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Tab } from '@shared/data/cache/cacheValueTypes'
+import { isSettingsPath } from '@shared/data/types/settingsPath'
+import { ArrowLeft } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import Sidebar from '../app/Sidebar'
 import { createRecentRouteEntryFromTab, recordGlobalSearchRecentEntry } from '../GlobalSearch/globalSearchGroups'
 import GlobalSearchPopup from '../GlobalSearch/GlobalSearchPopup'
 import MiniAppTabsPool from '../MiniApp/MiniAppTabsPool'
 import { ResourceViewSourceProvider } from '../ResourceViewSourceProvider'
+import { WindowControls } from '../WindowControls'
 import { AppShellTabBar } from './AppShellTabBar'
+import { useSettingsSurface } from './SettingsSurfaceProvider'
 import { TabRouter } from './TabRouter'
+
+const IMMERSIVE_SETTINGS_TAB_ID = 'immersive-settings'
+
+type ImmersiveSettingsShellProps = {
+  isFullscreen: boolean
+  isMacTransparentWindow: boolean
+  onBack: () => void
+  onUrlChange: (url: string) => void
+  settingsPath: string
+}
+
+function ImmersiveSettingsShell({
+  isFullscreen,
+  isMacTransparentWindow,
+  onBack,
+  onUrlChange,
+  settingsPath
+}: ImmersiveSettingsShellProps) {
+  const { t } = useTranslation()
+  const backButtonRef = useRef<HTMLButtonElement>(null)
+  const settingsTab = useMemo<Tab>(
+    () => ({
+      id: IMMERSIVE_SETTINGS_TAB_ID,
+      type: 'route',
+      url: settingsPath,
+      title: t('settings.title'),
+      isDormant: false
+    }),
+    [settingsPath, t]
+  )
+
+  useEffect(() => {
+    const previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    backButtonRef.current?.focus()
+
+    return () => previouslyFocusedElement?.focus()
+  }, [])
+
+  return (
+    <section
+      data-testid="settings-shell"
+      className={cn(
+        'flex h-screen w-screen flex-col overflow-hidden text-foreground',
+        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
+      )}>
+      {/* Two deliberate offsets keep Back on the traffic lights' line:
+          - the divider is an overlay, not a border, so it does not shrink the content box;
+          - macOS draws the lights from `trafficLightPosition` y=16 (windowRegistry) at ~13.5px, so
+            their centre sits ~0.75px below the centre of the 44px chrome. `pt-[1.5px]` moves the
+            row's centre down by exactly that much. Fullscreen hides the lights, so it drops out. */}
+      <header
+        data-testid="settings-title-bar"
+        className={cn(
+          "relative flex h-[var(--app-top-chrome-height)] shrink-0 items-center [-webkit-app-region:drag] after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-[0.5px] after:bg-border after:content-['']",
+          isMac && !isFullscreen && 'pt-[1.5px]'
+        )}>
+        {isMac && !isFullscreen && (
+          <div
+            aria-hidden="true"
+            data-testid="settings-macos-traffic-light-spacer"
+            className="h-full w-[env(titlebar-area-x)] shrink-0"
+          />
+        )}
+        <div className="flex h-full items-center px-2 [-webkit-app-region:no-drag]">
+          <Button
+            ref={backButtonRef}
+            type="button"
+            variant="ghost"
+            aria-label={t('common.back')}
+            onClick={onBack}
+            className="h-8 text-foreground text-sm dark:text-foreground">
+            <ArrowLeft size={16} />
+            <span>{t('common.back')}</span>
+          </Button>
+        </div>
+        <div className="ml-auto h-full">
+          <WindowControls />
+        </div>
+      </header>
+      <main className="relative min-h-0 flex-1 overflow-hidden bg-background">
+        <ResourceViewSourceProvider>
+          <TabRouter tab={settingsTab} isActive onUrlChange={onUrlChange} />
+        </ResourceViewSourceProvider>
+      </main>
+    </section>
+  )
+}
 
 export const AppShell = () => {
   const isMacTransparentWindow = useMacTransparentWindow()
@@ -33,12 +127,23 @@ export const AppShell = () => {
   } = useTabs()
   const activeTab = useMemo(() => tabs.find((tab) => tab.id === activeTabId), [activeTabId, tabs])
   const [isFullscreen, setIsFullscreen] = useState(false)
+  const { settingsPath, setSettingsPath, closeSettings } = useSettingsSurface()
 
   const handleOpenGlobalSearch = useCallback(() => {
+    if (settingsPath) return
     void GlobalSearchPopup.show()
-  }, [])
+  }, [settingsPath])
 
   useCommandHandler('app.search', handleOpenGlobalSearch)
+
+  // Blocking `show()` only covers searches started from here. A deep link or a menu entry can open
+  // Settings while global search is already up, and the popup lives in the window-level PopupHost —
+  // so it would keep covering the surface. Dismiss it as Settings takes over.
+  useEffect(() => {
+    if (settingsPath) {
+      GlobalSearchPopup.hide()
+    }
+  }, [settingsPath])
 
   useEffect(() => {
     if (!isMac) return
@@ -85,6 +190,11 @@ export const AppShell = () => {
   // session name + assistant / agent emoji), so we only sync the url and leave
   // title/icon alone, or navigating between topics would wipe them.
   const handleUrlChange = (tabId: string, url: string) => {
+    if (isSettingsPath(url)) {
+      setSettingsPath(url)
+      return
+    }
+
     const isPageTitled = isPageTitledRoute(url)
     const tab = tabs.find((candidate) => candidate.id === tabId)
     const patch = isPageTitled
@@ -132,7 +242,7 @@ export const AppShell = () => {
               <TabRouter
                 key={tab.id}
                 tab={tab}
-                isActive={tab.id === activeTabId}
+                isActive={tab.id === activeTabId && !settingsPath}
                 onUrlChange={(url) => handleUrlChange(tab.id, url)}
               />
             ))}
@@ -151,24 +261,24 @@ export const AppShell = () => {
     </div>
   )
 
-  if (!isMac) {
-    return (
-      <div
-        className={cn(
-          'flex h-screen w-screen flex-row overflow-hidden text-foreground',
-          isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
-        )}>
-        <Sidebar />
-        {contentColumn}
-      </div>
-    )
-  }
-
-  return (
+  const workspaceShell = !isMac ? (
     <div
+      data-testid="workspace-shell"
+      className={cn(
+        'flex h-screen w-screen flex-row overflow-hidden text-foreground',
+        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar',
+        settingsPath && 'hidden'
+      )}>
+      <Sidebar />
+      {contentColumn}
+    </div>
+  ) : (
+    <div
+      data-testid="workspace-shell"
       className={cn(
         'relative flex h-screen w-screen flex-row overflow-hidden text-foreground',
-        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar'
+        isMacTransparentWindow ? 'bg-transparent' : 'bg-sidebar',
+        settingsPath && 'hidden'
       )}>
       {!isFullscreen && (
         <div
@@ -189,5 +299,20 @@ export const AppShell = () => {
       </div>
       {contentColumn}
     </div>
+  )
+
+  return (
+    <>
+      {workspaceShell}
+      {settingsPath && (
+        <ImmersiveSettingsShell
+          settingsPath={settingsPath}
+          isFullscreen={isFullscreen}
+          isMacTransparentWindow={isMacTransparentWindow}
+          onBack={closeSettings}
+          onUrlChange={setSettingsPath}
+        />
+      )}
+    </>
   )
 }

--- a/src/renderer/components/layout/SettingsSurfaceProvider.tsx
+++ b/src/renderer/components/layout/SettingsSurfaceProvider.tsx
@@ -1,0 +1,31 @@
+import { useMainWindowNavigation } from '@renderer/hooks/tab'
+import type { SettingsPath } from '@shared/data/types/settingsPath'
+import { createContext, type ReactNode, use } from 'react'
+
+type SettingsSurfaceValue = {
+  settingsPath: SettingsPath | null
+  setSettingsPath: (path: string) => void
+  closeSettings: () => void
+}
+
+const SettingsSurfaceContext = createContext<SettingsSurfaceValue | null>(null)
+
+/**
+ * Mounts the main window's single navigation consumption point and publishes the immersive
+ * Settings state it produces. It wraps the window content — onboarding included — because route
+ * delivery and protocol readiness must not wait for AppShell, while AppShell is the only consumer
+ * of the Settings surface itself.
+ */
+export function SettingsSurfaceProvider({ children }: { children: ReactNode }) {
+  const settingsSurface = useMainWindowNavigation()
+
+  return <SettingsSurfaceContext value={settingsSurface}>{children}</SettingsSurfaceContext>
+}
+
+export function useSettingsSurface(): SettingsSurfaceValue {
+  const settingsSurface = use(SettingsSurfaceContext)
+  if (!settingsSurface) {
+    throw new Error('useSettingsSurface must be used within a SettingsSurfaceProvider')
+  }
+  return settingsSurface
+}

--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -39,6 +39,7 @@ const LEGACY_LIBRARY_ROUTE_PATH = '/app/library'
 // so an already-persisted OpenClaw pin is redirected here rather than restoring to a dead route.
 const LEGACY_OPENCLAW_ROUTE_PATH = '/app/openclaw'
 const CODE_ROUTE_PATH = '/app/code'
+const SETTINGS_ROUTE_PATH = '/settings'
 
 function routePathOfTab(tab: Tab): string | null {
   if (tab.type !== 'route') return null
@@ -49,11 +50,25 @@ function routePathOfTab(tab: Tab): string | null {
   }
 }
 
+function isSettingsRouteTab(tab: Tab): boolean {
+  const path = routePathOfTab(tab)
+  return path === SETTINGS_ROUTE_PATH || !!path?.startsWith(`${SETTINGS_ROUTE_PATH}/`)
+}
+
+/**
+ * Settings now opens as an application-level surface, so a Settings tab persisted by an older
+ * version must not be restored — reopening it would render Settings back inside the workspace.
+ * Pinned Settings tabs are dropped by `migratePinnedTabs`; this covers the normal-tab session.
+ */
+export function dropRestoredSettingsTabs(tabs: Tab[]): Tab[] {
+  return tabs.filter((tab) => !isSettingsRouteTab(tab))
+}
+
 /**
  * Reconcile persisted pinned tabs against routes that have since been removed or relocated: drop
- * `/app/library` pins outright, and redirect `/app/openclaw` pins to `/app/code` (deduping so the
- * redirect never produces a second Code pin). `changed` is true when anything was dropped or
- * rewritten, signalling the caller to write the reconciled list back to the persistent cache.
+ * `/app/library` and Settings pins outright, and redirect `/app/openclaw` pins to `/app/code`
+ * (deduping so the redirect never produces a second Code pin). `changed` is true when anything was
+ * dropped or rewritten, signalling the caller to write the reconciled list back to the cache.
  */
 export function migratePinnedTabs(pinnedTabs: Tab[]): { tabs: Tab[]; changed: boolean } {
   let hasCodePin = pinnedTabs.some((tab) => routePathOfTab(tab) === CODE_ROUTE_PATH)
@@ -61,7 +76,7 @@ export function migratePinnedTabs(pinnedTabs: Tab[]): { tabs: Tab[]; changed: bo
   let changed = false
   for (const tab of pinnedTabs) {
     const path = routePathOfTab(tab)
-    if (path === LEGACY_LIBRARY_ROUTE_PATH) {
+    if (path === LEGACY_LIBRARY_ROUTE_PATH || isSettingsRouteTab(tab)) {
       changed = true
       continue
     }
@@ -85,7 +100,7 @@ function withLocalizedRouteTitle(tab: Tab): Tab {
   if (isPageTitledRoute(tab.url)) {
     return tab.title ? tab : { ...tab, title: getDefaultRouteTitle(tab.url) }
   }
-  // Only auto-localize titles for top-level and settings routes. Parameterized
+  // Only auto-localize titles for top-level routes. Parameterized
   // routes (e.g. /app/mini-app/<id>) preserve the title supplied at openTab
   // time so callers can pass per-entity names like a mini-app's display name.
   //
@@ -94,15 +109,10 @@ function withLocalizedRouteTitle(tab: Tab): Tab {
   // per-entity route (e.g. opening a mini-app from the sidebar), forcing the
   // route default here clobbers the caller-supplied title every render and
   // fights MiniAppPage's title-sync effect, spinning into an infinite
-  // `updateTab` loop ("Maximum update depth exceeded"). On top-level / settings
-  // routes the branch below still relocalizes the home tab, so language changes
-  // are unaffected.
-  if (!isTopLevelRoute(tab.url) && !isSettingsRouteTab(tab)) return tab
+  // `updateTab` loop ("Maximum update depth exceeded"). On top-level routes the
+  // branch below still relocalizes the home tab, so language changes are unaffected.
+  if (!isTopLevelRoute(tab.url)) return tab
   return { ...tab, title: getDefaultRouteTitle(tab.url) }
-}
-
-function isSettingsRouteTab(tab: Tab): boolean {
-  return tab.type === 'route' && tab.url.startsWith('/settings')
 }
 
 type InitialSession = { normalTabs: Tab[]; pinnedTabs: Tab[]; activeTabId: string }
@@ -221,7 +231,7 @@ export function TabsProvider({
       // Check the active-pinned tab against the migrated set that actually renders, not the raw
       // persisted pins — a pin dropped/redirected by migratePinnedTabs must not resolve as active.
       pinnedTabs: availablePinnedTabs,
-      persistedNormalTabs: persistedNormalTabs ?? [],
+      persistedNormalTabs: dropRestoredSettingsTabs(persistedNormalTabs ?? []),
       persistedActiveTabId: persistedActiveTabId ?? ''
     })
   }

--- a/src/renderer/components/layout/__tests__/AppShell.test.tsx
+++ b/src/renderer/components/layout/__tests__/AppShell.test.tsx
@@ -297,12 +297,21 @@ describe('AppShell', () => {
 
     render(<AppShell />)
 
+    const settingsContent = screen.getByTestId('settings-router').closest('main')
+    const settingsTitleBar = screen.getByTestId('settings-title-bar')
+    const backButton = screen.getByRole('button', { name: /Back|返回/ })
+
     expect(screen.getByTestId('workspace-shell')).toHaveClass('hidden')
     expect(screen.getByTestId('settings-shell')).toBeVisible()
     expect(screen.getByTestId('settings-router')).toHaveAttribute('data-url', '/settings/provider')
+    expect(settingsContent?.parentElement).toHaveClass('px-2', 'pb-2')
+    expect(settingsContent).toHaveClass('rounded-[12px]', 'border-[0.5px]', 'border-border')
+    expect(settingsTitleBar).not.toHaveClass('after:h-[0.5px]')
+    expect(backButton).toHaveClass('h-7', 'min-h-7', 'gap-1', 'px-1.5')
+    expect(backButton).not.toHaveClass('h-8')
     expect(screen.getByTestId('window-controls')).toBeInTheDocument()
     expect(mocks.workspaceRouterProps).toHaveProperty('isActive', false)
-    expect(screen.getByRole('button', { name: /Back|返回/ })).toHaveFocus()
+    expect(backButton).toHaveFocus()
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/components/layout/__tests__/AppShell.test.tsx
+++ b/src/renderer/components/layout/__tests__/AppShell.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
 
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,9 +9,17 @@ const mocks = vi.hoisted(() => ({
   commandHandlers: new Map<string, () => void>(),
   ipcHandlers: new Map<string, (value: unknown) => void>(),
   ipcRequest: vi.fn(() => Promise.resolve(false)),
+  closeSettings: vi.fn(),
+  openTab: vi.fn(),
   platformState: { isMac: false },
+  settingsPath: null as string | null,
+  settingsRouterProps: undefined as Record<string, unknown> | undefined,
+  setSettingsPath: vi.fn(),
   tabBarProps: undefined as Record<string, unknown> | undefined,
-  showSearchPopup: vi.fn()
+  updateTab: vi.fn(),
+  workspaceRouterProps: undefined as Record<string, unknown> | undefined,
+  showSearchPopup: vi.fn(),
+  hideSearchPopup: vi.fn()
 }))
 
 vi.mock('@renderer/hooks/useMacTransparentWindow', () => ({
@@ -41,16 +49,24 @@ vi.mock('@renderer/ipc', () => ({
 
 vi.mock('@renderer/components/GlobalSearch/GlobalSearchPopup', () => ({
   default: {
-    show: mocks.showSearchPopup
+    show: mocks.showSearchPopup,
+    hide: mocks.hideSearchPopup
   }
 }))
 
+vi.mock('../SettingsSurfaceProvider', () => ({
+  useSettingsSurface: () => ({
+    closeSettings: mocks.closeSettings,
+    settingsPath: mocks.settingsPath,
+    setSettingsPath: mocks.setSettingsPath
+  })
+}))
+
 vi.mock('../../../hooks/tab', () => ({
-  useMainWindowNavigation: vi.fn(),
   useTabs: () => ({
     activeTabId: 'home',
     closeTab: vi.fn(),
-    openTab: vi.fn(),
+    openTab: mocks.openTab,
     pinTab: vi.fn(),
     reorderTabs: vi.fn(),
     setActiveTab: vi.fn(),
@@ -64,7 +80,7 @@ vi.mock('../../../hooks/tab', () => ({
       }
     ],
     unpinTab: vi.fn(),
-    updateTab: vi.fn()
+    updateTab: mocks.updateTab
   })
 }))
 
@@ -95,7 +111,19 @@ vi.mock('../AppShellTabBar', () => ({
 }))
 
 vi.mock('../TabRouter', () => ({
-  TabRouter: () => <section data-testid="tab-router" />
+  TabRouter: (props: Record<string, unknown>) => {
+    const tab = props.tab as { id: string; url: string }
+    if (tab.id === 'immersive-settings') {
+      mocks.settingsRouterProps = props
+      return <section data-testid="settings-router" data-url={tab.url} />
+    }
+    mocks.workspaceRouterProps = props
+    return <section data-testid="tab-router" />
+  }
+}))
+
+vi.mock('../../WindowControls', () => ({
+  WindowControls: () => (mocks.platformState.isMac ? null : <div data-testid="window-controls" />)
 }))
 
 import { AppShell } from '../AppShell'
@@ -107,7 +135,10 @@ afterEach(() => {
   mocks.ipcHandlers.clear()
   mocks.ipcRequest.mockResolvedValue(false)
   mocks.platformState.isMac = false
+  mocks.settingsPath = null
+  mocks.settingsRouterProps = undefined
   mocks.tabBarProps = undefined
+  mocks.workspaceRouterProps = undefined
 })
 
 describe('AppShell', () => {
@@ -128,6 +159,26 @@ describe('AppShell', () => {
     mocks.commandHandlers.get('app.search')?.()
 
     expect(mocks.showSearchPopup).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not open global search while settings is immersive', () => {
+    mocks.settingsPath = '/settings/provider'
+    render(<AppShell />)
+
+    mocks.commandHandlers.get('app.search')?.()
+
+    expect(mocks.showSearchPopup).not.toHaveBeenCalled()
+  })
+
+  it('dismisses an already-open global search when Settings takes over the window', () => {
+    const { rerender } = render(<AppShell />)
+
+    expect(mocks.hideSearchPopup).not.toHaveBeenCalled()
+
+    mocks.settingsPath = '/settings/provider'
+    rerender(<AppShell />)
+
+    expect(mocks.hideSearchPopup).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the Windows and Linux tab bar inside the content column beside the sidebar', () => {
@@ -239,5 +290,80 @@ describe('AppShell', () => {
     expect(await screen.findByTestId('macos-traffic-light-spacer')).toBeInTheDocument()
     expect(screen.getByTestId('macos-traffic-light-drag-region')).toBeInTheDocument()
     expect(mocks.tabBarProps).toHaveProperty('isFullscreen', false)
+  })
+
+  it('shows Settings as an immersive surface while preserving the hidden workspace shell', () => {
+    mocks.settingsPath = '/settings/provider'
+
+    render(<AppShell />)
+
+    expect(screen.getByTestId('workspace-shell')).toHaveClass('hidden')
+    expect(screen.getByTestId('settings-shell')).toBeVisible()
+    expect(screen.getByTestId('settings-router')).toHaveAttribute('data-url', '/settings/provider')
+    expect(screen.getByTestId('window-controls')).toBeInTheDocument()
+    expect(mocks.workspaceRouterProps).toHaveProperty('isActive', false)
+    expect(screen.getByRole('button', { name: /Back|返回/ })).toHaveFocus()
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('closes immersive Settings from the title-bar Back action without changing tabs', () => {
+    mocks.settingsPath = '/settings/provider'
+
+    render(<AppShell />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Back|返回/ }))
+
+    expect(mocks.closeSettings).toHaveBeenCalledTimes(1)
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('syncs navigation inside the Settings router without opening a tab', () => {
+    mocks.settingsPath = '/settings/provider'
+    render(<AppShell />)
+
+    act(() => {
+      const onUrlChange = mocks.settingsRouterProps?.onUrlChange as ((url: string) => void) | undefined
+      onUrlChange?.('/settings/about')
+    })
+
+    expect(mocks.setSettingsPath).toHaveBeenCalledWith('/settings/about')
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('promotes Settings navigation from a workspace router into the immersive surface', () => {
+    render(<AppShell />)
+
+    act(() => {
+      const onUrlChange = mocks.workspaceRouterProps?.onUrlChange as ((url: string) => void) | undefined
+      onUrlChange?.('/settings/provider?id=openai')
+    })
+
+    expect(mocks.setSettingsPath).toHaveBeenCalledWith('/settings/provider?id=openai')
+    expect(mocks.updateTab).not.toHaveBeenCalled()
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('places the macOS Back action after the traffic-light area', () => {
+    mocks.platformState.isMac = true
+    mocks.settingsPath = '/settings/provider'
+
+    render(<AppShell />)
+
+    const titleBar = screen.getByTestId('settings-title-bar')
+    expect(screen.getByTestId('settings-macos-traffic-light-spacer').parentElement).toBe(titleBar)
+    expect(screen.queryByTestId('window-controls')).toBeNull()
+    expect(screen.getByRole('button', { name: /Back|返回/ })).toBeInTheDocument()
+  })
+
+  it('removes the Settings traffic-light spacer in macOS fullscreen', async () => {
+    mocks.platformState.isMac = true
+    mocks.settingsPath = '/settings/provider'
+    mocks.ipcRequest.mockResolvedValue(true)
+
+    render(<AppShell />)
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('settings-macos-traffic-light-spacer')).toBeNull()
+    })
   })
 })

--- a/src/renderer/components/layout/__tests__/SettingsSurfaceProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/SettingsSurfaceProvider.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  useMainWindowNavigation: vi.fn(() => ({
+    settingsPath: '/settings/about' as string | null,
+    setSettingsPath: vi.fn(),
+    closeSettings: vi.fn()
+  }))
+}))
+
+vi.mock('@renderer/hooks/tab', () => ({
+  useMainWindowNavigation: mocks.useMainWindowNavigation
+}))
+
+import { SettingsSurfaceProvider, useSettingsSurface } from '../SettingsSurfaceProvider'
+
+function SettingsSurfaceConsumer() {
+  const { settingsPath } = useSettingsSurface()
+
+  return <output data-testid="settings-path">{settingsPath ?? 'closed'}</output>
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('SettingsSurfaceProvider', () => {
+  it('mounts the window navigation hook once and shares its Settings state', () => {
+    render(
+      <SettingsSurfaceProvider>
+        <SettingsSurfaceConsumer />
+        <SettingsSurfaceConsumer />
+      </SettingsSurfaceProvider>
+    )
+
+    expect(mocks.useMainWindowNavigation).toHaveBeenCalledTimes(1)
+    expect(screen.getAllByTestId('settings-path')).toHaveLength(2)
+    for (const output of screen.getAllByTestId('settings-path')) {
+      expect(output).toHaveTextContent('/settings/about')
+    }
+  })
+
+  it('fails loudly when the Settings surface is read outside the provider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() => render(<SettingsSurfaceConsumer />)).toThrow(/SettingsSurfaceProvider/)
+
+    consoleError.mockRestore()
+  })
+})

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -60,6 +60,16 @@ const HOME_TAB: Tab = {
   isDormant: false
 }
 
+const LEGACY_SETTINGS_PINNED_TAB: Tab = {
+  id: 'settings',
+  type: 'route',
+  url: '/settings/provider?id=openai',
+  title: 'Settings',
+  lastAccessTime: 0,
+  isDormant: false,
+  isPinned: true
+}
+
 // Stable reference: re-renders are then driven only by the i18n.language change,
 // not by a fresh pinnedTabs identity — which is what makes the test catch a dropped
 // i18n.language dependency in the tabs useMemo.
@@ -121,7 +131,7 @@ vi.mock('@renderer/ipc', () => ({
 
 import { useTabsContext } from '@renderer/hooks/tab'
 
-import { migratePinnedTabs, TabsProvider } from '../TabsProvider'
+import { dropRestoredSettingsTabs, migratePinnedTabs, TabsProvider } from '../TabsProvider'
 
 function TabTitleWriter() {
   const { tabs, updateTab } = useTabsContext()
@@ -755,10 +765,38 @@ describe('migratePinnedTabs', () => {
     expect(tabs).toEqual([PINNED_FILES_TAB])
   })
 
+  it('drops persisted Settings pins now that Settings is an application-level surface', () => {
+    const { tabs, changed } = migratePinnedTabs([LEGACY_SETTINGS_PINNED_TAB, PINNED_FILES_TAB])
+    expect(changed).toBe(true)
+    expect(tabs).toEqual([PINNED_FILES_TAB])
+  })
+
   it('is a no-op when nothing needs migrating', () => {
     const input = [PINNED_FILES_TAB, PINNED_CODE_TAB]
     const { tabs, changed } = migratePinnedTabs(input)
     expect(changed).toBe(false)
     expect(tabs).toEqual(input)
+  })
+})
+
+describe('dropRestoredSettingsTabs', () => {
+  const settingsTab: Tab = { ...LEGACY_SETTINGS_PINNED_TAB, isPinned: false }
+
+  it('drops a Settings tab persisted by an older version', () => {
+    expect(dropRestoredSettingsTabs([PINNED_FILES_TAB, settingsTab])).toEqual([PINNED_FILES_TAB])
+  })
+
+  it('drops the bare /settings route too', () => {
+    expect(dropRestoredSettingsTabs([{ ...settingsTab, url: '/settings' }])).toEqual([])
+  })
+
+  it('keeps routes that merely start with the same prefix', () => {
+    const lookalike: Tab = { ...settingsTab, url: '/settings-export' }
+    expect(dropRestoredSettingsTabs([lookalike])).toEqual([lookalike])
+  })
+
+  it('leaves a session without Settings tabs untouched', () => {
+    const input = [PINNED_FILES_TAB, PINNED_CODE_TAB]
+    expect(dropRestoredSettingsTabs(input)).toEqual(input)
   })
 })

--- a/src/renderer/hooks/tab/__tests__/useMainWindowNavigation.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useMainWindowNavigation.test.tsx
@@ -1,12 +1,9 @@
 // @vitest-environment jsdom
-import { cleanup, render } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   openTab: vi.fn(),
-  setActiveTab: vi.fn(),
-  updateTab: vi.fn(),
-  tabs: [] as Array<{ id: string; type: 'route' | 'miniapp'; url: string; title: string }>,
   initData: null as { kind: 'navigation'; to: string; requestId: number } | null,
   ipcListeners: new Map<string, (payload: unknown) => void>(),
   ipcRequest: vi.fn()
@@ -19,22 +16,13 @@ vi.mock('@renderer/ipc', () => ({
   }
 }))
 
-vi.mock('@renderer/i18n/resolver', () => ({
-  default: {
-    t: (key: string) => key
-  }
-}))
-
 vi.mock('@renderer/hooks/useWindowInitData', () => ({
   useWindowInitData: () => mocks.initData
 }))
 
 vi.mock('../useTabs', () => ({
   useTabs: () => ({
-    tabs: mocks.tabs,
-    openTab: mocks.openTab,
-    setActiveTab: mocks.setActiveTab,
-    updateTab: mocks.updateTab
+    openTab: mocks.openTab
   })
 }))
 
@@ -43,14 +31,30 @@ import { OPEN_MAIN_ROUTE_EVENT } from '@renderer/services/mainWindowNavigation'
 import { useMainWindowNavigation } from '../useMainWindowNavigation'
 
 function MainWindowNavigationHarness() {
-  useMainWindowNavigation()
-  return null
+  const { settingsPath, closeSettings } = useMainWindowNavigation()
+
+  return (
+    <>
+      <output data-testid="settings-path">{settingsPath ?? 'closed'}</output>
+      <button type="button" onClick={closeSettings}>
+        Close settings
+      </button>
+    </>
+  )
+}
+
+function dispatchMainRoute(path: string) {
+  const event = new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
+    cancelable: true,
+    detail: { path }
+  })
+  void act(() => window.dispatchEvent(event))
+  return event
 }
 
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
-  mocks.tabs = []
   mocks.initData = null
   mocks.ipcListeners.clear()
 })
@@ -63,83 +67,59 @@ describe('useMainWindowNavigation', () => {
     expect(mocks.ipcRequest).toHaveBeenCalledWith('navigation.protocol_dispatch_ready')
   })
 
-  it('opens a settings tab for renderer settings-tab events', () => {
+  it('opens Settings as application-level state without creating a workspace tab', () => {
     render(<MainWindowNavigationHarness />)
 
-    const event = new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
-      cancelable: true,
-      detail: { path: '/settings/provider?id=openai' }
-    })
-    window.dispatchEvent(event)
+    const event = dispatchMainRoute('/settings/provider?id=openai')
 
     expect(event.defaultPrevented).toBe(true)
-    expect(mocks.openTab).toHaveBeenCalledWith('/settings/provider?id=openai', { title: 'settings.title' })
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('/settings/provider?id=openai')
+    expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('reuses the existing settings tab for another settings path', () => {
-    mocks.tabs = [{ id: 'settings-1', type: 'route', url: '/settings/provider', title: 'settings.title' }]
+  it('treats the Settings index route as the immersive surface instead of a workspace tab', () => {
     render(<MainWindowNavigationHarness />)
 
-    window.dispatchEvent(
-      new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
-        cancelable: true,
-        detail: { path: '/settings/about' }
-      })
-    )
+    dispatchMainRoute('/settings')
 
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('/settings')
     expect(mocks.openTab).not.toHaveBeenCalled()
-    expect(mocks.updateTab).toHaveBeenCalledWith('settings-1', {
-      url: '/settings/about',
-      title: 'settings.title',
-      lastAccessTime: expect.any(Number)
-    })
-    expect(mocks.setActiveTab).toHaveBeenCalledWith('settings-1')
   })
 
-  it('does not create duplicate settings tabs for consecutive open requests before tabs refresh', () => {
-    mocks.openTab.mockReturnValue('settings-1')
-    const { rerender } = render(<MainWindowNavigationHarness />)
+  it('reuses the Settings surface for consecutive requests', () => {
+    render(<MainWindowNavigationHarness />)
 
-    window.dispatchEvent(
-      new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
-        cancelable: true,
-        detail: { path: '/settings/provider' }
-      })
-    )
-    window.dispatchEvent(
-      new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
-        cancelable: true,
-        detail: { path: '/settings/about' }
-      })
-    )
+    dispatchMainRoute('/settings/provider')
+    dispatchMainRoute('/settings/about')
 
-    expect(mocks.openTab).toHaveBeenCalledTimes(1)
-    expect(mocks.openTab).toHaveBeenCalledWith('/settings/provider', { title: 'settings.title' })
-
-    mocks.tabs = [{ id: 'settings-1', type: 'route', url: '/settings/provider', title: 'settings.title' }]
-    rerender(<MainWindowNavigationHarness />)
-
-    expect(mocks.updateTab).toHaveBeenCalledWith('settings-1', {
-      url: '/settings/about',
-      title: 'settings.title',
-      lastAccessTime: expect.any(Number)
-    })
-    expect(mocks.setActiveTab).toHaveBeenCalledWith('settings-1')
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('/settings/about')
+    expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('acknowledges main-window init data so it is not replayed after remount', () => {
+  it('closes Settings without navigating the workspace', () => {
+    render(<MainWindowNavigationHarness />)
+
+    dispatchMainRoute('/settings/appearance')
+    fireEvent.click(screen.getByRole('button', { name: 'Close settings' }))
+
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('closed')
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('opens Settings from main-window init data and acknowledges it so it is not replayed after remount', () => {
     mocks.initData = { kind: 'navigation', to: '/settings/about', requestId: 1 }
     mocks.ipcRequest.mockImplementation((channel: string) => {
       if (channel === 'navigation.ack_open_route') mocks.initData = null
     })
     const { unmount } = render(<MainWindowNavigationHarness />)
 
-    expect(mocks.openTab).toHaveBeenCalledWith('/settings/about', { title: 'settings.title' })
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('/settings/about')
+    expect(mocks.openTab).not.toHaveBeenCalled()
     expect(mocks.ipcRequest).toHaveBeenCalledWith('navigation.ack_open_route', { requestId: 1 })
 
     unmount()
     render(<MainWindowNavigationHarness />)
-    expect(mocks.openTab).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('closed')
   })
 
   it('opens a regular tab for non-settings navigation init data', () => {
@@ -147,74 +127,46 @@ describe('useMainWindowNavigation', () => {
     render(<MainWindowNavigationHarness />)
 
     expect(mocks.openTab).toHaveBeenCalledWith('/agents')
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('closed')
   })
 
-  it('opens a regular tab when a non-settings open_route_requested event arrives', () => {
+  it('opens a regular tab when a non-settings IPC event arrives', () => {
     render(<MainWindowNavigationHarness />)
 
-    mocks.ipcListeners.get('navigation.open_route_requested')?.({ to: '/knowledge' })
+    act(() => mocks.ipcListeners.get('navigation.open_route_requested')?.({ to: '/knowledge' }))
 
     expect(mocks.openTab).toHaveBeenCalledWith('/knowledge')
   })
 
-  it('routes a settings path from the open_route_requested event through the settings singleton', () => {
-    mocks.tabs = [{ id: 'settings-1', type: 'route', url: '/settings/provider', title: 'settings.title' }]
+  it('routes a Settings IPC event through the same immersive surface', () => {
     render(<MainWindowNavigationHarness />)
 
-    mocks.ipcListeners.get('navigation.open_route_requested')?.({ to: '/settings/about' })
+    act(() => mocks.ipcListeners.get('navigation.open_route_requested')?.({ to: '/settings/about' }))
 
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('/settings/about')
     expect(mocks.openTab).not.toHaveBeenCalled()
-    expect(mocks.updateTab).toHaveBeenCalledWith('settings-1', {
-      url: '/settings/about',
-      title: 'settings.title',
-      lastAccessTime: expect.any(Number)
-    })
-    expect(mocks.setActiveTab).toHaveBeenCalledWith('settings-1')
   })
 
-  it('opens settings again when init data request id changes', () => {
-    const { rerender } = render(<MainWindowNavigationHarness />)
-
-    mocks.initData = { kind: 'navigation', to: '/settings/provider', requestId: 1 }
-    rerender(<MainWindowNavigationHarness />)
-
-    mocks.tabs = [{ id: 'settings-1', type: 'route', url: '/settings/provider', title: 'settings.title' }]
-    mocks.initData = { kind: 'navigation', to: '/settings/about', requestId: 2 }
-    rerender(<MainWindowNavigationHarness />)
-
-    expect(mocks.openTab).toHaveBeenCalledWith('/settings/provider', { title: 'settings.title' })
-    expect(mocks.updateTab).toHaveBeenCalledWith('settings-1', {
-      url: '/settings/about',
-      title: 'settings.title',
-      lastAccessTime: expect.any(Number)
-    })
-  })
-
-  it('does not replay the same init data request when tabs change', () => {
-    mocks.initData = { kind: 'navigation', to: '/settings/provider', requestId: 1 }
-    const { rerender } = render(<MainWindowNavigationHarness />)
-
-    expect(mocks.openTab).toHaveBeenCalledTimes(1)
-
-    mocks.tabs = [{ id: 'settings-1', type: 'route', url: '/settings/provider', title: 'settings.title' }]
-    rerender(<MainWindowNavigationHarness />)
-
-    expect(mocks.openTab).toHaveBeenCalledTimes(1)
-    expect(mocks.updateTab).not.toHaveBeenCalled()
-    expect(mocks.setActiveTab).not.toHaveBeenCalled()
-  })
-
-  it('routes non-settings main-route event paths to a regular tab', () => {
+  it('leaves Settings when a regular route request arrives', () => {
     render(<MainWindowNavigationHarness />)
 
-    window.dispatchEvent(
-      new CustomEvent(OPEN_MAIN_ROUTE_EVENT, {
-        cancelable: true,
-        detail: { path: '/agents' }
-      })
-    )
+    dispatchMainRoute('/settings/provider')
+    dispatchMainRoute('/agents')
 
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('closed')
     expect(mocks.openTab).toHaveBeenCalledWith('/agents')
+  })
+
+  it('does not replay the same init-data request after Settings state changes', () => {
+    const { rerender } = render(<MainWindowNavigationHarness />)
+
+    mocks.initData = { kind: 'navigation', to: '/settings/provider', requestId: 1 }
+    rerender(<MainWindowNavigationHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Close settings' }))
+    rerender(<MainWindowNavigationHarness />)
+
+    expect(screen.getByTestId('settings-path')).toHaveTextContent('closed')
+    expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
   it('removes the main-route event bridge on unmount', () => {

--- a/src/renderer/hooks/tab/useMainWindowNavigation.ts
+++ b/src/renderer/hooks/tab/useMainWindowNavigation.ts
@@ -1,73 +1,11 @@
 import { useWindowInitData } from '@renderer/hooks/useWindowInitData'
-import i18n from '@renderer/i18n/resolver'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { OPEN_MAIN_ROUTE_EVENT, type OpenMainRouteEvent } from '@renderer/services/mainWindowNavigation'
 import { isSettingsPath, normalizeSettingsPath, type SettingsPath } from '@shared/data/types/settingsPath'
 import type { MainWindowInitData } from '@shared/types/mainWindow'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useTabs } from './useTabs'
-
-function isSettingsTabUrl(url: string) {
-  return url === '/settings' || url.startsWith('/settings/') || url.startsWith('/settings?')
-}
-
-function useOpenSettingsRoute() {
-  const { tabs, openTab, setActiveTab, updateTab } = useTabs()
-  const settingsTabIdRef = useRef<string | null>(null)
-  const pendingSettingsPathRef = useRef<SettingsPath | null>(null)
-
-  useEffect(() => {
-    const settingsTab = tabs.find((tab) => tab.type === 'route' && isSettingsTabUrl(tab.url))
-
-    if (!settingsTab) {
-      settingsTabIdRef.current = null
-      return
-    }
-
-    settingsTabIdRef.current = settingsTab.id
-
-    const pendingPath = pendingSettingsPathRef.current
-    if (!pendingPath) {
-      return
-    }
-
-    pendingSettingsPathRef.current = null
-    updateTab(settingsTab.id, {
-      url: pendingPath,
-      title: i18n.t('settings.title'),
-      lastAccessTime: Date.now()
-    })
-    setActiveTab(settingsTab.id)
-  }, [tabs, setActiveTab, updateTab])
-
-  return useCallback(
-    (path: SettingsPath) => {
-      const targetPath = normalizeSettingsPath(path)
-      const title = i18n.t('settings.title')
-      const settingsTab = tabs.find((tab) => tab.type === 'route' && isSettingsTabUrl(tab.url))
-
-      if (settingsTab) {
-        updateTab(settingsTab.id, {
-          url: targetPath,
-          title,
-          lastAccessTime: Date.now()
-        })
-        setActiveTab(settingsTab.id)
-        return
-      }
-
-      if (settingsTabIdRef.current) {
-        pendingSettingsPathRef.current = targetPath
-        return
-      }
-
-      const settingsTabId = openTab(targetPath, { title })
-      settingsTabIdRef.current = settingsTabId
-    },
-    [tabs, openTab, setActiveTab, updateTab]
-  )
-}
 
 function useMainRouteEventBridge(handleRoute: (path: string) => void) {
   useEffect(() => {
@@ -95,24 +33,33 @@ function useMainRouteEventBridge(handleRoute: (path: string) => void) {
  * - Navigation init data — the cold-start path only (the window was created FOR
  *   this route); `requestId` dedupes replays of the same stored payload.
  *
- * Settings paths land in the singleton settings tab; everything else goes
- * through `openTab`'s exact-URL dedupe.
+ * Settings paths open the application-level immersive Settings surface;
+ * everything else goes through `openTab`'s exact-URL dedupe.
  */
 export function useMainWindowNavigation() {
-  const openSettingsRoute = useOpenSettingsRoute()
   const { openTab } = useTabs()
   const initData = useWindowInitData<MainWindowInitData>()
   const handledNavigationRequestIdRef = useRef<number | null>(null)
+  const [settingsPath, setSettingsPathState] = useState<SettingsPath | null>(null)
+
+  const setSettingsPath = useCallback((path: string) => {
+    setSettingsPathState(normalizeSettingsPath(path))
+  }, [])
+
+  const closeSettings = useCallback(() => {
+    setSettingsPathState(null)
+  }, [])
 
   const handleRoute = useCallback(
     (to: string) => {
       if (isSettingsPath(to)) {
-        openSettingsRoute(to)
+        setSettingsPath(to)
       } else {
+        closeSettings()
         openTab(to)
       }
     },
-    [openSettingsRoute, openTab]
+    [closeSettings, openTab, setSettingsPath]
   )
 
   useIpcOn('navigation.open_route_requested', ({ to }) => handleRoute(to))
@@ -131,4 +78,6 @@ export function useMainWindowNavigation() {
   useEffect(() => {
     void ipcApi.request('navigation.protocol_dispatch_ready')
   }, [])
+
+  return { settingsPath, setSettingsPath, closeSettings }
 }

--- a/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
+++ b/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
@@ -32,6 +32,7 @@ const messageEditingMock = vi.hoisted(() => ({
 }))
 
 const commandHandlerMock = vi.hoisted(() => vi.fn())
+const navigateMock = vi.hoisted(() => vi.fn())
 const modelSelectorMock = vi.hoisted(() => ({
   props: [] as any[]
 }))
@@ -224,7 +225,7 @@ vi.mock('@shared/utils/model', () => ({
 }))
 
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn()
+  useNavigate: () => navigateMock
 }))
 
 vi.mock('react-i18next', () => ({
@@ -481,6 +482,16 @@ describe('useHomeMessageListProviderValue topic image actions', () => {
     expect(value?.state.messages[0]).toBe(firstHistoryItem)
     expect(vi.mocked(toMessageListItem).mock.calls.filter(([message]) => message === historyMessage)).toHaveLength(1)
     expect(vi.mocked(toMessageListItem).mock.calls.filter(([message]) => message.id === liveMessage.id)).toHaveLength(2)
+  })
+
+  it('routes Settings tool targets through the main-window dispatcher instead of the topic route', () => {
+    let value: MessageListProviderValue | undefined
+    render(<MessageListAdapterHarness topic={createTopic('topic-a')} onValue={(nextValue) => (value = nextValue)} />)
+
+    void value?.actions.navigateToRoute?.({ path: '/settings/provider', query: { id: 'provider-1' } })
+
+    expect(openRouteMock).toHaveBeenCalledWith('/settings/provider', { id: 'provider-1' })
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it.each(['embedding', 'rerank'])('filters %s models from the regenerate model picker', (capability) => {

--- a/src/renderer/routes/README.md
+++ b/src/renderer/routes/README.md
@@ -69,7 +69,7 @@ function SettingsLayout() {
 
 ## Navigation API
 
-This project provides two navigation methods:
+This project provides three navigation methods:
 
 ### 1. Tab-Level Navigation - `openTab`
 
@@ -82,13 +82,13 @@ function MyComponent() {
   const { openTab, closeTab } = useTabs()
 
   // Basic usage - reuse existing Tab or create new one
-  openTab('/settings')
+  openTab('/app/knowledge')
 
   // With title
   openTab('/chat/123', { title: 'Chat with Alice' })
 
   // Force new Tab (even if same URL exists)
-  openTab('/settings', { forceNew: true })
+  openTab('/app/knowledge', { forceNew: true })
 
   // Open Webview Tab
   openTab('https://example.com', {
@@ -101,7 +101,19 @@ function MyComponent() {
 }
 ```
 
-### 2. In-Tab Navigation - `useNavigate`
+### 2. Application-Level Settings Navigation - `openSettingsTab`
+
+Open the immersive Settings surface without creating or replacing a workspace Tab:
+
+```typescript
+import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
+
+openSettingsTab('/settings/provider')
+```
+
+Do not pass a Settings route to `openTab`. Workspace links that resolve to Settings are promoted by `AppShell`, but new callers should express the application-level intent directly with `openSettingsTab`.
+
+### 3. In-Tab Navigation - `useNavigate`
 
 Navigate within the same Tab (won't create a new Tab) using TanStack Router's `useNavigate`:
 
@@ -124,7 +136,8 @@ function SettingsPage() {
 | Scenario | Method | Result |
 |----------|--------|--------|
 | Open new feature module | `openTab('/knowledge')` | Creates new Tab |
-| Switch sub-page in settings | `navigate({ to: '/settings/provider' })` | Navigates within current Tab |
+| Open Settings from workspace content | `openSettingsTab('/settings/provider')` | Opens immersive Settings; preserves Tabs |
+| Switch sub-page inside Settings | `navigate({ to: '/settings/provider' })` | Navigates within the Settings surface |
 | Open detail from list | `openTab('/chat/123', { title: '...' })` | Creates new Tab |
 | Go back to previous page | `navigate({ to: '..' })` | Goes back within current Tab |
 
@@ -155,19 +168,17 @@ function SettingsPage() {
 
 ```text
 AppShell
-├── Sidebar
-├── TabBar
-└── Content Area
-    ├── TabRouter #1 (Home)
-    │   └── Activity(visible) → MemoryRouter → RouterProvider
-    ├── TabRouter #2 (Settings)
-    │   └── Activity(hidden) → MemoryRouter → RouterProvider
-    └── WebviewContainer (for webview tabs)
+├── Workspace Shell
+│   ├── Sidebar
+│   ├── TabBar
+│   └── TabRouter(s) → Activity → MemoryRouter → RouterProvider
+└── Immersive Settings Shell → MemoryRouter → RouterProvider
 ```
 
 - Each Tab has its own independent `MemoryRouter` instance
 - Uses React 19 `<Activity>` component to control visibility
 - Components are not unmounted on Tab switch, state is fully preserved (KeepAlive)
+- Settings is application-level UI, not a workspace Tab; Back restores the preserved workspace
 
 ## Error Handling
 
@@ -202,3 +213,4 @@ src/renderer/
 2. **File name determines route path** - `routes/settings.tsx` → `/settings`
 3. **Dynamic parameters use `$`** - `routes/chat/$topicId.tsx` → `/chat/:topicId`
 4. **Page state is automatically preserved** - Tab switching won't lose `useState`, scroll position, etc.
+5. **Never open Settings with `openTab`** - use `openSettingsTab` from workspace or external entry points, and `useNavigate` only between pages already inside Settings

--- a/src/renderer/routes/README.zh-CN.md
+++ b/src/renderer/routes/README.zh-CN.md
@@ -69,7 +69,7 @@ function SettingsLayout() {
 
 ## 导航 API
 
-本项目有两种导航方式：
+本项目有三种导航方式：
 
 ### 1. Tab 级别导航 - `openTab`
 
@@ -82,13 +82,13 @@ function MyComponent() {
   const { openTab, closeTab } = useTabs()
 
   // 基础用法 - 复用已有 Tab 或新建
-  openTab('/settings')
+  openTab('/app/knowledge')
 
   // 带标题
   openTab('/chat/123', { title: 'Chat with Alice' })
 
   // 强制新开 Tab（即使已有相同 URL）
-  openTab('/settings', { forceNew: true })
+  openTab('/app/knowledge', { forceNew: true })
 
   // 打开 Webview Tab
   openTab('https://example.com', {
@@ -101,7 +101,19 @@ function MyComponent() {
 }
 ```
 
-### 2. Tab 内部导航 - `useNavigate`
+### 2. 应用级设置导航 - `openSettingsTab`
+
+打开沉浸式设置界面，不创建或替换工作区 Tab：
+
+```typescript
+import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
+
+openSettingsTab('/settings/provider')
+```
+
+不要把设置路由传给 `openTab`。`AppShell` 会将工作区内误入设置的链接提升为应用级界面，但新调用方应直接使用 `openSettingsTab` 表达应用级导航意图。
+
+### 3. Tab 内部导航 - `useNavigate`
 
 在同一个 Tab 内跳转路由（不会新开 Tab），使用 TanStack Router 的 `useNavigate`：
 
@@ -124,7 +136,8 @@ function SettingsPage() {
 | 场景 | 使用 | 效果 |
 |-----|------|------|
 | 打开新功能模块 | `openTab('/knowledge')` | 新建 Tab |
-| 设置页内切换子页 | `navigate({ to: '/settings/provider' })` | 当前 Tab 内跳转 |
+| 从工作区内容打开设置 | `openSettingsTab('/settings/provider')` | 打开沉浸式设置并保留 Tab |
+| 设置页内切换子页 | `navigate({ to: '/settings/provider' })` | 在设置界面内跳转 |
 | 从列表打开详情 | `openTab('/chat/123', { title: '...' })` | 新建 Tab |
 | 返回上一页 | `navigate({ to: '..' })` | 当前 Tab 内返回 |
 
@@ -155,19 +168,17 @@ function SettingsPage() {
 
 ```text
 AppShell
-├── Sidebar
-├── TabBar
-└── Content Area
-    ├── TabRouter #1 (Home)
-    │   └── Activity(visible) → MemoryRouter → RouterProvider
-    ├── TabRouter #2 (Settings)
-    │   └── Activity(hidden) → MemoryRouter → RouterProvider
-    └── WebviewContainer (for webview tabs)
+├── Workspace Shell
+│   ├── Sidebar
+│   ├── TabBar
+│   └── TabRouter(s) → Activity → MemoryRouter → RouterProvider
+└── Immersive Settings Shell → MemoryRouter → RouterProvider
 ```
 
 - 每个 Tab 拥有独立的 `MemoryRouter` 实例
 - 使用 React 19 `<Activity>` 组件控制可见性
 - Tab 切换时组件不卸载，状态完全保持（KeepAlive）
+- 设置是应用级界面而非工作区 Tab；返回后恢复保留的工作区
 
 ## 错误处理
 
@@ -202,3 +213,4 @@ src/renderer/
 2. **路由文件命名即路径** - `routes/settings.tsx` → `/settings`
 3. **动态参数使用 `$`** - `routes/chat/$topicId.tsx` → `/chat/:topicId`
 4. **页面状态自动保持** - Tab 切换不会丢失 `useState`、滚动位置等
+5. **禁止用 `openTab` 打开设置** - 从工作区或外部入口使用 `openSettingsTab`，只在已经进入设置后使用 `useNavigate` 切换设置子页

--- a/src/renderer/services/__tests__/mainWindowNavigation.test.ts
+++ b/src/renderer/services/__tests__/mainWindowNavigation.test.ts
@@ -78,6 +78,18 @@ describe('openSettingsTab', () => {
     window.removeEventListener(OPEN_MAIN_ROUTE_EVENT, handler)
   })
 
+  it('merges structured search parameters before opening Settings', () => {
+    const handler = vi.fn((event: Event) => event.preventDefault())
+    window.addEventListener(OPEN_MAIN_ROUTE_EVENT, handler)
+
+    openSettingsTab('/settings/provider?source=existing', { id: 'open ai', source: 'diagnosis' })
+
+    const event = handler.mock.calls[0][0] as OpenMainRouteEvent
+    expect(event.detail).toEqual({ path: '/settings/provider?source=diagnosis&id=open+ai' })
+
+    window.removeEventListener(OPEN_MAIN_ROUTE_EVENT, handler)
+  })
+
   it('requests main-window navigation when the main-route event is unhandled', () => {
     openSettingsTab('/settings/mcp/servers')
 

--- a/src/renderer/services/mainWindowNavigation.ts
+++ b/src/renderer/services/mainWindowNavigation.ts
@@ -31,6 +31,19 @@ export function openRoute(path: string, query?: Record<string, string>): void {
   }
 }
 
-export function openSettingsTab(path: SettingsPath = DEFAULT_SETTINGS_PATH): void {
-  openRoute(normalizeSettingsPath(path))
+export function openSettingsTab(
+  path: SettingsPath = DEFAULT_SETTINGS_PATH,
+  search?: Readonly<Record<string, string>>
+): void {
+  const normalizedPath = normalizeSettingsPath(path)
+  if (!search) {
+    openRoute(normalizedPath)
+    return
+  }
+
+  const url = new URL(normalizedPath, 'https://www.cherry-ai.com')
+  for (const [key, value] of Object.entries(search)) {
+    url.searchParams.set(key, value)
+  }
+  openRoute(`${url.pathname}${url.search}`)
 }

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -4,12 +4,12 @@ import { CodeStyleProvider } from '@renderer/components/CodeStyleProvider'
 import { CommandContextKeyProvider, CommandProvider } from '@renderer/components/command'
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { AppShell } from '@renderer/components/layout/AppShell'
+import { SettingsSurfaceProvider } from '@renderer/components/layout/SettingsSurfaceProvider'
 import { TabsProvider } from '@renderer/components/layout/TabsProvider'
 import { PopupHost } from '@renderer/components/PopupHost'
 import { ThemeProvider } from '@renderer/components/ThemeProvider'
 import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
-import { useMainWindowNavigation } from '@renderer/hooks/tab'
 import { useStorageMonitorNotification } from '@renderer/hooks/useStorageMonitorNotification'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
 import { useEffect } from 'react'
@@ -36,7 +36,6 @@ const logger = loggerService.withContext('MainApp')
 // siblings in the App JSX below, so a window's host composition is visible there.
 function MainWindowRuntime(): null {
   useWindowRuntime()
-  useMainWindowNavigation()
 
   // Main-only: tear down the HTML boot spinner and end the `init` timer. Both are
   // paired with markup only main/index.html creates (`#spinner`, `console.time`), so
@@ -61,7 +60,9 @@ export function MainWindowContent(): React.ReactElement {
 
   return (
     <TabsProvider>
-      {providerSetupStatus === 'pending' ? <OnboardingPage /> : <AppShell />}
+      <SettingsSurfaceProvider>
+        {providerSetupStatus === 'pending' ? <OnboardingPage /> : <AppShell />}
+      </SettingsSurfaceProvider>
       <MainWindowRuntime />
       <PopupHost />
       <ToastHost />

--- a/src/shared/data/types/settingsPath.ts
+++ b/src/shared/data/types/settingsPath.ts
@@ -1,9 +1,12 @@
-export type SettingsPath = '/settings/provider' | `/settings/${string}`
+export type SettingsPath = '/settings' | `/settings?${string}` | '/settings/provider' | `/settings/${string}`
 
 export const DEFAULT_SETTINGS_PATH: SettingsPath = '/settings/provider'
 
 export function isSettingsPath(value: unknown): value is SettingsPath {
-  return typeof value === 'string' && (value === '/settings/provider' || value.startsWith('/settings/'))
+  return (
+    typeof value === 'string' &&
+    (value === '/settings' || value.startsWith('/settings?') || value.startsWith('/settings/'))
+  )
 }
 
 export function normalizeSettingsPath(value: unknown): SettingsPath {

--- a/v2-refactor-temp/docs/breaking-changes.md
+++ b/v2-refactor-temp/docs/breaking-changes.md
@@ -22,5 +22,6 @@
 
 | Date | Change | Document |
 | --- | --- | --- |
+| 2026-07-30 | Settings now opens as an immersive application surface | [2026-07-30-settings-immersive-surface.md](./breaking-changes/2026-07-30-settings-immersive-surface.md) |
 | 2026-06-12 | Default assistant and CherryAI defaults are seeded | [2026-06-12-default-assistant-name.md](./breaking-changes/2026-06-12-default-assistant-name.md) |
 | 2026-04-23 | Web Search 移除本地搜索引擎与 RAG 压缩配置 | [2026-04-23-web-search-remove-local-providers-and-rag.md](./breaking-changes/2026-04-23-web-search-remove-local-providers-and-rag.md) |

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-30-settings-immersive-surface.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-30-settings-immersive-surface.md
@@ -1,0 +1,23 @@
+---
+title: Settings now opens as an immersive application surface
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-07-30
+---
+
+## What changed
+
+Settings no longer opens as a workspace tab. It now temporarily replaces the workspace chrome with a dedicated Settings surface and a Back action.
+
+## Why this matters to the user
+
+Opening Settings hides the workspace tab strip and global sidebar, but it no longer adds or repurposes tabs. Returning from Settings restores the workspace and its previously active tab.
+
+## What the user should do
+
+Nothing — automatic. Use Back in the Settings title bar to return to the workspace.
+
+## Notes for release manager
+
+The title bar intentionally has no visible Settings title. On macOS, Back follows the traffic-light area; on Windows and Linux, it appears at the top left.


### PR DESCRIPTION
### What this PR does

Before this PR:

Settings opened as a workspace tab. Leaving Settings through the global sidebar turned the former Settings tab into an ordinary workspace tab, and opening Settings again created a new one — so the tab strip kept growing during ordinary navigation. Settings entries scattered across the app (provider errors, web-search setup, model selector, agent navigation) each navigated the *current* tab to `/settings/*`, so a chat tab could silently become a settings page while keeping its old title.

The screenshot below is the state after a single "open Settings → leave via the sidebar → open Settings again" round trip: the original Settings tab has degenerated into a duplicate chat tab, and a fresh Settings tab sits next to it.

<img alt="Before: Settings opens as a workspace tab; one round trip leaves a duplicate chat tab plus a new Settings tab" src="https://pub-a9416c5573a34388b8d9465d8bef4257.r2.dev/20260803/settings-before-tab-growth.png" />

After this PR:

Settings renders as an application-level surface inside the main window and never creates, replaces, or activates a workspace tab.

<img alt="After: Settings fills the window as an immersive surface with only window controls and a Back action" src="https://pub-a9416c5573a34388b8d9465d8bef4257.r2.dev/20260803/settings-after-immersive-surface.png" />

- While open, it hides the workspace tab strip and the global sidebar, and shows a title bar containing only the platform window controls and a Back action (no Settings title).
- Back restores the workspace exactly as it was — the same active tab and its in-page state (drafts survive) — regardless of how many Settings categories were visited.
- Every entry point (sidebar gear, shortcut, deep link, provider errors, web-search setup, model selector, agent navigation) routes to the same surface, so repeats update the current category instead of stacking surfaces or tabs.
- Settings tabs persisted by an older version — pinned or not — are dropped when the session is restored, so an upgrade cannot resurrect the old in-tab Settings. Stale Settings entries in global-search history are removed as well, and global search stays unavailable while Settings is open.

N/A

### Why we need it and why it was done in this way

Settings is a place users visit and leave, not a document they keep open. Modelling it as a tab made it compete for the same slots as chats, and made "go to Settings" mutate whatever the user was working on.

The following tradeoffs were made:

- The workspace shell is **hidden, not unmounted**, while Settings is open. That keeps every tab's in-page state alive (composer drafts, scroll position) at the cost of leaving the workspace mounted; unmounting would have been cheaper but would have broken the "return to exactly where I was" requirement.
- The Settings surface holds its own path in component state rather than in the persisted tab store. Re-entering Settings therefore always lands on Model Provider instead of the last visited category — a deliberate simplification, since the surface no longer has an identity that survives leaving it.
- The immersive title bar draws its divider as an overlay rather than a border, and offsets its content by 1.5px on macOS outside fullscreen, so the Back action sits on the traffic lights' centre line. The offset is scoped to the case where the lights actually exist.

The following alternatives were considered:

- Keeping Settings as a tab but making it a singleton that cannot be reordered or replaced — rejected because it still consumes a tab slot and still competes with the user's working context.
- Opening Settings in a separate window — rejected because it loses the "return to what I was doing" continuity and adds window management to every visit.

Links to places where the discussion took place: N/A

### Breaking changes

Settings no longer opens as a workspace tab, so it can no longer be pinned, reordered, or kept open alongside chats. Settings tabs persisted by an older version (pinned or normal) and stale Settings entries in global-search history are removed automatically on the first launch after upgrade; no user action is required. A breaking-change note is included at `v2-refactor-temp/docs/breaking-changes/2026-07-30-settings-immersive-surface.md`.

### Special notes for your reviewer

**Please run it rather than trusting the screenshots** — the two images above only show the end states, not the behaviour that matters (tab identity, restored in-page state, repeat entries). Suggested pass:

1. Open two chats, type a draft into the second one without sending, and leave it active. Open Settings from the gear: the tab strip and global sidebar disappear, the Settings category sidebar stays. Switch categories, then press Back — you should land back on the second chat with the draft intact and exactly two tabs.
2. Repeat "open Settings → Back" a dozen times and watch the tab count and order. Neither may change.
3. With Settings already open, trigger the Settings shortcut again and then a deep link (e.g. About). The same surface must switch category — no second surface, no new tab.
4. Trigger a provider error in a chat and use the error block's Settings action. The surface opens and the originating chat tab keeps its previous URL and title.
5. On macOS, check the Back action against the traffic lights outside fullscreen, then enter fullscreen — the reserved traffic-light gap must disappear.

Where the change lives:

- The behavioural core is `AppShell.tsx` (the surface plus the hidden workspace), `useMainWindowNavigation.ts` (the surface's path state) and `mainWindowNavigation.ts` (the single entry point). Most of the remaining diff is tests.
- `ErrorBlock`, `useMessageErrorActions`, `WebSearchButton` and the two message-list adapters are changed so in-app Settings links are promoted to the surface instead of rewriting the current tab's route. Without them a chat tab still turns into a settings page.
- `TabsProvider` and `globalSearchGroups` only reconcile leftovers persisted by the old tab-based Settings.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Settings now opens as an immersive application surface instead of a workspace tab. Opening Settings no longer adds or repurposes tabs, and Back returns to the workspace with the previously active tab and its in-page state intact. Settings tabs left over from an older version are removed on first launch.
```
