### PR TITLE
feat(chat): branch follow-up notice, tree direction toggle, and opt-in regenerate on edit

### DIFF
--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -44,7 +44,7 @@ import {
 import type { UniqueModelId } from '@shared/data/types/model'
 import { hasClearContextPart, isBlankUserTurn, readCherryMeta } from '@shared/data/types/uiParts'
 import { isToolUIPart } from 'ai'
-import { and, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm'
+import { and, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm'
 
 import { aiUsageRecordService, mergeMessageRuntimeStats } from './AiUsageRecordService'
 import { getDataService, registerDataService } from './dataServiceRegistry'
@@ -665,7 +665,14 @@ export class MessageService {
 
     // Return empty if no active node
     if (!nodeId) {
-      return { items: [], nextCursor: undefined, activeNodeId: null, assistantId: topic.assistantId, rootId }
+      return {
+        items: [],
+        nextCursor: undefined,
+        activeNodeId: null,
+        assistantId: topic.assistantId,
+        rootId,
+        followingBranchCount: 0
+      }
     }
 
     const fullPath = this.getPathRowsToNodeTx(db, nodeId, { topicId })
@@ -762,8 +769,60 @@ export class MessageService {
       nextCursor,
       activeNodeId: topic.activeNodeId,
       assistantId: topic.assistantId,
-      rootId
+      rootId,
+      followingBranchCount: this.countFollowingBranch(topicId, fullPath)
     }
+  }
+
+  /**
+   * Count live messages in a topic hidden from the active-branch view.
+   *
+   * A message counts as "hidden" when it is not on the root→activeNode path
+   * AND is not an alternative reply of a reply-group that is visible on the
+   * path (alternative replies surface via multi-model tabs / sibling
+   * navigator, so they are reachable from the view). The virtual root
+   * (parentId-null), soft-deleted rows, and in-flight `pending` placeholders
+   * are excluded. Topic-level and pagination-independent.
+   */
+  private countFollowingBranch(topicId: string, fullPath: MessageRow[]): number {
+    if (fullPath.length === 0) return 0
+    const db = application.get('DbService').getDb()
+
+    const activePathIds = fullPath.map((m) => m.id)
+    // Only exclude alternatives of reply-groups visible on the path:
+    // the (parentId, siblingsGroupId) pairs of every path node with a group.
+    const groupCombos: string[] = []
+    for (const m of fullPath) {
+      if (m.siblingsGroupId !== 0) {
+        groupCombos.push(`${m.parentId}:${m.siblingsGroupId}`)
+      }
+    }
+
+    const conditions = [
+      eq(messageTable.topicId, topicId),
+      isNull(messageTable.deletedAt),
+      isNotNull(messageTable.parentId),
+      ne(messageTable.status, 'pending'),
+      not(inArray(messageTable.id, activePathIds))
+    ]
+    for (const combo of groupCombos) {
+      const sep = combo.indexOf(':')
+      conditions.push(
+        not(
+          and(
+            eq(messageTable.parentId, combo.slice(0, sep)),
+            eq(messageTable.siblingsGroupId, Number(combo.slice(sep + 1)))
+          )
+        )
+      )
+    }
+
+    const [row] = db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(messageTable)
+      .where(and(...conditions))
+      .all()
+    return row?.count ?? 0
   }
 
   /**

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -456,6 +456,353 @@ describe('MessageService', () => {
     })
   })
 
+  describe('getBranchMessages — followingBranchCount', () => {
+    it('returns 0 for a linear tree with no hidden branches', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-linear', activeNodeId: 'm-a2', orderKey: 'c0' })
+      await dbh.db.insert(messageTable).values(
+        withRoot('topic-linear', [
+          {
+            id: 'm-u1',
+            parentId: null,
+            topicId: 'topic-linear',
+            role: 'user',
+            data: mainText('q1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 100,
+            updatedAt: 100
+          },
+          {
+            id: 'm-a1',
+            parentId: 'm-u1',
+            topicId: 'topic-linear',
+            role: 'assistant',
+            data: mainText('a1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 200,
+            updatedAt: 200
+          },
+          {
+            id: 'm-u2',
+            parentId: 'm-a1',
+            topicId: 'topic-linear',
+            role: 'user',
+            data: mainText('q2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 300,
+            updatedAt: 300
+          },
+          {
+            id: 'm-a2',
+            parentId: 'm-u2',
+            topicId: 'topic-linear',
+            role: 'assistant',
+            data: mainText('a2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 400,
+            updatedAt: 400
+          }
+        ])
+      )
+
+      const result = messageService.getBranchMessages('topic-linear', { includeSiblings: true })
+
+      expect(result.followingBranchCount).toBe(0)
+    })
+
+    it('counts hidden follow-ups after regenerating a mid-conversation message', async () => {
+      // root→U1→[A1(sg=1), A1'(sg=1, active)], A1→U2→A2. Regenerating A1 moved
+      // activeNode to A1', so U2→A2 under the old A1 branch are hidden.
+      await dbh.db.insert(topicTable).values({ id: 'topic-regen', activeNodeId: 'm-a1p', orderKey: 'c1' })
+      await dbh.db.insert(messageTable).values(
+        withRoot('topic-regen', [
+          {
+            id: 'm-u1',
+            parentId: null,
+            topicId: 'topic-regen',
+            role: 'user',
+            data: mainText('q1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 100,
+            updatedAt: 100
+          },
+          {
+            id: 'm-a1',
+            parentId: 'm-u1',
+            topicId: 'topic-regen',
+            role: 'assistant',
+            data: mainText('old reply'),
+            status: 'success',
+            siblingsGroupId: 1,
+            createdAt: 200,
+            updatedAt: 200
+          },
+          {
+            id: 'm-a1p',
+            parentId: 'm-u1',
+            topicId: 'topic-regen',
+            role: 'assistant',
+            data: mainText('new reply'),
+            status: 'success',
+            siblingsGroupId: 1,
+            createdAt: 210,
+            updatedAt: 210
+          },
+          {
+            id: 'm-u2',
+            parentId: 'm-a1',
+            topicId: 'topic-regen',
+            role: 'user',
+            data: mainText('q2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 300,
+            updatedAt: 300
+          },
+          {
+            id: 'm-a2',
+            parentId: 'm-u2',
+            topicId: 'topic-regen',
+            role: 'assistant',
+            data: mainText('a2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 400,
+            updatedAt: 400
+          }
+        ])
+      )
+
+      const result = messageService.getBranchMessages('topic-regen', { includeSiblings: true })
+
+      // A1 is an alternative reply of the visible group (excluded); U2 + A2 are
+      // genuinely hidden follow-ups on the old branch.
+      expect(result.followingBranchCount).toBe(2)
+    })
+
+    it('returns 0 for a multi-model reply group whose alternatives are visible', async () => {
+      await seedMultiModelTree()
+
+      const result = messageService.getBranchMessages('topic-1', { includeSiblings: true })
+
+      // m-a1 is an alternative reply of m-a2's visible group — excluded.
+      expect(result.followingBranchCount).toBe(0)
+    })
+
+    it('counts a user-forked branch that is not on the active path', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-fork', activeNodeId: 'm-a1', orderKey: 'c2' })
+      await dbh.db.insert(messageTable).values(
+        withRoot('topic-fork', [
+          {
+            id: 'm-u1',
+            parentId: null,
+            topicId: 'topic-fork',
+            role: 'user',
+            data: mainText('q1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 100,
+            updatedAt: 100
+          },
+          {
+            id: 'm-u1b',
+            parentId: null,
+            topicId: 'topic-fork',
+            role: 'user',
+            data: mainText('q1 edited'),
+            status: 'success',
+            siblingsGroupId: 2,
+            createdAt: 110,
+            updatedAt: 110
+          },
+          {
+            id: 'm-a1',
+            parentId: 'm-u1',
+            topicId: 'topic-fork',
+            role: 'assistant',
+            data: mainText('a1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 200,
+            updatedAt: 200
+          },
+          {
+            id: 'm-a1b',
+            parentId: 'm-u1b',
+            topicId: 'topic-fork',
+            role: 'assistant',
+            data: mainText('a1b'),
+            status: 'success',
+            siblingsGroupId: 2,
+            createdAt: 210,
+            updatedAt: 210
+          }
+        ])
+      )
+
+      const result = messageService.getBranchMessages('topic-fork', { includeSiblings: true })
+
+      // m-u1b + m-a1b are an off-path fork (different sibling group from the
+      // visible m-u1 path) → both counted.
+      expect(result.followingBranchCount).toBe(2)
+    })
+
+    it('returns the same count regardless of pagination', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-page', activeNodeId: 'm-follow2', orderKey: 'c3' })
+      await dbh.db.insert(messageTable).values(
+        withRoot('topic-page', [
+          {
+            id: 'm-u1',
+            parentId: null,
+            topicId: 'topic-page',
+            role: 'user',
+            data: mainText('q1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 100,
+            updatedAt: 100
+          },
+          {
+            id: 'm-a1',
+            parentId: 'm-u1',
+            topicId: 'topic-page',
+            role: 'assistant',
+            data: mainText('a1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 200,
+            updatedAt: 200
+          },
+          {
+            id: 'm-u2',
+            parentId: 'm-a1',
+            topicId: 'topic-page',
+            role: 'user',
+            data: mainText('q2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 300,
+            updatedAt: 300
+          },
+          {
+            id: 'm-a2',
+            parentId: 'm-u2',
+            topicId: 'topic-page',
+            role: 'assistant',
+            data: mainText('a2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 400,
+            updatedAt: 400
+          },
+          {
+            id: 'm-follow2',
+            parentId: 'm-a2',
+            topicId: 'topic-page',
+            role: 'user',
+            data: mainText('follow'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 500,
+            updatedAt: 500
+          },
+          // Hidden off-path branch: a sibling fork under m-u2.
+          {
+            id: 'm-a2b',
+            parentId: 'm-u2',
+            topicId: 'topic-page',
+            role: 'assistant',
+            data: mainText('a2b'),
+            status: 'success',
+            siblingsGroupId: 3,
+            createdAt: 450,
+            updatedAt: 450
+          }
+        ])
+      )
+
+      const first = messageService.getBranchMessages('topic-page', { includeSiblings: true, limit: 2 })
+      expect(first.followingBranchCount).toBe(1)
+
+      const second = messageService.getBranchMessages('topic-page', {
+        includeSiblings: true,
+        limit: 2,
+        cursor: first.nextCursor
+      })
+      expect(second.followingBranchCount).toBe(1)
+    })
+
+    it('returns 0 when no active node exists', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-empty', activeNodeId: null, orderKey: 'c4' })
+
+      const result = messageService.getBranchMessages('topic-empty', { includeSiblings: true })
+
+      expect(result.followingBranchCount).toBe(0)
+    })
+
+    it('excludes soft-deleted hidden messages from the count', async () => {
+      await dbh.db.insert(topicTable).values({ id: 'topic-deleted', activeNodeId: 'm-a1d', orderKey: 'c5' })
+      await dbh.db.insert(messageTable).values(
+        withRoot('topic-deleted', [
+          {
+            id: 'm-u1',
+            parentId: null,
+            topicId: 'topic-deleted',
+            role: 'user',
+            data: mainText('q1'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 100,
+            updatedAt: 100
+          },
+          {
+            id: 'm-a1d',
+            parentId: 'm-u1',
+            topicId: 'topic-deleted',
+            role: 'assistant',
+            data: mainText('active'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 200,
+            updatedAt: 200
+          },
+          {
+            id: 'm-a1x',
+            parentId: 'm-u1',
+            topicId: 'topic-deleted',
+            role: 'assistant',
+            data: mainText('hidden'),
+            status: 'success',
+            siblingsGroupId: 4,
+            createdAt: 210,
+            updatedAt: 210
+          },
+          {
+            id: 'm-u2',
+            parentId: 'm-a1x',
+            topicId: 'topic-deleted',
+            role: 'user',
+            data: mainText('q2'),
+            status: 'success',
+            siblingsGroupId: 0,
+            createdAt: 300,
+            updatedAt: 300
+          }
+        ])
+      )
+
+      // Soft-delete the hidden branch head.
+      await dbh.db.update(messageTable).set({ deletedAt: 999 }).where(eq(messageTable.id, 'm-a1x')).run()
+
+      // m-u2 is a live child of the soft-deleted m-a1x → still hidden and counted.
+      expect(messageService.getBranchMessages('topic-deleted').followingBranchCount).toBe(1)
+    })
+  })
+
   describe('search', () => {
     it('searches v2 parts text and returns message snippets', async () => {
       await dbh.db.insert(topicTable).values({ id: 'topic-search', activeNodeId: 'm-search-1', orderKey: 's0' })

--- a/src/renderer/components/chat/flow/index.ts
+++ b/src/renderer/components/chat/flow/index.ts
@@ -5,6 +5,7 @@ export type { TopicMessageFlowLiveNode, TopicMessageFlowLiveState } from './topi
 export { buildTopicMessageFlowLiveState, mergeTopicMessageFlowLiveTree } from './topicMessageFlowLiveTree'
 export { default as TopicMessageFlowNode } from './TopicMessageFlowNode'
 export type {
+  TopicMessageFlowDirection,
   TopicMessageFlowEdgeData,
   TopicMessageFlowGraph,
   TopicMessageFlowGraphEdge,

--- a/src/renderer/components/chat/flow/topicMessageFlowLayout.ts
+++ b/src/renderer/components/chat/flow/topicMessageFlowLayout.ts
@@ -2,6 +2,7 @@ import { graphlib, layout, type OrderConstraint } from '@dagrejs/dagre'
 import { MarkerType, Position } from '@xyflow/react'
 
 import type {
+  TopicMessageFlowDirection,
   TopicMessageFlowEdgeModel,
   TopicMessageFlowEdgeState,
   TopicMessageFlowGraph,
@@ -35,7 +36,10 @@ const EDGE_COLORS: Record<TopicMessageFlowEdgeState, string> = {
   sibling: 'var(--border)'
 }
 
-export function layoutTopicMessageFlowGraph(graph: TopicMessageFlowGraph): TopicMessageFlowLayout {
+export function layoutTopicMessageFlowGraph(
+  graph: TopicMessageFlowGraph,
+  direction: TopicMessageFlowDirection = 'top-to-bottom'
+): TopicMessageFlowLayout {
   const depthById = getDepthById(graph)
   const orderedNodes = [...graph.nodes].sort((a, b) => compareGraphNodes(a, b, depthById))
   const orderConstraints = buildSiblingOrderConstraints(orderedNodes)
@@ -52,9 +56,10 @@ export function layoutTopicMessageFlowGraph(graph: TopicMessageFlowGraph): Topic
     }
   }
 
+  const rankdir = direction === 'bottom-to-top' ? 'BT' : 'TB'
   const dagreGraph = new graphlib.Graph()
     .setGraph({
-      rankdir: 'TB',
+      rankdir,
       ...GRAPH_SPACING
     })
     .setDefaultEdgeLabel(() => ({}))
@@ -72,10 +77,14 @@ export function layoutTopicMessageFlowGraph(graph: TopicMessageFlowGraph): Topic
   const nodes = orderedNodes.map((node): TopicMessageFlowNodeModel => {
     const positioned = dagreGraph.node(node.id)
 
-    return toReactFlowNode(node, {
-      x: positioned.x - TOPIC_MESSAGE_FLOW_NODE_SIZE.width / 2,
-      y: positioned.y - TOPIC_MESSAGE_FLOW_NODE_SIZE.height / 2
-    })
+    return toReactFlowNode(
+      node,
+      {
+        x: positioned.x - TOPIC_MESSAGE_FLOW_NODE_SIZE.width / 2,
+        y: positioned.y - TOPIC_MESSAGE_FLOW_NODE_SIZE.height / 2
+      },
+      direction
+    )
   })
 
   return {
@@ -88,15 +97,18 @@ export function layoutTopicMessageFlowGraph(graph: TopicMessageFlowGraph): Topic
 
 function toReactFlowNode(
   node: TopicMessageFlowGraph['nodes'][number],
-  position: TopicMessageFlowNodeModel['position']
+  position: TopicMessageFlowNodeModel['position'],
+  direction: TopicMessageFlowDirection = 'top-to-bottom'
 ): TopicMessageFlowNodeModel {
+  const sourcePosition = direction === 'bottom-to-top' ? Position.Top : Position.Bottom
+  const targetPosition = direction === 'bottom-to-top' ? Position.Bottom : Position.Top
   return {
     id: node.id,
     type: TOPIC_MESSAGE_FLOW_NODE_TYPE,
     position,
     data: { ...node.data },
-    sourcePosition: Position.Bottom,
-    targetPosition: Position.Top,
+    sourcePosition,
+    targetPosition,
     draggable: false,
     connectable: false,
     selectable: true,

--- a/src/renderer/components/chat/flow/types.ts
+++ b/src/renderer/components/chat/flow/types.ts
@@ -5,6 +5,9 @@ export const TOPIC_MESSAGE_FLOW_NODE_TYPE = 'topicMessage'
 
 export type TopicMessageFlowEdgeState = 'active' | 'default' | 'inactive' | 'sibling'
 
+/** Flow tree direction: root at top (down) or root at bottom (up). */
+export type TopicMessageFlowDirection = 'top-to-bottom' | 'bottom-to-top'
+
 export interface TopicMessageFlowNodeData extends Record<string, unknown> {
   messageId: string
   role: MessageRole

--- a/src/renderer/components/chat/messages/FollowingBranchNotice.tsx
+++ b/src/renderer/components/chat/messages/FollowingBranchNotice.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@cherrystudio/ui'
+import { GitBranch } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  /** Number of hidden messages continuing in another branch. */
+  count: number
+  /** Opens the branch tree panel. */
+  onOpenBranches: () => void
+}
+
+/**
+ * Footer notice shown at the end of the active message path when live
+ * messages continue in another branch (e.g. after regenerating or editing a
+ * mid-conversation message). Clicking it opens the branch tree panel so the
+ * hidden conversation can be located or switched back to.
+ */
+function FollowingBranchNotice({ count, onOpenBranches }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex w-full justify-center px-4 py-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        data-testid="following-branch-notice"
+        onClick={onOpenBranches}
+        className="h-auto rounded-full border-border bg-background/60 px-3.5 py-1.5 text-foreground-tertiary text-xs shadow-sm backdrop-blur-sm transition-colors hover:bg-background hover:text-foreground">
+        <GitBranch className="mr-1.5 size-3.5 shrink-0 text-foreground-tertiary" aria-hidden="true" />
+        <span>{t('chat.message.following_branch.notice', { count })}</span>
+        <span className="ml-1.5 text-foreground-tertiary">·</span>
+        <span className="ml-1.5 font-medium text-foreground-secondary">{t('chat.message.following_branch.open')}</span>
+      </Button>
+    </div>
+  )
+}
+
+export default FollowingBranchNotice

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -184,7 +184,7 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   // message column; this component both writes it (via the resize observer
   // below) and renders from it.
   const { setForceWideLayout, railGutterPx, setRailGutterPx } = useChatLayoutMode()
-  const { topic, messages, beforeList, messageTail, hasOlder = false, messageNavigation } = data
+  const { topic, messages, beforeList, afterList, messageTail, hasOlder = false, messageNavigation } = data
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const { setTimeoutTimer } = useTimer()
   const isMultiSelectMode = selection?.isMultiSelectMode ?? false
@@ -761,6 +761,7 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
             overscan={data.overscan}
             topPadding={topPadding}
             bottomPadding={bottomPadding}
+            renderFooter={afterList}
             keepMountedKeys={keepMountedKeys}
             showScrollToBottomButton
             scrollToBottomButtonBottomOffset={Math.max(24, bottomPadding)}

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -39,6 +39,7 @@ type MessageListDataValue = Pick<
   MessageListState,
   | 'topic'
   | 'beforeList'
+  | 'afterList'
   | 'messageTail'
   | 'activeTurnStatus'
   | 'isInitialLoading'
@@ -91,6 +92,7 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
     () => ({
       topic: state.topic,
       beforeList: state.beforeList,
+      afterList: state.afterList,
       messageTail: state.messageTail,
       activeTurnStatus: state.activeTurnStatus,
       isInitialLoading: state.isInitialLoading,
@@ -107,6 +109,7 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
     [
       state.topic,
       state.beforeList,
+      state.afterList,
       state.messageTail,
       state.activeTurnStatus,
       state.isInitialLoading,

--- a/src/renderer/components/chat/messages/__tests__/FollowingBranchNotice.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/FollowingBranchNotice.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import FollowingBranchNotice from '../FollowingBranchNotice'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) => {
+      if (key === 'chat.message.following_branch.notice') return `${options?.count ?? 0} more messages`
+      if (key === 'chat.message.following_branch.open') return 'View branches'
+      return key
+    }
+  })
+}))
+
+describe('FollowingBranchNotice', () => {
+  it('renders the hidden-message count and a view-branches affordance', () => {
+    render(<FollowingBranchNotice count={3} onOpenBranches={() => {}} />)
+
+    expect(screen.getByTestId('following-branch-notice')).toBeInTheDocument()
+    expect(screen.getByText('3 more messages')).toBeInTheDocument()
+    expect(screen.getByText('View branches')).toBeInTheDocument()
+  })
+
+  it('calls onOpenBranches when clicked', () => {
+    const onOpenBranches = vi.fn()
+    render(<FollowingBranchNotice count={1} onOpenBranches={onOpenBranches} />)
+
+    fireEvent.click(screen.getByTestId('following-branch-notice'))
+
+    expect(onOpenBranches).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -196,6 +196,7 @@ vi.mock('../list/MessageVirtualList', async () => {
       items,
       keepMountedKeys,
       onScrollContainerReady,
+      renderFooter,
       renderItem,
       scrollToBottomButtonBottomOffset,
       showScrollToBottomButton,
@@ -237,6 +238,7 @@ vi.mock('../list/MessageVirtualList', async () => {
           {visibleItems.map((item: unknown, index: number) => (
             <div key={index}>{renderItem(item, index)}</div>
           ))}
+          {renderFooter != null && (typeof renderFooter === 'function' ? renderFooter() : renderFooter)}
         </div>
       )
     }
@@ -313,6 +315,19 @@ describe('MessageList', () => {
     renderMessageList([createMessage('assistant-1', 'assistant')])
 
     expect(screen.queryByTestId('message-list-search')).not.toBeInTheDocument()
+  })
+
+  it('renders the afterList footer after the last message', () => {
+    render(
+      <MessageListProvider
+        value={createValue([createMessage('assistant-1', 'assistant')], {
+          afterList: <div data-testid="after-list-footer" />
+        })}>
+        <MessageList />
+      </MessageListProvider>
+    )
+
+    expect(screen.getByTestId('after-list-footer')).toBeInTheDocument()
   })
 
   it('keeps search mounted while excluding pending and live message content', () => {

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -65,6 +65,8 @@ export interface MessageVirtualListProps<T> {
   getItemKey(item: T, index: number): string
   /** Render function for one item. */
   renderItem(item: T, index: number): ReactNode
+  /** Optional content rendered after the last item (inside the scroll content). */
+  renderFooter?: (() => ReactNode) | ReactNode
   /** Initial pixel estimate per item; refined as items are measured. */
   estimateSize?: number
   /** Items rendered off-screen on each side for smooth scroll. */
@@ -105,6 +107,7 @@ export function MessageVirtualList<T>({
   items,
   getItemKey,
   renderItem,
+  renderFooter,
   estimateSize,
   overscan = 6,
   onReachTop,
@@ -272,6 +275,11 @@ export function MessageVirtualList<T>({
               </Virtualizer>
             )}
           </ScrollOwnershipProvider>
+          {renderFooter != null && (
+            <div data-message-virtual-list-footer>
+              {typeof renderFooter === 'function' ? renderFooter() : renderFooter}
+            </div>
+          )}
         </div>
         {/* Outside the content wrapper so runtime-owned freeze slack does not
             inflate the natural content size observed above. */}

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -286,6 +286,8 @@ export interface MessageListState {
   /** When provided, streaming updates stay isolated from historical message subtrees. */
   streamingLayers?: MessageStreamingLayers
   beforeList?: ReactNode
+  /** Optional adapter-owned content rendered after the last message (e.g. a "continue in another branch" notice). */
+  afterList?: ReactNode
   /** Optional adapter-owned content rendered after one message's body. */
   messageTail?: MessageTailSlot
   /** Renders the live turn's processing status inline, replacing the default placeholder. Receives

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -22,6 +22,7 @@ import { ComposerPanelSymbol, getQuickPanelSearchAliases } from '@renderer/compo
 import { getComposerToolConfig } from '@renderer/components/composer/tools/registry'
 import NewConversationIcon from '@renderer/components/icons/NewConversationIcon'
 import { McpLogo } from '@renderer/components/icons/SvgIcon'
+import EditMessageSavePopup from '@renderer/components/popups/EditMessageSavePopup'
 import { type QuickPanelListItem, useOptionalQuickPanel } from '@renderer/components/QuickPanel'
 import { ResourceEditDialogEventHost } from '@renderer/components/resourceCatalog/dialogs/edit'
 import { useCache } from '@renderer/data/hooks/useCache'
@@ -1335,7 +1336,19 @@ const ChatComposerInner = ({
                         : 'default',
                   fastMode: fastMode && speedControlModel?.supportsFastMode === true
                 }
-            await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, savedParts, editedTurnOptions)
+            // Editing a user message no longer regenerates the conversation by
+            // default: ask the user whether to save the content only, or save
+            // and regenerate (which branches the tree and spends tokens).
+            const choice = await EditMessageSavePopup.show({ regenerateDisabled: isPending })
+            if (choice === null) {
+              // Cancelled — keep editing.
+              return
+            }
+            if (choice === 'save-and-regenerate') {
+              await chatWrite.forkAndResend(editingMessageForCurrentTopic.message.id, savedParts, editedTurnOptions)
+            } else {
+              await chatWrite.editMessage(editingMessageForCurrentTopic.message.id, savedParts)
+            }
           }
           if (editingMessageForCurrentTopicRef.current?.editingSessionId === editingSessionId) {
             restoreSavedDraft()

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -57,6 +57,7 @@ const mocks = vi.hoisted(() => ({
   dispatchLauncher: vi.fn(),
   unifiedPanelOpen: vi.fn(),
   unifiedPanelAvailable: true,
+  editMessageSaveChoice: null as 'save-only' | 'save-and-regenerate' | null | undefined,
   pinnedToolIds: ['composer:new-conversation', 'web-search'] as string[],
   ipcListeners: new Map<string, (_event: unknown, payload: unknown) => void>(),
   ipcOn: vi.fn(),
@@ -140,6 +141,15 @@ const ipcRequestMock = vi.hoisted(() => vi.fn())
 
 // Send-time attachment metadata (buildFileParts) resolves through IpcApi.
 vi.mock('@renderer/ipc', () => ({ ipcApi: { request: ipcRequestMock } }))
+
+// Editing a user message now asks how to save; default to regenerate so the
+// existing edit-save assertions (forkAndResend is called) keep their meaning.
+vi.mock('@renderer/components/popups/EditMessageSavePopup', () => ({
+  __esModule: true,
+  default: {
+    show: () => Promise.resolve(mocks.editMessageSaveChoice ?? 'save-and-regenerate')
+  }
+}))
 
 vi.mock('@renderer/components/composer/ComposerSurface', () => {
   function MockComposerSurface(props: ComposerSurfaceProps) {
@@ -743,6 +753,7 @@ describe('ChatComposer', () => {
     mocks.dispatchLauncher.mockReset()
     mocks.unifiedPanelOpen.mockReset()
     mocks.unifiedPanelAvailable = true
+    mocks.editMessageSaveChoice = undefined
     mocks.pinnedToolIds = ['composer:new-conversation', 'web-search']
     mocks.ipcListeners.clear()
     mocks.ipcOn.mockReset()

--- a/src/renderer/components/popups/EditMessageSavePopup.tsx
+++ b/src/renderer/components/popups/EditMessageSavePopup.tsx
@@ -1,0 +1,56 @@
+import { Box, Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@cherrystudio/ui'
+import { createPopup, type PopupInjectedProps } from '@renderer/services/popup'
+import { GitBranch, Save } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+/** How the user wants to save an edited user message. */
+export type EditMessageSaveChoice = 'save-only' | 'save-and-regenerate'
+
+interface EditMessageSavePopupParams {
+  /** Whether the topic currently has a live stream that blocks regeneration. */
+  regenerateDisabled?: boolean
+}
+
+type Props = EditMessageSavePopupParams & PopupInjectedProps<EditMessageSaveChoice | null>
+
+const EditMessageSavePopupContainer: React.FC<Props> = ({ regenerateDisabled = false, open, resolve }) => {
+  const { t } = useTranslation()
+
+  const onOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) resolve(null)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent closeOnOverlayClick={false} className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>{t('chat.message.edit_save.title')}</DialogTitle>
+        </DialogHeader>
+        <Box className="text-foreground-secondary text-sm">{t('chat.message.edit_save.description')}</Box>
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={() => resolve('save-only')}>
+            <Save className="mr-1.5 size-4" />
+            {t('chat.message.edit_save.save_only')}
+          </Button>
+          <Button onClick={() => resolve('save-and-regenerate')} disabled={regenerateDisabled}>
+            <GitBranch className="mr-1.5 size-4" />
+            {t('chat.message.edit_save.save_and_regenerate')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/**
+ * Ask how an edited user message should be saved. Editing a user message no
+ * longer regenerates the whole conversation by default — the user explicitly
+ * picks between a plain content save and a save + regenerate (which branches
+ * the tree and spends tokens).
+ */
+const EditMessageSavePopup = createPopup<EditMessageSavePopupParams, EditMessageSaveChoice | null>(
+  EditMessageSavePopupContainer,
+  { dismissResult: null }
+)
+
+export default EditMessageSavePopup

--- a/src/renderer/hooks/__tests__/useTopicMessages.test.ts
+++ b/src/renderer/hooks/__tests__/useTopicMessages.test.ts
@@ -1,7 +1,7 @@
 import { mockUseInfiniteQuery } from '@test-mocks/renderer/useDataApi'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 import { renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useTopicMessages } from '../useTopicMessages'
 
@@ -41,6 +41,44 @@ describe('useTopicMessages', () => {
         '/topics/:topicId/messages',
         expect.objectContaining({ limit: 50 })
       )
+    })
+  })
+
+  describe('followingBranchCount', () => {
+    it('reads the topic-level count off pages[0]', () => {
+      mockUseInfiniteQuery.mockReturnValue({
+        pages: [{ items: [], activeNodeId: 'node-1', followingBranchCount: 3 }],
+        isLoading: false,
+        isRefreshing: false,
+        error: undefined,
+        hasNext: false,
+        loadNext: vi.fn(),
+        refresh: vi.fn().mockResolvedValue(undefined),
+        reset: vi.fn(),
+        mutate: vi.fn().mockResolvedValue(undefined)
+      } as any)
+
+      const { result } = renderHook(() => useTopicMessages('topic-1'))
+
+      expect(result.current.followingBranchCount).toBe(3)
+    })
+
+    it('defaults to 0 when no page has loaded yet', () => {
+      mockUseInfiniteQuery.mockReturnValue({
+        pages: [],
+        isLoading: false,
+        isRefreshing: false,
+        error: undefined,
+        hasNext: false,
+        loadNext: vi.fn(),
+        refresh: vi.fn().mockResolvedValue(undefined),
+        reset: vi.fn(),
+        mutate: vi.fn().mockResolvedValue(undefined)
+      } as any)
+
+      const { result } = renderHook(() => useTopicMessages('topic-1'))
+
+      expect(result.current.followingBranchCount).toBe(0)
     })
   })
 })

--- a/src/renderer/hooks/useTopicMessages.ts
+++ b/src/renderer/hooks/useTopicMessages.ts
@@ -168,6 +168,13 @@ export interface UseTopicMessagesResult {
   isStale: boolean
   refresh: () => Promise<CherryUIMessage[]>
   activeNodeId: string | null
+  /**
+   * Live messages in this topic hidden from the active-branch view (not on
+   * the root→activeNode path and not an alternative reply of a visible
+   * reply-group). Read off `pages[0]` per the pagination guide's extension
+   * convention; the value is topic-level, so any page carries the same count.
+   */
+  followingBranchCount: number
   /** Load the next (older) page of branch history. */
   loadOlder: () => void
   /** Whether older pages remain on the server. */
@@ -220,6 +227,7 @@ export function useTopicMessages(
     [pages, topicId]
   )
   const activeNodeId = pages[0]?.activeNodeId ?? null
+  const followingBranchCount = pages[0]?.followingBranchCount ?? 0
 
   // On remount with stale SWR cache, SWR may expose cached data while it
   // revalidates. Track freshness per topic so the loading gate blocks stale
@@ -271,6 +279,7 @@ export function useTopicMessages(
     isStale,
     refresh,
     activeNodeId,
+    followingBranchCount,
     loadOlder: loadNext,
     hasOlder: hasNext,
     mutate: mutate

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1660,6 +1660,12 @@
         "inline": "Cache {{hit_rate}}%",
         "tooltip": "Cache read {{cache_read}} / write {{cache_write}} / no cache {{no_cache}} · saved {{saved}} input tokens"
       },
+      "edit_save": {
+        "description": "Save the edited message, or save it and generate a new reply on a new branch?",
+        "save_and_regenerate": "Save & Regenerate",
+        "save_only": "Save Only",
+        "title": "Save Edited Message"
+      },
       "editing_current": "This message is being edited in the composer",
       "flow": {
         "branches": "branches",
@@ -1667,11 +1673,18 @@
           "created": "Copied to a new conversation",
           "label": "Copy as New Conversation"
         },
+        "direction_down": "Root at top",
+        "direction_toggle": "Toggle tree direction",
+        "direction_up": "Root at bottom",
         "nodes": "nodes",
         "status": {
           "awaiting_input": "Awaiting input"
         },
         "title": "Branch Management"
+      },
+      "following_branch": {
+        "notice": "{{count}} more message(s) continue in another branch after this point",
+        "open": "View branches"
       },
       "more": "More actions",
       "new": {

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1660,6 +1660,12 @@
         "inline": "缓存 {{hit_rate}}%",
         "tooltip": "缓存读取 {{cache_read}} / 写入 {{cache_write}} / 未缓存 {{no_cache}} · 节省 {{saved}} 输入 Token"
       },
+      "edit_save": {
+        "description": "保存修改后的消息，还是保存并重新生成回复（会创建新分支）？",
+        "save_and_regenerate": "保存并重新生成",
+        "save_only": "仅保存",
+        "title": "保存修改后的消息"
+      },
       "editing_current": "这条消息正在输入框中编辑",
       "flow": {
         "branches": "分支",
@@ -1667,11 +1673,18 @@
           "created": "已复制为新对话",
           "label": "复制为新对话"
         },
+        "direction_down": "根节点在上方",
+        "direction_toggle": "切换树状图方向",
+        "direction_up": "根节点在下方",
         "nodes": "节点",
         "status": {
           "awaiting_input": "待输入"
         },
         "title": "分支管理"
+      },
+      "following_branch": {
+        "notice": "此处之后还有 {{count}} 条对话在其它分支",
+        "open": "查看分支"
       },
       "more": "更多操作",
       "new": {

--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -71,6 +71,7 @@ const ChatContent: FC<Props> = ({
     isStale: isHistoryStale,
     refresh,
     activeNodeId,
+    followingBranchCount,
     loadOlder,
     hasOlder,
     mutate: messagesCacheMutate
@@ -95,6 +96,7 @@ const ChatContent: FC<Props> = ({
       siblingsMap={siblingsMap}
       refresh={refresh}
       activeNodeId={activeNodeId}
+      followingBranchCount={followingBranchCount}
       loadOlder={loadOlder}
       hasOlder={hasOlder}
       messagesCacheMutate={messagesCacheMutate}
@@ -117,6 +119,7 @@ interface InnerProps extends Props {
   siblingsMap: ReturnType<typeof useTopicMessages>['siblingsMap']
   refresh: () => Promise<CherryUIMessage[]>
   activeNodeId: string | null
+  followingBranchCount: number
   loadOlder: () => void
   hasOlder: boolean
   messagesCacheMutate: ReturnType<typeof useTopicMessages>['mutate']
@@ -140,6 +143,7 @@ const ChatContentInner: FC<InnerProps> = ({
   siblingsMap,
   refresh,
   activeNodeId,
+  followingBranchCount,
   loadOlder,
   hasOlder,
   messagesCacheMutate
@@ -212,6 +216,7 @@ const ChatContentInner: FC<InnerProps> = ({
         isMessagesStale={isHistoryStale}
         loadOlder={loadOlder}
         hasOlder={hasOlder}
+        followingBranchCount={followingBranchCount}
         openCitationsPanel={onOpenCitationsPanel}
         onStartBranchDraft={reserveBranch}
       />

--- a/src/renderer/pages/home/ChatMain.tsx
+++ b/src/renderer/pages/home/ChatMain.tsx
@@ -19,6 +19,7 @@ interface ChatMainProps {
   isMessagesStale?: boolean
   loadOlder: () => void
   hasOlder: boolean
+  followingBranchCount: number
   openCitationsPanel?: MessageListActions['openCitationsPanel']
   onStartBranchDraft?: MessageListActions['startMessageBranch']
 }
@@ -34,6 +35,7 @@ const ChatMain: FC<ChatMainProps> = ({
   isMessagesStale,
   loadOlder,
   hasOlder,
+  followingBranchCount,
   openCitationsPanel,
   onStartBranchDraft
 }) => {
@@ -48,6 +50,7 @@ const ChatMain: FC<ChatMainProps> = ({
     isMessagesStale,
     loadOlder,
     hasOlder,
+    followingBranchCount,
     openCitationsPanel,
     onStartBranchDraft
   })

--- a/src/renderer/pages/home/components/TopicBranchPanel.tsx
+++ b/src/renderer/pages/home/components/TopicBranchPanel.tsx
@@ -8,6 +8,7 @@ import {
   layoutTopicMessageFlowGraph,
   mergeTopicMessageFlowLiveTree,
   TopicMessageFlowCanvas,
+  type TopicMessageFlowDirection,
   type TopicMessageFlowLiveState
 } from '@renderer/components/chat/flow'
 import { CommandContextMenu } from '@renderer/components/command'
@@ -15,9 +16,9 @@ import DeleteIcon from '@renderer/components/icons/DeleteIcon'
 import { toast } from '@renderer/services/toast'
 import { DataApiError, ErrorCode } from '@shared/data/api/errors'
 import type { Message as DbMessage, TreeResponse } from '@shared/data/types/message'
-import { CopyPlus, GitBranch } from 'lucide-react'
+import { ArrowDownToLine, ArrowUpToLine, CopyPlus, GitBranch } from 'lucide-react'
 import type { FC, MouseEvent } from 'react'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useTopicBranchActions } from '../hooks/useTopicBranchActions'
@@ -58,6 +59,7 @@ const TopicBranchPanel: FC<Props> = ({
 }) => {
   const { t } = useTranslation()
   const contextMenuMessageIdRef = useRef<string | null>(null)
+  const [flowDirection, setFlowDirection] = useState<TopicMessageFlowDirection>('top-to-bottom')
   const messagesCachePath = `/topics/${topicId}/messages` as const
   const treeCachePath = `/topics/${topicId}/tree` as const
   const { data, error, isLoading, refetch } = useQuery('/topics/:topicId/tree', {
@@ -77,7 +79,10 @@ const TopicBranchPanel: FC<Props> = ({
     () => mergeTopicMessageFlowLiveTree(data ?? emptyTree, liveState?.topicId === topicId ? liveState : null),
     [data, liveState, topicId]
   )
-  const graph = useMemo(() => layoutTopicMessageFlowGraph(buildTopicMessageFlowGraph(tree)), [tree])
+  const graph = useMemo(
+    () => layoutTopicMessageFlowGraph(buildTopicMessageFlowGraph(tree), flowDirection),
+    [tree, flowDirection]
+  )
 
   const handleNodeSelect = useCallback(
     async (messageId: string) => {
@@ -266,6 +271,25 @@ const TopicBranchPanel: FC<Props> = ({
         <span className="shrink-0 text-foreground-tertiary">
           {graph.stats.nodeCount} {t('chat.message.flow.nodes', { defaultValue: 'nodes' })}
         </span>
+        <button
+          type="button"
+          data-testid="topic-message-flow-direction-toggle"
+          aria-label={t('chat.message.flow.direction_toggle', { defaultValue: 'Toggle tree direction' })}
+          title={
+            flowDirection === 'top-to-bottom'
+              ? t('chat.message.flow.direction_down', { defaultValue: 'Root at top' })
+              : t('chat.message.flow.direction_up', { defaultValue: 'Root at bottom' })
+          }
+          onClick={() =>
+            setFlowDirection((direction) => (direction === 'top-to-bottom' ? 'bottom-to-top' : 'top-to-bottom'))
+          }
+          className="ml-auto flex h-6 shrink-0 items-center gap-1 rounded-md border border-border-subtle px-1.5 text-foreground-tertiary transition-colors hover:bg-muted hover:text-foreground">
+          {flowDirection === 'top-to-bottom' ? (
+            <ArrowDownToLine className="size-3.5" />
+          ) : (
+            <ArrowUpToLine className="size-3.5" />
+          )}
+        </button>
       </div>
       <div className="min-h-0 flex-1">
         {error ? (

--- a/src/renderer/pages/home/hooks/useTopicMessagesCache.ts
+++ b/src/renderer/pages/home/hooks/useTopicMessagesCache.ts
@@ -131,7 +131,16 @@ export function useTopicMessagesCache({ topicId, mutate }: UseTopicMessagesCache
         (pages) => {
           const currentPages = pages?.length
             ? pages
-            : [{ items: [], nextCursor: undefined, activeNodeId: null, assistantId: null, rootId: null }]
+            : [
+                {
+                  items: [],
+                  nextCursor: undefined,
+                  activeNodeId: null,
+                  assistantId: null,
+                  rootId: null,
+                  followingBranchCount: 0
+                }
+              ]
           const existingIds = new Set(
             currentPages.flatMap((page) =>
               page.items.flatMap((item) => [
@@ -160,9 +169,19 @@ export function useTopicMessagesCache({ topicId, mutate }: UseTopicMessagesCache
 
   /** Replace the branch cache with a single empty page. */
   const clearBranchCache = useCallback(async () => {
-    await mutate([{ items: [], nextCursor: undefined, activeNodeId: null, assistantId: null, rootId: null }], {
-      revalidate: false
-    })
+    await mutate(
+      [
+        {
+          items: [],
+          nextCursor: undefined,
+          activeNodeId: null,
+          assistantId: null,
+          rootId: null,
+          followingBranchCount: 0
+        }
+      ],
+      { revalidate: false }
+    )
   }, [mutate])
 
   // `useInvalidateCache`'s `invalidatePathPatterns` walks both scalar and

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -32,6 +32,8 @@ import { ModelSelector } from '@renderer/components/ModelSelector'
 import { useChatWrite } from '@renderer/hooks/chat/ChatWriteContext'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { SiblingsContext } from '@renderer/hooks/SiblingsContext'
+import FollowingBranchNotice from '@renderer/components/chat/messages/FollowingBranchNotice'
+import { useRightPanelActions } from '@renderer/components/chat/panes/Shell'
 import { useLanguages } from '@renderer/hooks/translate'
 import { ipcApi } from '@renderer/ipc'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -74,6 +76,8 @@ interface HomeMessageListParams {
   isMessagesStale?: boolean
   loadOlder?: () => void
   hasOlder?: boolean
+  /** Live messages hidden on other branches after the active path end. */
+  followingBranchCount?: number
   openCitationsPanel?: MessageListActions['openCitationsPanel']
   imageActionConsumer?: 'capture'
   onBindRuntime?: MessageListActions['bindRuntime']
@@ -92,6 +96,7 @@ export function useHomeMessageListProviderValue({
   isMessagesStale = false,
   loadOlder,
   hasOlder = false,
+  followingBranchCount = 0,
   openCitationsPanel,
   imageActionConsumer,
   onBindRuntime,
@@ -781,6 +786,17 @@ export function useHomeMessageListProviderValue({
     [regenerateMessageUsingModel, t]
   )
 
+  const rightPanelActions = useRightPanelActions()
+  const afterList = useMemo<React.ReactNode>(() => {
+    if (!followingBranchCount || followingBranchCount <= 0) return undefined
+    return (
+      <FollowingBranchNotice
+        count={followingBranchCount}
+        onOpenBranches={() => rightPanelActions.tryOpen('branch', { userInitiated: true })}
+      />
+    )
+  }, [followingBranchCount, rightPanelActions])
+
   const state = useMemo<MessageListState>(
     () => ({
       topic,
@@ -791,6 +807,7 @@ export function useHomeMessageListProviderValue({
       isMessagesStale,
       hasOlder,
       messageNavigation,
+      afterList,
       ...DEFAULT_MESSAGE_LIST_CONFIG,
       listKey: resolvedAssistantId,
       renderConfig,
@@ -812,6 +829,7 @@ export function useHomeMessageListProviderValue({
       getMessageSiblings,
       isMessageTranslating,
       getTranslationLanguageLabel,
+      afterList,
       hasOlder,
       isInitialLoading,
       isMessagesStale,

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -635,4 +635,12 @@ export interface BranchMessagesResponse extends CursorPaginationResponse<BranchM
    * with its parent assistant's id. Always present in successful responses.
    */
   assistantId: string | null
+  /**
+   * Live messages in this topic hidden from the active-branch view: not on
+   * the root→activeNode path, and not an alternative reply of a reply-group
+   * that is visible on the path (those surface via multi-model tabs / sibling
+   * navigator). Topic-level and pagination-independent; the same value rides
+   * on every page.
+   */
+  followingBranchCount: number
 }


### PR DESCRIPTION
## Summary

Three related UX improvements for the v2 branch-based conversation tree.

### 1. Branch follow-up notice (feat: branch-conversation-ux)

Regenerating or editing a mid-conversation message moves the active node onto a new branch, hiding the messages that continued on the old branch (they are still stored, just not on the root→activeNode path). Previously the view gave no hint they existed — users thought the conversation had been deleted.

- `BranchMessagesResponse` gains a topic-level `followingBranchCount` (live messages not on the active path, excluding alternative replies of visible reply-groups).
- The message list renders a clickable notice after the last message when the count is > 0; clicking opens the branch tree panel.

### 2. Branch tree direction toggle

The branch tree panel (TopicBranchPanel) now has a header toggle to flip between root-at-top (dagre `TB`) and root-at-bottom (`BT`), with node handles swapped accordingly.

### 3. Edited user messages no longer always regenerate

Editing a user message previously forked and regenerated the whole conversation immediately, spending tokens even for a wording-only change. Now the user is asked: **Save only** (editMessage) or **Save & Regenerate** (forkAndResend). Regenerate is disabled while a stream is live.

## Changes

- `feat(chat): surface hidden branch follow-ups in the message list`
- `feat(chat-flow): add top-to-bottom / bottom-to-top tree direction toggle`
- `feat(chat-composer): let edited user messages save without regenerating`
- `feat(i18n): add branch notice, tree direction and edit-save strings`

## Testing

- Backend: `MessageService.test.ts` — 7 new `followingBranchCount` scenarios (linear / regenerated-mid / multi-model group / user fork / pagination / no active node / soft-deleted hidden)
- Frontend: `useTopicMessages` (pages[0] read + default 0), `MessageList` (afterList footer), new `FollowingBranchNotice` tests; ChatComposer suite mocks the save-choice popup (defaults to regenerate)
- All related suites pass (453 tests), Biome clean, tsgo typecheck clean for changed files

> Note: commits are DCO-signed (`Signed-off-by`); GPG signing is not configured on the contributor's machine.