### PR TITLE
fix(claude-code): replace prompt variables in agent session system prompt

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -22,7 +22,8 @@ const {
   mockProvisionBuiltinAgent,
   mockBuildMemoriesSection,
   mockGetAppLanguage,
-  mockBuildPrompt
+  mockBuildPrompt,
+  mockReplacePromptVariables
 } = vi.hoisted(() => ({
   mockFindBySessionId: vi.fn(),
   mockMkdir: vi.fn(),
@@ -34,7 +35,8 @@ const {
   mockProvisionBuiltinAgent: vi.fn(),
   mockBuildMemoriesSection: vi.fn(),
   mockGetAppLanguage: vi.fn(() => 'en-US'),
-  mockBuildPrompt: vi.fn().mockResolvedValue('SOUL_PROMPT')
+  mockBuildPrompt: vi.fn().mockResolvedValue('SOUL_PROMPT'),
+  mockReplacePromptVariables: vi.fn().mockImplementation(async (input: string) => input)
 }))
 
 vi.mock('@logger', () => ({
@@ -54,6 +56,10 @@ vi.mock('node:fs', async (importOriginal) => {
 
 vi.mock('@application', () => ({
   application: { get: mockApplicationGet, getPath: mockGetPath }
+}))
+
+vi.mock('@main/utils/prompt', () => ({
+  replacePromptVariables: mockReplacePromptVariables
 }))
 
 vi.mock('@main/i18n', () => ({
@@ -401,5 +407,71 @@ describe('buildSystemPrompt — builtin Cherry Assistant definition', () => {
     const result = await buildSystemPrompt(makeSession(), agent, '/tmp/cwd')
 
     expect(result as string).not.toContain(CHANNEL_SECURITY_PROMPT)
+  })
+})
+
+describe('buildSystemPrompt — prompt variable replacement', () => {
+  beforeEach(() => {
+    mockFindBySessionId.mockReturnValue(null)
+    mockReplacePromptVariables.mockReset().mockImplementation(async (input: string) => input)
+  })
+
+  it('replaces {{date}} and {{time}} in user instructions for regular agents', async () => {
+    mockReplacePromptVariables.mockImplementation(async (input: string) =>
+      input.replace(/\{\{date\}\}/g, '2026-04-20').replace(/\{\{time\}\}/g, '10:00:00')
+    )
+
+    const result = await buildSystemPrompt(
+      makeSession(),
+      makeAgent({ instructions: 'Current time is {{date}}T{{time}}' }),
+      '/tmp/cwd'
+    )
+
+    const append = getPresetAppend(result)
+    expect(append).toContain('Current time is 2026-04-20T10:00:00')
+    expect(append).not.toContain('{{date}}')
+    expect(append).not.toContain('{{time}}')
+    expect(mockReplacePromptVariables).toHaveBeenCalledWith('Current time is {{date}}T{{time}}')
+  })
+
+  it('replaces {{date}} and {{time}} in user instructions for assistant agents', async () => {
+    mockReplacePromptVariables.mockImplementation(async (input: string) =>
+      input.replace(/\{\{date\}\}/g, '2026-04-20').replace(/\{\{time\}\}/g, '10:00:00')
+    )
+
+    const result = await buildSystemPrompt(
+      makeSession(),
+      makeAgent({
+        instructions: 'Current time is {{date}}T{{time}}',
+        configuration: { builtin_role: 'assistant' } as never
+      }),
+      '/tmp/cwd'
+    )
+
+    expect(result as string).toContain('Current time is 2026-04-20T10:00:00')
+    expect(result as string).not.toContain('{{date}}')
+    expect(result as string).not.toContain('{{time}}')
+  })
+
+  it('replaces variables in bundled builtin instructions', async () => {
+    mockLoadBuiltinAgentDefinition.mockReturnValue({ instructions: 'Bundled: {{date}} {{time}}' })
+    mockReplacePromptVariables.mockImplementation(async (input: string) =>
+      input.replace(/\{\{date\}\}/g, '2026-04-20').replace(/\{\{time\}\}/g, '10:00:00')
+    )
+
+    const result = await buildSystemPrompt(
+      makeSession(),
+      makeAgent({ instructions: '', configuration: { builtin_role: 'assistant' } as never }),
+      '/tmp/cwd'
+    )
+
+    expect(result as string).toContain('Bundled: 2026-04-20 10:00:00')
+    expect(result as string).not.toContain('{{date}}')
+  })
+
+  it('does not call replacePromptVariables when instructions are empty', async () => {
+    await buildSystemPrompt(makeSession(), makeAgent({ instructions: '' }), '/tmp/cwd')
+
+    expect(mockReplacePromptVariables).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -65,6 +65,7 @@ import { toAsarUnpackedPath } from '@main/utils/asar'
 import { getBinaryPath } from '@main/utils/binaryResolver'
 import { autoDiscoverGitBash } from '@main/utils/commandResolver'
 import { getPathStatus, isPathInside, type PathStatus } from '@main/utils/file'
+import { replacePromptVariables } from '@main/utils/prompt'
 import { redactUrlToOrigin } from '@main/utils/redactUrl'
 import { rtkRewrite } from '@main/utils/rtk'
 import { getShellEnv } from '@main/utils/shellEnv'
@@ -1412,6 +1413,12 @@ export async function buildSystemPrompt(
       logger.error('Builtin Cherry Assistant definition missing; using minimal fallback instructions')
       instructions = MINIMAL_CHERRY_ASSISTANT_INSTRUCTIONS
     }
+  }
+
+  // Replace prompt variables ({{date}}, {{time}}, etc.) — the regular-chat
+  // path does this in assembleSystemPrompt; the agent-session path must too.
+  if (instructions) {
+    instructions = await replacePromptVariables(instructions)
   }
 
   // Persona and memory templates belong in the app-owned agent data directory. Bundled


### PR DESCRIPTION
### What this PR does

Before this PR: In the Claude Code runtime (used for agent sessions), the buildSystemPrompt function uses agent.instructions directly without calling replacePromptVariables(). This means template variables like {{date}}, {{time}}, {{username}}, {{system}}, {{language}}, and {{arch}} were never substituted in agent sessions, leaving them as literal strings in the system prompt. Regular chat sessions were unaffected because they go through assembleSystemPrompt which already handled this.

After this PR: The buildSystemPrompt function now calls replacePromptVariables() on the resolved instructions after the builtin/user ownership decision, matching the behavior of the regular-chat path. This ensures that all prompt variables are properly substituted in agent sessions as well.

Fixes #17894

### Why we need it and why it was done in this way

The fix follows the existing pattern from the regular-chat path (assembleSystemPrompt.ts line 33) to maintain consistency. The replacement is applied after the builtin agent definition loading to ensure user-authored instructions take precedence.

### Breaking changes

None.

### Special notes for your reviewer

- The fix adds a single call to replacePromptVariables() after the instruction resolution logic
- Tests added verify the replacement works for regular agents, assistant agents, and bundled builtin instructions
- Tests also verify that replacement is not called when instructions are empty

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix {{date}} and {{time}} prompt variables not being replaced in agent sessions
```
