### PR TITLE
fix(chat): show model identity on single replies

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -349,6 +349,14 @@ describe('MessageGroup', () => {
     expect(getByTestId('message-parts-content')).toHaveAttribute('data-part-text', 'updated')
   })
 
+  it('shows the snapshot model identity for a single assistant reply', () => {
+    const messages = [createMessage('msg-1', 0, 'fold')]
+
+    render(<MessageGroup messages={messages} />)
+
+    expectEveryMessageHeaderToShowModelIdentity(true)
+  })
+
   it.each(['vertical', 'grid'] as const)(
     'always shows each model identity in %s multi-model layout',
     (multiModelMessageStyle) => {

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -306,7 +306,7 @@ const MessageGroup = ({
         isGrouped,
         isHorizontalMultiModelLayout: multiModelMessageStyle === 'horizontal',
         isLatestAssistantMessage: isLatestAssistantGroup && message.role === 'assistant',
-        showModelIdentity: isMultiModelGroup && multiModelMessageStyle !== 'fold',
+        showModelIdentity: !isMultiModelGroup || multiModelMessageStyle !== 'fold',
         lockedMentionedModels: directAssistantModelsByUserId?.get(message.id),
         messageTail: messageTail?.messageId === message.id ? messageTail.content : undefined,
         message,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Single-model assistant replies displayed only the producing assistant name. Although each message already retained its generating model snapshot, the header exposed model identity only for non-fold multi-model layouts.

After this PR:

Single-model assistant replies display the snapshotted model icon and name beside the producing assistant. Multi-model fold layout remains unchanged because its existing selector already identifies the active model.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Showing the per-message model snapshot makes it clear which model generated a reply and keeps historical identity stable after the assistant's current model changes.

The following tradeoffs were made:

- Keep the producing assistant as the primary author and show the model as secondary identity.
- Keep model identity out of multi-model fold headers to avoid duplicating the existing model selector.

The following alternatives were considered:

- Replace the assistant name with the model name, which would lose producing-author identity.
- Show model identity in every fold header, which would duplicate the selector in multi-model conversations.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/discussions/17918

### Breaking changes

<!-- optional -->

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

<!-- optional -->

Focused regression coverage verifies both single-model visibility and the existing multi-model fold behavior.

Validation:

- `pnpm exec vitest run src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx` — passed (38 tests)
- `pnpm lint` — passed (37 pre-existing warnings, 0 errors; typecheck, i18n, and format passed)
- `pnpm test` — stopped at the author's request; before termination, unrelated OpenClaw and JobManager suites reported failures
- Runtime UI verification was blocked by an inaccessible legacy userData migration gate in the isolated development profile

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Single-model replies now show the generating model's snapshotted icon and name beside the assistant.
```
