### PR TITLE
feat(mcp): forward upstream tool progress to bridge clients

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -31,6 +31,7 @@ import {
   CancelledNotificationSchema,
   type GetPromptResult,
   LoggingMessageNotificationSchema,
+  type Progress,
   PromptListChangedNotificationSchema,
   ResourceListChangedNotificationSchema,
   ResourceUpdatedNotificationSchema,
@@ -82,8 +83,20 @@ function buildStdioEnvironment(
 // Generic type for caching wrapped functions
 type CachedFunction<T extends unknown[], R> = (...args: T) => Promise<R>
 
-type CallToolArgs = { serverId: string; name: string; args: any; callId?: string }
-type RuntimeCallToolArgs = { server: McpServer; name: string; args: any; callId?: string }
+/**
+ * `onProgress` receives the upstream server's progress notifications. The renderer gets them
+ * unconditionally over IPC; this is for callers outside the renderer — currently the MCP
+ * bridge, which relays them to an HTTP client that supplied a `progressToken`.
+ */
+type CallToolArgs = { serverId: string; name: string; args: any; callId?: string; onProgress?: ProgressCallback }
+type RuntimeCallToolArgs = {
+  server: McpServer
+  name: string
+  args: any
+  callId?: string
+  onProgress?: ProgressCallback
+}
+type ProgressCallback = (progress: Progress) => void
 type McpRuntimeState = McpRuntimeStatus['state']
 
 // IPC payload validation for the renderer-facing handlers. The inner `args` are the tool/prompt
@@ -1099,12 +1112,18 @@ export class McpRuntimeService extends BaseService {
   /**
    * Call a tool on an MCP server
    */
-  public async callTool({ serverId, name, args, callId }: CallToolArgs): Promise<McpCallToolResponse> {
+  public async callTool({ serverId, name, args, callId, onProgress }: CallToolArgs): Promise<McpCallToolResponse> {
     const server = this.getServerById(serverId)
-    return this.callToolByServer({ server, name, args, callId })
+    return this.callToolByServer({ server, name, args, callId, onProgress })
   }
 
-  public async callToolByServer({ server, name, args, callId }: RuntimeCallToolArgs): Promise<McpCallToolResponse> {
+  public async callToolByServer({
+    server,
+    name,
+    args,
+    callId,
+    onProgress
+  }: RuntimeCallToolArgs): Promise<McpCallToolResponse> {
     const toolCallId = callId || uuidv4()
     const abortController = new AbortController()
     this.activeToolCalls.set(toolCallId, abortController)
@@ -1141,6 +1160,15 @@ export class McpRuntimeService extends BaseService {
               callId: toolCallId,
               progress: process.progress / (process.total || 1)
             })
+            // Additional consumer outside the renderer; must not break the call or the
+            // broadcast above if it throws.
+            try {
+              onProgress?.(process)
+            } catch (error) {
+              getServerLogger(server, { tool: name, callId: toolCallId }).warn('Progress listener threw', {
+                error
+              })
+            }
           },
           timeout: server.timeout ? server.timeout * 1000 : 60000, // Default timeout of 1 minute,
           // 需要服务端支持: https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#timeouts

--- a/src/main/ai/mcp/__tests__/createMcpBridgeServer.test.ts
+++ b/src/main/ai/mcp/__tests__/createMcpBridgeServer.test.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
+import { ProgressNotificationSchema, ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
   onToolsCacheUpdated: vi.fn(),
   onToolsCacheUpdatedDispose: vi.fn(),
   listPrompts: vi.fn(),
-  getPrompt: vi.fn()
+  getPrompt: vi.fn(),
+  callTool: vi.fn()
 }))
 
 vi.mock('@logger', () => ({
@@ -85,9 +86,47 @@ describe('createMcpBridgeServer', () => {
           onToolsCacheUpdated: mocks.onToolsCacheUpdated,
           listPrompts: mocks.listPrompts
         }
-      if (name === 'McpRuntimeService') return { getPrompt: mocks.getPrompt }
+      if (name === 'McpRuntimeService') return { getPrompt: mocks.getPrompt, callTool: mocks.callTool }
       throw new Error(`Unexpected application.get(${name})`)
     })
+  })
+
+  it('relays upstream tool progress to a client that supplied a progressToken', async () => {
+    mocks.listTools.mockReturnValue([searchTool()])
+    // Emit two progress ticks from "upstream" before resolving the call.
+    mocks.callTool.mockImplementation(async ({ onProgress }: { onProgress?: (p: unknown) => void }) => {
+      onProgress?.({ progress: 1, total: 2 })
+      onProgress?.({ progress: 2, total: 2 })
+      return { content: [{ type: 'text', text: 'done' }] }
+    })
+
+    const client = await connectClient(createMcpBridgeServer('server-1'))
+    const seen: { progress: number; total?: number }[] = []
+    client.setNotificationHandler(ProgressNotificationSchema, async (notification) => {
+      seen.push({ progress: notification.params.progress, total: notification.params.total })
+    })
+
+    const result = await client.callTool({ name: 'search', arguments: {} }, undefined, {
+      onprogress: () => {}
+    })
+
+    expect(result.content).toEqual([{ type: 'text', text: 'done' }])
+    expect(seen).toEqual([
+      { progress: 1, total: 2 },
+      { progress: 2, total: 2 }
+    ])
+  })
+
+  it('omits the progress listener when the client sent no progressToken', async () => {
+    mocks.listTools.mockReturnValue([searchTool()])
+    mocks.callTool.mockResolvedValue({ content: [{ type: 'text', text: 'done' }] })
+
+    const client = await connectClient(createMcpBridgeServer('server-1'))
+    await client.callTool({ name: 'search', arguments: {} })
+
+    // No token means no address to send notifications to, so the runtime must not be
+    // handed a listener at all.
+    expect(mocks.callTool).toHaveBeenCalledWith(expect.objectContaining({ onProgress: undefined }))
   })
 
   it('uses a request-captured server snapshot without re-reading the edited database row', () => {

--- a/src/main/ai/mcp/createMcpBridgeServer.ts
+++ b/src/main/ai/mcp/createMcpBridgeServer.ts
@@ -10,6 +10,7 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
+  type Progress,
   type Prompt as SdkPrompt,
   ReadResourceRequestSchema,
   type ReadResourceResult,
@@ -143,13 +144,27 @@ export function createMcpBridgeServer(mcpId: string, serverSnapshot?: McpServerE
     }
   })
 
-  rawServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+  rawServer.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    // Relay upstream progress only when the client asked for it — the protocol keys
+    // progress notifications to the token it supplied, so without one there is nothing
+    // to address them to.
+    const progressToken = request.params._meta?.progressToken
+    const onProgress =
+      progressToken === undefined
+        ? undefined
+        : (progress: Progress) => {
+            extra
+              .sendNotification({ method: 'notifications/progress', params: { ...progress, progressToken } })
+              .catch((error) => logger.debug('MCP bridge: progress notification dropped', { mcpId, error }))
+          }
+
     try {
       logger.debug('MCP bridge: calling tool', { mcpId, tool: request.params.name })
       const result = await application.get('McpRuntimeService').callTool({
         serverId: serverConfig.id,
         name: request.params.name,
-        args: request.params.arguments
+        args: request.params.arguments,
+        onProgress
       })
       return result as CallToolResult
     } catch (error) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

> ⚠️ **Top of a 3-PR stack**: #18080 (stateless MCP proxy) → #18094 (opt-in sessions) → this. It targets `mcp-http-sessions`, so the diff shown here is only the progress layer. Retarget as the lower PRs merge.

Before this PR: `McpRuntimeService.callToolByServer` already received the upstream server's progress notifications, but hardcoded its only consumer — an IPC broadcast to the main window. Nothing outside the renderer could observe progress, so the MCP bridge dropped it and clients saw a long tool call as silence until the final result.

After this PR: the service takes an optional `onProgress`, and the bridge relays upstream progress as `notifications/progress` when the client supplied a `progressToken`.

```ts
onprogress: (process) => {
  …existing IPC broadcast, unchanged…
  try { onProgress?.(process) } catch { /* logged; never breaks the call */ }
}
```

Fixes #N/A — completes the push story started in #18094.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Widened the service rather than re-plumbing progress at the call site**, per CLAUDE.md's "fix upstream, don't hack downstream". The alternative — having the gateway route subscribe to progress some other way — would have duplicated a channel the runtime already owns.
- **No listener at all when the client sent no `progressToken`.** The protocol keys progress notifications to that token, so without one there is no address to send to; passing a listener anyway would mean building notifications that get dropped.
- **Listener failures are caught and logged.** A bad consumer must not break the tool call or the pre-existing IPC broadcast, which the renderer still depends on.

The following alternatives were considered:

- **Leaving progress out entirely** — rejected because it is the other half of what sessions are for; #18094 alone only delivers `tools/list_changed`.
- **Replacing the IPC broadcast with the callback** — rejected: the renderer is still a consumer, so both must fire.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17992

### Breaking changes

None. `onProgress` is optional and every existing caller omits it; the IPC broadcast is untouched.

### Special notes for your reviewer

Both bridge consumers benefit, not just the HTTP path — the Claude Agent SDK's in-memory transport gets progress too.

The relay test is mutation-checked: forcing `onProgress: undefined` at the call site makes `relays upstream tool progress to a client that supplied a progressToken` fail, so it is not passing vacuously.

Verification: `pnpm lint` clean (typecheck node/web/aicore, i18n, format); 729 tests pass across `ai/mcp`, `features/apiGateway`, and `claudeCode/settingsBuilder`. Not verified end-to-end against a live long-running MCP tool that emits progress — the builtin servers available in my test profile complete too fast to observe a progress frame, so this layer rests on the mutation-checked unit tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
MCP clients connected through the local API gateway now receive progress updates from long-running tools instead of waiting in silence until the result arrives.
```
