### PR TITLE
fix(agents): sync accessible_paths to sessions when agent working directory changes

### DIFF
--- a/src/main/services/agents/services/AgentService.ts
+++ b/src/main/services/agents/services/AgentService.ts
@@ -574,7 +574,16 @@ export class AgentService extends BaseService {
     rawOldAgent: Record<string, unknown>,
     serializedUpdates: Record<string, unknown>
   ): Promise<void> {
-    const syncFields = ['model', 'plan_model', 'small_model', 'allowed_tools', 'configuration', 'mcps', 'instructions']
+    const syncFields = [
+      'model',
+      'plan_model',
+      'small_model',
+      'allowed_tools',
+      'configuration',
+      'mcps',
+      'instructions',
+      'accessible_paths'
+    ]
 
     // rawOldAgent is already in DB-serialized form (JSON strings), so we can
     // compare directly against session rows without normalization mismatch.

--- a/src/main/services/agents/services/__tests__/AgentService.test.ts
+++ b/src/main/services/agents/services/__tests__/AgentService.test.ts
@@ -80,6 +80,7 @@ import {
   channelTaskSubscriptionsTable,
   scheduledTasksTable,
   sessionMessagesTable,
+  type SessionRow,
   sessionsTable,
   taskRunLogsTable
 } from '../../database/schema'
@@ -164,7 +165,13 @@ async function createAgentDatabase(rows: AgentRow[]) {
     database,
     cleanup: () => {
       client.close()
-      fs.rmSync(directory, { recursive: true, force: true })
+      // On Windows the libsql client may not release the DB file handle synchronously
+      // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
+      try {
+        fs.rmSync(directory, { recursive: true, force: true })
+      } catch {
+        // ignore
+      }
     }
   }
 }
