### PR TITLE
fix(quick-panel): filter submenu panels from the composer input

### DIFF
--- a/src/renderer/components/QuickPanel/QuickPanelView.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelView.tsx
@@ -306,27 +306,6 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     consumeInputQuery()
   }, [consumeInputQuery])
 
-  const consumeInputTriggerSymbol = useCallback(() => {
-    if (!inputAdapter) return
-
-    const queryAnchor = queryAnchorRef.current ?? ctx.queryAnchor
-    if (queryAnchor === undefined) return
-
-    const text = inputAdapter.getText()
-    const cursorOffset = inputAdapter.getCursorOffset?.() ?? text.length
-    if (cursorOffset <= queryAnchor) return
-
-    if (!inputTriggerSymbol) return
-
-    const triggerSymbol = text.slice(queryAnchor, queryAnchor + inputTriggerSymbol.length)
-    if (triggerSymbol !== inputTriggerSymbol) return
-
-    inputTriggerConsumedRef.current = true
-    inputAdapter.deleteTriggerRange({ from: queryAnchor, to: queryAnchor + inputTriggerSymbol.length })
-    queryAnchorRef.current = queryAnchor
-    setInputSearchText(text.slice(queryAnchor + inputTriggerSymbol.length, cursorOffset))
-  }, [ctx.queryAnchor, inputAdapter, inputTriggerSymbol])
-
   const handleItemAction = useCallback(
     (item: QuickPanelListItem, action?: QuickPanelCloseAction) => {
       // Read-only panels (e.g. MCP status) stay non-interactive, except for pinned footer actions
@@ -378,7 +357,9 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
         if (ctx.triggerInfo?.type === 'button' && ctx.trackInputQuery) {
           consumeInputQueryOnce()
         } else {
-          consumeInputTriggerSymbol()
+          // Drop the whole trigger query so the submenu starts with an empty search.
+          inputTriggerConsumedRef.current = true
+          consumeInputQuery()
         }
       } else {
         consumeInputQuery()
@@ -405,7 +386,6 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       activeSearchQuery,
       getCurrentPanelOptions,
       activeIndex,
-      consumeInputTriggerSymbol,
       consumeInputQuery,
       consumeInputQueryOnce,
       inputAdapter,

--- a/src/renderer/components/__tests__/QuickPanelView.test.tsx
+++ b/src/renderer/components/__tests__/QuickPanelView.test.tsx
@@ -555,7 +555,7 @@ describe('QuickPanelView', () => {
       await waitFor(() => expect(screen.getByTestId('quick-panel')).not.toHaveClass('visible'))
     })
 
-    it('removes the trigger slash when opening a child panel without filtering the child panel', async () => {
+    it('removes the whole trigger query when opening a child panel so the child starts unfiltered', async () => {
       const input = createInputAdapter('/Child')
       const childAction = vi.fn()
       const rootItem: QuickPanelListItem = {
@@ -570,7 +570,8 @@ describe('QuickPanelView', () => {
             symbol: 'child',
             parentPanel,
             queryAnchor,
-            triggerInfo: context.triggerInfo
+            triggerInfo: { type: 'button' },
+            trackInputQuery: true
           })
         }
       }
@@ -584,13 +585,52 @@ describe('QuickPanelView', () => {
 
       fireEvent.keyDown(screen.getByTestId('quick-panel-body'), { key: 'Enter' })
 
-      expect(input.adapter.deleteTriggerRange).toHaveBeenCalledWith({ from: 0, to: 1 })
+      expect(input.adapter.deleteTriggerRange).toHaveBeenCalledWith({ from: 0, to: 6 })
+      expect(input.adapter.getText()).toBe('')
       await waitFor(() => expect(screen.getByText('Server 1')).toBeInTheDocument())
 
       fireEvent.keyDown(screen.getByTestId('quick-panel-body'), { key: 'Enter' })
 
-      expect(input.adapter.deleteTriggerRange).toHaveBeenLastCalledWith({ from: 0, to: 5 })
       expect(childAction).toHaveBeenCalledWith(expect.objectContaining({ action: 'enter', searchText: '' }))
+    })
+
+    it('filters a child panel from text typed after it opens', async () => {
+      const input = createInputAdapter('/Child')
+      const rootItem: QuickPanelListItem = {
+        label: 'Root',
+        filterText: 'Root Child',
+        icon: 'root',
+        isMenu: true,
+        action: ({ context, parentPanel, queryAnchor }) => {
+          context.open({
+            title: 'Child Panel',
+            list: [
+              { label: 'Alpha', filterText: 'Alpha', icon: 'a' },
+              { label: 'Beta', filterText: 'Beta', icon: 'b' }
+            ],
+            symbol: 'child',
+            parentPanel,
+            queryAnchor,
+            triggerInfo: { type: 'button' },
+            trackInputQuery: true
+          })
+        }
+      }
+
+      renderOpenPanel({
+        input,
+        list: [rootItem],
+        symbol: '/',
+        triggerInfo: { type: 'input', position: 0, originalText: '/Child' }
+      })
+
+      fireEvent.keyDown(screen.getByTestId('quick-panel-body'), { key: 'Enter' })
+      await waitFor(() => expect(screen.getByText('Alpha')).toBeInTheDocument())
+
+      input.setText('Beta')
+
+      await waitFor(() => expect(screen.queryByText('Alpha')).not.toBeInTheDocument())
+      expect(screen.getByText('Beta')).toBeInTheDocument()
     })
 
     it('does not filter non-root multi-select panels from composer input changes', async () => {

--- a/src/renderer/components/composer/quickPanel/__tests__/unifiedPanel.test.ts
+++ b/src/renderer/components/composer/quickPanel/__tests__/unifiedPanel.test.ts
@@ -544,7 +544,8 @@ describe('createUnifiedQuickPanelOpenOptions', () => {
         symbol: 'thinking',
         parentPanel: options,
         queryAnchor: 0,
-        triggerInfo: { type: 'input', position: 0, originalText: '/think' },
+        triggerInfo: { type: 'button' },
+        trackInputQuery: true,
         list: [expect.objectContaining({ label: 'Low' })]
       })
     )

--- a/src/renderer/components/composer/quickPanel/unifiedPanel.ts
+++ b/src/renderer/components/composer/quickPanel/unifiedPanel.ts
@@ -370,7 +370,9 @@ function openUnifiedPanelSubmenu(
     symbol: launcher.id,
     parentPanel: options.parentPanel,
     queryAnchor: options.queryAnchor,
-    triggerInfo: options.triggerInfo ?? { type: 'button' }
+    // A submenu is opened by a selection, so its query starts empty and is typed, not triggered.
+    triggerInfo: { type: 'button' },
+    trackInputQuery: true
   })
 }
 

--- a/src/renderer/components/composer/tools/components/KnowledgeBaseButton.tsx
+++ b/src/renderer/components/composer/tools/components/KnowledgeBaseButton.tsx
@@ -176,7 +176,8 @@ const useKnowledgeBaseToolController = ({
         symbol: ComposerPanelSymbol.KnowledgeBase,
         parentPanel,
         queryAnchor: inputQueryCleared ? undefined : queryAnchor,
-        triggerInfo: inputQueryCleared ? { type: 'button' } : (triggerInfo ?? { type: 'button' }),
+        triggerInfo: { type: 'button' },
+        trackInputQuery: true,
         multiple: true,
         onClose: disposeCloseOnInputAfterSelection
       })

--- a/src/renderer/components/composer/tools/components/QuickPhrasesButton.tsx
+++ b/src/renderer/components/composer/tools/components/QuickPhrasesButton.tsx
@@ -180,7 +180,8 @@ const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
     () => ({
       title: t('settings.prompts.title'),
       list: phraseItems,
-      symbol: ComposerPanelSymbol.QuickPhrases
+      symbol: ComposerPanelSymbol.QuickPhrases,
+      trackInputQuery: true
     }),
     [phraseItems, t]
   )
@@ -198,12 +199,12 @@ const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
   }, [isQuickPanelVisible, phraseItems, quickPanelSymbol, updateQuickPanelList])
 
   const openQuickPanel = useCallback(
-    (parentPanel?: QuickPanelOpenOptions, queryAnchor?: number, triggerInfo?: QuickPanelOpenOptions['triggerInfo']) => {
+    (parentPanel?: QuickPanelOpenOptions, queryAnchor?: number) => {
       openQuickPanelContext({
         ...quickPanelOpenOptionsRef.current,
         parentPanel,
         queryAnchor,
-        triggerInfo
+        triggerInfo: { type: 'button' }
       })
     },
     [openQuickPanelContext]
@@ -217,9 +218,9 @@ const useQuickPhrasesToolController = ({ launcher, setInputValue }: Props) => {
         label: t('settings.prompts.title'),
         description: '',
         searchAliases: getQuickPanelSearchAliases(t, 'settings.prompts.title'),
-        action: ({ parentPanel, queryAnchor, triggerInfo }) => {
+        action: ({ parentPanel, queryAnchor }) => {
           setPromptsEnabled(true)
-          openQuickPanel(parentPanel, queryAnchor, triggerInfo)
+          openQuickPanel(parentPanel, queryAnchor)
         }
       }
     ])

--- a/src/renderer/components/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
@@ -148,7 +148,8 @@ describe('QuickPhrasesToolRuntime', () => {
         parentPanel,
         queryAnchor: 0,
         symbol: 'quick-phrases',
-        triggerInfo
+        triggerInfo: { type: 'button' },
+        trackInputQuery: true
       })
     )
   })

