### PR TITLE
fix(knowledge): prevent crash when refreshing knowledge item

### DIFF
--- a/src/renderer/src/hooks/useKnowledge.ts
+++ b/src/renderer/src/hooks/useKnowledge.ts
@@ -168,25 +168,6 @@ export const useKnowledge = (baseId: string) => {
       })
       checkAllBases()
     }
-
-    const removalParams = {
-      uniqueId: item.uniqueId,
-      uniqueIds: item.uniqueIds,
-      base: getKnowledgeBaseParams(base)
-    }
-
-    await window.api.knowledgeBase.remove(removalParams)
-
-    updateItem({
-      ...item,
-      processingStatus: 'pending',
-      processingProgress: 0,
-      processingError: '',
-      uniqueId: undefined,
-      retryCount: 0,
-      updated_at: Date.now()
-    })
-    setTimeout(() => KnowledgeQueue.checkAllBases(), 0)
   }
 
   // 更新处理状态


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

<!--

🚨 Branch Strategy Change (Effective April 3, 2026) 🚨

The `main` branch is now under CODE FREEZE.

- main branch: Only accepts critical bug fixes via `hotfix/*` branches. Fix PRs must be minimal in scope and must not include any refactoring code.
- v2 branch: All new features, refactoring, and optimizations should be submitted to the `v2` branch.

If you are submitting a bug fix to main, please ensure your PR is from a `hotfix/*` branch.

-->

### What this PR does

Before this PR: Clicking the update (refresh) button on a knowledge base content item on Windows could consistently crash the app (issue #17490, V1.9.12).

After this PR: The duplicated remove/re-index block at the end of `refreshItem` is removed, so each refresh removes the old embeddings once and re-adds the item through the queue once.

Fixes #17490

### Why we need it and why it was done in this way

`refreshItem` in `src/renderer/src/hooks/useKnowledge.ts` duplicated its remove/update logic: it called `window.api.knowledgeBase.remove` twice with the same loader `uniqueId`s and scheduled `KnowledgeQueue.checkAllBases()` twice. After the first remove and `checkAllBases()`, the queue already re-adds the item while the second `remove` is still in flight, so the vector store (libsql/SQLite) is written to concurrently by `deleteLoader` and `addLoader` — which crashes the app on Windows. The trailing block was accidentally appended by #8384 (commit b6d10656f9d) and is now deleted; the original guarded block already performs the remove, status reset, and queue check.

The following tradeoffs were made: None — this is a pure deletion of redundant code.

The following alternatives were considered: Guarding against concurrent queue processing; however, removing the duplicated block is minimal and restores the pre-regression behavior.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17490

### Breaking changes

None.

### Special notes for your reviewer

N/A

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note

Fixed a crash that occurred when clicking the update button on knowledge base content.

```
