### PR TITLE
test(file-processing): stabilize async processor interactions

### DIFF
--- a/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
+++ b/src/renderer/pages/settings/FileProcessingSettings/__tests__/FileProcessingSettings.test.tsx
@@ -430,16 +430,16 @@ describe('processing settings pages', () => {
   })
 
   it('stores API key input as file processing overrides', async () => {
+    const user = userEvent.setup()
     render(<OcrSettings />)
 
-    fireEvent.click(
-      (await screen.findAllByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ }))[0]
+    await user.click(
+      await screen.findByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ })
     )
     expect(screen.queryByText('settings.tool.file_processing.fields.model_id')).not.toBeInTheDocument()
-    fireEvent.change(screen.getByPlaceholderText('settings.tool.file_processing.fields.api_keys_placeholder'), {
-      target: { value: ' key-1, key-2 ' }
-    })
-    fireEvent.blur(screen.getByPlaceholderText('settings.tool.file_processing.fields.api_keys_placeholder'))
+    const apiKeysInput = await screen.findByPlaceholderText('settings.tool.file_processing.fields.api_keys_placeholder')
+    await user.type(apiKeysInput, ' key-1, key-2 ')
+    await user.tab()
 
     await waitFor(() => {
       expect(setOverridesMock).toHaveBeenCalledWith({
@@ -483,17 +483,18 @@ describe('processing settings pages', () => {
   })
 
   it('reports API host save failures', async () => {
+    const user = userEvent.setup()
     const error = new Error('persist failed')
     setOverridesMock.mockRejectedValueOnce(error)
     render(<OcrSettings />)
 
-    fireEvent.click(
-      (await screen.findAllByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ }))[0]
+    await user.click(
+      await screen.findByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ })
     )
-    fireEvent.change(screen.getByPlaceholderText('settings.provider.api_host'), {
-      target: { value: 'https://draft.example.com' }
-    })
-    fireEvent.blur(screen.getByPlaceholderText('settings.provider.api_host'))
+    const apiHostInput = await screen.findByPlaceholderText('settings.provider.api_host')
+    await user.clear(apiHostInput)
+    await user.type(apiHostInput, 'https://draft.example.com')
+    await user.tab()
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('settings.tool.file_processing.errors.save_failed')
@@ -502,17 +503,17 @@ describe('processing settings pages', () => {
   })
 
   it('trims API host before persisting', async () => {
+    const user = userEvent.setup()
     render(<OcrSettings />)
 
-    fireEvent.click(
-      (await screen.findAllByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ }))[0]
+    await user.click(
+      await screen.findByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ })
     )
 
-    const apiHostInput = screen.getByPlaceholderText('settings.provider.api_host')
-    fireEvent.change(apiHostInput, {
-      target: { value: '  https://draft.example.com  ' }
-    })
-    fireEvent.blur(apiHostInput)
+    const apiHostInput = await screen.findByPlaceholderText('settings.provider.api_host')
+    await user.clear(apiHostInput)
+    await user.type(apiHostInput, '  https://draft.example.com  ')
+    await user.tab()
 
     await waitFor(() => {
       expect(setOverridesMock).toHaveBeenCalledWith({
@@ -529,17 +530,17 @@ describe('processing settings pages', () => {
   })
 
   it('rejects invalid API host before persisting', async () => {
+    const user = userEvent.setup()
     render(<OcrSettings />)
 
-    fireEvent.click(
-      (await screen.findAllByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ }))[0]
+    await user.click(
+      await screen.findByRole('button', { name: /settings.tool.file_processing.processors.mistral.name/ })
     )
 
-    const apiHostInput = screen.getByPlaceholderText('settings.provider.api_host')
-    fireEvent.change(apiHostInput, {
-      target: { value: '  not-a-url  ' }
-    })
-    fireEvent.blur(apiHostInput)
+    const apiHostInput = await screen.findByPlaceholderText('settings.provider.api_host')
+    await user.clear(apiHostInput)
+    await user.type(apiHostInput, '  not-a-url  ')
+    await user.tab()
 
     await waitFor(() => {
       expect(toast.warning).toHaveBeenCalledWith('settings.tool.file_processing.errors.invalid_api_host')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: File processing settings tests could click a processor while its asynchronously loaded menu was still settling, causing API field lookups to fail intermittently in the renderer test shard.

After this PR: The affected tests wait for the Mistral processor panel and perform API key and host edits through `userEvent`, matching real user interaction timing.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR is merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: `userEvent` is slightly slower than low-level `fireEvent`, but it keeps the tests aligned with observable user behavior and React's asynchronous update boundary.

The following alternatives were considered: Changing production selection logic was rejected because the failure came from tests interacting inside an effect-settling interval that users cannot reach.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/30797901776

### Breaking changes

None.

### Special notes for your reviewer

The two failed CI attempts landed on different adjacent API host tests, confirming a shared timing race. The full `FileProcessingSettings.test.tsx` suite passed 11 consecutive runs after the fix; `pnpm format` and `pnpm lint` also passed, with 39 pre-existing warnings.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/everything/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered but is not required for this test-only change.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