@@ -551,6 +558,161 @@ describe('AgentService data repair', () => {
 
       expect(result.agents[0].updated_at).toBe('2026-07-23T12:43:20.097Z')
       expect(stored[0].updated_at).toBe(concurrentUpdatedAt)
+    } finally {
+      cleanup()
+    }
+  })
+})
+
+describe('AgentService session settings sync', () => {
+  const service = AgentService.getInstance()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createSessionRow(agentId: string, id: string, overrides: Partial<SessionRow> = {}): SessionRow {
+    return {
+      id,
+      agent_type: 'claude-code',
+      agent_id: agentId,
+      name: 'Test Session',
+      description: null,
+      accessible_paths: '[]',
+      instructions: 'Test instructions',
+      model: 'test-model',
+      plan_model: null,
+      small_model: null,
+      mcps: null,
+      allowed_tools: null,
+      slash_commands: null,
+      configuration: null,
+      sort_order: 0,
+      created_at: '2026-07-06T11:47:07.757Z',
+      updated_at: '2026-07-06T11:47:07.757Z',
+      ...overrides
+    }
+  }
+
+  async function createAgentWithSessionsDatabase(agent: AgentRow, sessions: SessionRow[]) {
+    const fs = await vi.importActual<TestFsModule>('node:fs')
+    const os = await vi.importActual<TestOsModule>('node:os')
+    const path = await vi.importActual<TestPathModule>('node:path')
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sync-test-'))
+    const client = createClient({ url: `file:${path.join(directory, 'agents.db')}`, intMode: 'number' })
+    const database = drizzle(client)
+
+    await client.execute(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        deleted_at TEXT,
+        accessible_paths TEXT,
+        instructions TEXT,
+        model TEXT NOT NULL,
+        plan_model TEXT,
+        small_model TEXT,
+        mcps TEXT,
+        allowed_tools TEXT,
+        configuration TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    await client.execute(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        agent_type TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        accessible_paths TEXT,
+        instructions TEXT,
+        model TEXT NOT NULL,
+        plan_model TEXT,
+        small_model TEXT,
+        mcps TEXT,
+        allowed_tools TEXT,
+        slash_commands TEXT,
+        configuration TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    await database.insert(agentsTable).values(agent)
+    await database.insert(sessionsTable).values(sessions)
+
+    return {
+      database,
+      cleanup: () => {
+        client.close()
+        // On Windows the libsql client may not release the DB file handle synchronously
+        // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
+        try {
+          fs.rmSync(directory, { recursive: true, force: true })
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  it('propagates accessible_paths changes to sessions that inherited the old agent value', async () => {
+    const agentId = 'agent_sync_test'
+    const inheritedSessionId = 'session_inherited'
+    const customizedSessionId = 'session_customized'
+    const oldPaths = JSON.stringify(['/old/workspace'])
+    const { cleanup, database } = await createAgentWithSessionsDatabase(
+      createAgentRow({ id: agentId, accessible_paths: oldPaths }),
+      [
+        createSessionRow(agentId, inheritedSessionId, { accessible_paths: oldPaths }),
+        createSessionRow(agentId, customizedSessionId, { accessible_paths: JSON.stringify(['/custom/workspace']) })
+      ]
+    )
+
+    try {
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      // Avoid creating real directories on disk while resolving paths in the test.
+      vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      const newPaths = ['/new/workspace']
+      await service.updateAgent(agentId, { accessible_paths: newPaths })
+
+      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+
+      expect(sessionsById.get(inheritedSessionId)?.accessible_paths).toBe(JSON.stringify(newPaths))
+      expect(sessionsById.get(customizedSessionId)?.accessible_paths).toBe(JSON.stringify(['/custom/workspace']))
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('does not sync accessible_paths to sessions when the agent value is unchanged', async () => {
+    const agentId = 'agent_sync_test'
+    const sessionId = 'session_inherited'
+    const paths = JSON.stringify(['/workspace'])
+    const { cleanup, database } = await createAgentWithSessionsDatabase(
+      createAgentRow({ id: agentId, accessible_paths: paths }),
+      [createSessionRow(agentId, sessionId, { accessible_paths: paths })]
+    )
+
+    try {
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      await service.updateAgent(agentId, { accessible_paths: ['/workspace'] })
+
+      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      expect(sessions[0].accessible_paths).toBe(paths)
     } finally {
       cleanup()
     }


### PR DESCRIPTION
### What this PR does

Before this PR:

When an agent's working directory (`accessible_paths`) was changed in the agent settings, existing sessions created with that agent kept displaying the old directory in the session workspace navbar. `AgentService.syncSettingsToSessions()` propagates agent setting changes to sessions, but `accessible_paths` was missing from its `syncFields` list, so the working directory change never reached existing sessions.

After this PR:

`accessible_paths` is included in the sync fields, so changing an agent's working directory propagates to sessions that inherited the old value and the navbar (which reads `session.accessible_paths[0]`) updates immediately. Sessions where the user customized the value are left untouched.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17796

### Why we need it and why it was done in this way

The following tradeoffs were made:

Only sessions that inherited the agent's default value are updated; sessions with a user-customized `accessible_paths` keep their own value. This matches the existing behavior of every other synced field (`model`, `configuration`, `instructions`, etc.), so changing the agent's setting never silently clobbers a user's per-session customization.

The following alternatives were considered:

- Updating `accessible_paths` on every session of the agent unconditionally — rejected because it would overwrite per-session customizations.
- Refreshing the value in the renderer only — rejected because the source of truth is the session row in the database; the backend sync is the correct layer to fix.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None. The change only makes the agent's working directory propagate to sessions that already inherited the old value; no schema or data migration is involved.

### Special notes for your reviewer

<!-- optional -->

This fix targets the `v1` branch. `AgentService.syncSettingsToSessions()` (and the session/agent code it touches) exists only on `v1`; `main`/`v2` use a different data layer (`src/main/data/migration/v2/migrators/AgentsMigrator.ts`) that is not affected by this bug. If that v2 migration path ever reuses the same session-sync logic, `accessible_paths` should be included there as well.

Two regression tests were added in `AgentService.test.ts` covering: (1) `accessible_paths` changes propagate to inherited sessions while skipping customized ones, and (2) no sync happens when the agent value is unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where changing an agent's working directory did not update existing sessions' displayed directory.
```
