### PR TITLE
feat(api-gateway): add opt-in MCP sessions with server-to-client push and progress

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -31,6 +31,7 @@ import {
   CancelledNotificationSchema,
   type GetPromptResult,
   LoggingMessageNotificationSchema,
+  type Progress,
   PromptListChangedNotificationSchema,
   ResourceListChangedNotificationSchema,
   ResourceUpdatedNotificationSchema,
@@ -95,6 +96,12 @@ type CallToolArgs = {
   /** Caller-isolation key (e.g. topicId) — abort-by-id only matches within the same scope. */
   scope?: string
   signal?: AbortSignal
+  /**
+   * Receives the upstream server's progress notifications. The renderer gets them
+   * unconditionally over IPC, so this is for callers outside it — currently the MCP bridge,
+   * relaying to a client that supplied a `progressToken`.
+   */
+  onProgress?: ProgressCallback
 }
 type RuntimeCallToolArgs = {
   server: McpServer
@@ -103,6 +110,7 @@ type RuntimeCallToolArgs = {
   callId?: string
   scope?: string
   signal?: AbortSignal
+  onProgress?: ProgressCallback
 }
 
 /**
@@ -115,6 +123,7 @@ function toolCallKey(callId: string, scope?: string): string {
   return scope ? `${scope}\u0000${callId}` : callId
 }
 
+type ProgressCallback = (progress: Progress) => void
 type McpRuntimeState = McpRuntimeStatus['state']
 
 // IPC payload validation for the renderer-facing handlers. The inner `args` are the tool/prompt
@@ -1166,9 +1175,17 @@ export class McpRuntimeService extends BaseService {
   /**
    * Call a tool on an MCP server
    */
-  public async callTool({ serverId, name, args, callId, scope, signal }: CallToolArgs): Promise<McpCallToolResponse> {
+  public async callTool({
+    serverId,
+    name,
+    args,
+    callId,
+    scope,
+    signal,
+    onProgress
+  }: CallToolArgs): Promise<McpCallToolResponse> {
     const server = this.getServerById(serverId)
-    return this.callToolByServer({ server, name, args, callId, scope, signal })
+    return this.callToolByServer({ server, name, args, callId, scope, signal, onProgress })
   }
 
   public async callToolByServer({
@@ -1177,7 +1194,8 @@ export class McpRuntimeService extends BaseService {
     args,
     callId,
     scope,
-    signal
+    signal,
+    onProgress
   }: RuntimeCallToolArgs): Promise<McpCallToolResponse> {
     const toolCallId = callId || uuidv4()
     const registrationKey = toolCallKey(toolCallId, scope)
@@ -1240,6 +1258,15 @@ export class McpRuntimeService extends BaseService {
               callId: toolCallId,
               progress: process.progress / (process.total || 1)
             })
+            // Additional consumer outside the renderer; must not break the call or the
+            // broadcast above if it throws.
+            try {
+              onProgress?.(process)
+            } catch (error) {
+              getServerLogger(server, { tool: name, callId: toolCallId }).warn('Progress listener threw', {
+                error
+              })
+            }
           },
           timeout: server.timeout ? server.timeout * 1000 : 60000, // Default timeout of 1 minute,
           // 需要服务端支持: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts

--- a/src/main/ai/mcp/__tests__/createMcpBridgeServer.test.ts
+++ b/src/main/ai/mcp/__tests__/createMcpBridgeServer.test.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
+import { ProgressNotificationSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -89,6 +89,44 @@ describe('createMcpBridgeServer', () => {
       if (name === 'McpRuntimeService') return { getPrompt: mocks.getPrompt, callTool: mocks.callTool }
       throw new Error(`Unexpected application.get(${name})`)
     })
+  })
+
+  it('relays upstream tool progress to a client that supplied a progressToken', async () => {
+    mocks.listTools.mockReturnValue([searchTool()])
+    // Emit two progress ticks from "upstream" before resolving the call.
+    mocks.callTool.mockImplementation(async ({ onProgress }: { onProgress?: (p: unknown) => void }) => {
+      onProgress?.({ progress: 1, total: 2 })
+      onProgress?.({ progress: 2, total: 2 })
+      return { content: [{ type: 'text', text: 'done' }] }
+    })
+
+    const client = await connectClient(createMcpBridgeServer('server-1'))
+    const seen: { progress: number; total?: number }[] = []
+    client.setNotificationHandler(ProgressNotificationSchema, async (notification) => {
+      seen.push({ progress: notification.params.progress, total: notification.params.total })
+    })
+
+    const result = await client.callTool({ name: 'search', arguments: {} }, undefined, {
+      onprogress: () => {}
+    })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'done' }])
+    expect(seen).toEqual([
+      { progress: 1, total: 2 },
+      { progress: 2, total: 2 }
+    ])
+  })
+
+  it('omits the progress listener when the client sent no progressToken', async () => {
+    mocks.listTools.mockReturnValue([searchTool()])
+    mocks.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] })
+
+    const client = await connectClient(createMcpBridgeServer('server-1'))
+    await client.callTool({ name: 'search', arguments: {} })
+
+    // No token means no address to send notifications to, so the runtime must not be
+    // handed a listener at all.
+    expect(mocks.callTool).toHaveBeenCalledWith(expect.objectContaining({ onProgress: undefined }))
   })
 
   it('uses a request-captured server snapshot without re-reading the edited database row', () => {

--- a/src/main/ai/mcp/createMcpBridgeServer.ts
+++ b/src/main/ai/mcp/createMcpBridgeServer.ts
@@ -11,6 +11,7 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
+  type Progress,
   type Prompt as SdkPrompt,
   ReadResourceRequestSchema,
   type ReadResourceResult,
@@ -166,12 +167,26 @@ export function createMcpBridgeServer(
   })
 
   rawServer.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    // Relay upstream progress only when the client asked for it — the protocol keys
+    // progress notifications to the token it supplied, so without one there is nothing
+    // to address them to.
+    const progressToken = request.params._meta?.progressToken
+    const onProgress =
+      progressToken === undefined
+        ? undefined
+        : (progress: Progress) => {
+            extra
+              .sendNotification({ method: 'notifications/progress', params: { ...progress, progressToken } })
+              .catch((error) => logger.debug('MCP bridge: progress notification dropped', { mcpId, error }))
+          }
+
     try {
       logger.debug('MCP bridge: calling tool', { mcpId, tool: request.params.name })
       const result = await application.get('McpRuntimeService').callTool({
         serverId: serverConfig.id,
         name: request.params.name,
         args: request.params.arguments,
+        onProgress,
         signal: extra.signal
       })
       return result as CallToolResult

--- a/src/main/features/apiGateway/McpSessionStore.ts
+++ b/src/main/features/apiGateway/McpSessionStore.ts
@@ -29,6 +29,14 @@ export class SessionLimitReachedError extends Error {
   }
 }
 
+/** Raised when a session is requested while the owning server is shutting down. */
+export class StoreClosedError extends Error {
+  constructor() {
+    super('MCP session store is closed')
+    this.name = 'StoreClosedError'
+  }
+}
+
 /**
  * Live `Mcp-Session-Id` → bridge/transport map for `/v1/mcps/:id/mcp`.
  *
@@ -42,33 +50,59 @@ export class SessionLimitReachedError extends Error {
 export class McpSessionStore {
   private readonly sessions = new Map<string, McpSession>()
   private sweepTimer: NodeJS.Timeout | null = null
+  /**
+   * Initializations that passed admission but have not reached `onsessioninitialized` yet.
+   * Counted against the cap: creation awaits `bridge.connect()` (and the route awaits cache
+   * warming before that), so a burst of concurrent initializes would otherwise all read a
+   * stale `sessions.size` and allocate unbounded bridges.
+   */
+  private pendingAdmissions = 0
+  /** Set by `closeAll()`. A session opened after the server started closing would never be reachable. */
+  private closed = false
 
   /**
    * Open a session for `server` and let it serve the `initialize` request that asked for one.
    * Creation and the first request are one step because the session id only exists once the
    * transport has processed that request — there is no meaningful half-built session to hand back.
    *
-   * Throws {@link SessionLimitReachedError} when the cap is reached.
+   * Throws {@link SessionLimitReachedError} when the cap is reached, or {@link StoreClosedError}
+   * once the owning server is shutting down.
    */
   async createAndHandle(server: McpServer, request: Request, parsedBody: unknown): Promise<Response> {
-    if (this.sessions.size >= MAX_SESSIONS) {
+    if (this.closed) throw new StoreClosedError()
+    // Reserve synchronously — nothing may await between the check and the increment.
+    if (this.sessions.size + this.pendingAdmissions >= MAX_SESSIONS) {
       throw new SessionLimitReachedError(MAX_SESSIONS)
     }
+    this.pendingAdmissions++
 
+    let registered = false
     const bridge = createMcpBridgeServer(server.id, server)
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
-      // POST replies stay plain JSON; server→client notifications ride the standalone
-      // GET stream instead, which `handleGetRequest` opens regardless of this flag.
-      enableJsonResponse: true,
+      // Responses stream as SSE rather than plain JSON: the SDK only writes
+      // request-related notifications (tool `notifications/progress`) when JSON response
+      // mode is OFF, so enabling it would resolve the call while silently dropping every
+      // progress update. See `WebStandardStreamableHTTPServerTransport.send`.
+      enableJsonResponse: false,
       onsessioninitialized: (sessionId) => {
-        this.sessions.set(sessionId, {
+        registered = true
+        const session: McpSession = {
           id: sessionId,
           serverId: server.id,
           transport,
           bridge,
           lastActivityAt: Date.now()
-        })
+        }
+        // Outbound traffic counts as activity too. Without this the timestamp only moves on a
+        // new HTTP request, so a client sitting on a GET stream and receiving notifications
+        // would be swept as "idle" — a hard lifetime, not the idle timeout we document.
+        const send = transport.send.bind(transport)
+        transport.send = async (message, options) => {
+          session.lastActivityAt = Date.now()
+          return send(message, options)
+        }
+        this.sessions.set(sessionId, session)
         this.ensureSweeping()
         logger.debug('MCP session opened', { sessionId, serverId: server.id, live: this.sessions.size })
       },
@@ -79,14 +113,19 @@ export class McpSessionStore {
       }
     })
 
-    await bridge.connect(transport)
-
     try {
-      return await transport.handleRequest(request, { parsedBody })
+      await bridge.connect(transport)
+      const response = await transport.handleRequest(request, { parsedBody })
+      // `closeAll()` may have run while we were connecting; that sweep could not have seen
+      // this session, so retire it here rather than leaving it behind a closed server.
+      if (registered && this.closed) await this.delete(transport.sessionId!)
+      return response
     } catch (error) {
-      // Nothing was registered if `initialize` failed — drop the bridge rather than leak it.
-      if (!transport.sessionId || !this.sessions.has(transport.sessionId)) await bridge.close().catch(() => {})
+      // A failed handshake registers nothing — drop the bridge rather than leak it.
+      if (!registered) await bridge.close().catch(() => {})
       throw error
+    } finally {
+      this.pendingAdmissions--
     }
   }
 
