### PR TITLE
fix(v2-migration): allow direct upgrades to v2.0.x

### DIFF
--- a/docs/references/data/v2-migration-guide.md
+++ b/docs/references/data/v2-migration-guide.md
@@ -8,12 +8,13 @@ The v2 migration system enforces a **linear upgrade path** to ensure
 data integrity:
 
 ```
-v1.old  →  v1.last (≥1.9.0)  →  v2.0.0  →  v2.x
+v1.old  →  v1.last (≥1.9.12)  →  v2.0.x  →  v2.1+
 ```
 
 ### Why a linear path?
 
-v2.0.0 contains the one-shot data migration from Redux/Dexie to SQLite.
+v2.0.0 introduced the one-shot data migration from Redux/Dexie to SQLite,
+and every v2.0.x patch retains that complete migration while adding fixes.
 Supporting migration from every v1 version would create an O(n²) test
 matrix. By requiring all users to be on the final v1 release first, the
 migration code only needs to handle a single source data format.
@@ -27,15 +28,15 @@ migration code only needs to handle a single source data format.
    `MigrationPaths.versionLogFile` (using the resolved userData path
    that accounts for v1 custom directories).
 3. If the previous version is too old, missing, or if the user skipped
-   v2.0.0, the gate shows an error dialog and quits.
+   the v2.0.x migration line, the gate shows an error dialog and quits.
 
 ### Blocking rules
 
 | Scenario | Block reason | User action |
 |----------|-------------|-------------|
-| No `version.log` (v1 < 1.7 user) | `no_version_log` | Install v1.last, run once, then install v2.0.0 |
-| Previous version < 1.9.0 | `v1_too_old` | Upgrade to v1.last first |
-| Previous version is v1.x but current > v2.0.0 | `v2_gateway_skipped` | Install v2.0.0 first |
+| No `version.log` (v1 < 1.7 user) | `no_version_log` | Install v1.last, run once, then install the latest v2.0.x release |
+| Previous version < 1.9.12 | `v1_too_old` | Upgrade to v1.last first |
+| Previous version is v1.x but current ≥ v2.1.0 | `v2_gateway_skipped` | Install the latest v2.0.x release first |
 
 ### Pre-release versions
 
@@ -45,8 +46,9 @@ per semver ordering. They are allowed as migration targets from v1.last
 passes). Pre-release to pre-release upgrades work because migration
 status is `completed` after the first successful run.
 
-The gateway is **strictly v2.0.0** — v2.0.x patches are blocked from
-being a first migration target. This may be relaxed in a future release.
+The verified direct migration targets are the complete **v2.0.x** release
+line. Starting with v2.1.0, later versions are blocked as a first migration
+target until their migration compatibility is explicitly verified.
 
 ### Relationship with the auto-updater
 

--- a/src/main/data/migration/v2/README.md
+++ b/src/main/data/migration/v2/README.md
@@ -84,7 +84,7 @@ Before the migration window is created, the gate validates the upgrade
 path using `core/versionPolicy.ts`. This catches manual installs that
 bypass the auto-updater's version filtering.
 
-**Required upgrade path**: `v1.old → v1.last (≥1.9.12) → v2.0.0 → v2.x`
+**Required upgrade path**: `v1.old → v1.last (≥1.9.12) → v2.0.x → v2.1+`
 
 ### Blocking rules
 
@@ -92,18 +92,18 @@ bypass the auto-updater's version filtering.
 |------|-----------|--------|
 | no_version_log | Legacy data exists but `version.log` is missing | User never ran a v1 version with VersionService (embedded since v1.7) |
 | v1_too_old | `previousVersion < V1_REQUIRED_VERSION` | Data not in final v1 form |
-| v2_gateway_skipped | `previousVersion < 2.0.0 && coerce(currentVersion) > 2.0.0` | Skipped the v2.0.0 migration gateway |
+| v2_gateway_skipped | `previousVersion < 2.0.0 && coerce(currentVersion) >= 2.1.0` | Skipped the v2.0.x migration line |
 
 ### Pre-release versions
 
 v2.0.0 pre-releases (alpha/beta/rc) are treated as **before v2.0.0**
 in semver ordering. This means:
 - v1.last → v2.0.0-alpha is allowed (the gateway check uses coerced
-  currentVersion, so `gt('2.0.0', '2.0.0')` is false)
+  currentVersion, so `gte('2.0.0', '2.1.0')` is false)
 - Pre-release → pre-release upgrades work because migration status is
   already `completed` after the first successful run
