### PR TITLE
refactor(agent-skills): route bundled runtimes through tool guide

### DIFF
--- a/resources/skills/cherry-tool-guide/SKILL.md
+++ b/resources/skills/cherry-tool-guide/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: cherry-tool-guide
-description: Cherry Studio first-party tool routing guide for general agents. Use this WHENEVER a task could be served by Cherry's built-in tools — even if the user never names a tool — including researching current/online information or requesting browser interaction (Cherry's web built-ins search and fetch but do not automate pages), answering from the user's own documents and knowledge bases, recalling or saving things across sessions (persistent memory), scheduling recurring or one-time tasks and sending notifications, connecting or repairing IM channels (Telegram/Feishu/Discord/Slack/WeChat/QQ), generating images or reporting produced files, discovering or installing command-line tools, and finding or installing new skills. Consult it BEFORE reaching for shell, Bash, or file tools to do any of these, so you route through the correct mcp__cherry-tools__*, mcp__agent-memory__*, and mcp__skills__* tool instead of inventing a workaround.
-version: 1.0.0
+description: Cherry Studio first-party tool routing guide for general agents. Use this WHENEVER a task could be served by Cherry's built-in tools — even if the user never names a tool — including researching current/online information or requesting browser interaction (Cherry's web built-ins search and fetch but do not automate pages), answering from the user's own documents and knowledge bases, recalling or saving things across sessions (persistent memory), scheduling recurring or one-time tasks and sending notifications, connecting or repairing IM channels (Telegram/Feishu/Discord/Slack/WeChat/QQ), generating images or reporting produced files, running JavaScript/TypeScript or Python, invoking one-off packages, searching local code/files, discovering or installing reusable command-line tools, and finding or installing new skills. Consult it BEFORE reaching for shell, Bash, or file tools to do any of these, so you route through the correct mcp__cherry-tools__*, mcp__agent-memory__*, mcp__skills__*, or bundled shell runtime instead of inventing a workaround.
+version: 1.1.0
 ---
 
 # Cherry Tool Guide
 
 Cherry Studio injects first-party tools into your session over three MCP servers
-(`mcp__cherry-tools__*`, `mcp__agent-memory__*`, `mcp__skills__*`). They act on the
-running app — the user's knowledge bases, IM channels, schedules, managed CLIs, and
+(`mcp__cherry-tools__*`, `mcp__agent-memory__*`, `mcp__skills__*`) and gives
+shell-capable general agents bundled runtimes for local execution. The MCP tools act on
+the running app — the user's knowledge bases, IM channels, schedules, managed CLIs, and
 skill library — through boundaries only Cherry owns. Shell and file tools cannot reach
-those boundaries correctly, so when a task matches a row below, route through the named
-tool rather than improvising with `Bash`/`Write`.
+those app boundaries correctly; use the bundled runtimes only for the local execution
+cases routed below.
 
 **This file is a router.** It carries only the global rules and the intent → tool →
 reference table. Each reference holds that domain's prerequisites, sequencing,
@@ -60,6 +61,7 @@ parameter names, enums, and required fields. Read it before every call.
 | Inspect / connect / repair IM channels, rename agent | `mcp__cherry-tools__config` | [autonomy.md](references/autonomy.md) |
 | Generate an image | `mcp__cherry-tools__generate_image` (needs a painting model) | [outputs.md](references/outputs.md) |
 | Declare final deliverable file(s) | `mcp__cherry-tools__report_artifacts` | [outputs.md](references/outputs.md) |
+| Run JS/TS or Python, invoke a one-off package, search local code/files | bundled `bun`, `uv` / `uvx`, or `rg` according to task lifetime | [cli.md](references/cli.md) |
 | Find / install a command-line tool | `command -v` check → `mcp__cherry-tools__cli_list` → `mcp__cherry-tools__cli_search` → `mcp__cherry-tools__cli_install` (approval) | [cli.md](references/cli.md) |
 | Find / install a new capability skill | `mcp__skills__search_skills` → `mcp__skills__install_skill` (approval) | [skills.md](references/skills.md) |
 

--- a/resources/skills/cherry-tool-guide/references/cli.md
+++ b/resources/skills/cherry-tool-guide/references/cli.md
@@ -1,17 +1,46 @@
-# Managed CLIs
+# Shell runtimes and managed CLIs
 
-Covers `mcp__cherry-tools__cli_list`, `mcp__cherry-tools__cli_search`, and
-`mcp__cherry-tools__cli_install`. Cherry keeps CLIs in an **isolated managed
-environment**, separate from the system PATH.
+Covers the bundled shell runtimes plus `mcp__cherry-tools__cli_list`,
+`mcp__cherry-tools__cli_search`, and `mcp__cherry-tools__cli_install`. The first group
+executes local, project-scoped, or one-off work; the MCP tools install reusable CLIs in
+Cherry's **isolated managed environment**.
 
 Get exact argument shapes from the live tool schema — this reference gives routing,
 sequencing, and safety only.
 
