### PR TITLE
fix(model-drawer): restore New API endpoint multi-select

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/modelPurpose.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/modelPurpose.test.ts
@@ -20,8 +20,8 @@ import {
 describe('getModelDrawerMode', () => {
   it.each([
     [{ id: 'custom-provider', presetProviderId: undefined }, 'purpose'],
-    [{ id: 'new-api', presetProviderId: 'new-api' }, 'purpose'],
-    [{ id: 'custom-new-api', presetProviderId: 'new-api' }, 'purpose'],
+    [{ id: 'new-api', presetProviderId: 'new-api' }, 'endpoint-types'],
+    [{ id: 'custom-new-api', presetProviderId: 'new-api' }, 'endpoint-types'],
     [{ id: 'cherryin', presetProviderId: 'cherryin' }, 'endpoint-types'],
     [{ id: 'custom-cherryin', presetProviderId: 'cherryin' }, 'endpoint-types'],
     [{ id: 'aionly', presetProviderId: 'aionly' }, 'endpoint-types'],

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/modelPurpose.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/modelPurpose.ts
@@ -62,10 +62,10 @@ function removeItem<T>(items: readonly T[] | undefined, item: T): T[] | undefine
 }
 
 export function getModelDrawerMode(provider: ModelDrawerProvider): ModelDrawerMode {
-  if (matchesPreset(provider, 'cherryin') || matchesPreset(provider, 'aionly')) {
+  if (matchesPreset(provider, 'new-api') || matchesPreset(provider, 'cherryin') || matchesPreset(provider, 'aionly')) {
     return 'endpoint-types'
   }
-  if (matchesPreset(provider, 'new-api') || (provider.presetProviderId == null && !isSystemProviderId(provider.id))) {
+  if (provider.presetProviderId == null && !isSystemProviderId(provider.id)) {
     return 'purpose'
   }
   return 'legacy'

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelDrawer.test.tsx
@@ -1,5 +1,6 @@
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import AddModelDrawer from '../ModelDrawer/AddModelDrawer'
@@ -164,7 +165,8 @@ describe('Model drawers', () => {
     expect(createModelMock).not.toHaveBeenCalled()
   })
 
-  it('renders the New API model-purpose surface and keeps the default chat endpoint in create payload', async () => {
+  it('creates a New API model with multiple endpoint types', async () => {
+    const user = userEvent.setup()
     useProviderMock.mockReturnValue({
       provider: { id: 'new-api', name: 'New API' }
     })
@@ -172,21 +174,21 @@ describe('Model drawers', () => {
     render(<AddModelDrawer providerId="new-api" open prefill={null} onClose={vi.fn()} />)
 
     expect(screen.getByTestId('provider-settings-model-add-dialog')).toBeInTheDocument()
-    expect(screen.queryByTestId('provider-settings-model-endpoint-type-field')).not.toBeInTheDocument()
-    expect(screen.getByText('settings.models.add.purpose.label')).toBeInTheDocument()
+    const endpointField = screen.getByTestId('provider-settings-model-endpoint-type-field')
+    const endpointSelect = within(endpointField).getByRole('combobox')
+    expect(endpointSelect).toHaveTextContent('endpoint_type.openai')
+    expect(screen.queryByText('settings.models.add.purpose.label')).not.toBeInTheDocument()
 
-    fireEvent.change(screen.getByLabelText('settings.models.add.model_id.label'), {
-      target: { value: 'claude-4-sonnet' }
-    })
-    await act(async () => {
-      fireEvent.submit(screen.getByTestId('provider-settings-model-add-drawer-content'))
-    })
+    await user.click(endpointSelect)
+    await user.click(await screen.findByRole('option', { name: 'endpoint_type.anthropic' }))
+    await user.type(screen.getByLabelText('settings.models.add.model_id.label'), 'claude-4-sonnet')
+    await user.click(screen.getByRole('button', { name: /settings\.models\.add\.add_model/i }))
 
     expect(createModelMock).toHaveBeenCalledWith(
       expect.objectContaining({
         providerId: 'new-api',
         modelId: 'claude-4-sonnet',
-        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
       })
     )
   })
@@ -419,8 +421,8 @@ describe('Model drawers', () => {
   it('does not overwrite the saved chat endpoint when opening the edit drawer', async () => {
     useProviderMock.mockReturnValue({
       provider: {
-        id: 'new-api',
-        name: 'New API',
+        id: 'custom-provider',
+        name: 'Custom Provider',
         endpointConfigs: {
           [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { baseUrl: 'https://api.example.com' },
           [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://api.example.com' }
@@ -430,13 +432,13 @@ describe('Model drawers', () => {
 
     render(
       <EditModelDrawer
-        providerId="new-api"
+        providerId="custom-provider"
         open
         onClose={vi.fn()}
         model={
           {
-            id: 'new-api::custom-openai-model',
-            providerId: 'new-api',
+            id: 'custom-provider::custom-openai-model',
+            providerId: 'custom-provider',
             name: 'Custom OpenAI Model',
             capabilities: [],
             endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS],
@@ -768,20 +770,21 @@ describe('Model drawers', () => {
     ])
   })
 
-  it('auto-saves cherryin endpoint type changes from the edit drawer', async () => {
+  it('auto-saves New API endpoint type changes from the edit drawer', async () => {
+    const user = userEvent.setup()
     useProviderMock.mockReturnValue({
-      provider: { id: 'cherryin', name: 'CherryIN' }
+      provider: { id: 'new-api', name: 'New API' }
     })
 
     render(
       <EditModelDrawer
-        providerId="cherryin"
+        providerId="new-api"
         open
         onClose={vi.fn()}
         model={
           {
-            id: 'cherryin::claude-4-sonnet',
-            providerId: 'cherryin',
+            id: 'new-api::claude-4-sonnet',
+            providerId: 'new-api',
             name: 'claude-4-sonnet',
             group: 'Anthropic',
             capabilities: [],
@@ -796,16 +799,17 @@ describe('Model drawers', () => {
       />
     )
 
-    await act(async () => {
-      fireEvent.click(
-        within(screen.getByTestId('provider-settings-model-endpoint-type-field')).getByRole('button', {
-          name: 'endpoint_type.openai'
-        })
-      )
-    })
+    const endpointField = screen.getByTestId('provider-settings-model-endpoint-type-field')
+    expect(within(endpointField).getByRole('button', { name: 'endpoint_type.openai-response' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(updateModelMock).not.toHaveBeenCalled()
+
+    await user.click(within(endpointField).getByRole('button', { name: 'endpoint_type.openai' }))
 
     expect(updateModelMock).toHaveBeenCalledWith(
-      'cherryin',
+      'new-api',
       'claude-4-sonnet',
       expect.objectContaining({
         endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.OPENAI_RESPONSES]


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

New API models used the single-purpose model drawer even though their provider supports multiple endpoint types. Users could not select and persist more than one endpoint for a New API model.

After this PR:

Built-in New API and providers derived from the New API preset use the existing endpoint-type multi-select flow, matching CherryIN and AiOnly. Ordinary custom providers continue to use the purpose flow, and other system providers keep the legacy flow.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The drawer mode is the boundary that selects between the purpose form and the existing endpoint-type controls. Correcting that classification restores multi-endpoint add and edit behavior without changing the form, persistence layer, or `endpointTypes` contract.

The following tradeoffs were made:

None. This reuses the established endpoint-type flow and keeps ordinary custom provider behavior unchanged.

The following alternatives were considered:

Adding New API-specific form or persistence logic was rejected because the existing endpoint-type flow already implements selection, ordering, validation, auto-save, and clearing behavior.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Focused renderer tests passed: `ModelDrawer.test.tsx` and `modelPurpose.test.ts` (38 tests).

Live Electron verification created a temporary New API model with OpenAI Chat Completions and Anthropic Messages, confirmed both endpoints remained selected after reopening the edit drawer without a mount-time save, and then removed the temporary model.

Full validation is delegated to remote CI as requested.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Restored multi-endpoint selection for New API models.
```
