### PR TITLE
fix(agent): restore context usage for gateway models

### DIFF
--- a/src/renderer/components/chat/agent/ContextUsageSummary.tsx
+++ b/src/renderer/components/chat/agent/ContextUsageSummary.tsx
@@ -31,6 +31,8 @@ interface ContextUsageSummaryProps {
   color?: string
   className?: string
   isCompacting?: boolean
+  /** Optional user-facing model name. Defaults to the raw runtime model id for diagnostic views. */
+  modelName?: string
   /** Show the per-category breakdown. Off for the composer, which only reports the total. */
   showCategories?: boolean
 }
@@ -41,6 +43,7 @@ export function ContextUsageSummary({
   color,
   className,
   isCompacting = false,
+  modelName,
   showCategories = true
 }: ContextUsageSummaryProps) {
   const { t } = useTranslation()
@@ -66,7 +69,7 @@ export function ContextUsageSummary({
             <span className="shrink-0">
               {usage.totalTokens.toLocaleString()} / {usage.maxTokens.toLocaleString()} ({normalizedPercentage}%)
             </span>
-            <span className="min-w-0 truncate">{usage.model}</span>
+            <span className="min-w-0 truncate">{modelName || usage.model}</span>
           </div>
           {visibleCategories.length > 0 && (
             <div className="space-y-1 border-border-subtle border-t pt-2">

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -62,6 +62,7 @@ import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import { getKnowledgeBaseIdsFromParts, withKnowledgeScopePart } from '@shared/data/types/uiParts'
 import type { OutputFor } from '@shared/ipc/types'
 import type { LocalSkill } from '@shared/types/skill'
+import { formatGatewayModelId } from '@shared/utils/apiGateway'
 import { type CanonicalFilePath, canonicalizeFilePath, createFilePathHandle, toFileUrl } from '@shared/utils/file'
 import { Settings2, Terminal, ToolCase } from 'lucide-react'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -472,6 +473,7 @@ function AgentComposerContextUsage({ model, sessionId }: { model?: Model; sessio
           percentage={percentage}
           color={ringColor}
           isCompacting={isCompacting}
+          modelName={model?.name}
           showCategories={false}
         />
       }>
@@ -502,7 +504,17 @@ function AgentComposerContextUsage({ model, sessionId }: { model?: Model; sessio
 
 function getContextUsageModelCandidates(model: Model | undefined): string[] | undefined {
   if (!model) return undefined
-  return [model.apiModelId, parseUniqueModelId(model.id).modelId].filter((value): value is string => Boolean(value))
+  const { providerId, modelId } = parseUniqueModelId(model.id)
+  const apiModelId = model.apiModelId ?? modelId
+  const candidates = [apiModelId, modelId]
+
+  try {
+    candidates.push(formatGatewayModelId(providerId, apiModelId))
+  } catch {
+    // Some models are intentionally not gateway-addressable; their direct ids remain valid candidates.
+  }
+
+  return candidates
 }
 
 type AgentComposerControlProps = Omit<

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -66,7 +66,6 @@ const mocks = vi.hoisted(() => ({
   openResourceEditDialog: vi.fn(),
   registeredLaunchers: new Map<string, ComposerToolLauncher[]>(),
   optionalQuickPanel: null as { isVisible: boolean; symbol: string; updateList: (items: unknown) => void } | null,
-  contextUsagePercentage: null as number | null,
   surfaceProps: undefined as ComposerSurfaceProps | undefined,
   getDraft: vi.fn(),
   derivedToolState: undefined as
@@ -451,29 +450,6 @@ vi.mock('@renderer/hooks/agent/useAgentModelFilter', () => ({
   useAgentModelFilter: () => undefined
 }))
 
-vi.mock('@renderer/hooks/agent/useAgentSessionContextUsage', () => ({
-  useAgentSessionContextUsage: () => ({
-    usage:
-      mocks.contextUsagePercentage === null
-        ? null
-        : {
-            categories: [],
-            totalTokens: 42,
-            maxTokens: 100,
-            rawMaxTokens: 100,
-            percentage: mocks.contextUsagePercentage,
-            gridRows: [],
-            model: 'agent/deepseek-v4-flash',
-            memoryFiles: [],
-            mcpTools: [],
-            agents: [],
-            isAutoCompactEnabled: false,
-            apiUsage: null
-          },
-    percentage: mocks.contextUsagePercentage
-  })
-}))
-
 vi.mock('@renderer/hooks/agent/useAgentSessionCompaction', () => ({
   useAgentSessionCompaction: () => ({ status: 'idle' })
 }))
@@ -831,7 +807,6 @@ describe('AgentComposer', () => {
     mocks.availableSkills = []
     mocks.availableSkillsRefresh.mockReset()
     mocks.availableSkillsRefresh.mockResolvedValue(undefined)
-    mocks.contextUsagePercentage = null
     mocks.surfaceProps = undefined
     mocks.speedControlProps = undefined
     mocks.derivedToolState = undefined
@@ -2147,11 +2122,31 @@ describe('AgentComposer', () => {
     })
   })
 
-  it('renders context usage next to the send action when cached usage exists', async () => {
-    mocks.contextUsagePercentage = 42
+  it('renders context usage for the selected Gateway model but hides a different model cache', async () => {
+    mocks.modelResult = {
+      ...model,
+      id: 'minimax::MiniMax-M3',
+      providerId: 'minimax',
+      apiModelId: 'MiniMax-M3',
+      name: 'MiniMax M3'
+    }
+    MockUseCacheUtils.setSharedCacheValue('agent.session.context_usage.session-1', {
+      categories: [],
+      totalTokens: 42,
+      maxTokens: 100,
+      rawMaxTokens: 100,
+      percentage: 42,
+      gridRows: [],
+      model: 'minimax:MiniMax-M3',
+      memoryFiles: [],
+      mcpTools: [],
+      agents: [],
+      isAutoCompactEnabled: false,
+      apiUsage: null
+    })
     mocks.sessionLayout = 'time'
 
-    render(
+    const view = render(
       <AgentComposer
         agentId="agent-1"
         sessionId="session-1"
@@ -2162,7 +2157,7 @@ describe('AgentComposer', () => {
     )
 
     const leftControls = screen.getByTestId('composer-left-controls')
-    const modelButton = within(leftControls).getByRole('button', { name: /Claude Sonnet 4.5/ })
+    const modelButton = within(leftControls).getByRole('button', { name: /MiniMax M3/ })
     const workspaceButton = within(leftControls).getByText('Workspace 1').closest('button')!
     const toolMenuButton = within(leftControls).getByRole('button', { name: 'tool menu' })
     const sendAccessory = screen.getByTestId('composer-send-accessory')
@@ -2177,7 +2172,36 @@ describe('AgentComposer', () => {
     expect(indicator).toHaveAttribute('style', expect.stringContaining('color-mix(in oklch'))
 
     await waitFor(() => expect(screen.getByText('42 / 100 (42%)')).toBeInTheDocument())
-    expect(screen.getByText('agent/deepseek-v4-flash')).toBeInTheDocument()
+    expect(within(sendAccessory).getByText('MiniMax M3')).toBeInTheDocument()
+    expect(within(sendAccessory).queryByText('minimax:MiniMax-M3')).not.toBeInTheDocument()
+
+    MockUseCacheUtils.setSharedCacheValue('agent.session.context_usage.session-1', {
+      categories: [],
+      totalTokens: 24,
+      maxTokens: 100,
+      rawMaxTokens: 100,
+      percentage: 24,
+      gridRows: [],
+      model: 'openai:gpt-4o',
+      memoryFiles: [],
+      mcpTools: [],
+      agents: [],
+      isAutoCompactEnabled: false,
+      apiUsage: null
+    })
+    view.rerender(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    expect(
+      within(screen.getByTestId('composer-send-accessory')).queryByLabelText(/context_usage/)
+    ).not.toBeInTheDocument()
   })
 
   it('provides workspace file resources through the @ mention suggestion source', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Agent context usage reported by a Gateway-routed model used the runtime identifier `providerId:apiModelId`, while the composer only accepted bare model identifiers. The valid cached reading was therefore treated as stale and the context-usage indicator stayed hidden. When visible, the composer tooltip also exposed the raw runtime identifier.

After this PR:

The composer accepts the shared Gateway model identifier as an additional identity candidate while preserving the stale-model guard. Its tooltip shows the selected model's display name; diagnostic views continue to show the raw runtime identifier.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Gateway routing and the composer cache filter used two legitimate representations of the same model. Reusing `formatGatewayModelId` aligns the consumer with the runtime contract without duplicating the identifier format or weakening model identity checks.

The following tradeoffs were made:

- Keep the strict stale-cache filter and add the Gateway representation as a candidate.
- Keep the shared summary component's raw-ID fallback so diagnostic consumers retain their existing behavior.

The following alternatives were considered:

- Removing the expected-model filter was rejected because it could display stale usage after switching models.
- Stripping provider prefixes was rejected because it would lose provider identity and could create cross-provider collisions.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/pull/16260
- https://github.com/CherryHQ/cherry-studio/pull/16399
- https://github.com/CherryHQ/cherry-studio/pull/17380

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- The right-pane context usage summary intentionally keeps the raw runtime model identifier.
- The composer test exercises the real cache hook, including a matching Gateway cache and a mismatched stale cache.
- Verified with 113 focused renderer tests and `pnpm typecheck:web`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Restore the context usage indicator for Gateway-routed agent models and show readable model names in the composer tooltip.
```
