### PR TITLE
fix(code-cli): respect Linux default terminal

### DIFF
--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -699,12 +699,19 @@ export class CodeCliService extends BaseService {
         break
       }
       case 'linux': {
-        // Linux - Try to use common terminal emulators
+        // Linux - Prefer the XDG-configured default terminal, then try common emulators.
         const envPrefix = buildEnvPrefix(false)
         const command = envPrefix ? `${envPrefix} && ${baseCommand}` : baseCommand
 
-        const linuxTerminals = ['gnome-terminal', 'konsole', 'deepin-terminal', 'xterm', 'x-terminal-emulator']
-        let foundTerminal = 'xterm' // Default to xterm
+        const linuxTerminals = [
+          'xdg-terminal-exec',
+          'gnome-terminal',
+          'konsole',
+          'deepin-terminal',
+          'xterm',
+          'x-terminal-emulator'
+        ]
+        let foundTerminal: string | undefined
 
         for (const terminal of linuxTerminals) {
           try {
@@ -727,7 +734,10 @@ export class CodeCliService extends BaseService {
           }
         }
 
-        if (foundTerminal === 'gnome-terminal') {
+        if (foundTerminal === 'xdg-terminal-exec') {
+          terminalCommand = 'xdg-terminal-exec'
+          terminalArgs = [`--dir=${directory}`, '--', 'bash', '-c', `clear && ${command}; exec bash`]
+        } else if (foundTerminal === 'gnome-terminal') {
           terminalCommand = 'gnome-terminal'
           terminalArgs = ['--working-directory', directory, '--', 'bash', '-c', `clear && ${command}; exec bash`]
         } else if (foundTerminal === 'konsole') {
@@ -736,6 +746,9 @@ export class CodeCliService extends BaseService {
         } else if (foundTerminal === 'deepin-terminal') {
           terminalCommand = 'deepin-terminal'
           terminalArgs = ['-w', directory, '-e', 'bash', '-c', `clear && ${command}; exec bash`]
+        } else if (foundTerminal === 'x-terminal-emulator') {
+          terminalCommand = 'x-terminal-emulator'
+          terminalArgs = ['-e', `cd ${posixQuote(directory)} && clear && ${command} && bash`]
         } else {
           // Default to xterm
           terminalCommand = 'xterm'

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -809,6 +809,44 @@ describe('CodeCliService', () => {
       expect(launch![2]).toMatchObject({ shell: false, detached: true })
     })
 
+    it('uses xdg-terminal-exec to respect the configured default terminal', async () => {
+      const spawn = await mockLinuxSpawn(['xdg-terminal-exec', 'xterm'])
+      const { codeCliService } = await loadModules()
+
+      const result = await codeCliService.run({
+        mode: 'login-flow',
+        cliTool: CodeCli.CLAUDE_CODE,
+        directory: '/home/me/my project'
+      })
+
+      expect(result.success).toBe(true)
+      const launch = vi.mocked(spawn).mock.calls.at(-1)
+      expect(launch?.[0]).toBe('xdg-terminal-exec')
+      expect(launch?.[1]).toEqual([
+        '--dir=/home/me/my project',
+        '--',
+        'bash',
+        '-c',
+        expect.stringContaining('clear && ')
+      ])
+    })
+
+    it('launches x-terminal-emulator itself when it is the only fallback', async () => {
+      const spawn = await mockLinuxSpawn(['x-terminal-emulator'])
+      const { codeCliService } = await loadModules()
+
+      const result = await codeCliService.run({
+        mode: 'login-flow',
+        cliTool: CodeCli.CLAUDE_CODE,
+        directory: '/home/me/proj'
+      })
+
+      expect(result.success).toBe(true)
+      const launch = vi.mocked(spawn).mock.calls.at(-1)
+      expect(launch?.[0]).toBe('x-terminal-emulator')
+      expect(launch?.[1]).toEqual(['-e', expect.stringContaining("cd '/home/me/proj'")])
+    })
+
     it('reports a failed launch when the terminal process errors at spawn', async () => {
       const { spawn } = await import('child_process')
       vi.mocked(spawn).mockImplementation(((cmd: string) => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Linux Coding Partner launches selected the first terminal from a hard-coded list, so an installed `xterm` could override the user's configured desktop terminal. The fallback also detected `x-terminal-emulator` but launched `xterm` instead.

After this PR:

Linux launches prefer `xdg-terminal-exec`, which resolves the user's configured XDG default terminal and working-directory arguments. Existing emulator probing remains as a compatibility fallback, and `x-terminal-emulator` is launched directly when selected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17888

### Why we need it and why it was done in this way

The existing hard-coded probe cannot represent desktop or user terminal preferences. `xdg-terminal-exec` already resolves the applicable XDG configuration and terminal-specific arguments, so using it when available keeps that policy at the Linux desktop boundary.

The following tradeoffs were made:

The existing terminal list is retained for distributions that do not ship `xdg-terminal-exec`. The final `xterm` fallback is also preserved for compatibility when no probe succeeds.

The following alternatives were considered:

Adding Ptyxis and other terminal names to the hard-coded list was rejected because it would still ignore the configured default and require ongoing terminal-specific maintenance. Parsing XDG terminal configuration inside Cherry Studio was rejected because it would duplicate `xdg-terminal-exec` behavior and desktop-entry handling.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17888

### Breaking changes

None.

### Special notes for your reviewer

- Focused verification: `pnpm exec vitest run --project main src/main/services/codeCli/__tests__/CodeCliService.test.ts` — 37 passed.
- `pnpm lint` passed, including typecheck, i18n check, and format.
- `pnpm test:lint` completed with 0 errors and 37 pre-existing warnings outside the changed files.
- The full `pnpm test` suite and `pnpm build:check` were intentionally not run per the requested validation scope.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Respect the configured default terminal when launching Coding Partner tools on Linux.
```
