### PR TITLE
fix(migration-v2): recover from irrecoverable IndexedDB data loss

### DIFF
--- a/src/main/data/migration/v2/README.md
+++ b/src/main/data/migration/v2/README.md
@@ -61,12 +61,13 @@ and **MUST NOT** be added to `MigrationPaths`. No broader migration filesystem a
 ## Migration Diagnostic Bundle
 
 Only Renderer error/version-incompatible pages can request a bundle; there is no native preboot entry. A bundle
-contains minimal system information plus a stable snapshot for one log date: prefer the failure panel's
-mount-time local date, otherwise choose the latest eligible date, and never mix dates. If a complete snapshot
-cannot be formed, publish metadata only and disclose that result in the UI only when the destination can still be
-proven safe. If destination or source identity cannot be established, saving fails without replacing the existing
-file. Metadata excludes failure stacks, paths, and run/process fields. Logs may be sensitive and must not be shared
-publicly or outside Cherry Studio support.
+contains minimal system information, the terminal migration error when present, any bounded Dexie recovery
+reports, plus a stable snapshot for one log date: prefer the failure panel's mount-time local date, otherwise choose
+the latest eligible date, and never mix dates. If a complete snapshot cannot be formed, publish metadata only and
+disclose that result in the UI only when the destination can still be proven safe. If destination or source identity
+cannot be established, saving fails without replacing the existing file. Metadata adds no stack, cause, dedicated
+path, or run/process fields; the user-visible error text may itself contain diagnostic details such as a path. Logs
+and error text may be sensitive and must not be shared publicly or outside Cherry Studio support.
 
 ## Version Compatibility Gate
 

--- a/src/main/data/migration/v2/__tests__/migrationDiagnosticBundle.test.ts
+++ b/src/main/data/migration/v2/__tests__/migrationDiagnosticBundle.test.ts
@@ -102,6 +102,42 @@ describe('saveMigrationDiagnosticBundle', () => {
     expect(JSON.stringify(metadata)).not.toMatch(/"(?:error|stack|cause|path|processId|runId)"\s*:/)
   })
 
