### PR TITLE
fix(skills): raise ZIP entry limit

### DIFF
--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -39,7 +39,7 @@ const CLAUDE_PLUGINS_API = 'https://api.claude-plugins.dev'
 
 // ZIP extraction limits
 const MAX_EXTRACTED_SIZE = 100 * 1024 * 1024 // 100MB
-const MAX_FILES_COUNT = 1000
+const MAX_FILES_COUNT = 2000
 const MAX_FOLDER_NAME_LENGTH = 80
 const SKILLS_PLUGIN_MANIFEST = `${JSON.stringify({ name: 'cherry-studio-skills' }, null, 2)}\n`
 const BUILTIN_VERSION_FILE = '.version'

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -11,6 +11,7 @@ import { agentSkillTable } from '@data/db/schemas/agentSkill'
 import { loggerService } from '@logger'
 import { findAllSkillDirectories, findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
 import { setupTestDatabase } from '@test-helpers/db'
+import AdmZip from 'adm-zip'
 import { eq } from 'drizzle-orm'
 import { net } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -680,6 +681,33 @@ describe('SkillService', () => {
 
       expect(extractZipSpy).toHaveBeenCalledWith(canonicalZipPath, extractDir)
       expect(installSkillDirSpy).toHaveBeenCalledWith(locatedSkillDir, 'zip', pathToFileURL(canonicalZipPath).href)
+    })
+
+    it('accepts ZIP archives containing 2,000 entries', async () => {
+      const skillService = new SkillService()
+      const root = await createTempDir('skill-zip-limit-')
+      const zipPath = path.join(root, 'limit.zip')
+      const extractDir = path.join(root, 'extract')
+      const zip = new AdmZip()
+      for (let index = 0; index < 2_000; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
+      zip.writeZip(zipPath)
+      await fs.promises.mkdir(extractDir)
+
+      await expect(skillService['extractZip'](zipPath, extractDir)).resolves.toBeUndefined()
+    })
+
+    it('rejects ZIP archives containing more than 2,000 entries', async () => {
+      const skillService = new SkillService()
+      const root = await createTempDir('skill-zip-limit-')
+      const zipPath = path.join(root, 'over-limit.zip')
+      const extractDir = path.join(root, 'extract')
+      const zip = new AdmZip()
+      for (let index = 0; index < 2_001; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
+      zip.writeZip(zipPath)
+
+      await expect(skillService['extractZip'](zipPath, extractDir)).rejects.toThrow(
+        'ZIP has too many files: 2001 exceeds 2000'
+      )
     })
 
     it('rejects a repository skill directory whose symlink resolves outside the clone', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

ZIP skill imports allowed at most 1,000 archive entries and rejected the archive when processing its 1,001st entry.

After this PR:

ZIP skill imports allow up to 2,000 archive entries and reject the archive when processing its 2,001st entry. Boundary tests cover both cases.

Fixes #

### Why we need it and why it was done in this way

Asset-heavy skills, including presentation-oriented skills, can legitimately contain more than 1,000 entries. Raising the entry limit preserves the ZIP bomb safeguard while accommodating these packages; the existing 100 MB extracted-size limit remains unchanged.

The following tradeoffs were made:

The allowed archive metadata and extraction workload can be up to twice the previous entry limit.

The following alternatives were considered:

Removing the entry limit was rejected because the count limit complements the extracted-size limit against archives containing many tiny files.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- `pnpm vitest run --project main src/main/ai/skills/__tests__/SkillService.test.ts` (66 tests passed)
- `pnpm lint`
- `pnpm format`

The full `pnpm test` and `pnpm build:check` suites were not run at the request of the submitter.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Increase the maximum number of entries in an imported skill ZIP from 1,000 to 2,000.
```
