### PR TITLE
fix(agent-files): localize workspace tree errors

### DIFF
--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -35,7 +35,12 @@ import { useTranslation } from 'react-i18next'
 
 import { type ArtifactPaneFileSelection, getArtifactPaneSelectionPath, WORKSPACE_ROOT_ID } from './artifactPanePath'
 import OpenExternalAppButton from './OpenExternalAppButton'
-import { type ArtifactFileTreeModel, isSelectableFileNode, useArtifactFileTreeModel } from './useArtifactFileTreeModel'
+import {
+  type ArtifactFileTreeErrorKind,
+  type ArtifactFileTreeModel,
+  isSelectableFileNode,
+  useArtifactFileTreeModel
+} from './useArtifactFileTreeModel'
 
 // Re-exported from their home modules so existing imports of these from
 // `ArtifactPane` keep working.
@@ -47,6 +52,17 @@ export {
 } from './artifactPanePath'
 
 const logger = loggerService.withContext('ArtifactPane')
+
+const ARTIFACT_FILE_TREE_ERROR_KEYS = {
+  invalid_path: {
+    description: 'agent.preview_pane.tree_error.invalid_path.description',
+    title: 'agent.preview_pane.tree_error.invalid_path.title'
+  },
+  load_error: {
+    description: 'agent.preview_pane.tree_error.load_error.description',
+    title: 'agent.preview_pane.tree_error.load_error.title'
+  }
+} as const satisfies Record<ArtifactFileTreeErrorKind, { description: string; title: string }>
 
 export interface ArtifactPaneProps {
   workspacePath?: string
@@ -151,18 +167,20 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
   const { refresh, reloadExpandedDirectories } = model
 
   const trimmedFileSearch = enableFileSearch ? searchKeyword.trim() : ''
+  const treeErrorKeys = model.errorKind ? ARTIFACT_FILE_TREE_ERROR_KEYS[model.errorKind] : undefined
+  const hasInvalidWorkspacePath = model.errorKind === 'invalid_path'
   const overlaySelection = useMemo(
     () =>
       previewFileSelection
         ? previewFileSelection
-        : workspacePath && selectedFile
+        : workspacePath && !hasInvalidWorkspacePath && selectedFile
           ? { workspacePath, filePath: selectedFile }
           : null,
-    [previewFileSelection, selectedFile, workspacePath]
+    [hasInvalidWorkspacePath, previewFileSelection, selectedFile, workspacePath]
   )
   const overlayWorkspacePath = overlaySelection?.workspacePath
   const overlayFilePath = overlaySelection?.filePath
-  const previewWorkspacePath = overlayWorkspacePath ?? workspacePath
+  const previewWorkspacePath = overlayWorkspacePath ?? (hasInvalidWorkspacePath ? undefined : workspacePath)
   const previewFilePath = overlayFilePath ?? selectedFile
   const previewKey = `${previewWorkspacePath ?? ''}\0${previewFilePath ?? ''}`
   const previousPreviewKeyRef = useRef(previewKey)
@@ -392,10 +410,10 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
       props.headerVariant === 'pane' ? undefined : (
         <div className="flex shrink-0 items-center gap-1">
           {refreshButton}
-          {workspacePath ? <OpenExternalAppButton workdir={workspacePath} /> : null}
+          {workspacePath && !hasInvalidWorkspacePath ? <OpenExternalAppButton workdir={workspacePath} /> : null}
         </div>
       ),
-    [props.headerVariant, refreshButton, workspacePath]
+    [hasInvalidWorkspacePath, props.headerVariant, refreshButton, workspacePath]
   )
 
   const handleEditorModeChange = useCallback(
@@ -652,8 +670,8 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
           getMenuItems={getFileTreeMenuItems}
           emptyState={
             <div className="px-2 py-3 text-muted-foreground text-xs">
-              {model.error
-                ? t('common.error')
+              {treeErrorKeys
+                ? t(treeErrorKeys.title)
                 : trimmedFileSearch
                   ? t('agent.preview_pane.no_search_results')
                   : workspacePath
@@ -668,7 +686,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
       model.filteredTree,
       model.effectiveExpandedIds,
       model.setExpandedIds,
-      model.error,
+      treeErrorKeys,
       selectedFile,
       handleSelectedChange,
       enableFileSearch,
@@ -700,7 +718,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
     )
   }
 
-  if (model.error && !overlaySelection) {
+  if (treeErrorKeys && !overlaySelection) {
     return (
       <div
         ref={artifactPaneRef}
@@ -709,7 +727,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
           maximized && 'rounded-lg border border-border-subtle shadow-sm'
         )}>
         {paneHeader}
-        <EmptyState icon={AlertCircle} title={t('common.error')} description={model.error.message} />
+        <EmptyState icon={AlertCircle} title={t(treeErrorKeys.title)} description={t(treeErrorKeys.description)} />
       </div>
     )
   }

--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -21,6 +21,7 @@ import { buildEditorUrl } from '@renderer/utils/editor'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { joinPath } from '@renderer/utils/path'
 import { isMac, isWin } from '@renderer/utils/platform'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { AlertCircle, ArrowLeft, Eye, FileText, FolderOpen, RotateCw, Sparkles, SquarePen, X } from 'lucide-react'
 import {
   type KeyboardEvent as ReactKeyboardEvent,
@@ -167,16 +168,26 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
   const { refresh, reloadExpandedDirectories } = model
 
   const trimmedFileSearch = enableFileSearch ? searchKeyword.trim() : ''
-  const treeErrorKeys = model.errorKind ? ARTIFACT_FILE_TREE_ERROR_KEYS[model.errorKind] : undefined
-  const hasInvalidWorkspacePath = model.errorKind === 'invalid_path'
+  const previewSelectionWorkspacePath = previewFileSelection?.workspacePath
+  const parsedPreviewWorkspacePath = useMemo(
+    () => (previewSelectionWorkspacePath ? AbsoluteFilePathSchema.safeParse(previewSelectionWorkspacePath) : null),
+    [previewSelectionWorkspacePath]
+  )
+  const hasInvalidPreviewSelection = Boolean(previewFileSelection && !parsedPreviewWorkspacePath?.success)
+  const validPreviewFileSelection = parsedPreviewWorkspacePath?.success ? previewFileSelection : null
+  const effectiveTreeErrorKind: ArtifactFileTreeErrorKind | undefined = hasInvalidPreviewSelection
+    ? 'invalid_path'
+    : model.errorKind
+  const treeErrorKeys = effectiveTreeErrorKind ? ARTIFACT_FILE_TREE_ERROR_KEYS[effectiveTreeErrorKind] : undefined
+  const hasInvalidWorkspacePath = effectiveTreeErrorKind === 'invalid_path'
   const overlaySelection = useMemo(
     () =>
-      previewFileSelection
-        ? previewFileSelection
+      validPreviewFileSelection
+        ? validPreviewFileSelection
         : workspacePath && !hasInvalidWorkspacePath && selectedFile
           ? { workspacePath, filePath: selectedFile }
           : null,
-    [hasInvalidWorkspacePath, previewFileSelection, selectedFile, workspacePath]
+    [hasInvalidWorkspacePath, selectedFile, validPreviewFileSelection, workspacePath]
   )
   const overlayWorkspacePath = overlaySelection?.workspacePath
   const overlayFilePath = overlaySelection?.filePath

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -713,6 +713,19 @@ describe('ArtifactPane', () => {
     expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.empty.description')
   })
 
+  it('shows a localized invalid-path state without requesting the filesystem', async () => {
+    render(<ArtifactPane workspacePath="relative/workspace" />)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.invalid_path.title')
+    )
+    expect(screen.getByTestId('empty-state')).toHaveTextContent(
+      'agent.preview_pane.tree_error.invalid_path.description'
+    )
+    expect(mocks.treeCreate).not.toHaveBeenCalled()
+    expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
+  })
+
   it('requests the workspace tree from DirectoryTreeBuilder', async () => {
     mockWorkspaceTree('/tmp/workspace', ['README.md', 'src/index.ts'])
 
@@ -1272,15 +1285,18 @@ describe('ArtifactPane', () => {
     )
   })
 
-  it('logs and displays directory listing errors', async () => {
+  it('logs directory listing errors and displays a localized load-error state', async () => {
     const error = new Error('Permission denied')
     const errorSpy = vi.spyOn(loggerService, 'error').mockImplementation(() => undefined)
     mocks.treeCreate.mockRejectedValueOnce(error)
 
     render(<ArtifactPane workspacePath="/tmp/workspace" />)
 
-    await waitFor(() => expect(screen.getByText('Permission denied')).toBeInTheDocument())
-    expect(screen.getByTestId('empty-state')).toHaveTextContent('common.error')
+    await waitFor(() =>
+      expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.load_error.title')
+    )
+    expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.load_error.description')
+    expect(screen.queryByText('Permission denied')).not.toBeInTheDocument()
     expect(screen.getByTestId('empty-state')).not.toHaveTextContent('agent.preview_pane.empty.title')
     expect(errorSpy).toHaveBeenCalledWith('Failed to create directory tree for /tmp/workspace', error)
   })

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -679,6 +679,10 @@ describe('ArtifactPane', () => {
     })
   })
 
+  it('rejects a workspace-relative artifact when the workspace path is relative', () => {
+    expect(resolveArtifactPaneFileSelection('relative/workspace', 'report.md')).toBeNull()
+  })
+
   it('re-roots a workspace-relative path that escapes via ".." so the tree root and previewed file agree', () => {
     // Out-of-workspace previews are intentional (the agent creates files outside the workspace), but a
     // `..`-escaping path must re-root like the absolute branch — otherwise the tree shows the workspace
@@ -714,7 +718,12 @@ describe('ArtifactPane', () => {
   })
 
   it('shows a localized invalid-path state without requesting the filesystem', async () => {
-    render(<ArtifactPane workspacePath="relative/workspace" />)
+    render(
+      <ArtifactPane
+        workspacePath="relative/workspace"
+        previewFileSelection={{ workspacePath: 'relative/workspace', filePath: 'report.md' }}
+      />
+    )
 
     await waitFor(() =>
       expect(screen.getByTestId('empty-state')).toHaveTextContent('agent.preview_pane.tree_error.invalid_path.title')
@@ -722,6 +731,9 @@ describe('ArtifactPane', () => {
     expect(screen.getByTestId('empty-state')).toHaveTextContent(
       'agent.preview_pane.tree_error.invalid_path.description'
     )
+    expect(screen.queryByTestId('artifact-file-preview-overlay')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-preview')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Open in Finder' })).not.toBeInTheDocument()
     expect(mocks.treeCreate).not.toHaveBeenCalled()
     expect(mocks.listDirectoryEntries).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/chat/panes/artifactPanePath.ts
+++ b/src/renderer/components/chat/panes/artifactPanePath.ts
@@ -1,5 +1,5 @@
 import { joinPath } from '@renderer/utils/path'
-import type { AbsoluteFilePath } from '@shared/types/file'
+import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
 import { canonicalizeFilePath } from '@shared/utils/file'
 
 /**
@@ -70,18 +70,20 @@ export const resolveArtifactPaneFileSelection = (
   const normalized = normalizeTreePath(rawPath)
   if (!normalized) return null
 
-  if (workspacePath) {
-    const workspaceFilePath = normalizeArtifactPaneFilePath(workspacePath, normalized)
+  const parsedWorkspacePath = workspacePath ? AbsoluteFilePathSchema.safeParse(workspacePath) : null
+  if (parsedWorkspacePath?.success) {
+    const validWorkspacePath = parsedWorkspacePath.data
+    const workspaceFilePath = normalizeArtifactPaneFilePath(validWorkspacePath, normalized)
     if (workspaceFilePath) {
       if (!hasParentTraversal(workspaceFilePath)) {
-        return { workspacePath, filePath: workspaceFilePath }
+        return { workspacePath: validWorkspacePath, filePath: workspaceFilePath }
       }
       // Deliberate: a workspace-relative artifact path that climbs out via `..` is allowed — the
       // agent legitimately creates files outside the workspace — but re-root it to the resolved
       // file's directory (like the absolute-path branch below) so the displayed tree root and the
       // previewed file stay consistent, instead of showing the workspace while reading outside it.
       // Sandboxing, if ever needed, is the consumer's responsibility at the trust boundary.
-      const resolvedAbsolute = joinPath(normalizeTreePath(workspacePath), workspaceFilePath)
+      const resolvedAbsolute = joinPath(normalizeTreePath(validWorkspacePath), workspaceFilePath)
       const escapedWorkspacePath = getPathDirname(resolvedAbsolute)
       const escapedFilePath = getPathBasename(resolvedAbsolute)
       return escapedWorkspacePath && escapedFilePath && escapedFilePath !== escapedWorkspacePath

--- a/src/renderer/components/chat/panes/useArtifactFileTreeModel.ts
+++ b/src/renderer/components/chat/panes/useArtifactFileTreeModel.ts
@@ -565,11 +565,13 @@ export interface ArtifactFileTreeModel {
   nodeById: ReadonlyMap<string, FileTreeNode>
   isLoading: boolean
   hasLoaded: boolean
-  error?: Error
+  errorKind?: ArtifactFileTreeErrorKind
   setExpandedIds: (ids: ReadonlySet<string>) => void
   reloadExpandedDirectories: () => void
   refresh: () => void
 }
+
+export type ArtifactFileTreeErrorKind = 'invalid_path' | 'load_error'
 
 /**
  * Owns the workspace directory tree: materialization (`useDirectoryTree`),
@@ -589,8 +591,18 @@ export function useArtifactFileTreeModel({
   selectedFile,
   onExpandedIdsChange
 }: UseArtifactFileTreeModelParams): ArtifactFileTreeModel {
+  const workspacePathResult = workspacePath ? AbsoluteFilePathSchema.safeParse(workspacePath) : null
+  const validWorkspacePath = workspacePathResult?.success ? workspacePathResult.data : undefined
+  const invalidWorkspacePath = Boolean(workspacePath && !workspacePathResult?.success)
+
+  useEffect(() => {
+    if (invalidWorkspacePath) {
+      logger.warn('Skipped artifact file tree for invalid workspace path', { workspacePath })
+    }
+  }, [invalidWorkspacePath, workspacePath])
+
   const { tree, isLoading, hasLoaded, error, refresh } = useWorkspaceFileTree(
-    treeOpen ? workspacePath : undefined,
+    treeOpen ? validWorkspacePath : undefined,
     watchMissingRoot
   )
   const {
@@ -599,7 +611,7 @@ export function useArtifactFileTreeModel({
     loadDirectoryChildren,
     reloadExpandedDirectories
   } = useLazyArtifactFileTree({
-    workspacePath,
+    workspacePath: validWorkspacePath,
     treeOpen,
     tree,
     expandedIds
@@ -617,7 +629,10 @@ export function useArtifactFileTreeModel({
   )
 
   const trimmedFileSearch = enableFileSearch ? searchKeyword.trim() : ''
-  const searchTree = useArtifactFileSearch(treeOpen && enableFileSearch ? workspacePath : undefined, trimmedFileSearch)
+  const searchTree = useArtifactFileSearch(
+    treeOpen && enableFileSearch ? validWorkspacePath : undefined,
+    trimmedFileSearch
+  )
   const searchableTree = useMemo(() => {
     if (!trimmedFileSearch || !searchTree) return displayTree
     return mergeFileTreeNodeLists(displayTree, searchTree)
@@ -628,7 +643,7 @@ export function useArtifactFileTreeModel({
   const preservedSelectedSearchNodeRef = useRef<FileTreeNode | null>(null)
 
   useEffect(() => {
-    if (!selectedFile || !workspacePath) {
+    if (!selectedFile || !validWorkspacePath) {
       preservedSelectedSearchNodeRef.current = null
       return
     }
@@ -648,7 +663,7 @@ export function useArtifactFileTreeModel({
     if (preservedSelectedSearchNodeRef.current?.id !== selectedFile) {
       preservedSelectedSearchNodeRef.current = null
     }
-  }, [displayNodeById, searchableNodeById, selectedFile, trimmedFileSearch, workspacePath])
+  }, [displayNodeById, searchableNodeById, selectedFile, trimmedFileSearch, validWorkspacePath])
 
   const nodeById = useMemo(() => {
     const result = new Map(searchableNodeById)
@@ -660,11 +675,11 @@ export function useArtifactFileTreeModel({
   }, [searchableNodeById])
 
   const expandedIdsWithWorkspaceRoot = useMemo<ReadonlySet<string>>(() => {
-    if (!workspacePath) return expandedIds
+    if (!validWorkspacePath) return expandedIds
     const next = new Set(expandedIds)
     next.add(WORKSPACE_ROOT_ID)
     return next
-  }, [expandedIds, workspacePath])
+  }, [expandedIds, validWorkspacePath])
 
   const filteredTree = useMemo<FileTreeNode[]>(() => {
     if (!trimmedFileSearch) return displayTree
@@ -709,7 +724,7 @@ export function useArtifactFileTreeModel({
     nodeById,
     isLoading,
     hasLoaded: hasLoaded && !isLazyLoading,
-    error,
+    errorKind: invalidWorkspacePath ? 'invalid_path' : error ? 'load_error' : undefined,
     setExpandedIds,
     reloadExpandedDirectories,
     refresh

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -279,6 +279,16 @@
         "description": "File exceeds the {{limit}} preview limit.",
         "title": "File too large to preview"
       },
+      "tree_error": {
+        "invalid_path": {
+          "description": "The file panel requires a valid absolute local path. Please select the work directory again.",
+          "title": "Invalid workspace path"
+        },
+        "load_error": {
+          "description": "Make sure the work directory still exists and is accessible, then try again.",
+          "title": "Couldn't load workspace files"
+        }
+      },
       "unavailable": {
         "description": "This file couldn't be opened — it may have been moved or deleted.",
         "title": "File unavailable"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -279,6 +279,16 @@
         "description": "文件超过 {{limit}} 预览上限。",
         "title": "文件太大，无法预览"
       },
+      "tree_error": {
+        "invalid_path": {
+          "description": "文件面板需要有效的本地绝对路径，请重新选择工作目录。",
+          "title": "工作区路径无效"
+        },
+        "load_error": {
+          "description": "请确认工作目录仍然存在且可以访问，然后重试。",
+          "title": "无法加载工作区文件"
+        }
+      },
       "unavailable": {
         "description": "无法打开此文件，它可能已被移动或删除。",
         "title": "文件不可用"

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -51,6 +51,7 @@ import type { AgentSessionTaskEvents } from '@shared/ai/agentSessionBackgroundTa
 import { isDeferredToolOutput } from '@shared/ai/transport'
 import { AGENT_WORKSPACE_TYPE, type AgentWorkspaceType } from '@shared/data/api/schemas/agentWorkspaces'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { createFilePathHandle, type TreeDirRoot } from '@shared/utils/file'
 import {
   Activity,
@@ -392,7 +393,11 @@ function AgentRightPaneStateProvider({
   const editHandle = useMemo(() => (editPath ? createFilePathHandle(editPath) : undefined), [editPath])
   const fileSession = useFileEditSession(editHandle)
   const discardFileDraft = fileSession.discard
-  const systemWorkspacePath = workspaceType === AGENT_WORKSPACE_TYPE.SYSTEM ? workspacePath : undefined
+  const systemWorkspacePath = useMemo(() => {
+    if (workspaceType !== AGENT_WORKSPACE_TYPE.SYSTEM || !workspacePath) return undefined
+    const result = AbsoluteFilePathSchema.safeParse(workspacePath)
+    return result.success ? result.data : undefined
+  }, [workspacePath, workspaceType])
   const { root: systemWorkspaceRoot, version: systemWorkspaceTreeVersion } = useDirectoryTree(
     systemWorkspacePath,
     ARTIFACT_MISSING_WORKSPACE_TREE_OPTIONS

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -709,6 +709,22 @@ describe('AgentRightPane', () => {
     )
   })
 
+  it('does not request a system workspace tree for a relative path', () => {
+    render(
+      <TestAgentRightPane
+        sessionId="session-a"
+        workspacePath="relative/workspace"
+        workspaceType="system"
+        messages={[]}
+        partsByMessageId={{}}>
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    expect(useDirectoryTreeMock).toHaveBeenLastCalledWith(undefined, { watchMissingRoot: true })
+  })
+
   it('hides conversation shortcuts when the conversation is unavailable', () => {
     render(
       <TestAgentRightPane

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -843,6 +843,26 @@ describe('AgentRightPane', () => {
     })
   })
 
+  it('rejects direct relative artifact opening from a relative workspace before metadata lookup', async () => {
+    const artifactPanePath = await vi.importActual<typeof ArtifactPanePath>(
+      '@renderer/components/chat/panes/artifactPanePath'
+    )
+    resolveArtifactPaneFileSelectionMock.mockImplementation(artifactPanePath.resolveArtifactPaneFileSelection)
+
+    render(
+      <TestAgentRightPane sessionId="session-a" workspacePath="relative/workspace" messages={[]} partsByMessageId={{}}>
+        <OpenArtifactButton />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'open artifact' }))
+
+    expect(screen.getByTestId('right-pane')).toHaveAttribute('data-open', 'true')
+    expect(ipcRequestMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('artifact-file-preview-overlay')).toBeNull()
+  })
+
   it('ignores a stale artifact metadata resolution after the workspace switches', async () => {
     resolveArtifactPaneFileSelectionMock.mockReturnValue({
       workspacePath: '/workspace-a',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent file panes could send a relative workspace path to the filesystem tree IPC and render the resulting raw Electron error in English.

After this PR:

Agent file panes reject invalid workspace paths before filesystem requests and render localized invalid-path or load-error states while retaining raw error details in logs.
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a06eb537-77df-491b-9db3-34bd66a05b2e" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The renderer now exposes two stable file-tree error kinds (`invalid_path` and `load_error`) instead of coupling user-visible text to raw IPC error messages. Absolute-path validation is applied before the regular tree, lazy tree, search, preview, and external-open paths, including the system-workspace pre-scan.

The following tradeoffs were made:

- Keep actionable localized messages in the UI while preserving technical errors in centralized logs.
- Validate at the feature boundary instead of weakening the filesystem IPC absolute-path contract.
- Use workspace-specific i18n keys rather than reusing file-preview copy with different semantics.

The following alternatives were considered:

- Translating raw Electron or Zod messages was rejected because those strings are unstable implementation details.
- Resolving relative paths against the process working directory was rejected because the intended base directory is ambiguous.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Added regression coverage for relative user and system workspace paths and localized load failures.
- Verified the behavior against an isolated SQLite workspace row containing a relative path.
- Focused renderer tests: 74 passed across `ArtifactPane.test.tsx` and `AgentRightPane.test.tsx`.
- `pnpm typecheck:web`, `pnpm i18n:check`, targeted ESLint/Oxlint/Biome checks, and `git diff --check` passed.
- The full repository test suite was not run per the requested focused-test scope.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Localized agent file-pane errors and prevented relative workspace paths from reaching filesystem tree requests.
```
