### PR TITLE
refactor(ui-theme): separate v2 theme variable semantics

### DIFF
--- a/packages/ui/docs/design-token-system.md
+++ b/packages/ui/docs/design-token-system.md
@@ -39,7 +39,7 @@ foundation values
               │
               ▼
 controlled runtime inputs
-  (--cs-theme-primary, --cs-theme-primary-foreground)
+  (--cs-theme-control-accent, --cs-theme-control-accent-foreground)
               │
               ▼
 public semantic contract
@@ -76,13 +76,14 @@ This contract includes:
 6. a machine-readable registry and syntax-aware exact-migration codemod;
 7. owner-local values for historical rendering that has no stable shared semantic role;
 8. renderer boundary checks that keep removed compatibility layers and authored `--color-*` usage from returning.
+9. the shared Lucide icon stroke used across product and shared UI components.
 
 This contract does not include:
 
 - contextual or review-only migration rules that require UI judgment;
 - promotion of historical or owner-local values without semantic and visual review;
 - renaming every primitive to a new reference-token namespace;
-- redesigning spacing, typography, shadow, or motion scales;
+- redesigning spacing, typography, shadow, or motion scales beyond the shared icon stroke;
 - adopting DTCG JSON as a required build input;
 - changing the current visual palette merely to resemble a Shadcn demo theme.
 
@@ -110,19 +111,18 @@ product role.
 `theme-input.css` owns the small, explicit set of values that runtime theme code may write:
 
 ```css
---cs-theme-primary
---cs-theme-primary-foreground
+--cs-theme-control-accent
+--cs-theme-control-accent-foreground
 ```
 
-These variables are inputs, not design semantics. The host theme service writes them; `shadcn.css` decides which
-official role consumes them. Components must not consume them directly, and the Tailwind generator must not emit
+These variables are inputs, not design semantics. The host theme service writes them; the semantic layers decide
+which public roles consume them. Components must not consume them directly, and the Tailwind generator must not emit
 `--color-theme-*` aliases for them. Every input must be registered in `RUNTIME_THEME_INPUT_TOKENS`, have an
 authored foundation fallback, and have a real runtime producer plus a semantic consumer.
 
-This boundary deliberately avoids asserting that a user-selected color is permanently identical to Shadcn
-`primary`. The host writes the primary surface and its derived contrast-safe foreground as one runtime theme
-operation. A future consumer-backed theme model may route the same inputs to different semantic roles without
-changing component APIs.
+The host writes the selected control accent and its derived contrast-safe foreground as one runtime theme
+operation. Shadcn `primary` remains a neutral strong-action role; the product layer routes the runtime pair to
+`control-accent` / `control-accent-foreground`. `link` remains on the fixed light/dark blue scale.
 
 Renderer-only runtime settings are not shared theme inputs. For example, user-selected UI and code fonts are
 written as `--app-user-font-family` and `--app-user-code-font-family` and consumed only by the renderer-owned
@@ -312,7 +312,8 @@ The contract preserves current design decisions by using the existing semantic l
 | `foreground` | `--cs-foreground` |
 | `card` / `card-foreground` | `--cs-card` / `--cs-card-foreground` |
 | `popover` / `popover-foreground` | `--cs-popover` / `--cs-popover-foreground` |
-| `primary` / `primary-foreground` | paired runtime primary inputs |
+| `primary` / `primary-foreground` | neutral `--cs-primary` / `--cs-primary-foreground` providers |
+| `control-accent` / `control-accent-foreground` | paired runtime theme inputs in the product contract |
 | `secondary` / `secondary-foreground` | `--cs-secondary` / `--cs-secondary-foreground` |
 | `muted` / `muted-foreground` | `--cs-muted` / `--cs-muted-foreground` |
 | `accent` / `accent-foreground` | `--cs-accent` / `--cs-accent-foreground` |
@@ -340,8 +341,8 @@ with:
 
 Foreground roles use solid providers so their resolved foreground color does not change with the surface beneath
 them. Contrast still depends on the foreground/background pair and must be validated on every supported surface.
