### PR TITLE
fix(resource-pagination): avoid redundant first-page requests

### DIFF
--- a/src/renderer/data/hooks/__tests__/useDataApi.test.ts
+++ b/src/renderer/data/hooks/__tests__/useDataApi.test.ts
@@ -772,12 +772,16 @@ describe('useInfiniteQuery integration', () => {
     expect(result.current.pages).toBe(firstRef)
   })
 
-  it('passes swrOptions through to useSWRInfinite', async () => {
-    // Sanity-check that `swrOptions` reach `useSWRInfinite` by setting
-    // `revalidateFirstPage: false` and verifying `refresh()` does NOT refetch
-    // page 1 when only one page is loaded.
+  it('does not revalidate the first page while pagination grows when explicitly disabled', async () => {
     const getSpy = spyGet()
-    getSpy.mockResolvedValueOnce({ items: [], nextCursor: undefined, activeNodeId: null } as never)
+    const cursors: Array<string | null> = []
+    getSpy.mockImplementation((async (_path: string, opts: { query?: { cursor?: string } } = {}) => {
+      const cursor = opts.query?.cursor ?? null
+      cursors.push(cursor)
+      if (cursor === null) return { items: [], nextCursor: 'c1', activeNodeId: null }
+      if (cursor === 'c1') return { items: [], nextCursor: 'c2', activeNodeId: null }
+      return { items: [], nextCursor: undefined, activeNodeId: null }
+    }) as never)
 
     const { Wrapper } = makeWrapper()
     const { result } = renderHook(
@@ -790,7 +794,12 @@ describe('useInfiniteQuery integration', () => {
     )
 
     await waitFor(() => expect(result.current.pages).toHaveLength(1))
-    expect(getSpy).toHaveBeenCalledTimes(1)
+    await act(async () => result.current.loadNext())
+    await waitFor(() => expect(result.current.pages).toHaveLength(2))
+    await act(async () => result.current.loadNext())
+    await waitFor(() => expect(result.current.pages).toHaveLength(3))
+
+    expect(cursors).toEqual([null, 'c1', 'c2'])
   })
 })
 

--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -77,14 +77,14 @@ describe('useTopics', () => {
     vi.clearAllMocks()
   })
 
-  it('keeps revalidateAll off while a load-all topic chain is still growing', () => {
+  it('disables loaded-page revalidation while a load-all topic chain is still growing', () => {
     renderHook(() => useTopics({ loadAll: true }))
 
     expect(mockUseInfiniteQuery).toHaveBeenCalledWith('/topics', {
       query: undefined,
       limit: 200,
       enabled: undefined,
-      swrOptions: { revalidateAll: false }
+      swrOptions: { revalidateAll: false, revalidateFirstPage: false }
     })
   })
 
@@ -107,7 +107,7 @@ describe('useTopics', () => {
       query: undefined,
       limit: 200,
       enabled: undefined,
-      swrOptions: { revalidateAll: true }
+      swrOptions: { revalidateAll: true, revalidateFirstPage: false }
     })
   })
 
@@ -118,7 +118,7 @@ describe('useTopics', () => {
       query: undefined,
       limit: 50,
       enabled: undefined,
-      swrOptions: { revalidateAll: false }
+      swrOptions: { revalidateAll: false, revalidateFirstPage: true }
     })
   })
 
