### PR TITLE
fix(claude-code): use preset append mode for agent prompts

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -96,6 +96,11 @@ const ARTIFACTS_MARKER = '## Reporting deliverables'
 const RUNTIME_MARKER = '## Available Runtimes'
 const WORKSPACE_MARKER = '## Current Workspace'
 
+function getPresetAppend(prompt: Awaited<ReturnType<typeof buildSystemPrompt>>): string {
+  expect(prompt).toMatchObject({ type: 'preset', preset: 'claude_code' })
+  return (prompt as { append: string }).append
+}
+
 beforeEach(() => {
   vi.unstubAllGlobals()
   mockApplicationGet.mockReturnValue({ get: vi.fn(() => undefined) })
@@ -131,16 +136,17 @@ describe('buildSystemPrompt — current workspace', () => {
       false,
       '/data/Agents/agent-1'
     )
-    expect(result as string).toContain('"/workspace/project-a"')
+    expect(getPresetAppend(result)).toContain('"/workspace/project-a"')
   })
 
   it('injects the current workspace and default path resolution for regular agents', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent(), '/workspace/project-a')
 
-    expect(result as string).toContain(WORKSPACE_MARKER)
-    expect(result as string).toContain('"/workspace/project-a"')
-    expect(result as string).toContain('resolve unspecified or relative paths against it')
-    expect(result as string).not.toContain('Work outside it only when the user explicitly asks')
+    const append = getPresetAppend(result)
+    expect(append).toContain(WORKSPACE_MARKER)
+    expect(append).toContain('"/workspace/project-a"')
+    expect(append).toContain('resolve unspecified or relative paths against it')
+    expect(append).not.toContain('Work outside it only when the user explicitly asks')
   })
 
   it('injects the current workspace for the built-in assistant path', async () => {
@@ -161,10 +167,12 @@ describe('buildSystemPrompt — current workspace', () => {
     const first = await buildSystemPrompt(makeSession(), agent, '/workspace/project-a')
     const second = await buildSystemPrompt(makeSession(), agent, '/workspace/project-b')
 
-    expect(first as string).toContain('"/workspace/project-a"')
-    expect(first as string).not.toContain('"/workspace/project-b"')
-    expect(second as string).toContain('"/workspace/project-b"')
-    expect(second as string).not.toContain('"/workspace/project-a"')
+    const firstAppend = getPresetAppend(first)
+    const secondAppend = getPresetAppend(second)
+    expect(firstAppend).toContain('"/workspace/project-a"')
+    expect(firstAppend).not.toContain('"/workspace/project-b"')
+    expect(secondAppend).toContain('"/workspace/project-b"')
+    expect(secondAppend).not.toContain('"/workspace/project-a"')
   })
 })
 
@@ -173,20 +181,17 @@ describe('buildSystemPrompt — report_artifacts prompt', () => {
     mockFindBySessionId.mockReturnValue(null)
   })
 
-  it('appends the report_artifacts prompt with user instructions (raw-string path)', async () => {
+  it('appends the report_artifacts prompt to the Claude Code preset with user instructions', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent({ instructions: 'Do the task.' }), '/tmp/cwd')
-    // Every agent returns a raw string (not a `{ type: 'preset', append }` object) that carries the
-    // soul prompt + user instructions + the artifacts block.
-    expect(typeof result).toBe('string')
-    expect(result as string).toContain('SOUL_PROMPT')
-    expect(result as string).toContain('Do the task.')
-    expect(result as string).toContain(ARTIFACTS_MARKER)
+    const append = getPresetAppend(result)
+    expect(append).toContain('SOUL_PROMPT')
+    expect(append).toContain('Do the task.')
+    expect(append).toContain(ARTIFACTS_MARKER)
   })
 
   it('appends the report_artifacts prompt without user instructions', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent(), '/tmp/cwd')
