### PR TITLE
fix(html-artifact): prevent inline preview height jitter

### DIFF
--- a/src/renderer/components/chat/HtmlArtifactView.tsx
+++ b/src/renderer/components/chat/HtmlArtifactView.tsx
@@ -209,14 +209,17 @@ function getIframeContentHeight(iframe: HTMLIFrameElement): number | null {
     const scrollTop = frameWindow.scrollY || documentElement.scrollTop || body.scrollTop
     let renderedContentBottom = 0
 
-    for (const child of body.children) {
-      const bounds = child.getBoundingClientRect()
+    // A last descendant's margin can collapse through otherwise margin-less wrappers. Measuring
+    // only body.children then underestimates the natural document height and can make this preview
+    // alternate forever between that smaller value and documentScrollHeight.
+    for (const element of body.querySelectorAll('*')) {
+      const bounds = element.getBoundingClientRect()
       if (bounds.width === 0 && bounds.height === 0) continue
 
-      const childMarginBottom = Number.parseFloat(frameWindow.getComputedStyle(child).marginBottom) || 0
+      const elementMarginBottom = Number.parseFloat(frameWindow.getComputedStyle(element).marginBottom) || 0
       renderedContentBottom = Math.max(
         renderedContentBottom,
-        bounds.bottom + scrollTop + Math.max(childMarginBottom, bodyMarginBottom) + bodyEndSpacing
+        bounds.bottom + scrollTop + Math.max(elementMarginBottom, bodyMarginBottom) + bodyEndSpacing
       )
     }
 

--- a/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
+++ b/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
@@ -443,6 +443,51 @@ describe('HtmlArtifactView', () => {
     )
   })
 
+  it('stabilizes at the natural height when a nested bottom margin collapses through its wrapper', () => {
+    render(<HtmlArtifactView html="<main><p>Page</p></main>" title="Preview" />)
+
+    const surface = screen.getByTestId('html-artifact-surface')
+    const iframe = screen.getByTestId<HTMLIFrameElement>('html-preview-frame')
+    const frameDocument = iframe.contentDocument
+    if (!frameDocument) throw new Error('Expected iframe document')
+
+    const { body, documentElement } = frameDocument
+    body.style.margin = '8px'
+    const wrapper = frameDocument.createElement('main')
+    const paragraph = frameDocument.createElement('p')
+    paragraph.style.marginBottom = '16px'
+    wrapper.append(paragraph)
+    body.replaceChildren(wrapper)
+
+    Object.defineProperty(iframe, 'clientHeight', {
+      configurable: true,
+      get: () => Number.parseFloat(surface.style.height) || 0
+    })
+    Object.defineProperty(body, 'scrollHeight', { configurable: true, get: () => 183 })
+    Object.defineProperty(documentElement, 'scrollHeight', {
+      configurable: true,
+      get: () => Math.max(221, iframe.clientHeight)
+    })
+    vi.spyOn(wrapper, 'getBoundingClientRect').mockReturnValue({
+      bottom: 204.6875,
+      height: 183.25,
+      width: 100
+    } as DOMRect)
+    vi.spyOn(paragraph, 'getBoundingClientRect').mockReturnValue({
+      bottom: 204.6875,
+      height: 20,
+      width: 100
+    } as DOMRect)
+
+    fireEvent.load(iframe)
+    expect(surface).toHaveStyle({ height: '221px' })
+
+    for (const callback of mocks.resizeObserverCallbacks) {
+      act(() => callback([], {} as ResizeObserver))
+      expect(surface).toHaveStyle({ height: '221px' })
+    }
+  })
+
   it('renders a streaming fragment as a restricted DOM preview without controls', () => {
     const html = '<div><script>document.body.textContent = "interactive"</script></div>'
     render(<HtmlArtifactView html={html} title="Preview" kind="fragment" isStreaming />)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Static inline HTML previews could alternate continuously between two heights when a nested bottom margin collapsed through a top-level wrapper. The resulting ResizeObserver loop caused visible jitter and sustained renderer/GPU CPU usage.

After this PR:

Inline preview sizing measures rendered descendants, including nested collapsed margins, so the preview converges on its natural height. A regression test covers the previously unstable nested-margin layout.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A (no linked issue)

### Why we need it and why it was done in this way

The previous measurement inspected only direct `body` children. That undercounted content whose final descendant margin collapsed through a wrapper, while `documentScrollHeight` still reported the larger natural height after the iframe shrank. Measuring all rendered descendants fixes the incorrect input at its source and lets the existing observer/state flow settle normally.

The following tradeoffs were made:

- Height synchronization now performs one descendant traversal instead of inspecting only top-level children. This adds bounded work when the existing observer runs, but prevents the unbounded resize/render loop and handles real nested HTML structure correctly.

The following alternatives were considered:

- Debouncing or adding height hysteresis was rejected because it would mask the incorrect measurement and could leave previews at the wrong size.
- Resetting iframe margins was rejected because it would change the artifact's authored rendering.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm lint` passed with no errors (37 pre-existing repository warnings were reported).
- `pnpm format` passed.
- Tests and `pnpm build:check` were not run under the workspace's user-owned verification policy.
- The pushed commit is SSH-signed, DCO-signed off, and reported as Verified by GitHub.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix inline immersive HTML previews that could jitter continuously and consume excessive CPU.
```
