### PR TITLE
fix(runtime): restore managed CLI and MCP launches on Windows

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -56,6 +56,27 @@ import { McpOAuthClientProvider } from './oauth/provider'
 import { ServerLogBuffer } from './ServerLogBuffer'
 import type { GetResourceResponse, McpCallToolResponse } from './types'
 
+function buildStdioEnvironment(
+  loginShellEnv: Record<string, string>,
+  serverEnv: Record<string, string>
+): Record<string, string> {
+  const env = { ...loginShellEnv, ...serverEnv }
+  const serverPathKey = Object.keys(serverEnv)
+    .filter((key) => key.toLowerCase() === 'path')
+    .at(-1)
+  const shellPathKey = Object.keys(loginShellEnv)
+    .filter((key) => key.toLowerCase() === 'path')
+    .at(-1)
+  const pathValue = serverPathKey ? serverEnv[serverPathKey] : shellPathKey ? loginShellEnv[shellPathKey] : undefined
+
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') delete env[key]
+  }
+  if (pathValue !== undefined) env.PATH = pathValue
+
+  return env
+}
+
 // Generic type for caching wrapped functions
 type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
 
@@ -596,10 +617,9 @@ export class McpRuntimeService extends BaseService {
             const transportOptions: StdioServerParameters = {
               command: cmd,
               args,
-              env: {
-                ...loginShellEnv,
-                ...connectEnv
-              },
+              // The SDK prepends process.env.PATH before this object. Always use
+              // the same canonical key so our fresh shell PATH replaces it on Windows.
+              env: buildStdioEnvironment(loginShellEnv, connectEnv),
               stderr: 'pipe'
             }
 

--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -61,6 +61,8 @@ function buildStdioEnvironment(
   serverEnv: Record<string, string>
 ): Record<string, string> {
   const env = { ...loginShellEnv, ...serverEnv }
+  if (process.platform !== 'win32') return env
+
   const serverPathKey = Object.keys(serverEnv)
     .filter((key) => key.toLowerCase() === 'path')
     .at(-1)
@@ -617,8 +619,8 @@ export class McpRuntimeService extends BaseService {
             const transportOptions: StdioServerParameters = {
               command: cmd,
               args,
-              // The SDK prepends process.env.PATH before this object. Always use
-              // the same canonical key so our fresh shell PATH replaces it on Windows.
+              // On Windows the SDK prepends process.env.PATH before this object, so use
+              // one canonical key to ensure our fresh shell PATH replaces the stale value.
               env: buildStdioEnvironment(loginShellEnv, connectEnv),
               stderr: 'pipe'
             }

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -20,6 +20,20 @@ vi.mock('@data/services/McpServerService', () => ({
   }
 }))
 
+const shellEnvMock = vi.hoisted(() => ({
+  getShellEnv: vi.fn().mockResolvedValue({ Path: 'C:\\Users\\me\\.cherrystudio\\bin;C:\\Windows' })
+}))
+vi.mock('@main/utils/shellEnv', () => ({
+  getShellEnv: shellEnvMock.getShellEnv
+}))
+
+const commandResolverMock = vi.hoisted(() => ({
+  findCommandInShellEnv: vi.fn().mockResolvedValue('C:\\Tools\\npx.exe')
+}))
+vi.mock('@main/utils/commandResolver', () => ({
+  findCommandInShellEnv: commandResolverMock.findCommandInShellEnv
+}))
+
 // Mock the MCP SDK transports + Client so we can drive the transport-fallback path without
 // a real network server. SSE connect throws a 405 (mirrors the issue); streamableHttp succeeds.
 const mcpSdkMock = vi.hoisted(() => {
@@ -82,12 +96,22 @@ const mcpSdkMock = vi.hoisted(() => {
       this.code = code
     }
   }
+  const stdioTransports: Array<{ env?: Record<string, string> }> = []
+  class StdioClientTransport {
+    kind = 'stdio' as const
+    stderr = null
+    constructor(params: { env?: Record<string, string> }) {
+      stdioTransports.push(params)
+    }
+  }
   return {
     SseError,
     SSEClientTransport,
     StreamableHTTPClientTransport,
     Client,
     StreamableHTTPError,
+    StdioClientTransport,
+    stdioTransports,
     clients,
     state: { failStreamable: false, failStreamableCode: 503 }
   }
@@ -103,6 +127,9 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
 }))
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: mcpSdkMock.Client
+}))
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: mcpSdkMock.StdioClientTransport
 }))
 
 const { McpRuntimeService, redactSensitive, McpCallToolPayloadSchema, McpGetResourcePayloadSchema } = await import(
@@ -130,6 +157,32 @@ function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void
   })
   return { promise, resolve }
 }
