### PR TITLE
feat(claude-code): enable CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT

### DIFF
--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -724,6 +724,7 @@ async function buildEnvironment(provider: Provider, agent: AgentEntity): Promise
     // The stream adapter's background-work release waits for `session_state_changed: idle`
     // (streamAdapter.ts), which the CLI only emits when this flag is set.
     CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: '1',
+    CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT: '1',
     CHERRY_STUDIO_BUN_PATH: bunPath,
     CHERRY_STUDIO_SKILLS_DIR: application.getPath('feature.agents.skills'),
     ...(customGitBashPath ? { CLAUDE_CODE_GIT_BASH_PATH: customGitBashPath } : {})


### PR DESCRIPTION
### What this PR does

Before this PR: the Claude Code runtime spawned the CLI without `CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT`, so the agent always received the CLI's full built-in system prompt.

After this PR: `settingsBuilder.ts` sets `CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT: '1'` in the spawned CLI environment, so the agent runs with the CLI's simplified system prompt.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Set as a plain default in the env block next to the other `CLAUDE_CODE_*` flags, rather than adding a user-facing setting — no configuration surface was requested.
- Not added to `BLOCKED_ENV_KEYS`: unlike auth/model keys, a user override of this flag via `env_vars` is harmless, so it stays overridable.

The following alternatives were considered:

- Exposing it as an agent configuration toggle — rejected as speculative for now.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

One-line change in `src/main/ai/runtime/claudeCode/settingsBuilder.ts`. Tests and `build:check` were not run locally at the author's request; CI covers them.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
