### PR TITLE
fix(model-icons): recognize Kimi K3 model ids

### DIFF
--- a/packages/provider-registry/src/__tests__/vendor-patterns.test.ts
+++ b/packages/provider-registry/src/__tests__/vendor-patterns.test.ts
@@ -19,6 +19,9 @@ describe('matchVendor — anchored, order-independent (#5)', () => {
     expect(matchVendor('deepseek-r1')).toBe('deepseek')
     expect(matchVendor('grok-4')).toBe('grok')
     expect(matchVendor('mixtral-8x7b')).toBe('mistral')
+    expect(matchVendor('k3')).toBe('kimi')
+    expect(matchVendor('k3-256k')).toBe('kimi')
+    expect(matchVendor('k3po')).toBeUndefined()
   })
 })
 

--- a/packages/provider-registry/src/patterns/vendor-patterns.ts
+++ b/packages/provider-registry/src/patterns/vendor-patterns.ts
@@ -62,8 +62,8 @@ export const VENDOR_PATTERNS = {
   /** Tencent Hunyuan family — `hunyuan-*`, the `hy-*` SKUs, and the versioned `hyN` namespace (`hy3-preview`). */
   hunyuan: /^(?:hunyuan|hy-|hy\d)/i,
 
-  /** Moonshot / Kimi family. */
-  kimi: /^(?:kimi|moonshot)/i,
+  /** Moonshot / Kimi family, including Kimi Code's bare K3 model IDs. */
+  kimi: /^(?:kimi|moonshot|k3(?:[-_.]|$))/i,
 
   /** DeepSeek family. */
   deepseek: /^deepseek/i,

--- a/packages/ui/src/components/icons/__tests__/registry.test.ts
+++ b/packages/ui/src/components/icons/__tests__/registry.test.ts
@@ -139,7 +139,9 @@ describe('resolveModelIconRef — dedicated model marks', () => {
     ['internvl-3', 'internlm'],
     ['01-ai/yi-large', 'yi'],
     ['baidu/ernie-4.5', 'wenxin'],
-    ['stepfun/step-3.5-flash', 'stepfun']
+    ['stepfun/step-3.5-flash', 'stepfun'],
+    ['k3', 'kimi'],
+    ['k3-256k', 'kimi']
   ] as const
 
   it.each(familyCases)('routes %s to %s', (modelId, key) => {
@@ -151,6 +153,7 @@ describe('resolveModelIconRef — dedicated model marks', () => {
     expect(resolveModelIconRef('influxdb-query')?.key).not.toBe('flux')
     expect(resolveModelIconRef('sonarqube-code')?.key).not.toBe('perplexity')
     expect(resolveModelIconRef('sparkling-image')?.key).not.toBe('kling')
+    expect(resolveModelIconRef('k3po')?.key).not.toBe('kimi')
   })
 })
 

--- a/packages/ui/src/components/icons/registry.ts
+++ b/packages/ui/src/components/icons/registry.ts
@@ -140,7 +140,7 @@ const MODEL_ICON_PATTERNS: ReadonlyArray<[RegExp, string]> = [
   // `seed-2.0-lite`/`seed-1.6` match, while `seedream`/`seedance` keep their explicit alts
   [/doubao|seedream|seedance|ep-202|(?:^|[-_/])seed(?:[-_\d]|$)/i, 'doubao'],
   [/^(?:hunyuan|hy-|hy\d)/i, 'hunyuan'],
-  [/kimi|moonshot/i, 'kimi'],
+  [/kimi|moonshot|^k3(?:[-_.]|$)/i, 'kimi'],
   // Other model-specific icons
   [/grok/i, 'grok'],
   [/hailuo/i, 'hailuo'],


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Custom providers using Kimi Code's bare `k3` or `k3-256k` model IDs could not resolve the Kimi model icon, leaving the assistant avatar blank.

After this PR:

Bare Kimi K3 model IDs resolve to the Kimi icon while unrelated IDs such as `k3po` remain unmatched.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #17854

### Why we need it and why it was done in this way

The icon fallback chain identifies custom-provider models by model ID because a generated provider UUID has no catalog icon. Kimi Code exposes K3 as the bare IDs `k3` and `k3-256k`, which were not covered by the existing `kimi|moonshot` pattern. This change adds a start-anchored, delimiter-bounded K3 pattern to both the shared vendor taxonomy and the UI icon registry.

The following tradeoffs were made:

The matcher deliberately accepts only `k3` followed by the end of the ID or a known delimiter. This avoids treating arbitrary IDs containing `k3` as Kimi models.

The following alternatives were considered:

Falling back through a custom provider's display name or persisted logo metadata was considered, but it would broaden the model-avatar data flow for a pair of official, stable model IDs. A bounded vendor pattern is smaller and keeps capability/vendor detection aligned with icon routing.

Links to places where the discussion took place: #17854

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation performed without the repository-wide `pnpm test` suite:

- `pnpm exec vitest run src/components/icons/__tests__/registry.test.ts` (82 tests passed)
- Direct TypeScript assertions for `k3`, `k3-256k`, and the `k3po` negative case in `matchVendor`
- `pnpm lint`
- `pnpm format`
- `pnpm docs:check-links`
- `pnpm test:lint`

`pnpm build:check` was not completed because the current script includes the full `pnpm test` suite.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed missing Kimi model avatars for custom providers using the K3 model IDs.
```
