### PR TITLE
feat(feedback): add localized feedback options

### DIFF
--- a/resources/builtin-agents/cherry-assistant/.claude/skills/cherry-assistant-guide/SKILL.md
+++ b/resources/builtin-agents/cherry-assistant/.claude/skills/cherry-assistant-guide/SKILL.md
@@ -111,7 +111,7 @@ Cmd/Ctrl + N 新建话题, +F 搜索, +Shift+F 全局搜索, +K 新上下文, +L
 
 ## 反馈渠道
 
-**Bug/需求提交**(推荐): 飞书表单 https://mcnnox2fhjfq.feishu.cn/share/base/form/shrcnkR1s45VDuFnV3GbD6VhnIJ
+**Bug/需求提交**(推荐): 飞书表单 https://mcnnox2fhjfq.feishu.cn/share/base/form/shrcnsjfFkx4gy6wx9LQ70tMaKe
 
 **GitHub**: Issues https://github.com/CherryHQ/cherry-studio/issues | Discussions https://github.com/CherryHQ/cherry-studio/discussions | 看板 https://github.com/orgs/CherryHQ/projects/7
 

--- a/resources/builtin-agents/cherry-assistant/.claude/skills/issue-reporter/SKILL.md
+++ b/resources/builtin-agents/cherry-assistant/.claude/skills/issue-reporter/SKILL.md
@@ -26,7 +26,7 @@ Bug 存 `.cherry-assistant/bug-reports.md`，Feature 存 `feature-requests.md`�
 ---
 ```
 
-存档后引导: GitHub(推荐) https://github.com/CherryHQ/cherry-studio/issues | 论坛 linux.do | 飞书表单
+存档后引导: GitHub(推荐) https://github.com/CherryHQ/cherry-studio/issues | 论坛 linux.do | 飞书表单 https://mcnnox2fhjfq.feishu.cn/share/base/form/shrcnsjfFkx4gy6wx9LQ70tMaKe
 
 **批量提交**: 有权限时可说「帮我把待提交的都提交了」→读文件→筛待提交→逐个查重预览确认→更新状态为「已提交 #号」
 

--- a/src/main/ai/agents/__tests__/ensureBuiltinAssistant.test.ts
+++ b/src/main/ai/agents/__tests__/ensureBuiltinAssistant.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  appGet: vi.fn(),
+  ensure: vi.fn(),
+  loadDefinition: vi.fn(),
+  preferenceGet: vi.fn()
+}))
+
+vi.mock('@application', () => ({ application: { get: mocks.appGet } }))
+vi.mock('@data/services/AgentService', () => ({
+  agentService: { ensureBuiltinAssistant: mocks.ensure }
+}))
+vi.mock('@main/ai/agents/builtin/BuiltinAgentProvisioner', () => ({
+  loadBuiltinAgentDefinition: mocks.loadDefinition
+}))
+
+import { ensureBuiltinAssistant } from '../ensureBuiltinAssistant'
+
+describe('ensureBuiltinAssistant command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.appGet.mockReturnValue({ get: mocks.preferenceGet })
+    mocks.preferenceGet.mockReturnValue('anthropic::claude-sonnet-4-5')
+    mocks.loadDefinition.mockReturnValue({
+      name: 'Cherry Assistant',
+      configuration: {
+        avatar: '🍒',
+        permission_mode: 'default',
+        max_turns: 100,
+        env_vars: {}
+      }
+    })
+    mocks.ensure.mockReturnValue({ id: 'assistant-1' })
+  })
+
+  it('uses the current package definition and configured default model', () => {
+    expect(ensureBuiltinAssistant()).toEqual({ id: 'assistant-1' })
+
+    expect(mocks.appGet).toHaveBeenCalledWith('PreferenceService')
+    expect(mocks.preferenceGet).toHaveBeenCalledWith('chat.default_model_id')
+    expect(mocks.ensure).toHaveBeenCalledWith({
+      name: 'Cherry Assistant',
+      defaultModelId: 'anthropic::claude-sonnet-4-5',
+      configuration: {
+        avatar: '🍒',
+        permission_mode: 'default',
+        max_turns: 100,
+        env_vars: {}
+      }
+    })
+  })
+
+  it('refuses to create a system Agent from an invalid package definition', () => {
+    mocks.loadDefinition.mockReturnValue({
+      name: 'Cherry Assistant',
+      configuration: { max_turns: 'invalid' }
+    })
+
+    expect(() => ensureBuiltinAssistant()).toThrow('Cherry Assistant package configuration is invalid')
+    expect(mocks.ensure).not.toHaveBeenCalled()
+  })
+
+  it('fails when the package definition is unavailable', () => {
+    mocks.loadDefinition.mockReturnValue(undefined)
+
+    expect(() => ensureBuiltinAssistant()).toThrow('Cherry Assistant package definition is unavailable')
+    expect(mocks.ensure).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ai/agents/builtin/BuiltinAgentProvisioner.ts
+++ b/src/main/ai/agents/builtin/BuiltinAgentProvisioner.ts
@@ -82,7 +82,7 @@ export function loadBuiltinAgentDefinition(builtinRole: string): BuiltinAgentCon
   try {
     const agentConfig = JSON.parse(fs.readFileSync(agentJsonPath, 'utf-8'))
     return {
-      name: agentConfig.name,
+      name: resolveLocalizedField(agentConfig.name),
       instructions: resolveLocalizedField(agentConfig.instructions),
       configuration: agentConfig.configuration
     } as BuiltinAgentConfig

--- a/src/main/ai/agents/builtin/__tests__/BuiltinAgentProvisioner.test.ts
+++ b/src/main/ai/agents/builtin/__tests__/BuiltinAgentProvisioner.test.ts
@@ -21,6 +21,7 @@ vi.mock('fs', async (importOriginal) => {
 import { loadBuiltinAgentDefinition } from '../BuiltinAgentProvisioner'
 
 const localizedDefinition = JSON.stringify({
+  name: { 'en-US': 'Cherry Assistant', 'zh-CN': 'Cherry 小助手' },
   instructions: { 'en-US': 'English instructions', 'zh-CN': '中文指令' },
   configuration: {}
 })
@@ -41,6 +42,7 @@ describe('loadBuiltinAgentDefinition', () => {
     vi.mocked(app.getLocale).mockReturnValue('zh-CN')
 
     expect(loadBuiltinAgentDefinition('assistant')).toMatchObject({
+      name: 'Cherry 小助手',
       instructions: '中文指令'
     })
   })
@@ -50,6 +52,7 @@ describe('loadBuiltinAgentDefinition', () => {
     vi.mocked(app.getLocale).mockReturnValue('zh-CN')
 
     expect(loadBuiltinAgentDefinition('assistant')).toMatchObject({
+      name: 'Cherry Assistant',
       instructions: 'English instructions'
     })
   })

--- a/src/main/ai/agents/ensureBuiltinAssistant.ts
+++ b/src/main/ai/agents/ensureBuiltinAssistant.ts
@@ -1,0 +1,25 @@
+import { application } from '@application'
+import { agentService } from '@data/services/AgentService'
+import { loadBuiltinAgentDefinition } from '@main/ai/agents/builtin/BuiltinAgentProvisioner'
+import { type AgentEntity, sanitizeAgentConfiguration } from '@shared/data/api/schemas/agents'
+import type { UniqueModelId } from '@shared/data/types/model'
+
+export function ensureBuiltinAssistant(): AgentEntity {
+  const definition = loadBuiltinAgentDefinition('assistant')
+  if (!definition) {
+    throw new Error('Cherry Assistant package definition is unavailable')
+  }
+
+  const { data: configuration, invalidKeys } = sanitizeAgentConfiguration(definition.configuration)
+  if (!configuration || invalidKeys.length > 0) {
+    throw new Error(`Cherry Assistant package configuration is invalid: ${invalidKeys.join(', ') || '<root>'}`)
+  }
+
+  const defaultModelId = (application.get('PreferenceService').get('chat.default_model_id') ??
+    null) as UniqueModelId | null
+  return agentService.ensureBuiltinAssistant({
+    name: definition.name ?? 'Cherry Assistant',
+    configuration,
+    defaultModelId
+  })
+}

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -29,7 +29,9 @@ import type { EntitySearchItem } from '@shared/data/api/schemas/search'
 import type { ListOptions } from '@shared/data/api/types'
 import type { AgentType } from '@shared/data/types/agent'
 import type { UniqueModelId } from '@shared/data/types/model'
+import { isGatewayRoutableModel } from '@shared/utils/model'
 import { and, asc, count, desc, eq, gte, inArray, isNull, or, type SQL, sql } from 'drizzle-orm'
+import { v4 as uuidv4 } from 'uuid'
 
 const logger = loggerService.withContext('AgentService')
 
@@ -53,6 +55,12 @@ type AgentRelationField = 'mcps' | 'knowledgeBaseIds'
 type AgentCreateInput = AgentBase & {
   type: AgentType
   skillIds?: string[]
+}
+
+export interface EnsureBuiltinAssistantInput {
+  configuration: AgentConfiguration
+  defaultModelId: UniqueModelId | null
+  name: string
 }
 
 function getAgentDescription(description: string, configuration: unknown): string {
@@ -312,6 +320,75 @@ export class AgentService {
       ? (modelService.getNamesByUniqueIdsTx(tx, [agent.model]).get(agent.model) ?? null)
       : null
     return { agent, modelName }
+  }
+
+  /**
+   * Return the active Cherry Assistant or restore one from trusted package defaults.
+   *
+   * The reserved role is injected here, inside the table-owning service, so no
+   * renderer or generic Agent create path can forge the built-in identity. The
+   * read-before-write transaction makes repeated or concurrent ensure commands
+   * converge on one active system Agent.
+   */
+  ensureBuiltinAssistant(input: EnsureBuiltinAssistantInput): AgentEntity {
+    const result = application.get('DbService').withWriteTx((tx) => {
+      const [existing] = tx
+        .select()
+        .from(agentsTable)
+        .where(
+          and(
+            isNull(agentsTable.deletedAt),
+            sql`json_extract(${agentsTable.configuration}, '$.builtin_role') = 'assistant'`
+          )
+        )
+        .limit(1)
+        .all()
+
+      if (existing) {
+        const mcps = fetchMcpsForAgents(tx, [existing.id]).get(existing.id) ?? []
+        const knowledgeBaseIds = fetchKnowledgeBasesForAgents(tx, [existing.id]).get(existing.id) ?? []
+        const modelName = existing.model
+          ? (modelService.getNamesByUniqueIdsTx(tx, [existing.model]).get(existing.model) ?? null)
+          : null
+        return {
+          agent: rowToAgent(existing, modelName, mcps, knowledgeBaseIds),
+          created: false
+        }
+      }
+
+      const defaultModel = input.defaultModelId ? modelService.findByIdTx(tx, input.defaultModelId) : null
+      const model = defaultModel && isGatewayRoutableModel(defaultModel) ? input.defaultModelId : null
+      const agentId = uuidv4()
+      const created = this.createAgentTx(tx, agentId, {
+        id: agentId,
+        type: 'claude-code',
+        name: input.name.trim() || 'Cherry Assistant',
+        description: '',
+        instructions: '',
+        model,
+        configuration: {
+          ...input.configuration,
+          builtin_role: 'assistant'
+        }
+      })
+
+      if (!created) {
+        throw DataApiErrorFactory.invalidOperation(
+          'restore Cherry Assistant',
+          'insert succeeded but select returned no row'
+        )
+      }
+
+      return {
+        agent: rowToAgent(created.agent, created.modelName, [], []),
+        created: true
+      }
+    })
+
+    if (result.created) {
+      this._onAgentCreated.fire({ agentId: result.agent.id, agent: result.agent })
+    }
+    return result.agent
   }
 
   private findAgentRow(id: string, options: { includeDeleted?: boolean } = {}): AgentRow | undefined {

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -14,7 +14,7 @@ import { userProviderTable } from '@data/db/schemas/userProvider'
 // Importing the singleton loads AgentGlobalSkillService so it self-registers in the
 // data-service registry, which createAgent resolves lazily for skill validation/join.
 import { agentGlobalSkillService } from '@data/services/AgentGlobalSkillService'
-import { agentService } from '@data/services/AgentService'
+import { agentService, type EnsureBuiltinAssistantInput } from '@data/services/AgentService'
 import { knowledgeBaseService } from '@data/services/KnowledgeBaseService'
 import { mcpServerService } from '@data/services/McpServerService'
 import { pinService } from '@data/services/PinService'
@@ -23,7 +23,7 @@ import { ErrorCode } from '@shared/data/api/errors'
 import { createUniqueModelId } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 // The data-service layer is synchronous under better-sqlite3: failing calls
@@ -227,6 +227,103 @@ describe('AgentService', () => {
       })
       const reloaded = agentService.getAgent(agent.id)
       expect(reloaded?.disabledTools).toEqual([])
+    })
+  })
+
+  describe('ensureBuiltinAssistant', () => {
+    const defaults: EnsureBuiltinAssistantInput = {
+      name: 'Cherry Assistant',
+      defaultModelId: TEST_MODEL_ID,
+      configuration: {
+        avatar: '🍒',
+        permission_mode: 'default' as const,
+        max_turns: 100,
+        env_vars: {}
+      }
+    }
+
+    function builtinRows() {
+      return dbh.db
+        .select()
+        .from(agentTable)
+        .where(sql`json_extract(${agentTable.configuration}, '$.builtin_role') = 'assistant'`)
+        .all()
+    }
+
+    function activeBuiltinRows() {
+      return dbh.db
+        .select()
+        .from(agentTable)
+        .where(
+          sql`${agentTable.deletedAt} IS NULL AND json_extract(${agentTable.configuration}, '$.builtin_role') = 'assistant'`
+        )
+        .all()
+    }
+
+    it('creates one protected assistant and returns it unchanged on repeated calls', () => {
+      const first = agentService.ensureBuiltinAssistant(defaults)
+      const second = agentService.ensureBuiltinAssistant({
+        name: 'Replacement Name',
+        defaultModelId: null,
+        configuration: { avatar: '🤖' }
+      })
+
+      expect(second).toEqual(first)
+      expect(first).toMatchObject({
+        name: 'Cherry Assistant',
+        model: TEST_MODEL_ID,
+        configuration: {
+          avatar: '🍒',
+          permission_mode: 'default',
+          max_turns: 100,
+          env_vars: {},
+          builtin_role: 'assistant'
+        }
+      })
+      expect(activeBuiltinRows()).toHaveLength(1)
+    })
+
+    it('restores exactly one active assistant after the previous row was soft-deleted', () => {
+      const first = agentService.ensureBuiltinAssistant(defaults)
+      dbh.db
+        .update(agentTable)
+        .set({ deletedAt: Date.UTC(2026, 0, 1) })
+        .where(eq(agentTable.id, first.id))
+        .run()
+
+      const restored = agentService.ensureBuiltinAssistant(defaults)
+      const repeated = agentService.ensureBuiltinAssistant(defaults)
+
+      expect(restored.id).not.toBe(first.id)
+      expect(repeated.id).toBe(restored.id)
+      expect(builtinRows()).toHaveLength(2)
+      expect(activeBuiltinRows()).toHaveLength(1)
+    })
+
+    it('leaves the model unset when the default cannot run the Agent runtime', () => {
+      dbh.db
+        .insert(userProviderTable)
+        .values({ providerId: 'embedding', name: 'Embedding', orderKey: generateOrderKeyBetween(null, null) })
+        .run()
+      dbh.db
+        .insert(userModelTable)
+        .values({
+          id: 'embedding::vectors',
+          providerId: 'embedding',
+          modelId: 'vectors',
+          name: 'Vectors',
+          capabilities: ['embedding'],
+          supportsStreaming: false,
+          orderKey: generateOrderKeyBetween(null, null)
+        })
+        .run()
+
+      const assistant = agentService.ensureBuiltinAssistant({
+        ...defaults,
+        defaultModelId: 'embedding::vectors'
+      })
+
+      expect(assistant.model).toBeNull()
     })
   })
 

--- a/src/main/ipc/handlers/__tests__/ai.test.ts
+++ b/src/main/ipc/handlers/__tests__/ai.test.ts
@@ -2,16 +2,20 @@ import { aiErrorCodes } from '@shared/ipc/errors/ai'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { appGetMock, agentSessionMessageService, messageService, createAgent } = vi.hoisted(() => ({
-  appGetMock: vi.fn(),
-  agentSessionMessageService: { getSessionMessage: vi.fn() },
-  messageService: { getById: vi.fn() },
-  createAgent: vi.fn()
-}))
+const { appGetMock, agentSessionMessageService, messageService, createAgent, ensureBuiltinAssistant } = vi.hoisted(
+  () => ({
+    appGetMock: vi.fn(),
+    agentSessionMessageService: { getSessionMessage: vi.fn() },
+    messageService: { getById: vi.fn() },
+    createAgent: vi.fn(),
+    ensureBuiltinAssistant: vi.fn()
+  })
+)
 vi.mock('@application', () => ({ application: { get: appGetMock } }))
 vi.mock('@data/services/AgentSessionMessageService', () => ({ agentSessionMessageService }))
 vi.mock('@data/services/MessageService', () => ({ messageService }))
 vi.mock('@main/ai/agents/createAgent', () => ({ createAgent }))
+vi.mock('@main/ai/agents/ensureBuiltinAssistant', () => ({ ensureBuiltinAssistant }))
 
 import { aiHandlers } from '../ai'
 
@@ -62,6 +66,7 @@ const windowManager = { getWindow: vi.fn() }
 beforeEach(() => {
   vi.clearAllMocks()
   createAgent.mockImplementation(async (request: object) => ({ id: 'agent-1', ...request }))
+  ensureBuiltinAssistant.mockReturnValue({ id: 'cherry-assistant' })
   windowManager.getWindow.mockReturnValue({ webContents: fakeWebContents })
   appGetMock.mockImplementation((name: string) => {
     switch (name) {
@@ -90,6 +95,13 @@ beforeEach(() => {
 const ctx = { senderId: 'w1' }
 
 describe('aiHandlers', () => {
+  it('delegates built-in assistant ensure and returns its authoritative entity', async () => {
+    const result = await aiHandlers['ai.agent.builtin_assistant.ensure'](undefined, ctx)
+
+    expect(ensureBuiltinAssistant).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ id: 'cherry-assistant' })
+  })
+
   it('generate_text forwards the request and returns the AiService result', async () => {
     const request = { uniqueModelId: 'openai::gpt-4o', system: 'sys', prompt: 'hi' } as const
     const out = { text: 'hello', usage: { inputTokens: 1, outputTokens: 2 } }

--- a/src/main/ipc/handlers/ai.ts
+++ b/src/main/ipc/handlers/ai.ts
@@ -3,6 +3,7 @@ import { agentSessionMessageService } from '@data/services/AgentSessionMessageSe
 import { messageService } from '@data/services/MessageService'
 import { loggerService } from '@logger'
 import { createAgent } from '@main/ai/agents/createAgent'
+import { ensureBuiltinAssistant } from '@main/ai/agents/ensureBuiltinAssistant'
 import { extractAgentSessionId, isAgentSessionTopic } from '@main/ai/agentSession/topic'
 import { WebContentsListener } from '@main/ai/streamManager'
 import { serializeError } from '@main/ai/utils/serializeError'
@@ -144,6 +145,7 @@ export const aiHandlers: IpcHandlersFor<typeof aiRequestSchemas> = {
 
   // ── Agent creation + session warm-connection lifecycle. ──
   'ai.agent.create': createAgent,
+  'ai.agent.builtin_assistant.ensure': async () => ensureBuiltinAssistant(),
   // Open the live connection eagerly (not just a warm-query park) so the session's slash-command
   // catalog is read into the cache before the first message — the warm-query handle can't expose it.
   // Trace mode is no exception: the primed connection resolves the session's container trace up front

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -85,6 +85,7 @@ import {
   getAgentDraftTokens,
   getCachedSkillTokens,
   getSkillFromCachedToken,
+  hasAgentDraftCache,
   readAgentDraftCache,
   writeAgentDraftCache
 } from './agent/agentDraftCache'
@@ -260,6 +261,12 @@ export interface AgentComposerSendBody {
 
 export type AgentComposerSendOptions = { body?: AgentComposerSendBody }
 
+export interface AgentComposerLaunchOptions {
+  draftCacheKey: string
+  initialDraft: AgentComposerDraftCache
+  onSent?: () => void
+}
+
 type Props = {
   agentId: string
   sessionId: string
@@ -282,6 +289,7 @@ type Props = {
   isStreaming: boolean
   sendDisabled?: boolean
   compactWhenSingleLine?: boolean
+  launchOptions?: AgentComposerLaunchOptions
 }
 
 type AgentComposerRootProps = Props & {
@@ -312,6 +320,7 @@ const AgentComposerRoot = ({
   isStreaming,
   sendDisabled = false,
   compactWhenSingleLine = false,
+  launchOptions,
   renderControls,
   forceNarrowLayout = false,
   deferQuickPanel = false
@@ -325,6 +334,13 @@ const AgentComposerRoot = ({
   )
   const sessionModel = resolvedModel ?? loadedModel
   const actionsRef = useRef<ProviderActionHandlers>({ ...emptyActions })
+  const launchIdentityRef = useRef({ sessionId, draftCacheKey: launchOptions?.draftCacheKey })
+  if (launchIdentityRef.current.sessionId !== sessionId) {
+    launchIdentityRef.current = { sessionId, draftCacheKey: launchOptions?.draftCacheKey }
+  } else if (launchOptions) {
+    launchIdentityRef.current.draftCacheKey = launchOptions.draftCacheKey
+  }
+  const composerInstanceKey = `${sessionId}:${launchIdentityRef.current.draftCacheKey ?? 'default'}`
   const handleNewSessionShortcut = useCallback(() => {
     void onCreateEmptySession?.()
   }, [onCreateEmptySession])
@@ -374,6 +390,7 @@ const AgentComposerRoot = ({
         }
       }}>
       <AgentComposerInner
+        key={composerInstanceKey}
         agent={agent}
         model={sessionModel}
         modelPending={!resolvedModel && (isModelLoading || (externalContextControls && sendDisabled))}
@@ -396,6 +413,7 @@ const AgentComposerRoot = ({
         isStreaming={isStreaming}
         sendDisabled={sendDisabled}
         compactWhenSingleLine={compactWhenSingleLine}
+        launchOptions={launchOptions}
         renderControls={renderControls}
         forceNarrowLayout={forceNarrowLayout}
         deferQuickPanel={deferQuickPanel}
@@ -434,6 +452,7 @@ interface InnerProps {
   isStreaming: boolean
   sendDisabled: boolean
   compactWhenSingleLine: boolean
+  launchOptions?: AgentComposerLaunchOptions
   renderControls: AgentComposerControlsRenderer
   forceNarrowLayout?: boolean
   deferQuickPanel?: boolean
@@ -664,6 +683,7 @@ const AgentComposerInner = ({
   isStreaming,
   sendDisabled,
   compactWhenSingleLine,
+  launchOptions,
   renderControls,
   forceNarrowLayout = false,
   deferQuickPanel = false,
@@ -702,9 +722,14 @@ const AgentComposerInner = ({
     () => pinnedToolIds.map((id) => (id === 'skills' ? AGENT_SKILLS_LAUNCHER_ID : id)),
     [pinnedToolIds]
   )
+  const draftCacheKey = launchOptions?.draftCacheKey ?? getAgentDraftCacheKey(agentId)
+  const shouldPersistInitialDraftRef = useRef(false)
   const initialDraftRef = useRef<AgentComposerDraftCache | null>(null)
   if (initialDraftRef.current === null) {
-    initialDraftRef.current = readAgentDraftCache(getAgentDraftCacheKey(agentId))
+    const hasCachedDraft = hasAgentDraftCache(draftCacheKey)
+    const cachedDraft = readAgentDraftCache(draftCacheKey)
+    initialDraftRef.current = hasCachedDraft ? cachedDraft : (launchOptions?.initialDraft ?? cachedDraft)
+    shouldPersistInitialDraftRef.current = !hasCachedDraft && launchOptions?.initialDraft !== undefined
   }
 
   const configuredReasoningEffort = agent?.configuration?.reasoning_effort ?? 'default'
@@ -746,7 +771,6 @@ const AgentComposerInner = ({
   const [selectedSkills, setSelectedSkills] = useState<LocalSkill[]>(() =>
     getCachedSkillTokens(initialDraftRef.current?.tokens ?? []).map(getSkillFromCachedToken)
   )
-  const draftCacheKey = getAgentDraftCacheKey(agentId)
   const [text, setTextState] = useState(() => initialDraftRef.current?.text ?? '')
   const [draftTokens, setDraftTokens] = useState<ComposerSerializedToken[]>(() => initialDraftRef.current?.tokens ?? [])
   const textRef = useRef(text)
@@ -780,6 +804,12 @@ const AgentComposerInner = ({
   const { bases: allKnowledgeBases, isLoading: isKnowledgeBasesLoading } = useKnowledgeBases({
     enabled: knowledgeBasesDataEnabled
   })
+
+  useEffect(() => {
+    if (!shouldPersistInitialDraftRef.current || !initialDraftRef.current) return
+    shouldPersistInitialDraftRef.current = false
+    writeAgentDraftCache(draftCacheKey, initialDraftRef.current.text, initialDraftRef.current.tokens)
+  }, [draftCacheKey])
 
   const { canAddImageFile, supportedExts } = useComposerFileCapabilities(model)
 
@@ -911,6 +941,12 @@ const AgentComposerInner = ({
       actionsRef.current.focus('end')
     })
   }, [actionsRef, sessionTopicId])
+
+  useEffect(() => {
+    if (!launchOptions?.initialDraft) return
+    const frameId = window.requestAnimationFrame(() => actionsRef.current.focus('end'))
+    return () => window.cancelAnimationFrame(frameId)
+  }, [actionsRef, launchOptions?.initialDraft])
 
   const insertSkillToken = useCallback(
     (skill: LocalSkill, inputAdapter?: QuickPanelInputAdapter) => {
@@ -1222,6 +1258,7 @@ const AgentComposerInner = ({
         )
         void EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
         saveHistory(getComposerHistoryText(payload.userMessageParts))
+        launchOptions?.onSent?.()
         return true
       } catch (error: unknown) {
         logger.warn('Failed to send message:', error as Error)
@@ -1233,6 +1270,7 @@ const AgentComposerInner = ({
       agentId,
       captureLocalSendScrollEligibility,
       chatSendMessage,
+      launchOptions,
       saveHistory,
       sessionId,
       sessionTopicId

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   setFiles: vi.fn(),
   setSelectedKnowledgeBases: vi.fn(),
   inputAdapterFocus: vi.fn(),
+  surfaceFocus: vi.fn(),
   quickPanelOpen: vi.fn(),
   pinnedToolIds: ['composer:new-session', 'skills'] as string[],
   pinnedLauncherIds: [] as readonly string[],
@@ -189,6 +190,7 @@ vi.mock('@renderer/ipc', () => ({
 vi.mock('@data/CacheService', () => ({
   cacheService: {
     getCasual: vi.fn(() => ''),
+    hasCasual: vi.fn(() => false),
     setCasual: vi.fn(),
     subscribe: vi.fn(() => () => {})
   }
@@ -206,7 +208,7 @@ vi.mock('@renderer/components/composer/ComposerSurface', () => {
   function MockComposerSurface(props: ComposerSurfaceProps) {
     useEffect(() => {
       props.onActionsChange?.({
-        focus: vi.fn(),
+        focus: mocks.surfaceFocus,
         onTextChange: (updater) => {
           const nextText = typeof updater === 'function' ? updater(props.text) : updater
           props.onTextChange(nextText)
@@ -747,6 +749,8 @@ describe('AgentComposer', () => {
     mocks.listDirectoryEntries.mockResolvedValue([])
     vi.mocked(cacheService.getCasual).mockReset()
     vi.mocked(cacheService.getCasual).mockReturnValue('')
+    vi.mocked(cacheService.hasCasual).mockReset()
+    vi.mocked(cacheService.hasCasual).mockReturnValue(false)
     vi.mocked(cacheService.setCasual).mockReset()
     mocks.createInternalEntry.mockReset()
     mocks.createInternalEntry.mockResolvedValue({ id: 'fe-1', ext: 'png' })
@@ -801,6 +805,7 @@ describe('AgentComposer', () => {
     mocks.setFiles.mockReset()
     mocks.setSelectedKnowledgeBases.mockReset()
     mocks.inputAdapterFocus.mockReset()
+    mocks.surfaceFocus.mockReset()
     mocks.quickPanelOpen.mockReset()
     mocks.pinnedToolIds = ['composer:new-session', 'skills']
     mocks.pinnedLauncherIds = []
@@ -2803,6 +2808,199 @@ describe('AgentComposer', () => {
         textOffset: 0
       }
     ])
+  })
+
+  it('uses an isolated launch draft, selects its skill, and focuses without sending', async () => {
+    const issueReporter = { name: 'issue-reporter', filename: 'issue-reporter' }
+    const issueReporterToken = {
+      id: 'skill:issue-reporter',
+      kind: 'skill' as const,
+      label: 'issue-reporter',
+      promptText: 'Use the issue-reporter skill.',
+      payload: issueReporter,
+      index: 0,
+      textOffset: 0
+    }
+    vi.mocked(cacheService.getCasual).mockImplementation((key: string) =>
+      key === 'agent-session-draft-agent-1' ? { text: 'preserved ordinary draft', tokens: [] } : undefined
+    )
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="feedback-session"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        launchOptions={{
+          draftCacheKey: 'agent-feedback-draft-feedback-session',
+          initialDraft: {
+            text: 'Use the issue-reporter skill.',
+            tokens: [issueReporterToken]
+          }
+        }}
+      />
+    )
+
+    expect(cacheService.getCasual).toHaveBeenCalledWith('agent-feedback-draft-feedback-session')
+    expect(cacheService.getCasual).not.toHaveBeenCalledWith('agent-session-draft-agent-1')
+    expect(mocks.surfaceProps?.text).toBe('Use the issue-reporter skill.')
+    expect(mocks.surfaceProps?.tokens).toContainEqual(expect.objectContaining({ id: 'skill:issue-reporter' }))
+    expect(mocks.surfaceProps?.draftTokens).toEqual([issueReporterToken])
+    expect(cacheService.setCasual).toHaveBeenCalledWith(
+      'agent-feedback-draft-feedback-session',
+      { text: 'Use the issue-reporter skill.', tokens: [issueReporterToken] },
+      expect.any(Number)
+    )
+    await waitFor(() => expect(mocks.surfaceFocus).toHaveBeenCalledWith('end'))
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('adopts launch options that arrive after the restored session first renders', async () => {
+    const issueReporterToken = {
+      id: 'skill:issue-reporter',
+      kind: 'skill' as const,
+      label: 'issue-reporter',
+      promptText: 'Use the issue-reporter skill.',
+      payload: { name: 'issue-reporter', filename: 'issue-reporter' },
+      index: 0,
+      textOffset: 0
+    }
+    const defaultProps = {
+      agentId: 'restored-assistant',
+      sessionId: 'feedback-session',
+      sendMessage: mocks.sendMessage,
+      stop: mocks.stop,
+      isStreaming: false
+    }
+    const view = render(<AgentComposer {...defaultProps} />)
+
+    expect(mocks.surfaceProps?.text).toBe('')
+
+    view.rerender(
+      <AgentComposer
+        {...defaultProps}
+        launchOptions={{
+          draftCacheKey: 'agent-feedback-draft-feedback-session',
+          initialDraft: { text: 'Use the issue-reporter skill.', tokens: [issueReporterToken] }
+        }}
+      />
+    )
+
+    expect(mocks.surfaceProps?.text).toBe('Use the issue-reporter skill.')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([issueReporterToken])
+    expect(mocks.surfaceProps?.tokens).toContainEqual(expect.objectContaining({ id: 'skill:issue-reporter' }))
+    await waitFor(() => expect(mocks.surfaceFocus).toHaveBeenCalledWith('end'))
+
+    view.rerender(<AgentComposer {...defaultProps} />)
+
+    expect(mocks.surfaceProps?.text).toBe('Use the issue-reporter skill.')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([issueReporterToken])
+  })
+
+  it('does not restore the launch template after the isolated draft was intentionally cleared', () => {
+    vi.mocked(cacheService.hasCasual).mockReturnValue(true)
+    vi.mocked(cacheService.getCasual).mockReturnValue({ text: '', tokens: [] })
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="feedback-session"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        launchOptions={{
+          draftCacheKey: 'agent-feedback-draft-feedback-session',
+          initialDraft: { text: 'Use the issue-reporter skill.', tokens: [] }
+        }}
+      />
+    )
+
+    expect(mocks.surfaceProps?.text).toBe('')
+    expect(mocks.surfaceProps?.draftTokens).toEqual([])
+    expect(cacheService.setCasual).not.toHaveBeenCalledWith(
+      'agent-feedback-draft-feedback-session',
+      { text: 'Use the issue-reporter skill.', tokens: [] },
+      expect.any(Number)
+    )
+  })
+
+  it('consumes the launch state only after the user successfully sends the editable draft', async () => {
+    const onSent = vi.fn()
+    const token = {
+      id: 'skill:issue-reporter',
+      kind: 'skill' as const,
+      label: 'issue-reporter',
+      promptText: 'Use the issue-reporter skill.',
+      payload: { name: 'issue-reporter', filename: 'issue-reporter' },
+      index: 0,
+      textOffset: 0
+    }
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="feedback-session"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        launchOptions={{
+          draftCacheKey: 'agent-feedback-draft-feedback-session',
+          initialDraft: { text: 'Use the issue-reporter skill.', tokens: [token] },
+          onSent
+        }}
+      />
+    )
+
+    expect(onSent).not.toHaveBeenCalled()
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({
+        text: 'Use the issue-reporter skill. The settings page is unresponsive.',
+        tokens: [token]
+      })
+    })
+
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+    expect(onSent).toHaveBeenCalledTimes(1)
+    expect(cacheService.setCasual).toHaveBeenLastCalledWith(
+      'agent-feedback-draft-feedback-session',
+      { text: '', tokens: [] },
+      expect.any(Number)
+    )
+    expect(cacheService.setCasual).not.toHaveBeenCalledWith(
+      'agent-session-draft-agent-1',
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it('keeps the launch state when sending fails', async () => {
+    const onSent = vi.fn()
+    mocks.sendMessage.mockRejectedValue(new Error('send failed'))
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="feedback-session"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+        launchOptions={{
+          draftCacheKey: 'agent-feedback-draft-feedback-session',
+          initialDraft: { text: 'Use the issue-reporter skill.', tokens: [] },
+          onSent
+        }}
+      />
+    )
+
+    await act(async () => {
+      await mocks.surfaceProps?.onSendDraft({ text: 'Use the issue-reporter skill.', tokens: [] })
+    })
+
+    expect(onSent).not.toHaveBeenCalled()
+    expect(cacheService.setCasual).toHaveBeenLastCalledWith(
+      'agent-feedback-draft-feedback-session',
+      { text: 'Use the issue-reporter skill.', tokens: [] },
+      expect.any(Number)
+    )
   })
 
   it('drops a cached knowledge chip together with its prompt text', () => {

--- a/src/renderer/components/composer/variants/__tests__/agentDraftCache.test.ts
+++ b/src/renderer/components/composer/variants/__tests__/agentDraftCache.test.ts
@@ -7,6 +7,7 @@ import {
   getAgentDraftTokens,
   getCacheableAgentDraft,
   getCachedSkillTokens,
+  hasAgentDraftCache,
   readAgentDraftCache,
   writeAgentDraftCache
 } from '../agent/agentDraftCache'
@@ -14,6 +15,7 @@ import {
 vi.mock('@data/CacheService', () => ({
   cacheService: {
     getCasual: vi.fn(),
+    hasCasual: vi.fn(),
     setCasual: vi.fn()
   }
 }))
@@ -104,7 +106,15 @@ const legacyCommandToken: ComposerSerializedToken = {
 describe('agentDraftCache', () => {
   beforeEach(() => {
     vi.mocked(cacheService.getCasual).mockReset()
+    vi.mocked(cacheService.hasCasual).mockReset()
     vi.mocked(cacheService.setCasual).mockReset()
+  })
+
+  it('distinguishes an intentionally empty cached draft from a missing draft', () => {
+    vi.mocked(cacheService.hasCasual).mockReturnValue(true)
+
+    expect(hasAgentDraftCache('agent-feedback-draft-session-1')).toBe(true)
+    expect(cacheService.hasCasual).toHaveBeenCalledWith('agent-feedback-draft-session-1')
   })
 
   it('keeps every active non-file input token in the live Agent draft', () => {

--- a/src/renderer/components/composer/variants/agent/agentDraftCache.ts
+++ b/src/renderer/components/composer/variants/agent/agentDraftCache.ts
@@ -72,6 +72,10 @@ export function readAgentDraftCache(cacheKey: string): AgentComposerDraftCache {
   return getCacheableAgentDraft({ text: cached.text, tokens: cached.tokens })
 }
 
+export function hasAgentDraftCache(cacheKey: string): boolean {
+  return cacheService.hasCasual(cacheKey)
+}
+
 export function writeAgentDraftCache(cacheKey: string, text: string, tokens: readonly ComposerSerializedToken[]) {
   const cacheableDraft = getCacheableAgentDraft({ text, tokens: [...tokens] })
   cacheService.setCasual<AgentComposerDraftCache>(cacheKey, cacheableDraft, DRAFT_CACHE_TTL)

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5786,7 +5786,25 @@
         "title": "Enterprise"
       },
       "feedback": {
+        "agent": {
+          "description": "Chat with Cherry Assistant to share feedback.",
+          "title": "Use Agent"
+        },
+        "agent_error": "Unable to open Cherry Assistant for feedback. Please try again.",
         "button": "Feedback",
+        "dialog": {
+          "description": "Choose how to share feedback and help us make Cherry Studio better.",
+          "title": "Choose a feedback channel"
+        },
+        "github": {
+          "description": "Create a bug report or feature request on GitHub.",
+          "title": "GitHub Issue"
+        },
+        "recommended": "Recommended",
+        "survey": {
+          "description": "Share feedback through our Feishu survey.",
+          "title": "Feedback survey"
+        },
         "title": "Feedback"
       },
       "label": "About & Feedback",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5786,7 +5786,25 @@
         "title": "企业版"
       },
       "feedback": {
+        "agent": {
+          "description": "通过与 Cherry Assistant 对话反馈问题。",
+          "title": "使用 Agent 提交"
+        },
+        "agent_error": "无法为反馈打开 Cherry Assistant，请重试。",
         "button": "反馈",
+        "dialog": {
+          "description": "选择一种方式反馈问题，帮助我们把 Cherry Studio 做得更好。",
+          "title": "选择反馈方式"
+        },
+        "github": {
+          "description": "前往 GitHub 创建 Bug 报告或功能建议。",
+          "title": "GitHub Issue"
+        },
+        "recommended": "推荐",
+        "survey": {
+          "description": "通过飞书问卷提交反馈。",
+          "title": "反馈问卷"
+        },
         "title": "意见反馈"
       },
       "label": "关于我们",

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -20,7 +20,10 @@ import {
   AgentConversationControls,
   type AgentConversationControlsProps
 } from '@renderer/components/composer/variants/agent/AgentConversationControls'
-import { MissingAgentHomeComposer } from '@renderer/components/composer/variants/AgentComposer'
+import {
+  type AgentComposerLaunchOptions,
+  MissingAgentHomeComposer
+} from '@renderer/components/composer/variants/AgentComposer'
 import { useCache, useSharedCache } from '@renderer/data/hooks/useCache'
 import { useAgent, useUpdateAgent } from '@renderer/hooks/agent/useAgent'
 import { useAgentModelFilter } from '@renderer/hooks/agent/useAgentModelFilter'
@@ -108,6 +111,7 @@ interface AgentChatProps {
   sessionPaneOpen?: boolean
   onSessionPaneOpenChange?: (open: boolean) => void
   sessionPaneUserOpenIntentSeq?: number
+  composerLaunchOptions?: AgentComposerLaunchOptions
 }
 
 interface AgentChatLayoutProps {
@@ -170,7 +174,8 @@ const AgentChat = ({
   resourcePaneRevealRequest,
   sessionPaneOpen,
   onSessionPaneOpenChange,
-  sessionPaneUserOpenIntentSeq
+  sessionPaneUserOpenIntentSeq,
+  composerLaunchOptions
 }: AgentChatProps) => {
   const { t } = useTranslation()
   const [messageStyle] = usePreference('chat.message.style')
@@ -446,6 +451,7 @@ const AgentChat = ({
         sessionMessagesEnabled={sessionMessagesEnabled}
         onOpenCitationsPanel={handleOpenCitationsPanel}
         onCreateEmptySession={sessionAgentId && onCreateEmptySession ? handleCreateEmptySession : undefined}
+        composerLaunchOptions={composerLaunchOptions}
       />
     )
   }
@@ -540,6 +546,7 @@ interface AgentChatSessionCenterProps {
   sessionMessagesEnabled: boolean
   onOpenCitationsPanel: (payload: { citations: Citation[] }) => void
   onCreateEmptySession?: () => void | Promise<unknown>
+  composerLaunchOptions?: AgentComposerLaunchOptions
 }
 
 const AgentChatSessionCenter = ({
@@ -555,7 +562,8 @@ const AgentChatSessionCenter = ({
   isMultiSelectMode,
   sessionMessagesEnabled,
   onOpenCitationsPanel,
-  onCreateEmptySession
+  onCreateEmptySession,
+  composerLaunchOptions
 }: AgentChatSessionCenterProps) => {
   const composer = (
     <AgentComposerSlot
@@ -573,6 +581,7 @@ const AgentChatSessionCenter = ({
       sendDisabled={composerPending}
       onCreateEmptySession={onCreateEmptySession}
       composerContext={runtime.composerContext}
+      composerLaunchOptions={composerLaunchOptions}
     />
   )
   const main = (

--- a/src/renderer/pages/agents/AgentComposerSlot.tsx
+++ b/src/renderer/pages/agents/AgentComposerSlot.tsx
@@ -1,7 +1,7 @@
 import { useOptionalRightPanelState } from '@renderer/components/chat/panes/Shell'
 import type { ComposerContextValue } from '@renderer/components/composer/ComposerContext'
 import ConversationComposerSlot from '@renderer/components/composer/ConversationComposerSlot'
-import AgentComposer from '@renderer/components/composer/variants/AgentComposer'
+import AgentComposer, { type AgentComposerLaunchOptions } from '@renderer/components/composer/variants/AgentComposer'
 import type { GetAgentResponse } from '@renderer/types/agent'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { Model } from '@shared/data/types/model'
@@ -24,6 +24,7 @@ interface AgentComposerSlotProps {
   sendDisabled: boolean
   onCreateEmptySession?: () => void | Promise<unknown>
   composerContext: ComposerContextValue
+  composerLaunchOptions?: AgentComposerLaunchOptions
 }
 
 function AgentComposerSlot({
@@ -40,7 +41,8 @@ function AgentComposerSlot({
   isStreaming,
   sendDisabled,
   onCreateEmptySession,
-  composerContext
+  composerContext,
+  composerLaunchOptions
 }: AgentComposerSlotProps) {
   const rightPanelState = useOptionalRightPanelState()
   const compactWhenSingleLine = Boolean(
@@ -63,6 +65,7 @@ function AgentComposerSlot({
         sendDisabled={sendDisabled}
         onCreateEmptySession={onCreateEmptySession}
         compactWhenSingleLine={compactWhenSingleLine}
+        launchOptions={composerLaunchOptions}
       />
     ) : undefined
 

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -6,6 +6,9 @@ import type { ResourcePaneConfig, ResourcePaneCountButtonProps } from '@renderer
 import { AgentResourceList } from '@renderer/components/chat/resourceList/AgentResourceList'
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
 import { ConversationSidebarToggleButton } from '@renderer/components/chat/shell/ConversationSidebarToggleButton'
+import { writeAgentDraftCache } from '@renderer/components/composer/variants/agent/agentDraftCache'
+import type { AgentComposerLaunchOptions } from '@renderer/components/composer/variants/AgentComposer'
+import { agentSkillToComposerToken } from '@renderer/components/composer/variants/agentComposerTokens'
 import {
   createRecentSessionEntryFromSession,
   recordGlobalSearchRecentEntry
@@ -52,8 +55,9 @@ import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { AGENT_WORKSPACE_TYPE, type AgentSessionWorkspaceSource } from '@shared/data/api/schemas/agentWorkspaces'
 import type { CursorPaginationResponse } from '@shared/data/api/types'
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
+import type { LocalSkill } from '@shared/types/skill'
 import { MIN_WINDOW_HEIGHT, SECOND_MIN_WINDOW_WIDTH } from '@shared/utils/window'
-import { useSearch } from '@tanstack/react-router'
+import { useNavigate, useSearch } from '@tanstack/react-router'
 import { Bot } from 'lucide-react'
 import type { PropsWithChildren } from 'react'
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
@@ -70,6 +74,52 @@ import type { CreateAgentSessionDefaults } from './types'
 const logger = loggerService.withContext('AgentPage')
 type AgentConversationResourceKind = 'agent'
 const MAX_REUSABLE_EMPTY_MESSAGE_CHECKS = 8
+const FEEDBACK_SKILL = { name: 'issue-reporter', filename: 'issue-reporter' } satisfies LocalSkill
+const FEEDBACK_DRAFT_TEXT = 'Use the issue-reporter skill.'
+const FEEDBACK_LAUNCH_TTL_MS = 24 * 60 * 60 * 1000
+const FEEDBACK_INTENT_GUARD_TTL_MS = 5 * 60 * 1000
+
+type FeedbackComposerLaunch = Omit<AgentComposerLaunchOptions, 'onSent'> & { sessionId: string }
+
+export function getFeedbackDraftCacheKey(sessionId: string): string {
+  return `agent-feedback-draft-${sessionId}`
+}
+
+function getFeedbackLaunchCacheKey(sessionId: string): string {
+  return `agent-feedback-launch-${sessionId}`
+}
+
+function getFeedbackIntentGuardCacheKey(tabId: string): string {
+  return `agent-feedback-intent-${tabId}`
+}
+
+export function createFeedbackComposerDraft(): AgentComposerLaunchOptions['initialDraft'] {
+  const skillToken = agentSkillToComposerToken(FEEDBACK_SKILL)
+  return {
+    text: FEEDBACK_DRAFT_TEXT,
+    tokens: [{ ...skillToken, index: 0, textOffset: 0 }]
+  }
+}
+
+function persistFeedbackComposerLaunch(sessionId: string): FeedbackComposerLaunch {
+  const launch = {
+    sessionId,
+    draftCacheKey: getFeedbackDraftCacheKey(sessionId),
+    initialDraft: createFeedbackComposerDraft()
+  }
+  writeAgentDraftCache(launch.draftCacheKey, launch.initialDraft.text, launch.initialDraft.tokens)
+  cacheService.setCasual(getFeedbackLaunchCacheKey(sessionId), launch, FEEDBACK_LAUNCH_TTL_MS)
+  return launch
+}
+
+function readFeedbackComposerLaunch(sessionId: string): FeedbackComposerLaunch | null {
+  const launch = cacheService.getCasual<FeedbackComposerLaunch>(getFeedbackLaunchCacheKey(sessionId))
+  return launch?.sessionId === sessionId ? launch : null
+}
+
+function clearFeedbackComposerLaunch(launch: FeedbackComposerLaunch): void {
+  cacheService.deleteCasual(getFeedbackLaunchCacheKey(launch.sessionId))
+}
 
 function isUserWorkspaceSession(session: AgentSessionEntity | null | undefined): boolean {
   return !!session?.workspaceId && session.workspace?.type !== 'system'
@@ -169,11 +219,14 @@ const AgentPage = () => {
   const [panePosition, setPanePosition] = usePreference('agent.session.position')
   const isClassicSessionLayout = sessionDisplayMode === 'agent'
   const routeSearch = parseAgentRouteSearch(useSearch({ strict: false }) as Record<string, unknown>)
+  const navigate = useNavigate()
+  const isFeedbackIntent = routeSearch.intent === 'feedback'
   const currentTab = useCurrentTab()
   const routeSessionId = routeSearch.sessionId
   const tabMetadataSessionId = currentTab ? getTabInstanceKey(currentTab, 'agents') : undefined
   const isMessageOnlyView = routeSearch.view === 'message' && !!routeSessionId
-  const routeActiveSessionId = isMessageOnlyView ? null : (routeSessionId ?? tabMetadataSessionId ?? null)
+  const routeActiveSessionId =
+    isMessageOnlyView || isFeedbackIntent ? null : (routeSessionId ?? tabMetadataSessionId ?? null)
   // Shared full-list source for the session UI and the composer reuse path. Reuse must read this
   // upper-layer data instead of issuing a second ad-hoc full pagination request.
   const agentSessionsSource = useAgentSessionsSource()
@@ -230,13 +283,13 @@ const AgentPage = () => {
   // activates, so a reactive read would chase this page's own writes. Route / tab-metadata
   // targets take precedence over resume.
   const [resumeSessionId] = useState<string | null>(() =>
-    isMessageOnlyView || routeActiveSessionId ? null : lastUsedSessionId
+    isMessageOnlyView || isFeedbackIntent || routeActiveSessionId ? null : lastUsedSessionId
   )
   const { session: resumeSession, isLoading: isResumeSessionLoading } = useSession(resumeSessionId)
   // The global latest query is the final fallback, not a parallel page dependency. An explicit route/tab
   // target wins outright; a remembered session gets one chance to resolve before we ask for latest.
   const shouldLoadLatestSession =
-    !isMessageOnlyView && !routeActiveSessionId && !isResumeSessionLoading && !resumeSession
+    !isMessageOnlyView && !isFeedbackIntent && !routeActiveSessionId && !isResumeSessionLoading && !resumeSession
   const { latestSession, isLoading: isLatestSessionLoading } = useLatestSession({
     enabled: shouldLoadLatestSession
   })
@@ -246,6 +299,7 @@ const AgentPage = () => {
   const [pendingLocateMessageId, setPendingLocateMessageId] = useState<string | undefined>()
   const sessionRevealRequestIdRef = useRef(0)
   const initialEmptySessionEvaluatedRef = useRef(false)
+  const [feedbackComposerLaunch, setFeedbackComposerLaunch] = useState<FeedbackComposerLaunch | null>(null)
   const [selectingMissingAgent, setSelectingMissingAgent] = useState(false)
   const [replacingSessionWorkspace, setReplacingSessionWorkspace] = useState(false)
   const [missingAgentSelection, setMissingAgentSelection] = useState(false)
@@ -502,13 +556,15 @@ const AgentPage = () => {
         const workspaceSource = await resolveCreateWorkspaceSource(defaults, visibleSession)
         // Drop the session being replaced (post-delete): a stale candidate list still holds it, and
         // reusing it would reactivate the just-deleted session instead of opening a fresh one.
-        const reuseCandidates = getSessionReuseCandidates().filter(
-          (candidate) => candidate.id !== defaults.excludeReuseSessionId
-        )
-        const reusableSessions = await findReusableEmptySessions(
-          reuseCandidates,
-          (candidate) => candidate.agentId === agentId && sessionMatchesWorkspaceSource(candidate, workspaceSource)
-        )
+        const reuseCandidates = defaults.forceNewSession
+          ? []
+          : getSessionReuseCandidates().filter((candidate) => candidate.id !== defaults.excludeReuseSessionId)
+        const reusableSessions = defaults.forceNewSession
+          ? []
+          : await findReusableEmptySessions(
+              reuseCandidates,
+              (candidate) => candidate.agentId === agentId && sessionMatchesWorkspaceSource(candidate, workspaceSource)
+            )
         const reusableSession = reusableSessions[0]
         const duplicateEmptySystemSessionIds =
           workspaceSource.type === AGENT_WORKSPACE_TYPE.SYSTEM
@@ -537,7 +593,11 @@ const AgentPage = () => {
         return session
       } catch (err) {
         logger.error('Failed to create empty agent session', err as Error, { agentId })
-        toast.error(formatErrorMessageWithPrefix(err, t('agent.session.create.error.failed')))
+        toast.error(
+          defaults.forceNewSession
+            ? t('settings.about.feedback.agent_error')
+            : formatErrorMessageWithPrefix(err, t('agent.session.create.error.failed'))
+        )
         return null
       } finally {
         isCreatingEmptySessionRef.current = false
@@ -760,10 +820,63 @@ const AgentPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads latest tab/session state without resubscribing.
   }, [currentTabId])
 
+  const runFeedbackIntent = useEffectEvent(async (intentGuardCacheKey: string) => {
+    initialEmptySessionEvaluatedRef.current = true
+    setFeedbackComposerLaunch(null)
+    closeSurface()
+    setPendingLocateMessageId(undefined)
+    clearActiveSession()
+    setMissingAgentSelection(false)
+
+    try {
+      const assistant = await ipcApi.request('ai.agent.builtin_assistant.ensure')
+      try {
+        await invalidateCache(['/agents', `/agents/${assistant.id}`])
+      } catch (err) {
+        logger.warn('Failed to refresh Agent cache after restoring Cherry Assistant', err as Error, {
+          agentId: assistant.id
+        })
+      }
+
+      const session = await createAndActivateEmptySession({
+        agentId: assistant.id,
+        workspaceMode: 'system',
+        forceNewSession: true
+      })
+      if (!session) {
+        showMissingAgentSelection()
+        return
+      }
+
+      setFeedbackComposerLaunch(persistFeedbackComposerLaunch(session.id))
+    } catch (err) {
+      logger.error('Failed to prepare Cherry Assistant feedback session', err as Error)
+      toast.error(t('settings.about.feedback.agent_error'))
+      showMissingAgentSelection()
+    } finally {
+      try {
+        await navigate({ to: '/app/agents', search: {}, replace: true })
+      } finally {
+        cacheService.deleteCasual(intentGuardCacheKey)
+      }
+    }
+  })
+
+  useEffect(() => {
+    if (!isFeedbackIntent || !currentTabId) return
+    const intentGuardCacheKey = getFeedbackIntentGuardCacheKey(currentTabId)
+    if (cacheService.hasCasual(intentGuardCacheKey)) return
+    cacheService.setCasual(intentGuardCacheKey, true, FEEDBACK_INTENT_GUARD_TTL_MS)
+    void runFeedbackIntent(intentGuardCacheKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads the latest feedback orchestration without resubscribing.
+  }, [currentTabId, isFeedbackIntent])
+
   useEffect(() => {
     if (initialEmptySessionEvaluatedRef.current) {
       return
     }
+
+    if (isFeedbackIntent) return
 
     if (isMessageOnlyView) {
       initialEmptySessionEvaluatedRef.current = true
@@ -820,6 +933,7 @@ const AgentPage = () => {
     agents,
     createDefaultEmptySession,
     isAgentsLoading,
+    isFeedbackIntent,
     isLatestSessionReady,
     isMessageOnlyView,
     isResumeSessionLoading,
@@ -830,6 +944,33 @@ const AgentPage = () => {
     setActiveSession,
     setActiveSessionId
   ])
+
+  const visibleSessionId = visibleSession?.id
+  useEffect(() => {
+    if (!visibleSessionId) return
+    const cachedLaunch = readFeedbackComposerLaunch(visibleSessionId)
+    if (!cachedLaunch) return
+    setFeedbackComposerLaunch((current) => (current?.sessionId === visibleSessionId ? current : cachedLaunch))
+  }, [visibleSessionId])
+
+  const visibleFeedbackComposerLaunch =
+    feedbackComposerLaunch?.sessionId === visibleSessionId
+      ? feedbackComposerLaunch
+      : visibleSessionId
+        ? readFeedbackComposerLaunch(visibleSessionId)
+        : null
+  const composerLaunchOptions = useMemo<AgentComposerLaunchOptions | undefined>(() => {
+    if (!visibleFeedbackComposerLaunch) return undefined
+    const launch = visibleFeedbackComposerLaunch
+    return {
+      draftCacheKey: launch.draftCacheKey,
+      initialDraft: launch.initialDraft,
+      onSent: () => {
+        clearFeedbackComposerLaunch(launch)
+        setFeedbackComposerLaunch((current) => (current?.sessionId === launch.sessionId ? null : current))
+      }
+    }
+  }, [visibleFeedbackComposerLaunch])
 
   const setActiveSessionAndClearTransient = useCallback(
     (sessionId: string | null, session?: AgentSessionEntity | null) => {
@@ -1086,6 +1227,7 @@ const AgentPage = () => {
           sessionPaneOpen={isClassicSessionLayout ? sessionPaneOpen : undefined}
           onSessionPaneOpenChange={isClassicSessionLayout ? setSessionPaneOpen : undefined}
           sessionPaneUserOpenIntentSeq={sessionPaneUserOpenIntentSeq}
+          composerLaunchOptions={composerLaunchOptions}
         />
       </div>
       <AgentCreateDialog

--- a/src/renderer/pages/agents/__tests__/AgentComposerSlot.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentComposerSlot.test.tsx
@@ -77,6 +77,18 @@ describe('AgentComposerSlot', () => {
     expect(agentComposerPropsMock.last?.onWorkspaceChange).toBeUndefined()
   })
 
+  it('forwards one-shot launch options to the real composer', () => {
+    const launchOptions = {
+      draftCacheKey: 'agent-feedback-draft-session-1',
+      initialDraft: { text: 'Use the issue-reporter skill.', tokens: [] },
+      onSent: vi.fn()
+    }
+
+    render(<AgentComposerSlot {...baseProps} composerLaunchOptions={launchOptions} />)
+
+    expect(agentComposerPropsMock.last?.launchOptions).toBe(launchOptions)
+  })
+
   it('does not leave an orphan session in a permanent loading state', () => {
     const { container } = render(<AgentComposerSlot {...baseProps} agentId={undefined} />)
 

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -81,6 +81,8 @@ const agentPageMocks = vi.hoisted(() => ({
   isActiveTab: false,
   showSidebar: false,
   routeSearch: { sessionId: 'session-initial' } as Record<string, unknown>,
+  navigate: vi.fn(),
+  composerLaunchOptions: undefined as any,
   dataApiGet: vi.fn(),
   dataApiPost: vi.fn(),
   dataApiDelete: vi.fn(),
@@ -312,6 +314,7 @@ vi.mock('@renderer/data/hooks/useDataApi', async () => ({
 }))
 
 vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => agentPageMocks.navigate,
   useSearch: () => agentPageMocks.routeSearch
 }))
 
@@ -392,7 +395,8 @@ vi.mock('../AgentChat', () => ({
     onPaneCollapse,
     onPaneAutoCollapseChange,
     onFileNavigationRequestChange,
-    paneManualToggle
+    paneManualToggle,
+    composerLaunchOptions
   }: {
     centerSurface?: { content?: ReactNode } | null
     activeSession?: { id: string } | null
@@ -421,10 +425,14 @@ vi.mock('../AgentChat', () => ({
     onPaneAutoCollapseChange?: (collapsed: boolean) => void
     onFileNavigationRequestChange?: (request: ((transition: () => void) => void) | null) => void
     paneManualToggle?: { seq: number; open: boolean }
+    composerLaunchOptions?: unknown
   }) => (
     <section
       data-testid="agent-chat"
-      ref={(node) => onFileNavigationRequestChange?.(node ? agentPageMocks.fileNavigationRequest : null)}>
+      ref={(node) => {
+        agentPageMocks.composerLaunchOptions = composerLaunchOptions
+        onFileNavigationRequestChange?.(node ? agentPageMocks.fileNavigationRequest : null)
+      }}>
       <output data-testid="active-session">{activeSession?.id ?? ''}</output>
       <output data-testid="active-session-loading">{String(Boolean(activeSessionLoading))}</output>
       <output data-testid="missing-agent-selection">{String(Boolean(missingAgentSelection))}</output>
@@ -695,6 +703,9 @@ describe('AgentPage', () => {
     vi.clearAllMocks()
     agentPageMocks.fileNavigationRequest.mockImplementation((transition) => transition())
     agentPageMocks.routeSearch = { sessionId: 'session-initial' }
+    agentPageMocks.navigate.mockReset()
+    agentPageMocks.navigate.mockResolvedValue(undefined)
+    agentPageMocks.composerLaunchOptions = undefined
     agentPageMocks.agents = [{ id: 'agent-a', model: 'model-a', name: 'Agent A' }]
     agentPageMocks.classicLayoutSessions = []
     agentPageMocks.sessionsFirstPageLoading = false
@@ -741,7 +752,107 @@ describe('AgentPage', () => {
     activeSessionMocks.isLoading = false
     activeSessionMocks.sessionSource = 'none'
 
-    ipcMocks.request.mockClear()
+    ipcMocks.request.mockReset()
+    ipcMocks.request.mockResolvedValue(undefined)
+  })
+
+  it('consumes feedback intent once, skips resume, and creates an isolated system task', async () => {
+    const previousSession = {
+      ...agentPageMocks.persistedSession,
+      id: 'session-previous',
+      agentId: 'cherry-assistant',
+      name: '',
+      workspaceId: undefined,
+      workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+    }
+    const feedbackSession = {
+      ...agentPageMocks.persistedSession,
+      id: 'session-feedback',
+      agentId: 'cherry-assistant',
+      workspaceId: undefined,
+      workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+    }
+    agentPageMocks.routeSearch = { intent: 'feedback' }
+    agentPageMocks.lastUsedSessionId = previousSession.id
+    agentPageMocks.sessionsById.set(previousSession.id, previousSession)
+    agentPageMocks.classicLayoutSessions = [previousSession]
+    agentPageMocks.latestSessionOverride = previousSession
+    agentPageMocks.dataApiPost.mockResolvedValue(feedbackSession)
+    ipcMocks.request.mockImplementation(async (route: string) => {
+      if (route === 'ai.agent.builtin_assistant.ensure') {
+        return { id: 'cherry-assistant', name: 'Cherry Assistant' }
+      }
+      return undefined
+    })
+
+    const view = render(<AgentPage />)
+
+    await waitFor(() => {
+      expect(agentPageMocks.dataApiPost).toHaveBeenCalledWith('/agent-sessions', {
+        body: {
+          agentId: 'cherry-assistant',
+          name: '',
+          workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+        }
+      })
+    })
+    expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-feedback')
+    expect(agentPageMocks.dataApiGet).not.toHaveBeenCalledWith(
+      `/agent-sessions/${previousSession.id}/messages`,
+      expect.anything()
+    )
+    expect(agentPageMocks.dataApiDelete).not.toHaveBeenCalled()
+    expect(agentPageMocks.composerLaunchOptions).toMatchObject({
+      draftCacheKey: 'agent-feedback-draft-session-feedback',
+      initialDraft: {
+        text: 'Use the issue-reporter skill.',
+        tokens: [expect.objectContaining({ id: 'skill:issue-reporter', kind: 'skill' })]
+      }
+    })
+    expect(agentPageMocks.navigate).toHaveBeenCalledWith({ to: '/app/agents', search: {}, replace: true })
+    expect(cacheService.hasCasual('agent-feedback-launch-session-feedback')).toBe(true)
+    expect(cacheService.hasCasual('agent-feedback-draft-session-feedback')).toBe(true)
+
+    agentPageMocks.routeSearch = { sessionId: 'session-feedback' }
+    view.unmount()
+    agentPageMocks.composerLaunchOptions = undefined
+    render(<AgentPage />)
+
+    await waitFor(() => {
+      expect(agentPageMocks.composerLaunchOptions).toMatchObject({
+        draftCacheKey: 'agent-feedback-draft-session-feedback',
+        initialDraft: { text: 'Use the issue-reporter skill.' }
+      })
+    })
+    expect(ipcMocks.request.mock.calls.filter(([route]) => route === 'ai.agent.builtin_assistant.ensure')).toHaveLength(
+      1
+    )
+
+    act(() => {
+      agentPageMocks.composerLaunchOptions.onSent()
+    })
+    await waitFor(() => expect(agentPageMocks.composerLaunchOptions).toBeUndefined())
+    expect(cacheService.hasCasual('agent-feedback-launch-session-feedback')).toBe(false)
+  })
+
+  it('stays on the Agent page without selecting another Agent when feedback setup fails', async () => {
+    agentPageMocks.routeSearch = { intent: 'feedback' }
+    agentPageMocks.latestSessionOverride = {
+      ...agentPageMocks.persistedSession,
+      id: 'session-previous'
+    }
+    ipcMocks.request.mockImplementation(async (route: string) => {
+      if (route === 'ai.agent.builtin_assistant.ensure') throw new Error('restore failed')
+      return undefined
+    })
+
+    render(<AgentPage />)
+
+    await waitFor(() => expect(screen.getByTestId('missing-agent-selection')).toHaveTextContent('true'))
+    expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBeNull()
+    expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith('settings.about.feedback.agent_error')
+    expect(agentPageMocks.navigate).toHaveBeenCalledWith({ to: '/app/agents', search: {}, replace: true })
   })
 
   it('warms the visible agent model from the agent list', () => {

--- a/src/renderer/pages/agents/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/agents/__tests__/routeSearch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAgentRouteSearch } from '../routeSearch'
+
+describe('parseAgentRouteSearch', () => {
+  it('accepts the feedback intent alongside existing search fields', () => {
+    expect(parseAgentRouteSearch({ intent: 'feedback', sessionId: 'session-1', view: 'message' })).toEqual({
+      intent: 'feedback',
+      sessionId: 'session-1',
+      view: 'message'
+    })
+  })
+
+  it('drops unknown intents', () => {
+    expect(parseAgentRouteSearch({ intent: 'other' })).toEqual({
+      intent: undefined,
+      sessionId: undefined,
+      view: undefined
+    })
+  })
+})

--- a/src/renderer/pages/agents/routeSearch.ts
+++ b/src/renderer/pages/agents/routeSearch.ts
@@ -1,13 +1,15 @@
 export const MESSAGE_VIEW = 'message' as const
 
 export type AgentRouteSearch = {
+  intent?: 'feedback'
   sessionId?: string
   view?: typeof MESSAGE_VIEW
 }
 
 export function parseAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
+  const intent = search.intent === 'feedback' ? 'feedback' : undefined
   const sessionId = typeof search.sessionId === 'string' ? search.sessionId : undefined
   const view = search.view === MESSAGE_VIEW ? MESSAGE_VIEW : undefined
 
-  return { sessionId, view }
+  return { intent, sessionId, view }
 }

--- a/src/renderer/pages/agents/types.ts
+++ b/src/renderer/pages/agents/types.ts
@@ -8,4 +8,6 @@ export type CreateAgentSessionDefaults = {
   // Id of a session being replaced (post-delete): excluded from empty-session reuse so a stale
   // candidate list can't reactivate the just-deleted session instead of creating a fresh one.
   excludeReuseSessionId?: string
+  // Explicit entry flows such as feedback must always receive an isolated task.
+  forceNewSession?: boolean
 }

--- a/src/renderer/pages/settings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings.tsx
@@ -30,10 +30,12 @@ import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
 import { ThemeMode, UpgradeChannel } from '@shared/data/preference/preferenceTypes'
 import { debounce } from 'es-toolkit/compat'
-import { BadgeQuestionMark, Briefcase, Bug, Building2, Github, Globe, Mail, Rss } from 'lucide-react'
+import { BadgeQuestionMark, Briefcase, Bug, Building2, Github, Globe, Mail, MessageSquareText, Rss } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { FeedbackDialog } from './FeedbackDialog'
 
 const AboutSettings: FC = () => {
   const [autoCheckUpdate, setAutoCheckUpdate] = usePreference('app.dist.auto_update.enabled')
@@ -42,6 +44,7 @@ const AboutSettings: FC = () => {
 
   const [version, setVersion] = useState('')
   const [isPortable, setIsPortable] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
   const { t } = useTranslation()
   const { theme } = useTheme()
   const { openSmartMiniApp } = useMiniAppPopup()
@@ -339,10 +342,10 @@ const AboutSettings: FC = () => {
         />
         <Divider className="my-3" />
         <AboutActionRow
-          icon={<Github className="size-4.5" />}
+          icon={<MessageSquareText className="size-4.5" />}
           title={t('settings.about.feedback.title')}
           actionLabel={t('settings.about.feedback.button')}
-          onAction={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio/issues/new/choose')}
+          onAction={() => setFeedbackOpen(true)}
         />
         <Divider className="my-3" />
         <AboutActionRow
@@ -373,6 +376,7 @@ const AboutSettings: FC = () => {
           onAction={debug}
         />
       </SettingGroup>
+      <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
     </SettingsContentColumn>
   )
 }

--- a/src/renderer/pages/settings/FeedbackDialog.tsx
+++ b/src/renderer/pages/settings/FeedbackDialog.tsx
@@ -1,0 +1,115 @@
+import {
+  Badge,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle
+} from '@cherrystudio/ui'
+import { ipcApi } from '@renderer/ipc'
+import { openRoute } from '@renderer/services/mainWindowNavigation'
+import { Bot, ChevronRight, ClipboardList, Github } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+
+export const FEEDBACK_SURVEY_URL = 'https://mcnnox2fhjfq.feishu.cn/share/base/form/shrcnsjfFkx4gy6wx9LQ70tMaKe'
+export const FEEDBACK_GITHUB_URL = 'https://github.com/CherryHQ/cherry-studio/issues/new/choose'
+export const FEEDBACK_AGENT_ROUTE = '/app/agents?intent=feedback'
+
+export function isChineseFeedbackLanguage(language: string | undefined): boolean {
+  return language === 'zh-CN' || language === 'zh-TW'
+}
+
+interface FeedbackDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface FeedbackOptionProps {
+  description: string
+  icon: ReactNode
+  recommended?: boolean
+  title: string
+  onSelect: () => void | Promise<void>
+}
+
+function FeedbackOption({ description, icon, recommended = false, title, onSelect }: FeedbackOptionProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Item asChild size="sm" variant="outline" className="w-full cursor-pointer hover:bg-accent/50">
+      <button type="button" onClick={() => void onSelect()}>
+        <ItemMedia variant="icon" className="border-primary/20 bg-primary/10 text-primary">
+          {icon}
+        </ItemMedia>
+        <ItemContent className="min-w-0 text-left">
+          <ItemTitle>
+            {title}
+            {recommended && (
+              <Badge className="border-primary/20 bg-primary/10 text-primary">
+                {t('settings.about.feedback.recommended')}
+              </Badge>
+            )}
+          </ItemTitle>
+          <ItemDescription className="line-clamp-none">{description}</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <ChevronRight className="size-4 text-muted-foreground" />
+        </ItemActions>
+      </button>
+    </Item>
+  )
+}
+
+export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+  const { t, i18n } = useTranslation()
+  const language = i18n.resolvedLanguage ?? i18n.language
+  const showSurvey = isChineseFeedbackLanguage(language)
+
+  const selectOption = (action: () => void | Promise<void>) => {
+    onOpenChange(false)
+    void action()
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>{t('settings.about.feedback.dialog.title')}</DialogTitle>
+          <DialogDescription>{t('settings.about.feedback.dialog.description')}</DialogDescription>
+        </DialogHeader>
+
+        <ItemGroup className="gap-3 px-2">
+          <FeedbackOption
+            icon={<Bot className="size-5" />}
+            title={t('settings.about.feedback.agent.title')}
+            description={t('settings.about.feedback.agent.description')}
+            recommended
+            onSelect={() => selectOption(() => openRoute(FEEDBACK_AGENT_ROUTE))}
+          />
+          <FeedbackOption
+            icon={<Github className="size-5" />}
+            title={t('settings.about.feedback.github.title')}
+            description={t('settings.about.feedback.github.description')}
+            onSelect={() => selectOption(() => ipcApi.request('system.shell.open_website', FEEDBACK_GITHUB_URL))}
+          />
+          {showSurvey && (
+            <FeedbackOption
+              icon={<ClipboardList className="size-5" />}
+              title={t('settings.about.feedback.survey.title')}
+              description={t('settings.about.feedback.survey.description')}
+              onSelect={() => selectOption(() => ipcApi.request('system.shell.open_website', FEEDBACK_SURVEY_URL))}
+            />
+          )}
+        </ItemGroup>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/pages/settings/FeedbackDialog.tsx
+++ b/src/renderer/pages/settings/FeedbackDialog.tsx
@@ -44,9 +44,11 @@ function FeedbackOption({ description, icon, recommended = false, title, onSelec
   const { t } = useTranslation()
 
   return (
-    <Item asChild size="sm" variant="outline" className="w-full cursor-pointer hover:bg-accent/50">
+    <Item asChild size="sm" variant="outline" className="w-full cursor-pointer rounded-xl hover:bg-accent/50">
       <button type="button" onClick={() => void onSelect()}>
-        <ItemMedia variant="icon" className="border-primary/20 bg-primary/10 text-primary">
+        <ItemMedia
+          variant="icon"
+          className="border-primary/20 bg-primary/10 text-primary [&_.lucide:not(.lucide-custom)]:text-current!">
           {icon}
         </ItemMedia>
         <ItemContent className="min-w-0 text-left">

--- a/src/renderer/pages/settings/__tests__/FeedbackDialog.test.tsx
+++ b/src/renderer/pages/settings/__tests__/FeedbackDialog.test.tsx
@@ -1,0 +1,125 @@
+import '@testing-library/jest-dom/vitest'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useState } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  ipcRequest: vi.fn(),
+  language: 'en-US',
+  openRoute: vi.fn()
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: (...args: unknown[]) => mocks.ipcRequest(...args)
+  }
+}))
+
+vi.mock('@renderer/services/mainWindowNavigation', () => ({
+  openRoute: (...args: unknown[]) => mocks.openRoute(...args)
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      language: mocks.language,
+      resolvedLanguage: mocks.language
+    }
+  })
+}))
+
+import {
+  FEEDBACK_AGENT_ROUTE,
+  FEEDBACK_GITHUB_URL,
+  FEEDBACK_SURVEY_URL,
+  FeedbackDialog,
+  isChineseFeedbackLanguage
+} from '../FeedbackDialog'
+
+function ControlledFeedbackDialog() {
+  const [open, setOpen] = useState(true)
+  return <FeedbackDialog open={open} onOpenChange={setOpen} />
+}
+
+describe('feedback region selection', () => {
+  it.each(['zh-CN', 'zh-TW'])('treats %s as Chinese', (language) => {
+    expect(isChineseFeedbackLanguage(language)).toBe(true)
+  })
+
+  it.each(['en-US', 'ja-JP', 'zh-HK', undefined])('treats %s as overseas', (language) => {
+    expect(isChineseFeedbackLanguage(language)).toBe(false)
+  })
+})
+
+describe('FeedbackDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.language = 'en-US'
+    mocks.ipcRequest.mockResolvedValue(undefined)
+  })
+
+  it.each(['zh-CN', 'zh-TW'])('shows the Feishu survey for %s', (language) => {
+    mocks.language = language
+
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: /settings.about.feedback.survey.title/ })).toBeInTheDocument()
+  })
+
+  it.each(['en-US', 'ja-JP'])('hides the Feishu survey for %s', (language) => {
+    mocks.language = language
+
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: /settings.about.feedback.survey.title/ })).not.toBeInTheDocument()
+  })
+
+  it('places the recommended Agent first and GitHub before the Chinese survey', () => {
+    mocks.language = 'zh-CN'
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    const agent = screen.getByRole('button', { name: /settings.about.feedback.agent.title/ })
+    const github = screen.getByRole('button', { name: /settings.about.feedback.github.title/ })
+    const survey = screen.getByRole('button', { name: /settings.about.feedback.survey.title/ })
+    const recommended = screen.getByText('settings.about.feedback.recommended')
+
+    expect(agent.compareDocumentPosition(github)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(github.compareDocumentPosition(survey)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(recommended).toHaveClass('bg-primary/10', 'text-primary')
+  })
+
+  it('uses the shared large dialog size with inset, spacious options', () => {
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    expect(screen.getByTestId('dialog-content')).toHaveAttribute('data-size', 'lg')
+    expect(screen.getByRole('list')).toHaveClass('gap-3', 'px-2')
+  })
+
+  it('opens the Agent feedback intent and closes the dialog', async () => {
+    render(<ControlledFeedbackDialog />)
+
+    fireEvent.click(screen.getByRole('button', { name: /settings.about.feedback.agent.title/ }))
+
+    expect(mocks.openRoute).toHaveBeenCalledWith(FEEDBACK_AGENT_ROUTE)
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('opens the Feishu survey for Chinese users', () => {
+    mocks.language = 'zh-CN'
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /settings.about.feedback.survey.title/ }))
+
+    expect(mocks.ipcRequest).toHaveBeenCalledWith('system.shell.open_website', FEEDBACK_SURVEY_URL)
+  })
+
+  it('opens the GitHub issue chooser', () => {
+    render(<FeedbackDialog open onOpenChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /settings.about.feedback.github.title/ }))
+
+    expect(mocks.ipcRequest).toHaveBeenCalledWith('system.shell.open_website', FEEDBACK_GITHUB_URL)
+  })
+})

--- a/src/shared/ipc/schemas/__tests__/ai.test.ts
+++ b/src/shared/ipc/schemas/__tests__/ai.test.ts
@@ -61,3 +61,12 @@ describe('ai.agent.create IPC schema', () => {
     })
   })
 })
+
+describe('ai.agent.builtin_assistant.ensure IPC schema', () => {
+  const ensureAssistant = aiRequestSchemas['ai.agent.builtin_assistant.ensure'].input
+
+  it('accepts only a void command payload', () => {
+    expect(ensureAssistant.safeParse(undefined).success).toBe(true)
+    expect(ensureAssistant.safeParse({}).success).toBe(false)
+  })
+})

--- a/src/shared/ipc/schemas/ai.ts
+++ b/src/shared/ipc/schemas/ai.ts
@@ -248,6 +248,10 @@ export const aiRequestSchemas = {
     input: CreateAgentCommandSchema,
     output: AgentEntitySchema
   }),
+  'ai.agent.builtin_assistant.ensure': defineRoute({
+    input: z.void(),
+    output: AgentEntitySchema
+  }),
   'ai.agent.session.prewarm': defineRoute({
     input: z.strictObject({ sessionId: z.string().min(1) }),
     output: z.void()

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -546,8 +546,8 @@ vi.mock('@cherrystudio/ui', () => {
       React.createElement('img', { ...props, alt: alt ?? item?.alt, src: item?.src }),
     Dialog: ({ children, onOpenChange: _onOpenChange, open, ...props }) =>
       open ? React.createElement('div', { ...props, role: 'dialog', 'data-testid': 'dialog' }, children) : null,
-    DialogContent: ({ children, closeOnOverlayClick: _closeOnOverlayClick, ...props }) =>
-      React.createElement('div', { ...props, 'data-testid': 'dialog-content' }, children),
+    DialogContent: ({ children, closeOnOverlayClick: _closeOnOverlayClick, size, ...props }) =>
+      React.createElement('div', { ...props, 'data-size': size, 'data-testid': 'dialog-content' }, children),
     DialogHeader: ({ children, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'dialog-header' }, children),
     DialogTitle: ({ children, ...props }) =>
@@ -556,6 +556,36 @@ vi.mock('@cherrystudio/ui', () => {
       React.createElement('p', { ...props, 'data-testid': 'dialog-description' }, children),
     DialogFooter: ({ children, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'dialog-footer' }, children),
+    Item: ({ asChild, children, className, size, variant, ...props }) => {
+      const itemProps = {
+        ...props,
+        className,
+        'data-size': size,
+        'data-slot': 'item',
+        'data-variant': variant
+      }
+      if (asChild && React.isValidElement(children)) {
+        const childProps = children.props || {}
+        return React.cloneElement(children, {
+          ...itemProps,
+          ...childProps,
+          className: [className, childProps.className].filter(Boolean).join(' ') || undefined
+        })
+      }
+      return React.createElement('div', itemProps, children)
+    },
+    ItemActions: ({ children, ...props }) =>
+      React.createElement('div', { ...props, 'data-slot': 'item-actions' }, children),
+    ItemContent: ({ children, ...props }) =>
+      React.createElement('div', { ...props, 'data-slot': 'item-content' }, children),
+    ItemDescription: ({ children, ...props }) =>
+      React.createElement('p', { ...props, 'data-slot': 'item-description' }, children),
+    ItemGroup: ({ children, ...props }) =>
+      React.createElement('div', { ...props, role: 'list', 'data-slot': 'item-group' }, children),
+    ItemMedia: ({ children, variant, ...props }) =>
+      React.createElement('div', { ...props, 'data-slot': 'item-media', 'data-variant': variant }, children),
+    ItemTitle: ({ children, ...props }) =>
+      React.createElement('div', { ...props, 'data-slot': 'item-title' }, children),
     // Passthrough unless real react-hook-form methods are supplied, in which case the
     // provider is needed so FormField/FormMessage can read field state.
     Form: (props) => {

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-03-feedback-options.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-03-feedback-options.md
@@ -1,0 +1,21 @@
+---
+title: Feedback choices and assistant recovery
+category: changed
+severity: notice
+introduced_in_pr: TBD
+date: 2026-08-03
+---
+
+## What changed
+
+The About settings feedback action now opens localized channel choices instead of going directly to GitHub.
+Chinese app languages also show the Feishu survey. Choosing Agent feedback restores Cherry Assistant on demand when it is missing and opens a separate system task with the issue-reporting Skill prepared.
+
+## Why this matters to the user
+
+Users can choose the feedback channel that fits their language and can use Cherry Assistant to organize a report without losing an existing draft or conversation.
+The Agent draft remains editable and is never sent automatically.
+
+## What the user should do
+
+Choose a feedback channel in Settings > About & Feedback. When using Agent feedback, review and complete the prepared draft before sending it.

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-03-feedback-options.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-03-feedback-options.md
@@ -2,7 +2,7 @@
 title: Feedback choices and assistant recovery
 category: changed
 severity: notice
-introduced_in_pr: TBD
+introduced_in_pr: '#17790'
 date: 2026-08-03
 ---
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- Settings > About & Feedback opened the GitHub issue chooser directly.
- There was no supported feedback entry point that could restore a missing Cherry Assistant and prepare the issue-reporting Skill without disturbing existing tasks or drafts.

After this PR:

- Feedback opens a wider accessible dialog built from the shared `Dialog`, `Item`, and `Badge` components, preserving the product's standard radii while using theme-colored accents and roomier option spacing.
- `zh-CN` and `zh-TW` users see Agent feedback first (recommended), GitHub Issue second, and the Feishu survey. All other languages see Agent feedback first (recommended) and GitHub Issue.
- Agent feedback ensures the protected Cherry Assistant exists, creates a separate system task, and prepares an isolated editable `issue-reporter` draft. It focuses the composer but never sends a message automatically.
- The Feishu survey links in both Cherry Assistant feedback guides now use the current form URL.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The app language is a deterministic, privacy-preserving signal for the requested regional channel split. A trusted idempotent IpcApi command owns Cherry Assistant recovery so renderer and generic Agent creation paths cannot forge the reserved `builtin_role`. A forced system session and separate draft cache keep feedback isolated from normal Agent session reuse and unsent drafts.

The following tradeoffs were made:

- A compatible current default model is bound during recovery; incompatible defaults remain unconfigured so the existing model picker can guide the user.
- Feedback launch state is one-shot and cached separately per session, adding a small amount of orchestration in exchange for preserving ordinary Cherry Assistant drafts across navigation and remounts.

The following alternatives were considered:

- Geolocation was rejected because the requirement is explicitly based on the user's selected language.
- Reusing generic Agent creation or an existing empty task was rejected because it could expose the protected role or mix feedback with unrelated work.
- Automatically sending the prepared prompt was rejected so users remain in control of the report contents and model call.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/17398

### Breaking changes

None. This PR changes the feedback entry behavior but does not change the database schema and requires no migration.

### Special notes for your reviewer

- The Cherry Assistant package and protected-role behavior follow the current-package design in #17398; this PR adds only the feedback-specific on-demand recovery flow.
- The Agent composer is focused with `Use the issue-reporter skill.` prepared, but no message or model request is triggered until the user sends it.
- The composer also adopts feedback launch options that arrive after a restored session first renders, so the prepared content remains a real `issue-reporter` Skill token instead of plain text.
- Manual Electron QA covered the Chinese three-option dialog, English two-option dialog, exact shared-dialog geometry and theme colors, and deleting then restoring Cherry Assistant. The restored flow produced one protected Agent, a focused Skill token, and zero auto-sent messages.
- Validation passed: `pnpm lint`, `pnpm test` (20,110 passed), `pnpm format`, `pnpm build:check` (including a second 20,110-test run), `pnpm test:lint`, and `pnpm skills:check`.
- User documentation impact was assessed. The in-app localized guidance is self-contained; the behavior is recorded in `v2-refactor-temp/docs/breaking-changes/2026-08-03-feedback-options.md`, so no external user-guide change is required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Feedback in Settings now offers localized channel choices and recommends Cherry Assistant for preparing a report. Agent feedback opens a separate editable draft and never sends a message automatically.
```
