### PR TITLE
fix(horizontal-scroll-container): add bidirectional controls

### DIFF
--- a/packages/ui/src/components/composites/horizontal-scroll-container/__tests__/horizontal-scroll-container.test.tsx
+++ b/packages/ui/src/components/composites/horizontal-scroll-container/__tests__/horizontal-scroll-container.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import HorizontalScrollContainer from '../index'
+
+interface ResizeObserverMockInstance {
+  callback: ResizeObserverCallback
+  targets: Element[]
+}
+
+const originalResizeObserver = globalThis.ResizeObserver
+const resizeObserverInstances: ResizeObserverMockInstance[] = []
+const accessibleLabels = {
+  scrollLeftLabel: 'Scroll left',
+  scrollRightLabel: 'Scroll right'
+}
+
+function setElementSize(element: HTMLElement, sizes: { clientWidth: number; scrollWidth: number; scrollLeft: number }) {
+  Object.defineProperties(element, {
+    clientWidth: { configurable: true, value: sizes.clientWidth },
+    scrollLeft: { configurable: true, writable: true, value: sizes.scrollLeft },
+    scrollWidth: { configurable: true, value: sizes.scrollWidth }
+  })
+  Object.defineProperty(element.parentElement, 'clientWidth', {
+    configurable: true,
+    value: sizes.clientWidth
+  })
+}
+
+function triggerResizeObserver() {
+  const instance = resizeObserverInstances[0]
+  if (!instance || instance.targets.length === 0) {
+    throw new Error('Expected the scroll container to be observed')
+  }
+
+  act(() => {
+    instance.callback(
+      instance.targets.map((target) => ({ target }) as ResizeObserverEntry),
+      {} as ResizeObserver
+    )
+  })
+}
+
+function getScrollElement() {
+  return screen.getByTestId('scroll-item').closest('[data-scrolling]') as HTMLElement
+}
+
+describe('HorizontalScrollContainer', () => {
+  beforeEach(() => {
+    resizeObserverInstances.length = 0
+    globalThis.ResizeObserver = vi.fn((callback: ResizeObserverCallback) => {
+      const instance: ResizeObserverMockInstance = { callback, targets: [] }
+      resizeObserverInstances.push(instance)
+      return {
+        observe: vi.fn((target: Element) => instance.targets.push(target)),
+        disconnect: vi.fn()
+      } as unknown as ResizeObserver
+    }) as unknown as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it('shows only directions that can still scroll', () => {
+    render(
+      <HorizontalScrollContainer {...accessibleLabels}>
+        <span data-testid="scroll-item">Item</span>
+      </HorizontalScrollContainer>
+    )
+    const scrollElement = getScrollElement()
+    setElementSize(scrollElement, { clientWidth: 100, scrollLeft: 0, scrollWidth: 300 })
+
+    triggerResizeObserver()
+
+    expect(screen.queryByRole('button', { name: 'Scroll left' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scroll right' })).toBeInTheDocument()
+
+    scrollElement.scrollLeft = 100
+    fireEvent.scroll(scrollElement)
+
+    expect(screen.getByRole('button', { name: 'Scroll left' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scroll right' })).toBeInTheDocument()
+
+    scrollElement.scrollLeft = 200
+    fireEvent.scroll(scrollElement)
+
+    expect(screen.getByRole('button', { name: 'Scroll left' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Scroll right' })).not.toBeInTheDocument()
+  })
+
+  it('scrolls with shared icon buttons and custom accessible labels', () => {
+    render(
+      <HorizontalScrollContainer scrollDistance={120} scrollLeftLabel="Previous items" scrollRightLabel="Next items">
+        <span data-testid="scroll-item">Item</span>
+      </HorizontalScrollContainer>
+    )
+    const scrollElement = getScrollElement()
+    const scrollBy = vi.fn()
+    Object.defineProperty(scrollElement, 'scrollBy', { configurable: true, value: scrollBy })
+    setElementSize(scrollElement, { clientWidth: 100, scrollLeft: 100, scrollWidth: 300 })
+
+    triggerResizeObserver()
+
+    const leftButton = screen.getByRole('button', { name: 'Previous items' })
+    const rightButton = screen.getByRole('button', { name: 'Next items' })
+    expect(leftButton).toHaveAttribute('data-slot', 'button')
+    expect(rightButton).toHaveAttribute('data-variant', 'ghost')
+    expect(leftButton).toHaveClass('hover:bg-background', 'focus-visible:bg-background')
+    expect(rightButton).toHaveClass('hover:bg-background', 'focus-visible:bg-background')
+    expect(leftButton).not.toHaveClass('hover:bg-accent', 'focus-visible:bg-accent')
+    expect(rightButton).not.toHaveClass('hover:bg-accent', 'focus-visible:bg-accent')
+
+    fireEvent.click(leftButton)
+    fireEvent.click(rightButton)
+
+    expect(scrollBy).toHaveBeenNthCalledWith(1, { behavior: 'smooth', left: -120 })
+    expect(scrollBy).toHaveBeenNthCalledWith(2, { behavior: 'smooth', left: 120 })
+  })
+
+  it('recalculates for DOM content changes without recreating observers', async () => {
+    render(
+      <HorizontalScrollContainer {...accessibleLabels}>
+        <span data-testid="scroll-item">One</span>
+      </HorizontalScrollContainer>
+    )
+    const scrollElement = getScrollElement()
+    setElementSize(scrollElement, { clientWidth: 100, scrollLeft: 0, scrollWidth: 100 })
+    triggerResizeObserver()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+
+    setElementSize(scrollElement, { clientWidth: 100, scrollLeft: 0, scrollWidth: 300 })
+    act(() => {
+      screen.getByTestId('scroll-item').textContent = 'Two'
+    })
+
+    expect(await screen.findByRole('button', { name: 'Scroll right' })).toBeInTheDocument()
+    expect(resizeObserverInstances).toHaveLength(1)
+  })
+})

--- a/packages/ui/src/components/composites/horizontal-scroll-container/index.tsx
+++ b/packages/ui/src/components/composites/horizontal-scroll-container/index.tsx
@@ -1,14 +1,18 @@
 // Original: src/renderer/components/horizontal-scroll-container/index.tsx
 import { cn } from '@cherrystudio/ui/lib/utils'
-import { ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import * as React from 'react'
 
+import { Button } from '../../primitives/button'
 import Scrollbar from '../scrollbar'
+
+const SCROLL_POSITION_TOLERANCE = 1
 
 export interface HorizontalScrollContainerProps {
   children: React.ReactNode
-  dependencies?: readonly unknown[]
   scrollDistance?: number
+  scrollLeftLabel: string
+  scrollRightLabel: string
   className?: string
   gap?: string
   expandable?: boolean
@@ -16,16 +20,22 @@ export interface HorizontalScrollContainerProps {
 
 const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
   children,
-  dependencies = [],
   scrollDistance = 200,
+  scrollLeftLabel,
+  scrollRightLabel,
   className,
   gap = '8px',
   expandable = false
 }) => {
   const scrollRef = React.useRef<HTMLDivElement>(null)
-  const [canScroll, setCanScroll] = React.useState(false)
+  const [canScrollLeft, setCanScrollLeft] = React.useState(false)
+  const [canScrollRight, setCanScrollRight] = React.useState(false)
   const [isExpanded, setIsExpanded] = React.useState(false)
-  const [isScrolledToEnd, setIsScrolledToEnd] = React.useState(false)
+
+  const handleScrollLeft = (event: React.MouseEvent) => {
+    scrollRef.current?.scrollBy({ left: -scrollDistance, behavior: 'smooth' })
+    event.stopPropagation()
+  }
 
   const handleScrollRight = (event: React.MouseEvent) => {
     scrollRef.current?.scrollBy({ left: scrollDistance, behavior: 'smooth' })
@@ -52,14 +62,11 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
     const parentElement = scrollElement.parentElement
     const availableWidth = parentElement ? parentElement.clientWidth : scrollElement.clientWidth
     const canScrollValue = scrollElement.scrollWidth > Math.min(availableWidth, scrollElement.clientWidth)
-    setCanScroll(canScrollValue)
-
-    if (canScrollValue) {
-      const isAtEnd = Math.abs(scrollElement.scrollLeft + scrollElement.clientWidth - scrollElement.scrollWidth) <= 1
-      setIsScrolledToEnd(isAtEnd)
-    } else {
-      setIsScrolledToEnd(false)
-    }
+    setCanScrollLeft(canScrollValue && scrollElement.scrollLeft > SCROLL_POSITION_TOLERANCE)
+    setCanScrollRight(
+      canScrollValue &&
+        scrollElement.scrollLeft + scrollElement.clientWidth < scrollElement.scrollWidth - SCROLL_POSITION_TOLERANCE
+    )
   }, [])
 
   React.useEffect(() => {
@@ -68,24 +75,33 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
       return
     }
 
-    checkScrollability()
-
-    const handleScroll = () => {
-      checkScrollability()
-    }
-
     const resizeObserver = new ResizeObserver(checkScrollability)
-    resizeObserver.observe(scrollElement)
+    const observeResizeTargets = () => {
+      resizeObserver.disconnect()
+      resizeObserver.observe(scrollElement)
+      if (scrollElement.parentElement) {
+        resizeObserver.observe(scrollElement.parentElement)
+      }
+      for (const child of scrollElement.children) {
+        resizeObserver.observe(child)
+      }
+    }
+    const mutationObserver = new MutationObserver(() => {
+      observeResizeTargets()
+      checkScrollability()
+    })
 
-    scrollElement.addEventListener('scroll', handleScroll)
-    window.addEventListener('resize', checkScrollability)
+    observeResizeTargets()
+    mutationObserver.observe(scrollElement, { childList: true, subtree: true, characterData: true })
+    scrollElement.addEventListener('scroll', checkScrollability, { passive: true })
+    checkScrollability()
 
     return () => {
       resizeObserver.disconnect()
-      scrollElement.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('resize', checkScrollability)
+      mutationObserver.disconnect()
+      scrollElement.removeEventListener('scroll', checkScrollability)
     }
-  }, [checkScrollability, dependencies])
+  }, [checkScrollability])
 
   return (
     <div
@@ -107,15 +123,37 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
         }}>
         {children}
       </Scrollbar>
-      {canScroll && !isExpanded && !isScrolledToEnd && (
-        <div
+      {canScrollLeft && !isExpanded && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={scrollLeftLabel}
+          data-no-expand
           className={cn(
-            'scroll-right-button absolute top-1/2 right-2 z-[1] flex size-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-background opacity-0 shadow-[0_6px_16px_0_rgba(0,0,0,0.08),0_3px_6px_-4px_rgba(0,0,0,0.12),0_9px_28px_8px_rgba(0,0,0,0.05)] transition-opacity',
-            !isScrolledToEnd && 'group-hover/container:opacity-100'
+            'scroll-left-button absolute top-1/2 left-2 z-[1] -translate-y-1/2 rounded-full bg-background opacity-0 shadow-md transition-opacity hover:bg-background focus-visible:bg-background',
+            'text-muted-foreground hover:text-foreground focus-visible:text-foreground',
+            'group-hover/container:opacity-100 focus-visible:opacity-100'
+          )}
+          onClick={handleScrollLeft}>
+          <ChevronLeft className="size-3.5" />
+        </Button>
+      )}
+      {canScrollRight && !isExpanded && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={scrollRightLabel}
+          data-no-expand
+          className={cn(
+            'scroll-right-button absolute top-1/2 right-2 z-[1] -translate-y-1/2 rounded-full bg-background opacity-0 shadow-md transition-opacity hover:bg-background focus-visible:bg-background',
+            'text-muted-foreground hover:text-foreground focus-visible:text-foreground',
+            'group-hover/container:opacity-100 focus-visible:opacity-100'
           )}
           onClick={handleScrollRight}>
-          <ChevronRight size={14} className="text-muted-foreground hover:text-foreground" />
-        </div>
+          <ChevronRight className="size-3.5" />
+        </Button>
       )}
     </div>
   )

--- a/packages/ui/stories/components/composites/horizontal-scroll-container.stories.tsx
+++ b/packages/ui/stories/components/composites/horizontal-scroll-container.stories.tsx
@@ -3,6 +3,11 @@ import { useState } from 'react'
 
 import { HorizontalScrollContainer } from '../../../src/components'
 
+const scrollButtonLabels = {
+  scrollLeftLabel: 'Scroll left',
+  scrollRightLabel: 'Scroll right'
+}
+
 const meta: Meta<typeof HorizontalScrollContainer> = {
   title: 'Components/Composites/horizontal-scroll-container',
   component: HorizontalScrollContainer,
@@ -10,6 +15,7 @@ const meta: Meta<typeof HorizontalScrollContainer> = {
     layout: 'centered'
   },
   tags: ['autodocs'],
+  args: scrollButtonLabels,
   argTypes: {
     scrollDistance: { control: { type: 'range', min: 50, max: 500, step: 50 } },
     gap: { control: 'text' },
@@ -153,7 +159,7 @@ export const Interactive: Story = {
 
     return (
       <div className="w-96">
-        <HorizontalScrollContainer gap="8px" scrollDistance={150}>
+        <HorizontalScrollContainer {...scrollButtonLabels} gap="8px" scrollDistance={150}>
           {items.map((item) => (
             <div
               key={item}
@@ -180,7 +186,7 @@ export const DifferentGaps: Story = {
     <div className="flex w-96 flex-col gap-6">
       <div>
         <h4 className="mb-2 font-semibold">Small Gap (4px)</h4>
-        <HorizontalScrollContainer gap="4px">
+        <HorizontalScrollContainer {...scrollButtonLabels} gap="4px">
           {Array.from({ length: 15 }, (_, i) => (
             <span key={i} className="rounded bg-purple-600 px-3 py-1.5 text-white">
               Item {i + 1}
@@ -191,7 +197,7 @@ export const DifferentGaps: Story = {
 
       <div>
         <h4 className="mb-2 font-semibold">Medium Gap (12px)</h4>
-        <HorizontalScrollContainer gap="12px">
+        <HorizontalScrollContainer {...scrollButtonLabels} gap="12px">
           {Array.from({ length: 15 }, (_, i) => (
             <span key={i} className="rounded bg-cyan-500 px-3 py-1.5 text-white">
               Item {i + 1}
@@ -202,7 +208,7 @@ export const DifferentGaps: Story = {
 
       <div>
         <h4 className="mb-2 font-semibold">Large Gap (20px)</h4>
-        <HorizontalScrollContainer gap="20px">
+        <HorizontalScrollContainer {...scrollButtonLabels} gap="20px">
           {Array.from({ length: 15 }, (_, i) => (
             <span key={i} className="rounded bg-pink-500 px-3 py-1.5 text-white">
               Item {i + 1}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

The shared horizontal scroll container exposed only a right-side overlay control. After scrolling forward, users could not navigate back with an equivalent left-side control, and content changes relied on a caller-managed dependency list to refresh scrollability.

After this PR:

The container exposes accessible left and right controls only when content remains in that direction. It uses the shared icon button, keeps the floating button surface opaque on hover, and responds to container, child-size, and DOM-content changes without caller-managed effect dependencies.
<img width="920" height="200" alt="img_v3_02149_f1d80dca-98d0-4d65-b54b-d5a022955c8g" src="https://github.com/user-attachments/assets/0ae98a0a-c039-42f4-8d35-a4d474e31136" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #17880

### Why we need it and why it was done in this way

The scroll container owns its geometry, observers, event listeners, and directional state because these concerns are local to the rendered scroll surface. The public API only requires the scroll distance and localized accessible labels.

The following tradeoffs were made:

- A `MutationObserver` complements `ResizeObserver` so dynamic content updates are detected without accepting arbitrary React effect dependencies. This adds a small observer cost per mounted container.
- Accessible labels are required from callers so product integrations can provide localized text instead of inheriting hard-coded English defaults.

The following alternatives were considered:

- Reusing raw `div` or `button` controls was rejected because the shared `Button` already provides the repository's icon-button semantics and accessibility baseline.
- Changing the global ghost-button hover fill was rejected because it would alter every ghost-button consumer. The opaque hover surface is scoped to these floating arrows.
- Keeping the `dependencies` array was rejected because it exposes an implementation detail and can retrigger effects through unstable reference identity.

Links to places where the discussion took place: #17880, #16503

### Breaking changes

`HorizontalScrollContainer` now requires `scrollLeftLabel` and `scrollRightLabel`, and removes the optional `dependencies` prop. The package component currently has no production renderer consumers on `main`, so no existing application call site requires migration.

### Special notes for your reviewer

- Targeted component tests: `pnpm --filter @cherrystudio/ui exec vitest run src/components/composites/horizontal-scroll-container/__tests__/horizontal-scroll-container.test.tsx` (3 passed).
- `pnpm --filter @cherrystudio/ui type:check`, targeted Biome, targeted ESLint, and `git diff --check` passed.
- The Storybook interaction was inspected manually: hover reveals the control while preserving an opaque semantic background.
- The full test suite was not run, per the requested validation scope for this localized UI change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
