### PR TITLE
fix(agents-migration): copy shared v1 workspace once into the latest session

### DIFF
--- a/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.sessionCache.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/AgentsMigrator.sessionCache.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -261,11 +261,14 @@ describe('AgentsMigrator Claude session cache integration', () => {
     expect(messages.map((message) => message.runtimeResumeToken).sort()).toEqual(
       [CLAUDE_SESSION_IDS[0], CLAUDE_SESSION_IDS[0], CLAUDE_SESSION_IDS[1], ''].sort()
     )
+    // The shared v1 workspace content is materialized only into the latest
+    // session; the older session keeps an empty system workspace (issue #17830).
+    expect(await readFile(path.join(workspace.path, 'workspace.txt'), 'utf8')).toBe('legacy workspace')
     const [oldWorkspace] = await dbh.db
       .select()
       .from(agentWorkspaceTable)
       .where(eq(agentWorkspaceTable.id, oldSession.workspaceId))
-    expect(await readFile(path.join(oldWorkspace.path, 'workspace.txt'), 'utf8')).toBe('legacy workspace')
+    expect(await readdir(oldWorkspace.path)).toEqual([])
 
     const migratedProjectDirectory = path.join(
       claudeProjectsDir,

--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -678,9 +678,10 @@ describe('agentsFilesystemMigration', () => {
         path.join(agentDataPath, 'USER.md')
       )
       expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'memory-link'), 'utf8')).toBe('remember this')
-      expect(await readFile(path.join(oldSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
-        'workspace content'
-      )
+      // The shared v1 workspace is materialized only into the latest session; the
+      // older session keeps an empty system workspace (issue #17830).
+      expect((await lstat(oldSession.systemWorkspacePath!)).isDirectory()).toBe(true)
+      expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
 
       // The complete v1 workspace remains available for downgrade compatibility
       // even after the v2 destinations have been verified and published.
@@ -708,7 +709,7 @@ describe('agentsFilesystemMigration', () => {
     }
   )
 
-  it('copies ordinary output for every managed session without an age limit', async () => {
+  it('copies the shared workspace content only into the most recently active managed session', async () => {
     const { agentsDataRoot, legacyWorkspace } = await createFixture()
     await mkdir(legacyWorkspace, { recursive: true })
     await writeFile(path.join(legacyWorkspace, 'ordinary.txt'), 'workspace content')
@@ -732,43 +733,46 @@ describe('agentsFilesystemMigration', () => {
       sessions: [oldSession, recentSession]
     })
 
+    // Every managed session still gets its own system workspace directory, but the
+    // shared v1 content lands only in the latest one (issue #17830).
     expect((await lstat(oldSession.systemWorkspacePath!)).isDirectory()).toBe(true)
-    expect(await readFile(path.join(oldSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe('workspace content')
+    expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
     expect(await readFile(path.join(recentSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
       'workspace content'
     )
   })
 
-  it('reuses the first verified private copy for every later managed session', async () => {
+  it('copies a workspace shared by many managed sessions exactly once', async () => {
     const { agentsDataRoot, legacyWorkspace } = await createFixture()
     const sourceFile = path.join(legacyWorkspace, 'ordinary.txt')
     await mkdir(legacyWorkspace, { recursive: true })
     await writeFile(sourceFile, 'workspace content')
 
-    const oldSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
-      sourceSessionId: 'session_old',
-      finalSessionId: FINAL_OLD_SESSION_ID,
-      createdAt: Date.parse('2026-05-01T00:00:00Z'),
-      updatedAt: Date.parse('2026-05-02T00:00:00Z')
-    })
-    const recentSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
-      sourceSessionId: 'session_latest',
-      finalSessionId: FINAL_LATEST_SESSION_ID,
-      createdAt: Date.parse('2026-07-22T00:00:00Z'),
-      updatedAt: Date.parse('2026-07-23T00:00:00Z')
-    })
+    // Many historical sessions sharing one v1 default workspace must not fan the
+    // source out into one full copy per session (issue #17830 → ENOSPC).
+    const sessions = Array.from({ length: 12 }, (_, index) =>
+      sessionPlan(agentsDataRoot, legacyWorkspace, {
+        sourceSessionId: `session_${index.toString().padStart(2, '0')}`,
+        finalSessionId: `0000000${index.toString(16).padStart(4, '0')}-34a7-5ff9-994d-bf78596c777c`,
+        createdAt: Date.parse('2026-05-01T00:00:00Z') + index * 86_400_000,
+        updatedAt: Date.parse('2026-05-02T00:00:00Z') + index * 86_400_000
+      })
+    )
+    const latestSession = sessions.at(-1)!
 
     await stageLegacyAgentFiles({
       agentsDataRoot,
       agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-      sessions: [oldSession, recentSession]
+      sessions
     })
 
     expect(copyMutation.copyFileCalls.filter(([sourcePath]) => sourcePath === sourceFile)).toHaveLength(1)
-    expect(await readFile(path.join(oldSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe('workspace content')
-    expect(await readFile(path.join(recentSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
+    expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
       'workspace content'
     )
+    for (const session of sessions.slice(0, -1)) {
+      expect(await readdir(session.systemWorkspacePath!)).toEqual([])
+    }
   })
 
   it('bounds and continuously refills filesystem work for a high-fan-out workspace', async () => {
@@ -864,7 +868,7 @@ describe('agentsFilesystemMigration', () => {
   })
 
   it.runIf(process.platform !== 'win32')(
-    'reuses the first ordinary-content copy when a directory contains symlinks',
+    'materializes a directory that contains symlinks into the latest session',
     async () => {
       const { agentsDataRoot, legacyWorkspace } = await createFixture()
       const sourceBundle = path.join(legacyWorkspace, 'bundle')
@@ -873,65 +877,64 @@ describe('agentsFilesystemMigration', () => {
       await symlink('payload.txt', path.join(sourceBundle, 'payload-link'))
       await symlink(path.join(sourceBundle, 'payload.txt'), path.join(sourceBundle, 'absolute-payload-link'))
 
-      const sessions = [
-        sessionPlan(agentsDataRoot, legacyWorkspace, {
-          sourceSessionId: 'session_old',
-          finalSessionId: FINAL_OLD_SESSION_ID,
-          createdAt: Date.parse('2026-05-01T00:00:00Z'),
-          updatedAt: Date.parse('2026-05-02T00:00:00Z')
-        }),
-        sessionPlan(agentsDataRoot, legacyWorkspace, {
-          sourceSessionId: 'session_latest',
-          finalSessionId: FINAL_LATEST_SESSION_ID,
-          createdAt: Date.parse('2026-07-22T00:00:00Z'),
-          updatedAt: Date.parse('2026-07-23T00:00:00Z')
-        })
-      ]
-
-      await stageLegacyAgentFiles({
-        agentsDataRoot,
-        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-        sessions
-      })
-
-      expect(
-        copyMutation.copyFileCalls.filter(([sourcePath]) => sourcePath === path.join(sourceBundle, 'payload.txt'))
-      ).toHaveLength(1)
-      for (const session of sessions) {
-        expect(await readFile(path.join(session.systemWorkspacePath!, 'bundle', 'payload.txt'), 'utf8')).toBe(
-          'workspace content'
-        )
-        expect(await readlink(path.join(session.systemWorkspacePath!, 'bundle', 'payload-link'))).toBe('payload.txt')
-        expect(await readlink(path.join(session.systemWorkspacePath!, 'bundle', 'absolute-payload-link'))).toBe(
-          path.join(session.systemWorkspacePath!, 'bundle', 'payload.txt')
-        )
-      }
-    }
-  )
-
-  it('aborts if a cached workspace source changes while its private copy is reused', async () => {
-    const { agentsDataRoot, legacyWorkspace } = await createFixture()
-    const sourceFile = path.join(legacyWorkspace, 'ordinary.txt')
-    await mkdir(legacyWorkspace, { recursive: true })
-    await writeFile(sourceFile, 'original workspace content')
-
-    const sessions = [
-      sessionPlan(agentsDataRoot, legacyWorkspace, {
+      const oldSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
         sourceSessionId: 'session_old',
         finalSessionId: FINAL_OLD_SESSION_ID,
         createdAt: Date.parse('2026-05-01T00:00:00Z'),
         updatedAt: Date.parse('2026-05-02T00:00:00Z')
-      }),
-      sessionPlan(agentsDataRoot, legacyWorkspace, {
+      })
+      const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
         sourceSessionId: 'session_latest',
         finalSessionId: FINAL_LATEST_SESSION_ID,
         createdAt: Date.parse('2026-07-22T00:00:00Z'),
         updatedAt: Date.parse('2026-07-23T00:00:00Z')
       })
-    ]
-    let reusedCopies = 0
+
+      await stageLegacyAgentFiles({
+        agentsDataRoot,
+        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+        sessions: [oldSession, latestSession]
+      })
+
+      expect(
+        copyMutation.copyFileCalls.filter(([sourcePath]) => sourcePath === path.join(sourceBundle, 'payload.txt'))
+      ).toHaveLength(1)
+      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload.txt'), 'utf8')).toBe(
+        'workspace content'
+      )
+      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload-link'))).toBe(
+        'payload.txt'
+      )
+      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'bundle', 'absolute-payload-link'))).toBe(
+        path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload.txt')
+      )
+      expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
+    }
+  )
+
+  it('aborts if the workspace source changes while its private copy is verified', async () => {
+    const { agentsDataRoot, legacyWorkspace } = await createFixture()
+    const sourceFile = path.join(legacyWorkspace, 'ordinary.txt')
+    await mkdir(legacyWorkspace, { recursive: true })
+    await writeFile(sourceFile, 'original workspace content')
+
+    const oldSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
+      sourceSessionId: 'session_old',
+      finalSessionId: FINAL_OLD_SESSION_ID,
+      createdAt: Date.parse('2026-05-01T00:00:00Z'),
+      updatedAt: Date.parse('2026-05-02T00:00:00Z')
+    })
+    const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
+      sourceSessionId: 'session_latest',
+      finalSessionId: FINAL_LATEST_SESSION_ID,
+      createdAt: Date.parse('2026-07-22T00:00:00Z'),
+      updatedAt: Date.parse('2026-07-23T00:00:00Z')
+    })
+    // Mutate the source right after it is cloned into staging so the final
+    // source-metadata re-check detects the change and aborts before publishing.
     copyMutation.afterCopyFile = async (copiedSourcePath) => {
-      if (copiedSourcePath === sourceFile || ++reusedCopies !== 1) return
+      if (copiedSourcePath !== sourceFile) return
+      copyMutation.afterCopyFile = undefined
       await writeFile(sourceFile, 'changed workspace content')
     }
 
@@ -939,12 +942,12 @@ describe('agentsFilesystemMigration', () => {
       stageLegacyAgentFiles({
         agentsDataRoot,
         agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-        sessions
+        sessions: [oldSession, latestSession]
       })
-    ).rejects.toThrow(/changed while being copied/)
+    ).rejects.toThrow(/changed while being (copied|read)/)
 
     expect(await readFile(sourceFile, 'utf8')).toBe('changed workspace content')
-    for (const session of sessions) {
+    for (const session of [oldSession, latestSession]) {
       await expect(access(path.join(session.systemWorkspacePath!, 'ordinary.txt'))).rejects.toThrow()
       expect(
         (await readdir(path.dirname(session.systemWorkspacePath!))).every(
@@ -956,14 +959,13 @@ describe('agentsFilesystemMigration', () => {
     await stageLegacyAgentFiles({
       agentsDataRoot,
       agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-      sessions
+      sessions: [oldSession, latestSession]
     })
 
-    for (const session of sessions) {
-      expect(await readFile(path.join(session.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
-        'changed workspace content'
-      )
-    }
+    expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
+      'changed workspace content'
+    )
+    expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
   })
 
   it('keeps the newest identity entry when first-migration sources differ', async () => {

--- a/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
+++ b/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
@@ -247,6 +247,17 @@ export interface AgentFileSessionPlan {
   updatedAt: number
 }
 
+/**
+ * Order managed-default sessions by recency so the shared v1 workspace content is
+ * materialized into the session most likely to be resumed. Ties fall back to the
+ * lexicographically smaller session id, matching the identity-source ordering.
+ */
+function isLaterManagedSession(candidate: AgentFileSessionPlan, incumbent: AgentFileSessionPlan): boolean {
+  if (candidate.updatedAt !== incumbent.updatedAt) return candidate.updatedAt > incumbent.updatedAt
+  if (candidate.createdAt !== incumbent.createdAt) return candidate.createdAt > incumbent.createdAt
+  return candidate.sourceSessionId.localeCompare(incumbent.sourceSessionId) < 0
+}
+
 export function legacyAgentWorkspacePath(agentsDataRoot: string, legacyAgentId: string): string {
   const shortId = legacyAgentId.slice(-9)
   if (!shortId || shortId === '.' || shortId === '..' || /[\\/]/.test(shortId)) {
@@ -2141,9 +2152,23 @@ export async function stageLegacyAgentFiles(input: {
     reusableStagingPaths: new Map(),
     pendingPublications: []
   }
-  const totalWorkspaceSessions = input.sessions.filter(
-    (session) => session.isManagedDefault && session.systemWorkspacePath
-  ).length
+
+  // A v1 managed-default workspace was SHARED by every session of the agent.
+  // v2 gives each session its own exclusive system workspace, so copying that
+  // shared tree into all of them fanned one source out into N full copies and
+  // exhausted the disk (issue #17830). Materialize the shared content once, into
+  // the single most recently active session; the other sessions keep the empty
+  // system workspace directories they still get created below.
+  const contentSessionIdByAgent = new Map<string, string>()
+  for (const { sourceAgentId } of input.agents) {
+    const systemSessions = (plansByAgent.get(sourceAgentId) ?? []).filter(
+      (plan) => plan.isManagedDefault && plan.systemWorkspacePath
+    )
+    if (systemSessions.length === 0) continue
+    const latest = systemSessions.reduce((best, session) => (isLaterManagedSession(session, best) ? session : best))
+    contentSessionIdByAgent.set(sourceAgentId, latest.sourceSessionId)
+  }
+  const totalWorkspaceSessions = contentSessionIdByAgent.size
   let processedAgents = 0
   let processedWorkspaceSessions = 0
   let identityFileCount = 0
@@ -2201,28 +2226,29 @@ export async function stageLegacyAgentFiles(input: {
 
       if (path.resolve(defaultWorkspacePath) === path.resolve(agentDataPath)) continue
 
-      for (const session of systemSessions) {
-        if (!session.systemWorkspacePath) continue
-        const workspaceStats = await copyOrdinaryWorkspaceContent(
-          workspaceCopyContext,
-          input.agentsDataRoot,
-          session.sourceWorkspacePath,
-          session.systemWorkspacePath,
-          agentDataPath
-        )
-        copiedWorkspaceEntries += workspaceStats.copiedEntries
-        reusedWorkspaceEntries += workspaceStats.reusedEntries
-        workspaceFileCount += workspaceStats.fileCount
-        workspaceByteCount += workspaceStats.byteCount
-        processedWorkspaceSessions++
-        input.onProgress?.({
-          phase: 'workspace',
-          processed: processedWorkspaceSessions,
-          total: totalWorkspaceSessions,
-          fileCount: workspaceFileCount,
-          byteCount: workspaceByteCount
-        })
-      }
+      const contentSessionId = contentSessionIdByAgent.get(sourceAgentId)
+      const contentSession = systemSessions.find((session) => session.sourceSessionId === contentSessionId)
+      if (!contentSession?.systemWorkspacePath) continue
+
+      const workspaceStats = await copyOrdinaryWorkspaceContent(
+        workspaceCopyContext,
+        input.agentsDataRoot,
+        contentSession.sourceWorkspacePath,
+        contentSession.systemWorkspacePath,
+        agentDataPath
+      )
+      copiedWorkspaceEntries += workspaceStats.copiedEntries
+      reusedWorkspaceEntries += workspaceStats.reusedEntries
+      workspaceFileCount += workspaceStats.fileCount
+      workspaceByteCount += workspaceStats.byteCount
+      processedWorkspaceSessions++
+      input.onProgress?.({
+        phase: 'workspace',
+        processed: processedWorkspaceSessions,
+        total: totalWorkspaceSessions,
+        fileCount: workspaceFileCount,
+        byteCount: workspaceByteCount
+      })
     }
     await verifyWorkspaceSources(workspaceCopyContext)
     const publicationStats = await publishPreparedWorkspaceEntries(workspaceCopyContext)


### PR DESCRIPTION
### What this PR does

Before this PR:

The v2 Agent migration fanned a **shared** v1 workspace out to **every** historical session. A v1 managed-default workspace was shared by all of an agent's sessions, but v2 gives each session its own exclusive system workspace, so `stageLegacyAgentFiles` copied the entire source tree into every managed session's workspace. For one agent with 1,253 sessions pointing at a ~7 GiB default workspace, this produced ~8.7 TiB of logical copies and failed with `ENOSPC`.

After this PR:

The shared ordinary workspace content is materialized **once**, into the single most recently active session (ranked by `updatedAt` → `createdAt` → session id). Every managed session still gets its own system-workspace directory, but the older sessions keep it empty. The v1 workspace stays in place for downgrade compatibility.

This restores the behavior already documented in `v2-refactor-temp/docs/breaking-changes/2026-07-27-agent-data-workspace-split.md` (PR #17450) — the shipped code had regressed from that design into the N-way fan-out.

Fixes #17830

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Older migrated sessions open with empty system workspaces. This is unavoidable under v2's one-workspace-per-session model, and is semantically correct: v1 never stored a per-session workspace snapshot, so copying the single shared final state into every session would fabricate history that never existed for those sessions. Content remains recoverable from the latest session and from the retained v1 workspace.
- Kept the existing staging → fingerprint-verify → atomic-publish machinery unchanged; only the caller loop changed, so the copy path stays minimal and safe.

The following alternatives were considered:

- Map all of an agent's managed sessions to one shared workspace record. Rejected: it breaks the one-exclusive-system-workspace-per-session invariant (`AgentWorkspaceService.createSystemWorkspaceForSessionTx` + unique path).
- Copy-on-write / lazy materialization per session. Rejected as unnecessary complexity once the fan-out is removed.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17830

### Breaking changes

None beyond the already-documented `2026-07-27-agent-data-workspace-split` notice. No new breaking-changes entry is added because this PR restores that documented behavior rather than introducing a new one.

### Special notes for your reviewer

- Out of scope (noted in the issue as secondary, not the ENOSPC cause): run-scoped cleanup of orphaned `.<session>.migration-*` staging left by a killed process, and a preflight fan-out estimate. With the fan-out gone, staging is now bounded to one workspace copy per agent.
- Tests updated to the restored single-copy semantics, plus a new regression guard ("copies a workspace shared by many managed sessions exactly once") asserting a single `copyFile` for the source across 12 sessions.
- Verified locally: `agentsFilesystemMigration.test.ts` (49 passed, 1 skipped), `AgentsMigrator.test.ts` (16 passed), node + web typecheck (exit 0), oxlint + biome clean.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed v2 Agent migration running out of disk space when an agent had many historical sessions sharing one default workspace. The shared workspace content is now migrated once into the most recently used session instead of being duplicated into every session.
```
