### PR TITLE
fix(provider-settings): normalize deep-link addProviderData to string

### DIFF
--- a/src/renderer/routes/settings/provider.tsx
+++ b/src/renderer/routes/settings/provider.tsx
@@ -2,8 +2,14 @@ import { ProviderSettingsPage } from '@renderer/pages/settings/ProviderSettings'
 import { createFileRoute } from '@tanstack/react-router'
 import * as z from 'zod'
 
-const providerSettingsSearchSchema = z.object({
-  addProviderData: z.string().optional(),
+export const providerSettingsSearchSchema = z.object({
+  // The deep-link payload is a JSON-object string, but TanStack Router's default
+  // parseSearch JSON-parses query values, so this arrives as an object. Accept both
+  // and normalize back to the string the downstream consumer (JSON.parse) expects.
+  addProviderData: z
+    .union([z.string(), z.record(z.string(), z.unknown())])
+    .optional()
+    .transform((value) => (value == null || typeof value === 'string' ? value : JSON.stringify(value))),
   filter: z.string().optional(),
   id: z.string().optional()
 })


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: opening a one-click provider import deep link (`cherrystudio://providers/api-keys`, used by NewAPI and custom third-party providers) crashed the Model Provider settings page with `invalid_type` / `expected: "string"` on `addProviderData`.

After this PR: the `/settings/provider` route schema accepts `addProviderData` as either a string or an object and normalizes it back to a string. TanStack Router's default `parseSearch` JSON-parses query values, so the JSON-object payload arrived as an object and failed the previous `z.string()` validation; normalizing it restores the string contract the downstream `JSON.parse` consumer expects (matching the v1 behavior).

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: normalize inside the route search schema so no downstream consumer (`useProviderDeepLinkImport`) has to change.

The following alternatives were considered: switching the consumer to accept the parsed object directly, or base64-encoding the payload in the deep link; both touch more surface area than the schema-level normalization.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

The reported "endpoint/protocol type reverting to Anthropic after closing the settings page" is a separate sync-overwrite path and is not addressed here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix a crash on the Model Provider settings page when importing a third-party provider (e.g. NewAPI) via one-click deep link.
```
