### PR TITLE
fix(mcp-oauth): re-register OAuth client when auth server changes

### DIFF
--- a/src/main/services/mcp/oauth/provider.ts
+++ b/src/main/services/mcp/oauth/provider.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { loggerService } from '@logger'
 import { getConfigDir } from '@main/utils/file'
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth'
+import type { OAuthClientProvider, OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth'
 import type {
   OAuthClientInformation,
   OAuthClientInformationMixed,
@@ -18,6 +18,7 @@ const logger = loggerService.withContext('MCP:OAuthClientProvider')
 
 export class McpOAuthClientProvider implements OAuthClientProvider {
   private storage: JsonFileStorage
+  private lastDiscoveredAuthServerUrl?: string
   public readonly config: Required<OAuthProviderOptions>
 
   constructor(options: OAuthProviderOptions) {
@@ -53,7 +54,41 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   }
 
   async saveClientInformation(info: OAuthClientInformationMixed | undefined): Promise<void> {
+    if (!info) {
+      await this.storage.saveClientInformation(undefined)
+      // Drop the recorded auth server together with the client it was registered against
+      await this.storage.saveAuthServerUrl(undefined)
+      return
+    }
     await this.storage.saveClientInformation(info)
+    // Record which authorization server this client was registered against so we can
+    // detect future auth-server migrations and drop the stale registration.
+    if (this.lastDiscoveredAuthServerUrl) {
+      await this.storage.saveAuthServerUrl(this.lastDiscoveredAuthServerUrl)
+    }
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    this.lastDiscoveredAuthServerUrl = state.authorizationServerUrl
+    // Sequential reads: both call readStorage(), which lazily creates the file on
+    // first access — concurrent calls would race on the atomic write.
+    const clientInfo = await this.storage.getClientInformation()
+    const storedAuthServerUrl = await this.storage.getAuthServerUrl()
+    // The authorization server has changed since this client was registered (e.g. the
+    // provider migrated auth infrastructure, as alphaXiv did from Clerk to a custom
+    // OAuth server). The stored client_id is now stale: refreshes fail and many servers
+    // (including alphaXiv) reject unknown client_ids with an opaque error that the SDK
+    // treats as tokens-only invalidation, so the stale client would otherwise be reused
+    // on every retry. Clear it so the SDK re-registers against the current server.
+    if (clientInfo && storedAuthServerUrl && storedAuthServerUrl !== state.authorizationServerUrl) {
+      logger.warn('OAuth authorization server changed, clearing stale client registration', {
+        oldAuthServerUrl: storedAuthServerUrl,
+        newAuthServerUrl: state.authorizationServerUrl
+      })
+      await this.storage.saveClientInformation(undefined)
+      await this.storage.saveTokens(undefined)
+      await this.storage.saveAuthServerUrl(state.authorizationServerUrl)
+    }
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
@@ -93,8 +128,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
    *   - 'tokens': Clear only access and refresh tokens
    *   - 'client': Clear only client registration information
    *   - 'verifier': Clear only the PKCE code verifier
+   *   - 'discovery': Clear cached discovery state (re-discovery will happen on next attempt)
    */
-  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier'): Promise<void> {
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {
     logger.debug(`Invalidating credentials with scope: ${scope}`)
 
     switch (scope) {
@@ -104,16 +140,26 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
         logger.info('Cleared all OAuth credentials')
         break
 
-      case 'tokens':
-        // Clear only tokens, preserve client information for re-authentication
+      case 'tokens': {
+        // Clear only tokens. A legacy client registered before we recorded the auth
+        // server URL cannot be verified against the current authorization server
+        // (e.g. after an auth-server migration), so clear it as well to force a
+        // fresh dynamic registration — otherwise a stale client_id gets reused and
+        // the refresh fails repeatedly.
         await this.storage.saveTokens(undefined)
+        const authServerUrl = await this.storage.getAuthServerUrl()
+        if (!authServerUrl) {
+          await this.storage.saveClientInformation(undefined)
+        }
         logger.info('Cleared OAuth tokens (access and refresh tokens)')
         break
+      }
 
       case 'client':
         // Clear client registration information
         // Note: This requires re-registration with the authorization server
         await this.storage.saveClientInformation(undefined)
+        await this.storage.saveAuthServerUrl(undefined)
         logger.info('Cleared OAuth client information')
         break
 
@@ -121,6 +167,12 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
         // Clear PKCE code verifier
         await this.storage.saveCodeVerifier('')
         logger.info('Cleared OAuth code verifier')
+        break
+
+      case 'discovery':
+        // We cache no discovery state outside what the SDK holds; the SDK clears its
+        // own cache so re-discovery happens naturally on the next attempt.
+        logger.info('Cleared OAuth discovery state')
         break
 
       default:

--- a/src/main/services/mcp/oauth/storage.ts
+++ b/src/main/services/mcp/oauth/storage.ts
@@ -109,6 +109,19 @@ export class JsonFileStorage implements IOAuthStorage {
     })
   }
 
+  async getAuthServerUrl(): Promise<string | undefined> {
+    const data = await this.readStorage()
+    return data.authServerUrl
+  }
+
+  async saveAuthServerUrl(url: string | undefined): Promise<void> {
+    const data = await this.readStorage()
+    await this.writeStorage({
+      ...data,
+      authServerUrl: url
+    })
+  }
+
   async clear(): Promise<void> {
     try {
       await fs.unlink(this.filePath)

--- a/src/main/services/mcp/oauth/types.ts
+++ b/src/main/services/mcp/oauth/types.ts
@@ -10,6 +10,8 @@ export interface OAuthStorageData {
   clientInfo?: OAuthClientInformation
   tokens?: OAuthTokens
   codeVerifier?: string
+  /** Authorization server the stored client was registered against, used to detect auth-server migrations */
+  authServerUrl?: string
   lastUpdated: number
 }
 
@@ -17,6 +19,7 @@ export const OAuthStorageSchema = z.object({
   clientInfo: z.any().optional(),
   tokens: z.any().optional(),
   codeVerifier: z.string().optional(),
+  authServerUrl: z.string().optional(),
   lastUpdated: z.number()
 })
 
@@ -27,6 +30,8 @@ export interface IOAuthStorage {
   saveTokens(tokens: OAuthTokens | undefined): Promise<void>
   getCodeVerifier(): Promise<string>
   saveCodeVerifier(codeVerifier: string): Promise<void>
+  getAuthServerUrl(): Promise<string | undefined>
+  saveAuthServerUrl(url: string | undefined): Promise<void>
   clear(): Promise<void>
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR:

Users on v1 cannot complete OAuth for MCP servers whose authorization server has changed since the client was registered. After alphaXiv migrated from Clerk to a custom OAuth server, the stored `client_id` is stale: token refresh fails with `invalid_grant` (alphaXiv returns `invalid_grant` for unknown `client_id`s, not `invalid_client`), the SDK only clears tokens, and the stale `client_id` is reused in the authorization URL on every retry — the browser ends up redirected to `https://api.alphaxiv.org/?error=invalid_client&error_description=client_id+is+required`.

After this PR:

`McpOAuthClientProvider` implements the SDK's `saveDiscoveryState` hook. When discovery reports an authorization server different from the one the stored client was registered against, the stale client registration (and tokens) are cleared so the SDK dynamically re-registers against the current server. Legacy clients registered before this fix (no recorded auth-server URL) are cleared when their tokens are invalidated, since their validity cannot be verified. The `discovery` invalidation scope is also accepted.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17605

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix keys off the `authorizationServerUrl` discovered by the SDK and the URL recorded at registration time (persisted in the existing JSON storage file). This avoids any network heuristics and only clears a client when the auth server genuinely changed.
- Clearing is done in `saveDiscoveryState`, which the SDK calls during the discovery phase *before* `clientInformation()`/refresh/registration, so an in-flight authorization-code exchange is unaffected.
- For legacy clients (registered before this change recorded the auth-server URL), the recorded URL is absent, so `saveDiscoveryState` cannot verify them. Instead, `invalidateCredentials('tokens')` also clears the client when no auth-server URL is recorded — the SDK's own recovery path for `invalid_grant`, which is exactly the error alphaXiv returns for stale clients.

The following alternatives were considered:

- Special-casing alphaXiv's error responses (e.g., treating `invalid_grant` on token refresh as a client error). Rejected: server-specific, and incorrect for the general case where a refresh truly failed.
- Clearing all credentials on any `invalid_grant`. Rejected: would log users out on ordinary refresh-token expiry.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

This is the v1 hotfix; a forward-port to `main` will be submitted separately. The SDK's `OAuthClientProvider` interface documents `saveDiscoveryState` (called after successful discovery) and the `discovery` invalidation scope ("clear cached discovery state on repeated authentication failures ... to allow re-discovery in case the authorization server has changed").

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed MCP OAuth failing after a server's authorization provider changes (e.g. alphaXiv's migration from Clerk to a custom OAuth server): Cherry Studio now re-registers the OAuth client against the current authorization server instead of reusing the stale `client_id`.
```
