### PR TITLE
fix(electron-packaging): deduplicate Claude SDK binary

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -69,6 +69,7 @@ files:
   - "!node_modules/onnxruntime-web/**" # transformers.js's browser/WASM backend; local inference always runs onnxruntime-node instead
   - "!node_modules/@huggingface/transformers/node_modules/onnxruntime-web/**" # same package, nested copy
   - "!node_modules/onnxruntime-node/bin/**" # native binary is downloaded on first use (Toolchain/onnxruntime), never bundled — see OnnxRuntimeBinaryService
+  - "!node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-*/**" # keep the top-level native CLI only; nested copies duplicate ~200 MB
   - "!**/*.{h,iobj,ipdb,tlog,recipe,vcxproj,vcxproj.filters,Makefile,*.Makefile}" # filter .node build files
   - "resources/**/*" # include all files in resources, and unpack them from asar for runtime access
   - "!resources/devtools/**" # dev-only extensions are loaded from source in development

--- a/scripts/__tests__/before-pack.test.ts
+++ b/scripts/__tests__/before-pack.test.ts
@@ -4,18 +4,22 @@
  * stopped materialising both CPU architectures for the host OS — the packaging bug that
  * shipped a macOS x64 build without `@img/sharp-darwin-x64`.
  */
-import { readFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 import { parse } from 'yaml'
 
 // CJS build script — vitest interops the module.exports fine.
-import { assertPrebuiltPackages } from '../before-pack'
+import { assertClaudeAgentSdkNativeVersion, assertPrebuiltPackages } from '../before-pack'
 
 const hostPlatform = process.platform === 'darwin' ? 'darwin' : process.platform === 'win32' ? 'win32' : 'linux'
 const foreignPlatform = hostPlatform === 'darwin' ? 'win32' : 'darwin'
 const legacyMacOcrVersion = '1.0.2'
 const macOcrPackages = ['@napi-rs/system-ocr-darwin-arm64', '@napi-rs/system-ocr-darwin-x64']
+const nestedClaudeCliFilter =
+  '!node_modules/@anthropic-ai/claude-agent-sdk/node_modules/@anthropic-ai/claude-agent-sdk-*/**'
 
 describe('assertPrebuiltPackages', () => {
   it.each(['arm64', 'x64'])('passes for the host platform on %s', (arch) => {
@@ -41,6 +45,36 @@ describe('assertPrebuiltPackages', () => {
     for (const packageName of macOcrPackages) {
       expect(packageManifest.optionalDependencies[packageName]).toBe(legacyMacOcrVersion)
       expect(workspaceConfig.overrides[packageName]).toBe(legacyMacOcrVersion)
+    }
+  })
+
+  it('excludes only nested Claude Agent SDK native binaries', () => {
+    const builderConfig = parse(readFileSync('electron-builder.yml', 'utf8')) as { files: string[] }
+
+    expect(builderConfig.files).toContain(nestedClaudeCliFilter)
+    expect(builderConfig.files).not.toContain('!node_modules/@anthropic-ai/claude-agent-sdk-*/**')
+  })
+
+  it('rejects a native Claude binary from a different SDK release', () => {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'cherry-claude-sdk-'))
+    const sdkPackage = '@anthropic-ai/claude-agent-sdk'
+    const nativePackage = `${sdkPackage}-${hostPlatform}-arm64`
+
+    try {
+      for (const [packageName, version] of [
+        [sdkPackage, '0.3.185'],
+        [nativePackage, '0.3.168']
+      ]) {
+        const packageDirectory = path.join(fixtureRoot, 'node_modules', ...packageName.split('/'))
+        mkdirSync(packageDirectory, { recursive: true })
+        writeFileSync(path.join(packageDirectory, 'package.json'), JSON.stringify({ name: packageName, version }))
+      }
+
+      expect(() => assertClaudeAgentSdkNativeVersion(hostPlatform, 'arm64', fixtureRoot)).toThrow(
+        /Mismatched Claude Agent SDK packages.*0\.3\.185.*0\.3\.168/
+      )
+    } finally {
+      rmSync(fixtureRoot, { recursive: true })
     }
   })
 })

--- a/scripts/before-pack.js
+++ b/scripts/before-pack.js
@@ -67,6 +67,29 @@ const platformToArch = {
   linuxmusl: 'linuxmusl'
 }
 
+const projectRoot = path.join(__dirname, '..')
+
+const readPackageVersion = (root, packageName) => {
+  const manifestPath = path.join(root, 'node_modules', ...packageName.split('/'), 'package.json')
+  return JSON.parse(fs.readFileSync(manifestPath, 'utf8')).version
+}
+
+const assertClaudeAgentSdkNativeVersion = (platform, arch, root = projectRoot) => {
+  const sdkPackage = '@anthropic-ai/claude-agent-sdk'
+  const nativePackage = `${sdkPackage}-${platform}-${arch}`
+  const sdkVersion = readPackageVersion(root, sdkPackage)
+  const nativeVersion = readPackageVersion(root, nativePackage)
+
+  if (sdkVersion !== nativeVersion) {
+    throw new Error(
+      `Mismatched Claude Agent SDK packages for ${platform}-${arch}: ` +
+        `${sdkPackage}@${sdkVersion} and ${nativePackage}@${nativeVersion}. ` +
+        'Keep the SDK and all direct native optional dependencies on the same version.'
+    )
+  }
+}
+exports.assertClaudeAgentSdkNativeVersion = assertClaudeAgentSdkNativeVersion
+
 // Most native packages encode Electron's platform key (win32) in their name, but some
 // (e.g. sqlite-vec) use the npm `windows` convention. Match either so a win32 build keeps
 // sqlite-vec-windows-x64 instead of wrongly excluding it.
@@ -91,6 +114,8 @@ const assertPrebuiltPackages = (platform, arch) => {
         `on a fresh install, so plain \`pnpm install\` (even --force) will not fix it.`
     )
   }
