### PR TITLE
fix(file-processing): use native FormData for Open MinerU

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,7 +342,6 @@
     "fast-xml-parser": "5.5.6",
     "fetch-socks": "1.3.2",
     "file-type": "22.0.1",
-    "form-data": "4.0.6",
     "fractional-indexing": "^3.2.0",
     "franc-min": "^6.2.0",
     "fs-extra": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -822,9 +822,6 @@ importers:
       file-type:
         specifier: 22.0.1
         version: 22.0.1
-      form-data:
-        specifier: 4.0.6
-        version: 4.0.6
       fractional-indexing:
         specifier: ^3.2.0
         version: 3.2.0

--- a/src/main/features/fileProcessing/processors/openMineru/__tests__/utils.test.ts
+++ b/src/main/features/fileProcessing/processors/openMineru/__tests__/utils.test.ts
@@ -1,15 +1,11 @@
 import type * as NodeFs from 'node:fs'
 import fs from 'node:fs/promises'
-import { Readable } from 'node:stream'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { fetchMock, createReadStreamMock, destroyMock } = vi.hoisted(() => ({
+const { fetchMock, openAsBlobMock } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
-  destroyMock: vi.fn(),
-  createReadStreamMock: vi.fn(() => ({
-    destroy: vi.fn()
-  }))
+  openAsBlobMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -23,7 +19,7 @@ vi.mock('node:fs', async () => {
 
   return {
     ...actual,
-    createReadStream: createReadStreamMock
+    openAsBlob: openAsBlobMock
   }
 })
 
@@ -32,11 +28,7 @@ import { executeTask } from '../utils'
 describe('open-mineru utils', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    createReadStreamMock.mockImplementation(() => {
-      const stream = Readable.from(['file-data']) as Readable & { destroy: typeof destroyMock }
-      stream.destroy = destroyMock
-      return stream
-    })
+    openAsBlobMock.mockResolvedValue(new Blob(['file-data'], { type: 'application/pdf' }))
   })
 
   it('rejects files that are 200MB or larger before execution', async () => {
@@ -52,7 +44,7 @@ describe('open-mineru utils', () => {
     ).rejects.toThrow('Open MinerU file is too large (must be smaller than 200MB)')
   })
 
-  it('submits multipart form data through a stream body', async () => {
+  it('submits native multipart form data and lets fetch set the boundary', async () => {
     vi.spyOn(fs, 'stat').mockResolvedValue({ size: 1024 } as never)
     fetchMock.mockResolvedValueOnce(
       new Response(new Uint8Array([1, 2, 3]), {
@@ -76,7 +68,7 @@ describe('open-mineru utils', () => {
       } as never)
     ).resolves.toBeInstanceOf(Response)
 
-    expect(createReadStreamMock).toHaveBeenCalledWith('/tmp/file.pdf')
+    expect(openAsBlobMock).toHaveBeenCalledWith('/tmp/file.pdf')
     expect(fetchMock).toHaveBeenCalledWith(
       'http://127.0.0.1:8000/file_parse',
       expect.objectContaining({
@@ -84,10 +76,38 @@ describe('open-mineru utils', () => {
         headers: expect.objectContaining({
           Authorization: 'Bearer secret'
         }),
-        body: expect.any(Object),
-        duplex: 'half'
+        body: expect.any(FormData)
       })
     )
-    expect(destroyMock).toHaveBeenCalled()
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const formData = init.body as FormData
+    expect(formData.get('return_md')).toBe('true')
+    expect(formData.get('response_format_zip')).toBe('true')
+    expect(formData.get('files')).toBeInstanceOf(File)
+    expect((formData.get('files') as File).name).toBe('file.pdf')
+    expect(new Headers(init.headers).has('content-type')).toBe(false)
+  })
+
+  it('does not add an authorization header when no API key is configured', async () => {
+    vi.spyOn(fs, 'stat').mockResolvedValue({ size: 1024 } as never)
+    fetchMock.mockResolvedValueOnce(
+      new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'application/zip' }
+      })
+    )
+
+    await executeTask({
+      apiHost: 'http://127.0.0.1:8000',
+      file: {
+        path: '/tmp/file.pdf',
+        name: 'file',
+        ext: 'pdf'
+      }
+    } as never)
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(new Headers(init.headers).has('authorization')).toBe(false)
   })
 })

--- a/src/main/features/fileProcessing/processors/openMineru/utils.ts
+++ b/src/main/features/fileProcessing/processors/openMineru/utils.ts
@@ -1,9 +1,8 @@
-import { createReadStream } from 'node:fs'
+import { openAsBlob } from 'node:fs'
 import fs from 'node:fs/promises'
 
 import { MB } from '@shared/utils/constants'
 import { net } from 'electron'
-import FormData from 'form-data'
 
 import type { PreparedOpenMineruContext } from './types'
 
@@ -17,45 +16,35 @@ export async function executeTask(context: PreparedOpenMineruContext): Promise<R
     throw new Error('Open MinerU file is too large (must be smaller than 200MB)')
   }
 
-  const fileStream = createReadStream(context.file.path)
+  const file = await openAsBlob(context.file.path)
 
   const formData = new FormData()
   formData.append('return_md', 'true')
   formData.append('response_format_zip', 'true')
-  formData.append('files', fileStream, {
-    filename: context.file.ext ? `${context.file.name}.${context.file.ext}` : context.file.name
+  formData.append('files', file, context.file.ext ? `${context.file.name}.${context.file.ext}` : context.file.name)
+
+  const response = await net.fetch(endpoint, {
+    method: 'POST',
+    headers: context.apiKey ? { Authorization: `Bearer ${context.apiKey}` } : undefined,
+    body: formData,
+    signal: context.signal
   })
 
-  try {
-    const response = await net.fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        ...(context.apiKey ? { Authorization: `Bearer ${context.apiKey}` } : {}),
-        ...formData.getHeaders()
-      },
-      body: formData as any,
-      duplex: 'half',
-      signal: context.signal
-    } as any)
-
-    if (!response.ok) {
-      const message = await response.text()
-      throw new Error(`Open MinerU request failed: ${response.status} ${response.statusText} ${message}`)
-    }
-
-    const contentType = response.headers.get('content-type')
-
-    // Intentional contract check:
-    // when `response_format_zip=true`, this adapter only accepts an exact
-    // `application/zip` response. We fail fast on any other content-type
-    // instead of broadening compatibility implicitly, so provider contract
-    // changes stay explicit and visible.
-    if (contentType !== 'application/zip') {
-      throw new Error(`Open MinerU returned unexpected content-type: ${contentType}`)
-    }
-
-    return response
-  } finally {
-    fileStream.destroy()
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(`Open MinerU request failed: ${response.status} ${response.statusText} ${message}`)
   }
+
+  const contentType = response.headers.get('content-type')
+
+  // Intentional contract check:
+  // when `response_format_zip=true`, this adapter only accepts an exact
+  // `application/zip` response. We fail fast on any other content-type
+  // instead of broadening compatibility implicitly, so provider contract
+  // changes stay explicit and visible.
+  if (contentType !== 'application/zip') {
+    throw new Error(`Open MinerU returned unexpected content-type: ${contentType}`)
+  }
+
+  return response
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Open MinerU uploads used the npm `form-data` Node stream with manually copied multipart headers. Electron `net.fetch` could encode a different request body than the declared boundary, causing PDF and DOC uploads to fail with HTTP 400.

After this PR: Open MinerU uploads use native `FormData` with a file-backed `Blob`, allowing Fetch to encode the body and matching boundary together.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17919

### Why we need it and why it was done in this way

Electron `net.fetch` accepts standard Fetch `RequestInit` bodies. The previous npm `form-data` stream was outside that contract and required `as any`, while its manually supplied boundary could disagree with the body consumed by Fetch.

The following tradeoffs were made: `openAsBlob()` keeps the upload file-backed and streamable while producing a standards-compatible body. Fetch owns the multipart `Content-Type` so its boundary always matches the encoded body.

The following alternatives were considered: Buffering the file into memory was rejected because Open MinerU accepts files up to 200 MB. Keeping npm `form-data` and adapting its stream was rejected because it preserves the incompatible body contract that caused the bug.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17919

### Breaking changes

None.

### Special notes for your reviewer

Targeted coverage verifies native `FormData`, the required control fields, the uploaded filename, automatic multipart headers, and optional authorization behavior.

Validation:
- `pnpm vitest run --project main src/main/features/fileProcessing/processors/openMineru/__tests__/utils.test.ts --reporter=verbose`
- `pnpm lint`
- `pnpm format`
- `pnpm typecheck:node`
- Targeted ESLint and Biome checks for the changed files

Full `pnpm test` and `pnpm build:check` were intentionally not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Open MinerU PDF and DOC uploads failing with HTTP 400 because of an invalid multipart request body.
```