-    expect(typeof result).toBe('string')
-    expect(result as string).toContain(ARTIFACTS_MARKER)
+    expect(getPresetAppend(result)).toContain(ARTIFACTS_MARKER)
   })
 
   it('does not append it for the Cherry Assistant (parity with feat/chat-page)', async () => {
@@ -206,19 +211,20 @@ describe('buildSystemPrompt — bundled-runtime guidance', () => {
 
   it('steers the agent to bun/uv with user instructions', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent({ instructions: 'Do the task.' }), '/tmp/cwd')
-    expect(result as string).toContain(RUNTIME_MARKER)
+    const append = getPresetAppend(result)
+    expect(append).toContain(RUNTIME_MARKER)
     // The model is told to use bun / uv explicitly, not node/npm/pip.
-    expect(result as string).toContain('bun')
-    expect(result as string).toContain('uv run python')
+    expect(append).toContain('bun')
+    expect(append).toContain('uv run python')
   })
 
   it('steers the agent to bun/uv without user instructions', async () => {
     const result = await buildSystemPrompt(makeSession(), makeAgent(), '/tmp/cwd')
-    expect(result as string).toContain(RUNTIME_MARKER)
+    expect(getPresetAppend(result)).toContain(RUNTIME_MARKER)
   })
 
   it('routes reusable CLI installation through managed tools without blocking ordinary downloads', async () => {
-    const result = (await buildSystemPrompt(makeSession(), makeAgent(), '/tmp/cwd')) as string
+    const result = getPresetAppend(await buildSystemPrompt(makeSession(), makeAgent(), '/tmp/cwd'))
 
     expect(result).toContain('Call `cli_list` before assuming a reusable CLI is unavailable')
     expect(result).toContain('Install reusable CLIs only with `cli_install`')

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -205,6 +205,11 @@ const { buildClaudeCodeSessionSettings, disposeToolPolicySnapshot, registerMcpSe
   '../settingsBuilder'
 )
 
+function getPresetAppend(systemPrompt: unknown): string {
+  expect(systemPrompt).toMatchObject({ type: 'preset', preset: 'claude_code' })
+  return (systemPrompt as { append: string }).append
+}
+
 describe('buildClaudeCodeSessionSettings', () => {
   beforeEach(() => {
     // The per-session snapshot registry is module-level state; reset session-1 (reused across
@@ -329,7 +334,7 @@ describe('buildClaudeCodeSessionSettings', () => {
       true,
       '/app/feature.agents.data/agent-1'
     )
-    expect(settings.systemPrompt as string).toContain('"/workspace/project"')
+    expect(getPresetAppend(settings.systemPrompt)).toContain('"/workspace/project"')
     expect(settings.settings).toMatchObject({ autoCompactEnabled: true, fastMode: true })
     expect(settings).not.toHaveProperty('fastMode')
     expect(settings.forwardSubagentText).toBe(true)
@@ -903,7 +908,7 @@ describe('buildClaudeCodeSessionSettings', () => {
 
     const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
 
-    const systemPrompt = settings.systemPrompt as string
+    const systemPrompt = getPresetAppend(settings.systemPrompt)
     expect(systemPrompt).toContain('## Citations')
     expect(systemPrompt).toContain('mcp__cherry-tools__web_search')
     expect(systemPrompt).not.toContain('mcp__cherry-tools__kb_search')
@@ -927,7 +932,7 @@ describe('buildClaudeCodeSessionSettings', () => {
 
     const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
 
-    expect(settings.systemPrompt as string).toContain('mcp__cherry-tools__kb_search')
+    expect(getPresetAppend(settings.systemPrompt)).toContain('mcp__cherry-tools__kb_search')
   })
 
   // The kb_* tools are exposed from the resolved scope, so an unbound Agent still gets them from the
@@ -952,7 +957,7 @@ describe('buildClaudeCodeSessionSettings', () => {
       knowledgeBaseIds: ['kb-selected']
     })
 
-    expect(settings.systemPrompt as string).toContain('mcp__cherry-tools__kb_search')
+    expect(getPresetAppend(settings.systemPrompt)).toContain('mcp__cherry-tools__kb_search')
   })
 
   it('omits citation guidance when both web tools are disabled and no knowledge base is bound', async () => {
@@ -973,7 +978,7 @@ describe('buildClaudeCodeSessionSettings', () => {
 
     const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
 
-    expect(settings.systemPrompt as string).not.toContain('## Citations')
+    expect(getPresetAppend(settings.systemPrompt)).not.toContain('## Citations')
   })
 
   it('omits citation guidance when dependency propagation blocks every lookup tool', async () => {
@@ -996,7 +1001,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     const settings = await buildClaudeCodeSessionSettings(session as never, {} as never)
 
     expect(settings.disallowedTools).toEqual(expect.arrayContaining(['mcp__cherry-tools__kb_read']))
-    expect(settings.systemPrompt as string).not.toContain('## Citations')
+    expect(getPresetAppend(settings.systemPrompt)).not.toContain('## Citations')
   })
 
   it('composes disallowedTools: globals + EnterWorktree (no .git cwd) + dedup', async () => {

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -1468,7 +1468,11 @@ export async function buildSystemPrompt(
     agentDataPath
   )
   const userInstructions = instructions ? `\n\n${instructions}` : ''
-  return `${soulPrompt}${userInstructions}${workspaceContextBlock}${channelSecurityBlock}${citationsBlock}${artifactsBlock}${runtimeBlock}\n\n${langInstruction}`
+  return {
+    type: 'preset',
+    preset: 'claude_code',
+    append: `${soulPrompt}${userInstructions}${workspaceContextBlock}${channelSecurityBlock}${citationsBlock}${artifactsBlock}${runtimeBlock}\n\n${langInstruction}`
+  }
 }
 
 export function buildMcpServers(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Regular Claude Code Agent sessions passed Cherry Studio's assembled instructions as a custom string system prompt, replacing the built-in Claude Code prompt.

After this PR:

Regular Agent sessions use the `claude_code` preset and append Cherry Studio's assembled instructions. Cherry Assistant keeps its dedicated custom prompt because it has a different identity and interaction surface.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The Claude Agent SDK treats a string `systemPrompt` as a complete replacement. Using the preset object preserves Claude Code's built-in tool guidance, safety rules, coding conventions, and environment context while retaining all Cherry Studio-specific prompt blocks in `append`.

The following tradeoffs were made:

- The preset is restored only for regular Agent sessions. Cherry Assistant intentionally keeps its custom prompt to avoid conflicting Claude Code identity and terminal-oriented instructions.

The following alternatives were considered:

- Applying the preset to Cherry Assistant was rejected because the SDK documentation recommends a custom prompt for agents with a different identity, surface, or permission model.
- Omitting `systemPrompt` was rejected because the SDK default is a minimal tool-calling prompt, not the full Claude Code prompt.

Links to places where the discussion took place: https://code.claude.com/docs/en/agent-sdk/modifying-system-prompts

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Focused tests cover the preset shape and ensure the existing workspace, citation, runtime, and user instructions remain in `append`.
- `pnpm exec vitest run src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts` passed (110 tests).
- `pnpm format` passed.
- `pnpm lint` passed with 37 pre-existing warnings outside this change set.
- Full `pnpm test` and `pnpm build:check` were intentionally not run per request.
- No documentation update is required because this restores the intended runtime behavior without adding a user-facing setting or workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Claude Code Agent sessions now preserve Claude Code's built-in system prompt while applying Cherry Studio-specific instructions.
```
