### PR TITLE
fix(sidebar): normalize mini-app icon presentation

### DIFF
--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -376,7 +376,7 @@ describe('Sidebar resize handle', () => {
   })
 
   it('renders apps and direct mini app icons together in one full docked list', () => {
-    const { container } = render(
+    render(
       <Sidebar
         width={SIDEBAR_FULL_THRESHOLD}
         setWidth={vi.fn()}
@@ -393,15 +393,11 @@ describe('Sidebar resize handle', () => {
 
     expect(screen.getByText('Chat')).toBeInTheDocument()
     expect(screen.getByText('Qwen')).toBeInTheDocument()
-    expect(container.querySelector('[data-testid="resolved-mini-app-logo-avatar"]')).not.toBeInTheDocument()
-    expect(container.querySelector('[data-testid="resolved-mini-app-logo"]')).toHaveStyle({
-      width: '16px',
-      height: '16px'
-    })
+    expect(screen.getByLabelText('Qwen')).toBeInTheDocument()
   })
 
   it('gives docked mini apps the shared icon-row button sizing and hover styles', () => {
-    const { container } = render(
+    render(
       <Sidebar
         width={SIDEBAR_ICON_WIDTH}
         setWidth={vi.fn()}
@@ -416,10 +412,8 @@ describe('Sidebar resize handle', () => {
       />
     )
 
-    const miniAppLogo = container.querySelector('[data-testid="resolved-mini-app-logo"]')
-    const dockedMiniAppButton = miniAppLogo?.closest('button')
+    const dockedMiniAppButton = screen.getByRole('button', { name: 'Qwen' })
 
-    expect(miniAppLogo).toHaveStyle({ width: '22px', height: '22px' })
     expect(dockedMiniAppButton).toHaveClass('h-9', 'w-9')
     expect(dockedMiniAppButton).toHaveClass('hover:bg-accent/60', 'hover:text-foreground')
   })

--- a/src/renderer/components/Sidebar/primitives.tsx
+++ b/src/renderer/components/Sidebar/primitives.tsx
@@ -31,20 +31,19 @@ export function DefaultLogo({ title }: { title: string }) {
 }
 
 export function MiniAppIcon({ tab, size = 'sm' }: { tab: SidebarMiniAppTab; size?: MiniAppIconSize }) {
-  const pixelSize = size === 'sm' ? 14 : size === 'md' ? 16 : 22
+  const pixelSize = size === 'sm' ? 16 : size === 'md' ? 18 : 24
   const { miniApp } = tab
 
   if (miniApp.logo) {
-    return <MiniAppLogo app={{ logo: miniApp.logo, name: tab.title }} appearance="bare" size={pixelSize} />
+    return <MiniAppLogo app={{ logo: miniApp.logo, name: tab.title }} appearance="sidebar" size={pixelSize} />
   }
 
-  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : size === 'md' ? 'h-4 w-4' : 'h-[22px] w-[22px]'
-  const fontSize = size === 'sm' ? 'text-[6px]' : size === 'md' ? 'text-[8px]' : 'text-[11px]'
+  const fontSize = size === 'sm' ? 'text-[8px]' : size === 'md' ? 'text-[9px]' : 'text-xs'
 
   return (
     <div
-      className={`${iconSize} ${fontSize} flex flex-shrink-0 items-center justify-center rounded-[3px] text-white`}
-      style={{ background: miniApp.color ?? 'transparent' }}>
+      className={`${fontSize} flex flex-shrink-0 items-center justify-center rounded-full bg-muted text-white`}
+      style={{ width: pixelSize, height: pixelSize, background: miniApp.color }}>
       {tab.title?.[0] ?? ''}
     </div>
   )

--- a/src/renderer/components/icons/MiniAppIcon.tsx
+++ b/src/renderer/components/icons/MiniAppIcon.tsx
@@ -6,8 +6,8 @@ import { getIconDisplayConfig, miniAppContainedIcon } from './iconDisplayConfig'
 
 interface Props {
   app: Pick<MiniApp, 'logo' | 'logoSrc' | 'name' | 'background'>
-  /** `avatar` keeps the bordered Avatar chrome; `plain` uses launchpad sizing; `bare` leaves chrome to the caller. */
-  appearance?: 'avatar' | 'plain' | 'bare'
+  /** `avatar` keeps bordered Avatar chrome; `plain` uses launchpad sizing; `bare` is raw; `sidebar` is circular. */
+  appearance?: 'avatar' | 'plain' | 'bare' | 'sidebar'
   size?: number
   style?: React.CSSProperties
 }
@@ -27,9 +27,30 @@ const MiniAppIcon: FC<Props> = ({ app, appearance = 'avatar', size = 48, style }
     if (!Icon) {
       return (
         <span
-          className="flex shrink-0 items-center justify-center"
+          className={`flex shrink-0 items-center justify-center ${appearance === 'sidebar' ? 'overflow-hidden rounded-full border border-transparent bg-white/90 dark:border-border dark:bg-transparent' : ''}`}
           style={{ width: `${size}px`, height: `${size}px`, userSelect: 'none', ...style }}
         />
+      )
+    }
+    if (appearance === 'sidebar') {
+      const displayConfig = getIconDisplayConfig('mini-app', app.logo)
+      if (displayConfig?.scale && displayConfig.scale < 1) {
+        return <Icon.Avatar size={size} className="select-none" shape="circle" />
+      }
+
+      const iconScale = app.logo?.toLowerCase() === 'bolt' ? 1.3 : (displayConfig?.scale ?? 1)
+      const iconSize = size * iconScale
+
+      return (
+        <span
+          className="flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-transparent bg-white/90 dark:border-border dark:bg-transparent"
+          style={{ width: `${size}px`, height: `${size}px`, userSelect: 'none', ...style }}>
+          <Icon
+            aria-label={app.name || 'MiniApp Icon'}
+            className="select-none"
+            style={{ width: `${iconSize}px`, height: `${iconSize}px`, flexShrink: 0 }}
+          />
+        </span>
       )
     }
     if (appearance === 'plain' || appearance === 'bare') {
@@ -73,6 +94,29 @@ const MiniAppIcon: FC<Props> = ({ app, appearance = 'avatar', size = 48, style }
           draggable={false}
           alt={app.name || 'MiniApp Icon'}
         />
+      )
+    }
+    if (appearance === 'sidebar') {
+      const imageSize = size * 0.8
+
+      return (
+        <span
+          className="flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-transparent bg-white/90 dark:border-border dark:bg-transparent"
+          style={{
+            width: `${size}px`,
+            height: `${size}px`,
+            backgroundColor: app.background,
+            userSelect: 'none',
+            ...style
+          }}>
+          <img
+            src={src}
+            className="shrink-0 select-none object-contain"
+            style={{ width: `${imageSize}px`, height: `${imageSize}px` }}
+            draggable={false}
+            alt={app.name || 'MiniApp Icon'}
+          />
+        </span>
       )
     }
 

--- a/src/renderer/components/icons/iconDisplayConfig.ts
+++ b/src/renderer/components/icons/iconDisplayConfig.ts
@@ -14,6 +14,7 @@ const ICON_DISPLAY_CONFIG: Readonly<Record<IconDisplayContext, Readonly<Record<s
     abacus: miniAppContainedIcon,
     zeroone: miniAppContainedIcon,
     minimax: miniAppContainedIcon,
+    'radeon-cloud': miniAppContainedIcon,
     groq: miniAppContainedIcon,
     anthropic: miniAppContainedIcon,
     claude: miniAppContainedIcon,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Mini-app sidebar icons used inconsistent raw logo sizes, shapes, and backgrounds, causing some logos to appear clipped or visually smaller than others.

After this PR: Mini-app sidebar icons use a consistent circular presentation with normalized sizing, theme-aware badges for transparent logos, and contained handling for AMD GPU Cloud.

<img width="1336" height="924" alt="image" src="https://github.com/user-attachments/assets/b29093d9-6816-43b1-9255-2a89cc6e03ca" />

<img width="1338" height="924" alt="image" src="https://github.com/user-attachments/assets/ccd20a00-b346-40ef-b5b0-59fc7b8f9142" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Logos with complete branded backgrounds retain their generated avatar, while transparent logos use a circular wrapper with a subtle dark-mode border and automatic light/dark variants.

The following alternatives were considered: A single forced background and one-off per-brand styling were rejected because they reduced contrast or made icon treatment inconsistent.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validated in the live Electron app in light and dark themes; `pnpm format` and `pnpm lint` passed (37 existing warnings, 0 errors). Per the requested validation scope, `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Normalized mini-app sidebar icons so they render consistently without clipping across light and dark themes.
```
