### PR TITLE
fix(code-cli): allow enabling providers before installation

### DIFF
--- a/src/renderer/pages/code/hooks/__tests__/useConfigPanelController.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useConfigPanelController.test.ts
@@ -52,7 +52,6 @@ function baseOptions() {
   return {
     selectedCliTool: CodeCli.CLAUDE_CODE,
     toolName: 'Claude Code',
-    isToolInstalled: true,
     currentProviderId: 'p1',
     providerConfigs: {},
     upsertProviderConfig: vi.fn().mockResolvedValue('p1'),
@@ -142,15 +141,18 @@ describe('useConfigPanelController', () => {
     })
   })
 
-  describe('install gate', () => {
+  describe('enable without installation state', () => {
     beforeEach(() => {
       // clearAllMocks() keeps the never-resolving clearCliConfig impl from the in-flight guard tests.
       mocks.clearCliConfig.mockReset()
       mocks.clearCliConfig.mockResolvedValue(undefined)
+      mocks.writeCliConfigDraft.mockReset()
+      mocks.writeCliConfigDraft.mockResolvedValue(undefined)
     })
 
-    it('blocks enabling a provider and nudges to install when the CLI is not installed', async () => {
-      const options = { ...baseOptions(), isToolInstalled: false, currentProviderId: null }
+    it('enables a configured provider without requiring the CLI to be installed first', async () => {
+      mocks.resolveCliConfigApplyContext.mockReturnValue({ modelId: 'm1', writePrimaryModel: true })
+      const options = { ...baseOptions(), currentProviderId: null }
       const { result } = renderHook(() => useConfigPanelController(options))
       const provider = { id: 'p2' } as Provider // not current → enabling
 
@@ -159,13 +161,19 @@ describe('useConfigPanelController', () => {
         await flushMicrotasks()
       })
 
-      expect(toast.error).toHaveBeenCalledWith('code.install_tool_first')
-      expect(options.setCurrentProvider).not.toHaveBeenCalled()
-      expect(mocks.writeCliConfigDraft).not.toHaveBeenCalled()
+      expect(mocks.writeCliConfigDraft).toHaveBeenCalledWith({
+        cliTool: CodeCli.CLAUDE_CODE,
+        modelId: 'm1',
+        configBlob: undefined,
+        writePrimaryModel: true,
+        gateway: undefined
+      })
+      expect(options.setCurrentProvider).toHaveBeenCalledWith('p2')
+      expect(toast.error).not.toHaveBeenCalled()
     })
 
-    it('still allows disabling the current provider when the CLI is not installed', async () => {
-      const options = { ...baseOptions(), isToolInstalled: false, currentProviderId: 'p1' }
+    it('still allows disabling the current provider', async () => {
+      const options = { ...baseOptions(), currentProviderId: 'p1' }
       const { result } = renderHook(() => useConfigPanelController(options))
       const provider = { id: 'p1' } as Provider // current → disabling
 

--- a/src/renderer/pages/code/hooks/useCodeCliPageViewProps.ts
+++ b/src/renderer/pages/code/hooks/useCodeCliPageViewProps.ts
@@ -170,7 +170,6 @@ export function useCodeCliPageViewProps(): CodeCliPageViewProps {
   const configPanel = useConfigPanelController({
     selectedCliTool,
     toolName,
-    isToolInstalled: versionStatus.installed,
     currentProviderId,
     providerConfigs,
     upsertProviderConfig,

--- a/src/renderer/pages/code/hooks/useConfigPanelController.ts
+++ b/src/renderer/pages/code/hooks/useConfigPanelController.ts
@@ -29,7 +29,6 @@ const logger = loggerService.withContext('useConfigPanelController')
 interface UseConfigPanelControllerOptions {
   selectedCliTool: CodeCli
   toolName: string
-  isToolInstalled: boolean
   currentProviderId: string | null
   providerConfigs: Record<string, CliProviderConfig>
   upsertProviderConfig: (
@@ -55,7 +54,6 @@ interface ConfigPanelController {
 export function useConfigPanelController({
   selectedCliTool,
   toolName,
-  isToolInstalled,
   currentProviderId,
   providerConfigs,
   upsertProviderConfig,
@@ -201,13 +199,6 @@ export function useConfigPanelController({
   const handleToggleCurrent = useCallback(
     (provider: Provider) => {
       const isEnabling = currentProviderId !== provider.id
-      // Enabling injects config into the CLI's own files, which is meaningless until the CLI is
-      // installed — nudge the user to install it instead of marking a provider "enabled" that can
-      // never launch. Disabling (scrubbing config) stays allowed regardless.
-      if (isEnabling && !isToolInstalled) {
-        toast.error(t('code.install_tool_first', { toolName }))
-        return
-      }
       // Ignore a re-entrant toggle for the same tool while its config write/clear is still running.
       if (inFlightToolsRef.current.has(selectedCliTool)) return
       inFlightToolsRef.current.add(selectedCliTool)
@@ -295,8 +286,6 @@ export function useConfigPanelController({
     [
       currentProviderId,
       selectedCliTool,
-      toolName,
-      isToolInstalled,
       providerConfigs,
       upsertProviderConfig,
       setCurrentProvider,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Code CLI providers could not be enabled until the corresponding CLI tool was installed.

After this PR:

Users can enable and configure a Code CLI provider before installing the CLI tool.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

Provider configuration is useful before installation and can be written independently of the CLI executable. The controller no longer accepts installation state or blocks the existing provider configuration flow.

The following tradeoffs were made:

Configuration files may be created before the CLI executable exists; the normal launch and installation flows remain unchanged.

The following alternatives were considered:

Keeping the installation warning while persisting only the selected provider was rejected because it would leave the preference and native CLI configuration out of sync.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation completed:

- `pnpm lint`
- `pnpm exec vitest run --project renderer src/renderer/pages/code/hooks/__tests__/useConfigPanelController.test.ts`

Full `pnpm test` and `pnpm build:check` were not run per request.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Code CLI providers can now be enabled before their CLI tool is installed.
```