-- v2.0.0 is strictly required as the gateway — v2.0.x patches are
-  blocked until the policy is updated in a future release
+- The complete v2.0.x line is a verified direct migration target; v2.1.0 and
+  later remain blocked until their migration compatibility is explicitly verified
 
 ### Path safety for version.log
 

--- a/src/main/data/migration/v2/core/__tests__/versionPolicy.test.ts
+++ b/src/main/data/migration/v2/core/__tests__/versionPolicy.test.ts
@@ -59,39 +59,40 @@ describe('checkUpgradePathCompatibility', () => {
     expect(result).toStrictEqual({
       outcome: 'block',
       reason: 'v2_gateway_skipped',
-      details: { previousVersion: '1.9.12', currentVersion: '2.1.0', gatewayVersion: '2.0.0' }
+      details: { previousVersion: '1.9.12', currentVersion: '2.1.0', gatewayVersion: '2.0.x' }
     })
   })
 
-  it('#7 blocks when current is v2.0.1 (strict v2.0.0 requirement)', () => {
-    const result = check({ previousVersion: '1.9.12', versionLogExists: true, currentAppVersion: '2.0.1' })
-    expect(result).toStrictEqual({
-      outcome: 'block',
-      reason: 'v2_gateway_skipped',
-      details: { previousVersion: '1.9.12', currentVersion: '2.0.1', gatewayVersion: '2.0.0' }
-    })
+  it('#7 passes when v1.9.13 upgrades directly to v2.0.1', () => {
+    const result = check({ previousVersion: '1.9.13', versionLogExists: true, currentAppVersion: '2.0.1' })
+    expect(result).toStrictEqual({ outcome: 'pass' })
   })
 
-  it('#8 passes for v2 internal upgrade (2.0.0 -> 2.1.0)', () => {
+  it('#8 passes for later v2.0.x patch releases', () => {
+    const result = check({ previousVersion: '1.9.13', versionLogExists: true, currentAppVersion: '2.0.99' })
+    expect(result).toStrictEqual({ outcome: 'pass' })
+  })
+
+  it('#9 passes for v2 internal upgrade (2.0.0 -> 2.1.0)', () => {
     const result = check({ previousVersion: '2.0.0', versionLogExists: true, currentAppVersion: '2.1.0' })
     expect(result).toStrictEqual({ outcome: 'pass' })
   })
 
-  it('#9 blocks when previous is 2.0.0-beta (pre-release < 2.0.0)', () => {
+  it('#10 blocks when previous is 2.0.0-beta (pre-release < 2.0.0)', () => {
     const result = check({ previousVersion: '2.0.0-beta', versionLogExists: true, currentAppVersion: '2.1.0' })
     expect(result).toStrictEqual({
       outcome: 'block',
       reason: 'v2_gateway_skipped',
-      details: { previousVersion: '2.0.0-beta', currentVersion: '2.1.0', gatewayVersion: '2.0.0' }
+      details: { previousVersion: '2.0.0-beta', currentVersion: '2.1.0', gatewayVersion: '2.0.x' }
     })
   })
 
-  it('#10 passes when version.log exists but no previous version found', () => {
+  it('#11 passes when version.log exists but no previous version found', () => {
     const result = check({ previousVersion: null, versionLogExists: true, currentAppVersion: '2.0.0' })
     expect(result).toStrictEqual({ outcome: 'pass' })
   })
 
-  it('#11 passes when previous version is above V1_REQUIRED (1.9.13)', () => {
+  it('#12 passes when previous version is above V1_REQUIRED (1.9.13)', () => {
     const result = check({ previousVersion: '1.9.13', versionLogExists: true, currentAppVersion: '2.0.0' })
     expect(result).toStrictEqual({ outcome: 'pass' })
   })

--- a/src/main/data/migration/v2/core/versionPolicy.ts
+++ b/src/main/data/migration/v2/core/versionPolicy.ts
@@ -1,7 +1,7 @@
 /**
  * Version upgrade policy for the v1→v2 migration gate.
  *
- * Enforces a linear upgrade path: v1.old → v1.last → v2.0.0 → v2.x.
+ * Enforces a linear upgrade path: v1.old → v1.last → v2.0.x → v2.1+.
  * Called by `v2MigrationGate.ts` after `needsMigration()` returns true
  * and before the migration window is created. If the check fails, the
  * gate shows an error dialog and quits — the user never sees the
@@ -36,8 +36,14 @@ const logger = loggerService.withContext('VersionPolicy')
  */
 export const V1_REQUIRED_VERSION = '1.9.12'
 
-/** v2 migration gateway version — must not be skipped. */
+/** First version in the v2.0.x migration gateway line. */
 export const V2_GATEWAY_VERSION = '2.0.0'
+
+/** User-facing label for the accepted migration gateway line. */
+const V2_GATEWAY_SERIES = '2.0.x'
+
+/** First release line that cannot be a direct v1→v2 migration target. */
+const V2_DIRECT_MIGRATION_CEILING = '2.1.0'
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -93,17 +99,19 @@ export function checkUpgradePathCompatibility(input: VersionCheckInput): Version
     }
   }
 
-  // ❸ Previous version is v1.x and current version jumped past the
-  //    v2.0.0 gateway (e.g. v1.9.0 → v2.1.0, or v2.0.0-beta → v2.1.0).
+  // ❸ Previous version is v1.x and current version jumped past the v2.0.x
+  //    migration line (e.g. v1.9.12 → v2.1.0, or v2.0.0-beta → v2.1.0).
+  //    Every v2.0.x patch retains the complete one-shot migration and may
+  //    include fixes required by some v1 profiles.
   if (
     previousVersion &&
     semver.lt(previousVersion, V2_GATEWAY_VERSION) &&
-    semver.gt(coercedCurrent, V2_GATEWAY_VERSION)
+    semver.gte(coercedCurrent, V2_DIRECT_MIGRATION_CEILING)
   ) {
     return {
       outcome: 'block',
       reason: 'v2_gateway_skipped',
-      details: { previousVersion, currentVersion: currentAppVersion, gatewayVersion: V2_GATEWAY_VERSION }
+      details: { previousVersion, currentVersion: currentAppVersion, gatewayVersion: V2_GATEWAY_SERIES }
     }
   }
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-07-v1-direct-upgrade-to-v2-0-x.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-07-v1-direct-upgrade-to-v2-0-x.md
@@ -1,0 +1,30 @@
+---
+title: V1.9.13 can upgrade directly to any V2.0.x release
+category: data-migration
+severity: notice
+introduced_in_pr: TBD
+date: 2026-08-07
+---
+
+## What changed
+
+Every Cherry Studio v2.0.x patch is now accepted as a first v2 migration target
+for users upgrading from v1.9.13. Starting with v2.1.0, later releases still
+require users to pass through the v2.0.x migration line first.
+
+## Why this matters to the user
+
+V2.0.x patches retain the complete v1-to-v2 migration and can include fixes for
+migration crashes, memory pressure, Agent data paths, and legacy provider
+credentials. Users can install the latest v2.0.x patch directly instead of
+installing v2.0.0 first.
+
+## What the user should do
+
+Nothing — automatic once the managed release service targets v2.0.1 for v1.9.13
+clients.
+
+## Notes for release manager
+
+The managed release service gateway must be updated separately. At authoring
+time, production still routes v1.9.13 clients to v2.0.0.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: v1.9.13 users who installed v2.0.1 were blocked by the migration gate and told to install v2.0.0 first.

After this PR: any v2.0.x patch is accepted as a direct migration target, while v2.1.0 and later remain blocked until the user passes through the v2.0.x line.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

<img width="1000" height="720" alt="image" src="https://github.com/user-attachments/assets/f58c36ed-fed0-4b6e-b9ca-ce669a571b09" />

<img width="1000" height="720" alt="image" src="https://github.com/user-attachments/assets/e8ab164b-df4c-4152-9d4c-4d365f303147" />

Fixes # N/A

### Why we need it and why it was done in this way

Every v2.0.x patch retains the complete one-shot migration and may include fixes needed by v1 profiles, so the policy now uses v2.1.0 as the exclusive direct-migration ceiling.

The following tradeoffs were made: later release lines still require an explicit compatibility decision instead of being allowed automatically.

The following alternatives were considered: allowing only v2.0.1 was rejected because it would unnecessarily block later v2.0.x migration-fix releases.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None; this relaxes an upgrade restriction while preserving the v2.1.0 safety boundary.

### Special notes for your reviewer

<!-- optional -->

Validation: focused version-policy suite (21 tests), `pnpm format`, and `pnpm lint` (0 errors; 37 pre-existing warnings). The managed release service currently still routes v1.9.13 clients to v2.0.0 and must be updated separately before OTA clients receive v2.0.1 directly.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
V1 users can upgrade directly to any v2.0.x release while v2.1.0 and later remain protected by the migration gateway.
```