+## Choose by lifetime
+
+Use the shortest-lived mechanism that fits:
+
+| Need | Use |
+| --- | --- |
+| Run a JS/TS file | `bun <file>` |
+| Install an existing JS project's dependencies / add a project dependency | `bun install` / `bun add <pkg>` in the project cwd |
+| Run a one-off JavaScript package | `bun x <tool>` — only `bun` is bundled, not a `bunx` shim |
+| Run a Python file | `uv run python <file>` |
+| Run Python with a temporary dependency | `uv run --with <pkg> python <file>` |
+| Run a one-off Python CLI | `uvx <tool>` |
+| Search local files or contents | `rg` |
+| Keep a CLI for later tasks, login, or durable configuration | the managed CLI workflow below |
+
+Shell-capable general agents receive `bun`, `uv` / `uvx`, and `rg` on their execution
+PATH. Prefer them over `node` / `npm` / `npx` / `pip`, which are not guaranteed to
+exist. Do not assume a version or source: a Cherry-managed or system executable may
+shadow the bundled fallback. If `command -v` cannot resolve one of these expected
+commands, report an environment problem rather than pretending the command ran.
+
+Keep dependency changes inside the current project. Global installs (`-g` /
+`--global`, `uv tool install`, `pip install --user`) and direct `mise` mutations are
+blocked because they leak state across agent sessions. Use `bun x` / `uvx` for one-off
+tools and the managed workflow for anything persistent. Do not use `cli_install` for a
+project library, and do not use an ephemeral runner for a CLI that needs login or reuse.
+
 ## Conditional availability
 
-The `cli_*` tools are **absent for agents with no shell** (e.g. the built-in Assistant).
-If they're absent, you cannot install CLIs in this session — say so; don't work around
-it.
+The built-in Assistant does not expose the `cli_*` tools. For every other role, the live
+tool list is authoritative. If they're absent, you cannot install CLIs in this session —
+say so; don't work around it. The bundled shell-runtime guidance above likewise applies
+only when the session exposes a shell.
 
 ## Approval
 
@@ -23,11 +52,13 @@ the shell.
 
 Before installing anything:
 
-1. **Probe the real PATH.** `mcp__cherry-tools__cli_list` reports only Cherry-managed
+1. **Probe the agent's effective PATH.** `mcp__cherry-tools__cli_list` reports only Cherry-managed
    binaries and does **not** see the system PATH — so a tool it calls "unavailable" may
