### PR TITLE
fix(code-editor): honor custom code font in conversation code blocks

### DIFF
--- a/src/renderer/assets/styles/markdown.css
+++ b/src/renderer/assets/styles/markdown.css
@@ -724,7 +724,7 @@
   outline: none;
 }
 
-.cm-editor .cm-scroller {
+.code-editor .cm-editor .cm-scroller {
   font-family: var(--code-font-family);
   border-radius: inherit;
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Conversation code blocks rendered by CodeMirror ignored the configured code font because CodeMirror's runtime `monospace` rule had equal specificity and was injected later.

After this PR:

The application code font rule includes the stable `.code-editor` wrapper, giving it enough specificity to apply `--code-font-family` to the CodeMirror scroller.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18000

### Why we need it and why it was done in this way

The following tradeoffs were made:

The selector is slightly more specific, but remains scoped to Cherry Studio's code editor wrapper and avoids `!important`.

The following alternatives were considered:

Adding `!important` or introducing a new CodeEditor font API/theme extension. Both were unnecessary because the existing application stylesheet already owns the code-font preference; increasing the existing selector's specificity is the smallest fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18000

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm format` passed.
- `pnpm lint` passed with 37 pre-existing warnings unrelated to this change.
- `git diff --check` passed.
- Automated tests and post-fix interactive verification were not run.
- A documentation update is not required because this restores the documented code-font setting behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed custom code fonts being ignored in Conversation code blocks.
```
