### PR TITLE
feat(composer): animate effort gauge and refine slider feedback

### DIFF
--- a/src/renderer/components/composer/variants/shared/ComposerSpeedControl.tsx
+++ b/src/renderer/components/composer/variants/shared/ComposerSpeedControl.tsx
@@ -3,7 +3,7 @@ import type { ThinkingOption } from '@renderer/types/reasoning'
 import { cn } from '@renderer/utils/style'
 import { deriveThinkingOptions } from '@shared/ai/reasoning'
 import type { Model } from '@shared/data/types/model'
-import { ChevronDown, Gauge, Zap } from 'lucide-react'
+import { ChevronDown, Zap } from 'lucide-react'
 import { useEffect, useEffectEvent, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -100,12 +100,12 @@ function ComposerEffortSlider({ ariaLabel, efforts, value, valueText, onChange }
         getThumbAriaLabel={() => ariaLabel}
         getThumbAriaValueText={() => valueText}
         className={cn(
-          'h-8',
+          'h-8 cursor-grab active:cursor-grabbing',
           '[&_[data-slot=slider-track]]:h-2.5 [&_[data-slot=slider-track]]:bg-muted [&_[data-slot=slider-track]]:shadow-inner',
           '[&_[data-slot=slider-range]]:bg-primary',
           '[&_[data-slot=slider-thumb]]:z-20 [&_[data-slot=slider-thumb]]:size-5 [&_[data-slot=slider-thumb]]:rounded-full',
-          '[&_[data-slot=slider-thumb]]:border-border [&_[data-slot=slider-thumb]]:bg-popover! [&_[data-slot=slider-thumb]]:shadow-sm',
-          '[&_[data-slot=slider-thumb]:hover]:ring-0'
+          '[&_[data-slot=slider-thumb]]:cursor-grab [&_[data-slot=slider-thumb]]:border-border [&_[data-slot=slider-thumb]]:bg-popover! [&_[data-slot=slider-thumb]]:shadow-sm',
+          '[&_[data-slot=slider-thumb]:active]:cursor-grabbing [&_[data-slot=slider-thumb]:hover]:ring-0'
         )}
         onValueChange={([nextIndex]) => {
           const nextEffort = efforts[nextIndex]
@@ -126,6 +126,40 @@ function ComposerEffortSlider({ ariaLabel, efforts, value, valueText, onChange }
         )}
       </div>
     </div>
+  )
+}
+
+// Lucide Gauge geometry: dial centered at (12,14), arc ends ±120° from top, needle drawn at 45°.
+const GAUGE_NEEDLE_BASE_ANGLE = 45
+const GAUGE_MIN_ANGLE = -120
+const GAUGE_MAX_ANGLE = 120
+
+/** Lucide's Gauge icon with the needle aimed at `angle` (degrees clockwise from top). */
+function EffortGaugeIcon({ angle }: { angle: number }) {
+  return (
+    <svg
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0"
+      aria-hidden="true">
+      <path d="M3.34 19a10 10 0 1 1 17.32 0" />
+      <path
+        d="m12 14 4-4"
+        data-slot="composer-effort-gauge-needle"
+        className="transition-transform duration-300 ease-out motion-reduce:transition-none"
+        style={{
+          transform: `rotate(${angle - GAUGE_NEEDLE_BASE_ANGLE}deg)`,
+          transformOrigin: '12px 14px',
+          transformBox: 'view-box'
+        }}
+      />
+    </svg>
   )
 }
 
@@ -181,6 +215,12 @@ export function ComposerSpeedControl({
   const effortLabel = displayedEffort ? t(EFFORT_LABEL_KEYS[displayedEffort]) : ''
   const effortControlLabel = t('agent.speed.effort')
   const triggerLabel = fastMode ? t('agent.speed.fast') : t('agent.speed.label')
+  const gaugeEfforts = showEffortSlider ? sliderEfforts : reasoningOptions
+  const gaugeIndex = showEffortSlider ? currentIndex : displayedEffort ? gaugeEfforts.indexOf(displayedEffort) : -1
+  const gaugeFraction = gaugeEfforts.length > 1 && gaugeIndex > 0 ? gaugeIndex / (gaugeEfforts.length - 1) : 0
+  const gaugeAngle = supportsReasoning
+    ? GAUGE_MIN_ANGLE + (GAUGE_MAX_ANGLE - GAUGE_MIN_ANGLE) * gaugeFraction
+    : GAUGE_NEEDLE_BASE_ANGLE
 
   return (
     <Popover>
@@ -191,7 +231,7 @@ export function ComposerSpeedControl({
           size="sm"
           className="h-8 gap-1 rounded-md px-2.5 text-muted-foreground text-xs hover:text-foreground"
           aria-label={t('agent.speed.title')}>
-          <Gauge size={14} className="shrink-0" />
+          <EffortGaugeIcon angle={gaugeAngle} />
           <span>{supportsReasoning ? effortLabel : triggerLabel}</span>
           {supportsReasoning && fastMode && supportsFast ? <span>· {t('agent.speed.fast')}</span> : null}
           <ChevronDown size={13} className="shrink-0 text-muted-foreground" />
@@ -250,8 +290,14 @@ export function ComposerSpeedControl({
         {supportsReasoning && showEffortSlider ? (
           <div className="mx-2.5 mt-1 mb-2">
             <div className="flex items-center justify-between font-medium text-[11px]" aria-hidden="true">
-              <span className="text-muted-foreground">{t('agent.speed.faster')}</span>
-              <span className="text-primary">{t('agent.speed.smarter')}</span>
+              <span
+                className={cn('transition-colors', gaugeFraction < 0.5 ? 'text-foreground' : 'text-muted-foreground')}>
+                {t('agent.speed.faster')}
+              </span>
+              <span
+                className={cn('transition-colors', gaugeFraction > 0.5 ? 'text-foreground' : 'text-muted-foreground')}>
+                {t('agent.speed.smarter')}
+              </span>
             </div>
             <ComposerEffortSlider
               ariaLabel={effortControlLabel}


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR:** Depends on #17829. Review and merge #17829 first. This PR uses a base branch that mirrors #17829 so the diff contains only the gauge UX changes. After #17829 merges, rebase this PR onto `main` and retarget it to `main`.

### What this PR does

Before this PR:

- The speed-control trigger in the composer showed a static gauge icon regardless of the selected reasoning tier.
- The effort slider used the default arrow cursor while dragging.
- In the effort popup, the "Smarter" axis label was permanently accent-colored, reading like an active state even when the lowest tier was selected.

After this PR:

- The gauge icon's needle rotates to point at the selected tier, sweeping the dial's arc (±120° from top) with a smooth 300ms transition — it also follows live while dragging the slider.
- The slider thumb shows a grab cursor on hover and a grabbing cursor while dragging (including drags started on the track).
- The Faster/Smarter axis labels highlight whichever side the needle currently leans toward, with a color transition; neither is highlighted at the exact midpoint.


https://github.com/user-attachments/assets/4f75cc20-e569-41d5-8137-1b63b8709b28



Fixes: None

### Why we need it and why it was done in this way

A small UX polish pass on the composer speed control: the gauge metaphor was already there, so making the needle track the selection turns the icon into live feedback instead of decoration.

The following tradeoffs were made:

- The needle angle maps linearly over the model's selectable tiers rather than any semantic weighting; provider Default (with no declared default effort) rests at the far-left end, matching the slider thumb position.
- The rotating icon is a local inline SVG replicating lucide's `Gauge` paths (same stroke geometry), because rotating the whole lucide icon would also rotate the dial arc.

The following alternatives were considered:

- Restructuring the popup layout (relocating the fast-mode toggle, in-place expansion of the trigger) was prototyped and deliberately dropped — this PR keeps the popup layout untouched and changes only the trigger icon, cursor, and label accent behavior.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `ComposerSpeedControl.ui.test.tsx` required no changes — the existing 9 tests pass as-is.
- Verified locally with scoped checks: `vitest` on the component's test file, `tsgo --noEmit -p tsconfig.web.json`, and Biome on the touched file. Full `build:check` is left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
The reasoning effort control's gauge icon now animates its needle to match the selected tier, the effort slider shows grab/grabbing cursors while dragging, and the Faster/Smarter labels highlight the side nearest the current selection.
```