-`--link` is independent from `--primary` and uses the mode-aware product defaults `--cs-blue-600` in light mode and
-`--cs-blue-400` in dark mode.
+`--link` is independent from both `--primary` and the runtime `--control-accent`; clickable text uses the fixed blue
+scale (`--cs-blue-600` in light mode and `--cs-blue-400` in dark mode).
 
 The feedback intents are:
 
@@ -419,20 +420,18 @@ theme mappings continue to work, but changing their architecture requires separa
 
 Initial supported modes are `:root` and `.dark`.
 
-The current runtime primary inputs are declared in `theme-input.css` and remain supported:
+The runtime control-accent inputs are declared in `theme-input.css`:
 
 ```css
---cs-theme-primary
---cs-theme-primary-foreground
+--cs-theme-control-accent
+--cs-theme-control-accent-foreground
 ```
 
-`useUserTheme` writes the selected primary and derives its foreground by choosing the black or white value with
-the stronger WCAG contrast ratio. `--ring` resolves independently through the mode-aware `--cs-ring` provider, so
-an extreme user primary such as white in light mode or black in dark mode cannot also make the focus indicator
-disappear. Runtime code still does not mutate official semantics, `--color-primary`, or component variables
-directly. Renderer-owned font selection is separate from this shared graph and writes only host-local
-`--app-user-*` variables. The current primary connection is a compatibility mapping, not a promise that runtime
-selection and Shadcn primary are the same concept forever.
+`useUserTheme` writes the selected accent and derives its foreground by choosing the black or white value with
+the stronger WCAG contrast ratio. Neutral `--primary` and mode-aware `--ring` remain independent, so an extreme
+user accent cannot make strong actions or focus indicators disappear. Runtime code still does not mutate public
+semantics, generated `--color-*` adapters, or component variables directly. Renderer-owned font selection is
+separate from this shared graph and writes only host-local `--app-user-*` variables.
 
 Rules:
 

--- a/packages/ui/docs/variable-catalog.md
+++ b/packages/ui/docs/variable-catalog.md
@@ -39,8 +39,8 @@ contract use `styles/theme.css`.
 
 ## 3. Runtime inputs and local implementation variables
 
-The current registered runtime inputs are `--cs-theme-primary` and `--cs-theme-primary-foreground`. Host theme
-logic writes them as a pair, deriving the foreground for contrast; only the semantic layer may consume them.
+The registered runtime inputs are `--cs-theme-control-accent` and `--cs-theme-control-accent-foreground`. Host
+theme logic writes them as a pair, deriving the foreground for contrast; only the semantic layer may consume them.
 They are not stable product variables, component APIs, or Tailwind colors.
 
 Renderer-only runtime inputs use the owner-local `--app-*` namespace instead of the shared `--cs-*` namespace.
@@ -122,7 +122,10 @@ Stable product variables are allowed in new code when no official Shadcn role ex
 | `--border-subtle` | Very quiet `border-color` |
 | `--border-strong` | Higher-emphasis structural `border-color` |
 | `--border-selected` | Selected-state `border-color`; focus remains `--ring` |
-| `--link` | Clickable text `color`; independent default blue, separate from `--primary` |
+| `--control-accent` | User-selected accent for checked controls and interactive selection state |
+| `--control-accent-foreground` | Contrast-safe content on a `--control-accent` surface |
+| `--link` | Clickable text `color`; fixed blue (`--cs-blue-600` light / `--cs-blue-400` dark) |
+| `--icon-stroke` | Default `stroke-width` for product Lucide icons |
 
 ### Feedback families
 

