### PR TITLE
fix(design-tokens): let the input border composite against its surface

### DIFF
--- a/packages/ui/src/styles/tokens/colors/providers.css
+++ b/packages/ui/src/styles/tokens/colors/providers.css
@@ -62,8 +62,11 @@
   --cs-primary-foreground: oklch(0.985 0 0);
   --cs-destructive-foreground: var(--cs-white);
 
-  /* Input border */
-  --cs-input: oklch(0.922 0 0);
+  /* Input border — shares the neutral border role so it composites against
+   * whatever surface it sits on (DESIGN.md: neutral surface tints are
+   * black/white + alpha). In light mode this resolves to the same pixel the
+   * old fixed oklch(0.922) produced on white. */
+  --cs-input: var(--cs-border);
 
   /* Sidebar sub-palette */
   --cs-sidebar-foreground: oklch(0.145 0 0);
@@ -142,8 +145,10 @@
   --cs-primary-foreground: oklch(0.205 0 0);
   --cs-destructive-foreground: var(--cs-white);
 
-  /* Input border */
-  --cs-input: oklch(0.269 0 0);
+  /* Input border — see the light-mode note. The old fixed oklch(0.269) was
+   * stock Shadcn: it did not react to the surface, so it vanished entirely on
+   * popovers (identical lightness) and read weaker than every other border. */
+  --cs-input: var(--cs-border);
 
   /* Sidebar sub-palette */
   --cs-sidebar-foreground: oklch(0.985 0 0);


### PR DESCRIPTION
### What this PR does

Before this PR:

`--cs-input` was the one neutral border token still carrying stock Shadcn's fixed opaque greys — `oklch(0.922 0 0)` in light, `oklch(0.269 0 0)` in dark — inherited verbatim from #17182. Every other border role (`--cs-border`, `--cs-border-subtle`, `--cs-border-strong`, `--cs-border-selected`) had already moved to black/white + alpha so it composites against the surface beneath it, per DESIGN.md's Colour Model.

Light mode masked the divergence: black at 10% over white resolves to `rgb(229,229,229)`, the same pixel `oklch(0.922)` produces. Dark mode did not:

| Input border in dark | Contrast |
| --- | --- |
| On a dialog card (`oklch(0.2)`) | 1.20:1 |
| On a popover (`oklch(0.27)`) | **1.00:1 — identical to the surface, no border at all** |

The popover case is the visible bug: the built-in icon picker's search field, and any input inside a dropdown, rendered with no outline whatsoever. Meanwhile a `SelectTrigger` in the same form draws from `--border` and stays visible, so a single form was rendering two different border systems.

After this PR:

`--cs-input` resolves to `var(--cs-border)` in both themes.

- **Light mode is unchanged to the pixel.** Borders resolve to `rgb(229,229,229)` before and after; the `bg-input/30` fill resolves to `rgb(247,247,247)` before and after.
- **Dark mode**: 1.00:1 → 1.37:1 on popovers, and parity with every other border elsewhere (1.31:1 on cards, same as `SelectTrigger`).

Fixes #

### Why we need it and why it was done in this way

The token is the right layer. 22 call sites use `border-input`; fixing them individually would leave the token wrong and let the next component reintroduce the problem.

The following tradeoffs were made:

- **`--input` does double duty as a fill** (`bg-input/30` in `input.tsx` / `select.tsx` / `tabs.tsx` / `AppearanceSettings.tsx`; `bg-input` in `tree-select.tsx` / `button-group.tsx`). Moving it to an alpha value turns `/30` into alpha-times-alpha (0.1 × 0.3 = 0.03). Every one of the six was measured: light mode is pixel-identical, and on opaque dark surfaces the delta is ≤7/255 — below the just-noticeable threshold. On a popover the fill actually improves, because the old value was the popover's own colour.
- **Dark theme + transparent window + a bright wallpaper is the one place the fill and border read weaker than before**, since an alpha colour washes out over a bright composite where a fixed dark grey did not. This is not new behaviour being introduced: on the provider settings page in dark mode, all 70 rendered borders were already white-alpha (`/0.1` and `/0.05`). Inputs were the sole exception, which is exactly why they were invisible on popovers. This change makes them behave like everything else.
- **Dark-mode borders remain ~1.31–1.45:1, below the 3:1 WCAG 1.4.11 asks for UI component boundaries.** That is the app-wide baseline for every border, not something specific to inputs. Raising it is a separate, deliberate decision affecting every surface; this PR only pulls inputs back up to the baseline instead of leaving them below it.

The following alternatives were considered:

- Swapping `border-input` for `border-border` at all 22 call sites — leaves the token wrong and invites regression.
- Pointing inputs at `--border-strong` (white 20%, 1.89:1) — more visible, but breaks parity with `SelectTrigger` in the other direction and quietly raises inputs above the system baseline.

Links to places where the discussion took place: N/A

### Breaking changes

None. No public API changes; light mode is pixel-identical.

### Special notes for your reviewer

- The `--cs-input` → `--cs-border` reference is foundation-to-foundation and acyclic, so `check-theme-contract` passes. `theme.css` only forwards `--color-input: var(--input)` and needs no regeneration. Nothing in the repo pins the two old literals.
- Known follow-up, deliberately **not** in this PR: `--cs-sidebar-border` has the identical defect (light `oklch(0.922)` / dark `oklch(0.269)`, both stock Shadcn). In dark it measures 1.10:1 against `bg-sidebar`. Its only production consumer is `ResourceList.tsx:100`.
- Verified in a running dev build in both themes; contrast figures above are measured from the live renderer, not computed by hand.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed input field borders being invisible inside dropdowns and popovers in dark mode.
```