+  it('writes the terminal error and Dexie recovery reports into diagnostic metadata', async () => {
+    await writeLog(`app.${LOG_DATE}.log`, 'migration failed')
+
+    expect(
+      await saveMigrationDiagnosticBundle({
+        destination: destination(),
+        stage: 'error',
+        logDate: LOG_DATE,
+        error: 'Validation failed after degraded IndexedDB export',
+        dexieRecoveryReports: [
+          {
+            scope: 'records',
+            table: 'message_blocks',
+            skippedRecords: 1,
+            samplePrimaryKeys: ['block-2']
+          }
+        ]
+      })
+    ).toBe('included')
+
+    const zip = await readZip(destination())
+    const metadata = JSON.parse(zip.contents['migration-diagnostics.json'].toString())
+    expect(metadata.migration).toEqual({
+      stage: 'error',
+      error: 'Validation failed after degraded IndexedDB export',
+      dexieRecoveryReports: [
+        {
+          scope: 'records',
+          table: 'message_blocks',
+          skippedRecords: 1,
+          samplePrimaryKeys: ['block-2']
+        }
+      ]
+    })
+  })
+
   it('uses the failure-page log date even when a newer date exists', async () => {
     await Promise.all([
       writeLog(`app.${LOG_DATE}.log`, 'base'),

--- a/src/main/data/migration/v2/migrationDiagnosticBundle.ts
+++ b/src/main/data/migration/v2/migrationDiagnosticBundle.ts
@@ -6,7 +6,7 @@ import { type Readable, Transform } from 'node:stream'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { createAtomicWriteStream } from '@main/utils/file'
-import type { MigrationStage } from '@shared/data/migration/v2/types'
+import type { DexieRecoveryReport, MigrationStage } from '@shared/data/migration/v2/types'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
 import { ZipArchive } from 'archiver'
 import { app } from 'electron'
@@ -20,6 +20,8 @@ interface SaveMigrationDiagnosticBundleInput {
   destination: string
   stage: MigrationStage
   logDate: string
+  error?: string
+  dexieRecoveryReports?: DexieRecoveryReport[]
 }
 
 interface MigrationDiagnosticBundleDependencies {
@@ -241,7 +243,11 @@ export async function saveMigrationDiagnosticBundle(
   const metadata = JSON.stringify({
     application: { version: app.getVersion() },
     system: { platform: process.platform, arch: process.arch, release: release() },
-    migration: { stage: input.stage }
+    migration: {
+      stage: input.stage,
+      ...(input.error !== undefined ? { error: input.error } : {}),
+      ...(input.dexieRecoveryReports?.length ? { dexieRecoveryReports: input.dexieRecoveryReports } : {})
+    }
   })
   const handles: FileHandle[] = []
   const sourceIdentities: PresentFileIdentity[] = []

--- a/src/main/data/migration/v2/window/MigrationIpcHandler.ts
+++ b/src/main/data/migration/v2/window/MigrationIpcHandler.ts
@@ -6,8 +6,10 @@ import type { VersionBlockReason } from '@data/migration/v2/core/versionPolicy'
 import { loggerService } from '@logger'
 import { validateSender } from '@main/core/security/validateSender'
 import {
+  type DexieRecoveryReport,
   type MigrationDiagnosticSavePayload,
   type MigrationDiagnosticSaveResult,
+  type MigrationErrorReportPayload,
   type MigrationExportFileWriteMode,
   MigrationIpcChannels,
   type MigrationProgress,
@@ -47,6 +49,9 @@ let currentProgress: MigrationProgress = {
 // Held separately from currentProgress so it survives Retry (which rebuilds the
 // introduction progress from scratch) instead of vanishing after a failed run.
 let dataLocationNotice: string | null = null
+// Preserve observed legacy data loss for this main-process migration session; a clean retry cannot restore a
+// record Chromium removed.
+let retainedDexieRecoveryReports: DexieRecoveryReport[] = []
 
 function assertMigrationWindowSender(event: IpcMainInvokeEvent): void {
   if (!validateSender(event)) throw new Error('Unauthorized migration IPC sender.')
@@ -153,6 +158,8 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
       if (!parsedPayload.success) throw new Error('Invalid migration diagnostic save payload.')
       const { dialogTitle, logDate } = parsedPayload.data
       const stage = currentProgress.stage
+      const error = currentProgress.error
+      const dexieRecoveryReports = retainedDexieRecoveryReports.length ? retainedDexieRecoveryReports : undefined
       if (stage !== 'error' && stage !== 'version_incompatible') {
         throw new Error('Invalid migration diagnostic stage.')
       }
@@ -172,7 +179,9 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
           const logs = await saveMigrationDiagnosticBundle({
             destination: filePath,
             stage,
-            logDate
+            logDate,
+            ...(error !== undefined ? { error } : {}),
+            ...(dexieRecoveryReports ? { dexieRecoveryReports } : {})
           })
           if (!logs) return { status: 'failed' }
           lastSavedDiagnosticBundlePath = filePath
@@ -228,7 +237,8 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
     let runPromise: Promise<MigrationResult> | null = null
 
     try {
-      const { reduxData, dexieExportPath, localStorageExportPath, dexieRecovery } = payload
+      const { reduxData, dexieExportPath, localStorageExportPath, dexieRecoveryReports } = payload
+      retainDexieRecoveryReports(dexieRecoveryReports)
 
       if (!reduxData || !dexieExportPath) {
         throw new Error('Migration data not ready. Redux data or Dexie export path missing.')
@@ -268,15 +278,17 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
           })),
           warnings: result.migratorResults.flatMap((migratorResult) => migratorResult.warnings ?? []),
           summary: createMigrationSummary(result, currentProgress),
-          ...(dexieRecovery?.length ? { dexieRecovery } : {})
+          ...(retainedDexieRecoveryReports.length ? { dexieRecoveryReports: retainedDexieRecoveryReports } : {})
         })
       } else {
+        const errorMessage = result.error || 'Migration failed'
         updateProgress({
           stage: 'error',
           overallProgress: currentProgress.overallProgress,
-          currentMessage: result.error || 'Migration failed',
+          currentMessage: errorMessage,
           migrators: currentProgress.migrators,
-          error: result.error
+          error: errorMessage,
+          ...(retainedDexieRecoveryReports.length ? { dexieRecoveryReports: retainedDexieRecoveryReports } : {})
         })
       }
 
@@ -294,7 +306,8 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
         overallProgress: currentProgress.overallProgress,
         currentMessage: errorMessage,
         migrators: currentProgress.migrators,
-        error: errorMessage
+        error: errorMessage,
+        ...(retainedDexieRecoveryReports.length ? { dexieRecoveryReports: retainedDexieRecoveryReports } : {})
       })
 
       throw error
@@ -306,13 +319,16 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
   })
 
   // Mirror renderer-local failures into main so close handling sees the terminal error stage.
-  ipcMain.handle(MigrationIpcChannels.ReportError, (_event, message: string) => {
+  ipcMain.handle(MigrationIpcChannels.ReportError, (_event, payload: MigrationErrorReportPayload) => {
+    const { message, dexieRecoveryReports } = payload
+    retainDexieRecoveryReports(dexieRecoveryReports)
     updateProgress({
       stage: 'error',
       overallProgress: currentProgress.overallProgress,
       currentMessage: message,
       migrators: currentProgress.migrators,
-      error: message
+      error: message,
+      ...(retainedDexieRecoveryReports.length ? { dexieRecoveryReports: retainedDexieRecoveryReports } : {})
     })
     return true
   })
@@ -481,6 +497,7 @@ export function resetMigrationData(): void {
   inFlightDiagnosticSave = null
   quitScheduled = false
   dataLocationNotice = null
+  retainedDexieRecoveryReports = []
   lastSavedDiagnosticBundlePath = null
   currentProgress = {
     stage: 'introduction',
@@ -488,6 +505,12 @@ export function resetMigrationData(): void {
     currentMessage: 'Ready to start data migration',
     migrators: []
   }
+}
+
+function retainDexieRecoveryReports(reports: DexieRecoveryReport[] | undefined): void {
+  if (!reports?.length) return
+  retainedDexieRecoveryReports = reports
+  logger.warn('Migration received IndexedDB recovery reports', { dexieRecoveryReports: reports })
 }
 
 /**

--- a/src/main/data/migration/v2/window/MigrationIpcHandler.ts
+++ b/src/main/data/migration/v2/window/MigrationIpcHandler.ts
@@ -228,7 +228,7 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
     let runPromise: Promise<MigrationResult> | null = null
 
     try {
-      const { reduxData, dexieExportPath, localStorageExportPath } = payload
+      const { reduxData, dexieExportPath, localStorageExportPath, dexieRecovery } = payload
 
       if (!reduxData || !dexieExportPath) {
         throw new Error('Migration data not ready. Redux data or Dexie export path missing.')
@@ -267,7 +267,8 @@ export function registerMigrationIpcHandlers(userDataPath: string): void {
             status: 'completed'
           })),
           warnings: result.migratorResults.flatMap((migratorResult) => migratorResult.warnings ?? []),
-          summary: createMigrationSummary(result, currentProgress)
+          summary: createMigrationSummary(result, currentProgress),
+          ...(dexieRecovery?.length ? { dexieRecovery } : {})
         })
       } else {
         updateProgress({

--- a/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
+++ b/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
@@ -1,5 +1,6 @@
 import { application } from '@application'
 import { MigrationIpcChannels, type MigrationProgress, type MigrationResult } from '@shared/data/migration/v2/types'
+import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { dialog, ipcMain, type IpcMainInvokeEvent, shell } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -106,7 +107,7 @@ describe('MigrationIpcHandler', () => {
 
   describe('diagnostic bundle actions', () => {
     beforeEach(() => {
-      invoke(MigrationIpcChannels.ReportError, 'diagnostic test failure')
+      invoke(MigrationIpcChannels.ReportError, { message: 'diagnostic test failure' })
     })
 
     it('rejects save requests outside the error and version-incompatible stages', async () => {
@@ -204,7 +205,8 @@ describe('MigrationIpcHandler', () => {
       expect(diagnosticMocks.saveBundle).toHaveBeenCalledWith({
         destination: '/chosen/diagnostics.zip',
         stage: 'error',
-        logDate: '2026-07-23'
+        logDate: '2026-07-23',
+        error: 'diagnostic test failure'
       })
     })
 
@@ -216,7 +218,8 @@ describe('MigrationIpcHandler', () => {
       expect(diagnosticMocks.saveBundle).toHaveBeenCalledWith({
         destination: '/chosen/diagnostics.data',
         stage: 'error',
-        logDate: '2026-07-23'
+        logDate: '2026-07-23',
+        error: 'diagnostic test failure'
       })
     })
 
@@ -248,7 +251,7 @@ describe('MigrationIpcHandler', () => {
       const firstSave = invoke(MigrationIpcChannels.SaveDiagnosticBundle, savePayload)
       await vi.waitFor(() => expect(diagnosticMocks.saveBundle).toHaveBeenCalledOnce())
       await invoke(MigrationIpcChannels.Retry)
-      invoke(MigrationIpcChannels.ReportError, 'second diagnostic test failure')
+      invoke(MigrationIpcChannels.ReportError, { message: 'second diagnostic test failure' })
 
       await expect(invoke(MigrationIpcChannels.SaveDiagnosticBundle, savePayload)).resolves.toEqual({
         status: 'failed'
@@ -448,7 +451,7 @@ describe('MigrationIpcHandler', () => {
     await invoke(MigrationIpcChannels.StartMigration, {
       reduxData: {},
       dexieExportPath: '/dexie',
-      dexieRecovery: [
+      dexieRecoveryReports: [
         {
           scope: 'records',
           table: 'message_blocks',
@@ -467,7 +470,7 @@ describe('MigrationIpcHandler', () => {
       durationMs: 4200
     })
     expect(progress.warnings).toEqual(['w1'])
-    expect(progress.dexieRecovery).toEqual([
+    expect(progress.dexieRecoveryReports).toEqual([
       {
         scope: 'records',
         table: 'message_blocks',
@@ -573,6 +576,15 @@ describe('MigrationIpcHandler', () => {
   })
 
   describe('migration failure', () => {
+    const dexieRecoveryReports = [
+      {
+        scope: 'records' as const,
+        table: 'message_blocks',
+        skippedRecords: 1,
+        samplePrimaryKeys: ['block-2']
+      }
+    ]
+
     it('does not clean staged v1 agent files when a later migrator fails and the user skips migration', async () => {
       engineMock.run.mockResolvedValue({
         success: false,
@@ -613,6 +625,41 @@ describe('MigrationIpcHandler', () => {
       expect(windowSetStageMock).toHaveBeenCalledWith('error')
     })
 
+    it('preserves recovery reports when the run reports failure and includes them in diagnostics', async () => {
+      engineMock.run.mockResolvedValue({
+        success: false,
+        error: 'Validation failed',
+        totalDuration: 1200,
+        migratorResults: []
+      })
+
+      await invoke(MigrationIpcChannels.StartMigration, {
+        reduxData: {},
+        dexieExportPath: '/dexie',
+        dexieRecoveryReports
+      })
+
+      expect(lastProgress()).toMatchObject({
+        stage: 'error',
+        error: 'Validation failed',
+        dexieRecoveryReports
+      })
+      expect(mockMainLoggerService.warn).toHaveBeenCalledWith('Migration received IndexedDB recovery reports', {
+        dexieRecoveryReports
+      })
+
+      choosePath('/chosen/diagnostics.zip')
+      await invoke(MigrationIpcChannels.SaveDiagnosticBundle, savePayload)
+
+      expect(diagnosticMocks.saveBundle).toHaveBeenCalledWith({
+        destination: '/chosen/diagnostics.zip',
+        stage: 'error',
+        logDate: '2026-07-23',
+        error: 'Validation failed',
+        dexieRecoveryReports
+      })
+    })
+
     it('broadcasts the error stage when the run rejects, then frees the in-flight guard so a retry is not blocked', async () => {
       engineMock.run.mockRejectedValueOnce(new Error('Engine exploded'))
 
@@ -632,8 +679,26 @@ describe('MigrationIpcHandler', () => {
       expect(lastProgress().stage).toBe('completed')
     })
 
+    it('preserves recovery reports when the run rejects', async () => {
+      engineMock.run.mockRejectedValueOnce(new Error('Engine exploded'))
+
+      await expect(
+        invoke(MigrationIpcChannels.StartMigration, {
+          reduxData: {},
+          dexieExportPath: '/dexie',
+          dexieRecoveryReports
+        })
+      ).rejects.toThrow('Engine exploded')
+
+      expect(lastProgress()).toMatchObject({
+        stage: 'error',
+        error: 'Engine exploded',
+        dexieRecoveryReports
+      })
+    })
+
     it('transitions main to the terminal error stage when the renderer reports a pre-handoff failure', async () => {
-      const result = await invoke(MigrationIpcChannels.ReportError, 'Dexie export failed')
+      const result = await invoke(MigrationIpcChannels.ReportError, { message: 'Dexie export failed' })
 
       expect(result).toBe(true)
       const progress = lastProgress()
@@ -641,6 +706,56 @@ describe('MigrationIpcHandler', () => {
       expect(progress.error).toBe('Dexie export failed')
       expect(progress.currentMessage).toBe('Dexie export failed')
       expect(windowSetStageMock).toHaveBeenCalledWith('error')
+    })
+
+    it('preserves recovery reports from a renderer-side post-Dexie failure', async () => {
+      const result = await invoke(MigrationIpcChannels.ReportError, {
+        message: 'localStorage export failed',
+        dexieRecoveryReports
+      })
+
+      expect(result).toBe(true)
+      expect(lastProgress()).toMatchObject({
+        stage: 'error',
+        error: 'localStorage export failed',
+        dexieRecoveryReports
+      })
+    })
+
+    it('retains prior recovery reports when a clean retry completes', async () => {
+      engineMock.run
+        .mockResolvedValueOnce({ success: false, error: 'First run failed', totalDuration: 1, migratorResults: [] })
+        .mockResolvedValueOnce({ success: true, totalDuration: 1, migratorResults: [] })
+
+      await invoke(MigrationIpcChannels.StartMigration, {
+        reduxData: {},
+        dexieExportPath: '/dexie',
+        dexieRecoveryReports
+      })
+      await invoke(MigrationIpcChannels.Retry)
+      await invoke(MigrationIpcChannels.StartMigration, { reduxData: {}, dexieExportPath: '/dexie' })
+
+      expect(lastProgress()).toMatchObject({
+        stage: 'completed',
+        dexieRecoveryReports
+      })
+    })
+
+    it('clears retained recovery reports when migration data is reset', async () => {
+      engineMock.run
+        .mockResolvedValueOnce({ success: false, error: 'First run failed', totalDuration: 1, migratorResults: [] })
+        .mockResolvedValueOnce({ success: true, totalDuration: 1, migratorResults: [] })
+
+      await invoke(MigrationIpcChannels.StartMigration, {
+        reduxData: {},
+        dexieExportPath: '/dexie',
+        dexieRecoveryReports
+      })
+      resetMigrationData()
+      await invoke(MigrationIpcChannels.StartMigration, { reduxData: {}, dexieExportPath: '/dexie' })
+
+      expect(lastProgress().stage).toBe('completed')
+      expect(lastProgress().dexieRecoveryReports).toBeUndefined()
     })
   })
 
@@ -699,7 +814,7 @@ describe('MigrationIpcHandler', () => {
     })
 
     it('pushes the live stage to the window manager on progress updates', async () => {
-      await invoke(MigrationIpcChannels.ReportError, 'boom')
+      await invoke(MigrationIpcChannels.ReportError, { message: 'boom' })
       expect(windowSetStageMock).toHaveBeenCalledWith('error')
     })
   })

--- a/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
+++ b/src/main/data/migration/v2/window/__tests__/MigrationIpcHandler.test.ts
@@ -434,7 +434,7 @@ describe('MigrationIpcHandler', () => {
     expect(windowSetStageMock).toHaveBeenCalledWith('introduction')
   })
 
-  it('derives summary and warnings on successful completion', async () => {
+  it('derives summary and preserves recovery details on successful completion', async () => {
     const result: MigrationResult = {
       success: true,
       totalDuration: 4200,
@@ -445,7 +445,18 @@ describe('MigrationIpcHandler', () => {
     }
     engineMock.run.mockResolvedValue(result)
 
-    await invoke(MigrationIpcChannels.StartMigration, { reduxData: {}, dexieExportPath: '/dexie' })
+    await invoke(MigrationIpcChannels.StartMigration, {
+      reduxData: {},
+      dexieExportPath: '/dexie',
+      dexieRecovery: [
+        {
+          scope: 'records',
+          table: 'message_blocks',
+          skippedRecords: 1,
+          samplePrimaryKeys: ['block-2']
+        }
+      ]
+    })
 
     const progress = lastProgress()
     expect(progress.stage).toBe('completed')
@@ -456,6 +467,14 @@ describe('MigrationIpcHandler', () => {
       durationMs: 4200
     })
     expect(progress.warnings).toEqual(['w1'])
+    expect(progress.dexieRecovery).toEqual([
+      {
+        scope: 'records',
+        table: 'message_blocks',
+        skippedRecords: 1,
+        samplePrimaryKeys: ['block-2']
+      }
+    ])
   })
 
   it('uses the live migrator count for totalMigrators, distinct from completedMigrators', async () => {

--- a/src/renderer/windows/migrationV2/MigrationApp.tsx
+++ b/src/renderer/windows/migrationV2/MigrationApp.tsx
@@ -25,7 +25,7 @@ import AppLogo from '@renderer/assets/images/logo.png'
 import ToastHost from '@renderer/components/ToastHost'
 import { loggerService } from '@renderer/services/LoggerService'
 import { isMac } from '@renderer/utils/platform'
-import { MigrationIpcChannels, type MigrationStage } from '@shared/data/migration/v2/types'
+import { type DexieRecoveryReport, MigrationIpcChannels, type MigrationStage } from '@shared/data/migration/v2/types'
 import {
   AlertTriangle,
   ArrowRight,
@@ -455,6 +455,7 @@ const MigrationApp: React.FC = () => {
     startGuardRef.current = true
     setIsLoading(true)
     setLocalMigrationError(null)
+    let dexieRecoveryReports: DexieRecoveryReport[] = []
     try {
       logger.info('Starting migration process...')
 
@@ -475,6 +476,7 @@ const MigrationApp: React.FC = () => {
       const dexieResult = await dexieExporter.exportAll((p) => {
         logger.info('Dexie export progress', p)
       })
+      dexieRecoveryReports = dexieResult.recoveryReports
 
       logger.info('Dexie data exported', { exportPath: dexieResult.exportPath })
 
@@ -492,13 +494,16 @@ const MigrationApp: React.FC = () => {
         reduxData: reduxResult.data,
         dexieExportPath: dexieResult.exportPath,
         localStorageExportPath: localStorageFilePath,
-        ...(dexieResult.recovery.length > 0 ? { dexieRecovery: dexieResult.recovery } : {})
+        ...(dexieRecoveryReports.length > 0 ? { dexieRecoveryReports } : {})
       })
     } catch (error) {
       logger.error('Failed to start migration', error as Error)
       const message = errorMessage(error)
       setLocalMigrationError(message)
-      void window.electron.ipcRenderer.invoke(MigrationIpcChannels.ReportError, message)
+      void window.electron.ipcRenderer.invoke(MigrationIpcChannels.ReportError, {
+        message,
+        ...(dexieRecoveryReports.length > 0 ? { dexieRecoveryReports } : {})
+      })
     } finally {
       startGuardRef.current = false
       setIsLoading(false)
@@ -656,7 +661,7 @@ const MigrationApp: React.FC = () => {
 
       case 'completed': {
         const summary = progress.summary
-        const recoveryIssues = progress.dexieRecovery ?? []
+        const recoveryIssues = progress.dexieRecoveryReports ?? []
         const isDegraded = recoveryIssues.length > 0
         const recoveryWarnings = recoveryIssues.map((issue) => {
           if (issue.scope === 'database') {

--- a/src/renderer/windows/migrationV2/MigrationApp.tsx
+++ b/src/renderer/windows/migrationV2/MigrationApp.tsx
@@ -352,6 +352,22 @@ const themeLabelKey: Record<string, string> = {
   system: 'settings.theme.system'
 }
 
+const dexieTableLabelKey: Record<string, string> = {
+  files: 'migration.completed.recovery_tables.files',
+  knowledge_notes: 'migration.completed.recovery_tables.knowledge_notes',
+  message_blocks: 'migration.completed.recovery_tables.message_blocks',
+  quick_phrases: 'migration.completed.recovery_tables.quick_phrases',
+  settings: 'migration.completed.recovery_tables.settings',
+  topics: 'migration.completed.recovery_tables.topics',
+  translate_history: 'migration.completed.recovery_tables.translate_history',
+  translate_languages: 'migration.completed.recovery_tables.translate_languages'
+}
+
+const dexieTableImpactKey: Partial<Record<string, string>> = {
+  message_blocks: 'migration.completed.recovery_impacts.message_blocks',
+  topics: 'migration.completed.recovery_impacts.topics'
+}
+
 const MigrationApp: React.FC = () => {
   const { t, i18n } = useTranslation()
   const { progress, lastError } = useMigrationProgress()
@@ -456,11 +472,11 @@ const MigrationApp: React.FC = () => {
       const dexieExportPath = `${exportBasePath}/dexie_export`
       const dexieExporter = new DexieExporter(dexieExportPath)
 
-      await dexieExporter.exportAll((p) => {
+      const dexieResult = await dexieExporter.exportAll((p) => {
         logger.info('Dexie export progress', p)
       })
 
-      logger.info('Dexie data exported', { exportPath: dexieExportPath })
+      logger.info('Dexie data exported', { exportPath: dexieResult.exportPath })
 
       // Export localStorage data
       const localStorageExportPath = `${exportBasePath}/localstorage_export`
@@ -474,8 +490,9 @@ const MigrationApp: React.FC = () => {
       // Start migration with exported data
       await actions.startMigration({
         reduxData: reduxResult.data,
-        dexieExportPath,
-        localStorageExportPath: localStorageFilePath
+        dexieExportPath: dexieResult.exportPath,
+        localStorageExportPath: localStorageFilePath,
+        ...(dexieResult.recovery.length > 0 ? { dexieRecovery: dexieResult.recovery } : {})
       })
     } catch (error) {
       logger.error('Failed to start migration', error as Error)
@@ -639,21 +656,44 @@ const MigrationApp: React.FC = () => {
 
       case 'completed': {
         const summary = progress.summary
-        const warnings = progress.warnings ?? []
+        const recoveryIssues = progress.dexieRecovery ?? []
+        const isDegraded = recoveryIssues.length > 0
+        const recoveryWarnings = recoveryIssues.map((issue) => {
+          if (issue.scope === 'database') {
+            return t('migration.completed.recovery_database')
+          }
+
+          const table = dexieTableLabelKey[issue.table] ? t(dexieTableLabelKey[issue.table]) : issue.table
+          const recoveryWarning =
+            issue.scope === 'records'
+              ? t('migration.completed.recovery_records', { count: issue.skippedRecords, table })
+              : t('migration.completed.recovery_table', { table })
+          const impactKey = dexieTableImpactKey[issue.table]
+          return impactKey ? `${recoveryWarning} ${t(impactKey)}` : recoveryWarning
+        })
+        const warnings = [...recoveryWarnings, ...(progress.warnings ?? [])]
         return (
           <div className="space-y-5">
             <TopContent>
-              <div className="relative mx-auto mb-4 inline-block text-[56px] leading-none">
-                🎉
-                <Confetti />
-              </div>
+              {isDegraded ? (
+                <StageBadge tone="warning">
+                  <AlertTriangle size={26} strokeWidth={1.5} />
+                </StageBadge>
+              ) : (
+                <div className="relative mx-auto mb-4 inline-block text-[56px] leading-none">
+                  🎉
+                  <Confetti />
+                </div>
+              )}
               <h2 className="font-semibold text-2xl text-foreground tracking-tight">
-                {t('migration.completed.title')}
+                {t(isDegraded ? 'migration.completed.degraded_title' : 'migration.completed.title')}
               </h2>
               <p className="mt-2.5 text-muted-foreground text-sm leading-relaxed">
-                {t('migration.completed.description')}
+                {t(isDegraded ? 'migration.completed.degraded_description' : 'migration.completed.description')}
               </p>
             </TopContent>
+
+            {isDegraded && <Alert type="warning" showIcon description={t('migration.completed.degraded_alert')} />}
 
             {summary && (
               <div className="grid grid-cols-3 divide-x divide-border rounded-xl border border-border bg-muted/10 py-4">

--- a/src/renderer/windows/migrationV2/README.md
+++ b/src/renderer/windows/migrationV2/README.md
@@ -26,6 +26,7 @@ src/renderer/windows/migrationV2/
 4. Exporters:
    - `ReduxExporter` pulls Redux Persist payload from `localStorage` (`persist:cherry-studio`), parses slices, and returns clean JS objects for main.
    - `DexieExporter` reads Dexie tables in primary-key pages and sends bounded JSON-array chunks via IPC (`migration:write-export-file`), so main can assemble the files on disk without direct browser access or whole-table renderer strings.
+   - For Chromium's exact irrecoverable missing-file error, `DexieExporter` falls back from a page to individual records, then to an empty table, then to empty supported Dexie tables if the database cannot open. Other errors remain fatal and the legacy database stays read-only.
 5. Components render the per-migrator list (`MigratorProgressList`), skip/close dialogs, window controls, and completion confetti used by the wizard.
 
 ## Failure Diagnostics
@@ -56,6 +57,11 @@ own.
 On completion, non-fatal migration notices stay collapsed into a single-line warning entry below Restart. The
 entry opens a scrollable dialog with the full notice list and a full-width copy action at the bottom of the
 content; the dialog intentionally has no footer.
+
+An IndexedDB recovery report still reaches the completed stage, but replaces confetti with a warning state and
+explains which user-facing data categories were not imported. Recovery notices are aggregated by table and
+merged with existing migrator notices in both the dialog and copied text. The UI never shows sampled primary
+keys or record content; conversation and message-content notices state their possible user-visible impact.
 
 ## Implementation Notes
 

--- a/src/renderer/windows/migrationV2/README.md
+++ b/src/renderer/windows/migrationV2/README.md
@@ -26,7 +26,7 @@ src/renderer/windows/migrationV2/
 4. Exporters:
    - `ReduxExporter` pulls Redux Persist payload from `localStorage` (`persist:cherry-studio`), parses slices, and returns clean JS objects for main.
    - `DexieExporter` reads Dexie tables in primary-key pages and sends bounded JSON-array chunks via IPC (`migration:write-export-file`), so main can assemble the files on disk without direct browser access or whole-table renderer strings.
-   - For Chromium's exact irrecoverable missing-file error, `DexieExporter` falls back from a page to individual records, then to an empty table, then to empty supported Dexie tables if the database cannot open. Other errors remain fatal and the legacy database stays read-only.
+   - For Chromium's exact irrecoverable missing-file error, `DexieExporter` recovers at the boundary that failed: a page read falls back to individual records, failed key enumeration exports that table as empty, and failed database inspection exports every supported Dexie table as empty. Other errors remain fatal and the legacy database stays read-only.
 5. Components render the per-migrator list (`MigratorProgressList`), skip/close dialogs, window controls, and completion confetti used by the wizard.
 
 ## Failure Diagnostics
@@ -61,7 +61,8 @@ content; the dialog intentionally has no footer.
 An IndexedDB recovery report still reaches the completed stage, but replaces confetti with a warning state and
 explains which user-facing data categories were not imported. Recovery notices are aggregated by table and
 merged with existing migrator notices in both the dialog and copied text. The UI never shows sampled primary
-keys or record content; conversation and message-content notices state their possible user-visible impact.
+keys or record content; conversation and message-content notices state their possible user-visible impact. Main
+retains a non-empty report across retries so a later clean export cannot hide data loss already observed.
 
 ## Implementation Notes
 

--- a/src/renderer/windows/migrationV2/__tests__/MigrationApp.test.tsx
+++ b/src/renderer/windows/migrationV2/__tests__/MigrationApp.test.tsx
@@ -38,7 +38,7 @@ const migrationHookMock = vi.hoisted(() => ({
   } as {
     currentMessage: string
     dataLocation?: string
-    dexieRecovery?: DexieRecoveryReport[]
+    dexieRecoveryReports?: DexieRecoveryReport[]
     i18nMessage?: { key: string; params?: Record<string, string | number> }
     migrators: unknown[]
     overallProgress: number
@@ -488,7 +488,7 @@ describe('MigrationApp', () => {
         ({
           exportAll: vi.fn().mockResolvedValue({
             exportPath: '/tmp/userData/migration_temp/dexie_export',
-            recovery: []
+            recoveryReports: []
           })
         }) as unknown as DexieExporter
     )
@@ -523,7 +523,7 @@ describe('MigrationApp', () => {
         ({
           exportAll: vi.fn().mockResolvedValue({
             exportPath: '/tmp/userData/migration_temp/dexie_export',
-            recovery: [
+            recoveryReports: [
               {
                 scope: 'records',
                 table: 'message_blocks',
@@ -553,7 +553,7 @@ describe('MigrationApp', () => {
       reduxData: {},
       dexieExportPath: '/tmp/userData/migration_temp/dexie_export',
       localStorageExportPath: '/tmp/userData/migration_temp/localstorage_export/localStorage.json',
-      dexieRecovery: [
+      dexieRecoveryReports: [
         {
           scope: 'records',
           table: 'message_blocks',
@@ -591,7 +591,48 @@ describe('MigrationApp', () => {
     expect(screen.getByText(/Dexie export failed/)).toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: 'migration.buttons.more_options' })).toHaveLength(1)
     expect(migrationHookMock.actions.startMigration).not.toHaveBeenCalled()
-    expect(invoke).toHaveBeenCalledWith(MigrationIpcChannels.ReportError, 'Dexie export failed')
+    expect(invoke).toHaveBeenCalledWith(MigrationIpcChannels.ReportError, { message: 'Dexie export failed' })
+  })
+
+  it('reports Dexie recovery details when a later renderer-side export rejects', async () => {
+    const dexieRecoveryReports = [
+      {
+        scope: 'records' as const,
+        table: 'message_blocks',
+        skippedRecords: 1,
+        samplePrimaryKeys: ['block-2']
+      }
+    ]
+    vi.mocked(ReduxExporter).mockImplementation(
+      () => ({ export: () => ({ data: {}, slicesFound: [], slicesMissing: [] }) }) as unknown as ReduxExporter
+    )
+    vi.mocked(DexieExporter).mockImplementation(
+      () =>
+        ({
+          exportAll: vi.fn().mockResolvedValue({
+            exportPath: '/tmp/userData/migration_temp/dexie_export',
+            recoveryReports: dexieRecoveryReports
+          })
+        }) as unknown as DexieExporter
+    )
+    vi.mocked(LocalStorageExporter).mockImplementation(
+      () =>
+        ({
+          export: vi.fn().mockRejectedValue(new Error('localStorage export failed')),
+          getEntryCount: vi.fn(() => 0)
+        }) as unknown as LocalStorageExporter
+    )
+    invoke.mockResolvedValue('/tmp/userData')
+
+    render(<MigrationApp />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'migration.buttons.start_migration' }))
+
+    expect(await screen.findByText(/localStorage export failed/)).toBeInTheDocument()
+    expect(invoke).toHaveBeenCalledWith(MigrationIpcChannels.ReportError, {
+      message: 'localStorage export failed',
+      dexieRecoveryReports
+    })
   })
 
   it('does not claim all data is unchanged when skipping fails', () => {
@@ -614,7 +655,7 @@ describe('MigrationApp', () => {
         ({
           exportAll: vi.fn().mockResolvedValue({
             exportPath: '/tmp/userData/migration_temp/dexie_export',
-            recovery: []
+            recoveryReports: []
           })
         }) as unknown as DexieExporter
     )
@@ -634,7 +675,7 @@ describe('MigrationApp', () => {
 
     expect(await screen.findByText('migration.error.title')).toBeInTheDocument()
     expect(screen.getByText(/StartMigration failed/)).toBeInTheDocument()
-    expect(invoke).toHaveBeenCalledWith(MigrationIpcChannels.ReportError, 'StartMigration failed')
+    expect(invoke).toHaveBeenCalledWith(MigrationIpcChannels.ReportError, { message: 'StartMigration failed' })
   })
 
   it('clears the local error latch when main later drives a non-error stage', async () => {
@@ -718,7 +759,7 @@ describe('MigrationApp', () => {
       overallProgress: 100,
       stage: 'completed',
       warnings: ['Existing migration notice'],
-      dexieRecovery: [
+      dexieRecoveryReports: [
         {
           scope: 'records',
           table: 'topics',

--- a/src/renderer/windows/migrationV2/__tests__/MigrationApp.test.tsx
+++ b/src/renderer/windows/migrationV2/__tests__/MigrationApp.test.tsx
@@ -1,5 +1,5 @@
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
-import { MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { type DexieRecoveryReport, MigrationIpcChannels } from '@shared/data/migration/v2/types'
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import type { ButtonHTMLAttributes, ReactElement, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -38,6 +38,7 @@ const migrationHookMock = vi.hoisted(() => ({
   } as {
     currentMessage: string
     dataLocation?: string
+    dexieRecovery?: DexieRecoveryReport[]
     i18nMessage?: { key: string; params?: Record<string, string | number> }
     migrators: unknown[]
     overallProgress: number
@@ -485,7 +486,10 @@ describe('MigrationApp', () => {
     vi.mocked(DexieExporter).mockImplementation(
       () =>
         ({
-          exportAll: vi.fn().mockResolvedValue('/tmp/userData/migration_temp/dexie_export')
+          exportAll: vi.fn().mockResolvedValue({
+            exportPath: '/tmp/userData/migration_temp/dexie_export',
+            recovery: []
+          })
         }) as unknown as DexieExporter
     )
     vi.mocked(LocalStorageExporter).mockImplementation(
@@ -507,6 +511,56 @@ describe('MigrationApp', () => {
       reduxData: { a: 1 },
       dexieExportPath: '/tmp/userData/migration_temp/dexie_export',
       localStorageExportPath: '/tmp/userData/migration_temp/localstorage_export/localStorage.json'
+    })
+  })
+
+  it('hands recoverable Dexie data loss details to the migration process', async () => {
+    vi.mocked(ReduxExporter).mockImplementation(
+      () => ({ export: () => ({ data: {}, slicesFound: [], slicesMissing: [] }) }) as unknown as ReduxExporter
+    )
+    vi.mocked(DexieExporter).mockImplementation(
+      () =>
+        ({
+          exportAll: vi.fn().mockResolvedValue({
+            exportPath: '/tmp/userData/migration_temp/dexie_export',
+            recovery: [
+              {
+                scope: 'records',
+                table: 'message_blocks',
+                skippedRecords: 1,
+                samplePrimaryKeys: ['block-2']
+              }
+            ]
+          })
+        }) as unknown as DexieExporter
+    )
+    vi.mocked(LocalStorageExporter).mockImplementation(
+      () =>
+        ({
+          export: vi.fn().mockResolvedValue('/tmp/userData/migration_temp/localstorage_export/localStorage.json'),
+          getEntryCount: vi.fn(() => 1)
+        }) as unknown as LocalStorageExporter
+    )
+    invoke.mockResolvedValue('/tmp/userData')
+
+    render(<MigrationApp />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'migration.buttons.start_migration' }))
+    })
+
+    expect(migrationHookMock.actions.startMigration).toHaveBeenCalledWith({
+      reduxData: {},
+      dexieExportPath: '/tmp/userData/migration_temp/dexie_export',
+      localStorageExportPath: '/tmp/userData/migration_temp/localstorage_export/localStorage.json',
+      dexieRecovery: [
+        {
+          scope: 'records',
+          table: 'message_blocks',
+          skippedRecords: 1,
+          samplePrimaryKeys: ['block-2']
+        }
+      ]
     })
   })
 
@@ -558,7 +612,10 @@ describe('MigrationApp', () => {
     vi.mocked(DexieExporter).mockImplementation(
       () =>
         ({
-          exportAll: vi.fn().mockResolvedValue('/tmp/userData/migration_temp/dexie_export')
+          exportAll: vi.fn().mockResolvedValue({
+            exportPath: '/tmp/userData/migration_temp/dexie_export',
+            recovery: []
+          })
         }) as unknown as DexieExporter
     )
     vi.mocked(LocalStorageExporter).mockImplementation(
@@ -652,6 +709,63 @@ describe('MigrationApp', () => {
     )
     expect(toastSuccessMock).toHaveBeenCalledWith('migration.completed.warning_copy_success')
     expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('completes with a visible degradation warning when irrecoverable Dexie data was skipped', async () => {
+    migrationHookMock.progress = {
+      currentMessage: 'Completed',
+      migrators: [],
+      overallProgress: 100,
+      stage: 'completed',
+      warnings: ['Existing migration notice'],
+      dexieRecovery: [
+        {
+          scope: 'records',
+          table: 'topics',
+          skippedRecords: 2,
+          samplePrimaryKeys: ['topic-1', 'topic-2']
+        },
+        { scope: 'table', table: 'message_blocks' }
+      ]
+    }
+
+    render(<MigrationApp />)
+
+    expect(screen.getByText('migration.completed.degraded_title')).toBeInTheDocument()
+    expect(screen.getByText('migration.completed.degraded_description')).toBeInTheDocument()
+    expect(screen.queryByText('migration.completed.title')).not.toBeInTheDocument()
+    expect(screen.queryByText('🎉')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'migration.buttons.restart' })).toBeInTheDocument()
+    const alert = screen.getByTestId('alert')
+    expect(alert).toHaveAttribute('data-type', 'warning')
+    expect(alert).toHaveTextContent('migration.completed.degraded_alert')
+
+    fireEvent.click(screen.getByRole('button', { name: 'migration.completed.warning_heading' }))
+
+    expect(
+      screen.getByText('migration.completed.recovery_records migration.completed.recovery_impacts.topics')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('migration.completed.recovery_table migration.completed.recovery_impacts.message_blocks')
+    ).toBeInTheDocument()
+    expect(screen.getByText('Existing migration notice')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'migration.completed.warning_copy' }))
+    })
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledExactlyOnceWith(
+      '1. migration.completed.recovery_records migration.completed.recovery_impacts.topics\n' +
+        '2. migration.completed.recovery_table migration.completed.recovery_impacts.message_blocks\n' +
+        '3. Existing migration notice'
+    )
+  })
+
+  it('explains the user-visible impact of damaged conversations and message content', () => {
+    expect(zhCN.migration.completed.recovery_impacts.topics).toContain('整个对话')
+    expect(zhCN.migration.completed.recovery_impacts.message_blocks).toContain('部分消息内容')
+    expect(enUS.migration.completed.recovery_impacts.topics).toContain('entire conversation')
+    expect(enUS.migration.completed.recovery_impacts.message_blocks).toContain('message content')
   })
 
   it('shows an error toast when completed migration notices cannot be copied', async () => {

--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -10,14 +10,24 @@
  * at its last version, so no Dexie upgrade hooks need to run before export.
  */
 
-import { type MigrationExportFileWriteMode, MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { loggerService } from '@renderer/services/LoggerService'
+import {
+  type DexieRecoveryReport,
+  type MigrationExportFileWriteMode,
+  MigrationIpcChannels
+} from '@shared/data/migration/v2/types'
 import { clampSurrogateBoundary } from '@shared/utils/text'
-import { Dexie, type IndexableType } from 'dexie'
+import { Dexie, type IndexableType, type Table } from 'dexie'
 
 /** Legacy v1 IndexedDB database name. */
 const DEXIE_DB_NAME = 'CherryStudio'
 const DEXIE_EXPORT_PAGE_SIZE = 100
 const DEXIE_EXPORT_CHUNK_CHAR_LIMIT = 1024 * 1024
+const RECOVERY_SAMPLE_KEY_LIMIT = 10
+const IRRECOVERABLE_MISSING_FILE_MESSAGE =
+  'Data lost due to missing file. Affected record should be considered irrecoverable'
+
+const logger = loggerService.withContext('DexieExporter')
 
 // Required tables that must exist
 const REQUIRED_TABLES = [
@@ -29,11 +39,45 @@ const REQUIRED_TABLES = [
 
 // Optional tables that may not exist in older versions
 const OPTIONAL_TABLES = ['settings', 'translate_history', 'quick_phrases', 'translate_languages']
+const SUPPORTED_TABLES = [...REQUIRED_TABLES, ...OPTIONAL_TABLES]
 
 export interface ExportProgress {
   table: string
   progress: number
   total: number
+}
+
+export interface DexieExportResult {
+  exportPath: string
+  recovery: DexieRecoveryReport[]
+}
+
+interface PageRecord {
+  primaryKey: IndexableType
+  record: Record<string, unknown> | undefined
+}
+
+interface PageReadResult {
+  records: PageRecord[]
+  skippedPrimaryKeys: IndexableType[]
+}
+
+function isIrrecoverableMissingFileError(error: unknown): boolean {
+  const visited = new Set<object>()
+  const pending: unknown[] = [error]
+
+  while (pending.length > 0) {
+    const current = pending.pop()
+    if (typeof current !== 'object' || current === null || visited.has(current)) continue
+    visited.add(current)
+    const candidate = current as { cause?: unknown; inner?: unknown; message?: unknown }
+    if (typeof candidate.message === 'string' && candidate.message.includes(IRRECOVERABLE_MISSING_FILE_MESSAGE)) {
+      return true
+    }
+    pending.push(candidate.cause, candidate.inner)
+  }
+
+  return false
 }
 
 export class DexieExporter {
@@ -66,6 +110,19 @@ export class DexieExporter {
     }
   }
 
+  private async writeEmptySupportedTables(): Promise<void> {
+    for (const tableName of SUPPORTED_TABLES) {
+      await this.writeExportText(tableName, '[]', 'overwrite')
+    }
+  }
+
+  private createResult(recovery: DexieRecoveryReport[]): DexieExportResult {
+    if (recovery.length > 0) {
+      logger.warn('Recovered migration export from irrecoverable IndexedDB data loss', { recovery })
+    }
+    return { exportPath: this.exportPath, recovery }
+  }
+
   private createRecordExportError(tableName: string, primaryKey: IndexableType, cause: unknown): Error {
     const causeMessage = cause instanceof Error ? cause.message : String(cause)
     return new Error(
@@ -74,28 +131,71 @@ export class DexieExporter {
     )
   }
 
-  private async exportTable(db: Dexie, tableName: string): Promise<void> {
+  private async readPage(
+    table: Table<Record<string, unknown>, IndexableType>,
+    tableName: string,
+    primaryKeys: IndexableType[]
+  ): Promise<PageReadResult> {
+    try {
+      const records = await table.bulkGet(primaryKeys)
+      return {
+        records: primaryKeys.map((primaryKey, index) => ({ primaryKey, record: records[index] })),
+        skippedPrimaryKeys: []
+      }
+    } catch (error) {
+      if (!isIrrecoverableMissingFileError(error)) throw error
+    }
+
+    const records: PageRecord[] = []
+    const skippedPrimaryKeys: IndexableType[] = []
+    for (const primaryKey of primaryKeys) {
+      try {
+        records.push({ primaryKey, record: await table.get(primaryKey) })
+      } catch (error) {
+        if (!isIrrecoverableMissingFileError(error)) {
+          throw this.createRecordExportError(tableName, primaryKey, error)
+        }
+        skippedPrimaryKeys.push(primaryKey)
+      }
+    }
+
+    return { records, skippedPrimaryKeys }
+  }
+
+  private async exportTable(db: Dexie, tableName: string): Promise<DexieRecoveryReport | undefined> {
     const table = db.table<Record<string, unknown>, IndexableType>(tableName)
     let lastPrimaryKey: IndexableType | undefined
     let pendingChunk = ''
     let hasRecords = false
+    let skippedRecords = 0
+    const samplePrimaryKeys: string[] = []
 
     await this.writeExportText(tableName, '[', 'overwrite')
 
     while (true) {
       const collection = lastPrimaryKey === undefined ? table.orderBy(':id') : table.where(':id').above(lastPrimaryKey)
-      const primaryKeys = await collection.limit(DEXIE_EXPORT_PAGE_SIZE).primaryKeys()
+      let primaryKeys: IndexableType[]
+      try {
+        primaryKeys = await collection.limit(DEXIE_EXPORT_PAGE_SIZE).primaryKeys()
+      } catch (error) {
+        if (!isIrrecoverableMissingFileError(error)) throw error
+        await this.writeExportText(tableName, '[]', 'overwrite')
+        return { scope: 'table', table: tableName }
+      }
 
       if (primaryKeys.length === 0) {
         break
       }
 
-      const records = await table.bulkGet(primaryKeys)
+      const page = await this.readPage(table, tableName, primaryKeys)
+      skippedRecords += page.skippedPrimaryKeys.length
+      for (const primaryKey of page.skippedPrimaryKeys) {
+        if (samplePrimaryKeys.length < RECOVERY_SAMPLE_KEY_LIMIT) {
+          samplePrimaryKeys.push(String(primaryKey))
+        }
+      }
 
-      for (let index = 0; index < primaryKeys.length; index++) {
-        const primaryKey = primaryKeys[index]
-        const record = records[index]
-
+      for (const { primaryKey, record } of page.records) {
         if (record === undefined) {
           throw this.createRecordExportError(tableName, primaryKey, new Error('Record missing from IndexedDB page'))
         }
@@ -132,6 +232,11 @@ export class DexieExporter {
       await this.writeExportText(tableName, pendingChunk, 'append')
     }
     await this.writeExportText(tableName, ']', 'append')
+
+    if (skippedRecords > 0) {
+      return { scope: 'records', table: tableName, skippedRecords, samplePrimaryKeys }
+    }
+    return undefined
   }
 
   /**
@@ -144,8 +249,13 @@ export class DexieExporter {
       return null
     }
     const db = new Dexie(DEXIE_DB_NAME)
-    await db.open()
-    return db
+    try {
+      await db.open()
+      return db
+    } catch (error) {
+      db.close()
+      throw error
+    }
   }
 
   /**
@@ -153,18 +263,26 @@ export class DexieExporter {
    * @param onProgress - Progress callback
    * @returns Export path
    */
-  async exportAll(onProgress?: (progress: ExportProgress) => void): Promise<string> {
-    const db = await this.openLegacyDb()
+  async exportAll(onProgress?: (progress: ExportProgress) => void): Promise<DexieExportResult> {
+    let db: Dexie | null
+    try {
+      db = await this.openLegacyDb()
+    } catch (error) {
+      if (!isIrrecoverableMissingFileError(error)) throw error
+      await this.writeEmptySupportedTables()
+      return this.createResult([{ scope: 'database' }])
+    }
     if (!db) {
       // No Dexie database at all — fresh install, nothing to export
-      return this.exportPath
+      return this.createResult([])
     }
 
     try {
+      const recovery: DexieRecoveryReport[] = []
       const existingTables = db.tables.map((t) => t.name)
 
       // Determine which tables to export (skip missing ones gracefully)
-      const tablesToExport = [...REQUIRED_TABLES, ...OPTIONAL_TABLES].filter((t) => existingTables.includes(t))
+      const tablesToExport = SUPPORTED_TABLES.filter((t) => existingTables.includes(t))
 
       // Export each table
       for (let i = 0; i < tablesToExport.length; i++) {
@@ -176,7 +294,8 @@ export class DexieExporter {
           total: tablesToExport.length
         })
 
-        await this.exportTable(db, tableName)
+        const issue = await this.exportTable(db, tableName)
+        if (issue) recovery.push(issue)
 
         onProgress?.({
           table: tableName,
@@ -185,7 +304,7 @@ export class DexieExporter {
         })
       }
 
-      return this.exportPath
+      return this.createResult(recovery)
     } finally {
       db.close()
     }

--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -24,6 +24,11 @@ const DEXIE_DB_NAME = 'CherryStudio'
 const DEXIE_EXPORT_PAGE_SIZE = 100
 const DEXIE_EXPORT_CHUNK_CHAR_LIMIT = 1024 * 1024
 const RECOVERY_SAMPLE_KEY_LIMIT = 10
+const RECOVERY_ERROR_SAMPLE_LIMIT = 10
+const RECOVERY_WRAPPED_ERROR_LIMIT = 5
+// Chromium emits this exact two-sentence message when an IndexedDB backing file is gone. Match it as a
+// substring because Dexie may prefix the message while wrapping the DOMException in `cause` or `inner`.
+// If Chromium changes the wording, matching safely stops and the migration remains fatal.
 const IRRECOVERABLE_MISSING_FILE_MESSAGE =
   'Data lost due to missing file. Affected record should be considered irrecoverable'
 
@@ -49,7 +54,7 @@ export interface ExportProgress {
 
 export interface DexieExportResult {
   exportPath: string
-  recovery: DexieRecoveryReport[]
+  recoveryReports: DexieRecoveryReport[]
 }
 
 interface PageRecord {
@@ -61,6 +66,18 @@ interface PageReadResult {
   records: PageRecord[]
   skippedPrimaryKeys: IndexableType[]
 }
+
+interface RecoveryLogBudget {
+  remaining: number
+}
+
+interface RecoveryErrorDetails {
+  errorName: string
+  errorMessage: string
+  errorStack?: string
+}
+
+type RecoveryOperation = 'bulkGet' | 'exists' | 'get' | 'open' | 'primaryKeys'
 
 function isIrrecoverableMissingFileError(error: unknown): boolean {
   const visited = new Set<object>()
@@ -78,6 +95,39 @@ function isIrrecoverableMissingFileError(error: unknown): boolean {
   }
 
   return false
+}
+
+function getRecoveryErrorDetails(error: unknown): RecoveryErrorDetails {
+  if (typeof error !== 'object' || error === null) {
+    return { errorName: 'UnknownError', errorMessage: String(error) }
+  }
+
+  const candidate = error as { message?: unknown; name?: unknown; stack?: unknown }
+  return {
+    errorName: typeof candidate.name === 'string' ? candidate.name : 'UnknownError',
+    errorMessage: typeof candidate.message === 'string' ? candidate.message : String(error),
+    ...(typeof candidate.stack === 'string' ? { errorStack: candidate.stack } : {})
+  }
+}
+
+function getWrappedRecoveryErrors(error: unknown): RecoveryErrorDetails[] {
+  if (typeof error !== 'object' || error === null) return []
+
+  const visited = new Set<object>([error])
+  const root = error as { cause?: unknown; inner?: unknown }
+  const pending = [root.cause, root.inner]
+  const wrappedErrors: RecoveryErrorDetails[] = []
+
+  while (pending.length > 0 && wrappedErrors.length < RECOVERY_WRAPPED_ERROR_LIMIT) {
+    const current = pending.pop()
+    if (typeof current !== 'object' || current === null || visited.has(current)) continue
+    visited.add(current)
+    wrappedErrors.push(getRecoveryErrorDetails(current))
+    const candidate = current as { cause?: unknown; inner?: unknown }
+    pending.push(candidate.cause, candidate.inner)
+  }
+
+  return wrappedErrors
 }
 
 export class DexieExporter {
@@ -116,11 +166,30 @@ export class DexieExporter {
     }
   }
 
-  private createResult(recovery: DexieRecoveryReport[]): DexieExportResult {
-    if (recovery.length > 0) {
-      logger.warn('Recovered migration export from irrecoverable IndexedDB data loss', { recovery })
+  private createResult(recoveryReports: DexieRecoveryReport[]): DexieExportResult {
+    if (recoveryReports.length > 0) {
+      logger.warn('Recovered migration export from irrecoverable IndexedDB data loss', { recoveryReports })
     }
-    return { exportPath: this.exportPath, recovery }
+    return { exportPath: this.exportPath, recoveryReports }
+  }
+
+  private logRecoveryError(
+    budget: RecoveryLogBudget | undefined,
+    context: {
+      scope: DexieRecoveryReport['scope']
+      operation: RecoveryOperation
+      tableName?: string
+      primaryKey?: string
+    },
+    error: unknown
+  ): void {
+    if (!budget || budget.remaining <= 0) return
+    budget.remaining -= 1
+    logger.warn('Recovering from irrecoverable IndexedDB read error', {
+      ...context,
+      ...getRecoveryErrorDetails(error),
+      wrappedErrors: getWrappedRecoveryErrors(error)
+    })
   }
 
   private createRecordExportError(tableName: string, primaryKey: IndexableType, cause: unknown): Error {
@@ -134,7 +203,8 @@ export class DexieExporter {
   private async readPage(
     table: Table<Record<string, unknown>, IndexableType>,
     tableName: string,
-    primaryKeys: IndexableType[]
+    primaryKeys: IndexableType[],
+    recoveryLogBudget: RecoveryLogBudget
   ): Promise<PageReadResult> {
     try {
       const records = await table.bulkGet(primaryKeys)
@@ -144,18 +214,29 @@ export class DexieExporter {
       }
     } catch (error) {
       if (!isIrrecoverableMissingFileError(error)) throw error
+      this.logRecoveryError(recoveryLogBudget, { scope: 'records', operation: 'bulkGet', tableName }, error)
     }
 
     const records: PageRecord[] = []
     const skippedPrimaryKeys: IndexableType[] = []
     for (const primaryKey of primaryKeys) {
       try {
-        records.push({ primaryKey, record: await table.get(primaryKey) })
+        const record = await table.get(primaryKey)
+        if (record === undefined) {
+          skippedPrimaryKeys.push(primaryKey)
+        } else {
+          records.push({ primaryKey, record })
+        }
       } catch (error) {
         if (!isIrrecoverableMissingFileError(error)) {
           throw this.createRecordExportError(tableName, primaryKey, error)
         }
         skippedPrimaryKeys.push(primaryKey)
+        this.logRecoveryError(
+          recoveryLogBudget,
+          { scope: 'records', operation: 'get', tableName, primaryKey: String(primaryKey) },
+          error
+        )
       }
     }
 
@@ -169,6 +250,7 @@ export class DexieExporter {
     let hasRecords = false
     let skippedRecords = 0
     const samplePrimaryKeys: string[] = []
+    const recoveryLogBudget = { remaining: RECOVERY_ERROR_SAMPLE_LIMIT }
 
     await this.writeExportText(tableName, '[', 'overwrite')
 
@@ -179,6 +261,8 @@ export class DexieExporter {
         primaryKeys = await collection.limit(DEXIE_EXPORT_PAGE_SIZE).primaryKeys()
       } catch (error) {
         if (!isIrrecoverableMissingFileError(error)) throw error
+        this.logRecoveryError(recoveryLogBudget, { scope: 'table', operation: 'primaryKeys', tableName }, error)
+        // Key enumeration can no longer prove which pages remain complete, so discard every partial page.
         await this.writeExportText(tableName, '[]', 'overwrite')
         return { scope: 'table', table: tableName }
       }
@@ -187,7 +271,7 @@ export class DexieExporter {
         break
       }
 
-      const page = await this.readPage(table, tableName, primaryKeys)
+      const page = await this.readPage(table, tableName, primaryKeys, recoveryLogBudget)
       skippedRecords += page.skippedPrimaryKeys.length
       for (const primaryKey of page.skippedPrimaryKeys) {
         if (samplePrimaryKeys.length < RECOVERY_SAMPLE_KEY_LIMIT) {
@@ -244,8 +328,17 @@ export class DexieExporter {
    * database exists (fresh install — nothing to migrate). The caller owns
    * closing the returned instance.
    */
-  private async openLegacyDb(): Promise<Dexie | null> {
-    if (!(await Dexie.exists(DEXIE_DB_NAME))) {
+  private async openLegacyDb(recoveryLogBudget?: RecoveryLogBudget): Promise<Dexie | null> {
+    let exists: boolean
+    try {
+      exists = await Dexie.exists(DEXIE_DB_NAME)
+    } catch (error) {
+      if (isIrrecoverableMissingFileError(error)) {
+        this.logRecoveryError(recoveryLogBudget, { scope: 'database', operation: 'exists' }, error)
+      }
+      throw error
+    }
+    if (!exists) {
       return null
     }
     const db = new Dexie(DEXIE_DB_NAME)
@@ -254,19 +347,23 @@ export class DexieExporter {
       return db
     } catch (error) {
       db.close()
+      if (isIrrecoverableMissingFileError(error)) {
+        this.logRecoveryError(recoveryLogBudget, { scope: 'database', operation: 'open' }, error)
+      }
       throw error
     }
   }
 
   /**
-   * Export all Dexie tables to JSON files
+   * Export all supported Dexie tables to JSON files.
    * @param onProgress - Progress callback
-   * @returns Export path
+   * @returns Export directory and any reports describing irrecoverable data skipped during export
    */
   async exportAll(onProgress?: (progress: ExportProgress) => void): Promise<DexieExportResult> {
     let db: Dexie | null
+    const recoveryLogBudget = { remaining: RECOVERY_ERROR_SAMPLE_LIMIT }
     try {
-      db = await this.openLegacyDb()
+      db = await this.openLegacyDb(recoveryLogBudget)
     } catch (error) {
       if (!isIrrecoverableMissingFileError(error)) throw error
       await this.writeEmptySupportedTables()
@@ -278,7 +375,7 @@ export class DexieExporter {
     }
 
     try {
-      const recovery: DexieRecoveryReport[] = []
+      const recoveryReports: DexieRecoveryReport[] = []
       const existingTables = db.tables.map((t) => t.name)
 
       // Determine which tables to export (skip missing ones gracefully)
@@ -295,7 +392,7 @@ export class DexieExporter {
         })
 
         const issue = await this.exportTable(db, tableName)
-        if (issue) recovery.push(issue)
+        if (issue) recoveryReports.push(issue)
 
         onProgress?.({
           table: tableName,
@@ -304,7 +401,7 @@ export class DexieExporter {
         })
       }
 
-      return this.createResult(recovery)
+      return this.createResult(recoveryReports)
     } finally {
       db.close()
     }

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -1,4 +1,5 @@
 import { MigrationIpcChannels } from '@shared/data/migration/v2/types'
+import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 interface LegacyRecord {
@@ -13,6 +14,7 @@ const dexieMock = vi.hoisted(() => ({
   table: vi.fn(),
   tableNames: [] as string[]
 }))
+const loggerWarn = vi.spyOn(mockRendererLoggerService, 'warn').mockImplementation(() => undefined)
 
 vi.mock('dexie', () => ({
   Dexie: class MockDexie {
@@ -205,7 +207,7 @@ describe('DexieExporter', () => {
     expect(JSON.parse(exportedText())).toEqual([{ id: 'block-1' }, { id: 'block-3' }])
     expect(result).toEqual({
       exportPath: '/export',
-      recovery: [
+      recoveryReports: [
         {
           scope: 'records',
           table: 'message_blocks',
@@ -214,6 +216,66 @@ describe('DexieExporter', () => {
         }
       ]
     })
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Recovering from irrecoverable IndexedDB read error',
+      expect.objectContaining({
+        errorMessage: 'Dexie read failed',
+        errorName: 'Error',
+        operation: 'bulkGet',
+        scope: 'records',
+        tableName: 'message_blocks',
+        wrappedErrors: [
+          expect.objectContaining({
+            errorMessage: 'Data lost due to missing file. Affected record should be considered irrecoverable',
+            errorName: 'NotReadableError'
+          })
+        ]
+      })
+    )
+  })
+
+  it('skips an irrecoverable fallback record that disappeared before get', async () => {
+    const rows = [{ id: 'block-1' }, { id: 'block-2' }, { id: 'block-3' }]
+    const table = createTableMock(rows)
+    const dataLoss = new DOMException(
+      'Data lost due to missing file. Affected record should be considered irrecoverable',
+      'NotReadableError'
+    )
+    table.bulkGet.mockRejectedValueOnce(dataLoss)
+    table.get.mockImplementation(async (key) => (key === 'block-2' ? undefined : rows.find((row) => row.id === key)))
+    dexieMock.table.mockReturnValue(table)
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(JSON.parse(exportedText())).toEqual([{ id: 'block-1' }, { id: 'block-3' }])
+    expect(result.recoveryReports).toEqual([
+      {
+        scope: 'records',
+        table: 'message_blocks',
+        skippedRecords: 1,
+        samplePrimaryKeys: ['block-2']
+      }
+    ])
+  })
+
+  it('keeps non-matching fallback get errors fatal', async () => {
+    const rows = [{ id: 'block-1' }, { id: 'block-2' }]
+    const table = createTableMock(rows)
+    table.bulkGet.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+    table.get.mockImplementation(async (key) => {
+      if (key === 'block-2') throw new Error('transient read failure')
+      return rows.find((row) => row.id === key)
+    })
+    dexieMock.table.mockReturnValue(table)
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow(
+      'Failed to export Dexie table "message_blocks" at primary key "block-2": transient read failure'
+    )
   })
 
   it('exports an empty table when its primary keys cannot be read', async () => {
@@ -231,8 +293,34 @@ describe('DexieExporter', () => {
     expect(exportedText()).toBe('[]')
     expect(result).toEqual({
       exportPath: '/export',
-      recovery: [{ scope: 'table', table: 'message_blocks' }]
+      recoveryReports: [{ scope: 'table', table: 'message_blocks' }]
     })
+  })
+
+  it('overwrites earlier pages when primary-key enumeration fails mid-table', async () => {
+    const rows = Array.from({ length: 105 }, (_, index) => ({ id: `block-${String(index).padStart(3, '0')}` }))
+    const table = createTableMock(rows)
+    table.primaryKeys
+      .mockResolvedValueOnce(rows.slice(0, 100).map((row) => row.id))
+      .mockRejectedValueOnce(
+        new DOMException(
+          'Data lost due to missing file. Affected record should be considered irrecoverable',
+          'NotReadableError'
+        )
+      )
+    dexieMock.table.mockReturnValue(table)
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(exportedText()).toBe('[]')
+    expect(result.recoveryReports).toEqual([{ scope: 'table', table: 'message_blocks' }])
+    expect(invoke.mock.calls).toContainEqual([
+      MigrationIpcChannels.WriteExportFile,
+      '/export',
+      'message_blocks',
+      '[]',
+      'overwrite'
+    ])
   })
 
   it('exports every supported table as empty when the database cannot be inspected', async () => {
@@ -262,7 +350,7 @@ describe('DexieExporter', () => {
     )
     expect(result).toEqual({
       exportPath: '/export',
-      recovery: [{ scope: 'database' }]
+      recoveryReports: [{ scope: 'database' }]
     })
   })
 
@@ -279,7 +367,7 @@ describe('DexieExporter', () => {
 
     const result = await new DexieExporter('/export').exportAll()
 
-    expect(result.recovery).toEqual([{ scope: 'database' }])
+    expect(result.recoveryReports).toEqual([{ scope: 'database' }])
   })
 
   it('closes the failed database handle before recovering from an open error', async () => {
@@ -292,8 +380,17 @@ describe('DexieExporter', () => {
 
     const result = await new DexieExporter('/export').exportAll()
 
-    expect(result.recovery).toEqual([{ scope: 'database' }])
+    expect(result.recoveryReports).toEqual([{ scope: 'database' }])
     expect(dexieMock.close).toHaveBeenCalledOnce()
+  })
+
+  it('closes the failed database handle and rejects a non-matching open error', async () => {
+    dexieMock.open.mockRejectedValueOnce(new DOMException('Database is temporarily unavailable', 'NotReadableError'))
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow('Database is temporarily unavailable')
+
+    expect(dexieMock.close).toHaveBeenCalledOnce()
+    expect(invoke).not.toHaveBeenCalled()
   })
 
   it('aggregates skipped records across pages and caps primary-key samples', async () => {
@@ -322,7 +419,7 @@ describe('DexieExporter', () => {
     const exported = JSON.parse(exportedText()) as LegacyRecord[]
     expect(exported).toHaveLength(93)
     expect(exported.some((row) => badIds.has(row.id))).toBe(false)
-    expect(result.recovery).toEqual([
+    expect(result.recoveryReports).toEqual([
       {
         scope: 'records',
         table: 'message_blocks',

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -38,33 +38,38 @@ function createTableMock(inputRows: LegacyRecord[]) {
   const rows = [...inputRows].sort((a, b) => a.id.localeCompare(b.id))
   const rowsById = new Map(rows.map((row) => [row.id, row]))
   const pageQuery = vi.fn()
+  const primaryKeys = vi.fn(async (lastPrimaryKey: string | undefined, limit: number) => {
+    pageQuery()
+    return rows
+      .filter((row) => lastPrimaryKey === undefined || row.id > lastPrimaryKey)
+      .slice(0, limit)
+      .map((row) => row.id)
+  })
 
   const createCollection = (lastPrimaryKey?: string) => ({
     limit: (limit: number) => ({
-      primaryKeys: async () => {
-        pageQuery()
-        return rows
-          .filter((row) => lastPrimaryKey === undefined || row.id > lastPrimaryKey)
-          .slice(0, limit)
-          .map((row) => row.id)
-      }
+      primaryKeys: () => primaryKeys(lastPrimaryKey, limit)
     })
   })
 
   return {
     bulkGet: vi.fn(async (keys: string[]) => keys.map((key) => rowsById.get(key))),
+    get: vi.fn(async (key: string) => rowsById.get(key)),
     orderBy: vi.fn(() => createCollection()),
     pageQuery,
+    primaryKeys,
     toArray: vi.fn(async () => rows),
     where: vi.fn(() => ({ above: (key: string) => createCollection(key) }))
   }
 }
 
 function exportedText(): string {
-  return invoke.mock.calls
-    .filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
-    .map(([, , , chunk]) => chunk)
-    .join('')
+  let text = ''
+  for (const [channel, , , chunk, writeMode = 'overwrite'] of invoke.mock.calls) {
+    if (channel !== MigrationIpcChannels.WriteExportFile) continue
+    text = writeMode === 'append' ? `${text}${chunk}` : String(chunk)
+  }
+  return text
 }
 
 describe('DexieExporter', () => {
@@ -179,5 +184,182 @@ describe('DexieExporter', () => {
     await expect(new DexieExporter('/export').exportAll()).rejects.toThrow(
       'Failed to export Dexie table "message_blocks" at primary key "block-1"'
     )
+  })
+
+  it('skips only irrecoverable records when a bulk page read fails', async () => {
+    const rows = [{ id: 'block-1' }, { id: 'block-2' }, { id: 'block-3' }]
+    const table = createTableMock(rows)
+    const dataLoss = new DOMException(
+      'Data lost due to missing file. Affected record should be considered irrecoverable',
+      'NotReadableError'
+    )
+    table.bulkGet.mockRejectedValueOnce(new Error('Dexie read failed', { cause: dataLoss }))
+    table.get.mockImplementation(async (key) => {
+      if (key === 'block-2') throw dataLoss
+      return rows.find((row) => row.id === key)
+    })
+    dexieMock.table.mockReturnValue(table)
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(JSON.parse(exportedText())).toEqual([{ id: 'block-1' }, { id: 'block-3' }])
+    expect(result).toEqual({
+      exportPath: '/export',
+      recovery: [
+        {
+          scope: 'records',
+          table: 'message_blocks',
+          skippedRecords: 1,
+          samplePrimaryKeys: ['block-2']
+        }
+      ]
+    })
+  })
+
+  it('exports an empty table when its primary keys cannot be read', async () => {
+    const table = createTableMock([{ id: 'block-1' }])
+    table.primaryKeys.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+    dexieMock.table.mockReturnValue(table)
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(exportedText()).toBe('[]')
+    expect(result).toEqual({
+      exportPath: '/export',
+      recovery: [{ scope: 'table', table: 'message_blocks' }]
+    })
+  })
+
+  it('exports every supported table as empty when the database cannot be inspected', async () => {
+    dexieMock.exists.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    const emptyTableWrites = invoke.mock.calls
+      .filter(([channel]) => channel === MigrationIpcChannels.WriteExportFile)
+      .map(([, exportPath, tableName, chunk, writeMode]) => ({ exportPath, tableName, chunk, writeMode }))
+    expect(emptyTableWrites).toEqual(
+      [
+        'topics',
+        'files',
+        'knowledge_notes',
+        'message_blocks',
+        'settings',
+        'translate_history',
+        'quick_phrases',
+        'translate_languages'
+      ].map((tableName) => ({ exportPath: '/export', tableName, chunk: '[]', writeMode: 'overwrite' }))
+    )
+    expect(result).toEqual({
+      exportPath: '/export',
+      recovery: [{ scope: 'database' }]
+    })
+  })
+
+  it('finds irrecoverable data loss in either branch of a wrapped error', async () => {
+    const dataLoss = new DOMException(
+      'Data lost due to missing file. Affected record should be considered irrecoverable',
+      'NotReadableError'
+    )
+    dexieMock.exists.mockRejectedValueOnce({
+      cause: new Error('Unrelated wrapper cause'),
+      inner: dataLoss,
+      message: 'Dexie read failed'
+    })
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(result.recovery).toEqual([{ scope: 'database' }])
+  })
+
+  it('closes the failed database handle before recovering from an open error', async () => {
+    dexieMock.open.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    expect(result.recovery).toEqual([{ scope: 'database' }])
+    expect(dexieMock.close).toHaveBeenCalledOnce()
+  })
+
+  it('aggregates skipped records across pages and caps primary-key samples', async () => {
+    const rows = Array.from({ length: 105 }, (_, index) => ({
+      id: `block-${String(index).padStart(3, '0')}`,
+      secret: `content-${index}`
+    }))
+    const badIds = new Set([...Array.from({ length: 11 }, (_, index) => rows[index].id), rows[101].id])
+    const dataLoss = new DOMException(
+      'Data lost due to missing file. Affected record should be considered irrecoverable',
+      'NotReadableError'
+    )
+    const table = createTableMock(rows)
+    table.bulkGet.mockImplementation(async (keys) => {
+      if (keys.some((key) => badIds.has(key))) throw dataLoss
+      return keys.map((key) => rows.find((row) => row.id === key))
+    })
+    table.get.mockImplementation(async (key) => {
+      if (badIds.has(key)) throw dataLoss
+      return rows.find((row) => row.id === key)
+    })
+    dexieMock.table.mockReturnValue(table)
+
+    const result = await new DexieExporter('/export').exportAll()
+
+    const exported = JSON.parse(exportedText()) as LegacyRecord[]
+    expect(exported).toHaveLength(93)
+    expect(exported.some((row) => badIds.has(row.id))).toBe(false)
+    expect(result.recovery).toEqual([
+      {
+        scope: 'records',
+        table: 'message_blocks',
+        skippedRecords: 12,
+        samplePrimaryKeys: Array.from({ length: 10 }, (_, index) => `block-${String(index).padStart(3, '0')}`)
+      }
+    ])
+    expect(JSON.stringify(result)).not.toContain('content-')
+  })
+
+  it('does not degrade for other IndexedDB read errors', async () => {
+    dexieMock.exists.mockRejectedValueOnce(new DOMException('Failed to read large IndexedDB value', 'NotReadableError'))
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow('Failed to read large IndexedDB value')
+    expect(invoke).not.toHaveBeenCalledWith(
+      MigrationIpcChannels.WriteExportFile,
+      expect.anything(),
+      expect.anything(),
+      '[]',
+      'overwrite'
+    )
+  })
+
+  it('fails when an empty-table recovery export cannot be written', async () => {
+    const table = createTableMock([{ id: 'block-1' }])
+    table.primaryKeys.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+    dexieMock.table.mockReturnValue(table)
+    invoke.mockImplementation((_channel, _exportPath, _tableName, chunk) =>
+      chunk === '[]' ? Promise.reject(new Error('disk full')) : Promise.resolve(true)
+    )
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow('disk full')
+    expect(dexieMock.close).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/windows/migrationV2/exporters/index.ts
+++ b/src/renderer/windows/migrationV2/exporters/index.ts
@@ -2,6 +2,6 @@
  * Migration exporters
  */
 
-export { DexieExporter, type ExportProgress } from './DexieExporter'
+export { DexieExporter, type DexieExportResult, type ExportProgress } from './DexieExporter'
 export { LocalStorageExporter } from './LocalStorageExporter'
 export { ReduxExporter, type ReduxExportResult } from './ReduxExporter'

--- a/src/renderer/windows/migrationV2/i18n/locales.ts
+++ b/src/renderer/windows/migrationV2/i18n/locales.ts
@@ -150,9 +150,29 @@ export const zhCN = {
     completed: {
       title: '欢迎来到 Cherry Studio V2',
       description: '迁移完成，你的数据已经全部就位。重启应用即可开始使用 V2。',
+      degraded_title: '迁移已完成，部分数据未导入',
+      degraded_description: '无法读取的旧版数据已跳过，其余可用数据已完成迁移。重启应用即可使用 V2。',
+      degraded_alert: '旧版数据库中存在无法恢复的损坏记录。Cherry Studio 已跳过这些内容，其他可用数据均已迁移。',
       steps_label: '步骤已完成',
       items_label: '迁移项',
       duration_label: '迁移耗时',
+      recovery_records: '{{table}}：{{count}} 条无法恢复的记录未导入。',
+      recovery_table: '{{table}}：数据表无法读取，已跳过该类数据。',
+      recovery_database: '旧版本地数据库无法读取，其中的数据未导入；其他来源的数据已继续迁移。',
+      recovery_impacts: {
+        topics: '受影响的记录可能导致整个对话未导入。',
+        message_blocks: '受影响的记录可能导致部分消息内容缺失。'
+      },
+      recovery_tables: {
+        topics: '对话',
+        files: '文件记录',
+        knowledge_notes: '知识库笔记',
+        message_blocks: '消息内容',
+        settings: '应用设置',
+        translate_history: '翻译记录',
+        quick_phrases: '快捷短语',
+        translate_languages: '自定义翻译语言'
+      },
       warning_heading: '{{count}} 条迁移提示',
       warning_description: '数据已迁移完成，但以下内容需要注意。',
       warning_copy: '复制全部提示',
@@ -340,9 +360,32 @@ export const enUS = {
     completed: {
       title: 'Welcome to Cherry Studio V2',
       description: 'Migration is complete. Your data is ready. Restart the app to start using V2.',
+      degraded_title: 'Migration complete with some data not imported',
+      degraded_description:
+        'Unreadable legacy data was skipped and the remaining available data was migrated. Restart the app to use V2.',
+      degraded_alert:
+        'The legacy database contained records that could not be recovered. Cherry Studio skipped them and migrated the remaining available data.',
       steps_label: 'Steps completed',
       items_label: 'Migration items',
       duration_label: 'Migration time',
+      recovery_records: '{{table}}: {{count}} unrecoverable record(s) were not imported.',
+      recovery_table: '{{table}}: the data table could not be read and was skipped.',
+      recovery_database:
+        'The legacy local database could not be read, so its data was not imported. Data from other sources was still migrated.',
+      recovery_impacts: {
+        topics: 'Affected records may cause an entire conversation not to be imported.',
+        message_blocks: 'Affected records may leave some message content missing.'
+      },
+      recovery_tables: {
+        topics: 'Conversations',
+        files: 'File records',
+        knowledge_notes: 'Knowledge base notes',
+        message_blocks: 'Message content',
+        settings: 'App settings',
+        translate_history: 'Translation history',
+        quick_phrases: 'Quick phrases',
+        translate_languages: 'Custom translation languages'
+      },
       warning_heading: '{{count}} migration notice(s)',
       warning_description: 'Migration completed, but the following items need attention.',
       warning_copy: 'Copy all notices',

--- a/src/shared/data/migration/v2/types.ts
+++ b/src/shared/data/migration/v2/types.ts
@@ -44,8 +44,8 @@ export interface MigrationProgress {
   warnings?: string[]
   /** Completion-screen summary stats; written only on successful completion */
   summary?: MigrationSummary
-  /** Irrecoverable legacy IndexedDB data skipped so the remaining migration could complete. */
-  dexieRecovery?: DexieRecoveryReport[]
+  /** Non-empty reports for irrecoverable legacy IndexedDB data skipped during export. */
+  dexieRecoveryReports?: DexieRecoveryReport[]
   /**
    * Resolved v1 data directory to surface on the introduction screen, seeded
    * only when the migration gate auto-recovered a non-default custom userData
@@ -117,13 +117,25 @@ export interface MigrationResult {
 
 export type DexieRecoveryReport =
   | {
+      /** Individual records were skipped after a page read failed. */
       scope: 'records'
+      /** Legacy Dexie object store containing the damaged records. */
       table: string
+      /** Total records skipped from this table during the export. */
       skippedRecords: number
+      /** At most 10 primary keys for logs and diagnostics; never rendered in the migration UI. */
       samplePrimaryKeys: string[]
     }
-  | { scope: 'table'; table: string }
-  | { scope: 'database' }
+  | {
+      /** The table was exported as empty because its primary keys could not be enumerated. */
+      scope: 'table'
+      /** Legacy Dexie object store exported as empty. */
+      table: string
+    }
+  | {
+      /** Every supported Dexie table was exported as empty because the database could not be inspected. */
+      scope: 'database'
+    }
 
 // Migration status stored in app_state table
 export interface MigrationStatusValue {
@@ -144,7 +156,14 @@ export interface StartMigrationPayload {
   reduxData: Record<string, unknown>
   dexieExportPath: string
   localStorageExportPath?: string
-  dexieRecovery?: DexieRecoveryReport[]
+  /** Present only when the Dexie export returned one or more recovery reports. */
+  dexieRecoveryReports?: DexieRecoveryReport[]
+}
+
+export interface MigrationErrorReportPayload {
+  message: string
+  /** Present only when Dexie recovery completed before a later renderer-side migration step failed. */
+  dexieRecoveryReports?: DexieRecoveryReport[]
 }
 
 export type MigrationDiagnosticSaveResult =

--- a/src/shared/data/migration/v2/types.ts
+++ b/src/shared/data/migration/v2/types.ts
@@ -44,6 +44,8 @@ export interface MigrationProgress {
   warnings?: string[]
   /** Completion-screen summary stats; written only on successful completion */
   summary?: MigrationSummary
+  /** Irrecoverable legacy IndexedDB data skipped so the remaining migration could complete. */
+  dexieRecovery?: DexieRecoveryReport[]
   /**
    * Resolved v1 data directory to surface on the introduction screen, seeded
    * only when the migration gate auto-recovered a non-default custom userData
@@ -113,6 +115,16 @@ export interface MigrationResult {
   error?: string
 }
 
+export type DexieRecoveryReport =
+  | {
+      scope: 'records'
+      table: string
+      skippedRecords: number
+      samplePrimaryKeys: string[]
+    }
+  | { scope: 'table'; table: string }
+  | { scope: 'database' }
+
 // Migration status stored in app_state table
 export interface MigrationStatusValue {
   status: 'completed' | 'failed' | 'in_progress'
@@ -132,6 +144,7 @@ export interface StartMigrationPayload {
   reduxData: Record<string, unknown>
   dexieExportPath: string
   localStorageExportPath?: string
+  dexieRecovery?: DexieRecoveryReport[]
 }
 
 export type MigrationDiagnosticSaveResult =


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- A single unreadable Chromium IndexedDB record caused `DexieExporter.bulkGet()` to reject the entire page.
- The renderer aborted before handing the other usable migration sources to main, so retrying the same damaged database failed repeatedly.
- Recovery context existed only on the successful completion path. A later migrator failure, renderer-side failure, or retry could hide the earlier data-loss observation.
- The error page did not distinguish a partially recovered migration from a normal successful migration.

After this PR:

- The exporter recognizes only Chromium's exact irrecoverable missing-file message, including when Dexie wraps it in `cause` or `inner`.
- Recovery occurs at the IndexedDB operation that failed:
  - a failed page read falls back to serial primary-key reads and skips only irrecoverable or disappeared records;
  - failed primary-key enumeration overwrites the current table export with a valid empty JSON array;
  - failed database inspection overwrites every supported Dexie table with a valid empty JSON array.
- Redux, localStorage, and filesystem migration can continue when only Dexie data is irrecoverable. Serialization, disk, IPC, ordinary `NotReadableError`, and all other failures remain fatal.
- The legacy IndexedDB remains read-only. The recovery path never deletes or repairs the user's original database.
- Bounded, typed recovery reports survive engine failures, renderer failures, and retries; they are included in structured logs and diagnostic ZIP metadata.
- A degraded success still reaches `completed` and allows restart into v2, but displays a localized warning state, affected data categories, and conversation/message impact details instead of confetti.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: N/A

### Why we need it and why it was done in this way

The reported exception is Chromium's terminal IndexedDB data-loss signal:

```text
NotReadableError: Data lost due to missing file. Affected record should be considered irrecoverable
```

Chromium can still enumerate a key whose backing record file is gone. Dexie's `bulkGet()` then rejects the whole page, even though the other records and non-Dexie migration sources remain readable. The previous all-or-nothing exporter converted one permanently unreadable record into a permanent upgrade blocker.

The fix prioritizes completing the migration while keeping the failure classifier deliberately narrow. It matches the full Chromium message only at IndexedDB read boundaries and traverses bounded wrapper chains. If Chromium changes the wording, or if the error is transient or unrelated, the exporter fails closed and preserves the existing error behavior.

The following tradeoffs were made:

- Record recovery preserves the readable members of a failed page, but the affected records are omitted.
- If keys cannot be enumerated, retaining already-written pages could create a misleading partial table. The exporter therefore overwrites that table with `[]`.
- If the database cannot be inspected, no table boundary can be trusted. Only Dexie-backed sources are exported empty; Redux, localStorage, and filesystem sources continue normally.
- A damaged `topics` record can omit a conversation. A damaged `message_blocks` record can omit part of a message. The completion UI calls out both impacts.
- Reports retain at most 10 primary-key samples per table for logs and diagnostics. Record bodies are never logged, copied, or rendered.
- Recovery is automatic because the affected record is already declared irrecoverable; an additional confirmation step would not create a safer recovery option.

The following alternatives were considered:

- Keep failing the entire migration: rejected because repeated retries cannot restore a missing backing file and prevent access to otherwise usable data.
- Catch every `NotReadableError`: rejected because it could silently downgrade transient or unrelated storage failures.
- Preserve a partially written table after key enumeration fails: rejected because completeness can no longer be established.
- Modify, delete, or attempt to repair the legacy IndexedDB: rejected because it risks further data loss and violates the read-only migration boundary.
- Require the user to upload the full IndexedDB directory: rejected for this fix because the exact Chromium error is sufficient to define the safe fallback, and the database may contain private user content.

Links to places where the discussion took place: N/A (private user support case; no public diagnostic artifact)

### Breaking changes

None. This changes only migration behavior for Chromium's exact irrecoverable missing-file error.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

#### Migration error report (sanitized)

**Status**

- Incident triage: complete.
- Code fix and review follow-ups: complete.
- Automated verification on current `main`: complete.
- Validation on the affected user's original IndexedDB: pending; no test build has been run on that machine.

**Environment and upgrade path**

- Source version: `1.9.13`.
- Target version: `2.0.0-rc.5`.
- OS: Windows 10 x64 (`10.0.18363`).
- Diagnostic stage: `error`.

**Observed sequence**

1. At `11:04:27`, the v2 migration gate detected a supported `1.9.13` to `2.0.0-rc.5` upgrade and opened the migration window.
2. At `11:04:51`, the renderer reported `Failed to start migration` before any main-process migrator progress was recorded.
3. The user retried twice; the same renderer-side start failure was logged at `11:05:22` and `11:05:40`.
4. The migration UI preserved the complete Chromium message shown above. The old logger recorded only the top-level `Failed to start migration` text because its Error metadata was not serialized into the log line.

**Root-cause assessment**

- Confirmed proximal cause: Chromium found IndexedDB metadata for data whose backing file was missing and declared the affected record irrecoverable.
- Confirmed application failure mode: the exception occurred during renderer-side Dexie export, so the previous exporter aborted before the migration engine could consume the usable exports.
- Not established: which object store or primary key was damaged, or why the backing file disappeared. The supplied legacy diagnostic format did not retain those fields. Possible physical causes are outside the evidence and are intentionally not asserted here.
- The issue is not a SQLite schema migration failure: the v2 gate and migration database initialized successfully, and no migrator execution was reached.

**Expected behavior with this PR**

- If a page contains one damaged record, readable records are exported and the damaged record is reported as skipped.
- If the table or database cannot be enumerated safely, the narrower safe boundary is exported empty and the remaining sources continue.
- The completed page clearly reports degraded import status and still permits restart into v2.
- If a later migration step fails, the diagnostic bundle includes both the terminal error and the retained bounded recovery report.
- Any non-matching storage, serialization, disk, or IPC error still stops migration.

**Privacy note**

The raw user diagnostic bundle and screenshot are intentionally not attached. They contain a local Windows username/path and may contain sensitive application logs. This report includes only the minimum environment, timestamps, version transition, and error text needed for review.

**Verification**

- Focused migration tests: 4 files, 145 tests passed.
- `pnpm build:check`: passed on current `main`, including lint, typecheck, i18n, formatting, documentation links, and 1,722 test files / 21,149 tests.
- `pnpm test:lint`: exited successfully. It reports 37 pre-existing ESLint warnings outside this PR's changed files.
- Both commits are SSH-signed, DCO-signed-off, and reported as verified by GitHub.

Reviewer focus areas:

- Confirm the exact error classifier cannot downgrade ordinary `NotReadableError` or non-IndexedDB failures.
- Confirm every recovery branch writes valid JSON and cannot reuse a stale partial export.
- Confirm recovery reports remain bounded, contain no record bodies, and survive failure/retry paths.
- Confirm degraded completion remains a successful migration state and does not alter migration-engine count validation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed v1-to-v2 migration failures caused by Chromium reporting an irrecoverable missing IndexedDB file. Cherry Studio now migrates the remaining readable data, clearly reports any skipped IndexedDB data, and still stops for unrelated storage or export errors.
```