@@ -104,8 +143,15 @@ export class McpSessionStore {
     await this.closeSession(session)
   }
 
-  /** Drop every session and stop sweeping. Called by `ApiGateway.stop()`. */
+  /**
+   * Drop every session and stop sweeping, refusing new ones from here on.
+   *
+   * `ApiGateway.stop()` must call this **before** awaiting the HTTP server's close: a session's
+   * GET stream is an active response, and Node's `server.close()` waits for those, so closing
+   * in the other order deadlocks shutdown until the client disconnects.
+   */
   async closeAll(): Promise<void> {
+    this.closed = true
     if (this.sweepTimer) {
       clearInterval(this.sweepTimer)
       this.sweepTimer = null

--- a/src/main/features/apiGateway/__tests__/serverShutdown.test.ts
+++ b/src/main/features/apiGateway/__tests__/serverShutdown.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Regression guard for the shutdown deadlock: a session's `GET` stream is an *active
+ * HTTP response*, and `@elysia/node` closes the server via Node's `server.close()`
+ * without `closeAllConnections`, which waits for exactly those. Closing the sessions
+ * after that await therefore never ran — deactivate/restart/quit hung until the client
+ * disconnected or the 30-minute sweep fired.
+ *
+ * Runs against a real node-adapter socket because that is the only place the stall is
+ * observable; `app.handle(Request)` never touches `server.close()`.
+ */
+
+const mocks = vi.hoisted(() => ({
+  findByIdOrName: vi.fn(),
+  warmToolsCache: vi.fn(async () => undefined),
+  listTools: vi.fn(() => []),
+  callTool: vi.fn()
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const overrides = {
+    PreferenceService: {
+      // port 0 => OS picks a free port, so tests never collide.
+      get: (key: string) => (key.endsWith('port') ? 0 : '127.0.0.1')
+    },
+    McpCatalogService: {
+      warmToolsCache: mocks.warmToolsCache,
+      listTools: mocks.listTools,
+      listResources: vi.fn(async () => []),
+      listPrompts: vi.fn(async () => []),
+      onToolsCacheUpdated: vi.fn(() => ({ dispose: vi.fn() }))
+    },
+    McpRuntimeService: { callTool: mocks.callTool }
+  }
+  return mockApplicationFactory(overrides)
+})
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), silly: vi.fn() }))
+  }
+}))
+
+vi.mock('@data/services/McpServerService', () => ({
+  mcpServerService: { findByIdOrName: mocks.findByIdOrName, list: vi.fn(() => ({ items: [], total: 0, page: 1 })) }
+}))
+
+// Mount only the MCP routes on a real node adapter — the rest of `buildApp` pulls in
+// heavy services irrelevant to shutdown ordering.
+vi.mock('../app', async () => {
+  const { Elysia } = await import('elysia')
+  const { node } = await import('@elysia/node')
+  const { createMcpRoutes } = await import('../routes/mcp')
+  return {
+    buildApp: ({ mcpSessions }: { mcpSessions: McpSessionStore }) =>
+      new Elysia({ adapter: node() }).use(createMcpRoutes(mcpSessions))
+  }
+})
+
+import type { McpSessionStore } from '../McpSessionStore'
+import { ApiGateway } from '../server'
+
+const SERVER = { id: 'server-1', name: 'filesystem', type: 'stdio', isActive: true }
+const INITIALIZE = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } }
+}
+
+describe('ApiGateway shutdown with a live MCP session', () => {
+  let gateway: ApiGateway | null = null
+
+  afterEach(async () => {
+    await gateway?.stop().catch(() => {})
+    gateway = null
+    vi.clearAllMocks()
+  })
+
+  it('stops promptly while a session holds an open GET stream', async () => {
+    mocks.findByIdOrName.mockReturnValue(SERVER)
+    gateway = new ApiGateway()
+    await gateway.start()
+
+    const port = (
+      gateway as unknown as { serverInfo: { raw?: { node?: { server?: { address(): { port: number } } } } } }
+    ).serverInfo.raw!.node!.server!.address().port
+    const url = `http://127.0.0.1:${port}/mcps/server-1/mcp`
+    const mcpHeaders = { 'content-type': 'application/json', accept: 'application/json, text/event-stream' }
+
+    const init = await fetch(url, { method: 'POST', headers: mcpHeaders, body: JSON.stringify(INITIALIZE) })
+    const sessionId = init.headers.get('mcp-session-id')
+    expect(sessionId).toBeTruthy()
+    await init.text()
+
+    // Hold the notification stream open, exactly as a real client does. Deliberately not
+    // cancelled before `stop()` — that is the situation that used to deadlock.
+    const stream = await fetch(url, {
+      headers: { accept: 'text/event-stream', 'mcp-session-id': sessionId! }
+    })
+    expect(stream.status).toBe(200)
+    const reader = stream.body!.getReader()
+    void reader.read()
+
+    const started = Date.now()
+    await gateway.stop()
+    expect(Date.now() - started).toBeLessThan(5_000)
+    expect(gateway.isRunning()).toBe(false)
+
+    void reader.cancel().catch(() => {})
+    gateway = null
+  }, 20_000)
+})

--- a/src/main/features/apiGateway/app.ts
+++ b/src/main/features/apiGateway/app.ts
@@ -7,6 +7,7 @@ import { Elysia } from 'elysia'
 import { v4 as uuidv4 } from 'uuid'
 
 import { gatewayErrorHandler } from './errors'