--- a/packages/ui/scripts/__tests__/build-theme-css.test.ts
+++ b/packages/ui/scripts/__tests__/build-theme-css.test.ts
@@ -67,6 +67,8 @@ describe('buildThemeContractCss', () => {
     expect(css).toContain('--color-foreground-tertiary: var(--foreground-tertiary);')
     expect(css).toContain('--color-foreground-disabled: var(--foreground-disabled);')
     expect(css).toContain('--color-border-selected: var(--border-selected);')
+    expect(css).toContain('--color-control-accent: var(--control-accent);')
+    expect(css).toContain('--color-control-accent-foreground: var(--control-accent-foreground);')
     expect(css).toContain('--color-link: var(--link);')
     expect(css).toContain('--color-ring: var(--ring);')
     expect(css).not.toContain('--color-primary: var(--cs-theme-primary);')

--- a/packages/ui/scripts/__tests__/validate-migration-contract.test.ts
+++ b/packages/ui/scripts/__tests__/validate-migration-contract.test.ts
@@ -165,18 +165,12 @@ describe('validateMigrationContractSources', () => {
     }
   })
 
-  it('keeps the runtime-accent link migration under review', () => {
+  it('keeps the historical runtime-accent link on the canonical link role', () => {
     const registry = JSON.parse(sources.migrationRegistry) as {
       rules: Array<{ source: string; target: string | null; strategy: string }>
     }
 
-    expect(registry.rules).toContainEqual(
-      expect.objectContaining({
-        source: '--cs-link',
-        target: null,
-        strategy: 'review'
-      })
-    )
+    expect(registry.rules).toContainEqual({ source: '--cs-link', target: '--link', strategy: 'exact' })
   })
 
   it('keeps renderer Sidebar effects out of the shared migration contract', () => {
@@ -274,7 +268,7 @@ describe('validateMigrationContractSources', () => {
         ...sources,
         rendererTypeScriptSources: {
           'example.ts': `
-            document.documentElement.style.setProperty('--cs-theme-primary', '#00b96b')
+            document.documentElement.style.setProperty('--cs-theme-control-accent', '#00b96b')
             document.documentElement.style.setProperty('--app-user-font-family', 'Inter')
           `
         }

--- a/packages/ui/scripts/__tests__/validate-theme-contract.test.ts
+++ b/packages/ui/scripts/__tests__/validate-theme-contract.test.ts
@@ -21,21 +21,35 @@ describe('validateThemeContractSources', () => {
     expect(() => validateThemeContractSources(sources)).not.toThrow()
   })
 
-  it('pairs the runtime primary with an adaptive foreground and an independent ring', async () => {
+  it('routes the runtime accent through a paired product semantic and keeps primary neutral', async () => {
     const sources = await loadSources()
 
-    expect(sources.themeInput).toContain('--cs-theme-primary-foreground: var(--cs-primary-foreground);')
-    expect(sources.shadcn).toContain('--primary-foreground: var(--cs-theme-primary-foreground);')
+    expect(sources.themeInput).toContain('--cs-theme-control-accent: var(--cs-brand-500);')
+    expect(sources.themeInput).toContain('--cs-theme-control-accent-foreground: var(--cs-neutral-950);')
+    expect(sources.shadcn).toContain('--primary: var(--cs-primary);')
+    expect(sources.product).toContain('--control-accent: var(--cs-theme-control-accent);')
+    expect(sources.product).toContain('--control-accent-foreground: var(--cs-theme-control-accent-foreground);')
     expect(sources.shadcn).toContain('--ring: var(--cs-ring);')
-    expect(sources.shadcn).not.toContain('--ring: color-mix(in srgb, var(--primary)')
   })
 
-  it('keeps product links independent from the runtime primary', async () => {
+  it('keeps product links on the fixed light and dark blue scale', async () => {
     const sources = await loadSources()
 
     expect(sources.product).toContain('--link: var(--cs-blue-600);')
     expect(sources.product).toContain('--link: var(--cs-blue-400);')
+    expect(sources.product).not.toContain('--link: var(--control-accent);')
     expect(sources.product).not.toContain('--link: var(--primary);')
+  })
+
+  it('preserves the v2 light and dark foundation palette', async () => {
+    const sources = await loadSources()
+
+    expect(sources.providerColors).toContain('--cs-background: #ffffff;')
+    expect(sources.providerColors).toContain('--cs-foreground: #1a1c1f;')
+    expect(sources.providerColors).toContain('--cs-sidebar: #f7f8f7;')
+    expect(sources.providerColors).toContain('--cs-background: #1515148c;')
+    expect(sources.providerColors).toContain('--cs-foreground: #e8e9eb;')
+    expect(sources.providerColors).toContain('--cs-sidebar: #1c1d1a;')
   })
 
   it('rejects cross-layer duplicate ownership', async () => {
@@ -48,7 +62,7 @@ describe('validateThemeContractSources', () => {
   it('rejects an upward dependency from the foundation layer', async () => {
     const sources = await loadSources()
     sources.providerColors = sources.providerColors.replace(
-      '--cs-primary: var(--cs-brand-500);',
+      '--cs-primary: var(--cs-neutral-900);',
       '--cs-primary: var(--background);'
     )
 
@@ -58,7 +72,7 @@ describe('validateThemeContractSources', () => {
   it('rejects a product dependency from the foundation layer', async () => {
     const sources = await loadSources()
     sources.providerColors = sources.providerColors.replace(
-      '--cs-primary: var(--cs-brand-500);',
+      '--cs-primary: var(--cs-neutral-900);',
       '--cs-primary: var(--success);'
     )
 
@@ -84,7 +98,7 @@ describe('validateThemeContractSources', () => {
   it('resolves references with whitespace after var opening', async () => {
     const sources = await loadSources()
     sources.providerColors = sources.providerColors.replace(
-      '--cs-primary: var(--cs-brand-500);',
+      '--cs-primary: var(--cs-neutral-900);',
       '--cs-primary: var( --cs-missing-primary);'
     )
 
@@ -114,7 +128,7 @@ describe('validateThemeContractSources', () => {
 
   it('rejects an upper-layer dependency from a runtime input', async () => {
     const sources = await loadSources()
-    sources.themeInput = sources.themeInput.replace('var(--cs-primary)', 'var(--primary)')
+    sources.themeInput = sources.themeInput.replace('var(--cs-brand-500)', 'var(--primary)')
 
     expect(() => validateThemeContractSources(sources)).toThrow(/runtime input .* cannot depend on upper-layer/)
   })
@@ -154,7 +168,7 @@ describe('validateThemeContractSources', () => {
   it('rejects unresolved references introduced by a dark override', async () => {
     const sources = await loadSources()
     sources.providerColors = sources.providerColors.replace(
-      '--cs-background: oklch(0.209 0 0 / 0.55);',
+      '--cs-background: #1515148c;',
       '--cs-background: var( --cs-missing-dark-background);'
     )
 

--- a/packages/ui/scripts/migrations/shadcn-v2.json
+++ b/packages/ui/scripts/migrations/shadcn-v2.json
@@ -85,6 +85,12 @@
     { "source": "--cs-border-subtle", "target": "--border-subtle", "strategy": "exact" },
     { "source": "--cs-border-strong", "target": "--border-strong", "strategy": "exact" },
     { "source": "--cs-border-selected", "target": "--border-selected", "strategy": "exact" },
+    { "source": "--cs-control-accent", "target": "--control-accent", "strategy": "exact" },
+    {
+      "source": "--cs-control-accent-foreground",
+      "target": "--control-accent-foreground",
+      "strategy": "exact"
+    },
     { "source": "--cs-success", "target": "--success", "strategy": "exact" },
     { "source": "--cs-success-subtle", "target": "--success-subtle", "strategy": "exact" },
     {
@@ -113,12 +119,8 @@
       "strategy": "exact"
     },
     { "source": "--cs-error-border", "target": "--error-border", "strategy": "exact" },
-    {
-      "source": "--cs-link",
-      "target": null,
-      "strategy": "review",
-      "reason": "The historical link followed the runtime accent text input, while the product link now uses an independent mode-aware blue."
-    },
+    { "source": "--cs-link", "target": "--link", "strategy": "exact" },
+    { "source": "--cs-icon-stroke", "target": "--icon-stroke", "strategy": "exact" },
     { "source": "--cs-code-block", "target": "--code-block", "strategy": "exact" },
     { "source": "--cs-inline-code", "target": "--inline-code", "strategy": "exact" },
     {

--- a/packages/ui/scripts/theme-contract.ts
+++ b/packages/ui/scripts/theme-contract.ts
@@ -9,7 +9,7 @@
  * - Tailwind color variables are generated only for roles used as utilities.
  */
 
-export const RUNTIME_THEME_INPUT_TOKENS = ['primary', 'primary-foreground'] as const
+export const RUNTIME_THEME_INPUT_TOKENS = ['control-accent', 'control-accent-foreground'] as const
 
 export const SHADCN_COLOR_TOKENS = [
   'background',
@@ -70,7 +70,10 @@ export const CHERRY_PRODUCT_VARIABLE_TOKENS = [
   'border-subtle',
   'border-strong',
   'border-selected',
+  'control-accent',
+  'control-accent-foreground',
   'link',
+  'icon-stroke',
 
   /* Feedback */
   'success',
@@ -110,6 +113,8 @@ export const CHERRY_PRODUCT_COLOR_TOKENS = [
   'border-subtle',
   'border-strong',
   'border-selected',
+  'control-accent',
+  'control-accent-foreground',
   'link',
   'success',
   'success-subtle',
@@ -149,6 +154,7 @@ export const COMPATIBILITY_COLOR_TOKENS = [
 ] as const
 
 export const CHERRY_PRODUCT_SURFACE_PAIRS = [
+  ['control-accent', 'control-accent-foreground'],
   ['success-subtle', 'success-subtle-foreground'],
   ['warning-subtle', 'warning-subtle-foreground'],
   ['info-subtle', 'info-subtle-foreground'],

--- a/packages/ui/src/styles/product.css
+++ b/packages/ui/src/styles/product.css
@@ -15,7 +15,10 @@
   --border-subtle: var(--cs-border-subtle);
   --border-strong: var(--cs-border-strong);
   --border-selected: var(--cs-border-selected);
+  --control-accent: var(--cs-theme-control-accent);
+  --control-accent-foreground: var(--cs-theme-control-accent-foreground);
   --link: var(--cs-blue-600);
+  --icon-stroke: var(--cs-icon-stroke);
 
   /* Feedback */
   --success: var(--cs-success);

--- a/packages/ui/src/styles/shadcn.css
+++ b/packages/ui/src/styles/shadcn.css
@@ -16,8 +16,8 @@
   --card-foreground: var(--cs-card-foreground);
   --popover: var(--cs-popover);
   --popover-foreground: var(--cs-popover-foreground);
-  --primary: var(--cs-theme-primary);
-  --primary-foreground: var(--cs-theme-primary-foreground);
+  --primary: var(--cs-primary);
+  --primary-foreground: var(--cs-primary-foreground);
   --secondary: var(--cs-secondary);
   --secondary-foreground: var(--cs-secondary-foreground);
   --muted: var(--cs-muted);

--- a/packages/ui/src/styles/theme-input.css
+++ b/packages/ui/src/styles/theme-input.css
@@ -7,7 +7,7 @@
  */
 
 :root {
-  /* Current compatibility inputs written by useUserTheme. */
-  --cs-theme-primary: var(--cs-primary);
-  --cs-theme-primary-foreground: var(--cs-primary-foreground);
+  /* User-selected accent and its contrast-safe foreground. */
+  --cs-theme-control-accent: var(--cs-brand-500);
+  --cs-theme-control-accent-foreground: var(--cs-neutral-950);
 }

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -315,6 +315,8 @@
   --color-border-subtle: var(--border-subtle);
   --color-border-strong: var(--border-strong);
   --color-border-selected: var(--border-selected);
+  --color-control-accent: var(--control-accent);
+  --color-control-accent-foreground: var(--control-accent-foreground);
   --color-link: var(--link);
   --color-success: var(--success);
   --color-success-subtle: var(--success-subtle);
@@ -387,6 +389,7 @@
   --font-weight-regular: var(--cs-font-weight-regular);
   --font-weight-medium: var(--cs-font-weight-medium);
   --font-weight-bold: var(--cs-font-weight-bold);
+  --icon-stroke: var(--cs-icon-stroke);
   --font-size-body-xs: var(--cs-font-size-body-xs);
   --font-size-body-sm: var(--cs-font-size-body-sm);
   --font-size-body-md: var(--cs-font-size-body-md);

--- a/packages/ui/src/styles/tokens/colors/providers.css
+++ b/packages/ui/src/styles/tokens/colors/providers.css
@@ -12,7 +12,7 @@
 
 :root {
   /* Brand Colors */
-  --cs-primary: var(--cs-brand-500);
+  --cs-primary: var(--cs-neutral-900);
   --cs-destructive: var(--cs-red-500);
   --cs-destructive-hover: var(--cs-red-400);
   --cs-success: var(--cs-green-500);
@@ -20,9 +20,9 @@
   --cs-info: var(--cs-blue-500);
 
   /* Background & Foreground */
-  --cs-background: var(--cs-white);
+  --cs-background: #ffffff;
   --cs-background-subtle: oklch(0 0 0 / 0.02);
-  --cs-foreground: oklch(0.213 0 0);
+  --cs-foreground: #1a1c1f;
   --cs-muted-foreground: oklch(0.556 0 0);
   --cs-foreground-tertiary: oklch(0.669 0 0);
   --cs-foreground-disabled: var(--cs-foreground-tertiary);
@@ -49,7 +49,7 @@
   --cs-ghost-active: oklch(0 0 0 / 0.1); /* Ghost Button Active */
 
   /* Sidebar */
-  --cs-sidebar: oklch(0.9672 0 0);
+  --cs-sidebar: #f7f8f7;
   --cs-sidebar-accent: oklch(0.97 0 0);
 
   /* Surface-paired foregrounds */
@@ -95,14 +95,15 @@
 
 /* Dark Mode */
 .dark {
+  --cs-primary: var(--cs-neutral-100);
   --cs-success: var(--cs-green-400);
   --cs-warning: var(--cs-amber-400);
   --cs-info: var(--cs-blue-400);
 
   /* Background & Foreground */
-  --cs-background: oklch(0.209 0 0 / 0.55);
+  --cs-background: #1515148c;
   --cs-background-subtle: oklch(1 0 0 / 0.02);
-  --cs-foreground: oklch(0.931 0 0);
+  --cs-foreground: #e8e9eb;
   --cs-muted-foreground: oklch(0.708 0 0);
   --cs-foreground-tertiary: oklch(0.559 0 0);
 
@@ -117,8 +118,8 @@
   --cs-border-strong: oklch(1 0 0 / 0.2);
   --cs-border-selected: oklch(1 0 0 / 0.3);
 
-  /* Ring (Focus) - 保持不变 */
-  --cs-ring: oklch(0.76 0.204 131 / 0.4);
+  /* Ring (Focus) */
+  --cs-ring: color-mix(in srgb, var(--cs-primary) 40%, transparent);
 
   /* UI Element Colors - Dark Mode */
   --cs-secondary: oklch(1 0 0 / 0.1); /* Secondary Button Background */
@@ -129,7 +130,7 @@
   --cs-ghost-active: oklch(1 0 0 / 0.15); /* Ghost Button Active */
 
   /* Sidebar */
-  --cs-sidebar: oklch(0.2393 0 0);
+  --cs-sidebar: #1c1d1a;
   --cs-sidebar-accent: oklch(0.269 0 0);
 
   /* Surface-paired foregrounds */

--- a/packages/ui/src/styles/tokens/typography.css
+++ b/packages/ui/src/styles/tokens/typography.css
@@ -13,6 +13,9 @@
   --cs-font-weight-medium: 500;
   --cs-font-weight-bold: 700;
 
+  /* Iconography */
+  --cs-icon-stroke: 1.6;
+
   /* Font Sizes - Body */
   --cs-font-size-body-xs: 0.75rem; /* 12px */
   --cs-font-size-body-sm: 0.875rem; /* 14px */

--- a/src/renderer/hooks/__tests__/useUserTheme.test.ts
+++ b/src/renderer/hooks/__tests__/useUserTheme.test.ts
@@ -19,7 +19,7 @@ describe('useUserTheme', () => {
 
     act(() => result.current.initUserTheme({ colorPrimary: primary }))
 
-    expect(document.documentElement.style.getPropertyValue('--cs-theme-primary-foreground')).toBe(foreground)
+    expect(document.documentElement.style.getPropertyValue('--cs-theme-control-accent-foreground')).toBe(foreground)
   })
 
   it('keeps user font inputs in the renderer-owned namespace', () => {

--- a/src/renderer/hooks/useUserTheme.ts
+++ b/src/renderer/hooks/useUserTheme.ts
@@ -19,8 +19,11 @@ export default function useUserTheme() {
   const initUserTheme = (theme: { colorPrimary: string } = { colorPrimary }) => {
     const colorPrimary = Color(theme.colorPrimary)
 
-    document.documentElement.style.setProperty('--cs-theme-primary', colorPrimary.toString())
-    document.documentElement.style.setProperty('--cs-theme-primary-foreground', getForegroundColor(colorPrimary.hex()))
+    document.documentElement.style.setProperty('--cs-theme-control-accent', colorPrimary.toString())
+    document.documentElement.style.setProperty(
+      '--cs-theme-control-accent-foreground',
+      getForegroundColor(colorPrimary.hex())
+    )
     setOptionalCssVar('--app-user-font-family', userFontFamily)
     setOptionalCssVar('--app-user-code-font-family', userCodeFontFamily)
   }


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- The runtime theme color fed Shadcn `primary`, mixing strong actions, selected controls, and user accent semantics.
- Theme inputs were named as primary roles even though they were host-written implementation inputs.
- Link, focus, and icon-stroke contracts were not fully separated from the action/accent model.

After this PR:

- `primary` is a neutral, contrast-bearing strong-action role in both light and dark themes.
- The runtime theme color writes `control-accent` and `control-accent-foreground` only.
- Clickable text uses a fixed blue `link` role (`--cs-blue-600` light / `--cs-blue-400` dark).
- Focus ring color remains mode-aware and independent from extreme user accent colors.
- The shared Lucide icon stroke is exposed through the product token contract.
- Theme generation, migration metadata, validation tests, and token documentation describe the same contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

None

### Why we need it and why it was done in this way

Strong actions, selected controls, and links have different contrast and interaction responsibilities. Giving each one a dedicated semantic role prevents a user-selected color from weakening primary actions, focus indicators, or link recognition while keeping component APIs semantic.

The following tradeoffs were made:

- This introduces explicit control-accent inputs and requires selection-state consumers to migrate in the dependent component PRs.
- Neutral provider values are intentionally defined centrally instead of being restated by individual components.

The following alternatives were considered:

- Keep the user color connected to `primary`: rejected because action contrast and selection customization remain coupled.
- Hard-code accent colors in controls: rejected because it bypasses the shared theme contract.
- Make links follow the user accent: rejected in favor of a stable, recognizable blue link color.

Links to places where the discussion took place: #16503, #16505

### Breaking changes

The private runtime input names change from `--cs-theme-primary*` to `--cs-theme-control-accent*`. Supported public component roles remain semantic; custom CSS that depended on the private input names should use `--primary`, `--control-accent`, or `--link` according to intent.

### Special notes for your reviewer

- This is stack 1/3 and targets `main`.
- Stack 2 is #16503 (shared components); stack 3 is #16505 (business components and App Shell).
- The review fixes did not modify this variable branch; it remains at `0ca85a3703`.
- Validation: this unchanged variable head retains its passing CI; both dependent review-fix heads also pass manually dispatched full CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Separated neutral primary actions, user-selected control accents, fixed-blue links, and focus colors in the v2 theme system.
```