@@ -126,9 +126,9 @@ describe('useTopics', () => {
     // Simulate a multi-page loadAll: each render grows `pages` by one and
     // keeps `hasNext` true until the final page. The auto-paginate effect
     // drives `loadNext`; we assert that across every growth render the
-    // `swrOptions.revalidateAll` passed to `useInfiniteQuery` stays false
-    // (no quadratic re-fetch of earlier pages) and `loadNext` is invoked
-    // once per new page — never extra revalidation-triggered fetches.
+    // loaded-page revalidation stays disabled: `revalidateAll` prevents a
+    // quadratic re-fetch of earlier pages, while `revalidateFirstPage`
+    // prevents one redundant page-0 request per `loadNext`.
     const loadNext = vi.fn()
     let pages: Array<{ items: Array<{ id: string }>; nextCursor?: string }> = [
       { items: [{ id: 't1' }], nextCursor: 'c1' }
@@ -161,21 +161,20 @@ describe('useTopics', () => {
     act(() => rerender())
 
     // The auto-paginate effect drives loadNext; the key regression check is
-    // that revalidateAll stays false across every growth render so earlier
-    // pages are never re-fetched on each setSize (1+2+...+n IPC traffic).
+    // that neither previous pages nor page 0 are revalidated during growth.
     expect(loadNext).toHaveBeenCalled()
 
     // All calls during growth (every call except the final post-fully-loaded
-    // re-render where the effect flips revalidateAll on) must keep
-    // revalidateAll off.
+    // re-render where the effect flips revalidateAll on) must keep both
+    // growth-time revalidation modes off.
     const growthCalls = mockUseInfiniteQuery.mock.calls.slice(0, -1)
     expect(growthCalls.length).toBeGreaterThan(0)
     for (const call of growthCalls) {
-      expect(call[1]).toMatchObject({ swrOptions: { revalidateAll: false } })
+      expect(call[1]).toMatchObject({ swrOptions: { revalidateAll: false, revalidateFirstPage: false } })
     }
     // The final call — after the chain is fully loaded — flips revalidateAll on.
     const lastCall = mockUseInfiniteQuery.mock.calls[mockUseInfiniteQuery.mock.calls.length - 1]
-    expect(lastCall[1]).toMatchObject({ swrOptions: { revalidateAll: true } })
+    expect(lastCall[1]).toMatchObject({ swrOptions: { revalidateAll: true, revalidateFirstPage: false } })
   })
 })
 

--- a/src/renderer/hooks/agent/__tests__/useSession.test.ts
+++ b/src/renderer/hooks/agent/__tests__/useSession.test.ts
@@ -275,14 +275,14 @@ describe('useSessions', () => {
     vi.clearAllMocks()
   })
 
-  it('keeps revalidateAll off while a load-all session chain is still growing', () => {
+  it('disables loaded-page revalidation while a load-all session chain is still growing', () => {
     renderHook(() => useSessions(undefined, { loadAll: true, pageSize: 200 }))
 
     expect(mockUseInfiniteQuery).toHaveBeenCalledWith('/agent-sessions', {
       query: undefined,
       limit: 200,
       enabled: undefined,
-      swrOptions: { revalidateAll: false }
+      swrOptions: { revalidateAll: false, revalidateFirstPage: false }
     })
   })
 
@@ -300,7 +300,7 @@ describe('useSessions', () => {
       query: undefined,
       limit: 200,
       enabled: undefined,
-      swrOptions: { revalidateAll: true }
+      swrOptions: { revalidateAll: true, revalidateFirstPage: false }
     })
   })
 
@@ -311,7 +311,7 @@ describe('useSessions', () => {
       query: undefined,
       limit: 20,
       enabled: undefined,
-      swrOptions: { revalidateAll: false }
+      swrOptions: { revalidateAll: false, revalidateFirstPage: true }
     })
   })
 
