### PR TITLE
fix(provider-registry): serve DeepSeek V4 models over the Anthropic endpoint

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -424,6 +424,24 @@
       }
     },
     {
+      "capabilities": ["image-recognition", "image-generation"],
+      "id": "qwen-image-3",
+      "inputModalities": ["text", "image"],
+      "metadata": {},
+      "name": "Qwen: Qwen Image 3",
+      "outputModalities": ["image"],
+      "ownedBy": "alibaba"
+    },
+    {
+      "capabilities": ["image-recognition", "image-generation"],
+      "id": "qwen-image-3-pro",
+      "inputModalities": ["text", "image"],
+      "metadata": {},
+      "name": "Qwen: Qwen Image 3 Pro",
+      "outputModalities": ["image"],
+      "ownedBy": "alibaba"
+    },
+    {
       "capabilities": ["image-recognition", "image-generation", "file-input"],
       "family": "qwen",
       "id": "qwen-image-edit",
@@ -2143,9 +2161,12 @@
             "kind": "budget",
             "max": 262144,
             "min": 0
+          },
+          {
+            "kind": "toggle"
           }
         ],
-        "supportedEfforts": ["low", "medium", "xhigh"],
+        "supportedEfforts": ["low", "medium", "xhigh", "none"],
         "thinkingTokenLimits": {
           "max": 262144,
           "min": 0
@@ -7423,13 +7444,13 @@
         "controls": [
           {
             "kind": "effort",
-            "values": ["none", "high", "max", "xhigh"]
+            "values": ["none", "high", "max", "low", "xhigh"]
           },
           {
             "kind": "toggle"
           }
         ],
-        "supportedEfforts": ["none", "high", "max", "xhigh"]
+        "supportedEfforts": ["none", "high", "max", "low", "xhigh"]
       }
     },
     {
@@ -7463,11 +7484,11 @@
     },
     {
       "capabilities": ["function-call", "reasoning", "structured-output"],
-      "contextWindow": 1048576,
+      "contextWindow": 1048600,
       "family": "deepseek-thinking",
       "id": "deepseek-v4-pro",
       "inputModalities": ["text"],
-      "maxOutputTokens": 393216,
+      "maxOutputTokens": 1048600,
       "metadata": {},
       "name": "DeepSeek V4 Pro",
       "openWeights": true,
@@ -13093,11 +13114,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.075
+          "perMillionTokens": 0.09375
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.19999999999999998
+          "perMillionTokens": 0.25
         }
       }
     },
@@ -20996,5 +21017,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "3c1a2cdf9bbd80a9"
+  "version": "1d6b730d3fd11b20"
 }

--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -8251,7 +8251,7 @@
       "providerId": "deepseek"
     },
     {
-      "endpointTypes": ["openai-responses", "openai-chat-completions"],
+      "endpointTypes": ["openai-responses", "openai-chat-completions", "anthropic-messages"],
       "modelId": "deepseek-v4-flash",
       "providerId": "deepseek",
       "reasoningContracts": {
@@ -8368,7 +8368,7 @@
       }
     },
     {
-      "endpointTypes": ["openai-chat-completions"],
+      "endpointTypes": ["openai-chat-completions", "anthropic-messages"],
       "modelId": "deepseek-v4-pro",
       "providerId": "deepseek",
       "reasoningContracts": {
@@ -11538,15 +11538,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.0036
+          "perMillionTokens": 0.14
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.435
+          "perMillionTokens": 1.74
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.87
+          "perMillionTokens": 3.48
         }
       },
       "providerId": "gateway"
