### PR TITLE
fix(resource-catalog): stop repeated saves after failures

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -24,6 +24,7 @@ import { useCloseBeforeAction } from '@renderer/hooks/useCloseBeforeAction'
 import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
 import { useInstalledSkills, useReconcileSkillsOnOpen } from '@renderer/hooks/useSkills'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
+import { toast } from '@renderer/services/toast'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import { permissionModeCards } from '@renderer/utils/agent'
 import {
@@ -176,6 +177,10 @@ function buildAgentFormState(baseline: AgentFormState, values: AgentEditFormValu
   }
 }
 
+function serializeAgentSaveAttempt(values: AgentEditFormValues, payload: UpdateAgentDto): string {
+  return JSON.stringify({ values, payload })
+}
+
 function advanceAgentFormBaseline(
   latest: AgentFormState,
   submitted: AgentFormState,
@@ -248,6 +253,7 @@ function AgentEditDialogContent({
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAgent(resource))
   const [formBaseline, setFormBaseline] = useState<AgentFormState>(() => buildInitialAgentFormState(resource))
   const formBaselineRef = useRef(formBaseline)
+  const failedSaveKeyRef = useRef<string | null>(null)
   const [baselineSkillAgentId, setBaselineSkillAgentId] = useState<string | null>(null)
   const defaultValues = useMemo(() => defaultValuesForAgent(resource), [resource])
   const form = useForm<AgentEditFormValues>({ defaultValues })
@@ -323,6 +329,7 @@ function AgentEditDialogContent({
     setModelLabels(modelLabelsForAgent(resource))
     replaceFormBaseline(buildInitialAgentFormState(resource))
     setBaselineSkillAgentId(null)
+    failedSaveKeyRef.current = null
   }, [defaultValues, form, initialTab, open, replaceFormBaseline, resource])
 
   // Cached skill rows may render during revalidation, but the editable skill
@@ -368,29 +375,34 @@ function AgentEditDialogContent({
 
   const rootError = form.formState.errors.root?.message
   const autoSaveChangeKey =
-    saveIntent && values.name.trim().length > 0 ? JSON.stringify({ values, payload: saveIntent.payload }) : null
+    saveIntent && values.name.trim().length > 0 ? serializeAgentSaveAttempt(values, saveIntent.payload) : null
   const canPersist = autoSaveChangeKey !== null
-  // Tracks whether the most recent save attempt failed, so the close path can
-  // keep the dialog open (and the error visible) instead of closing over a loss.
-  const saveFailedRef = useRef(false)
+  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
 
   const persist = async () => {
     // Recompute from refs at execution time: the serialized autosave queue may
     // start its follow-up pass before React has rendered the baseline state
     // advanced by the previous pass.
-    const submittedFormState = buildAgentFormState(formBaselineRef.current, form.getValues())
+    const submittedValues = form.getValues()
+    const submittedFormState = buildAgentFormState(formBaselineRef.current, submittedValues)
     const pending = diffAgentSaveIntent(submittedFormState, formBaselineRef.current)
     if (!pending) return
+    const attemptedKey = serializeAgentSaveAttempt(submittedValues, pending.payload)
+
+    // A close-triggered flush does not cancel the already scheduled debounce.
+    // Keep both paths from resending an unchanged payload that already failed.
+    if (failedSaveKeyRef.current === attemptedKey) return
 
     form.clearErrors('root')
-    saveFailedRef.current = false
+    failedSaveKeyRef.current = null
 
     try {
       await updateAgent(pending.payload)
     } catch (error) {
       logger.error('Failed to auto-save agent edit dialog', error as Error, { agentId: resource.id })
-      form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
-      saveFailedRef.current = true
+      failedSaveKeyRef.current = attemptedKey
+      form.setError('root', { message: saveFailedMessage })
+      toast.error(saveFailedMessage)
       return
     }
 
@@ -418,9 +430,13 @@ function AgentEditDialogContent({
       onOpenChange(next)
       return
     }
+    if (failedSaveKeyRef.current === autoSaveChangeKey) {
+      toast.error(saveFailedMessage)
+      return
+    }
     void (async () => {
       await flush()
-      if (saveFailedRef.current) return
+      if (failedSaveKeyRef.current !== null) return
       onOpenChange(false)
     })()
   }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -26,6 +26,7 @@ import { useAssistantMutationsById } from '@renderer/hooks/resourceCatalog'
 import { useCloseBeforeAction } from '@renderer/hooks/useCloseBeforeAction'
 import { useGroupMutations, useGroups } from '@renderer/hooks/useGroups'
 import { usePromptProcessor } from '@renderer/hooks/usePromptProcessor'
+import { toast } from '@renderer/services/toast'
 import { MCP_MODE_OPTIONS, RESOURCE_PROMPT_POLISH_SYSTEM_PROMPT } from '@renderer/utils/resourceCatalog'
 import {
   type AssistantFormState,
@@ -234,8 +235,8 @@ function AssistantEditDialogContent({
     [t]
   )
 
-  // Tracks the exact form snapshot that failed so the first close keeps the
-  // error visible, while a repeated close can explicitly discard that snapshot.
+  // Tracks the exact form snapshot that failed so it cannot be retried until
+  // the user changes the form.
   const failedSaveKeyRef = useRef<string | null>(null)
 
   const wasOpenRef = useRef(false)
@@ -264,11 +265,16 @@ function AssistantEditDialogContent({
   const rootError = form.formState.errors.root?.message
   const canPersist = Boolean(saveIntent) && values.name.trim().length > 0
   const changeKey = canPersist ? JSON.stringify(values) : null
+  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
 
   const persist = async () => {
     const pending = saveIntent
-    if (!pending) return
+    if (!pending || !changeKey) return
     const attemptedKey = changeKey
+
+    // A close-triggered flush does not cancel the already scheduled debounce.
+    // Keep both paths from resending an unchanged payload that already failed.
+    if (failedSaveKeyRef.current === attemptedKey) return
 
     form.clearErrors('root')
     failedSaveKeyRef.current = null
@@ -278,7 +284,8 @@ function AssistantEditDialogContent({
     } catch (error) {
       logger.error('Failed to auto-save assistant edit dialog', error as Error, { assistantId: resource.id })
       failedSaveKeyRef.current = attemptedKey
-      form.setError('root', { message: t('library.config.dialogs.edit.save_failed') })
+      form.setError('root', { message: saveFailedMessage })
+      toast.error(saveFailedMessage)
     }
   }
 
@@ -301,12 +308,12 @@ function AssistantEditDialogContent({
       return
     }
     if (failedSaveKeyRef.current === changeKey) {
-      onOpenChange(false)
+      toast.error(saveFailedMessage)
       return
     }
     void (async () => {
       await flush()
-      if (failedSaveKeyRef.current === changeKey) return
+      if (failedSaveKeyRef.current !== null) return
       onOpenChange(false)
     })()
   }

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1,4 +1,5 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
+import { toast } from '@renderer/services/toast'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import type { Assistant } from '@shared/data/types/assistant'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
@@ -1477,8 +1478,8 @@ describe('edit dialogs', () => {
     })
   })
 
-  it('keeps the dialog open with a visible error when the save on close fails', async () => {
-    updateAssistantMock.mockRejectedValue(new Error('Network down'))
+  it('prompts without closing or retrying an unchanged failed assistant save', async () => {
+    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
@@ -1486,14 +1487,18 @@ describe('edit dialogs', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(toast.error).toHaveBeenCalledWith('Save failed')
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
     const saveAttemptsAfterFailure = updateAssistantMock.mock.calls.length
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await new Promise((resolve) => setTimeout(resolve, 700))
 
-    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(toast.error).toHaveBeenCalledTimes(2)
     expect(updateAssistantMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
 
   it('retries saving when the form changes after a failed close', async () => {
@@ -1519,7 +1524,7 @@ describe('edit dialogs', () => {
     await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 
-  it('does not silently discard a save when reopened within the exit-animation window with an identical edit', async () => {
+  it('clears the failed assistant save snapshot when reopened within the exit-animation window', async () => {
     // The host (useResourceCatalogController) keeps this dialog instance mounted for
     // DIALOG_EXIT_ANIMATION_MS after `open` goes false, so a reopen within that window
     // reuses the SAME component instance instead of remounting — simulate that with
@@ -1534,17 +1539,13 @@ describe('edit dialogs', () => {
     await screen.findByText('Save failed', undefined, { timeout: 5000 })
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
 
-    // Discard-close, then reopen on the same instance before it unmounts.
+    // Simulate an external close, then reopen on the same instance before it unmounts.
     rerender(<AssistantEditDialog open={false} resource={ASSISTANT} onOpenChange={onOpenChange} />)
     rerender(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
     const saveAttemptsBeforeRetry = updateAssistantMock.mock.calls.length
 
-    // Make the exact same edit again — this reproduces the identical changeKey as the
-    // failed attempt above. Without clearing failedSaveKeyRef on reopen, the stale key
-    // still matches this "new" changeKey, so handleOpenChange takes its synchronous
-    // discard branch and calls onOpenChange(false) immediately — without ever invoking
-    // the save mutation a second time. Assert synchronously (no waitFor) right after the
-    // click so an independent debounced auto-save firing later can't mask that bug.
+    // Make the exact same edit again. The new editing session must not mistake it
+    // for the prior session's failed snapshot and block the save.
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Repro Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
@@ -1581,16 +1582,36 @@ describe('edit dialogs', () => {
     expect(updateAssistantMock).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps the agent dialog open with a visible error when the save on close fails', async () => {
-    updateAgentMock.mockRejectedValue(new Error('Network down'))
+  it('prompts without closing or retrying an unchanged failed agent save', async () => {
+    updateAgentMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
     render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Agent' } })
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'Closing Agent' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(toast.error).toHaveBeenCalledWith('Save failed')
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    const saveAttemptsAfterFailure = updateAgentMock.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await new Promise((resolve) => setTimeout(resolve, 700))
+
+    expect(toast.error).toHaveBeenCalledTimes(2)
+    expect(updateAgentMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    fireEvent.change(nameInput, { target: { value: 'Retry Agent' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    await waitFor(() => expect(updateAgentMock.mock.calls.length).toBeGreaterThan(saveAttemptsAfterFailure))
+    expect(updateAgentMock).toHaveBeenLastCalledWith({
+      body: expect.objectContaining({ name: 'Retry Agent' })
+    })
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent and assistant edit dialogs handled failed auto-saves inconsistently. Repeated close attempts could resend an unchanged failed PATCH, a pending debounce could enter the same save path again, and the assistant dialog could close and discard the failed edit on the second close attempt.

After this PR:

Both edit dialogs show persistent inline feedback plus an error toast, remain open after a failed save, and suppress the same failed form snapshot until the user changes the form. Reopening starts a fresh editing session. Regression coverage verifies unchanged snapshots are not retried and changed snapshots can be saved.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Failed auto-saves must not produce request bursts or silently lose edits. The dialogs now track the exact failed save key and gate both close-triggered flushes and pending debounced passes. The shared debounce hook remains focused on scheduling and serialization rather than UI-specific errors and notifications.

The following tradeoffs were made:

An unchanged failed payload cannot be manually retried by repeatedly closing the dialog; the user must change the form to create a new save attempt.

The following alternatives were considered:

Adding retry/discard controls or coupling form errors and toast behavior into the generic debounce hook was considered, but would expand the UI and the shared hook's responsibility beyond this focused fix.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation completed: `pnpm lint`, `pnpm format`, and `git diff --check`. The existing lint run reported 37 warnings and no errors. Tests and interactive Electron verification were not run because repository verification is user-owned and was not explicitly requested.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent and assistant edit dialogs now stay open after save failures and avoid retrying unchanged failed edits.
```