@@ -319,9 +319,9 @@ describe('useSessions', () => {
     // Simulate a multi-page loadAll: each render grows `pages` by one and
     // keeps `hasNext` true until the final page. The auto-paginate effect
     // drives `loadNext`; we assert that across every growth render the
-    // `swrOptions.revalidateAll` passed to `useInfiniteQuery` stays false
-    // (no quadratic re-fetch of earlier pages) and `loadNext` is invoked
-    // once per new page — never extra revalidation-triggered fetches.
+    // loaded-page revalidation stays disabled: `revalidateAll` prevents a
+    // quadratic re-fetch of earlier pages, while `revalidateFirstPage`
+    // prevents one redundant page-0 request per `loadNext`.
     const loadNext = vi.fn()
     let pages: Array<{ items: Array<{ id: string; name: string }>; nextCursor?: string }> = [
       { items: [{ id: 's1', name: 'S1' }], nextCursor: 'c1' }
@@ -348,21 +348,20 @@ describe('useSessions', () => {
     act(() => rerender())
 
     // The auto-paginate effect drives loadNext; the key regression check is
-    // that revalidateAll stays false across every growth render so earlier
-    // pages are never re-fetched on each setSize (1+2+...+n IPC traffic).
+    // that neither previous pages nor page 0 are revalidated during growth.
     expect(loadNext).toHaveBeenCalled()
 
     // All calls during growth (every call except the final post-fully-loaded
-    // re-render where the effect flips revalidateAll on) must keep
-    // revalidateAll off.
+    // re-render where the effect flips revalidateAll on) must keep both
+    // growth-time revalidation modes off.
     const growthCalls = mockUseInfiniteQuery.mock.calls.slice(0, -1)
     expect(growthCalls.length).toBeGreaterThan(0)
     for (const call of growthCalls) {
-      expect(call[1]).toMatchObject({ swrOptions: { revalidateAll: false } })
+      expect(call[1]).toMatchObject({ swrOptions: { revalidateAll: false, revalidateFirstPage: false } })
     }
     // The final call — after the chain is fully loaded — flips revalidateAll on.
     const lastCall = mockUseInfiniteQuery.mock.calls[mockUseInfiniteQuery.mock.calls.length - 1]
-    expect(lastCall[1]).toMatchObject({ swrOptions: { revalidateAll: true } })
+    expect(lastCall[1]).toMatchObject({ swrOptions: { revalidateAll: true, revalidateFirstPage: false } })
   })
 
   it('returns empty sessions when agentId is null', () => {

--- a/src/renderer/hooks/agent/useSession.ts
+++ b/src/renderer/hooks/agent/useSession.ts
@@ -210,19 +210,18 @@ export const useSessions = (
   const loadAll = typeof options === 'number' ? false : (options.loadAll ?? false)
   const enabled = typeof options === 'number' ? undefined : options.enabled
 
-  // SWR Infinite revalidates only the first page by default. A load-all source
-  // must refresh every loaded page before publishing its complete snapshot — but
-  // only once the chain is complete. Leaving `revalidateAll` on while the chain
-  // is still growing makes each `setSize` re-fetch every previously loaded page
-  // before fetching the next, producing 1+2+...+n IPC reads. Keep it off during
-  // growth and flip it on only when fully loaded so mutations/passive
-  // revalidation still refresh every loaded page.
+  // A load-all source must refresh every loaded page once the chain is complete,
+  // but it should fetch only the new page while the chain is growing. SWR
+  // Infinite otherwise revalidates page 0 on every `setSize`, and `revalidateAll`
+  // would re-fetch every previous page. Disable both growth-time behaviors;
+  // once fully loaded, `revalidateAll` still keeps mutations/passive refreshes
+  // complete. Progressive pagination retains SWR's first-page revalidation.
   const [revalidateAllPages, setRevalidateAllPages] = useState(false)
   const { pages, isLoading, isRefreshing, error, hasNext, loadNext, refresh } = useInfiniteQuery('/agent-sessions', {
     query: agentId ? { agentId } : undefined,
     limit: pageSize,
     enabled,
-    swrOptions: { revalidateAll: revalidateAllPages }
+    swrOptions: { revalidateAll: revalidateAllPages, revalidateFirstPage: !loadAll }
   })
   // Cache key includes the query, so reorder operates on the same key.
   const { applyReorderedList } = useReorder('/agent-sessions')

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -235,19 +235,18 @@ export function useTopics(opts?: { q?: string; loadAll?: boolean; pageSize?: num
   const query = opts?.q?.trim() ? { q: opts.q.trim() } : undefined
   const loadAll = opts?.loadAll === true
   const pageSize = opts?.pageSize ?? (loadAll ? LOAD_ALL_TOPIC_PAGE_SIZE : DEFAULT_TOPIC_PAGE_SIZE)
-  // SWR Infinite revalidates only the first page by default. A load-all source
-  // must refresh every loaded page before publishing its complete snapshot — but
-  // only once the chain is complete. Leaving `revalidateAll` on while the chain
-  // is still growing makes each `setSize` re-fetch every previously loaded page
-  // before fetching the next, producing 1+2+...+n IPC reads. Keep it off during
-  // growth and flip it on only when fully loaded so mutations/passive
-  // revalidation still refresh every loaded page.
+  // A load-all source must refresh every loaded page once the chain is complete,
+  // but it should fetch only the new page while the chain is growing. SWR
+  // Infinite otherwise revalidates page 0 on every `setSize`, and `revalidateAll`
+  // would re-fetch every previous page. Disable both growth-time behaviors;
+  // once fully loaded, `revalidateAll` still keeps mutations/passive refreshes
+  // complete. Progressive pagination retains SWR's first-page revalidation.
   const [revalidateAllPages, setRevalidateAllPages] = useState(false)
   const { pages, isLoading, isRefreshing, error, hasNext, loadNext, refresh, mutate } = useInfiniteQuery('/topics', {
     query,
     limit: pageSize,
     enabled: opts?.enabled,
-    swrOptions: { revalidateAll: revalidateAllPages }
+    swrOptions: { revalidateAll: revalidateAllPages, revalidateFirstPage: !loadAll }
   })
   const topics = useInfiniteFlatItems(pages)
   const isFullyLoaded = !loadAll || (!isLoading && !hasNext)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Load-all session and topic pagination left SWR Infinite's `revalidateFirstPage` default enabled. Every `setSize()` fetched page 0 again before fetching the next cursor page.

After this PR:

Load-all pagination disables first-page revalidation while retaining the existing full-page refresh after the chain is complete. Progressive pagination keeps SWR's default behavior. Regression coverage verifies the exact three-page cursor request sequence.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

This removes one redundant page-0 DataApi request for every additional page loaded. In an isolated Electron run with 401 sessions and a page size of 200, the load-all sequence issued exactly three requests (one first page and two cursor pages) instead of the five-request sequence reproduced with the previous SWR configuration.

The following tradeoffs were made:

- Only load-all consumers disable `revalidateFirstPage`; progressive pagination retains SWR's freshness semantics.
- Once a load-all chain is complete, `revalidateAll` still refreshes every loaded page for mutations and passive revalidation.

The following alternatives were considered:

- Changing the shared `useInfiniteQuery` default was rejected because it would alter freshness behavior for unrelated progressive pagination consumers.
- Relying only on `revalidateAll: false` was insufficient because SWR independently revalidates page 0 by default.

Links to places where the discussion took place: #17878

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Focused Vitest: 132 tests passed across `useSession`, `useTopic`, and `useDataApi`.
- `pnpm run typecheck:web` passed.
- Targeted Biome, Oxlint, and ESLint checks passed for the five changed files.
- Electron runtime validation: 401 isolated sessions, three pages, three successful requests, page 0 requested once, and zero benchmark records remaining after cleanup.
- Full `pnpm test` and `pnpm build:check` were intentionally not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
