### PR TITLE
fix(web-search): keep numeric queries as strings to prevent trim crash

### DIFF
--- a/src/renderer/src/aiCore/tools/WebSearchTool.ts
+++ b/src/renderer/src/aiCore/tools/WebSearchTool.ts
@@ -16,18 +16,24 @@ function normalizeWebSearchQueries(questions: string[]): string[] {
 
   const seen = new Set<string>()
 
-  return questions
-    .map((question) => question.trim())
-    .filter((question) => question.length > 0)
-    .filter((question) => {
-      const key = question.toLocaleLowerCase()
-      if (seen.has(key)) {
-        return false
-      }
-      seen.add(key)
-      return true
-    })
-    .slice(0, MAX_BUILTIN_WEB_SEARCH_QUERIES)
+  return (
+    questions
+      // Coerce defensively: extracted queries come from untrusted model XML, where
+      // an entry can arrive as a number (numeric query like "2028") or, with
+      // malformed nesting, a non-primitive. Drop anything that isn't a string or
+      // number so `.trim()` never throws.
+      .map((question) => (typeof question === 'string' || typeof question === 'number' ? String(question).trim() : ''))
+      .filter((question) => question.length > 0)
+      .filter((question) => {
+        const key = question.toLocaleLowerCase()
+        if (seen.has(key)) {
+          return false
+        }
+        seen.add(key)
+        return true
+      })
+      .slice(0, MAX_BUILTIN_WEB_SEARCH_QUERIES)
+  )
 }
 
 /**

--- a/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
+++ b/src/renderer/src/aiCore/tools/__tests__/WebSearchTool.test.ts
@@ -58,6 +58,31 @@ describe('webSearchToolWithPreExtractedKeywords', () => {
     expect(modelText).toContain('"url": "https://example.com/path?utm_source=newsletter#details"')
   })
 
+  it('normalizes non-string prepared queries without throwing', async () => {
+    // Regression: numeric queries (e.g. "2028") arrive as numbers from the XML
+    // intent extraction and previously crashed with "question.trim is not a function".
+    const searchTool = webSearchToolWithPreExtractedKeywords(
+      'tavily',
+      {
+        question: [2028, { nested: 'object' }, 'valid'] as unknown as string[]
+      },
+      'request-1'
+    ) as any
+
+    await expect(searchTool.execute({})).resolves.toBeDefined()
+
+    expect(WebSearchService.processWebsearch).toHaveBeenCalledWith(
+      { id: 'tavily' },
+      {
+        websearch: {
+          question: ['2028', 'valid'],
+          links: undefined
+        }
+      },
+      'request-1'
+    )
+  })
+
   it('reuses the in-flight search request for concurrent executions', async () => {
     const searchResponse = {
       query: 'first',

--- a/src/renderer/src/utils/__tests__/extract.test.ts
+++ b/src/renderer/src/utils/__tests__/extract.test.ts
@@ -90,6 +90,25 @@ describe('extract', () => {
       })
     })
 
+    it('should keep purely numeric questions as strings', () => {
+      // Regression: default value coercion turned "2028" into the number 2028,
+      // which later crashed with "question.trim is not a function".
+      const xml = `
+        <websearch>
+          <question>2028</question>
+        </websearch>
+      `
+
+      const result = extractInfoFromXML(xml)
+
+      expect(result).toEqual({
+        websearch: {
+          question: ['2028']
+        }
+      })
+      expect(typeof result.websearch?.question[0]).toBe('string')
+    })
+
     it('should handle XML with special characters', () => {
       const xml = `
         <websearch>

--- a/src/renderer/src/utils/extract.ts
+++ b/src/renderer/src/utils/extract.ts
@@ -26,7 +26,12 @@ export const extractInfoFromXML = (text: string): ExtractResults => {
   const parser = new XMLParser({
     isArray: (name) => {
       return name === 'question' || name === 'links'
-    }
+    },
+    // Keep tag values as strings. Without this, a purely numeric query like
+    // "2028" is coerced to a number, and downstream `question.trim()` throws
+    // "TypeError: question.trim is not a function". `question`/`links`/`rewrite`
+    // are declared `string`, so this also keeps the parsed shape honest.
+    parseTagValue: false
   })
   // Logger.log('Extracted results:', extractResults)
   return parser.parse(text)


### PR DESCRIPTION
### What this PR does

Before this PR:

The built-in web search tool (`builtin_web_search`) crashed with `TypeError: question.trim is not a function` whenever the extracted search query was purely numeric. The intent extractor (`extractInfoFromXML`) uses `fast-xml-parser` with its default value coercion, so a query like `<question>2028</question>` was parsed as the **number** `2028`. `normalizeWebSearchQueries` then called `question.trim()` on it and threw. This matched the reported symptom exactly: the failure appeared/disappeared depending on whether the query text happened to be numeric, and it reproduced across all models, providers, and argument shapes because the crash happens before any real search request.

After this PR:

- `extractInfoFromXML` sets `parseTagValue: false`, so `question` / `links` / `rewrite` stay strings — matching their declared `string` types and keeping the parsed shape honest.
- `normalizeWebSearchQueries` defensively coerces entries (string/number → trimmed string, anything else dropped), so malformed model XML (e.g. nested tags producing non-primitive entries) can never crash the tool again.

Added regression tests: a numeric `<question>` now parses to a string, and `normalizeWebSearchQueries` tolerates numeric and non-primitive entries without throwing.

Fixes #17953

### Why we need it and why it was done in this way

The root cause is XML value coercion, so the primary fix is at the parser (`parseTagValue: false`) — this fixes it for every consumer of `extractInfoFromXML` (both web and knowledge intent extraction) and restores the declared `string[]` contract. The `normalizeWebSearchQueries` guard is defense-in-depth for untrusted LLM-generated XML, which the parser fix alone doesn't cover (e.g. nested tags yielding objects).

The following alternatives were considered: guarding only at `normalizeWebSearchQueries` — rejected because it leaves the `question: string[]` type dishonest and leaves numbers flowing into the knowledge-search path too.

### Breaking changes

None.

### Special notes for your reviewer

Targets the `v1` branch since this is a v1.9.13 maintenance bug; the v2 web-search path takes a schema-validated `query: string` and is unaffected.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix built-in web search always failing with "TypeError: question.trim is not a function" when the search query is purely numeric.
```
