### PR TITLE
fix(i18n): keep AI token as Token in Traditional Chinese

### DIFF
--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -1710,7 +1710,7 @@
         "request_duration": "生成時機",
         "text_generation": "文字生成",
         "text_output": "文字輸出",
-        "tokens": "{{value}} 代幣",
+        "tokens": "{{value}} Tokens",
         "tokens_per_second_value": "{{value}} Tokens/s",
         "total_duration": "端到端持續時間",
         "uncached": "未快取",
@@ -3622,7 +3622,7 @@
         "polish_variables_changed_description": "優化後的結果變更或移除了提示變數。請再試一次。",
         "polish_variables_changed_title": "無法應用優化提示",
         "title": "提示",
-        "tokens_label": "代幣：",
+        "tokens_label": "Tokens: ",
         "variables_description": "可在系統提示中插入這些系統變數；每次助手回覆前，系統會按當時的資訊自動填寫。",
         "variables_example": "例如：今天是 {{variable}}，會使用目前日期。",
         "variables_title": "系統變數",
@@ -8417,7 +8417,7 @@
       "metric": {
         "cost": "成本",
         "requests": "請求",
-        "tokens": "代幣"
+        "tokens": "Token"
       },
       "overview": {
         "title": "概述"
@@ -8434,7 +8434,7 @@
         "date": "日期",
         "model": "模型",
         "source": "來源",
-        "tokens": "代幣",
+        "tokens": "Token",
         "tps": "TPS",
         "tpsValue": "{{value}} tok/s",
         "ttft": "TTFT"


### PR DESCRIPTION
### What this PR does

Before this PR:
- Traditional Chinese (`zh-TW`) localized AI model "token" as 「代幣」 in several UI strings (message token details, prompt token label, usage analytics metric/table).

After this PR:
- Those strings keep the English form `Token` / `Tokens`, consistent with Simplified Chinese and the expected LLM terminology.

Fixes #18034

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Only the four strings that used the incorrect 「代幣」 translation were changed; other token-related wording (e.g. auth/API 「權杖」) was left untouched per scope.

The following alternatives were considered:
- Broader cleanup of other AI-token mistranslations (e.g. 「權杖」 / 「標記」) — deferred to keep the fix minimal and issue-scoped.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18034

### Breaking changes

None

### Special notes for your reviewer

- File: `src/renderer/i18n/translate/zh-tw.json`
- Value-only i18n string updates; no key structure changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(i18n): keep AI "token" as Token/Tokens in Traditional Chinese instead of 「代幣」
```
