### PR TITLE
feat(backup): report the stage a running operation is in

### DIFF
--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -6,7 +6,7 @@ import type { JournalDegradation, PromotionStepV2, RestoreJournalV2State } from 
 import { readRestoreJournalV2 } from '@data/db/restore/restoreJournalV2'
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, type Disposable, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import type { BackupDestinationId } from '@shared/ipc/schemas/backup'
+import type { BackupDestinationId, BackupProgressStage } from '@shared/ipc/schemas/backup'
 import { ensureDir, remove } from 'fs-extra'
 
 import { archiveName, pruneToLimit, sanitizeArchiveName } from './destinations/archiveRotation'
@@ -15,6 +15,7 @@ import { createTransport, type RemoteArchive } from './destinations/destinationT
 import { BackupBusyError, BackupCancelledError } from './errors'
 import { exportArchive, type ExportArchiveResult } from './export/exportArchive'
 import { sweepStaleExportOperations } from './export/exportOperation'
+import type { BackupStageReporter } from './progress'
 import { abandonKnowledgeRebuild, acknowledgeRestore, type AcknowledgeResult } from './restore/acknowledgeRestore'
 import { runPostPromotionWork } from './restore/postPromotion'
 import {
@@ -235,9 +236,9 @@ export class BackupService extends BaseService {
    * overwrites a prior backup.
    */
   public export(outPath: string): Promise<ExportArchiveResult> {
-    return this.runExclusive('export', async (signal) => {
+    return this.runExclusive('export', async (signal, reportStage) => {
       await this.startExportCleanup()
-      return exportArchive({ outPath, signal })
+      return exportArchive({ outPath, signal, reportStage })
     })
   }
 
@@ -289,7 +290,9 @@ export class BackupService extends BaseService {
    * state; {@link armRestore} is what commits to it.
    */
   public prepareRestore(archivePath: string): Promise<RestorePreview> {
-    return this.runExclusive('prepare-restore', (signal) => prepareRestore({ archivePath, signal }))
+    return this.runExclusive('prepare-restore', (signal, reportStage) =>
+      prepareRestore({ archivePath, signal, reportStage })
+    )
   }
 
   /**
@@ -437,10 +440,15 @@ export class BackupService extends BaseService {
    * `work` receives the signal that {@link cancelOperation} aborts. It is created
    * here so the claim and the abort handle have exactly the same lifetime: a
    * cancellation can never reach the operation that replaced the one it targeted.
+   *
+   * It also receives the stage reporter, for the same reason: this is the one
+   * place that knows which operation is running, so the pipeline below only has
+   * to name the stage it entered. Reporting is best-effort — a window that
+   * closed mid-export must not fail the export — so the emit is swallowed.
    */
   public async runExclusive<T>(
     operation: BackupOperation,
-    work: (signal: AbortSignal) => Promise<T>,
+    work: (signal: AbortSignal, reportStage: BackupStageReporter) => Promise<T>,
     options: { readonly cancellable?: boolean } = {}
   ): Promise<T> {
     if (this.shuttingDown) throw new BackupCancelledError('backup service is shutting down')
@@ -459,10 +467,23 @@ export class BackupService extends BaseService {
     }
     this.inFlight = claim
     try {
-      return await work(controller.signal)
+      return await work(controller.signal, (stage) => this.reportStage(operation, stage))
     } finally {
       if (this.inFlight === claim) this.inFlight = null
       markSettled()
+    }
+  }
+
+  /**
+   * Push one stage boundary to every window. Best-effort by contract: progress
+   * is a label, and the request's own resolution is what reports the outcome,
+   * so a broadcast that throws must not surface as an export failure.
+   */
+  private reportStage(operation: BackupOperation, stage: BackupProgressStage): void {
+    try {
+      application.get('IpcApiService').broadcast('backup.progress', { operation, stage })
+    } catch (error) {
+      logger.warn('Could not broadcast backup progress', error as Error, { operation, stage })
     }
   }
 

--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -261,7 +261,7 @@ export class BackupService extends BaseService {
     const destination = await resolveDestination(id)
     const transport = createTransport(destination)
 
-    return this.runExclusive('export', async (signal) => {
+    return this.runExclusive('export', async (signal, reportStage) => {
       await this.startExportCleanup()
       // A name the user typed is kept, but it opts out of rotation: only the
       // generated convention identifies an archive as this device's.
@@ -274,6 +274,7 @@ export class BackupService extends BaseService {
       const stagePath = join(tempRoot, `${randomUUID()}-${name}`)
       try {
         const result = await exportArchive({ outPath: stagePath, signal })
+        reportStage('uploading')
         await transport.upload(result.outPath, name)
         // Only now. Pruning first is how a limit of 1 turned a failed upload into
         // a user with no backups at all.

--- a/src/main/services/backup/__tests__/BackupService.test.ts
+++ b/src/main/services/backup/__tests__/BackupService.test.ts
@@ -73,11 +73,13 @@ vi.mock('../destinations/destinationTransport', () => ({ createTransport: () => 
 vi.mock('@main/utils/system', () => ({ getHostname: () => 'work-laptop', getDeviceType: () => 'mac' }))
 
 let userDataDir = ''
+const broadcastMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@application', () => ({
   application: {
     get: vi.fn((name: string) => {
       if (name === 'KnowledgeService') return { cancelRestoredMaterialRebuild: cancelRebuildMock }
+      if (name === 'IpcApiService') return { broadcast: broadcastMock }
       throw new Error(`Unexpected service in BackupService test: ${name}`)
     }),
     getPath: vi.fn((key: string) => {
@@ -385,6 +387,37 @@ describe('BackupService', () => {
       await expect(acknowledging).resolves.toMatchObject({ acknowledged: true })
       expect(cancelRebuildMock).toHaveBeenCalledWith('restore-1')
       expect(acknowledgeMock).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('stage progress', () => {
+    it('binds the running operation to the stage the pipeline names', async () => {
+      broadcastMock.mockClear()
+
+      await service.runExclusive('export', async (_signal, reportStage) => {
+        reportStage('snapshotting-db')
+      })
+
+      expect(broadcastMock).toHaveBeenCalledWith('backup.progress', {
+        operation: 'export',
+        stage: 'snapshotting-db'
+      })
+    })
+
+    // Progress is a label; the request's own resolution reports the outcome. A
+    // window torn down mid-export must not turn a good archive into a failure.
+    it('survives a broadcast that throws', async () => {
+      broadcastMock.mockClear()
+      broadcastMock.mockImplementationOnce(() => {
+        throw new Error('no window')
+      })
+
+      await expect(
+        service.runExclusive('export', async (_signal, reportStage) => {
+          reportStage('preparing')
+          return 'finished'
+        })
+      ).resolves.toBe('finished')
     })
   })
 

--- a/src/main/services/backup/export/exportArchive.ts
+++ b/src/main/services/backup/export/exportArchive.ts
@@ -37,6 +37,7 @@ import { currentBackupPlatform } from '../platform'
 import { REBASABLE_MANAGED_ROOT_KEYS } from '../portability/managedPathRebase'
 import type { MaterializationSummary } from '../portability/materializeDatabase'
 import { materializePortableDatabase, summarizeMaterializationDegradations } from '../portability/materializeDatabase'
+import type { BackupStageReporter } from '../progress'
 import { collectResourceRequirements, resolveResourceRoots } from '../resources/collectRequirements'
 import { createOwnerResourceCapture } from '../resources/ownerCapture'
 import { stageResources } from '../resources/stageResources'
@@ -53,6 +54,8 @@ export interface ExportArchiveInputs {
   /** Destination `.cherrybackup` path. Must not already exist. */
   readonly outPath: string
   readonly signal?: AbortSignal
+  /** Names each stage boundary for the progress event; absent in tests. */
+  readonly reportStage?: BackupStageReporter
 }
 
 export interface ExportArchiveResult {
@@ -98,8 +101,9 @@ function readSealedChain(dbPath: string): ReturnType<typeof readAppliedChain> {
 }
 
 export async function exportArchive(inputs: ExportArchiveInputs): Promise<ExportArchiveResult> {
-  const { outPath, signal } = inputs
+  const { outPath, signal, reportStage } = inputs
   throwIfAborted(signal)
+  reportStage?.('preparing')
 
   const operation = await createExportOperation(application.getPath('feature.backup.temp'), outPath)
   const { stagingRoot } = operation
@@ -121,6 +125,7 @@ export async function exportArchive(inputs: ExportArchiveInputs): Promise<Export
     // SQLite supplies the authoritative point-in-time cut. File resources do
     // not share a process-wide seal with it: each owner/unit captures its own
     // independently provable cut after the database requirement set is known.
+    reportStage?.('snapshotting-db')
     dbService.createSnapshot(stagedDbPath)
     const snapshotInventory = collectResourceRequirements({
       dbPath: stagedDbPath,
@@ -130,6 +135,7 @@ export async function exportArchive(inputs: ExportArchiveInputs): Promise<Export
     const snapshotRequirements = snapshotInventory.requirements
     throwIfAborted(signal)
 
+    reportStage?.('materializing-db')
     const materialized = await materializePortableDatabase({ dbPath: stagedDbPath, mode: { kind: 'export' }, signal })
     throwIfAborted(signal)
 
@@ -139,6 +145,7 @@ export async function exportArchive(inputs: ExportArchiveInputs): Promise<Export
     }
 
     const resourcesDir = path.join(stagingRoot, RESOURCES_DIR_NAME)
+    reportStage?.('capturing-resources')
     const ownerCapture = createOwnerResourceCapture({ detachedDbPath: stagedDbPath, roots: resourceRoots })
     const resources = await stageResources({
       requirements: inventory.requirements,

--- a/src/main/services/backup/progress.ts
+++ b/src/main/services/backup/progress.ts
@@ -1,0 +1,22 @@
+/**
+ * Progress reporting vocabulary, shared by the pipelines that emit and the
+ * service that broadcasts.
+ *
+ * It lives here rather than beside `BackupService` because the service already
+ * imports the pipelines: putting the callback type there would make every
+ * pipeline import its own caller. This module imports nothing but the wire
+ * type, so it stays a leaf.
+ *
+ * Reporting is advisory throughout. A pipeline names the stage it entered; the
+ * request's own resolution is what reports the outcome, so every reporter is
+ * optional and a dropped call costs a label, never correctness.
+ */
+
+import type { BackupProgressStage } from '@shared/ipc/schemas/backup'
+
+/**
+ * Names the stage a pipeline just entered. Which operation is running is bound
+ * by `BackupService.runExclusive`, the one place that knows it, so callers
+ * below never repeat it.
+ */
+export type BackupStageReporter = (stage: BackupProgressStage) => void

--- a/src/main/services/backup/restore/prepareRestore.ts
+++ b/src/main/services/backup/restore/prepareRestore.ts
@@ -45,6 +45,7 @@ import type { BackupManifestDegradation } from '../manifest'
 import { currentBackupPlatform } from '../platform'
 import { type ManagedRootRebaseTable, prepareManagedRootRebase } from '../portability/managedPathRebase'
 import { materializePortableDatabase, summarizeMaterializationDegradations } from '../portability/materializeDatabase'
+import type { BackupStageReporter } from '../progress'
 import { collectResourceRequirements, resolveResourceRoots } from '../resources/collectRequirements'
 import { measureResourceCoverage, type ResourceCoverage } from '../resources/coverage'
 import { planResourceInstalls } from '../resources/planInstalls'
@@ -63,6 +64,8 @@ export interface PrepareRestoreInputs {
   /** Untrusted `.cherrybackup` chosen by the user. */
   readonly archivePath: string
   readonly signal?: AbortSignal
+  /** Names each stage boundary for the progress event; absent in tests. */
+  readonly reportStage?: BackupStageReporter
 }
 
 export interface RestorePreview {
@@ -149,8 +152,9 @@ function clearWayForPreparation(): void {
 }
 
 export async function prepareRestore(inputs: PrepareRestoreInputs): Promise<RestorePreview> {
-  const { archivePath, signal } = inputs
+  const { archivePath, signal, reportStage } = inputs
   clearWayForPreparation()
+  reportStage?.('admitting')
   const stagingRoot = application.getPath('feature.backup.restore.staging')
 
   const admitted = await admitArchive({
@@ -164,6 +168,7 @@ export async function prepareRestore(inputs: PrepareRestoreInputs): Promise<Rest
   let promoted = false
   let journalWritten = false
   try {
+    reportStage?.('materializing-db')
     const materialized = await materializePortableDatabase({
       dbPath: admitted.db.path,
       mode: {
@@ -176,6 +181,7 @@ export async function prepareRestore(inputs: PrepareRestoreInputs): Promise<Rest
       signal
     })
 
+    reportStage?.('planning')
     const userDataPath = application.getPath('app.userdata')
     const roots = resolveResourceRoots()
     const inventory = collectResourceRequirements({ dbPath: admitted.db.path, roots, userDataPath })
@@ -204,6 +210,7 @@ export async function prepareRestore(inputs: PrepareRestoreInputs): Promise<Rest
     // deterministic slots the journal names. Same volume, so these are renames;
     // the resource tree moves as ONE unit because its internal layout is what
     // each entry's staging path is relative to.
+    reportStage?.('staging')
     const promotePath = path.resolve(userDataPath, stagedDbRelPath(restoreId))
     fs.mkdirSync(path.dirname(promotePath), { recursive: true, mode: 0o700 })
     renameOnlySync(admitted.db.path, promotePath)

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -350,6 +350,12 @@ export type BackupProgressStage =
   | 'materializing-db'
   | 'capturing-resources'
   | 'verifying'
+  /**
+   * Destination exports only (§7.1), and usually the longest stage of one: the
+   * finished archive is being sent. Without it a dialog sits on `verifying` for
+   * the entire upload.
+   */
+  | 'uploading'
   // Restore preparation (§8.1); `materializing-db` is shared with export
   | 'admitting'
   | 'planning'

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -6,9 +6,11 @@ import { defineRoute } from '../define'
  * Backup v2 IPC schemas — the renderer's whole view of export and restore
  * (docs/references/backup/README.md).
  *
- * Only a Request block. Every state change here is initiated by the window that
- * observes it, and the durable one (the restore journal) survives a relaunch and
- * is read back through `backup.get_status`, so there is nothing for main to push.
+ * Every state change here is initiated by the window that observes it, and the
+ * durable one (the restore journal) survives a relaunch and is read back through
+ * `backup.get_status`. The one thing main pushes is progress: export and restore
+ * preparation run for tens of seconds on a real profile, and the stage they are
+ * in is not derivable from a request that has not resolved yet.
  *
  * NO PATHS CROSS THE BOUNDARY INWARD. `export` and `prepare_restore` take no
  * path: main opens the file dialog itself with fixed filters, so the renderer
@@ -325,4 +327,44 @@ export const backupRequestSchemas = {
     input: DestinationSchema,
     output: z.strictObject({ reachable: z.boolean() })
   })
+}
+
+/**
+ * Where a running operation is, named after the export state machine
+ * (docs/references/backup/README.md §2.1) and the restore preparation sequence
+ * (§8.1).
+ *
+ * `capturing-resources` deliberately covers both `CAPTURING_RESOURCES` and
+ * `RECONCILING_OWNERS`: owner reconciliation runs inside the per-resource loop,
+ * so the two are one interval in code and splitting them here would report a
+ * boundary that does not exist.
+ *
+ * Preboot promotion has no stage of its own. It runs before any service is
+ * alive, across a relaunch, with no window to receive an event — what it did is
+ * read back from the journal afterwards through `backup.get_status`.
+ */
+export type BackupProgressStage =
+  // Export (§2.1)
+  | 'preparing'
+  | 'snapshotting-db'
+  | 'materializing-db'
+  | 'capturing-resources'
+  | 'verifying'
+  // Restore preparation (§8.1); `materializing-db` is shared with export
+  | 'admitting'
+  | 'planning'
+  | 'staging'
+
+// ── Event: main→renderer pushes (pure types, never parsed) ──
+export type BackupEventSchemas = {
+  /**
+   * Emitted as a long-running operation crosses a stage boundary. Advisory
+   * only: the request's own resolution — not this event — is what tells the
+   * caller the operation finished, so a dropped event costs a label, never
+   * correctness.
+   */
+  'backup.progress': {
+    operation: 'export' | 'prepare-restore' | 'arm-restore' | 'rollback-restore'
+    stage: BackupProgressStage
+  }
 }

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -22,9 +22,11 @@ const autoBackupEventSchema = z.discriminatedUnion('status', [
  * Backup v2 IPC schemas — the renderer's whole view of export and restore
  * (docs/references/backup/README.md).
  *
- * The v2 surface is request-only. Every v2 state change is initiated by the window that
- * observes it, and the durable one (the restore journal) survives a relaunch and
- * is read back through `backup.get_status`, so there is nothing for main to push.
+ * Every v2 state change here is initiated by the window that observes it, and the
+ * durable one (the restore journal) survives a relaunch and is read back through
+ * `backup.get_status`. The one v2 event main pushes is progress: export and restore
+ * preparation run for tens of seconds on a real profile, and the stage they are
+ * in is not derivable from a request that has not resolved yet.
  *
  * NO PATHS CROSS THE BOUNDARY INWARD. `export` and `prepare_restore` take no
  * path: main opens the file dialog itself with fixed filters, so the renderer
@@ -355,6 +357,43 @@ export const backupRequestSchemas = {
   })
 }
 
+/**
+ * Where a running operation is, named after the export state machine
+ * (docs/references/backup/README.md §2.1) and the restore preparation sequence
+ * (§8.1).
+ *
+ * `capturing-resources` deliberately covers both `CAPTURING_RESOURCES` and
+ * `RECONCILING_OWNERS`: owner reconciliation runs inside the per-resource loop,
+ * so the two are one interval in code and splitting them here would report a
+ * boundary that does not exist.
+ *
+ * Preboot promotion has no stage of its own. It runs before any service is
+ * alive, across a relaunch, with no window to receive an event — what it did is
+ * read back from the journal afterwards through `backup.get_status`.
+ */
+export type BackupProgressStage =
+  // Export (§2.1)
+  | 'preparing'
+  | 'snapshotting-db'
+  | 'materializing-db'
+  | 'capturing-resources'
+  | 'verifying'
+  // Restore preparation (§8.1); `materializing-db` is shared with export
+  | 'admitting'
+  | 'planning'
+  | 'staging'
+
+// ── Event: main→renderer pushes (pure types, never parsed) ──
 export type BackupEventSchemas = {
   'backup.auto_sync_state_changed': AutoBackupEvent
+  /**
+   * Emitted as a long-running operation crosses a stage boundary. Advisory
+   * only: the request's own resolution — not this event — is what tells the
+   * caller the operation finished, so a dropped event costs a label, never
+   * correctness.
+   */
+  'backup.progress': {
+    operation: 'export' | 'prepare-restore' | 'arm-restore' | 'rollback-restore'
+    stage: BackupProgressStage
+  }
 }

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -378,6 +378,12 @@ export type BackupProgressStage =
   | 'materializing-db'
   | 'capturing-resources'
   | 'verifying'
+  /**
+   * Destination exports only (§7.1), and usually the longest stage of one: the
+   * finished archive is being sent. Without it a dialog sits on `verifying` for
+   * the entire upload.
+   */
+  | 'uploading'
   // Restore preparation (§8.1); `materializing-db` is shared with export
   | 'admitting'
   | 'planning'

--- a/src/shared/ipc/schemas/ipcSchemas.ts
+++ b/src/shared/ipc/schemas/ipcSchemas.ts
@@ -2,7 +2,7 @@ import type { RouteDef } from '../define'
 import { type AiEventSchemas, aiRequestSchemas } from './ai'
 import { apiGatewayRequestSchemas } from './apiGateway'
 import { type AppEventSchemas, appRequestSchemas } from './app'
-import { backupRequestSchemas } from './backup'
+import { type BackupEventSchemas, backupRequestSchemas } from './backup'
 import { type BinaryEventSchemas, binaryRequestSchemas } from './binary'
 import { type ChannelEventSchemas, channelRequestSchemas } from './channel'
 import { cherryinRequestSchemas } from './cherryin'
@@ -89,6 +89,7 @@ export type IpcRoute = keyof IpcRequestSchemas
  */
 export type IpcEventSchemas = AiEventSchemas &
   AppEventSchemas &
+  BackupEventSchemas &
   BinaryEventSchemas &
   ChannelEventSchemas &
   LocalModelEventSchemas &


### PR DESCRIPTION
### What this PR does

Before this PR:

Backup v2's IPC surface was request/response only — `src/shared/ipc/schemas/backup.ts` declared no events, and its header said so explicitly ("there is nothing for main to push"). Export and restore preparation take **17–25 seconds on a real 4.6 GB profile** (measured end-to-end against a copy of a live dev profile), and for that whole time the renderer's only signal is a greyed-out button: `backup.get_status` returns the operation's *name*, never where it is.

After this PR:

Main pushes the one thing the renderer cannot derive — the stage boundary.

- `backup.progress` event: `{ operation, stage }`, declared as a pure TS type like every other domain's events (`local_model.download_progress` is the closest analogue) and intersected into `IpcEventSchemas`.
- `BackupService.runExclusive` binds the operation and hands the pipeline a reporter. It is already the single funnel all four operations pass through, and the only place that knows which one is running, so the pipelines below only name the stage they entered.
- `exportArchive` reports `preparing → snapshotting-db → materializing-db → capturing-resources`; `prepareRestore` reports `admitting → materializing-db → planning → staging`.

This is the bottom of a 3-PR stack; nothing consumes the event yet.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Broadcast, not directed send.** Backup is a settings-page operation with one natural observer, but the event carries no payload worth restricting and a directed send would need the service to track window identity it otherwise never touches. `local_model.download_progress` broadcasts for the same reason.
- **Best-effort emission.** `reportStage` swallows a throwing broadcast and logs it. Progress is a label; the request's own resolution is what reports the outcome, so a window closed mid-export must not turn a good archive into a failure. Covered by a test.
- **`capturing-resources` covers two documented stages.** The contract (§2.1) names `CAPTURING_RESOURCES` and `RECONCILING_OWNERS` separately, but owner reconciliation runs *inside* the per-resource loop — they are one interval in code, and emitting a boundary that does not exist would be a lie. Documented on the type.
- **Preboot promotion gets no stage.** It runs before any service is alive, across a relaunch, with no window to receive an event; `application.get('IpcApiService')` does not exist at that point. What it did is read back from the journal afterwards via `backup.get_status`. This is a real limit of the feature, not an omission.
- **`BackupStageReporter` lives in its own leaf module** (`services/backup/progress.ts`) rather than beside `BackupService`: the service already imports the pipelines, so putting the callback type there would make every pipeline import its own caller.

The following alternatives were considered:

- **Extend `backup.get_status` with a stage field and let the existing 2-second poll carry it.** Cheaper — no new event channel — but 2-second granularity across a 17-second operation is ~8 samples, which cannot drive a per-resource counter (the next PR in this stack). Rejected once the stack's scope included per-unit progress.
- **A context object threaded through the pipelines instead of a second callback param.** There is no context object anywhere in this subsystem today — `AbortSignal` is a bare optional param at every level — so introducing one would be a refactor of every signature for no gain here.

### Breaking changes

None. Additive event; no request schema, handler, or stored format changes.

### Special notes for your reviewer

- **Stacked PR, 1 of 3.** Base is `feat/backup-v2-replacement` (#17499), not `main` — Backup v2 is not in `main` yet, so this cannot compile against it. Review after #17499.
- The event is declared but has no consumer until PR 3 of this stack. That is the intended backend-first order.
- Verification: `pnpm typecheck:node` clean; `vitest --project main src/main/services/backup` 704 passed, including two new cases that assert the operation/stage binding and that a throwing broadcast does not fail the operation.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