+
+  assertClaudeAgentSdkNativeVersion(platform, arch)
 }
 exports.assertPrebuiltPackages = assertPrebuiltPackages
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Electron packages could contain both the root Claude Agent SDK native binary and a second copy nested under `@anthropic-ai/claude-agent-sdk`, adding roughly 200–250 MB to the unpacked application. Packaging also did not reject a root native package whose version differed from the SDK.

After this PR:

Electron packaging keeps only the root platform-specific Claude binary. The `beforePack` check now requires that binary's package version to match `@anthropic-ai/claude-agent-sdk`, so a stale or partially upgraded dependency tree fails before the nested compatible binary is excluded.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The duplicate binary was introduced by commit [`9eb784fc2f`](https://github.com/CherryHQ/cherry-studio/commit/9eb784fc2ff7bfe57b3808f8e555615fec99624a). That commit upgraded `@anthropic-ai/claude-agent-sdk` from `0.3.168` to `0.3.185` but forgot to remove or update the directly declared platform-native packages, which remained at `0.3.168`. Because the SDK requires its matching native package exactly, pnpm had to retain the old `0.3.168` root package and install `0.3.185` beneath the SDK. The resulting macOS artifact therefore bundled both Claude Code `2.1.168` and `2.1.185`.

Commit [`5706307451`](https://github.com/CherryHQ/cherry-studio/commit/5706307451648bd3a169bff04e27bdcd45e98c78) had originally added the root native packages intentionally for cross-architecture packaging. It did not introduce the duplicate because the SDK and native packages were both `0.3.145` and pnpm could deduplicate them. Commit [`c40827f2b5`](https://github.com/CherryHQ/cherry-studio/commit/c40827f2b5aad59c6f7aa84ce7164e03a785c383) later realigned both sets of packages at `0.3.218`, but no packaging guard prevented the omission from recurring and no filter removed nested copies from an already mismatched dependency tree.

The following tradeoffs were made:

- Keep the root native package because the cross-architecture packaging flow explicitly materializes and validates it.
- Exclude only the SDK-nested native package after verifying that the retained root package matches the SDK version.
- Fail packaging on a version mismatch instead of silently retaining a potentially incompatible binary.

The following alternatives were considered:

- Depending on a user-installed Claude Code CLI was rejected because it may be absent, removed, or incompatible with the bundled SDK.
- Removing the direct native optional dependencies was rejected because the release build intentionally installs both target CPU architectures and validates their root packages before packaging.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm test`: passed (1,722 files; 21,133 tests passed, 66 skipped).
- `pnpm format`: passed.
- `./node_modules/.bin/electron-builder --dir --arm64`: passed; the unpacked artifact contains one Claude binary (`0.3.220`, 256,908,272 bytes) at the retained root package path.
- The focused packaging test passes and reproduces the historical `0.3.185` SDK / `0.3.168` native mismatch.
- `pnpm lint` and `pnpm build:check` are locally blocked by a pre-existing case-insensitive checkout conflict between tracked `src/renderer/components/popups` paths and the on-disk `Popups` spelling, which causes `tsgolint` to panic. This PR does not touch those files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