+
+describe('McpRuntimeService stdio environment', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    MockMainCacheServiceUtils.resetMocks()
+    mcpSdkMock.stdioTransports.length = 0
+  })
+
+  it('canonicalizes a mixed-case Windows Path key to PATH before crossing the MCP SDK boundary', async () => {
+    const service = new McpRuntimeService()
+    const server = {
+      id: 'stdio-server',
+      name: 'stdio-server',
+      command: 'npx',
+      args: ['-y', 'example-mcp'],
+      isActive: true
+    } as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    await service.withClient(server.id, async () => undefined)
+
+    const transportEnv = mcpSdkMock.stdioTransports.at(-1)?.env
+    expect(Object.keys(transportEnv ?? {}).filter((key) => key.toLowerCase() === 'path')).toEqual(['PATH'])
+    expect(transportEnv?.PATH).toBe('C:\\Users\\me\\.cherrystudio\\bin;C:\\Windows')
+  })
+})
 
 describe('McpRuntimeService.setServerStatus', () => {
   beforeEach(() => {

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -163,9 +163,11 @@ describe('McpRuntimeService stdio environment', () => {
     BaseService.resetInstances()
     MockMainCacheServiceUtils.resetMocks()
     mcpSdkMock.stdioTransports.length = 0
+    shellEnvMock.getShellEnv.mockResolvedValue({ Path: 'C:\\Users\\me\\.cherrystudio\\bin;C:\\Windows' })
   })
 
   it('canonicalizes a mixed-case Windows Path key to PATH before crossing the MCP SDK boundary', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const service = new McpRuntimeService()
     const server = {
       id: 'stdio-server',
@@ -181,6 +183,29 @@ describe('McpRuntimeService stdio environment', () => {
     const transportEnv = mcpSdkMock.stdioTransports.at(-1)?.env
     expect(Object.keys(transportEnv ?? {}).filter((key) => key.toLowerCase() === 'path')).toEqual(['PATH'])
     expect(transportEnv?.PATH).toBe('C:\\Users\\me\\.cherrystudio\\bin;C:\\Windows')
+    platformSpy.mockRestore()
+  })
+
+  it('preserves distinct PATH key casing on POSIX', async () => {
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    shellEnvMock.getShellEnv.mockResolvedValue({ PATH: '/shell/bin', Path: 'shell-metadata' })
+    const service = new McpRuntimeService()
+    const server = {
+      id: 'stdio-server',
+      name: 'stdio-server',
+      command: 'npx',
+      args: ['-y', 'example-mcp'],
+      env: { Path: 'server-metadata' },
+      isActive: true
+    } as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    await service.withClient(server.id, async () => undefined)
+
+    const transportEnv = mcpSdkMock.stdioTransports.at(-1)?.env
+    expect(transportEnv?.PATH).toBe('/shell/bin')
+    expect(transportEnv?.Path).toBe('server-metadata')
+    platformSpy.mockRestore()
   })
 })
 

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -440,7 +440,9 @@ export class CodeCliService extends BaseService {
     const rawPathEnv = Object.fromEntries(
       Object.entries(rawShellEnv ?? {}).filter(([key]) => key.toLowerCase() === 'path')
     )
-    const env: Record<string, string> = usesCherryExecutionEnv ? mergeBinaryExecutionEnv(rawPathEnv) : {}
+    const env: Record<string, string> = usesCherryExecutionEnv
+      ? mergeBinaryExecutionEnv(rawPathEnv, [application.getPath('cherry.bin')])
+      : {}
     // For a managed Windows launch buildEnvPrefix rewrites PATH inside the
     // terminal from `env`, so the bundled-git tail must land here too, not only
     // in the spawn env assembled below.

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -672,7 +672,7 @@ describe('CodeCliService', () => {
       }
     })
 
-    it('appends the bundled MinGit dir to a managed launch PATH tail (#16402)', async () => {
+    it('includes cherry.bin and appends the bundled MinGit dir to a managed launch PATH tail (#16402)', async () => {
       // Regression (PR #16402 review): the launch env must carry the bundled
       // git dir at the very tail so a terminal-launched CLI resolves a bare
       // `git` on a machine without system git, while any real git ahead wins.
@@ -694,6 +694,7 @@ describe('CodeCliService', () => {
 
         expect(result.success).toBe(true)
         const spawnEnv = (vi.mocked(spawn).mock.calls.at(-1)![2] as { env: Record<string, string> }).env
+        expect(spawnEnv.Path.split(';')).toContain('/mock/binary-data')
         expect(spawnEnv.Path.split(';').at(-1)).toBe(gitDir)
         expect(spawnEnv.Path).toContain('C:\\Windows\\System32')
         // The bat rewrites PATH inside the terminal, so the tail must be in the

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -546,7 +546,7 @@ describe('CodeCliService', () => {
       const launchArgs = (launchCall[1] ?? []).join(' ')
       const launchEnv = launchCall[2]?.env as Record<string, string>
       expect(launchArgs).toContain(
-        "PATH='\\''/mock/binary-data/shims:/usr/local/$(touch /tmp/pwn):`whoami`:$HOME:/usr/bin'\\''"
+        "PATH='\\''/mock/binary-data/shims:/mock/binary-data:/usr/local/$(touch /tmp/pwn):`whoami`:$HOME:/usr/bin'\\''"
       )
       expect(launchArgs).toContain("MISE_DATA_DIR='\\''/mock/binary-data'\\''")
       expect(launchArgs).toContain('for _cherry_mise_key in $(env | sed -n')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Managed Code CLI shims could not find Cherry's bundled `mise.exe` because `~/.cherrystudio/bin` was missing from their PATH. Stdio MCP servers could receive both `PATH` and `Path`, allowing the MCP SDK's stale inherited PATH to win on Windows.

After this PR:

Managed Code CLI launches include `cherry.bin`, and stdio MCP environments expose one canonical `PATH` key while preserving server-level PATH overrides.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Both failures occurred after command discovery succeeded, because the spawned shim process could not resolve the bundled mise runtime. The fixes keep the existing binary extraction and precedence model intact and correct the environment at each process boundary.

The following tradeoffs were made:

The Code CLI fix adds only `cherry.bin` for Cherry-managed tools; system CLIs still avoid Cherry's isolated `MISE_*` environment. The MCP fix canonicalizes PATH only for stdio transports so HTTP and in-memory transports remain unchanged.

The following alternatives were considered:

Running binaries directly from application resources or removing the extraction step was rejected because existing binary resolution relies on the stable, writable `cherry.bin` location. Changing the MCP SDK was rejected in favor of normalizing the environment before crossing the SDK boundary.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Targeted regression tests pass, `pnpm lint` passes, and both flows were manually verified on Windows. The full `pnpm test` run was stopped at the user's request. Commits are currently unsigned and will be re-signed by the author from another machine.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix managed Code CLI and stdio MCP server launches on Windows when Cherry's bundled mise runtime was not resolved from PATH.
```
