### PR TITLE
feat(backup): report each resource unit as it is entered

### DIFF
--- a/src/main/services/backup/BackupService.ts
+++ b/src/main/services/backup/BackupService.ts
@@ -7,6 +7,7 @@ import { readRestoreJournalV2 } from '@data/db/restore/restoreJournalV2'
 import { loggerService } from '@logger'
 import { BaseService, DependsOn, type Disposable, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import type { BackupDestinationId, BackupProgressStage } from '@shared/ipc/schemas/backup'
+import type { EventPayload } from '@shared/ipc/types'
 import { ensureDir, remove } from 'fs-extra'
 
 import { archiveName, pruneToLimit, sanitizeArchiveName } from './destinations/archiveRotation'
@@ -15,7 +16,7 @@ import { createTransport, type RemoteArchive } from './destinations/destinationT
 import { BackupBusyError, BackupCancelledError } from './errors'
 import { exportArchive, type ExportArchiveResult } from './export/exportArchive'
 import { sweepStaleExportOperations } from './export/exportOperation'
-import type { BackupStageReporter } from './progress'
+import type { BackupResourceReporter, BackupStageReporter } from './progress'
 import { abandonKnowledgeRebuild, acknowledgeRestore, type AcknowledgeResult } from './restore/acknowledgeRestore'
 import { runPostPromotionWork } from './restore/postPromotion'
 import {
@@ -125,6 +126,8 @@ export class BackupService extends BaseService {
   private exportCleanupWork: Promise<void> | null = null
   private postPromotionPoll: Disposable | null = null
   private postPromotionSuppressed = false
+  /** Last stage reported per operation, so a unit report can name its phase. */
+  private readonly stageOf = new Map<BackupOperation, BackupProgressStage>()
 
   protected onInit(): void {
     // Lifecycle services may be restarted on the same instance.
@@ -236,9 +239,9 @@ export class BackupService extends BaseService {
    * overwrites a prior backup.
    */
   public export(outPath: string): Promise<ExportArchiveResult> {
-    return this.runExclusive('export', async (signal, reportStage) => {
+    return this.runExclusive('export', async (signal, reportStage, reportUnit) => {
       await this.startExportCleanup()
-      return exportArchive({ outPath, signal, reportStage })
+      return exportArchive({ outPath, signal, reportStage, reportUnit })
     })
   }
 
@@ -449,7 +452,7 @@ export class BackupService extends BaseService {
    */
   public async runExclusive<T>(
     operation: BackupOperation,
-    work: (signal: AbortSignal, reportStage: BackupStageReporter) => Promise<T>,
+    work: (signal: AbortSignal, reportStage: BackupStageReporter, reportUnit: BackupResourceReporter) => Promise<T>,
     options: { readonly cancellable?: boolean } = {}
   ): Promise<T> {
     if (this.shuttingDown) throw new BackupCancelledError('backup service is shutting down')
@@ -468,9 +471,14 @@ export class BackupService extends BaseService {
     }
     this.inFlight = claim
     try {
-      return await work(controller.signal, (stage) => this.reportStage(operation, stage))
+      return await work(
+        controller.signal,
+        (stage) => this.reportStage(operation, stage),
+        (unit) => this.reportResource(operation, unit)
+      )
     } finally {
       if (this.inFlight === claim) this.inFlight = null
+      this.stageOf.delete(operation)
       markSettled()
     }
   }
@@ -481,10 +489,35 @@ export class BackupService extends BaseService {
    * so a broadcast that throws must not surface as an export failure.
    */
   private reportStage(operation: BackupOperation, stage: BackupProgressStage): void {
+    this.stageOf.set(operation, stage)
+    this.emitProgress({ operation, stage })
+  }
+
+  /**
+   * Push one resource unit, tagged with the stage that is walking them.
+   *
+   * The stage comes from the last {@link reportStage} for this operation rather
+   * than from the caller: a loop reports units, not which phase it belongs to,
+   * and re-deriving that here would duplicate the pipeline's own ordering.
+   */
+  private reportResource(operation: BackupOperation, unit: Parameters<BackupResourceReporter>[0]): void {
+    const stage = this.stageOf.get(operation)
+    if (!stage) return
+    this.emitProgress({
+      operation,
+      stage,
+      resources: { done: unit.done, total: unit.total, kind: unit.kind, livePath: unit.livePath }
+    })
+  }
+
+  private emitProgress(payload: EventPayload<'backup.progress'>): void {
     try {
-      application.get('IpcApiService').broadcast('backup.progress', { operation, stage })
+      application.get('IpcApiService').broadcast('backup.progress', payload)
     } catch (error) {
-      logger.warn('Could not broadcast backup progress', error as Error, { operation, stage })
+      logger.warn('Could not broadcast backup progress', error as Error, {
+        operation: payload.operation,
+        stage: payload.stage
+      })
     }
   }
 

--- a/src/main/services/backup/export/exportArchive.ts
+++ b/src/main/services/backup/export/exportArchive.ts
@@ -37,7 +37,7 @@ import { currentBackupPlatform } from '../platform'
 import { REBASABLE_MANAGED_ROOT_KEYS } from '../portability/managedPathRebase'
 import type { MaterializationSummary } from '../portability/materializeDatabase'
 import { materializePortableDatabase, summarizeMaterializationDegradations } from '../portability/materializeDatabase'
-import type { BackupStageReporter } from '../progress'
+import type { BackupResourceReporter, BackupStageReporter } from '../progress'
 import { collectResourceRequirements, resolveResourceRoots } from '../resources/collectRequirements'
 import { createOwnerResourceCapture } from '../resources/ownerCapture'
 import { stageResources } from '../resources/stageResources'
@@ -56,6 +56,8 @@ export interface ExportArchiveInputs {
   readonly signal?: AbortSignal
   /** Names each stage boundary for the progress event; absent in tests. */
   readonly reportStage?: BackupStageReporter
+  /** Called as each resource unit is entered; absent in tests. */
+  readonly reportUnit?: BackupResourceReporter
 }
 
 export interface ExportArchiveResult {
@@ -101,7 +103,7 @@ function readSealedChain(dbPath: string): ReturnType<typeof readAppliedChain> {
 }
 
 export async function exportArchive(inputs: ExportArchiveInputs): Promise<ExportArchiveResult> {
-  const { outPath, signal, reportStage } = inputs
+  const { outPath, signal, reportStage, reportUnit } = inputs
   throwIfAborted(signal)
   reportStage?.('preparing')
 
@@ -154,7 +156,8 @@ export async function exportArchive(inputs: ExportArchiveInputs): Promise<Export
       resourcesDir,
       requiredContent: inventory.requiredContent,
       ...ownerCapture,
-      signal
+      signal,
+      reportUnit
     })
     throwIfAborted(signal)
 

--- a/src/main/services/backup/progress.ts
+++ b/src/main/services/backup/progress.ts
@@ -20,3 +20,19 @@ import type { BackupProgressStage } from '@shared/ipc/schemas/backup'
  * below never repeat it.
  */
 export type BackupStageReporter = (stage: BackupProgressStage) => void
+
+/**
+ * A resource unit is being entered, inside a stage that walks a known set.
+ *
+ * Called on ENTRY, not on completion: entry is the one point every unit passes
+ * through exactly once. A unit can leave its loop staged, skipped, degraded, or
+ * over a ceiling — reporting at those exits would mean revisiting every one of
+ * them the day a new outcome appears, and missing one would stall the count.
+ */
+export type BackupResourceReporter = (unit: {
+  kind: string
+  livePath: string
+  /** 1-based position of this unit. */
+  done: number
+  total: number
+}) => void

--- a/src/main/services/backup/resources/__tests__/stageResources.test.ts
+++ b/src/main/services/backup/resources/__tests__/stageResources.test.ts
@@ -265,6 +265,26 @@ describe('stageResources', () => {
     ])
   })
 
+  // Reporting on entry is what makes the count reach its total: the second unit
+  // here never produces a payload, and counting staged units would stall at 1/2.
+  it('counts every unit it enters, including one that degrades out', async () => {
+    writeSource('Data/Files/here.pdf', 'HERE')
+    const seen: Array<{ done: number; total: number; livePath: string }> = []
+
+    const result = await stageResources({
+      requirements: [req('file-blob', 'file', 'Data/Files/here.pdf'), req('file-blob', 'file', 'Data/Files/gone.pdf')],
+      userDataPath: userData,
+      resourcesDir,
+      reportUnit: ({ done, total, livePath }) => seen.push({ done, total, livePath })
+    })
+
+    expect(result.payloads).toHaveLength(1)
+    expect(seen).toEqual([
+      { done: 1, total: 2, livePath: 'Data/Files/here.pdf' },
+      { done: 2, total: 2, livePath: 'Data/Files/gone.pdf' }
+    ])
+  })
+
   it('omits a symlink standing where a managed directory belongs and discloses the whole unit', async () => {
     mkdirSync(join(userData, 'Data', 'KnowledgeBase'), { recursive: true })
     const target = join(userData, 'Data', 'KnowledgeBase', 'kb-1')

--- a/src/main/services/backup/resources/stageResources.ts
+++ b/src/main/services/backup/resources/stageResources.ts
@@ -30,6 +30,7 @@ import {
   type ResourcePayload,
   type ResourceRequirement
 } from '../manifest'
+import type { BackupResourceReporter } from '../progress'
 import { stageDirectoryWithDriftCheck, stageFileWithDriftCheck, stagePartialDirectoryTree } from '../sourceDrift'
 import {
   captureModeForKind,
@@ -81,6 +82,8 @@ export interface StageResourcesInput {
   readonly captureOwnerResource?: CaptureOwnerResource
   readonly runOwnerCaptureBoundary?: RunOwnerCaptureBoundary
   readonly signal?: AbortSignal
+  /** Called as each unit is entered; absent in tests. */
+  readonly reportUnit?: BackupResourceReporter
 }
 
 export interface StagedResources {
@@ -263,7 +266,8 @@ export async function stageResources(input: StageResourcesInput): Promise<Staged
     roots,
     captureOwnerResource,
     runOwnerCaptureBoundary,
-    signal
+    signal,
+    reportUnit
   } = input
   throwIfAborted(signal)
   assertRequirementSet(requirements)
@@ -273,8 +277,14 @@ export async function stageResources(input: StageResourcesInput): Promise<Staged
   let archiveEntries = FIXED_ARCHIVE_ENTRIES
   let archiveBytes = 0
 
-  for (const requirement of requirements) {
+  for (const [index, requirement] of requirements.entries()) {
     throwIfAborted(signal)
+    reportUnit?.({
+      kind: requirement.kind,
+      livePath: requirement.livePath,
+      done: index + 1,
+      total: requirements.length
+    })
     const sourcePath = absoluteOf(userDataPath, requirement.livePath)
     const stagingPath = path.join(resourcesDir, ...requirement.livePath.split('/'))
     const mode = captureModeForKind(requirement.kind)

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -372,5 +372,23 @@ export type BackupEventSchemas = {
   'backup.progress': {
     operation: 'export' | 'prepare-restore' | 'arm-restore' | 'rollback-restore'
     stage: BackupProgressStage
+    /**
+     * Present only while a stage walks a known set of resource units.
+     *
+     * Reported as each unit is ENTERED, so `done` reads "unit N of total" and
+     * `kind`/`livePath` name the unit being worked on. Entry is the one point
+     * every unit passes through exactly once — a unit can leave the loop
+     * staged, skipped, degraded, or over a ceiling, and counting exits would
+     * silently under-report the day a new outcome is added.
+     *
+     * `livePath` is userData-relative and safe to display: an external user
+     * path is never a resource unit (§3.1).
+     */
+    resources?: {
+      done: number
+      total: number
+      kind: string
+      livePath: string
+    }
   }
 }

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -401,5 +401,23 @@ export type BackupEventSchemas = {
   'backup.progress': {
     operation: 'export' | 'prepare-restore' | 'arm-restore' | 'rollback-restore'
     stage: BackupProgressStage
+    /**
+     * Present only while a stage walks a known set of resource units.
+     *
+     * Reported as each unit is ENTERED, so `done` reads "unit N of total" and
+     * `kind`/`livePath` name the unit being worked on. Entry is the one point
+     * every unit passes through exactly once — a unit can leave the loop
+     * staged, skipped, degraded, or over a ceiling, and counting exits would
+     * silently under-report the day a new outcome is added.
+     *
+     * `livePath` is userData-relative and safe to display: an external user
+     * path is never a resource unit (§3.1).
+     */
+    resources?: {
+      done: number
+      total: number
+      kind: string
+      livePath: string
+    }
   }
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

The stage stream from #17817 reports `capturing-resources` and then goes quiet. On a real profile that stage stages **85–88 resource units** and is most of an export's wall clock, so the progress indicator would sit still through the longest part of the operation — exactly the stretch that looks hung.

After this PR:

`backup.progress` gains an optional `resources: { done, total, kind, livePath }`, populated as `stageResources` walks its requirement set.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Reported on ENTRY, not on completion.** This is the load-bearing decision. A unit leaves that loop through five different exits today — staged, source-unavailable, unrebuildable-content, ceiling-exceeded, or degraded-in-catch. Counting exits means touching all five, and the day a sixth outcome is added the count silently stalls short of its total. Entry is the one point every unit passes through exactly once, so `done` reads "unit N of total" and always reaches it. A test covers the case that motivates this: two units where the second degrades out, asserting the count still reaches 2/2.
- **The counter is carried by the reporter, not accumulated in the service.** `stageResources` already knows both the index and the length, so the service stays stateless about counts and only tags the unit with the stage it is in.
- **No progress for the restore install loop.** `installResourceUnits` runs at preboot promotion, where no lifecycle service exists and the app is mid-relaunch with no window. Restore's per-resource visibility therefore covers preparation only. Called out in the contract's doc comment so the next reader does not go looking for it.
- **`livePath` is displayed as-is.** It is userData-relative and an external user path is never a resource unit (§3.1), so this leaks no filesystem layout.

The following alternatives were considered:

- **Wrapping the loop body in `try/finally` to report on every exit.** Bulletproof for exit-counting, but re-indents ~110 lines of stable code for a diff that is otherwise 6 lines, and still reports a unit that an abort skipped. Entry-reporting gets the same guarantee for one call site.
- **Byte-based progress instead of unit-based.** Units vary enormously in size (a 4 KB blob vs a Knowledge base), so bytes would be a smoother bar — but the sizes are only known after staging each unit, which is the thing being measured.

### Breaking changes

None. The payload field is optional and additive.

### Special notes for your reviewer

- **Stacked PR, 2 of 3.** Base is `feat/backup-progress-events` (#17817). Review that first.
- The whole behavioural claim is one test: `stageResources > counts every unit it enters, including one that degrades out`.
- Verification: `pnpm typecheck:node` clean; `vitest --project main src/main/services/backup` 705 passed.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