-   already exist on the machine. Run `command -v <name>` (shell inspection is fine) to
-   check the real PATH before installing a duplicate. Use `mcp__cherry-tools__cli_list`
-   to see what Cherry already manages.
+   already resolve in the agent shell. Run `command -v <name>` (shell inspection is
+   fine) to inspect the agent's effective PATH before installing a duplicate. This PATH
+   includes Cherry-managed and bundled locations as well as the user's shell PATH; do
+   not treat it as a pure system-only probe. Use `mcp__cherry-tools__cli_list` to see
+   what Cherry already manages.
 2. **`mcp__cherry-tools__cli_search`** — look up the exact `name`/`tool` recipe from the
    registry. Never guess the executable name or recipe.
 3. **`mcp__cherry-tools__cli_install`** — install using the recipe from search (or one
@@ -50,7 +81,7 @@ gain by shelling out — you only lose Cherry's bookkeeping.
 
 > "I need `ripgrep` available for searches."
 
-`command -v rg` to check the real PATH → if absent, `mcp__cherry-tools__cli_list` to see
+`command -v rg` to check the agent's effective PATH → if absent, `mcp__cherry-tools__cli_list` to see
 if Cherry already manages it → `mcp__cherry-tools__cli_search` "ripgrep" for the exact
 recipe → `mcp__cherry-tools__cli_install` with that recipe (approval runs). Never
 `brew install` / `cargo install` it yourself.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Normal Agent sessions always received a runtime and managed-CLI handbook from `buildRuntimeContext()`, while the built-in Cherry tool guide covered only managed CLI discovery and installation. Runtime selection therefore occupied every system prompt instead of following the existing lazy skill boundary used by other Cherry tool-routing policy.

After this PR:

- The `cherry-tool-guide` metadata gives shell-capable agents the direct fast path for bundled `bun`, `uv` / `uvx`, and `rg` commands without loading the skill body.
- Its CLI reference owns the detailed choice between one-off execution, project dependencies, and reusable managed CLIs.
- `buildRuntimeContext()` and its always-injected handbook are removed from the Agent system prompt.
- Runtime availability remains owned by PATH construction, and global/shared installs remain enforced by the existing dependency guard.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Agents need enough always-visible information to choose Cherry's bundled runtimes, but detailed tool-lifetime policy does not belong in every session's system prompt. The skill metadata now carries the small direct-execution contract, while progressive disclosure loads the full CLI workflow only when dependency lifetime or persistent installation matters.

This remains effective without `buildRuntimeContext()` because the responsibilities are independent:

1. **Tool choice is advisory:** the default-enabled skill metadata is visible in the Agent's skill catalog, so straightforward tasks can select `bun`, `uv` / `uvx`, or `rg` without loading the full skill body.
2. **Runtime availability is deterministic:** `getShellEnv()` still constructs PATH with Cherry-managed, user, and bundled binary locations.
3. **Isolation is deterministic:** the existing `PreToolUse` dependency guard still rejects global installs and direct `mise` mutations even if the model chooses a bad command.
4. **Detailed policy is lazy:** project dependencies, one-off packages, and reusable managed CLIs are explained in `references/cli.md` only when that decision matters.

The following tradeoffs were made:

The tool guide is default-enabled but can be explicitly disabled by the user. Disabling it now also opts out of its advisory runtime routing; the binaries remain available on PATH and the dependency guard continues to enforce isolation independently.

The following alternatives were considered:

Keeping `buildRuntimeContext()` alongside the guide was rejected because it created two owners for the same routing policy and retained the prompt cost this change is intended to remove. A smaller always-injected runtime block was also rejected: the skill metadata is already always visible when the guide is enabled and can carry the same direct commands without another prompt mechanism.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- `buildRuntimeContext()` is removed completely; `getBinaryPath('bun')` remains because `buildEnvironment()` still uses it for `CHERRY_STUDIO_BUN_PATH`.
- `getShellEnv()` remains the source of truth for managed, user, and bundled PATH entries.
- `dependencyGuard.ts` remains the hard enforcement boundary for global installs and direct `mise` mutations.

#### Test plan

**Focused automated coverage**

- `buildSystemPrompt.test.ts`: 23/23 passed, including Claude Code preset, custom `system.md`, and Cherry Assistant paths; each asserts that the old runtime/CLI handbook is absent.
- `dependencyGuard.test.ts`: 47/47 passed, confirming global install and direct `mise` mutation enforcement remains intact.
- `pnpm skills:check`: passed for all 9 public skills.

**Full repository gates after rebasing onto current `main`**

- `pnpm lint`: passed (repository-existing ESLint warnings only).
- `pnpm test`: 1,735 files passed; 21,367 tests passed and 66 skipped.
- `pnpm format`: passed with no remaining changes.
- `pnpm build:check`: passed.
- `pnpm test:lint`: passed.

**Runtime/package verification**

- Rebuilt the Electron native dependency and restarted the tracked development instance from the rebased PR head.
- Confirmed the built main bundle contains none of the former `## Available Runtimes`, `## Managed CLI Installation`, or managed-install handbook markers.
- Confirmed the source and development-profile copies of `cherry-tool-guide/SKILL.md` have the same SHA-256 hash after built-in skill synchronization.
- Confirmed the main and subwindow renderer targets loaded successfully over CDP.

**Interactive Agent scenarios**

All five scenarios exercised in the development app passed:

1. **Bundled runtimes:** an ordinary Agent created and ran TypeScript with `bun`, ran Python with `uv run python`, and found both output markers with `rg`; it did not use `node`, `npm`, or `pip`, and did not request persistent-install approval.
2. **One-off packages:** the Agent ran `cowsay` with `bun x` without changing project dependencies or calling `cli_install`; the Python counterpart used `uv run --with humanize python` without creating a project virtual environment.
3. **Persistent CLI routing:** for a reusable `hyperfine` installation, the Agent checked existing availability, used the managed CLI discovery flow, requested approval, installed through `cli_install`, and verified the command.
4. **Global-install blocking:** an explicit `npm install -g cowsay` request was rejected before Bash execution; no global install occurred, and the Agent redirected the task toward an ephemeral or managed option.
5. **Cherry Assistant boundary:** the built-in Cherry Assistant declined persistent CLI management and did not bypass the boundary with shell, Homebrew, or a remote install script.

These scenarios verify the intended lifetime decisions end to end: one-off tasks remain ephemeral, reusable CLIs use the approval-gated managed path, global installs remain blocked, and Assistant capability boundaries are preserved.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (`resources/skills/cherry-tool-guide/`) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agents now use Cherry Studio's bundled JavaScript, Python, and search runtimes through the built-in tool guide without carrying duplicate runtime instructions in every session.
```