--- a/src/renderer/components/composer/tools/definitions/mcpStatusTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/mcpStatusTool.tsx
@@ -277,7 +277,8 @@ export function createMcpStatusLauncher(
         symbol: ComposerPanelSymbol.McpStatus,
         parentPanel,
         queryAnchor,
-        triggerInfo: triggerInfo ?? { type: 'button' },
+        triggerInfo: { type: 'button' },
+        trackInputQuery: true,
         readOnly: !editable
       })
     }

--- a/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/noteReferenceTool.tsx
@@ -124,7 +124,7 @@ export const NoteReferenceComposerRuntime = ({ context }: { context: NoteReferen
   }, [isVisible, panelItems, symbol, updateList])
 
   const openNoteReferencePanel = useCallback<NonNullable<ComposerToolLauncher['action']>>(
-    ({ parentPanel, queryAnchor, quickPanel, triggerInfo }) => {
+    ({ parentPanel, queryAnchor, quickPanel }) => {
       setDataRequested(true)
       setResolvedNotesPath(undefined)
       setPathError(null)
@@ -139,7 +139,8 @@ export const NoteReferenceComposerRuntime = ({ context }: { context: NoteReferen
         symbol: ComposerPanelSymbol.Notes,
         parentPanel,
         queryAnchor,
-        triggerInfo: triggerInfo ?? { type: 'button' }
+        triggerInfo: { type: 'button' },
+        trackInputQuery: true
       })
     },
     [notesPath, panelItems, t]

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -996,7 +996,7 @@ const AgentComposerInner = ({
       searchAliases: [skillLabel],
       panelSymbol: AGENT_SKILLS_LAUNCHER_ID,
       rootSearchItems: skillItems,
-      action: ({ parentPanel, queryAnchor, quickPanel, triggerInfo }) => {
+      action: ({ parentPanel, queryAnchor, quickPanel }) => {
         void refreshAvailableSkills().catch((error) => {
           logger.warn('Failed to refresh available skills when opening the skills panel', { error })
         })
@@ -1006,7 +1006,8 @@ const AgentComposerInner = ({
           symbol: AGENT_SKILLS_LAUNCHER_ID,
           parentPanel,
           queryAnchor,
-          triggerInfo: triggerInfo ?? { type: 'button' }
+          triggerInfo: { type: 'button' },
+          trackInputQuery: true
         })
       }
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: only the root quick panel filtered as you typed in the composer. Every panel one level down — knowledge base, quick phrases, notes, MCP status, agent skills and all launcher submenus — ignored the typed text and showed its full list, and drilling in from `/知识库` left the parent query text sitting in the composer.

After this PR: submenu panels open as tracked button panels (`trackInputQuery: true`), and the parent consumes its whole trigger query before opening the child, so a submenu starts with an empty search and narrows as you type.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

`QuickPanelOpenOptions.trackInputQuery` is opt-in and only the root panel and the `@` mention panel ever set it, so `QuickPanelView` short-circuited filtering for every other panel. Opening a submenu previously deleted only the trigger symbol and handed the remaining query down as the child's search text, which could never match the child's rows — so the child now starts clean instead.

The following tradeoffs were made: each submenu open site opts in explicitly rather than flipping the provider default to `trackInputQuery ?? true`.

The following alternatives were considered: flipping that default, which was implemented and reverted — a panel opened by a leaf action that forwards an `input` trigger closes itself the moment the trigger character is gone (caught by the existing "does not close a replacement panel opened by a leaf action" test).

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Renderer-only. `consumeInputTriggerSymbol` in `QuickPanelView` is deleted because nothing calls it any more.
- Verified in a running Electron instance: quick phrases 7 → 3 rows for `go`, knowledge base 12 → 6 for `rag`, composer cleared on drill-in; root `/` panel, `@` mentions and the read-only MCP status panel unchanged.
- Validation: `pnpm lint` (oxlint + eslint + typecheck + i18n + format) and the QuickPanel/composer Vitest suites pass. The two `ComposerSurface` height tests that fail locally also fail on unmodified `main`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed quick panel submenus (knowledge base, quick phrases, notes, MCP, skills) not filtering as you type in the composer.
```
