### PR TITLE
feat(minimax-model): adding more price estimation functions and add minimax priority mode switch

### DIFF
--- a/migrations/sqlite-drizzle/0006_black_ezekiel.sql
+++ b/migrations/sqlite-drizzle/0006_black_ezekiel.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_model` ADD `use_priority_service_tier` integer DEFAULT false NOT NULL;

--- a/migrations/sqlite-drizzle/meta/0006_snapshot.json
+++ b/migrations/sqlite-drizzle/meta/0006_snapshot.json
@@ -1,0 +1,4585 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6859baad-a644-4574-9342-20049f0b1cf5",
+  "prevId": "ed05e43e-0dd4-41c7-80c8-bf99cc02c6de",
+  "tables": {
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_model": {
+          "name": "plan_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "small_model": {
+          "name": "small_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_name_idx": {
+          "name": "agent_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "agent_type_idx": {
+          "name": "agent_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_order_key_idx": {
+          "name": "agent_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_model_user_model_id_fk": {
+          "name": "agent_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_plan_model_user_model_id_fk": {
+          "name": "agent_plan_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["plan_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_small_model_user_model_id_fk": {
+          "name": "agent_small_model_user_model_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user_model",
+          "columnsFrom": ["small_model"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel": {
+      "name": "agent_channel",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace": {
+          "name": "workspace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "active_chat_ids": {
+          "name": "active_chat_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_agent_id_idx": {
+          "name": "agent_channel_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_channel_type_idx": {
+          "name": "agent_channel_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "agent_channel_session_id_idx": {
+          "name": "agent_channel_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_agent_id_agent_id_fk": {
+          "name": "agent_channel_agent_id_agent_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_channel_session_id_agent_session_id_fk": {
+          "name": "agent_channel_session_id_agent_session_id_fk",
+          "tableFrom": "agent_channel",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_channel_task": {
+      "name": "agent_channel_task",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_channel_task_channel_id_idx": {
+          "name": "agent_channel_task_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "agent_channel_task_task_id_idx": {
+          "name": "agent_channel_task_task_id_idx",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_channel_task_channel_id_agent_channel_id_fk": {
+          "name": "agent_channel_task_channel_id_agent_channel_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "agent_channel",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_channel_task_task_id_job_schedule_id_fk": {
+          "name": "agent_channel_task_task_id_job_schedule_id_fk",
+          "tableFrom": "agent_channel_task",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_channel_task_channel_id_task_id_pk": {
+          "columns": ["channel_id", "task_id"],
+          "name": "agent_channel_task_channel_id_task_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_global_skill": {
+      "name": "agent_global_skill",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder_name": {
+          "name": "folder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_global_skill_folder_name_unique": {
+          "name": "agent_global_skill_folder_name_unique",
+          "columns": ["folder_name"],
+          "isUnique": true
+        },
+        "agent_global_skill_source_idx": {
+          "name": "agent_global_skill_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "agent_global_skill_is_enabled_idx": {
+          "name": "agent_global_skill_is_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session": {
+      "name": "agent_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_schedule_id": {
+          "name": "task_schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_taskScheduleId_unique": {
+          "name": "agent_session_taskScheduleId_unique",
+          "columns": ["task_schedule_id"],
+          "isUnique": true
+        },
+        "agent_session_order_key_idx": {
+          "name": "agent_session_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        },
+        "agent_session_updated_at_idx": {
+          "name": "agent_session_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_session_agent_id_agent_id_fk": {
+          "name": "agent_session_agent_id_agent_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_session_workspace_id_agent_workspace_id_fk": {
+          "name": "agent_session_workspace_id_agent_workspace_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "agent_workspace",
+          "columnsFrom": ["workspace_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_task_schedule_id_job_schedule_id_fk": {
+          "name": "agent_session_task_schedule_id_job_schedule_id_fk",
+          "tableFrom": "agent_session",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["task_schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_session_message": {
+      "name": "agent_session_message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_snapshot": {
+          "name": "message_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "runtime_resume_token": {
+          "name": "runtime_resume_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_session_message_session_created_id_idx": {
+          "name": "agent_session_message_session_created_id_idx",
+          "columns": ["session_id", "created_at", "id"],
+          "isUnique": false
+        },
+        "agent_session_message_status_idx": {
+          "name": "agent_session_message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agent_session_message_fts_rowid_uniq": {
+          "name": "agent_session_message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "agent_session_message_session_id_agent_session_id_fk": {
+          "name": "agent_session_message_session_id_agent_session_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "agent_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_session_message_model_id_user_model_id_fk": {
+          "name": "agent_session_message_model_id_user_model_id_fk",
+          "tableFrom": "agent_session_message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_session_message_role_check": {
+          "name": "agent_session_message_role_check",
+          "value": "\"agent_session_message\".\"role\" IN ('user', 'assistant', 'system')"
+        },
+        "agent_session_message_status_check": {
+          "name": "agent_session_message_status_check",
+          "value": "\"agent_session_message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        }
+      }
+    },
+    "agent_skill": {
+      "name": "agent_skill",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_skill_agent_id_idx": {
+          "name": "agent_skill_agent_id_idx",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "agent_skill_skill_id_idx": {
+          "name": "agent_skill_skill_id_idx",
+          "columns": ["skill_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_skill_agent_id_agent_id_fk": {
+          "name": "agent_skill_agent_id_agent_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_skill_skill_id_agent_global_skill_id_fk": {
+          "name": "agent_skill_skill_id_agent_global_skill_id_fk",
+          "tableFrom": "agent_skill",
+          "tableTo": "agent_global_skill",
+          "columnsFrom": ["skill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_skill_agent_id_skill_id_pk": {
+          "columns": ["agent_id", "skill_id"],
+          "name": "agent_skill_agent_id_skill_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_workspace": {
+      "name": "agent_workspace",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agent_workspace_path_unique_idx": {
+          "name": "agent_workspace_path_unique_idx",
+          "columns": ["path"],
+          "isUnique": true
+        },
+        "agent_workspace_order_key_idx": {
+          "name": "agent_workspace_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agent_workspace_type_check": {
+          "name": "agent_workspace_type_check",
+          "value": "\"agent_workspace\".\"type\" IN ('user', 'system')"
+        }
+      }
+    },
+    "ai_usage_record": {
+      "name": "ai_usage_record",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "record_kind": {
+          "name": "record_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_kind": {
+          "name": "message_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_name": {
+          "name": "provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_name": {
+          "name": "model_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_icon": {
+          "name": "source_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_label": {
+          "name": "api_key_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_masked": {
+          "name": "api_key_masked",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key_attribution": {
+          "name": "api_key_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_cache_tokens": {
+          "name": "no_cache_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_source": {
+          "name": "cost_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_breakdown": {
+          "name": "cost_breakdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing_snapshot": {
+          "name": "pricing_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_first_token_ms": {
+          "name": "time_first_token_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_completion_ms": {
+          "name": "time_completion_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_thinking_ms": {
+          "name": "time_thinking_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usage_record_request_id_idx": {
+          "name": "ai_usage_record_request_id_idx",
+          "columns": ["request_id"],
+          "isUnique": true
+        },
+        "ai_usage_record_created_at_idx": {
+          "name": "ai_usage_record_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_message_created_idx": {
+          "name": "ai_usage_record_message_created_idx",
+          "columns": ["message_kind", "message_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_provider_created_idx": {
+          "name": "ai_usage_record_provider_created_idx",
+          "columns": ["provider_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_model_created_idx": {
+          "name": "ai_usage_record_model_created_idx",
+          "columns": ["model_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_api_key_created_idx": {
+          "name": "ai_usage_record_api_key_created_idx",
+          "columns": ["api_key_id", "created_at"],
+          "isUnique": false
+        },
+        "ai_usage_record_source_created_idx": {
+          "name": "ai_usage_record_source_created_idx",
+          "columns": ["source_type", "source_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ai_usage_record_record_kind_check": {
+          "name": "ai_usage_record_record_kind_check",
+          "value": "\"ai_usage_record\".\"record_kind\" IN ('invocation', 'legacy-aggregate')"
+        },
+        "ai_usage_record_message_kind_check": {
+          "name": "ai_usage_record_message_kind_check",
+          "value": "\"ai_usage_record\".\"message_kind\" IN ('chat', 'agent-session')"
+        },
+        "ai_usage_record_source_type_check": {
+          "name": "ai_usage_record_source_type_check",
+          "value": "\"ai_usage_record\".\"source_type\" IN ('assistant', 'agent')"
+        },
+        "ai_usage_record_modality_check": {
+          "name": "ai_usage_record_modality_check",
+          "value": "\"ai_usage_record\".\"modality\" IN ('language', 'embedding', 'image', 'rerank')"
+        },
+        "ai_usage_record_attribution_check": {
+          "name": "ai_usage_record_attribution_check",
+          "value": "\"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched', 'auth', 'unknown')"
+        },
+        "ai_usage_record_auth_method_check": {
+          "name": "ai_usage_record_auth_method_check",
+          "value": "\"ai_usage_record\".\"auth_method\" IN ('oauth', 'external-cli', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure')"
+        },
+        "ai_usage_record_cost_source_check": {
+          "name": "ai_usage_record_cost_source_check",
+          "value": "\"ai_usage_record\".\"cost_source\" IN ('provider', 'computed')"
+        },
+        "ai_usage_record_cost_currency_check": {
+          "name": "ai_usage_record_cost_currency_check",
+          "value": "\"ai_usage_record\".\"cost_currency\" IN ('USD', 'CNY')"
+        },
+        "ai_usage_record_kind_identity_check": {
+          "name": "ai_usage_record_kind_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"record_kind\" = 'invocation'\n        AND \"ai_usage_record\".\"request_count\" = 1\n        AND \"ai_usage_record\".\"provider_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"model_id\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"record_kind\" = 'legacy-aggregate'\n        AND \"ai_usage_record\".\"request_count\" >= 1\n        AND \"ai_usage_record\".\"message_kind\" IS NOT NULL\n        AND \"ai_usage_record\".\"message_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_message_identity_check": {
+          "name": "ai_usage_record_message_identity_check",
+          "value": "(\"ai_usage_record\".\"message_kind\" IS NULL AND \"ai_usage_record\".\"message_id\" IS NULL)\n        OR (\"ai_usage_record\".\"message_kind\" IS NOT NULL AND \"ai_usage_record\".\"message_id\" IS NOT NULL)"
+        },
+        "ai_usage_record_source_identity_check": {
+          "name": "ai_usage_record_source_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"source_type\" IS NULL\n        AND \"ai_usage_record\".\"source_id\" IS NULL\n        AND \"ai_usage_record\".\"source_name\" IS NULL\n        AND \"ai_usage_record\".\"source_icon\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"source_type\" IS NOT NULL\n        AND \"ai_usage_record\".\"source_id\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_api_key_identity_check": {
+          "name": "ai_usage_record_api_key_identity_check",
+          "value": "(\n        \"ai_usage_record\".\"api_key_attribution\" IN ('explicit', 'matched')\n        AND \"ai_usage_record\".\"api_key_id\" IS NOT NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'auth'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NOT NULL\n      ) OR (\n        \"ai_usage_record\".\"api_key_attribution\" = 'unknown'\n        AND \"ai_usage_record\".\"api_key_id\" IS NULL\n        AND \"ai_usage_record\".\"api_key_label\" IS NULL\n        AND \"ai_usage_record\".\"api_key_masked\" IS NULL\n        AND \"ai_usage_record\".\"auth_method\" IS NULL\n      )"
+        },
+        "ai_usage_record_cost_tuple_check": {
+          "name": "ai_usage_record_cost_tuple_check",
+          "value": "(\n        \"ai_usage_record\".\"cost\" IS NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NULL\n        AND \"ai_usage_record\".\"cost_breakdown\" IS NULL\n      ) OR (\n        \"ai_usage_record\".\"cost\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_currency\" IS NOT NULL\n        AND \"ai_usage_record\".\"cost_source\" IS NOT NULL\n      )"
+        },
+        "ai_usage_record_image_count_check": {
+          "name": "ai_usage_record_image_count_check",
+          "value": "(\n        \"ai_usage_record\".\"modality\" = 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NOT NULL\n        AND \"ai_usage_record\".\"image_count\" >= 0\n      ) OR (\n        \"ai_usage_record\".\"modality\" <> 'image'\n        AND \"ai_usage_record\".\"image_count\" IS NULL\n      )"
+        },
+        "ai_usage_record_nonnegative_check": {
+          "name": "ai_usage_record_nonnegative_check",
+          "value": "\n        (\"ai_usage_record\".\"input_tokens\" IS NULL OR \"ai_usage_record\".\"input_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR \"ai_usage_record\".\"output_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR \"ai_usage_record\".\"total_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR \"ai_usage_record\".\"reasoning_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR \"ai_usage_record\".\"no_cache_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR \"ai_usage_record\".\"cache_read_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR \"ai_usage_record\".\"cache_write_tokens\" >= 0)\n        AND (\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" >= 0)\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR \"ai_usage_record\".\"time_first_token_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR \"ai_usage_record\".\"time_completion_ms\" >= 0)\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR \"ai_usage_record\".\"time_thinking_ms\" >= 0)\n      "
+        },
+        "ai_usage_record_integer_check": {
+          "name": "ai_usage_record_integer_check",
+          "value": "\n        typeof(\"ai_usage_record\".\"request_count\") = 'integer'\n        AND (\"ai_usage_record\".\"input_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"input_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"output_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"output_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"total_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"total_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"reasoning_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"reasoning_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"no_cache_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"no_cache_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_read_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_read_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"cache_write_tokens\" IS NULL OR typeof(\"ai_usage_record\".\"cache_write_tokens\") = 'integer')\n        AND (\"ai_usage_record\".\"image_count\" IS NULL OR typeof(\"ai_usage_record\".\"image_count\") = 'integer')\n        AND (\"ai_usage_record\".\"time_first_token_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_first_token_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_completion_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_completion_ms\") = 'integer')\n        AND (\"ai_usage_record\".\"time_thinking_ms\" IS NULL OR typeof(\"ai_usage_record\".\"time_thinking_ms\") = 'integer')\n        AND typeof(\"ai_usage_record\".\"created_at\") = 'integer'\n      "
+        },
+        "ai_usage_record_finite_cost_check": {
+          "name": "ai_usage_record_finite_cost_check",
+          "value": "\"ai_usage_record\".\"cost\" IS NULL OR \"ai_usage_record\".\"cost\" <= 1.7976931348623157e308"
+        }
+      }
+    },
+    "app_state": {
+      "name": "app_state",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant": {
+      "name": "assistant",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistant_created_at_idx": {
+          "name": "assistant_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "assistant_order_key_idx": {
+          "name": "assistant_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistant_model_id_user_model_id_fk": {
+          "name": "assistant_model_id_user_model_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "assistant_group_id_group_id_fk": {
+          "name": "assistant_group_id_group_id_fk",
+          "tableFrom": "assistant",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_knowledge_base": {
+      "name": "agent_knowledge_base",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_knowledge_base_agent_id_agent_id_fk": {
+          "name": "agent_knowledge_base_agent_id_agent_id_fk",
+          "tableFrom": "agent_knowledge_base",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "agent_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "agent_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_knowledge_base_agent_id_knowledge_base_id_pk": {
+          "columns": ["agent_id", "knowledge_base_id"],
+          "name": "agent_knowledge_base_agent_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_mcp_server": {
+      "name": "agent_mcp_server",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_mcp_server_agent_id_agent_id_fk": {
+          "name": "agent_mcp_server_agent_id_agent_id_fk",
+          "tableFrom": "agent_mcp_server",
+          "tableTo": "agent",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "agent_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "agent_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_mcp_server_agent_id_mcp_server_id_pk": {
+          "columns": ["agent_id", "mcp_server_id"],
+          "name": "agent_mcp_server_agent_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_knowledge_base": {
+      "name": "assistant_knowledge_base",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "knowledge_base_id": {
+          "name": "knowledge_base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_knowledge_base_assistant_id_assistant_id_fk": {
+          "name": "assistant_knowledge_base_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk": {
+          "name": "assistant_knowledge_base_knowledge_base_id_knowledge_base_id_fk",
+          "tableFrom": "assistant_knowledge_base",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["knowledge_base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_knowledge_base_assistant_id_knowledge_base_id_pk": {
+          "columns": ["assistant_id", "knowledge_base_id"],
+          "name": "assistant_knowledge_base_assistant_id_knowledge_base_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistant_mcp_server": {
+      "name": "assistant_mcp_server",
+      "columns": {
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "assistant_mcp_server_assistant_id_assistant_id_fk": {
+          "name": "assistant_mcp_server_assistant_id_assistant_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "assistant_mcp_server_mcp_server_id_mcp_server_id_fk": {
+          "name": "assistant_mcp_server_mcp_server_id_mcp_server_id_fk",
+          "tableFrom": "assistant_mcp_server",
+          "tableTo": "mcp_server",
+          "columnsFrom": ["mcp_server_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "assistant_mcp_server_assistant_id_mcp_server_id_pk": {
+          "columns": ["assistant_id", "mcp_server_id"],
+          "name": "assistant_mcp_server_assistant_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_entry": {
+      "name": "file_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_path": {
+          "name": "external_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cleanup_policy": {
+          "name": "cleanup_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "fe_deleted_at_idx": {
+          "name": "fe_deleted_at_idx",
+          "columns": ["deleted_at"],
+          "isUnique": false
+        },
+        "fe_created_at_idx": {
+          "name": "fe_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "fe_content_hash_idx": {
+          "name": "fe_content_hash_idx",
+          "columns": ["content_hash"],
+          "isUnique": false
+        },
+        "fe_external_path_lower_unique_idx": {
+          "name": "fe_external_path_lower_unique_idx",
+          "columns": ["lower(\"external_path\")"],
+          "isUnique": true
+        },
+        "fe_external_path_idx": {
+          "name": "fe_external_path_idx",
+          "columns": ["external_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "fe_origin_check": {
+          "name": "fe_origin_check",
+          "value": "\"file_entry\".\"origin\" IN ('internal', 'external')"
+        },
+        "fe_cleanup_policy_check": {
+          "name": "fe_cleanup_policy_check",
+          "value": "\"file_entry\".\"cleanup_policy\" IN ('manual', 'delete_when_unreferenced')"
+        },
+        "fe_origin_consistency": {
+          "name": "fe_origin_consistency",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"external_path\" IS NULL) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"external_path\" IS NOT NULL)"
+        },
+        "fe_external_no_delete": {
+          "name": "fe_external_no_delete",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"deleted_at\" IS NULL"
+        },
+        "fe_contenthash_external_null": {
+          "name": "fe_contenthash_external_null",
+          "value": "\"file_entry\".\"origin\" != 'external' OR \"file_entry\".\"content_hash\" IS NULL"
+        },
+        "fe_size_internal_only": {
+          "name": "fe_size_internal_only",
+          "value": "(\"file_entry\".\"origin\" = 'internal' AND \"file_entry\".\"size\" IS NOT NULL AND \"file_entry\".\"size\" >= 0) OR (\"file_entry\".\"origin\" = 'external' AND \"file_entry\".\"size\" IS NULL)"
+        }
+      }
+    },
+    "chat_message_file_ref": {
+      "name": "chat_message_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "cmfr_entry_id_idx": {
+          "name": "cmfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "cmfr_source_id_idx": {
+          "name": "cmfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "cmfr_unique_idx": {
+          "name": "cmfr_unique_idx",
+          "columns": ["file_entry_id", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "chat_message_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "chat_message_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "chat_message_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_message_file_ref_source_id_message_id_fk": {
+          "name": "chat_message_file_ref_source_id_message_id_fk",
+          "tableFrom": "chat_message_file_ref",
+          "tableTo": "message",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "cmfr_role_check": {
+          "name": "cmfr_role_check",
+          "value": "\"chat_message_file_ref\".\"role\" IN ('attachment', 'tool_output')"
+        }
+      }
+    },
+    "job_file_ref": {
+      "name": "job_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "jfr_entry_id_idx": {
+          "name": "jfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "jfr_source_id_idx": {
+          "name": "jfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "jfr_unique_idx": {
+          "name": "jfr_unique_idx",
+          "columns": ["file_entry_id", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "job_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "job_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "job_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_file_ref_source_id_job_id_fk": {
+          "name": "job_file_ref_source_id_job_id_fk",
+          "tableFrom": "job_file_ref",
+          "tableTo": "job",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "jfr_role_check": {
+          "name": "jfr_role_check",
+          "value": "\"job_file_ref\".\"role\" IN ('input', 'mask')"
+        }
+      }
+    },
+    "mini_app_logo_file_ref": {
+      "name": "mini_app_logo_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "malfr_entry_id_idx": {
+          "name": "malfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "malfr_source_id_idx": {
+          "name": "malfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mini_app_logo_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "mini_app_logo_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "mini_app_logo_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mini_app_logo_file_ref_source_id_mini_app_app_id_fk": {
+          "name": "mini_app_logo_file_ref_source_id_mini_app_app_id_fk",
+          "tableFrom": "mini_app_logo_file_ref",
+          "tableTo": "mini_app",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["app_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "painting_file_ref": {
+      "name": "painting_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pfr_entry_id_idx": {
+          "name": "pfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "pfr_source_id_idx": {
+          "name": "pfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "pfr_unique_idx": {
+          "name": "pfr_unique_idx",
+          "columns": ["file_entry_id", "source_id", "role"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "painting_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "painting_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "painting_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "painting_file_ref_source_id_painting_id_fk": {
+          "name": "painting_file_ref_source_id_painting_id_fk",
+          "tableFrom": "painting_file_ref",
+          "tableTo": "painting",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "pfr_role_check": {
+          "name": "pfr_role_check",
+          "value": "\"painting_file_ref\".\"role\" IN ('output', 'input')"
+        }
+      }
+    },
+    "provider_logo_file_ref": {
+      "name": "provider_logo_file_ref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_entry_id": {
+          "name": "file_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plfr_entry_id_idx": {
+          "name": "plfr_entry_id_idx",
+          "columns": ["file_entry_id"],
+          "isUnique": false
+        },
+        "plfr_source_id_idx": {
+          "name": "plfr_source_id_idx",
+          "columns": ["source_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "provider_logo_file_ref_file_entry_id_file_entry_id_fk": {
+          "name": "provider_logo_file_ref_file_entry_id_file_entry_id_fk",
+          "tableFrom": "provider_logo_file_ref",
+          "tableTo": "file_entry",
+          "columnsFrom": ["file_entry_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_logo_file_ref_source_id_user_provider_provider_id_fk": {
+          "name": "provider_logo_file_ref_source_id_user_provider_provider_id_fk",
+          "tableFrom": "provider_logo_file_ref",
+          "tableTo": "user_provider",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group": {
+      "name": "group",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_entity_type_order_key_idx": {
+          "name": "group_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job_schedule": {
+      "name": "job_schedule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_input_template": {
+          "name": "job_input_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run": {
+          "name": "last_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catch_up_policy": {
+          "name": "catch_up_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_schedule_type_name_uq": {
+          "name": "job_schedule_type_name_uq",
+          "columns": ["type", "name"],
+          "isUnique": true
+        },
+        "job_schedule_enabled_next_run_idx": {
+          "name": "job_schedule_enabled_next_run_idx",
+          "columns": ["enabled", "next_run"],
+          "isUnique": false
+        },
+        "job_schedule_type_idx": {
+          "name": "job_schedule_type_idx",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "job": {
+      "name": "job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output": {
+          "name": "output",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancel_requested": {
+          "name": "cancel_requested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "job_queue_status_scheduled_at_idx": {
+          "name": "job_queue_status_scheduled_at_idx",
+          "columns": ["queue", "status", "scheduled_at"],
+          "isUnique": false
+        },
+        "job_status_idx": {
+          "name": "job_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "job_schedule_id_finished_at_idx": {
+          "name": "job_schedule_id_finished_at_idx",
+          "columns": ["schedule_id", "finished_at"],
+          "isUnique": false
+        },
+        "job_parent_id_idx": {
+          "name": "job_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "job_idempotency_key_partial_uq": {
+          "name": "job_idempotency_key_partial_uq",
+          "columns": ["idempotency_key"],
+          "isUnique": true,
+          "where": "\"job\".\"idempotency_key\" IS NOT NULL AND \"job\".\"status\" NOT IN ('completed','failed','cancelled')"
+        }
+      },
+      "foreignKeys": {
+        "job_schedule_id_job_schedule_id_fk": {
+          "name": "job_schedule_id_job_schedule_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job_schedule",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "job_parent_id_job_id_fk": {
+          "name": "job_parent_id_job_id_fk",
+          "tableFrom": "job",
+          "tableTo": "job",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "job_status_check": {
+          "name": "job_status_check",
+          "value": "\"job\".\"status\" IN ('pending','delayed','running','completed','failed','cancelled')"
+        }
+      }
+    },
+    "knowledge_base": {
+      "name": "knowledge_base",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rerank_model_id": {
+          "name": "rerank_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_processor_id": {
+          "name": "file_processor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_size": {
+          "name": "chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_overlap": {
+          "name": "chunk_overlap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_strategy": {
+          "name": "chunk_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'structured'"
+        },
+        "chunk_separator": {
+          "name": "chunk_separator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\\n\\n'"
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "document_count": {
+          "name": "document_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "knowledge_base_group_id_group_id_fk": {
+          "name": "knowledge_base_group_id_group_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "group",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_embedding_model_id_user_model_id_fk": {
+          "name": "knowledge_base_embedding_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["embedding_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "knowledge_base_rerank_model_id_user_model_id_fk": {
+          "name": "knowledge_base_rerank_model_id_user_model_id_fk",
+          "tableFrom": "knowledge_base",
+          "tableTo": "user_model",
+          "columnsFrom": ["rerank_model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_base_chunk_strategy_check": {
+          "name": "knowledge_base_chunk_strategy_check",
+          "value": "\"knowledge_base\".\"chunk_strategy\" IN ('structured', 'delimiter')"
+        },
+        "knowledge_base_status_check": {
+          "name": "knowledge_base_status_check",
+          "value": "\"knowledge_base\".\"status\" IN ('completed', 'failed')"
+        },
+        "knowledge_base_status_error_check": {
+          "name": "knowledge_base_status_error_check",
+          "value": "\n        (\n          \"knowledge_base\".\"status\" = 'completed'\n          AND \"knowledge_base\".\"error\" IS NULL\n          AND (\n            (\n              \"knowledge_base\".\"embedding_model_id\" IS NOT NULL\n              AND \"knowledge_base\".\"dimensions\" IS NOT NULL\n              AND \"knowledge_base\".\"dimensions\" > 0\n            )\n            OR (\n              \"knowledge_base\".\"embedding_model_id\" IS NULL\n              AND \"knowledge_base\".\"dimensions\" IS NULL\n            )\n          )\n        )\n        OR (\n          \"knowledge_base\".\"status\" = 'failed'\n          AND \"knowledge_base\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_base\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "knowledge_item": {
+      "name": "knowledge_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_id": {
+          "name": "base_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "knowledge_item_base_type_created_idx": {
+          "name": "knowledge_item_base_type_created_idx",
+          "columns": ["base_id", "type", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_base_group_created_idx": {
+          "name": "knowledge_item_base_group_created_idx",
+          "columns": ["base_id", "group_id", "created_at"],
+          "isUnique": false
+        },
+        "knowledge_item_baseId_id_unique": {
+          "name": "knowledge_item_baseId_id_unique",
+          "columns": ["base_id", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "knowledge_item_base_id_knowledge_base_id_fk": {
+          "name": "knowledge_item_base_id_knowledge_base_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_base",
+          "columnsFrom": ["base_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk": {
+          "name": "knowledge_item_base_id_group_id_knowledge_item_base_id_id_fk",
+          "tableFrom": "knowledge_item",
+          "tableTo": "knowledge_item",
+          "columnsFrom": ["base_id", "group_id"],
+          "columnsTo": ["base_id", "id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "knowledge_item_type_check": {
+          "name": "knowledge_item_type_check",
+          "value": "\"knowledge_item\".\"type\" IN ('file', 'url', 'note', 'directory')"
+        },
+        "knowledge_item_status_check": {
+          "name": "knowledge_item_status_check",
+          "value": "\"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting')"
+        },
+        "knowledge_item_type_status_check": {
+          "name": "knowledge_item_type_status_check",
+          "value": "\n        (\"knowledge_item\".\"type\" IN ('file', 'url', 'note') AND \"knowledge_item\".\"status\" IN ('idle', 'processing', 'reading', 'embedding', 'completed', 'failed', 'deleting'))\n        OR (\"knowledge_item\".\"type\" = 'directory' AND \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'completed', 'failed', 'deleting'))\n      "
+        },
+        "knowledge_item_status_error_check": {
+          "name": "knowledge_item_status_error_check",
+          "value": "\n        (\n          \"knowledge_item\".\"status\" IN ('idle', 'preparing', 'processing', 'reading', 'embedding', 'completed', 'deleting')\n          AND \"knowledge_item\".\"error\" IS NULL\n        )\n        OR (\n          \"knowledge_item\".\"status\" = 'failed'\n          AND \"knowledge_item\".\"error\" IS NOT NULL\n          AND length(trim(\"knowledge_item\".\"error\")) > 0\n        )\n      "
+        }
+      }
+    },
+    "mcp_server": {
+      "name": "mcp_server",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_url": {
+          "name": "provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "long_running": {
+          "name": "long_running",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeout": {
+          "name": "timeout",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_version": {
+          "name": "dxt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dxt_path": {
+          "name": "dxt_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "search_key": {
+          "name": "search_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config_sample": {
+          "name": "config_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_tools": {
+          "name": "disabled_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_auto_approve_tools": {
+          "name": "disabled_auto_approve_tools",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "should_config": {
+          "name": "should_config",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_trusted": {
+          "name": "is_trusted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trusted_at": {
+          "name": "trusted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mcp_server_name_idx": {
+          "name": "mcp_server_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "mcp_server_is_active_idx": {
+          "name": "mcp_server_is_active_idx",
+          "columns": ["is_active"],
+          "isUnique": false
+        },
+        "mcp_server_sort_order_idx": {
+          "name": "mcp_server_sort_order_idx",
+          "columns": ["sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mcp_server_type_check": {
+          "name": "mcp_server_type_check",
+          "value": "\"mcp_server\".\"type\" IS NULL OR \"mcp_server\".\"type\" IN ('stdio', 'sse', 'streamableHttp', 'inMemory')"
+        },
+        "mcp_server_install_source_check": {
+          "name": "mcp_server_install_source_check",
+          "value": "\"mcp_server\".\"install_source\" IS NULL OR \"mcp_server\".\"install_source\" IN ('builtin', 'manual', 'protocol', 'unknown')"
+        }
+      }
+    },
+    "message": {
+      "name": "message",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "searchable_text": {
+          "name": "searchable_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "siblings_group_id": {
+          "name": "siblings_group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_snapshot": {
+          "name": "message_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compaction_summary": {
+          "name": "compaction_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_parent_id_idx": {
+          "name": "message_parent_id_idx",
+          "columns": ["parent_id"],
+          "isUnique": false
+        },
+        "message_topic_created_idx": {
+          "name": "message_topic_created_idx",
+          "columns": ["topic_id", "created_at"],
+          "isUnique": false
+        },
+        "message_status_idx": {
+          "name": "message_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "message_topic_root_uniq": {
+          "name": "message_topic_root_uniq",
+          "columns": ["topic_id"],
+          "isUnique": true,
+          "where": "\"message\".\"parent_id\" is null and \"message\".\"deleted_at\" is null"
+        },
+        "message_fts_rowid_uniq": {
+          "name": "message_fts_rowid_uniq",
+          "columns": ["fts_rowid"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "message_topic_id_topic_id_fk": {
+          "name": "message_topic_id_topic_id_fk",
+          "tableFrom": "message",
+          "tableTo": "topic",
+          "columnsFrom": ["topic_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_model_id_user_model_id_fk": {
+          "name": "message_model_id_user_model_id_fk",
+          "tableFrom": "message",
+          "tableTo": "user_model",
+          "columnsFrom": ["model_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "message_parent_id_message_id_fk": {
+          "name": "message_parent_id_message_id_fk",
+          "tableFrom": "message",
+          "tableTo": "message",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "message_role_check": {
+          "name": "message_role_check",
+          "value": "\"message\".\"role\" IN ('user', 'assistant', 'system', 'root')"
+        },
+        "message_status_check": {
+          "name": "message_status_check",
+          "value": "\"message\".\"status\" IN ('pending', 'success', 'error', 'paused')"
+        },
+        "message_root_parent_check": {
+          "name": "message_root_parent_check",
+          "value": "(\"message\".\"role\" = 'root') = (\"message\".\"parent_id\" is null)"
+        }
+      }
+    },
+    "mini_app": {
+      "name": "mini_app",
+      "columns": {
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_mini_app_id": {
+          "name": "preset_mini_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'enabled'"
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bordered": {
+          "name": "bordered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "background": {
+          "name": "background",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supported_regions": {
+          "name": "supported_regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name_key": {
+          "name": "name_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "mini_app_status_order_key_idx": {
+          "name": "mini_app_status_order_key_idx",
+          "columns": ["status", "order_key"],
+          "isUnique": false
+        },
+        "mini_app_preset_mini_app_id_idx": {
+          "name": "mini_app_preset_mini_app_id_idx",
+          "columns": ["preset_mini_app_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "mini_app_status_check": {
+          "name": "mini_app_status_check",
+          "value": "\"mini_app\".\"status\" IN ('enabled', 'disabled', 'pinned')"
+        }
+      }
+    },
+    "note": {
+      "name": "note",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "root_path": {
+          "name": "root_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_starred": {
+          "name": "is_starred",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "note_root_path_path_unique_idx": {
+          "name": "note_root_path_path_unique_idx",
+          "columns": ["root_path", "path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "note_has_state_check": {
+          "name": "note_has_state_check",
+          "value": "\"note\".\"is_starred\" = 1 OR \"note\".\"is_expanded\" = 1"
+        }
+      }
+    },
+    "painting": {
+      "name": "painting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "painting_order_key_idx": {
+          "name": "painting_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin": {
+      "name": "pin",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pin_entity_type_entity_id_unique_idx": {
+          "name": "pin_entity_type_entity_id_unique_idx",
+          "columns": ["entity_type", "entity_id"],
+          "isUnique": true
+        },
+        "pin_entity_type_order_key_idx": {
+          "name": "pin_entity_type_order_key_idx",
+          "columns": ["entity_type", "order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "preference": {
+      "name": "preference",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "preference_scope_key_pk": {
+          "columns": ["scope", "key"],
+          "name": "preference_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt": {
+      "name": "prompt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_order_key_idx": {
+          "name": "prompt_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_tag": {
+      "name": "entity_tag",
+      "columns": {
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entity_tag_tag_id_idx": {
+          "name": "entity_tag_tag_id_idx",
+          "columns": ["tag_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "entity_tag_tag_id_tag_id_fk": {
+          "name": "entity_tag_tag_id_tag_id_fk",
+          "tableFrom": "entity_tag",
+          "tableTo": "tag",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_tag_entity_type_entity_id_tag_id_pk": {
+          "columns": ["entity_type", "entity_id", "tag_id"],
+          "name": "entity_tag_entity_type_entity_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tag": {
+      "name": "tag",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tag_name_unique": {
+          "name": "tag_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "topic": {
+      "name": "topic",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "is_name_manually_edited": {
+          "name": "is_name_manually_edited",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_node_id": {
+          "name": "active_node_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trace_id": {
+          "name": "trace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "topic_updated_at_idx": {
+          "name": "topic_updated_at_idx",
+          "columns": ["updated_at"],
+          "isUnique": false
+        },
+        "topic_order_key_idx": {
+          "name": "topic_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        },
+        "topic_assistant_id_idx": {
+          "name": "topic_assistant_id_idx",
+          "columns": ["assistant_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "topic_assistant_id_assistant_id_fk": {
+          "name": "topic_assistant_id_assistant_id_fk",
+          "tableFrom": "topic",
+          "tableTo": "assistant",
+          "columnsFrom": ["assistant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_history": {
+      "name": "translate_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_text": {
+          "name": "source_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_text": {
+          "name": "target_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_language": {
+          "name": "source_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_language": {
+          "name": "target_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "star": {
+          "name": "star",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "translate_history_created_at_idx": {
+          "name": "translate_history_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "translate_history_star_created_at_idx": {
+          "name": "translate_history_star_created_at_idx",
+          "columns": ["star", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translate_history_source_language_translate_language_lang_code_fk": {
+          "name": "translate_history_source_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["source_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "translate_history_target_language_translate_language_lang_code_fk": {
+          "name": "translate_history_target_language_translate_language_lang_code_fk",
+          "tableFrom": "translate_history",
+          "tableTo": "translate_language",
+          "columnsFrom": ["target_language"],
+          "columnsTo": ["lang_code"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translate_language": {
+      "name": "translate_language",
+      "columns": {
+        "lang_code": {
+          "name": "lang_code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_model": {
+      "name": "user_model",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_model_id": {
+          "name": "preset_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_types": {
+          "name": "endpoint_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_input_tokens": {
+          "name": "max_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_output_tokens": {
+          "name": "max_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_streaming": {
+          "name": "supports_streaming",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pricing": {
+          "name": "pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "is_hidden": {
+          "name": "is_hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_deprecated": {
+          "name": "is_deprecated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "use_priority_service_tier": {
+          "name": "use_priority_service_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_model_preset_idx": {
+          "name": "user_model_preset_idx",
+          "columns": ["preset_model_id"],
+          "isUnique": false
+        },
+        "user_model_provider_enabled_idx": {
+          "name": "user_model_provider_enabled_idx",
+          "columns": ["provider_id", "is_enabled"],
+          "isUnique": false
+        },
+        "user_model_provider_id_order_key_idx": {
+          "name": "user_model_provider_id_order_key_idx",
+          "columns": ["provider_id", "order_key"],
+          "isUnique": false
+        },
+        "user_model_provider_model_unique": {
+          "name": "user_model_provider_model_unique",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_model_provider_id_user_provider_provider_id_fk": {
+          "name": "user_model_provider_id_user_provider_provider_id_fk",
+          "tableFrom": "user_model",
+          "tableTo": "user_provider",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["provider_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "user_model_custom_config_check": {
+          "name": "user_model_custom_config_check",
+          "value": "\"user_model\".\"preset_model_id\" IS NOT NULL OR (\"user_model\".\"name\" IS NOT NULL AND \"user_model\".\"capabilities\" IS NOT NULL AND \"user_model\".\"supports_streaming\" IS NOT NULL)"
+        }
+      }
+    },
+    "user_provider": {
+      "name": "user_provider",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_provider_id": {
+          "name": "preset_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_key": {
+          "name": "logo_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endpoint_configs": {
+          "name": "endpoint_configs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_chat_endpoint": {
+          "name": "default_chat_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_keys": {
+          "name": "api_keys",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_features": {
+          "name": "api_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_settings": {
+          "name": "provider_settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order_key": {
+          "name": "order_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_preset_idx": {
+          "name": "user_provider_preset_idx",
+          "columns": ["preset_provider_id"],
+          "isUnique": false
+        },
+        "user_provider_enabled_idx": {
+          "name": "user_provider_enabled_idx",
+          "columns": ["is_enabled"],
+          "isUnique": false
+        },
+        "user_provider_order_key_idx": {
+          "name": "user_provider_order_key_idx",
+          "columns": ["order_key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "fe_external_path_lower_unique_idx": {
+        "columns": {
+          "lower(\"external_path\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/migrations/sqlite-drizzle/meta/_journal.json
+++ b/migrations/sqlite-drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785848624191,
       "tag": "0005_slow_obadiah_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1786070563646,
+      "tag": "0006_black_ezekiel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -35,6 +35,7 @@ import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import type { Base64String, CreateInternalEntryIpcParams, UrlString } from '@shared/types/file'
 import { isEmbeddingModel, isFunctionCallingModel, isRerankModel } from '@shared/utils/model'
+import { MINIMAX_PRIORITY_TIER_PRICE_MULTIPLIER, usesMinimaxPriorityTier } from '@shared/utils/provider'
 import {
   type EmbeddingModelUsage,
   isToolUIPart,
@@ -114,6 +115,7 @@ function createCaptureContext(input: {
     modelId: input.sdkModelId,
     modelName: input.model.name,
     pricing: input.model.pricing,
+    priceMultiplier: usesMinimaxPriorityTier(input.provider, input.model) ? MINIMAX_PRIORITY_TIER_PRICE_MULTIPLIER : 1,
     trustProviderReportedCost: input.provider.apiFeatures.reportsActualCost,
     reportedCostCurrency: input.provider.reportedCostCurrency,
     credentialReceipt: input.credentialReceipt,

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -918,6 +918,64 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       const config = await providerToAiSdkConfig(provider, model)
 
       expect(config.providerId).toBe('openai-compatible')
+      expect((config.providerSettings as Record<string, unknown>).transformRequestBody).toBeUndefined()
+    })
+
+    it.each([
+      ['minimax', undefined],
+      ['minimax-global', 'minimax']
+    ])('sends service_tier=priority on every %s chat request when the model opts in', async (id, presetProviderId) => {
+      const provider = makeProvider({
+        id,
+        presetProviderId,
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: 'https://api.minimaxi.com/v1',
+            adapterFamily: 'openai-compatible'
+          }
+        }
+      })
+      const model = makeModel({
+        providerId: id,
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS],
+        usePriorityServiceTier: true
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const transformRequestBody = (config.providerSettings as Record<string, unknown>).transformRequestBody as (
+        args: Record<string, unknown>
+      ) => Record<string, unknown>
+
+      expect(config.providerId).toBe('openai-compatible')
+      expect(transformRequestBody({ model: 'minimax-m2', stream: true })).toEqual({
+        model: 'minimax-m2',
+        stream: true,
+        service_tier: 'priority'
+      })
+    })
+
+    it('keeps MiniMax IMAGE models on the bespoke transport even when priority is enabled', async () => {
+      const provider = makeProvider({
+        id: 'minimax',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: 'https://api.minimaxi.com/v1',
+            adapterFamily: 'openai-compatible'
+          }
+        }
+      })
+      const model = makeModel({
+        providerId: 'minimax',
+        capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+        usePriorityServiceTier: true
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      expect(config.providerId).toBe('minimax')
+      expect((config.providerSettings as Record<string, unknown>).transformRequestBody).toBeUndefined()
     })
 
     it('routes Doubao IMAGE models through Doubao config (Ark protocol + the providerOptions key)', async () => {

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -301,6 +301,24 @@ export async function resolveProviderAiSdkConfig(
         }
       }))
     },
+    // MiniMax's priority tier is a plain body field, and it must ride EVERY request
+    // for the model — billing applies the 1.5x surcharge at capture time, so a
+    // request that silently went out on the standard tier would be over-charged.
+    // providerOptions cannot carry it: `buildCapabilityProviderOptions` is skipped
+    // for assistant-less callers (translate, topic naming), which would leave
+    // exactly that mismatch. A body transform runs on every assembled request.
+    {
+      match: (p, id) =>
+        id === 'openai-compatible' && matchesPreset(p, 'minimax') && model.usePriorityServiceTier === true,
+      build: withSelectedApiKey((ctx) => {
+        const config = buildOpenAICompatibleConfig(ctx)
+        config.providerSettings.transformRequestBody = (args: Record<string, any>) => ({
+          ...args,
+          service_tier: 'priority'
+        })
+        return config
+      })
+    },
     { match: (_, id) => id === 'bedrock', build: buildBedrockConfig },
     // `google-vertex-anthropic` (Vertex on an anthropic-messages endpoint) must route here
     // too — `buildVertexConfig` branches on `isAnthropic`. Otherwise it falls through to the

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -177,6 +177,8 @@ function buildUsageModels(
   for (const { sdkModelId, ref } of entries) {
     const current = byModelId.get(ref.modelId) ?? {
       modelName: ref.model?.name ?? ref.modelId,
+      // No priority-tier multiplier here: agent sessions run on the Agent SDK's
+      // anthropic-messages endpoint, which never carries `service_tier`.
       pricingSnapshot: createAiUsagePricingSnapshot(ref.model?.pricing),
       aliases: new Set<string>()
     }

--- a/src/main/ai/utils/usageCapture.ts
+++ b/src/main/ai/utils/usageCapture.ts
@@ -14,6 +14,8 @@ export interface CreateAiUsageCaptureContextInput {
   modelName?: string | null
   pricing?: RuntimeModelPricing | null
   pricingSnapshot?: AiUsagePricingSnapshot | null
+  /** Scales every captured rate — 1.5 for MiniMax's priority tier, 1 otherwise. */
+  priceMultiplier?: number
   trustProviderReportedCost?: boolean
   reportedCostCurrency?: Currency | null
   credentialReceipt?: AiUsageCredentialReceipt
@@ -46,30 +48,51 @@ function pricingCurrency(pricing: RuntimeModelPricing): AiUsagePricingSnapshot['
   return currencies[0]
 }
 
+/**
+ * Freeze the pricing that applies to this request. `multiplier` scales every
+ * rate so the snapshot records the *effective* price — surcharged routes like
+ * MiniMax's priority tier need no second adjustment at cost time.
+ */
 export function createAiUsagePricingSnapshot(
   pricing: RuntimeModelPricing | null | undefined,
-  capturedAt = new Date().toISOString()
+  capturedAt = new Date().toISOString(),
+  multiplier = 1
 ): AiUsagePricingSnapshot | null {
   if (!pricing) return null
   const currency = pricingCurrency(pricing)
   if (!currency) return null
 
+  const rate = (value: number) => value * multiplier
+
   const snapshot = {
     currency,
-    ...(pricing.input?.perMillionTokens != null ? { inputPerMillionTokens: pricing.input.perMillionTokens } : {}),
-    ...(pricing.output?.perMillionTokens != null ? { outputPerMillionTokens: pricing.output.perMillionTokens } : {}),
+    ...(pricing.input?.perMillionTokens != null ? { inputPerMillionTokens: rate(pricing.input.perMillionTokens) } : {}),
+    ...(pricing.output?.perMillionTokens != null
+      ? { outputPerMillionTokens: rate(pricing.output.perMillionTokens) }
+      : {}),
     ...(pricing.cacheRead?.perMillionTokens != null
-      ? { cacheReadPerMillionTokens: pricing.cacheRead.perMillionTokens }
+      ? { cacheReadPerMillionTokens: rate(pricing.cacheRead.perMillionTokens) }
       : {}),
     ...(pricing.cacheWrite?.perMillionTokens != null
-      ? { cacheWritePerMillionTokens: pricing.cacheWrite.perMillionTokens }
+      ? { cacheWritePerMillionTokens: rate(pricing.cacheWrite.perMillionTokens) }
       : {}),
     ...(pricing.perImage
       ? {
           perImage: {
-            price: pricing.perImage.price,
+            price: rate(pricing.perImage.price),
             unit: pricing.perImage.unit ?? 'image'
           }
+        }
+      : {}),
+    ...(pricing.thresholds?.length
+      ? {
+          thresholds: pricing.thresholds.map((threshold) => ({
+            aboveInputTokens: threshold.aboveInputTokens,
+            inputPerMillionTokens: rate(threshold.input),
+            outputPerMillionTokens: rate(threshold.output),
+            ...(threshold.cacheRead != null ? { cacheReadPerMillionTokens: rate(threshold.cacheRead) } : {}),
+            ...(threshold.cacheWrite != null ? { cacheWritePerMillionTokens: rate(threshold.cacheWrite) } : {})
+          }))
         }
       : {}),
     capturedAt
@@ -91,7 +114,7 @@ export function createAiUsageCaptureContext(input: CreateAiUsageCaptureContextIn
     modelName: input.modelName ?? null,
     pricingSnapshot:
       input.pricingSnapshot === undefined
-        ? createAiUsagePricingSnapshot(input.pricing, input.capturedAt)
+        ? createAiUsagePricingSnapshot(input.pricing, input.capturedAt, input.priceMultiplier)
         : input.pricingSnapshot === null
           ? null
           : (() => {

--- a/src/main/data/db/__tests__/applyMigrations.populated.test.ts
+++ b/src/main/data/db/__tests__/applyMigrations.populated.test.ts
@@ -177,7 +177,9 @@ describe('applyMigrations over a populated database', () => {
   })
 
   it('moves legacy sticky session pointers into the constrained relation', () => {
-    applyMigrations(db, baselineMigrationsFolder(join(tempDir, 'baseline')))
+    // Pinned now that this is a shipped migration: on the default (tip) target a
+    // later migration would seed the rows *after* the backfill already ran.
+    applyMigrations(db, baselineMigrationsFolder(join(tempDir, 'baseline'), '0005_slow_obadiah_stane'))
     const now = Date.now()
     sqlite
       .prepare(

--- a/src/main/data/db/schemas/userModel.ts
+++ b/src/main/data/db/schemas/userModel.ts
@@ -97,6 +97,9 @@ export const userModelTable = sqliteTable(
     /** Whether this model has been deprecated by the provider (no longer in API model list) */
     isDeprecated: integer({ mode: 'boolean' }).notNull().default(false),
 
+    /** Call MiniMax with `service_tier: priority` for this model (billed at 1.5x) */
+    usePriorityServiceTier: integer({ mode: 'boolean' }).notNull().default(false),
+
     /** Fractional-indexing order key scoped within provider. */
     ...orderKeyColumns,
 

--- a/src/main/data/services/AiUsageRecordService.ts
+++ b/src/main/data/services/AiUsageRecordService.ts
@@ -181,6 +181,38 @@ interface LanguageCostResult {
   breakdown: AiUsageCostBreakdown
 }
 
+interface ResolvedRates {
+  input: number | undefined
+  output: number | undefined
+  cacheRead: number | undefined
+  cacheWrite: number | undefined
+}
+
+/**
+ * Pick the rates a request bills at. A request whose all-in input count exceeds
+ * a threshold bills *every* bucket at that threshold's rates — the switch is
+ * wholesale, not graduated — and the highest matching threshold wins. Equal
+ * thresholds resolve to whichever the snapshot listed first (the sort is
+ * stable).
+ */
+function selectRates(pricing: AiUsagePricingSnapshot, totalInputTokens: number | undefined): ResolvedRates {
+  const matched =
+    totalInputTokens === undefined
+      ? undefined
+      : [...(pricing.thresholds ?? [])]
+          .sort((a, b) => b.aboveInputTokens - a.aboveInputTokens)
+          .find((threshold) => totalInputTokens > threshold.aboveInputTokens)
+
+  return {
+    input: matched?.inputPerMillionTokens ?? pricing.inputPerMillionTokens,
+    output: matched?.outputPerMillionTokens ?? pricing.outputPerMillionTokens,
+    // A matched threshold owns every bucket: an omitted cache rate falls back to
+    // that threshold's own input rate, never to the base rate it replaced.
+    cacheRead: matched ? matched.cacheReadPerMillionTokens : pricing.cacheReadPerMillionTokens,
+    cacheWrite: matched ? matched.cacheWritePerMillionTokens : pricing.cacheWritePerMillionTokens
+  }
+}
+
 /**
  * Compute the usage-record domain's cache-aware language cost from the all-in
  * input count and any provider breakdown. Partial cache details are subtracted
@@ -204,11 +236,21 @@ function computeLanguageCost(
         : usage.inputTokens
       : undefined)
 
+  // Thresholds key off the all-in input count (cached tokens included), matching
+  // how vendors define their long-context brackets. `nonCacheInput` is derived
+  // from this same total, so it cannot be the selector.
+  const totalInputTokens =
+    usage.inputTokens ??
+    (nonCacheInput !== undefined || hasCacheDetails
+      ? (nonCacheInput ?? 0) + (cacheReadTokens ?? 0) + (cacheWriteTokens ?? 0)
+      : undefined)
+  const rates = selectRates(pricing, totalInputTokens)
+
   const buckets = [
-    ['input', nonCacheInput, pricing.inputPerMillionTokens],
-    ['cacheRead', cacheReadTokens, pricing.cacheReadPerMillionTokens ?? pricing.inputPerMillionTokens],
-    ['cacheWrite', cacheWriteTokens, pricing.cacheWritePerMillionTokens ?? pricing.inputPerMillionTokens],
-    ['output', usage.outputTokens, pricing.outputPerMillionTokens]
+    ['input', nonCacheInput, rates.input],
+    ['cacheRead', cacheReadTokens, rates.cacheRead ?? rates.input],
+    ['cacheWrite', cacheWriteTokens, rates.cacheWrite ?? rates.input],
+    ['output', usage.outputTokens, rates.output]
   ] as const
 
   if (!buckets.some(([, tokens]) => tokens !== undefined)) return undefined
@@ -1199,9 +1241,12 @@ function computedCost(
   if (!pricing) return undefined
 
   if (input.modality === 'image') {
-    if (!pricing.perImage || pricing.perImage.unit !== 'image' || input.imageCount === undefined) return undefined
-    const amount = input.imageCount * pricing.perImage.price
-    return { amount, breakdown: { image: amount } }
+    if (pricing.perImage && pricing.perImage.unit === 'image' && input.imageCount !== undefined) {
+      const amount = input.imageCount * pricing.perImage.price
+      return { amount, breakdown: { image: amount } }
+    }
+    // No per-image rate (or an uncosted `pixel` unit): fall through to token
+    // pricing, which is how image models that report token usage are billed.
   }
   if (input.modality === 'rerank') return undefined
 

--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -263,6 +263,7 @@ export const UPDATE_MODEL_FIELD_MAP: Array<keyof UpdateModelDto | [keyof UpdateM
   'isEnabled',
   'isHidden',
   'isDeprecated',
+  'usePriorityServiceTier',
   'notes'
 ]
 
@@ -416,6 +417,7 @@ function customRowToRuntimeModel(row: UserModelRow): Model {
     isEnabled: row.isEnabled,
     isHidden: row.isHidden,
     isDeprecated: row.isDeprecated,
+    usePriorityServiceTier: row.usePriorityServiceTier,
     notes: row.notes ?? undefined
   }
 }
@@ -430,6 +432,7 @@ function applyStoredModelState(model: Model, row: UserModelRow): Model {
     isEnabled: row.isEnabled,
     isHidden: row.isHidden,
     isDeprecated: row.isDeprecated,
+    usePriorityServiceTier: row.usePriorityServiceTier,
     notes: row.notes ?? undefined
   }
 }

--- a/src/main/data/services/ProviderRegistryService.ts
+++ b/src/main/data/services/ProviderRegistryService.ts
@@ -172,7 +172,8 @@ function isEmptyPricingEcho(value: unknown): boolean {
     !pricing.cacheRead &&
     !pricing.cacheWrite &&
     !pricing.perImage &&
-    !pricing.perMinute
+    !pricing.perMinute &&
+    !pricing.thresholds?.length
   )
 }
 
@@ -187,8 +188,13 @@ function normalizePricingForComparison(pricing: RuntimeModelPricing): RuntimeMod
     output: normalizeTier(pricing.output),
     ...(pricing.cacheRead ? { cacheRead: normalizeTier(pricing.cacheRead) } : {}),
     ...(pricing.cacheWrite ? { cacheWrite: normalizeTier(pricing.cacheWrite) } : {}),
-    ...(pricing.perImage ? { perImage: pricing.perImage } : {}),
-    ...(pricing.perMinute ? { perMinute: pricing.perMinute } : {})
+    // The catalog leaves `unit` undefined while the model drawer writes 'image';
+    // default it so an untouched per-image price is not read as a user delta.
+    ...(pricing.perImage
+      ? { perImage: { price: pricing.perImage.price, unit: pricing.perImage.unit ?? 'image' } }
+      : {}),
+    ...(pricing.perMinute ? { perMinute: pricing.perMinute } : {}),
+    ...(pricing.thresholds?.length ? { thresholds: pricing.thresholds } : {})
   }
 }
 

--- a/src/main/data/services/__tests__/AiUsageRecordService.test.ts
+++ b/src/main/data/services/__tests__/AiUsageRecordService.test.ts
@@ -310,7 +310,118 @@ describe('AiUsageRecordService', () => {
     })
   })
 
-  it('keeps incomplete token pricing, pixel pricing, and untrusted provider cost unpriced', () => {
+  it('bills the whole request at the highest threshold its all-in input exceeds', () => {
+    const pricingSnapshot = {
+      currency: 'USD' as const,
+      inputPerMillionTokens: 2,
+      outputPerMillionTokens: 8,
+      // Deliberately unsorted: selection must not depend on authoring order.
+      thresholds: [
+        { aboveInputTokens: 2_000_000, inputPerMillionTokens: 8, outputPerMillionTokens: 32 },
+        { aboveInputTokens: 1_000_000, inputPerMillionTokens: 4, outputPerMillionTokens: 16 }
+      ],
+      capturedAt: '2026-07-28T00:00:00.000Z'
+    }
+
+    aiUsageRecordService.recordInvocations([
+      invocation({
+        requestId: 'at-boundary',
+        context: context({ pricingSnapshot }),
+        usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 }
+      }),
+      invocation({
+        requestId: 'first-tier',
+        context: context({ pricingSnapshot }),
+        usage: { inputTokens: 2_000_000, outputTokens: 1_000_000 }
+      }),
+      invocation({
+        requestId: 'second-tier',
+        context: context({ pricingSnapshot }),
+        usage: { inputTokens: 3_000_000, outputTokens: 1_000_000 }
+      })
+    ])
+
+    const costOf = (requestId: string) =>
+      dbh.db.select().from(aiUsageRecordTable).where(eq(aiUsageRecordTable.requestId, requestId)).get()?.cost
+
+    // `aboveInputTokens` is exclusive, so an exactly-equal request stays on base rates.
+    expect(costOf('at-boundary')).toBe(2 + 8)
+    expect(costOf('first-tier')).toBe(2 * 4 + 16)
+    expect(costOf('second-tier')).toBe(3 * 8 + 32)
+  })
+
+  it('resolves a threshold cache rate from that threshold, not the base rate it replaced', () => {
+    aiUsageRecordService.recordInvocation(
+      invocation({
+        requestId: 'threshold-cache',
+        context: context({
+          pricingSnapshot: {
+            currency: 'USD',
+            inputPerMillionTokens: 2,
+            outputPerMillionTokens: 8,
+            cacheReadPerMillionTokens: 0.5,
+            thresholds: [{ aboveInputTokens: 1_000_000, inputPerMillionTokens: 4, outputPerMillionTokens: 16 }],
+            capturedAt: '2026-07-28T00:00:00.000Z'
+          }
+        }),
+        usage: { inputTokens: 2_000_000, cacheReadTokens: 1_000_000, outputTokens: 0 }
+      })
+    )
+
+    expect(
+      dbh.db.select().from(aiUsageRecordTable).where(eq(aiUsageRecordTable.requestId, 'threshold-cache')).get()
+    ).toMatchObject({
+      cost: 8,
+      costBreakdown: { input: 4, cacheRead: 4, output: 0 }
+    })
+  })
+
+  it('bills image generation per image when configured, and by token otherwise', () => {
+    aiUsageRecordService.recordInvocations([
+      invocation({
+        requestId: 'per-image',
+        context: context({
+          pricingSnapshot: {
+            currency: 'USD',
+            inputPerMillionTokens: 1,
+            outputPerMillionTokens: 2,
+            perImage: { price: 0.5, unit: 'image' },
+            capturedAt: '2026-07-28T00:00:00.000Z'
+          }
+        }),
+        modality: 'image',
+        usage: { inputTokens: 1_000_000, outputTokens: 500_000 },
+        imageCount: 3
+      }),
+      invocation({
+        requestId: 'token-billed-image',
+        context: context({
+          pricingSnapshot: {
+            currency: 'USD',
+            inputPerMillionTokens: 1,
+            outputPerMillionTokens: 2,
+            capturedAt: '2026-07-28T00:00:00.000Z'
+          }
+        }),
+        modality: 'image',
+        usage: { inputTokens: 1_000_000, outputTokens: 500_000 },
+        imageCount: 3
+      })
+    ])
+
+    const rowOf = (requestId: string) =>
+      dbh.db.select().from(aiUsageRecordTable).where(eq(aiUsageRecordTable.requestId, requestId)).get()
+
+    expect(rowOf('per-image')).toMatchObject({ cost: 1.5, costSource: 'computed', costBreakdown: { image: 1.5 } })
+    // No per-image rate: the model's token rates take over.
+    expect(rowOf('token-billed-image')).toMatchObject({
+      cost: 2,
+      costSource: 'computed',
+      costBreakdown: { input: 1, output: 1 }
+    })
+  })
+
+  it('keeps incomplete token pricing, uncosted pixel pricing, and untrusted provider cost unpriced', () => {
     aiUsageRecordService.recordInvocations([
       invocation({
         requestId: 'missing-output-price',
@@ -323,6 +434,8 @@ describe('AiUsageRecordService', () => {
         }),
         usage: { outputTokens: 10 }
       }),
+      // `pixel` is not a costable unit, so this falls through to token pricing —
+      // which has neither usage nor rates here, leaving the record unpriced.
       invocation({
         requestId: 'pixel-image',
         context: context({
@@ -428,6 +541,37 @@ describe('AiUsageRecordService', () => {
       perImage: { price: 0.02, unit: 'image' },
       capturedAt: '2026-07-28T00:00:00.000Z'
     })
+  })
+
+  it('scales every captured rate by the price multiplier, leaving the default a no-op', () => {
+    const pricing = {
+      input: { perMillionTokens: 2, currency: 'CNY' as const },
+      output: { perMillionTokens: 8, currency: 'CNY' as const },
+      cacheRead: { perMillionTokens: 1, currency: 'CNY' as const },
+      perImage: { price: 0.5, unit: 'image' as const },
+      thresholds: [{ aboveInputTokens: 512_000, input: 4, output: 16, cacheRead: 2 }]
+    }
+
+    expect(createAiUsagePricingSnapshot(pricing, '2026-07-28T00:00:00.000Z', 1.5)).toEqual({
+      currency: 'CNY',
+      inputPerMillionTokens: 3,
+      outputPerMillionTokens: 12,
+      cacheReadPerMillionTokens: 1.5,
+      perImage: { price: 0.75, unit: 'image' },
+      thresholds: [
+        {
+          aboveInputTokens: 512_000,
+          inputPerMillionTokens: 6,
+          outputPerMillionTokens: 24,
+          cacheReadPerMillionTokens: 3
+        }
+      ],
+      capturedAt: '2026-07-28T00:00:00.000Z'
+    })
+
+    expect(createAiUsagePricingSnapshot(pricing, '2026-07-28T00:00:00.000Z')).toEqual(
+      createAiUsagePricingSnapshot(pricing, '2026-07-28T00:00:00.000Z', 1)
+    )
   })
 
   it('drops invalid non-integer or non-finite record metrics without disrupting message state', () => {

--- a/src/main/data/services/__tests__/ModelService.test.ts
+++ b/src/main/data/services/__tests__/ModelService.test.ts
@@ -144,6 +144,7 @@ describe('UPDATE_MODEL_FIELD_MAP completeness', () => {
       'isEnabled',
       'isHidden',
       'isDeprecated',
+      'usePriorityServiceTier',
       'notes'
     ]
 
@@ -2069,6 +2070,30 @@ describe('ModelService.bulkUpdate', () => {
 
     const [row] = await dbh.db.select().from(userModelTable).where(eq(userModelTable.id, 'openai::gpt-4o'))
     expect(row.name).toBeNull()
+  })
+
+  // A pricing sub-field the baseline comparison ignores reads as "equal to
+  // preset", and the sparse-column write then nulls the whole pricing override.
+  it('keeps a threshold-only pricing PATCH out of the baseline-clearing path', async () => {
+    await dbh.db.insert(userProviderTable).values(providerRow('openai', 'OpenAI'))
+    await dbh.db.insert(userModelTable).values(modelRow('openai', 'gpt-4o', { presetModelId: 'gpt-4o' }))
+    const presetPricing = {
+      input: { perMillionTokens: 3, currency: 'USD' as const },
+      output: { perMillionTokens: 15, currency: 'USD' as const }
+    }
+    lookupModelMock.mockReturnValue({
+      presetModel: { id: 'gpt-4o', name: 'GPT-4o', pricing: presetPricing },
+      registryOverride: null,
+      reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
+    })
+
+    const thresholds = [{ aboveInputTokens: 512_000, input: 6, output: 30 }]
+    modelService.bulkUpdate([
+      { providerId: 'openai', modelId: 'gpt-4o', patch: { pricing: { ...presetPricing, thresholds } } }
+    ])
+
+    const [row] = await dbh.db.select().from(userModelTable).where(eq(userModelTable.id, 'openai::gpt-4o'))
+    expect(row.pricing).toMatchObject({ thresholds })
   })
 
   it('rejects managed CherryAI default model PATCHes before writing other rows', async () => {

--- a/src/main/data/services/__tests__/ProviderRegistryService.test.ts
+++ b/src/main/data/services/__tests__/ProviderRegistryService.test.ts
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { providerService } from '@data/services/ProviderService'
 import { generateOrderKeyBetween } from '@data/services/utils/orderKey'
-import { createUniqueModelId } from '@shared/data/types/model'
+import { createUniqueModelId, CURRENCY } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainDbServiceUtils } from '@test-mocks/main/DbService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -131,7 +131,9 @@ import {
 } from '@cherrystudio/provider-registry/node'
 
 // Must import after mocks are set up
-const { mergePresetModel, providerRegistryService } = await import('../ProviderRegistryService')
+const { matchesModelPricingBaseline, mergePresetModel, providerRegistryService } = await import(
+  '../ProviderRegistryService'
+)
 
 const mockReadModels = vi.mocked(readModelRegistry)
 const mockReadProviderModels = vi.mocked(readProviderModelRegistry)
@@ -841,6 +843,47 @@ describe('ProviderRegistryService', () => {
       const result = providerRegistryService.lookupModel('openai', 'gpt-4o')
 
       expect(result.reasoningProfile.format).toBe('openai-chat')
+    })
+  })
+
+  // `ModelService.buildUpdates` nulls the whole pricing column when a PATCH is
+  // judged baseline-equal, so any field this comparison ignores is a field a
+  // user can silently lose.
+  describe('matchesModelPricingBaseline', () => {
+    const baseTiers = {
+      input: { perMillionTokens: 3, currency: CURRENCY.USD },
+      output: { perMillionTokens: 15, currency: CURRENCY.USD }
+    }
+
+    it('treats a threshold-only difference as a real delta', () => {
+      expect(
+        matchesModelPricingBaseline(
+          { ...baseTiers, thresholds: [{ aboveInputTokens: 512_000, input: 6, output: 30 }] },
+          { ...baseTiers }
+        )
+      ).toBe(false)
+    })
+
+    it('does not read an empty-price echo carrying thresholds as an absent baseline', () => {
+      expect(
+        matchesModelPricingBaseline(
+          {
+            input: { perMillionTokens: 0, currency: CURRENCY.USD },
+            output: { perMillionTokens: 0, currency: CURRENCY.USD },
+            thresholds: [{ aboveInputTokens: 512_000, input: 6, output: 30 }]
+          },
+          undefined
+        )
+      ).toBe(false)
+    })
+
+    it('ignores a per-image unit the catalog leaves implicit', () => {
+      expect(
+        matchesModelPricingBaseline(
+          { ...baseTiers, perImage: { price: 0.04, unit: 'image' } },
+          { ...baseTiers, perImage: { price: 0.04 } }
+        )
+      ).toBe(true)
     })
   })
 })

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -4440,7 +4440,19 @@
       "input": "Input Price",
       "million_tokens": "M Tokens",
       "output": "Output Price",
-      "price": "Price"
+      "per_image": {
+        "label": "Bill per image",
+        "price": "Price per image",
+        "unit": "image"
+      },
+      "price": "Price",
+      "threshold": {
+        "above": "Input tokens above",
+        "add": "Add tier",
+        "description": "When a request exceeds a tier’s input tokens, the whole request is billed at that tier’s prices. The highest matching tier wins.",
+        "label": "Tiered pricing",
+        "remove": "Remove tier"
+      }
     },
     "reasoning": "Reasoning",
     "rerank_model": "Reranker",
@@ -4456,6 +4468,12 @@
       "remove_model": "Remove {{name}}",
       "restore_default": "Restore assistant model",
       "selected_models": "Selected models"
+    },
+    "service_tier": {
+      "priority": {
+        "label": "Priority service tier",
+        "tooltip": "Calls this model with service_tier=priority. MiniMax bills the priority tier at 1.5x the standard price, and usage costs are calculated accordingly."
+      }
     },
     "stream_output": "Stream output",
     "type": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -4440,7 +4440,19 @@
       "input": "输入价格",
       "million_tokens": "百万 Token",
       "output": "输出价格",
-      "price": "价格"
+      "per_image": {
+        "label": "按图片张数计费",
+        "price": "单张图片价格",
+        "unit": "张"
+      },
+      "price": "价格",
+      "threshold": {
+        "above": "输入 Token 超过",
+        "add": "添加阶梯",
+        "description": "当一次请求的输入 Token 超过某一阶梯时，整次请求按该阶梯的价格计费，命中多个时取最高一档。",
+        "label": "阶梯计价",
+        "remove": "删除阶梯"
+      }
     },
     "reasoning": "推理",
     "rerank_model": "重排模型",
@@ -4456,6 +4468,12 @@
       "remove_model": "移除 {{name}}",
       "restore_default": "恢复助手模型",
       "selected_models": "已选模型"
+    },
+    "service_tier": {
+      "priority": {
+        "label": "优先服务等级",
+        "tooltip": "调用该模型时携带 service_tier=priority。MiniMax 对优先层级按标准价格的 1.5 倍计费，用量成本也按此换算。"
+      }
     },
     "stream_output": "流式输出",
     "type": {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
@@ -16,6 +16,8 @@ import { toast } from '@renderer/services/toast'
 import { getDefaultGroupName } from '@renderer/utils/naming'
 import { CURRENCY, type Currency, type EndpointType, type Model } from '@shared/data/types/model'
 import { parseUniqueModelId } from '@shared/data/types/model'
+import { isGenerateImageModel } from '@shared/utils/model'
+import { matchesPreset } from '@shared/utils/provider'
 import { ChevronDown, ChevronUp, CircleHelp } from 'lucide-react'
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -37,6 +39,12 @@ import {
 import { ModelBasicFields } from './ModelBasicFields'
 import { ModelClassificationControls } from './ModelClassificationControls'
 import { ModelContextWindowFields } from './ModelContextWindowFields'
+import {
+  fromPricingThresholdDrafts,
+  type ModelPricingThresholdDraft,
+  ModelPricingThresholdFields,
+  toPricingThresholdDrafts
+} from './ModelPricingThresholdFields'
 import {
   applyModelPurpose,
   getInitialChatEndpointType,
@@ -72,6 +80,10 @@ interface BuildPatchOverrides {
   inputPrice?: string
   outputPrice?: string
   cacheReadPrice?: string
+  perImageEnabled?: boolean
+  perImagePrice?: string
+  thresholdDrafts?: ModelPricingThresholdDraft[]
+  usePriorityServiceTier?: boolean
   contextWindow?: string
   maxInputTokens?: string
   maxOutputTokens?: string
@@ -124,6 +136,10 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
   const [inputPrice, setInputPrice] = useState('0')
   const [outputPrice, setOutputPrice] = useState('0')
   const [cacheReadPrice, setCacheReadPrice] = useState('')
+  const [perImageEnabled, setPerImageEnabled] = useState(false)
+  const [perImagePrice, setPerImagePrice] = useState('')
+  const [thresholdDrafts, setThresholdDrafts] = useState<ModelPricingThresholdDraft[]>([])
+  const [usePriorityServiceTier, setUsePriorityServiceTier] = useState(false)
   const [contextWindow, setContextWindow] = useState('')
   const [maxInputTokens, setMaxInputTokens] = useState('')
   const [maxOutputTokens, setMaxOutputTokens] = useState('')
@@ -165,6 +181,13 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
     setOutputPrice(String(model.pricing?.output?.perMillionTokens ?? 0))
     const cacheReadRate = model.pricing?.cacheRead?.perMillionTokens
     setCacheReadPrice(cacheReadRate == null ? '' : String(cacheReadRate))
+    // Only the `image` unit is billable; a `pixel` price reads as "off" here.
+    const perImage = model.pricing?.perImage
+    const billsPerImage = perImage != null && (perImage.unit ?? 'image') === 'image'
+    setPerImageEnabled(billsPerImage)
+    setPerImagePrice(billsPerImage ? String(perImage.price) : '')
+    setThresholdDrafts(toPricingThresholdDrafts(model.pricing?.thresholds))
+    setUsePriorityServiceTier(model.usePriorityServiceTier ?? false)
     setContextWindow(model.contextWindow != null ? String(model.contextWindow) : '')
     setMaxInputTokens(model.maxInputTokens != null ? String(model.maxInputTokens) : '')
     setMaxOutputTokens(model.maxOutputTokens != null ? String(model.maxOutputTokens) : '')
@@ -184,7 +207,8 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
         contextWindow: patch.contextWindow,
         maxInputTokens: patch.maxInputTokens,
         maxOutputTokens: patch.maxOutputTokens,
-        pricing: patch.pricing
+        pricing: patch.pricing,
+        usePriorityServiceTier: patch.usePriorityServiceTier
       })
     },
     [updateModel]
@@ -206,6 +230,13 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
       const nextCacheReadPrice = nextCacheReadPriceValue.trim() === '' ? undefined : Number(nextCacheReadPriceValue)
       const hasCacheReadPrice =
         nextCacheReadPrice !== undefined && Number.isFinite(nextCacheReadPrice) && nextCacheReadPrice >= 0
+      const nextPerImageEnabled = overrides?.perImageEnabled ?? perImageEnabled
+      const nextPerImagePrice = Number(overrides?.perImagePrice ?? perImagePrice)
+      const perImage =
+        nextPerImageEnabled && Number.isFinite(nextPerImagePrice) && nextPerImagePrice >= 0
+          ? { price: nextPerImagePrice, unit: 'image' as const }
+          : undefined
+      const nextThresholds = fromPricingThresholdDrafts(overrides?.thresholdDrafts ?? thresholdDrafts)
       const hasEndpointTypesOverride = overrides != null && Object.hasOwn(overrides, 'endpointTypes')
       const hasPurposeFieldsOverride = overrides != null && Object.hasOwn(overrides, 'purposeFields')
       const nextPurposeFields = overrides?.purposeFields ?? purposeFields
@@ -261,6 +292,7 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
           ? { outputModalities: resolvedPurposeFields.outputModalities }
           : {}),
         supportsStreaming: overrides?.supportsStreaming ?? supportsStreaming,
+        usePriorityServiceTier: overrides?.usePriorityServiceTier ?? usePriorityServiceTier,
         contextWindow: Number(overrides?.contextWindow ?? contextWindow) || undefined,
         maxInputTokens: Number(overrides?.maxInputTokens ?? maxInputTokens) || undefined,
         maxOutputTokens: Number(overrides?.maxOutputTokens ?? maxOutputTokens) || undefined,
@@ -279,7 +311,14 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
           // Cache-write has no field in this drawer, but it must follow the selected currency:
           // `computeLanguageCost` sums every tier and labels the total with the input currency,
           // so a tier left behind in the old currency would be added across currencies.
-          ...(model.pricing?.cacheWrite ? { cacheWrite: { ...model.pricing.cacheWrite, currency: finalCurrency } } : {})
+          ...(model.pricing?.cacheWrite
+            ? { cacheWrite: { ...model.pricing.cacheWrite, currency: finalCurrency } }
+            : {}),
+          ...(perImage ? { perImage } : {}),
+          // Per-minute has no field here either; carry it through so an unrelated
+          // edit does not drop it (this object replaces `pricing` wholesale).
+          ...(model.pricing?.perMinute ? { perMinute: model.pricing.perMinute } : {}),
+          ...(nextThresholds.length > 0 ? { thresholds: nextThresholds } : {})
         }
       }
     },
@@ -295,10 +334,14 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
       model,
       name,
       outputPrice,
+      perImageEnabled,
+      perImagePrice,
       purposeFields,
       classification,
       defaultChatEndpoint,
-      supportsStreaming
+      supportsStreaming,
+      thresholdDrafts,
+      usePriorityServiceTier
     ]
   )
 
@@ -402,6 +445,10 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
   }
 
   const currentCurrency = currencySymbol || '$'
+  const isImageModel = isGenerateImageModel(model)
+  // MiniMax serves the priority tier on its OpenAI-compatible chat route only;
+  // image models go through the bespoke transport, which never sends it.
+  const supportsPriorityServiceTier = matchesPreset(provider, 'minimax') && !isImageModel
 
   return (
     <ProviderSettingsDrawer open={open} onClose={onClose} title={t('models.edit')}>
@@ -641,7 +688,88 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
                     </span>
                   </div>
                 </ProviderField>
+
+                {isImageModel && (
+                  <>
+                    <div className="flex min-w-0 items-center justify-between gap-3">
+                      <span className="truncate font-normal text-[13px] text-muted-foreground leading-5">
+                        {t('models.price.per_image.label')}
+                      </span>
+                      <Switch
+                        size="sm"
+                        aria-label={t('models.price.per_image.label')}
+                        checked={perImageEnabled}
+                        onCheckedChange={(checked) => {
+                          setPerImageEnabled(checked)
+                          autoSave({ perImageEnabled: checked })
+                        }}
+                      />
+                    </div>
+
+                    {perImageEnabled && (
+                      <ProviderField
+                        title={t('models.price.per_image.price')}
+                        titleClassName={drawerClasses.fieldTitle}>
+                        <div className={drawerClasses.responsiveValueRow}>
+                          <Input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            aria-label={t('models.price.per_image.price')}
+                            value={perImagePrice}
+                            placeholder="0.00"
+                            className={drawerClasses.input}
+                            onChange={(event) => {
+                              setPerImagePrice(event.target.value)
+                            }}
+                            onBlur={() => autoSave({ perImagePrice })}
+                          />
+                          <span className={drawerClasses.valueSuffix}>
+                            {currentCurrency} / {t('models.price.per_image.unit')}
+                          </span>
+                        </div>
+                      </ProviderField>
+                    )}
+                  </>
+                )}
               </div>
+
+              <div className={drawerClasses.sectionCard}>
+                <ProviderField title={t('models.price.threshold.label')} titleClassName={drawerClasses.fieldTitle}>
+                  <ModelPricingThresholdFields
+                    drafts={thresholdDrafts}
+                    currencySymbol={currentCurrency}
+                    onChange={setThresholdDrafts}
+                    onCommit={(drafts) => autoSave({ thresholdDrafts: drafts })}
+                  />
+                </ProviderField>
+              </div>
+
+              {supportsPriorityServiceTier && (
+                <div className={drawerClasses.switchCard}>
+                  <div className="flex min-w-0 items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate font-normal text-[13px] text-muted-foreground leading-5">
+                        {t('models.service_tier.priority.label')}
+                      </span>
+                      <Tooltip content={t('models.service_tier.priority.tooltip')}>
+                        <span className="inline-flex h-5 w-4 shrink-0 items-center justify-center text-muted-foreground">
+                          <CircleHelp aria-hidden className="size-3" />
+                        </span>
+                      </Tooltip>
+                    </div>
+                    <Switch
+                      size="sm"
+                      aria-label={t('models.service_tier.priority.label')}
+                      checked={usePriorityServiceTier}
+                      onCheckedChange={(checked) => {
+                        setUsePriorityServiceTier(checked)
+                        autoSave({ usePriorityServiceTier: checked })
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           </ProviderSection>
         )}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelPricingThresholdFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelPricingThresholdFields.tsx
@@ -1,0 +1,159 @@
+import { Button, Input } from '@cherrystudio/ui'
+import ProviderField from '@renderer/pages/settings/ProviderSettings/primitives/ProviderField'
+import { drawerClasses } from '@renderer/pages/settings/ProviderSettings/primitives/ProviderSettingsPrimitives'
+import type { ModelPricingThreshold } from '@shared/data/types/model'
+import { Plus, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+/** A threshold row while it is being typed — every field is free-form text. */
+export interface ModelPricingThresholdDraft {
+  aboveInputTokens: string
+  input: string
+  output: string
+  cacheRead: string
+}
+
+export const EMPTY_PRICING_THRESHOLD_DRAFT: ModelPricingThresholdDraft = {
+  aboveInputTokens: '',
+  input: '',
+  output: '',
+  cacheRead: ''
+}
+
+export function toPricingThresholdDrafts(thresholds: ModelPricingThreshold[] | undefined) {
+  return (thresholds ?? []).map((threshold) => ({
+    aboveInputTokens: String(threshold.aboveInputTokens),
+    input: String(threshold.input),
+    output: String(threshold.output),
+    cacheRead: threshold.cacheRead == null ? '' : String(threshold.cacheRead)
+  }))
+}
+
+const toRate = (value: string): number | undefined => {
+  const parsed = Number(value.trim())
+  return value.trim() !== '' && Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+/**
+ * Drop half-typed rows: a threshold only bills once it has a boundary and both
+ * required rates, and persisting a partial one would silently reprice requests.
+ */
+export function fromPricingThresholdDrafts(drafts: ModelPricingThresholdDraft[]): ModelPricingThreshold[] {
+  return drafts.flatMap((draft) => {
+    const aboveInputTokens = toRate(draft.aboveInputTokens)
+    const input = toRate(draft.input)
+    const output = toRate(draft.output)
+    if (!aboveInputTokens || input === undefined || output === undefined) return []
+
+    const cacheRead = toRate(draft.cacheRead)
+    return [
+      {
+        aboveInputTokens: Math.floor(aboveInputTokens),
+        input,
+        output,
+        ...(cacheRead !== undefined ? { cacheRead } : {})
+      }
+    ]
+  })
+}
+
+interface ModelPricingThresholdFieldsProps {
+  drafts: ModelPricingThresholdDraft[]
+  currencySymbol: string
+  onChange: (drafts: ModelPricingThresholdDraft[]) => void
+  onCommit: (drafts: ModelPricingThresholdDraft[]) => void
+}
+
+export function ModelPricingThresholdFields({
+  drafts,
+  currencySymbol,
+  onChange,
+  onCommit
+}: ModelPricingThresholdFieldsProps) {
+  const { t } = useTranslation()
+
+  const update = (index: number, patch: Partial<ModelPricingThresholdDraft>) =>
+    drafts.map((draft, position) => (position === index ? { ...draft, ...patch } : draft))
+
+  const priceField = (index: number, key: 'input' | 'output' | 'cacheRead', label: string, placeholder: string) => (
+    <ProviderField title={label} titleClassName={drawerClasses.fieldTitle} className={drawerClasses.field}>
+      <div className={drawerClasses.responsiveValueRow}>
+        <Input
+          type="number"
+          min="0"
+          step="0.01"
+          aria-label={`${label} — ${t('models.price.threshold.label')} ${index + 1}`}
+          value={drafts[index][key]}
+          placeholder={placeholder}
+          className={drawerClasses.input}
+          onChange={(event) => onChange(update(index, { [key]: event.target.value }))}
+          onBlur={() => onCommit(drafts)}
+        />
+        <span className={drawerClasses.valueSuffix}>
+          {currencySymbol} / {t('models.price.million_tokens')}
+        </span>
+      </div>
+    </ProviderField>
+  )
+
+  return (
+    <div className="space-y-3" data-testid="provider-settings-model-pricing-thresholds">
+      <p className={drawerClasses.sectionDescription}>{t('models.price.threshold.description')}</p>
+
+      {drafts.map((draft, index) => (
+        // Rows carry no id and cannot be reordered; every input is controlled from
+        // `drafts`, so an index key stays consistent across add and remove.
+        <div key={index} className="space-y-3.5 rounded-md border border-border-subtle px-3 py-3">
+          <div className="flex items-end gap-2">
+            <ProviderField
+              title={t('models.price.threshold.above')}
+              titleClassName={drawerClasses.fieldTitle}
+              className={`${drawerClasses.field} min-w-0 flex-1`}>
+              <Input
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                aria-label={`${t('models.price.threshold.above')} ${index + 1}`}
+                value={draft.aboveInputTokens}
+                placeholder="512000"
+                className={drawerClasses.input}
+                onChange={(event) =>
+                  onChange(update(index, { aboveInputTokens: event.target.value.replace(/[^\d]/g, '') }))
+                }
+                onBlur={() => onCommit(drafts)}
+              />
+            </ProviderField>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
+              aria-label={`${t('models.price.threshold.remove')} ${index + 1}`}
+              onClick={() => {
+                const next = drafts.filter((_, position) => position !== index)
+                onChange(next)
+                onCommit(next)
+              }}>
+              <Trash2 size={14} />
+            </Button>
+          </div>
+
+          {priceField(index, 'input', t('models.price.input'), '0.00')}
+          {priceField(index, 'output', t('models.price.output'), '0.00')}
+          {priceField(index, 'cacheRead', t('models.price.cache_read'), '0.00')}
+        </div>
+      ))}
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={() => onChange([...drafts, { ...EMPTY_PRICING_THRESHOLD_DRAFT }])}>
+        <Plus size={14} />
+        {t('models.price.threshold.add')}
+      </Button>
+    </div>
+  )
+}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
@@ -192,6 +192,41 @@ describe('EditModelDrawer pricing currency', () => {
     )
   })
 
+  it('carries per-image, per-minute, and threshold pricing through an unrelated edit', async () => {
+    const model = {
+      ...modelWithFullPricing,
+      pricing: {
+        ...modelWithFullPricing.pricing,
+        perImage: { price: 0.04, unit: 'image' },
+        perMinute: { price: 0.006 },
+        thresholds: [{ aboveInputTokens: 512_000, input: 6, output: 30, cacheRead: 0.6 }]
+      }
+    } as unknown as Model
+
+    render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={model} />)
+
+    await act(async () => {
+      const modelName = screen.getByLabelText('settings.models.add.model_name.label')
+      fireEvent.change(modelName, { target: { value: 'Claude 4 Sonnet Renamed' } })
+      fireEvent.blur(modelName)
+    })
+
+    expect(updateModelMock).toHaveBeenCalledTimes(1)
+    expect(updateModelMock.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        pricing: {
+          input: { perMillionTokens: 3, currency: CURRENCY.USD },
+          output: { perMillionTokens: 15, currency: CURRENCY.USD },
+          cacheRead: { perMillionTokens: 0.3, currency: CURRENCY.USD },
+          cacheWrite: { perMillionTokens: 3.75, currency: CURRENCY.USD },
+          perImage: { price: 0.04, unit: 'image' },
+          perMinute: { price: 0.006 },
+          thresholds: [{ aboveInputTokens: 512_000, input: 6, output: 30, cacheRead: 0.6 }]
+        }
+      })
+    )
+  })
+
   it('moves every pricing tier to the newly selected currency', async () => {
     render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={modelWithFullPricing} />)
 

--- a/src/shared/data/api/schemas/models.ts
+++ b/src/shared/data/api/schemas/models.ts
@@ -94,6 +94,7 @@ export const UpdateModelSchema = CreateModelSchema.omit({
     isEnabled: z.boolean().optional(),
     isHidden: z.boolean().optional(),
     isDeprecated: z.boolean().optional(),
+    usePriorityServiceTier: z.boolean().optional(),
     notes: z.string().optional()
   })
 export type UpdateModelDto = z.infer<typeof UpdateModelSchema>

--- a/src/shared/data/types/aiUsageRecord.ts
+++ b/src/shared/data/types/aiUsageRecord.ts
@@ -32,6 +32,19 @@ export const AiUsageCostBreakdownSchema = z.strictObject({
 })
 export type AiUsageCostBreakdown = z.infer<typeof AiUsageCostBreakdownSchema>
 
+/**
+ * Flattened threshold entry. A request whose all-in input token count exceeds
+ * `aboveInputTokens` bills every bucket at these rates instead of the
+ * snapshot's base rates.
+ */
+const AiUsagePricingThresholdSchema = z.strictObject({
+  aboveInputTokens: FiniteNonnegativeIntegerSchema,
+  inputPerMillionTokens: FiniteNonnegativeNumberSchema,
+  outputPerMillionTokens: FiniteNonnegativeNumberSchema,
+  cacheReadPerMillionTokens: FiniteNonnegativeNumberSchema.optional(),
+  cacheWritePerMillionTokens: FiniteNonnegativeNumberSchema.optional()
+})
+
 export const AiUsagePricingSnapshotSchema = z.strictObject({
   currency: z.enum(objectValues(CURRENCY)),
   inputPerMillionTokens: FiniteNonnegativeNumberSchema.optional(),
@@ -44,6 +57,7 @@ export const AiUsagePricingSnapshotSchema = z.strictObject({
       unit: z.enum(['image', 'pixel'])
     })
     .optional(),
+  thresholds: z.array(AiUsagePricingThresholdSchema).optional(),
   capturedAt: z.iso.datetime()
 })
 export type AiUsagePricingSnapshot = z.infer<typeof AiUsagePricingSnapshotSchema>

--- a/src/shared/data/types/model.ts
+++ b/src/shared/data/types/model.ts
@@ -281,6 +281,22 @@ export type RuntimeParameterSupport = z.infer<typeof RuntimeParameterSupportSche
 export const PricingTierSchema = PricePerTokenSchema
 export type PricingTier = z.infer<typeof PricingTierSchema>
 
+/**
+ * Whole-request threshold pricing. When a request's all-in input token count
+ * exceeds `aboveInputTokens`, every bucket of that request bills at this
+ * entry's rates instead of the base rates — the switch is wholesale, not
+ * graduated. Rates are per million tokens in the model's base currency, so
+ * entries carry no currency of their own.
+ */
+export const ModelPricingThresholdSchema = z.object({
+  aboveInputTokens: z.number().positive(),
+  input: z.number().nonnegative(),
+  output: z.number().nonnegative(),
+  cacheRead: z.number().nonnegative().optional(),
+  cacheWrite: z.number().nonnegative().optional()
+})
+export type ModelPricingThreshold = z.infer<typeof ModelPricingThresholdSchema>
+
 export const RuntimeModelPricingSchema = z.object({
   input: PricePerTokenSchema,
   output: PricePerTokenSchema,
@@ -296,7 +312,8 @@ export const RuntimeModelPricingSchema = z.object({
     .object({
       price: z.number()
     })
-    .optional()
+    .optional(),
+  thresholds: z.array(ModelPricingThresholdSchema).optional()
 })
 export type RuntimeModelPricing = z.infer<typeof RuntimeModelPricingSchema>
 
@@ -366,6 +383,8 @@ export const ModelSchema = z.object({
   isHidden: z.boolean(),
   /** Whether this model has been deprecated by provider sync */
   isDeprecated: z.boolean().optional(),
+  /** Call MiniMax with `service_tier: priority` — billed at 1.5x the standard price */
+  usePriorityServiceTier: z.boolean().optional(),
   /** Replacement model if this one is deprecated */
   replaceWith: UniqueModelIdSchema.optional(),
 

--- a/src/shared/utils/provider.ts
+++ b/src/shared/utils/provider.ts
@@ -182,6 +182,21 @@ export function isSupportServiceTierProvider(provider: Provider): boolean {
   return provider.apiFeatures?.serviceTier ?? false
 }
 
+/** MiniMax's priority route is billed at 1.5x the standard price. */
+export const MINIMAX_PRIORITY_TIER_PRICE_MULTIPLIER = 1.5
+
+/**
+ * Whether this request rides MiniMax's priority service tier. Like Fast mode,
+ * it belongs to the provider-model pair: the toggle is per model, but only
+ * MiniMax (and its global mirror) serves the tier.
+ */
+export function usesMinimaxPriorityTier(
+  provider: Pick<Provider, 'id' | 'presetProviderId'>,
+  model: Pick<Model, 'usePriorityServiceTier'>
+): boolean {
+  return model.usePriorityServiceTier === true && matchesPreset(provider, 'minimax')
+}
+
 /** Effective Fast support belongs to the provider-model pair, not either side alone. */
 export function isSupportFastMode(
   provider: Pick<Provider, 'fastMode'>,


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Cost estimation only understood "one flat rate × token count". `RuntimeModelPricing` carried four fixed rates and `AiUsageRecordService.computeLanguageCost()` multiplied them straight through, so three real-world billing models could not be expressed and the Usage panel disagreed with the actual invoice.

Before this PR:

- **Long-context pricing was unrepresentable.** Vendors (Gemini, Qwen, MiniMax, …) switch to a higher rate once input tokens pass a threshold. Only one rate could be entered, so long-context requests were badly under-estimated.
- **Image generation never produced a cost.** `pricing.perImage` already existed in the types, the frozen snapshot, and the cost function — but **no UI could set it**, and `packages/provider-registry/data/*.json` contains zero `perImage` entries. Every image record persisted `cost: null`.
- **MiniMax's priority tier was unreachable.** No way to send `service_tier: "priority"`, and no way to bill it at the 1.5× it actually costs.

After this PR:

- **Tiered pricing.** `RuntimeModelPricing.thresholds[]` holds any number of `{ aboveInputTokens, input, output, cacheRead?, cacheWrite? }` entries. Selection keys off the request's **all-in input token count** (cached tokens included), and the **highest matching tier bills the whole request** — wholesale, not graduated, which is how vendors actually price it. Editable per model in the model drawer.
- **Per-image billing.** A "bill per image" switch (shown only for image-generation models) plus a price field. On → `imageCount × price`. Off → the model's token rates apply.
- **MiniMax priority tier.** A per-model switch (visible only on MiniMax / MiniMax Global chat models). When on, every request for that model carries `service_tier: "priority"` and its usage record is costed at 1.5× the configured price.

Also fixes a pre-existing data-loss bug found on the way: `EditModelDrawer.buildPatch()` rebuilt `pricing` from scratch on every autosave with only `input`/`output`/`cacheRead`/`cacheWrite`, so **the first time a user touched the drawer any existing `perImage` / `perMinute` was silently dropped**.

Fixes # N/A

### Why we need it and why it was done in this way

Cost figures that quietly disagree with the vendor's bill are worse than no figures, so each of the three gaps was closed at the layer that already owns the concern rather than bolted on beside it.

The following tradeoffs were made:

- **The 1.5× surcharge is baked into the frozen pricing snapshot** (`createAiUsagePricingSnapshot`'s new `multiplier` arg) rather than stored as a multiplier and applied at cost time. One mutation point covers base rates, tier rates, and `perImage`, and it matches the snapshot's documented contract ("the pricing applied to this record"). Cost: the list price is no longer recoverable from the record. `costBreakdown` still carries the per-bucket split, and nothing in the renderer reads snapshot rate fields.
- **`service_tier` is injected via `transformRequestBody` in `config.ts`, not via `providerOptions` in `options.ts`.** `buildAgentParams.ts:485` only calls `buildCapabilityProviderOptions` when an assistant is present — translate, topic-naming, and prompt streams skip it. Emitting from `options.ts` would have produced requests **billed at 1.5× but sent on the standard tier**. A body transform runs on every assembled request, and sidesteps the snake_case-key hazard documented at `options.ts:289`.
- **`computedCost` now falls through to token pricing for `modality: 'image'`** when no per-image rate is set. Without it the switch is "on / nothing" rather than a genuine either-or. See Breaking changes.
- **`usePriorityServiceTier` is modelled as user state, not a preset delta** — same path as `isDeprecated` / `notes`. It touches 3 sites instead of 7, and a request-routing flag has no registry baseline to diff against.
- **Threshold entries carry no `currency` of their own.** Per-entry currency would break `usageCapture.pricingCurrency()` and allow a single record to sum across currencies.

The following alternatives were considered:

- **A single threshold instead of an array** — simpler UI, but does not cover Qwen-style 3–4 bracket schedules. Confirmed with the requester that multiple tiers are needed.
- **Graduated/marginal pricing** (tokens below the threshold at the low rate, the excess at the high rate). Rejected: vendors bill the whole request at the matched tier, and the two differ substantially (¥2.54 vs ¥1.46 on a 600K-token request).
- **A provider-level priority toggle** instead of per-model. Smaller change, but priority applies per model in practice; per-model was chosen deliberately, accepting the new column + migration.
- **Reusing the existing `apiFeatures.serviceTier` / `provider.settings.serviceTier` plumbing.** Not viable: `getServiceTier()` hard-requires `isOpenAIModel(model)`, and `getProviderApiOptionsVisibility()` hides API-feature toggles for system providers like MiniMax. That plumbing also has no v2 UI setting its value.
- **A generic `user_model.settings` JSON bag** to avoid a migration. Rejected — one explicit boolean column matches the table's existing style.
- **Changing `packages/provider-registry`.** Not touched: `data/*.json` is a generated artifact CI rejects hand-edits to, and this feature is entirely user-entered pricing.

Links to places where the discussion took place: N/A

### Breaking changes

**Image-generation records that previously had no cost may now show one.** `computedCost` no longer returns `undefined` for `modality: 'image'` when per-image pricing is absent — it falls through to the model's token rates. Image models that report token usage *and* have token prices configured (e.g. `gpt-image-1`, Gemini image models) previously persisted `cost: null` and will now produce a computed cost. Existing rows are untouched; only new records are affected. No action required.

No schema or API compatibility breaks: `thresholds` is optional on both `RuntimeModelPricing` (a JSON column, no migration) and `AiUsagePricingSnapshot`, and migration `0006` is an appended `ALTER TABLE … ADD COLUMN … DEFAULT false`.

### Special notes for your reviewer

- **The highest-risk change is `ProviderRegistryService.normalizePricingForComparison`.** It is a field **whitelist**, and `ModelService.buildUpdates:513` writes **`null` over the entire pricing column** when a PATCH reads as baseline-equal. Omitting `thresholds` there means a threshold-only edit is silently erased. `isEmptyPricingEcho` needed the same treatment. Guarded by a DB-backed regression test — verified non-vacuous by temporarily reverting the whitelist fix and confirming `row.pricing` comes back `null`.
- **`agentSessionWarmup.ts` is deliberately left un-multiplied** (comment added at the call site): agent sessions run on the Agent SDK's `anthropic-messages` endpoint, which never carries `service_tier`.
- **Known residual, not fixed:** if a user manually routes a MiniMax *chat* model onto the `anthropic-messages` endpoint, the request bypasses `transformRequestBody` but is still billed 1.5×. Closing it means threading `endpointType` through 4 `createCaptureContext` call sites — disproportionate for the case.
- **`applyMigrations.populated.test.ts` needed its baseline target pinned** to `0005_slow_obadiah_stane`. That helper defaults to "the tip", so adding `0006` would have made it seed rows *after* the backfill it exists to prove. This is exactly the maintenance its own doc comment prescribes for a now-shipped migration.
- **Pre-existing gaps flagged, not fixed:** image records set `messageRef: null` (`AiService.ts:701`, `imageGenerationJobHandler.ts:86`), so image cost lands in the global Usage dashboard but never rolls into per-message stats; the drawer still never round-trips `cacheWrite`'s *rate* (only its currency); `OpenClawService.toOpenClawCost` exports base rates only, so tiers and the multiplier are absent from exported OpenClaw config. `PricingTierSchema` / `PricingTier` are dead (zero references) — flagged, not deleted, per `CLAUDE.md`.
- **Verification:** `pnpm lint` (0 errors), all three typecheck projects, `pnpm i18n:check`, `pnpm docs:check-links`, and `pnpm db:migrations:check` pass. `pnpm test` → **21492 passed, 1 failed**. The single failure is `src/main/ai/inference/__tests__/inferenceWorkerProxy.test.ts` (local HTTP-proxy socket binding), which **fails identically on a clean checkout of `main`** — confirmed by stashing this branch's changes — and is unrelated to this PR.
- i18n changes are confined to `locales/en-us.json` + `locales/zh-cn.json`; `i18n/translate/*` is CI-generated and untouched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [[Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans)](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [[Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [[left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [[user-guide update](https://docs.cherry-ai.com/)](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`[/gh-pr-review](file:///.claude/skills/gh-pr-review/SKILL.md)`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Model pricing now supports tiered rates, per-image billing, and MiniMax's priority tier.

- Tiered pricing: add any number of input-token thresholds per model. When a request's input tokens exceed a threshold, the whole request is billed at that tier's rates (highest matching tier wins) — matching how vendors price long context.
- Per-image billing: image-generation models can now be billed by output image count instead of tokens. Previously image generations never produced a cost estimate at all.
- MiniMax priority tier: a per-model switch that sends `service_tier: priority` on every request for that model and estimates its cost at 1.5x the configured price.
- Fixed: editing any field in the model drawer silently discarded a model's existing per-image and per-minute prices.
```