@@ -15905,6 +15905,22 @@
       "providerId": "grok-cli"
     },
     {
+      "apiModelId": "allam-2-7b",
+      "modelId": "allam-2-7b",
+      "name": "ALLaM-2-7b",
+      "pricing": {
+        "input": {
+          "currency": "USD",
+          "perMillionTokens": 0
+        },
+        "output": {
+          "currency": "USD",
+          "perMillionTokens": 0
+        }
+      },
+      "providerId": "groq"
+    },
+    {
       "apiModelId": "openai/gpt-oss-120b",
       "modelId": "gpt-oss-120b",
       "pricing": {
@@ -15990,22 +16006,6 @@
       "providerId": "groq"
     },
     {
-      "apiModelId": "meta-llama/llama-4-scout-17b-16e-instruct",
-      "modelId": "llama-4-scout-17b-16e-instruct",
-      "name": "Llama 4 Scout 17B 16E",
-      "pricing": {
-        "input": {
-          "currency": "USD",
-          "perMillionTokens": 0.11
-        },
-        "output": {
-          "currency": "USD",
-          "perMillionTokens": 0.34
-        }
-      },
-      "providerId": "groq"
-    },
-    {
       "apiModelId": "meta-llama/llama-prompt-guard-2-22m",
       "modelId": "llama-prompt-guard-2-22m",
       "name": "Llama Prompt Guard 2 22M",
@@ -16038,16 +16038,20 @@
       "providerId": "groq"
     },
     {
-      "apiModelId": "qwen/qwen3-32b",
-      "modelId": "qwen3-32b",
+      "apiModelId": "qwen/qwen3.6-27b",
+      "modelId": "qwen3-6-27b",
       "pricing": {
+        "cacheRead": {
+          "currency": "USD",
+          "perMillionTokens": 0.3
+        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.29
+          "perMillionTokens": 0.6
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.59
+          "perMillionTokens": 3
         }
       },
       "providerId": "groq"
@@ -27307,15 +27311,15 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.05
+          "perMillionTokens": 0.054
         },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.25
+          "perMillionTokens": 0.27
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1
+          "perMillionTokens": 1.08
         }
       },
       "providerId": "openrouter",
@@ -27620,11 +27624,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.075
+          "perMillionTokens": 0.09375
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.2
+          "perMillionTokens": 0.25
         }
       },
       "providerId": "openrouter"
