### PR TITLE
fix(mcp): prevent stdio client process leaks

### DIFF
--- a/src/main/services/MCPService.ts
+++ b/src/main/services/MCPService.ts
@@ -151,6 +151,7 @@ function withCache<T extends unknown[], R>(
 class McpService {
   private clients: Map<string, Client> = new Map()
   private pendingClients: Map<string, Promise<Client>> = new Map()
+  private clientOperations: Map<string, Promise<Client>> = new Map()
   private dxtService = new DxtService()
   private activeToolCalls: Map<string, AbortController> = new Map()
   private serverLogs = new ServerLogBuffer(200)
@@ -261,6 +262,26 @@ class McpService {
 
   async initClient(server: MCPServer): Promise<Client> {
     const serverKey = this.getServerKey(server)
+    const pendingOperation = this.clientOperations.get(serverKey)
+    if (pendingOperation) {
+      getServerLogger(server).silly(`Waiting for pending client operation`)
+      return pendingOperation
+    }
+
+    const operation = this.initClientOnce(server)
+    this.clientOperations.set(serverKey, operation)
+
+    try {
+      return await operation
+    } finally {
+      if (this.clientOperations.get(serverKey) === operation) {
+        this.clientOperations.delete(serverKey)
+      }
+    }
+  }
+
+  private async initClientOnce(server: MCPServer): Promise<Client> {
+    const serverKey = this.getServerKey(server)
 
     // If there's a pending initialization, wait for it
     const pendingClient = this.pendingClients.get(serverKey)
@@ -272,22 +293,26 @@ class McpService {
     // Check if we already have a client for this server configuration
     const existingClient = this.clients.get(serverKey)
     if (existingClient) {
+      let pingResult: Awaited<ReturnType<Client['ping']>> | undefined
       try {
         // Check if the existing client is still connected
-        const pingResult = await existingClient.ping({
+        pingResult = await existingClient.ping({
           // add short timeout to prevent hanging
           timeout: 1000
         })
         getServerLogger(server).debug(`Ping result`, { ok: !!pingResult })
-        // If the ping fails, remove the client from the cache
-        // and create a new one
-        if (!pingResult) {
-          this.clients.delete(serverKey)
-        } else {
-          return existingClient
-        }
-      } catch (error: any) {
+      } catch (error) {
         getServerLogger(server).error(`Error pinging server ${server.name}`, error as Error)
+      }
+
+      if (pingResult) {
+        return existingClient
+      }
+
+      // Keep the stale client tracked until close succeeds. If close fails, abort
+      // replacement so we do not knowingly add another child process beside it.
+      await existingClient.close()
+      if (this.clients.get(serverKey) === existingClient) {
         this.clients.delete(serverKey)
       }
     }
@@ -649,6 +674,14 @@ class McpService {
           })
           return client
         } catch (error) {
+          try {
+            await client.close()
+            if (this.clients.get(serverKey) === client) {
+              this.clients.delete(serverKey)
+            }
+          } catch (closeError) {
+            getServerLogger(server).error(`Failed to close client after activation error`, closeError as Error)
+          }
           getServerLogger(server).error(`Error activating server ${server.name}`, error as Error)
           this.emitServerLog(server, {
             timestamp: Date.now(),
@@ -766,6 +799,10 @@ class McpService {
     }
   }
 
+  private async waitForClientOperation(serverKey: string): Promise<void> {
+    await this.clientOperations.get(serverKey)?.catch(() => undefined)
+  }
+
   async stopServer(_: Electron.IpcMainInvokeEvent, server: MCPServer) {
     const serverKey = this.getServerKey(server)
     getServerLogger(server).debug(`Stopping server`)
@@ -775,11 +812,13 @@ class McpService {
       message: 'Stopping server',
       source: 'client'
     })
+    await this.waitForClientOperation(serverKey)
     await this.closeClient(serverKey)
   }
 
   async removeServer(_: Electron.IpcMainInvokeEvent, server: MCPServer) {
     const serverKey = this.getServerKey(server)
+    await this.waitForClientOperation(serverKey)
     const existingClient = this.clients.get(serverKey)
     if (existingClient) {
       await this.closeClient(serverKey)
@@ -830,6 +869,7 @@ class McpService {
       message: 'Restarting server',
       source: 'client'
     })
+    await this.waitForClientOperation(serverKey)
     await this.closeClient(serverKey)
     // Clear cache before restarting to ensure fresh data
     this.clearServerCache(serverKey)
@@ -837,6 +877,7 @@ class McpService {
   }
 
   async cleanup() {
+    await Promise.allSettled(this.clientOperations.values())
     for (const [key] of this.clients) {
       try {
         await this.closeClient(key)

--- a/src/main/services/__tests__/MCPService.test.ts
+++ b/src/main/services/__tests__/MCPService.test.ts
@@ -1,6 +1,35 @@
 import type { MCPServer, MCPTool } from '@types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const mcpSdkMock = vi.hoisted(() => {
+  const clients: Array<InstanceType<typeof Client>> = []
+  const state = { failClose: false, failConnect: false }
+
+  class Client {
+    close = vi.fn().mockImplementation(async () => {
+      if (state.failClose) {
+        throw new Error('close failed')
+      }
+    })
+    connect = vi.fn().mockImplementation(async () => {
+      if (state.failConnect) {
+        throw new Error('connect failed')
+      }
+    })
+    ping = vi.fn().mockResolvedValue(true)
+    setNotificationHandler = vi.fn()
+
+    constructor() {
+      clients.push(this)
+    }
+  }
+
+  class SSEClientTransport {}
+  class StreamableHTTPClientTransport {}
+
+  return { Client, SSEClientTransport, StreamableHTTPClientTransport, clients, state }
+})
+
 vi.mock('@main/apiServer/utils/mcp', () => ({
   getMCPServersFromRedux: vi.fn()
 }))
@@ -11,7 +40,20 @@ vi.mock('@main/services/WindowService', () => ({
   }
 }))
 
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: mcpSdkMock.Client
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: mcpSdkMock.SSEClientTransport
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp', () => ({
+  StreamableHTTPClientTransport: mcpSdkMock.StreamableHTTPClientTransport
+}))
+
 import { getMCPServersFromRedux } from '@main/apiServer/utils/mcp'
+import { CacheService } from '@main/services/CacheService'
 import mcpService from '@main/services/MCPService'
 
 const baseInputSchema: { type: 'object'; properties: Record<string, unknown>; required: string[] } = {
@@ -30,6 +72,24 @@ const createTool = (overrides: Partial<MCPTool>): MCPTool => ({
   type: 'mcp',
   ...overrides
 })
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+function serverForReplacement(): MCPServer {
+  return {
+    id: 'replacement-server',
+    name: 'replacement-server',
+    type: 'streamableHttp',
+    baseUrl: 'https://example.com/mcp',
+    isActive: true
+  }
+}
 
 describe('MCPService.listAllActiveServerTools', () => {
   beforeEach(() => {
@@ -71,5 +131,116 @@ describe('MCPService.listAllActiveServerTools', () => {
 
     expect(listToolsSpy).toHaveBeenCalledTimes(2)
     expect(tools.map((tool) => tool.name)).toEqual(['enabled_tool', 'beta_tool'])
+  })
+})
+
+describe('MCPService client replacement lifecycle (issue #17689)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    CacheService.clear()
+    mcpSdkMock.clients.length = 0
+    mcpSdkMock.state.failClose = false
+    mcpSdkMock.state.failConnect = false
+    ;(mcpService as any).clients.clear()
+    ;(mcpService as any).pendingClients.clear()
+    if ((mcpService as any).clientOperations) {
+      ;(mcpService as any).clientOperations.clear()
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('closes a cached client whose ping throws before creating its replacement', async () => {
+    const server = serverForReplacement()
+    const staleClient = (await mcpService.initClient(server)) as unknown as InstanceType<typeof mcpSdkMock.Client>
+    staleClient.ping.mockRejectedValue(new Error('ping timed out'))
+
+    const replacement = await mcpService.initClient(server)
+
+    expect(staleClient.close).toHaveBeenCalledTimes(1)
+    expect(replacement).not.toBe(staleClient)
+    expect(mcpSdkMock.clients).toHaveLength(2)
+  })
+
+  it('coalesces concurrent unhealthy-client checks into one replacement', async () => {
+    const server = serverForReplacement()
+    const staleClient = (await mcpService.initClient(server)) as unknown as InstanceType<typeof mcpSdkMock.Client>
+    const ping = createDeferred<boolean>()
+    staleClient.ping.mockImplementation(() => ping.promise)
+
+    const requests = Array.from({ length: 7 }, () => mcpService.initClient(server))
+    await new Promise((resolve) => setImmediate(resolve))
+    ping.resolve(false)
+    const replacements = await Promise.all(requests)
+
+    expect(staleClient.ping).toHaveBeenCalledTimes(1)
+    expect(staleClient.close).toHaveBeenCalledTimes(1)
+    expect(new Set(replacements).size).toBe(1)
+    expect(mcpSdkMock.clients).toHaveLength(2)
+  })
+
+  it('does not create a replacement when the stale client cannot be closed', async () => {
+    const server = serverForReplacement()
+    const staleClient = (await mcpService.initClient(server)) as unknown as InstanceType<typeof mcpSdkMock.Client>
+    staleClient.ping.mockResolvedValue(false)
+    staleClient.close.mockRejectedValue(new Error('close failed'))
+
+    await expect(mcpService.initClient(server)).rejects.toThrow('close failed')
+    expect(mcpSdkMock.clients).toHaveLength(1)
+    expect((mcpService as any).clients.get((mcpService as any).getServerKey(server))).toBe(staleClient)
+  })
+
+  it('closes a newly created client when activation fails and allows a later retry', async () => {
+    const server = serverForReplacement()
+    mcpSdkMock.state.failConnect = true
+
+    await expect(mcpService.initClient(server)).rejects.toThrow('connect failed')
+
+    expect(mcpSdkMock.clients).toHaveLength(1)
+    expect(mcpSdkMock.clients[0].close).toHaveBeenCalledTimes(1)
+    expect((mcpService as any).clientOperations.size).toBe(0)
+
+    mcpSdkMock.state.failConnect = false
+    await expect(mcpService.initClient(server)).resolves.toBeInstanceOf(mcpSdkMock.Client)
+    expect(mcpSdkMock.clients).toHaveLength(2)
+  })
+
+  it('keeps a tracked client when activation cleanup cannot close it', async () => {
+    const server = serverForReplacement()
+    mcpSdkMock.state.failClose = true
+    vi.spyOn(CacheService, 'remove').mockImplementationOnce(() => {
+      throw new Error('cache cleanup failed')
+    })
+
+    await expect(mcpService.initClient(server)).rejects.toThrow('cache cleanup failed')
+
+    const client = mcpSdkMock.clients[0]
+    expect(client.close).toHaveBeenCalledTimes(1)
+    expect((mcpService as any).clients.get((mcpService as any).getServerKey(server))).toBe(client)
+  })
+
+  it('waits for an in-flight client operation before stopping the server', async () => {
+    const server = serverForReplacement()
+    const serverKey = (mcpService as any).getServerKey(server)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const deferred = createDeferred<{ close: typeof close }>()
+    const operation = deferred.promise.then((client) => {
+      ;(mcpService as any).clients.set(serverKey, client)
+      return client
+    })
+    ;(mcpService as any).clientOperations = new Map([[serverKey, operation]])
+    let stopped = false
+
+    const stopPromise = mcpService.stopServer(null as unknown as Electron.IpcMainInvokeEvent, server).then(() => {
+      stopped = true
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(stopped).toBe(false)
+    deferred.resolve({ close })
+    await stopPromise
+    expect(close).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

- MCPService.initClient() deleted an unhealthy cached client without closing it, leaving its stdio child process alive.
- The pending-client guard was installed only after the asynchronous ping and environment setup, so concurrent callers could each create a replacement client while only the last one remained tracked.

After this PR:

- Health checks, stale-client cleanup, and replacement initialization are serialized per server key.
- Stale and partially initialized clients are closed before replacement or retry.
- Stop, remove, restart, and cleanup paths wait for in-flight client operations.
- Regression tests cover failed pings, concurrent replacement, close/connect failures, retry behavior, and teardown during initialization.

Fixes #17689

### Why we need it and why it was done in this way

The v1.9.12 lifecycle allowed live stdio MCP child processes to become untracked. Repeated health-check failures or concurrent gateway requests could therefore accumulate child processes and increase memory usage over long sessions.

A per-server single-flight operation covers the complete health-check and replacement lifecycle. Cleanup failures remain observable and tracked instead of being hidden by deleting the client reference.

The following tradeoffs were made:

- Concurrent callers for the same server wait on one operation, prioritizing lifecycle correctness over parallel initialization.
- If a stale client cannot be closed, replacement is aborted so another untracked process is not created.

The following alternatives were considered:

- Moving the existing pending assignment earlier was insufficient because it did not cover stale-client cleanup and teardown coordination.
- Closing only after deletion was rejected because a close failure would lose the final tracked reference.

Links to places where the discussion took place:

- #17689

### Breaking changes

None.

### Special notes for your reviewer

This is a minimal v1 hotfix. It changes only MCPService lifecycle coordination and its focused test suite.

Checks run:

- pnpm test:main -- src/main/services/__tests__/MCPService.test.ts (7/7)
- pnpm typecheck:node
- pnpm exec oxlint --deny-warnings src/main/services/MCPService.ts src/main/services/__tests__/MCPService.test.ts
- pnpm exec eslint src/main/services/MCPService.ts src/main/services/__tests__/MCPService.test.ts
- pnpm exec biome format src/main/services/MCPService.ts src/main/services/__tests__/MCPService.test.ts
- git diff --check

The full Electron/native build was not run in this Windows environment; dependencies were installed with lifecycle scripts disabled.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The change is focused and keeps the lifecycle logic explicit
- [x] Refactor: No unrelated refactoring is included
- [x] Upgrade: No migration or upgrade-flow change is required
- [x] Documentation: No user-guide update is required
- [x] Self-review: The remote diff and focused checks were reviewed before opening this draft

### Release note

```release-note
Prevent MCP stdio child processes from leaking during client replacement.
```