+import { McpSessionStore } from './mcpSessionStore'
 import { authorizeApiRequest } from './middleware/auth'
 import {
   buildOpenApiDocument,
@@ -19,7 +20,7 @@ import {
 import { chatRoutes } from './routes/chat'
 import { geminiRoutes } from './routes/gemini'
 import { knowledgeRoutes } from './routes/knowledge'
-import { mcpRoutes } from './routes/mcp'
+import { createMcpRoutes } from './routes/mcp'
 import { messagesRoutes } from './routes/messages'
 import { modelsRoutes } from './routes/models'
 import { responsesRoutes } from './routes/responses'
@@ -32,29 +33,35 @@ const logger = loggerService.withContext('ApiGateway')
  * shaped by the single root `gatewayErrorHandler` (see `buildApp`), which selects
  * the dialect by path.
  */
-const v1Routes = new Elysia({ prefix: '/v1' })
-  // `@elysia/bearer` derives `bearer` from `Authorization: Bearer …` / `?access_token`.
-  .use(bearer())
-  .guard({
-    as: 'scoped',
-    beforeHandle: ({ bearer, headers, set }) => {
-      const failure = authorizeApiRequest(headers['x-api-key'], bearer)
-      if (!failure) return undefined
-      set.status = failure.status
-      return { error: failure.error }
-    }
-  })
-  .use(messagesRoutes)
-  .use(chatRoutes)
-  .use(responsesRoutes)
-  .use(modelsRoutes)
-  .use(knowledgeRoutes)
-  .use(mcpRoutes)
+const buildV1Routes = (mcpSessions: McpSessionStore) =>
+  new Elysia({ prefix: '/v1' })
+    // `@elysia/bearer` derives `bearer` from `Authorization: Bearer …` / `?access_token`.
+    .use(bearer())
+    .guard({
+      as: 'scoped',
+      beforeHandle: ({ bearer, headers, set }) => {
+        const failure = authorizeApiRequest(headers['x-api-key'], bearer)
+        if (!failure) return undefined
+        set.status = failure.status
+        return { error: failure.error }
+      }
+    })
+    .use(messagesRoutes)
+    .use(chatRoutes)
+    .use(responsesRoutes)
+    .use(modelsRoutes)
+    .use(knowledgeRoutes)
+    .use(createMcpRoutes(mcpSessions))
 
 /** Where the gateway listens; used to render an absolute OpenAPI server URL. */
 interface BuildAppOptions {
   host?: string
   port?: number
+  /**
+   * Live MCP sessions. `server.ts` passes the store it owns so gateway shutdown closes
+   * them; omitting it (tests, `buildApp()` with no args) gets a throwaway store.
+   */
+  mcpSessions?: McpSessionStore
 }
 
 /**
@@ -70,7 +77,11 @@ interface BuildAppOptions {
  *
  * Exported for both the runtime server (`server.ts`) and the integration tests.
  */
-export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions = {}) {
+export function buildApp({
+  host = '127.0.0.1',
+  port = 23333,
+  mcpSessions = new McpSessionStore()
+}: BuildAppOptions = {}) {
   const app = new Elysia({ adapter: node() })
     .use(
       cors({
@@ -162,7 +173,7 @@ export function buildApp({ host = '127.0.0.1', port = 23333 }: BuildAppOptions =
     // `?key=` credentials). Registering `/v1beta` first keeps it out of that guard's
     // reach; the `local` gemini guard does not leak back onto `/v1`.
     .use(geminiRoutes)
-    .use(v1Routes)
+    .use(buildV1Routes(mcpSessions))
 
   return app
 }

--- a/src/main/features/apiGateway/app.ts
+++ b/src/main/features/apiGateway/app.ts
@@ -7,7 +7,7 @@ import { Elysia } from 'elysia'
 import { v4 as uuidv4 } from 'uuid'
 
 import { gatewayErrorHandler } from './errors'
-import { McpSessionStore } from './mcpSessionStore'
+import { McpSessionStore } from './McpSessionStore'
 import { authorizeApiRequest } from './middleware/auth'
 import {
   buildOpenApiDocument,
@@ -94,6 +94,11 @@ export function buildApp({
         // boundary here (the API key is; non-browser clients ignore CORS entirely), so
         // reflecting the requested headers is the correct, maintenance-free choice.
         allowedHeaders: true,
+        // Must be an explicit list, not the default `true`. That default reflects the
+        // *request's* header names, and an `initialize` request cannot carry `mcp-session-id`
+        // yet — so a browser client would be unable to read the id the server just issued,
+        // would send every later request without it, and would orphan the session.
+        exposeHeaders: ['mcp-session-id', 'x-request-id'],
         methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
       })
     )

--- a/src/main/features/apiGateway/mcpSessionStore.ts
+++ b/src/main/features/apiGateway/mcpSessionStore.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from 'node:crypto'
+
+import { loggerService } from '@logger'
+import { createMcpBridgeServer } from '@main/ai/mcp/createMcpBridgeServer'
+import type { McpServer as McpBridgeServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import type { McpServer } from '@shared/data/types/mcpServer'
+
+const logger = loggerService.withContext('McpSessionStore')
+
+/** Matches the gateway's other long-lived stream budget (`GATEWAY_STREAM_IDLE_TIMEOUT_MS` in proxyStream.ts). */
+const SESSION_IDLE_TIMEOUT_MS = 30 * 60_000
+const SWEEP_INTERVAL_MS = 60_000
+/** A client that never sends DELETE still gets swept, but a runaway one must not grow the map first. */
+const MAX_SESSIONS = 64
+
+export interface McpSession {
+  id: string
+  serverId: string
+  transport: WebStandardStreamableHTTPServerTransport
+  bridge: McpBridgeServer
+  lastActivityAt: number
+}
+
+export class SessionLimitReachedError extends Error {
+  constructor(limit: number) {
+    super(`Too many MCP sessions (limit ${limit})`)
+    this.name = 'SessionLimitReachedError'
+  }
+}
+
+/**
+ * Live `Mcp-Session-Id` → bridge/transport map for `/v1/mcps/:id/mcp`.
+ *
+ * Owned by `ApiGateway`, so session lifetime is exactly HTTP-server lifetime: once the
+ * server closes, every session's socket is dead anyway, and `closeAll()` on the way down
+ * is what keeps this from becoming v1's `transports` record — which was never evicted.
+ *
+ * Sessions are created only when a client opts in by sending `initialize`; the sessionless
+ * one-shot path in `routes/mcp.ts` never reaches this store.
+ */
+export class McpSessionStore {
+  private readonly sessions = new Map<string, McpSession>()
+  private sweepTimer: NodeJS.Timeout | null = null
+
+  /**
+   * Open a session for `server` and let it serve the `initialize` request that asked for one.
+   * Creation and the first request are one step because the session id only exists once the
+   * transport has processed that request — there is no meaningful half-built session to hand back.
+   *
+   * Throws {@link SessionLimitReachedError} when the cap is reached.
+   */
+  async createAndHandle(server: McpServer, request: Request, parsedBody: unknown): Promise<Response> {
+    if (this.sessions.size >= MAX_SESSIONS) {
+      throw new SessionLimitReachedError(MAX_SESSIONS)
+    }
+
+    const bridge = createMcpBridgeServer(server.id, server)
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      // POST replies stay plain JSON; server→client notifications ride the standalone
+      // GET stream instead, which `handleGetRequest` opens regardless of this flag.
+      enableJsonResponse: true,
+      onsessioninitialized: (sessionId) => {
+        this.sessions.set(sessionId, {
+          id: sessionId,
+          serverId: server.id,
+          transport,
+          bridge,
+          lastActivityAt: Date.now()
+        })
+        this.ensureSweeping()
+        logger.debug('MCP session opened', { sessionId, serverId: server.id, live: this.sessions.size })
+      },
+      // The SDK's own DELETE path ends here, so the map can't outlive the transport.
+      onsessionclosed: (sessionId) => {
+        this.sessions.delete(sessionId)
+        logger.debug('MCP session closed', { sessionId, live: this.sessions.size })
+      }
+    })
+
+    await bridge.connect(transport)
+
+    try {
+      return await transport.handleRequest(request, { parsedBody })
+    } catch (error) {
+      // Nothing was registered if `initialize` failed — drop the bridge rather than leak it.
+      if (!transport.sessionId || !this.sessions.has(transport.sessionId)) await bridge.close().catch(() => {})
+      throw error
+    }
+  }
+
+  /** Look up a live session, stamping it so the idle sweep leaves it alone. */
+  get(sessionId: string): McpSession | undefined {
+    const session = this.sessions.get(sessionId)
+    if (session) session.lastActivityAt = Date.now()
+    return session
+  }
+
+  async delete(sessionId: string): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (!session) return
+    this.sessions.delete(sessionId)
+    await this.closeSession(session)
+  }
+
+  /** Drop every session and stop sweeping. Called by `ApiGateway.stop()`. */
+  async closeAll(): Promise<void> {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+    const live = [...this.sessions.values()]
+    this.sessions.clear()
+    await Promise.all(live.map((session) => this.closeSession(session)))
+    if (live.length > 0) logger.info('Closed MCP sessions', { count: live.length })
+  }
+
+  get size(): number {
+    return this.sessions.size
+  }
+
+  private async closeSession(session: McpSession): Promise<void> {
+    // Closes the transport too, which ends any open SSE stream.
+    await session.bridge
+      .close()
+      .catch((error) => logger.warn('Failed to close MCP session', { sessionId: session.id, error }))
+  }
+
+  private ensureSweeping(): void {
+    if (this.sweepTimer) return
+    this.sweepTimer = setInterval(() => void this.sweepIdle(), SWEEP_INTERVAL_MS)
+    // Never hold the event loop open for a housekeeping timer.
+    this.sweepTimer.unref?.()
+  }
+
+  private async sweepIdle(): Promise<void> {
+    const deadline = Date.now() - SESSION_IDLE_TIMEOUT_MS
+    const expired = [...this.sessions.values()].filter((session) => session.lastActivityAt < deadline)
+    for (const session of expired) this.sessions.delete(session.id)
+    await Promise.all(expired.map((session) => this.closeSession(session)))
+    if (expired.length > 0) logger.info('Swept idle MCP sessions', { count: expired.length, live: this.sessions.size })
+    if (this.sessions.size === 0 && this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+  }
+}

--- a/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
  * `/v1/mcps*` integration tests — drive the real Elysia app via `app.handle(Request)`
@@ -7,16 +7,25 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
  * `mcpServerService` and the MCP runtime/catalog services.
  */
 
-const { mockPreferenceGet, mockList, mockFindByIdOrName, mockListTools, mockWarmToolsCache, mockCallTool } = vi.hoisted(
-  () => ({
-    mockPreferenceGet: vi.fn<(key: string) => unknown>(() => 'test-key'),
-    mockList: vi.fn(),
-    mockFindByIdOrName: vi.fn(),
-    mockListTools: vi.fn(),
-    mockWarmToolsCache: vi.fn(async () => undefined),
-    mockCallTool: vi.fn()
-  })
-)
+const {
+  mockPreferenceGet,
+  mockList,
+  mockFindByIdOrName,
+  mockListTools,
+  mockWarmToolsCache,
+  mockCallTool,
+  toolsCacheListeners
+} = vi.hoisted(() => ({
+  mockPreferenceGet: vi.fn<(key: string) => unknown>(() => 'test-key'),
+  mockList: vi.fn(),
+  mockFindByIdOrName: vi.fn(),
+  mockListTools: vi.fn(),
+  mockWarmToolsCache: vi.fn(async () => undefined),
+  mockCallTool: vi.fn(),
+  // Real listener set so a test can actually fire the event the bridge relays as
+  // `tools/list_changed` — the whole point of sessions.
+  toolsCacheListeners: new Set<(event: { serverId: string }) => void>()
+}))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -27,7 +36,10 @@ vi.mock('@application', async () => {
       warmToolsCache: mockWarmToolsCache,
       listResources: vi.fn(async () => []),
       listPrompts: vi.fn(async () => []),
-      onToolsCacheUpdated: vi.fn(() => ({ dispose: vi.fn() }))
+      onToolsCacheUpdated: vi.fn((listener: (event: { serverId: string }) => void) => {
+        toolsCacheListeners.add(listener)
+        return { dispose: () => toolsCacheListeners.delete(listener) }
+      })
     },
     McpRuntimeService: { callTool: mockCallTool }
   }
@@ -61,6 +73,7 @@ vi.mock('@data/services/KnowledgeBaseService', () => ({
 }))
 
 import { buildApp } from '../../app'
+import { McpSessionStore } from '../../mcpSessionStore'
 
 const ACTIVE_SERVER = { id: 'server-1', name: 'filesystem', type: 'stdio', description: 'Local files', isActive: true }
 const TOOL = {
@@ -88,10 +101,43 @@ function get(
   return app.handle(new Request(`http://localhost${path}`, { method: 'GET', headers }))
 }
 
-function rpc(app: ReturnType<typeof buildApp>, path: string, body: unknown) {
+function rpc(app: ReturnType<typeof buildApp>, path: string, body: unknown, extraHeaders: Record<string, string> = {}) {
   return app.handle(
-    new Request(`http://localhost${path}`, { method: 'POST', headers: MCP_HEADERS, body: JSON.stringify(body) })
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      headers: { ...MCP_HEADERS, ...extraHeaders },
+      body: JSON.stringify(body)
+    })
   )
+}
+
+/** Drive the full handshake and return the id the transport assigned. */
+async function openSession(app: ReturnType<typeof buildApp>, path = '/v1/mcps/server-1/mcp'): Promise<string> {
+  const res = await rpc(app, path, INITIALIZE)
+  const sessionId = res.headers.get('mcp-session-id')
+  if (!sessionId) throw new Error(`no session id issued (status ${res.status})`)
+  // The SDK client always follows initialize with this; it is what arms the bridge's relay.
+  await rpc(app, path, { jsonrpc: '2.0', method: 'notifications/initialized' }, { 'mcp-session-id': sessionId })
+  return sessionId
+}
+
+/** Read SSE frames off a stream until `predicate` matches or the budget runs out. */
+async function readFrames(res: Response, predicate: (text: string) => boolean, budget = 40): Promise<string> {
+  const reader = res.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  for (let i = 0; i < budget; i++) {
+    const chunk = await Promise.race([
+      reader.read(),
+      new Promise<{ value: undefined; done: false }>((resolve) =>
+        setTimeout(() => resolve({ value: undefined, done: false }), 25)
+      )
+    ])
+    if (chunk.value) buffer += decoder.decode(chunk.value, { stream: true })
+    if (predicate(buffer)) break
+  }
+  void reader.cancel()
+  return buffer
 }
 
 const INITIALIZE = {
@@ -103,15 +149,22 @@ const INITIALIZE = {
 
 describe('/v1/mcps', () => {
   let app: ReturnType<typeof buildApp>
+  let sessions: McpSessionStore
 
   beforeEach(() => {
     vi.clearAllMocks()
+    toolsCacheListeners.clear()
     mockPreferenceGet.mockReturnValue('test-key')
     mockList.mockReturnValue({ items: [ACTIVE_SERVER], total: 1, page: 1 })
     mockFindByIdOrName.mockImplementation((id: string) => (id === 'server-1' ? ACTIVE_SERVER : undefined))
     mockListTools.mockReturnValue([TOOL])
     mockWarmToolsCache.mockResolvedValue(undefined)
-    app = buildApp()
+    sessions = new McpSessionStore()
+    app = buildApp({ mcpSessions: sessions })
+  })
+
+  afterEach(async () => {
+    await sessions.closeAll()
   })
 
   it('GET /v1/mcps lists active servers with an absolute proxy url', async () => {
@@ -155,13 +208,7 @@ describe('/v1/mcps', () => {
     expect(res.status).toBe(404)
   })
 
-  it('proxies tools/list over stateless Streamable HTTP without a session header', async () => {
-    const init = await rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE)
-    expect(init.status).toBe(200)
-    // Stateless mode issues no session id, so the client has nothing to echo back.
-    expect(init.headers.get('mcp-session-id')).toBeNull()
-    expect((await init.json()).result.serverInfo.name).toBe('filesystem')
-
+  it('proxies tools/list with full tool metadata', async () => {
     const list = await rpc(app, '/v1/mcps/server-1/mcp', { jsonrpc: '2.0', id: 2, method: 'tools/list' })
     expect(list.status).toBe(200)
     const body = await list.json()
@@ -269,8 +316,109 @@ describe('/v1/mcps', () => {
       })
     )
     expect(res.status).toBe(405)
-    expect(res.headers.get('allow')).toBe('POST')
+    expect(res.headers.get('allow')).toBe('POST, GET, DELETE')
     expect((await res.json()).error).toMatchObject({ code: -32000, message: 'Method not allowed.' })
+  })
+
+  describe('sessions (opt-in via initialize)', () => {
+    it('issues an Mcp-Session-Id on initialize and reuses it for follow-up calls', async () => {
+      const res = await rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE)
+      const sessionId = res.headers.get('mcp-session-id')
+      expect(res.status).toBe(200)
+      expect(sessionId).toBeTruthy()
+      expect(sessions.size).toBe(1)
+
+      const list = await rpc(
+        app,
+        '/v1/mcps/server-1/mcp',
+        { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+        { 'mcp-session-id': sessionId! }
+      )
+      expect(list.status).toBe(200)
+      expect((await list.json()).result.tools).toHaveLength(1)
+    })
+
+    // The hybrid contract: clients that never handshake keep the behaviour shipped in #18080.
+    it('still serves a sessionless tools/list with no handshake', async () => {
+      const res = await rpc(app, '/v1/mcps/server-1/mcp', { jsonrpc: '2.0', id: 3, method: 'tools/list' })
+      expect(res.status).toBe(200)
+      expect((await res.json()).result.tools).toHaveLength(1)
+      expect(sessions.size).toBe(0)
+    })
+
+    it('rejects an unknown session id with 404', async () => {
+      const res = await rpc(
+        app,
+        '/v1/mcps/server-1/mcp',
+        { jsonrpc: '2.0', id: 4, method: 'tools/list' },
+        { 'mcp-session-id': 'nope' }
+      )
+      expect(res.status).toBe(404)
+    })
+
+    it('GET opens an SSE stream for a session and still 405s without one', async () => {
+      expect((await get(app, '/v1/mcps/server-1/mcp', { 'x-api-key': 'test-key' })).status).toBe(405)
+
+      const sessionId = await openSession(app)
+      const stream = await get(app, '/v1/mcps/server-1/mcp', {
+        'x-api-key': 'test-key',
+        accept: 'text/event-stream',
+        'mcp-session-id': sessionId
+      })
+      expect(stream.status).toBe(200)
+      expect(stream.headers.get('content-type')).toContain('text/event-stream')
+      void stream.body?.cancel()
+    })
+
+    // The feature itself: without this, sessions buy nothing over #18080's stateless proxy.
+    it('pushes tools/list_changed onto a session stream when the tools cache changes', async () => {
+      const sessionId = await openSession(app)
+      const stream = await get(app, '/v1/mcps/server-1/mcp', {
+        'x-api-key': 'test-key',
+        accept: 'text/event-stream',
+        'mcp-session-id': sessionId
+      })
+      expect(toolsCacheListeners.size).toBeGreaterThan(0)
+
+      for (const listener of toolsCacheListeners) listener({ serverId: 'server-1' })
+
+      const frames = await readFrames(stream, (text) => text.includes('tools/list_changed'))
+      expect(frames).toContain('notifications/tools/list_changed')
+    })
+
+    it('DELETE terminates a session; the id is unusable afterwards', async () => {
+      const sessionId = await openSession(app)
+      const del = await app.handle(
+        new Request('http://localhost/v1/mcps/server-1/mcp', {
+          method: 'DELETE',
+          headers: { 'x-api-key': 'test-key', 'mcp-session-id': sessionId }
+        })
+      )
+      expect(del.status).toBe(200)
+      expect(sessions.size).toBe(0)
+
+      const after = await rpc(
+        app,
+        '/v1/mcps/server-1/mcp',
+        { jsonrpc: '2.0', id: 5, method: 'tools/list' },
+        { 'mcp-session-id': sessionId }
+      )
+      expect(after.status).toBe(404)
+    })
+
+    it('closeAll drops every session, so gateway shutdown cannot leak bridges', async () => {
+      const sessionId = await openSession(app)
+      await sessions.closeAll()
+      expect(sessions.size).toBe(0)
+
+      const after = await rpc(
+        app,
+        '/v1/mcps/server-1/mcp',
+        { jsonrpc: '2.0', id: 6, method: 'tools/list' },
+        { 'mcp-session-id': sessionId }
+      )
+      expect(after.status).toBe(404)
+    })
   })
 
   it('documents the endpoints in the OpenAPI spec', async () => {

--- a/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
@@ -489,6 +489,26 @@ describe('/v1/mcps', () => {
       expect(res.headers.get('access-control-expose-headers')?.toLowerCase()).toContain('mcp-session-id')
     })
 
+    // The SDK unregisters its standalone stream from that stream's `cancel` callback, so a
+    // cancellation that never reaches the source strands the mapping and every later GET on
+    // the session answers 409 — for the rest of its life, since nothing else clears it.
+    it('lets a client reopen the stream after cancelling the previous one', async () => {
+      const sessionId = await openSession(app)
+      const streamHeaders = {
+        'x-api-key': 'test-key',
+        accept: 'text/event-stream',
+        'mcp-session-id': sessionId
+      }
+
+      const first = await get(app, '/v1/mcps/server-1/mcp', streamHeaders)
+      expect(first.status).toBe(200)
+      await first.body!.cancel()
+
+      const second = await get(app, '/v1/mcps/server-1/mcp', streamHeaders)
+      expect(second.status).toBe(200)
+      void second.body?.cancel()
+    })
+
     it('refuses new sessions once closed, so a shutdown race cannot strand one', async () => {
       await sessions.closeAll()
       const res = await rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE)
@@ -518,5 +538,14 @@ describe('/v1/mcps', () => {
     expect(spec.paths['/v1/mcps/{server_id}/mcp'].post.description).toBe('apiGateway.docs.operations.mcp_proxy::en-US')
     // GET/DELETE on the proxy path are transport plumbing, not part of the documented API.
     expect(spec.paths['/v1/mcps/{server_id}/mcp'].get).toBeUndefined()
+  })
+
+  // The proxy answers JSON on the one-shot path and SSE on a session, so a client generated
+  // from this spec must be told about both — declaring only JSON makes it pick a JSON parser
+  // and never see a session response.
+  it('advertises both response media types for the proxy', async () => {
+    const spec = await (await get(app, '/openapi/json', {})).json()
+    const content = spec.paths['/v1/mcps/{server_id}/mcp'].post.responses['200'].content
+    expect(Object.keys(content).sort()).toEqual(['application/json', 'text/event-stream'])
   })
 })

--- a/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/mcp.test.ts
@@ -73,7 +73,7 @@ vi.mock('@data/services/KnowledgeBaseService', () => ({
 }))
 
 import { buildApp } from '../../app'
-import { McpSessionStore } from '../../mcpSessionStore'
+import { McpSessionStore } from '../../McpSessionStore'
 
 const ACTIVE_SERVER = { id: 'server-1', name: 'filesystem', type: 'stdio', description: 'Local files', isActive: true }
 const TOOL = {
@@ -119,6 +119,25 @@ async function openSession(app: ReturnType<typeof buildApp>, path = '/v1/mcps/se
   // The SDK client always follows initialize with this; it is what arms the bridge's relay.
   await rpc(app, path, { jsonrpc: '2.0', method: 'notifications/initialized' }, { 'mcp-session-id': sessionId })
   return sessionId
+}
+
+/**
+ * Drain a session POST response. Session transports answer in SSE (not JSON) so that
+ * request-related notifications such as `notifications/progress` are actually written —
+ * the SDK drops those under `enableJsonResponse`. Returns every JSON-RPC message in order.
+ */
+async function readSseMessages(res: Response): Promise<any[]> {
+  const text = await res.text()
+  return text
+    .split('\n')
+    .filter((line) => line.startsWith('data: '))
+    .map((line) => JSON.parse(line.slice(6)))
+}
+
+/** The final result message of a session POST (notifications may precede it). */
+async function sseResult(res: Response): Promise<any> {
+  const messages = await readSseMessages(res)
+  return messages.find((message) => 'result' in message || 'error' in message)
 }
 
 /** Read SSE frames off a stream until `predicate` matches or the budget runs out. */
@@ -267,11 +286,13 @@ describe('/v1/mcps', () => {
     expect(mockWarmToolsCache).toHaveBeenCalledWith('server-1')
   })
 
-  // Declaring listChanged on a transport that cannot deliver it makes clients trust a heal
-  // that never arrives and keep a stale tool list.
-  it('does not advertise tools.listChanged to a stateless HTTP client', async () => {
+  // The capability must track what the transport can actually deliver. A session holds a
+  // stream, so it advertises listChanged; the one-shot path builds its bridge with
+  // `listChanged: false` (it has no stream), and never reaches a client because only an
+  // `initialize` — which opens a session — is answered with capabilities at all.
+  it('advertises tools.listChanged to a session client, which can receive it', async () => {
     const res = await rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE)
-    expect((await res.json()).result.capabilities.tools).toEqual({})
+    expect((await sseResult(res)).result.capabilities.tools).toEqual({ listChanged: true })
   })
 
   // The MCP transport spec requires Origin validation to block DNS rebinding; native
@@ -335,7 +356,39 @@ describe('/v1/mcps', () => {
         { 'mcp-session-id': sessionId! }
       )
       expect(list.status).toBe(200)
-      expect((await list.json()).result.tools).toHaveLength(1)
+      expect((await sseResult(list)).result.tools).toHaveLength(1)
+    })
+
+    // Regression for the silent-drop this PR fixes: with `enableJsonResponse: true` the SDK
+    // resolves the call but never writes request-related notifications, so an HTTP client
+    // saw the result and lost every progress update. An in-memory transport cannot show this.
+    it('delivers notifications/progress to a session client over the HTTP transport', async () => {
+      mockCallTool.mockImplementation(async ({ onProgress }: { onProgress?: (p: unknown) => void }) => {
+        onProgress?.({ progress: 1, total: 2 })
+        onProgress?.({ progress: 2, total: 2 })
+        return { content: [{ type: 'text', text: 'done' }] }
+      })
+
+      const sessionId = await openSession(app)
+      const res = await rpc(
+        app,
+        '/v1/mcps/server-1/mcp',
+        {
+          jsonrpc: '2.0',
+          id: 7,
+          method: 'tools/call',
+          params: { name: 'read_file', arguments: { path: '/tmp/a.txt' }, _meta: { progressToken: 'tok-1' } }
+        },
+        { 'mcp-session-id': sessionId }
+      )
+
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toContain('text/event-stream')
+      const messages = await readSseMessages(res)
+      const progress = messages.filter((m) => m.method === 'notifications/progress')
+      expect(progress.map((m) => m.params.progress)).toEqual([1, 2])
+      expect(progress.every((m) => m.params.progressToken === 'tok-1')).toBe(true)
+      expect(messages.find((m) => 'result' in m).result.content).toEqual([{ type: 'text', text: 'done' }])
     })
 
     // The hybrid contract: clients that never handshake keep the behaviour shipped in #18080.
@@ -404,6 +457,43 @@ describe('/v1/mcps', () => {
         { 'mcp-session-id': sessionId }
       )
       expect(after.status).toBe(404)
+    })
+
+    // The cap used to be checked against `sessions.size` alone, which is only updated after
+    // `bridge.connect()` resolves — so a concurrent burst all passed the check at once.
+    it('holds the session cap under a concurrent initialize burst', async () => {
+      const burst = 80
+      const responses = await Promise.all(
+        Array.from({ length: burst }, () => rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE))
+      )
+
+      const opened = responses.filter((res) => res.headers.get('mcp-session-id')).length
+      const refused = responses.filter((res) => res.status === 503).length
+      expect(sessions.size).toBeLessThanOrEqual(64)
+      expect(opened).toBeLessThanOrEqual(64)
+      expect(opened + refused).toBe(burst)
+    })
+
+    // Browsers cannot read a response header that is not in access-control-expose-headers,
+    // so without this the official client reads a null id and orphans the session.
+    it('exposes mcp-session-id to browser clients', async () => {
+      const res = await app.handle(
+        new Request('http://localhost/v1/mcps/server-1/mcp', {
+          method: 'POST',
+          // Loopback: a non-local Origin is rejected outright by the transport-boundary check.
+          headers: { ...MCP_HEADERS, origin: 'http://localhost:5173' },
+          body: JSON.stringify(INITIALIZE)
+        })
+      )
+      expect(res.headers.get('mcp-session-id')).toBeTruthy()
+      expect(res.headers.get('access-control-expose-headers')?.toLowerCase()).toContain('mcp-session-id')
+    })
+
+    it('refuses new sessions once closed, so a shutdown race cannot strand one', async () => {
+      await sessions.closeAll()
+      const res = await rpc(app, '/v1/mcps/server-1/mcp', INITIALIZE)
+      expect(res.status).toBe(503)
+      expect(sessions.size).toBe(0)
     })
 
     it('closeAll drops every session, so gateway shutdown cannot leak bridges', async () => {

--- a/src/main/features/apiGateway/routes/mcp.ts
+++ b/src/main/features/apiGateway/routes/mcp.ts
@@ -69,6 +69,13 @@ const JSON_RPC_REQUEST_DOC = {
   },
   example: { jsonrpc: '2.0', id: 1, method: 'tools/list' }
 } as const
+/** The SSE framing a session request answers with; each `data:` line is a JSON-RPC message. */
+const SSE_RESPONSE_DOC = {
+  type: 'string',
+  description:
+    'Server-sent event stream. Each event carries one JSON-RPC message in `data:` — zero or more notifications, then the response.',
+  example: 'event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n'
+} as const
 const JSON_RPC_RESPONSE_DOC = {
   type: 'object',
   properties: {
@@ -203,8 +210,12 @@ export function createMcpRoutes(sessions: McpSessionStore) {
             },
             responses: {
               200: {
-                description: 'JSON-RPC response',
-                content: { 'application/json': { schema: JSON_RPC_RESPONSE_DOC } }
+                description:
+                  'JSON-RPC response. A session request — one carrying `Mcp-Session-Id`, and the `initialize` that opens one — answers as `text/event-stream`, so notifications tied to the request (a tool call’s `notifications/progress`) can precede its result. The sessionless one-shot path answers as `application/json`.',
+                content: {
+                  'application/json': { schema: JSON_RPC_RESPONSE_DOC },
+                  'text/event-stream': { schema: SSE_RESPONSE_DOC }
+                }
               },
               403: { description: 'Origin is not local' },
               404: { description: 'MCP server not found, or unknown Mcp-Session-Id' },
@@ -387,8 +398,20 @@ function primeEventStream(response: Response): Response {
 
 async function primeAndPipe(writable: WritableStream<Uint8Array>, source: ReadableStream<Uint8Array>): Promise<void> {
   const writer = writable.getWriter()
-  await writer.write(new TextEncoder().encode(': open\n\n'))
-  writer.releaseLock()
+  try {
+    await writer.write(new TextEncoder().encode(': open\n\n'))
+  } catch (error) {
+    // The client vanished before the priming byte landed, so the `pipeTo` below never runs.
+    // `pipeTo` is what would otherwise cancel `source`, and the SDK unregisters its standalone
+    // stream from that cancel callback — skipping it strands the mapping, so every later GET
+    // on this session answers 409 "only one SSE stream" until DELETE or the idle sweep.
+    await source.cancel(error).catch(() => {})
+    throw error
+  } finally {
+    writer.releaseLock()
+  }
+  // Past this point cancellation is `pipeTo`'s job: a destination error cancels the source,
+  // since `preventCancel` defaults to false.
   await source.pipeTo(writable)
 }
 

--- a/src/main/features/apiGateway/routes/mcp.ts
+++ b/src/main/features/apiGateway/routes/mcp.ts
@@ -3,12 +3,14 @@ import { mcpServerService } from '@data/services/McpServerService'
 import { loggerService } from '@logger'
 import { createMcpBridgeServer } from '@main/ai/mcp/createMcpBridgeServer'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { McpServer } from '@shared/data/types/mcpServer'
 import { Elysia } from 'elysia'
 import * as z from 'zod'
 
 import { jsonRpcEnvelope, MCP_TRANSPORT_ERROR } from '../errors'
+import { type McpSessionStore, SessionLimitReachedError } from '../mcpSessionStore'
 import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 
 const logger = loggerService.withContext('McpRoutes')
@@ -94,119 +96,138 @@ function resolveServer(idOrName: string): McpServer {
  * endpoints this restores are documented in
  * `v2-refactor-temp/docs/breaking-changes/2026-06-05-api-gateway-mcp-http-removed.md`).
  *
- * The proxy runs **stateless**: no `Mcp-Session-Id` is issued and a fresh bridge +
- * transport is built per request. The expensive resource — the upstream MCP client —
- * is cached by `McpRuntimeService` either way, so this costs nothing and removes the
- * session map v1 never evicted.
+ * Sessions are **opt-in by the client** (see `handleProxyPost`): one that sends `initialize`
+ * gets an `Mcp-Session-Id` and may hold a `GET` stream for server→client push; one that just
+ * POSTs a method — the shape plain `curl` and the v1 endpoints allow — keeps the one-shot
+ * path, where a fresh bridge serves the request and is torn down with it.
  *
- * What statelessness costs, and how each cost is handled honestly rather than papered over:
- * - No server→client push. `GET` returns 405 and the bridge is built with
- *   `listChanged: false`, so the client is never told to expect a `tools/list_changed`
- *   it cannot receive; it re-lists instead.
- * - No cross-request cancellation. `notifications/cancelled` arrives on a *different*
- *   bridge than the in-flight `tools/call`, and the SDK keeps abort controllers per
- *   `Server` instance, so it cannot reach the running request. What does work is
- *   request-scoped abort: the call-tool handler forwards `extra.signal` into the runtime,
- *   so a dropped connection or transport-level abort stops the upstream call.
- * - Only `tools/list` waits on the tools cache (see `needsWarmTools`).
+ * The two paths differ where the transport genuinely differs, never cosmetically:
+ * - **Capability.** Sessions build the bridge with `listChanged: true` because they can
+ *   deliver the notification; the one-shot path passes `false` so a client is never told to
+ *   expect a heal that cannot arrive, and re-lists instead.
+ * - **Response encoding.** Session POSTs answer in SSE, the one-shot path in JSON: the SDK
+ *   only writes request-related notifications (a tool's `notifications/progress`) when JSON
+ *   response mode is off. The one-shot path has no stream for them either way.
+ * - **Cancellation.** Within a session `notifications/cancelled` reaches the bridge that owns
+ *   the running request. One-shot cannot — the notification lands on a *different* bridge and
+ *   the SDK keeps abort controllers per `Server` instance. Both forward `extra.signal` into
+ *   the runtime, so a dropped connection stops the upstream call regardless.
+ *
+ * Only `tools/list` waits on the tools cache (see `needsWarmTools`); gating the handshake on
+ * an upstream probe is what times clients out.
  *
  * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
-export const mcpRoutes = new Elysia({ prefix: '/mcps' })
-  .get(
-    '/',
-    ({ request }) => {
-      const origin = new URL(request.url).origin
-      const { items } = mcpServerService.list({ isActive: true })
-      return {
-        servers: items.map((server) => ({
-          id: server.id,
-          name: server.name,
-          // Always `streamableHttp`: this is the transport the client speaks to *us*,
-          // regardless of how Cherry Studio reaches the server upstream.
-          type: 'streamableHttp' as const,
-          description: server.description,
-          url: `${origin}/v1/mcps/${server.id}/mcp`
-        }))
-      }
-    },
-    {
-      response: { 200: ListMcpServersResponseSchema },
-      detail: { tags: [DOC_TAGS.cherry], summary: 'List MCP Servers', description: DOC_DESCRIPTIONS.list_mcp_servers }
-    }
-  )
-  .get(
-    '/:server_id',
-    async ({ params }) => {
-      const server = resolveServer(params.server_id)
-      // Never rejects — a dead server degrades to an empty tool list rather than a 5xx.
-      await application.get('McpCatalogService').warmToolsCache(server.id)
-      return {
-        id: server.id,
-        name: server.name,
-        type: server.type,
-        description: server.description,
-        tools: application.get('McpCatalogService').listTools(server.id)
-      }
-    },
-    {
-      params: ServerIdParamSchema,
-      detail: {
-        tags: [DOC_TAGS.cherry],
-        summary: 'Get MCP Server',
-        description: DOC_DESCRIPTIONS.get_mcp_server,
-        responses: {
-          200: {
-            description: 'MCP server with its tools',
-            content: { 'application/json': { schema: MCP_SERVER_DETAIL_DOC } }
-          },
-          404: { description: 'MCP server not found' }
-        }
-      }
-    }
-  )
-  // Streamable HTTP proxy. Registered as explicit methods rather than `.all()` so
-  // `toOpenAPISchema` sees ordinary operations; only POST carries traffic, so the two
-  // 405 responders stay out of the docs.
-  .post(
-    '/:server_id/mcp',
-    ({ params, request, body }) => forbiddenOrigin(request) ?? handleMcpRequest(params.server_id, request, body),
-    {
-      params: ServerIdParamSchema,
-      detail: {
-        tags: [DOC_TAGS.cherry],
-        summary: 'MCP Proxy',
-        description: DOC_DESCRIPTIONS.mcp_proxy,
-        // Documentation-only: the body stays untyped by Elysia so the raw JSON-RPC payload
-        // reaches the transport's own parser untouched.
-        requestBody: {
-          required: true,
-          content: { 'application/json': { schema: JSON_RPC_REQUEST_DOC } }
+export function createMcpRoutes(sessions: McpSessionStore) {
+  return (
+    new Elysia({ prefix: '/mcps' })
+      .get(
+        '/',
+        ({ request }) => {
+          const origin = new URL(request.url).origin
+          const { items } = mcpServerService.list({ isActive: true })
+          return {
+            servers: items.map((server) => ({
+              id: server.id,
+              name: server.name,
+              // Always `streamableHttp`: this is the transport the client speaks to *us*,
+              // regardless of how Cherry Studio reaches the server upstream.
+              type: 'streamableHttp' as const,
+              description: server.description,
+              url: `${origin}/v1/mcps/${server.id}/mcp`
+            }))
+          }
         },
-        responses: {
-          200: {
-            description: 'JSON-RPC response',
-            content: { 'application/json': { schema: JSON_RPC_RESPONSE_DOC } }
-          },
-          403: { description: 'Origin is not local' },
-          404: { description: 'MCP server not found' },
-          405: { description: 'Method not allowed on this endpoint' }
+        {
+          response: { 200: ListMcpServersResponseSchema },
+          detail: {
+            tags: [DOC_TAGS.cherry],
+            summary: 'List MCP Servers',
+            description: DOC_DESCRIPTIONS.list_mcp_servers
+          }
         }
-      }
-    }
+      )
+      .get(
+        '/:server_id',
+        async ({ params }) => {
+          const server = resolveServer(params.server_id)
+          // Never rejects — a dead server degrades to an empty tool list rather than a 5xx.
+          await application.get('McpCatalogService').warmToolsCache(server.id)
+          return {
+            id: server.id,
+            name: server.name,
+            type: server.type,
+            description: server.description,
+            tools: application.get('McpCatalogService').listTools(server.id)
+          }
+        },
+        {
+          params: ServerIdParamSchema,
+          detail: {
+            tags: [DOC_TAGS.cherry],
+            summary: 'Get MCP Server',
+            description: DOC_DESCRIPTIONS.get_mcp_server,
+            responses: {
+              200: {
+                description: 'MCP server with its tools',
+                content: { 'application/json': { schema: MCP_SERVER_DETAIL_DOC } }
+              },
+              404: { description: 'MCP server not found' }
+            }
+          }
+        }
+      )
+      // Streamable HTTP proxy. Registered as explicit methods rather than `.all()` so
+      // `toOpenAPISchema` sees ordinary operations; only POST carries traffic, so the two
+      // 405 responders stay out of the docs.
+      .post(
+        '/:server_id/mcp',
+        ({ params, request, body }) =>
+          forbiddenOrigin(request) ?? handleProxyPost(sessions, params.server_id, request, body),
+        {
+          params: ServerIdParamSchema,
+          detail: {
+            tags: [DOC_TAGS.cherry],
+            summary: 'MCP Proxy',
+            description: DOC_DESCRIPTIONS.mcp_proxy,
+            // Documentation-only: the body stays untyped by Elysia so the raw JSON-RPC payload
+            // reaches the transport's own parser untouched.
+            requestBody: {
+              required: true,
+              content: { 'application/json': { schema: JSON_RPC_REQUEST_DOC } }
+            },
+            responses: {
+              200: {
+                description: 'JSON-RPC response',
+                content: { 'application/json': { schema: JSON_RPC_RESPONSE_DOC } }
+              },
+              403: { description: 'Origin is not local' },
+              404: { description: 'MCP server not found, or unknown Mcp-Session-Id' },
+              405: { description: 'Method not allowed on this endpoint' },
+              503: { description: 'Too many live sessions, or the gateway is shutting down' }
+            }
+          }
+        }
+      )
+      // Opens the standalone SSE stream that carries server→client push. Only meaningful for a
+      // session: without one there is nothing to push through, and letting the transport handle
+      // it would open a stream that this request's own teardown closes, handing the client a
+      // dead stream instead of an honest refusal.
+      .get(
+        '/:server_id/mcp',
+        ({ params, request }) =>
+          forbiddenOrigin(request) ?? handleProxySessionOnly(sessions, params.server_id, request),
+        { params: ServerIdParamSchema, detail: { hide: true } }
+      )
+      // Session termination. Sessionless clients have nothing to terminate → 405, per spec.
+      .delete(
+        '/:server_id/mcp',
+        ({ params, request }) =>
+          forbiddenOrigin(request) ?? handleProxySessionOnly(sessions, params.server_id, request),
+        { params: ServerIdParamSchema, detail: { hide: true } }
+      )
   )
-  // Stateless means no standalone SSE stream and no session to terminate, and the spec's
-  // answer in both cases is 405. Handled here rather than by the transport: its GET branch
-  // ignores stateless mode and opens an SSE stream that this request's own teardown would
-  // close immediately, handing the client a dead stream instead of an honest refusal.
-  .get('/:server_id/mcp', ({ request }) => forbiddenOrigin(request) ?? methodNotAllowed(), {
-    params: ServerIdParamSchema,
-    detail: { hide: true }
-  })
-  .delete('/:server_id/mcp', ({ request }) => forbiddenOrigin(request) ?? methodNotAllowed(), {
-    params: ServerIdParamSchema,
-    detail: { hide: true }
-  })
+}
 
 /**
  * Reject a browser `Origin` the MCP transport spec does not consider local.
@@ -243,10 +264,36 @@ function forbiddenOrigin(request: Request): Response | undefined {
 
 /** The MCP SDK's own 405 body, so clients see one shape whoever produced it. */
 function methodNotAllowed(): Response {
+  // GET/DELETE are allowed once sessions are on, so the header lists them even when this
+  // stateless refusal is what the request got.
   return new Response(JSON.stringify(jsonRpcEnvelope(MCP_TRANSPORT_ERROR, 'Method not allowed.')), {
     status: 405,
-    headers: { Allow: 'POST', 'Content-Type': 'application/json' }
+    headers: { Allow: 'POST, GET, DELETE', 'Content-Type': 'application/json' }
   })
+}
+
+/** Spec response for an `Mcp-Session-Id` the server doesn't know (expired, swept, or wrong server). */
+function sessionNotFound(): Response {
+  return new Response(
+    JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }),
+    { status: 404, headers: { 'Content-Type': 'application/json' } }
+  )
+}
+
+/** `initialize` is what opts a client into a session — including inside a JSON-RPC batch. */
+function isInitialize(body: unknown): boolean {
+  return Array.isArray(body) ? body.some(isInitializeRequest) : isInitializeRequest(body)
+}
+
+/**
+ * Resolve a session referenced by header, rejecting one that belongs to a different MCP
+ * server so a leaked id can't be replayed across servers.
+ */
+function lookupSession(sessions: McpSessionStore, request: Request, serverId: string) {
+  const sessionId = request.headers.get('mcp-session-id')
+  if (!sessionId) return undefined
+  const session = sessions.get(sessionId)
+  return session?.serverId === serverId ? session : null
 }
 
 /**
@@ -262,12 +309,87 @@ function needsWarmTools(body: unknown): boolean {
   return Array.isArray(body) ? body.some(wants) : wants(body)
 }
 
-async function handleMcpRequest(serverId: string, request: Request, body?: unknown): Promise<Response> {
-  const server = resolveServer(serverId)
+async function handleProxyPost(
+  sessions: McpSessionStore,
+  serverIdOrName: string,
+  request: Request,
+  body?: unknown
+): Promise<Response> {
+  const server = resolveServer(serverIdOrName)
   if (needsWarmTools(body)) {
     await application.get('McpCatalogService').warmToolsCache(server.id)
   }
 
+  const session = lookupSession(sessions, request, server.id)
+  if (session === null) return sessionNotFound()
+  // Elysia has already consumed the body stream, so every path below hands the parsed
+  // value over rather than letting the transport re-read `request.json()`.
+  if (session) return session.transport.handleRequest(request, { parsedBody: body })
+
+  if (isInitialize(body)) {
+    try {
+      return await sessions.createAndHandle(server, request, body)
+    } catch (error) {
+      if (error instanceof SessionLimitReachedError) {
+        logger.warn('Refused MCP session', { serverId: server.id, error })
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: error.message }, id: null }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      throw error
+    }
+  }
+
+  return handleOneShot(server, request, body)
+}
+
+/** GET/DELETE carry no body to opt into a session, so they serve existing ones or refuse. */
+async function handleProxySessionOnly(
+  sessions: McpSessionStore,
+  serverIdOrName: string,
+  request: Request
+): Promise<Response> {
+  const server = resolveServer(serverIdOrName)
+  const session = lookupSession(sessions, request, server.id)
+  if (session === null) return sessionNotFound()
+  if (!session) return methodNotAllowed()
+  return primeEventStream(await session.transport.handleRequest(request))
+}
+
+/**
+ * Emit one SSE comment up front so the client actually receives the response head.
+ *
+ * The notification stream opens silent — nothing is written until a notification happens —
+ * and Node only flushes headers with the first body chunk. Without this a client's `GET`
+ * hangs with no status at all, and because the transport has already registered the stream
+ * its retry gets 409 "only one SSE stream per session". A comment line is inert per the SSE
+ * grammar, so every client ignores it.
+ */
+function primeEventStream(response: Response): Response {
+  if (!response.body || !response.headers.get('content-type')?.includes('text/event-stream')) return response
+
+  const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
+  const source = response.body
+  // A client that disconnects rejects the write, the pipe, or both; that is an ordinary
+  // end-of-stream here, not an error anyone can act on.
+  void primeAndPipe(writable, source).catch(() => {})
+
+  return new Response(readable, { status: response.status, headers: response.headers })
+}
+
+async function primeAndPipe(writable: WritableStream<Uint8Array>, source: ReadableStream<Uint8Array>): Promise<void> {
+  const writer = writable.getWriter()
+  await writer.write(new TextEncoder().encode(': open\n\n'))
+  writer.releaseLock()
+  await source.pipeTo(writable)
+}
+
+/**
+ * Sessionless path: a throwaway bridge serves this one request. Kept for clients that POST a
+ * method without an `initialize` handshake — the shape plain `curl` and the v1 endpoints allow.
+ */
+async function handleOneShot(server: McpServer, request: Request, body?: unknown): Promise<Response> {
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
     enableJsonResponse: true
@@ -278,8 +400,6 @@ async function handleMcpRequest(serverId: string, request: Request, body?: unkno
   await bridge.connect(transport)
 
   try {
-    // Elysia has already consumed the body stream, so hand the parsed value over
-    // rather than letting the transport re-read `request.json()`.
     return await transport.handleRequest(request, body === undefined ? undefined : { parsedBody: body })
   } finally {
     // `handleRequest` resolves only once the JSON response is fully built

--- a/src/main/features/apiGateway/routes/mcp.ts
+++ b/src/main/features/apiGateway/routes/mcp.ts
@@ -10,7 +10,7 @@ import { Elysia } from 'elysia'
 import * as z from 'zod'
 
 import { jsonRpcEnvelope, MCP_TRANSPORT_ERROR } from '../errors'
-import { type McpSessionStore, SessionLimitReachedError } from '../mcpSessionStore'
+import { type McpSessionStore, SessionLimitReachedError, StoreClosedError } from '../McpSessionStore'
 import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 
 const logger = loggerService.withContext('McpRoutes')
@@ -115,6 +115,11 @@ function resolveServer(idOrName: string): McpServer {
  *
  * Only `tools/list` waits on the tools cache (see `needsWarmTools`); gating the handshake on
  * an upstream probe is what times clients out.
+ *
+ * Session POSTs answer in SSE, the one-shot path in JSON: the SDK only writes
+ * request-related notifications (a tool's `notifications/progress`) when JSON response
+ * mode is off, so a session using it would resolve the call and drop every progress
+ * update. The one-shot path has no stream to deliver them on either way.
  *
  * `detail.tags`/`summary` hold i18n *keys*, not translated text — see chat.ts.
  */
@@ -330,7 +335,9 @@ async function handleProxyPost(
     try {
       return await sessions.createAndHandle(server, request, body)
     } catch (error) {
-      if (error instanceof SessionLimitReachedError) {
+      // Both mean "cannot take a new session right now", which is a retryable 503 rather
+      // than a fault in the request.
+      if (error instanceof SessionLimitReachedError || error instanceof StoreClosedError) {
         logger.warn('Refused MCP session', { serverId: server.id, error })
         return new Response(
           JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: error.message }, id: null }),

--- a/src/main/features/apiGateway/server.ts
+++ b/src/main/features/apiGateway/server.ts
@@ -4,6 +4,7 @@ import type { Server } from 'elysia/universal/server'
 import type { Server as HttpServer } from 'http'
 
 import { type ApiGatewayApp, buildApp } from './app'
+import { McpSessionStore } from './mcpSessionStore'
 
 const logger = loggerService.withContext('ApiGateway')
 
@@ -30,6 +31,12 @@ export class ApiGateway {
   private app: ApiGatewayApp | null = null
   private serverInfo: NodeServerInfo | null = null
   private running = false
+  /**
+   * Owned here so session lifetime is exactly server lifetime: once the socket closes every
+   * session is unreachable, so `stop()` must drop them rather than leak bridges into the next
+   * activation (a restart builds a fresh `ApiGateway`, and a port change is a stop→start).
+   */
+  private readonly mcpSessions = new McpSessionStore()
 
   async start(): Promise<void> {
     if (this.running) {
@@ -42,7 +49,7 @@ export class ApiGateway {
     const port = preferenceService.get('feature.api_gateway.port')
     const host = preferenceService.get('feature.api_gateway.host')
 
-    const app = buildApp({ host, port })
+    const app = buildApp({ host, port, mcpSessions: this.mcpSessions })
     this.app = app
 
     return new Promise((resolve, reject) => {
@@ -110,6 +117,9 @@ export class ApiGateway {
       // leave the service stuck `_activated` with a stale `running` cache state.
       await this.serverInfo?.stop?.()
     } finally {
+      // After the socket is gone every session is unreachable; close them so their bridges
+      // and idle sweep don't outlive the server.
+      await this.mcpSessions.closeAll()
       this.running = false
       this.serverInfo = null
       this.app = null

--- a/src/main/features/apiGateway/server.ts
+++ b/src/main/features/apiGateway/server.ts
@@ -4,7 +4,7 @@ import type { Server } from 'elysia/universal/server'
 import type { Server as HttpServer } from 'http'
 
 import { type ApiGatewayApp, buildApp } from './app'
-import { McpSessionStore } from './mcpSessionStore'
+import { McpSessionStore } from './McpSessionStore'
 
 const logger = loggerService.withContext('ApiGateway')
 
@@ -115,11 +115,14 @@ export class ApiGateway {
       // never assigns `app.server`, so Elysia core's web-standard `stop()` throws
       // "Elysia isn't running". An unhandled throw would skip the cleanup below and
       // leave the service stuck `_activated` with a stale `running` cache state.
+      // BEFORE awaiting the close, not after: a session's GET stream is an active response,
+      // and `server.close()` waits for those to finish, so stopping first would hang here
+      // until the client disconnected or the idle sweep fired half an hour later. Closing the
+      // sessions ends those streams, which is what lets the close below settle. `closeAll`
+      // also latches the store shut, so an initialize racing this shutdown is refused.
+      await this.mcpSessions.closeAll()
       await this.serverInfo?.stop?.()
     } finally {
-      // After the socket is gone every session is unreachable; close them so their bridges
-      // and idle sweep don't outlive the server.
-      await this.mcpSessions.closeAll()
       this.running = false
       this.serverInfo = null
       this.app = null

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-07-api-gateway-mcp-http-restored.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-07-api-gateway-mcp-http-restored.md
@@ -16,9 +16,10 @@ The `/v1/mcps*` endpoints removed in v2.0.0 are back on the API gateway, so exte
 
 They authenticate like every other gateway route (`Authorization: Bearer` / `x-api-key`) and appear in `/openapi`.
 
-Two differences from the v1 endpoints:
+Four differences from the v1 endpoints:
 
-- **Sessions are opt-in.** A client that sends `initialize` gets an `Mcp-Session-Id` and may hold a `GET` stream for server-initiated messages, including `tools/list_changed`. A client that just POSTs a method without handshaking — what plain `curl` and some v1 scripts do — is still served, one request at a time, gets 405 on `GET`, and is told up front that `tools.listChanged` is unavailable so it re-lists instead of waiting for a notification.
+- **Sessions are opt-in.** A client that sends `initialize` gets an `Mcp-Session-Id` and may hold a `GET` stream for server-initiated messages, including `tools/list_changed` and tool progress. A client that just POSTs a method without handshaking — what plain `curl` and some v1 scripts do — is still served, one request at a time, gets 405 on `GET`, and is told up front that `tools.listChanged` is unavailable so it re-lists instead of waiting for a notification.
+- **Sessions are capped and expire.** The handshake is compatible with v1, but the lifecycle is not: at most 64 sessions exist at once, and one goes away after 30 minutes with no traffic in either direction. v1 kept every session forever. So a client can now get a `503` during a burst, or a `404` on a session it left idle, and must re-`initialize` in both cases — clients that assume a session id is valid indefinitely need a retry path.
 - **Browser callers must be local.** As the MCP transport spec requires, a request carrying an `Origin` that is not a loopback address is rejected with 403, so a malicious web page cannot drive this endpoint through a browser that already holds gateway credentials. Native clients send no `Origin` and are unaffected.
 - **Response bodies.** The two `GET` endpoints return plain objects (`{ servers: [...] }`, `{ id, name, type, description, tools }`) instead of v1's `{ success: true, data: ... }` wrapper. Errors use the gateway's standard error envelope.
 
@@ -28,7 +29,7 @@ Users who ran external automation against Cherry Studio's MCP servers (browser t
 
 ## What the user should do
 
-Nothing to enable — the endpoints are live whenever the API gateway is on. Clients written against v1 should drop the `success`/`data` unwrapping; session handling is unchanged from v1 for clients that handshake.
+Nothing to enable — the endpoints are live whenever the API gateway is on. Clients written against v1 should drop the `success`/`data` unwrapping, and should re-`initialize` when a request comes back `404` (session expired) or `503` (server at capacity) rather than treating a session id as permanent.
 
 ## Notes for release manager
 

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-07-api-gateway-mcp-http-restored.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-07-api-gateway-mcp-http-restored.md
@@ -18,7 +18,7 @@ They authenticate like every other gateway route (`Authorization: Bearer` / `x-a
 
 Two differences from the v1 endpoints:
 
-- **No sessions.** The proxy is stateless: no `Mcp-Session-Id` is issued, and `GET` on the proxy path returns 405 instead of opening an SSE stream. Standard MCP clients handle this — the spec allows a server not to assign session ids. Because there is no stream to push on, the server does **not** advertise `tools.listChanged`, so a client knows up front to re-list rather than waiting for a notification. Cross-request cancellation (`notifications/cancelled`) is likewise not honored; dropping the connection does stop the upstream call.
+- **Sessions are opt-in.** A client that sends `initialize` gets an `Mcp-Session-Id` and may hold a `GET` stream for server-initiated messages, including `tools/list_changed`. A client that just POSTs a method without handshaking — what plain `curl` and some v1 scripts do — is still served, one request at a time, gets 405 on `GET`, and is told up front that `tools.listChanged` is unavailable so it re-lists instead of waiting for a notification.
 - **Browser callers must be local.** As the MCP transport spec requires, a request carrying an `Origin` that is not a loopback address is rejected with 403, so a malicious web page cannot drive this endpoint through a browser that already holds gateway credentials. Native clients send no `Origin` and are unaffected.
 - **Response bodies.** The two `GET` endpoints return plain objects (`{ servers: [...] }`, `{ id, name, type, description, tools }`) instead of v1's `{ success: true, data: ... }` wrapper. Errors use the gateway's standard error envelope.
 
@@ -28,7 +28,7 @@ Users who ran external automation against Cherry Studio's MCP servers (browser t
 
 ## What the user should do
 
-Nothing to enable — the endpoints are live whenever the API gateway is on. Clients written against v1 should drop the `success`/`data` unwrapping and stop relying on `Mcp-Session-Id`.
+Nothing to enable — the endpoints are live whenever the API gateway is on. Clients written against v1 should drop the `success`/`data` unwrapping; session handling is unchanged from v1 for clients that handshake.
 
 ## Notes for release manager
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

> ⚠️ **Stacked on #18080** — targets `proxy-mcp-server-support`, not `main`. Review #18080 first. **#18097 (progress forwarding) has merged into this branch**, so this PR now covers both server→client push mechanisms.

Before this PR: the restored MCP proxy is stateless, so it cannot deliver server-initiated messages. The `tools/list_changed` relay that `createMcpBridgeServer` already implements is dead over HTTP — `notifications/initialized` arrives as a *separate* POST on a *fresh* bridge whose teardown disposes the subscription milliseconds later, and there is no standalone SSE stream to send on. Tool progress is not forwarded at all.

After this PR: a client that sends `initialize` gets an `Mcp-Session-Id`, can hold a `GET` stream that receives `notifications/tools/list_changed`, and receives `notifications/progress` for long-running tool calls.

Sessions are **opt-in by the client**, so nothing that worked before breaks:

| Request | Behaviour |
| --- | --- |
| `Mcp-Session-Id` present | routed to that session; 404 if unknown, or if the id belongs to a different MCP server |
| body is `initialize` | opens a session, returns its id |
| neither | the existing one-shot stateless path, unchanged |

`GET` opens the notification stream for a session and still answers 405 without one. `DELETE` terminates a session and still answers 405 without one.

Fixes #N/A — the issue (#17992) is closed by #18080; this PR builds on it.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **The store is owned by `ApiGateway`, not the lifecycle container.** Session lifetime is exactly HTTP-server lifetime, so `stop()` drops them rather than leaking bridges into the next activation. `CacheService` cannot hold live transports needing an explicit `close()`.
- **Hybrid rather than spec-strict.** A strict server 400s any non-`initialize` POST without a session header, which would break the bare-`curl` shape #18080 shipped. A client that skips `initialize` is already off-spec, so serving it leniently is an extension, not a violation.
- **Session POSTs answer in SSE, the one-shot path in JSON.** The SDK only writes request-related notifications when JSON response mode is off, so a session using it would resolve the call and drop every progress update.
- **Bounded by construction.** Admission is reserved synchronously (pending initializations counted), capped at 64, and swept after 30 minutes of inactivity in *either* direction. v1's equivalent map was never evicted at all.

The following alternatives were considered:

- **Keeping it stateless** — rejected, but the benefit is narrower than it looks: sessions do **not** give per-client isolation of upstream state, since every bridge shares the one `McpRuntimeService`-cached upstream client.
- **Routing progress onto the standalone GET stream instead of switching to SSE responses** — rejected: it would only work for clients that also hold a GET stream open.
- **Letting the SDK transport handle `GET` unconditionally** — rejected: that produced the dead-stream bug fixed in #18080.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17992

### Breaking changes

None for callers of #18080 — every request shape that worked there still works. Relative to **v1**, the session *lifecycle* differs even though the handshake is compatible: at most 64 live sessions, and expiry after 30 minutes idle. A v1 client that treats a session id as permanent must handle `503` (at capacity) and `404` (expired) by re-`initialize`-ing. This is recorded in the breaking-changes entry, which this PR corrects — it previously claimed session handling was unchanged from v1.

### Special notes for your reviewer

**All seven review findings are fixed** (commit `4be8c5ca8d`); each is covered by a test that fails without its fix:

| # | Finding | Fix |
| --- | --- | --- |
| A5 | `stop()` blocked on a live SSE response | Close sessions *before* awaiting the server close; `closeAll` latches the store shut against a racing initialize |
| A1 | Progress dropped under JSON response mode | Session transports answer in SSE; tested through the real WebStandard HTTP path, not `InMemoryTransport` |
| A7 | Cap bypassed by concurrent initialize | Admission slot reserved synchronously, pending inits counted |
| A1 | Idle accounting expired active streams | Outbound delivery refreshes the timestamp |
| B4 | CORS hid `mcp-session-id` from browsers | Explicit `exposeHeaders` allowlist |
| A1 | Doc claimed v1-unchanged session handling | Rewritten to describe capacity + expiry |
| C2 | File name did not match exported class | Renamed to `McpSessionStore.ts` |

Chasing A5 with a real socket surfaced **an eighth defect the review did not name**: the notification stream never opened at all. Nothing is written to it until a notification arrives, and Node withholds headers until the first body chunk — so a client's `GET` hung with no status, and its retry hit 409 "only one SSE stream per session". `app.handle(Request)` cannot see this because no socket is involved. Fixed by priming the stream with an inert SSE comment; `__tests__/serverShutdown.test.ts` now drives a real `node`-adapter server end to end.

Mutation-checked rather than trusted green: reverting the shutdown order reproduces the 20s deadlock; restoring `enableJsonResponse: true` fails the progress test; dropping the pending-admission counter fails the burst test.

Verification: `oxlint` clean on the touched module, 22/22 on the session + shutdown suites, 641 tests across `features/apiGateway` and `ai/mcp`. Per the author's instruction this push skipped `build:check` and the full-repo suite — CI covers both.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
MCP clients connecting to the local API gateway can now open a session to receive live tool-list updates and progress from long-running tools, instead of serving a stale tool list and waiting in silence. Simple scripts that call the endpoint without an MCP handshake keep working unchanged.
```