@@ -28354,6 +28358,178 @@
       "providerId": "openrouter"
     },
     {
+      "apiModelId": "qwen/qwen-image-3",
+      "capabilities": {
+        "add": ["image-generation"]
+      },
+      "endpointTypes": ["openai-image-generation"],
+      "imageGeneration": {
+        "modes": {
+          "edit": {
+            "maxInputImages": 4,
+            "supports": {
+              "aspectRatio": {
+                "options": [
+                  "1:1",
+                  "1:2",
+                  "1:4",
+                  "2:1",
+                  "2:3",
+                  "3:2",
+                  "3:4",
+                  "4:1",
+                  "4:3",
+                  "4:5",
+                  "5:4",
+                  "9:16",
+                  "16:9"
+                ],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 6,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "resolution": {
+                "options": ["1K", "2K"],
+                "type": "enum"
+              },
+              "seed": {
+                "type": "text"
+              }
+            }
+          },
+          "generate": {
+            "supports": {
+              "aspectRatio": {
+                "options": [
+                  "1:1",
+                  "1:2",
+                  "1:4",
+                  "2:1",
+                  "2:3",
+                  "3:2",
+                  "3:4",
+                  "4:1",
+                  "4:3",
+                  "4:5",
+                  "5:4",
+                  "9:16",
+                  "16:9"
+                ],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 6,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "resolution": {
+                "options": ["1K", "2K"],
+                "type": "enum"
+              },
+              "seed": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "inputModalities": ["text", "image"],
+      "modelId": "qwen-image-3",
+      "outputModalities": ["image"],
+      "providerId": "openrouter"
+    },
+    {
+      "apiModelId": "qwen/qwen-image-3-pro",
+      "capabilities": {
+        "add": ["image-generation"]
+      },
+      "endpointTypes": ["openai-image-generation"],
+      "imageGeneration": {
+        "modes": {
+          "edit": {
+            "maxInputImages": 4,
+            "supports": {
+              "aspectRatio": {
+                "options": [
+                  "1:1",
+                  "1:2",
+                  "1:4",
+                  "2:1",
+                  "2:3",
+                  "3:2",
+                  "3:4",
+                  "4:1",
+                  "4:3",
+                  "4:5",
+                  "5:4",
+                  "9:16",
+                  "16:9"
+                ],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 6,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "resolution": {
+                "options": ["1K", "2K"],
+                "type": "enum"
+              },
+              "seed": {
+                "type": "text"
+              }
+            }
+          },
+          "generate": {
+            "supports": {
+              "aspectRatio": {
+                "options": [
+                  "1:1",
+                  "1:2",
+                  "1:4",
+                  "2:1",
+                  "2:3",
+                  "3:2",
+                  "3:4",
+                  "4:1",
+                  "4:3",
+                  "4:5",
+                  "5:4",
+                  "9:16",
+                  "16:9"
+                ],
+                "type": "enum"
+              },
+              "numImages": {
+                "max": 6,
+                "min": 1,
+                "step": 1,
+                "type": "range"
+              },
+              "resolution": {
+                "options": ["1K", "2K"],
+                "type": "enum"
+              },
+              "seed": {
+                "type": "text"
+              }
+            }
+          }
+        }
+      },
+      "inputModalities": ["text", "image"],
+      "modelId": "qwen-image-3-pro",
+      "outputModalities": ["image"],
+      "providerId": "openrouter"
+    },
+    {
       "apiModelId": "qwen/qwen-plus-2025-07-28:thinking",
       "modelId": "qwen-plus",
       "pricing": {
@@ -28383,17 +28559,13 @@
       "apiModelId": "qwen/qwen2.5-vl-72b-instruct",
       "modelId": "qwen2-5-vl-72b-instruct",
       "pricing": {
-        "cacheRead": {
-          "currency": "USD",
-          "perMillionTokens": 0.4
-        },
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.8
+          "perMillionTokens": 0.25
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 1
+          "perMillionTokens": 0.75
         }
       },
       "providerId": "openrouter"
@@ -36180,5 +36352,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "d5bd189d246ec8e3"
+  "version": "cfc23aa59b891b91"
 }

--- a/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
@@ -74,11 +74,27 @@ describe('deepseek endpoint matrix', () => {
   })
 
   it('prefers Responses for V4 Flash while keeping Chat Completions selectable', () => {
-    expect(endpointsOf('deepseek', 'deepseek-v4-flash')).toEqual(['openai-responses', 'openai-chat-completions'])
+    expect(endpointsOf('deepseek', 'deepseek-v4-flash')).toEqual([
+      'openai-responses',
+      'openai-chat-completions',
+      'anthropic-messages'
+    ])
   })
 
-  it.each(['deepseek-v4-pro', 'deepseek-chat', 'deepseek-reasoner'])(
-    'pins %s to Chat Completions while DeepSeek Responses does not serve it',
+  /**
+   * The Anthropic-compatible endpoint (api-docs.deepseek.com/zh-cn/guides/anthropic_api,
+   * https://api.deepseek.com/anthropic) documents V4 Pro and V4 Flash only — it maps `claude-opus*`
+   * onto v4-pro, `claude-sonnet*`/`claude-haiku*` onto v4-flash, and silently rewrites any other
+   * model name to v4-flash. So chat/reasoner stay off it: reaching them through it would serve a
+   * different model than the one selected. It trails Chat Completions on both V4 SKUs because
+   * `endpointTypes[0]` is what routes in-app chat.
+   */
+  it('exposes the Anthropic-compatible endpoint on V4 Pro without displacing its Chat default', () => {
+    expect(endpointsOf('deepseek', 'deepseek-v4-pro')).toEqual(['openai-chat-completions', 'anthropic-messages'])
+  })
+
+  it.each(['deepseek-chat', 'deepseek-reasoner'])(
+    'pins %s to Chat Completions, the only endpoint DeepSeek serves it on',
     (modelId) => {
       expect(endpointsOf('deepseek', modelId)).toEqual(['openai-chat-completions'])
     }

--- a/packages/provider-registry/src/providers/deepseek.ts
+++ b/packages/provider-registry/src/providers/deepseek.ts
@@ -102,12 +102,15 @@ export default defineProvider({
       official: 'https://deepseek.com/'
     }
   },
+  // The Anthropic-compatible endpoint serves V4 Pro / V4 Flash only, and silently maps any other
+  // model name onto v4-flash — so it is pinned on those two and withheld from chat/reasoner. It
+  // trails Chat Completions because `endpointTypes[0]` routes in-app chat.
   overrides: [
     { modelId: 'deepseek-chat', endpointTypes: ['openai-chat-completions'] },
     { modelId: 'deepseek-reasoner', endpointTypes: ['openai-chat-completions'] },
     {
       modelId: 'deepseek-v4-flash',
-      endpointTypes: ['openai-responses', 'openai-chat-completions'],
+      endpointTypes: ['openai-responses', 'openai-chat-completions', 'anthropic-messages'],
       reasoningContracts: {
         'openai-chat-completions': { wire: flashChatEffortWire },
         'openai-responses': { wire: responsesEffortWire }
@@ -115,7 +118,7 @@ export default defineProvider({
     },
     {
       modelId: 'deepseek-v4-pro',
-      endpointTypes: ['openai-chat-completions'],
+      endpointTypes: ['openai-chat-completions', 'anthropic-messages'],
       reasoningContracts: {
         'openai-chat-completions': { wire: proChatEffortWire }
       }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

- In Code Mate, picking Claude Code + DeepSeek showed the provider card but an **empty model dropdown** — none of the four DeepSeek models were selectable.
- `CLI_TOOL_PROVIDER_MAP` admitted the provider (it only checks `endpointConfigs`, and DeepSeek does declare `https://api.deepseek.com/anthropic`), but `modelSupportsCliTool` gates each model on its own `endpointTypes`, and none of them carried `anthropic-messages`.

After this PR:

- `deepseek-v4-pro` and `deepseek-v4-flash` are selectable for Claude Code and inject `ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic`.
- `deepseek-chat` / `deepseek-reasoner` stay off that endpoint deliberately (see tradeoffs).
- Codex (V4 Flash only) and Qwen Code (all four) are byte-for-byte unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

This is a regression from #17694. Before it, the four DeepSeek overrides were bare `{ modelId }`, and `hasModelEndpoint` fails open on an empty array — so every model was selectable in Claude Code. That PR pinned `endpointTypes` on all four to express "V4 Pro has no Responses support", which incidentally stripped `anthropic-messages` from each of them. A full catalog scan shows DeepSeek is the only provider that declares an Anthropic endpoint yet exposes **zero** models through it (openrouter 296/334, dashscope 39/56 and opencode 10/24 are merely partial).

The fix restores the capability where the vendor documents it, per DeepSeek's Anthropic API guide: the endpoint serves V4 Pro and V4 Flash, maps `claude-opus*` to v4-pro and `claude-sonnet*`/`claude-haiku*` to v4-flash.

The following tradeoffs were made:

- **`deepseek-chat` / `deepseek-reasoner` are withheld.** That endpoint silently rewrites unknown model names to `deepseek-v4-flash`, so exposing them would serve a different model than the one the user selected — worse than not offering them.
- **`anthropic-messages` is appended last, never first.** `endpointTypes[0]` is what `resolveEffectiveEndpoint` routes in-app chat through, so Responses stays default for V4 Flash and Chat Completions for V4 Pro. In-app chat behavior is unchanged.
- **No `reasoningContracts['anthropic-messages']` added.** Under the default `defaultChatEndpoint`, `resolveReasoningEndpointType` still resolves both SKUs to `openai-chat-completions`, so the existing wires keep applying. `longcat` and `poe` set the same precedent.
- **`data/*.json` carries unrelated drift.** `pnpm generate` re-reads models.dev and OpenRouter live; the non-DeepSeek changes here are that refresh, not hand edits.

The following alternatives were considered:

- Relaxing `modelSupportsCliTool` to fall back to provider-level capability was rejected for this PR: it would loosen the gate for every provider at once, well beyond the reported bug. The underlying coupling — a registry field meaning "in-app chat endpoints" being reused as a CLI compatibility matrix — is worth addressing separately.
- Adding `openai-responses` to `deepseek-v4-pro` (so it appears under Codex too) was rejected: DeepSeek's Responses API guide still states V4 Pro is not yet supported, with support planned for early August 2026.

Links to places where the discussion took place: https://api-docs.deepseek.com/zh-cn/guides/anthropic_api, https://api-docs.deepseek.com/zh-cn/guides/responses_api, #17694

### Breaking changes

None. Existing installs pick this up with no sync or reset: preset-backed model rows store `endpointTypes` as NULL and re-resolve from the registry on every read (`enrichRowsFromRegistry`), the same invariant `presetProviderSeeder` documents.

### Special notes for your reviewer

- **Not yet verified end-to-end against the live API.** Cherry writes `ANTHROPIC_AUTH_TOKEN` (→ `Authorization: Bearer`) and actively scrubs `ANTHROPIC_API_KEY` (#15089), whereas DeepSeek's guide uses `ANTHROPIC_API_KEY` and marks `x-api-key` as fully supported. Providers on the same code path (longcat, fireworks) work, so this is expected to be fine — but if it returns 401, that is a separate renderer-side issue this registry change cannot fix.
- Reviewing `packages/provider-registry/src/providers/deepseek.ts` plus the endpoint-matrix test is enough to judge the intent; the rest of the diff is generated output.
- Verified: `pnpm test:provider-registry` (18 files / 286 tests, including `catalog-source-sync` and `catalog-invariants`) and `pnpm test:lint` (exit 0, no provider-registry findings), both re-run after rebasing onto current `main`. Simulating the CLI filter against the regenerated catalog yields `claude-code: v4-flash, v4-pro` / `codex: v4-flash` / `qwen-code: all four`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix DeepSeek models being unselectable for Claude Code in Code Mate: DeepSeek V4 Pro and V4 Flash can now be picked and are served over DeepSeek's Anthropic-compatible endpoint.
```
