### PR TITLE
fix(agent-migration): skip symlinks during migration

### DIFF
--- a/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
+++ b/src/main/data/migration/v2/migrators/README-AgentsMigrator.md
@@ -78,17 +78,13 @@ For each migrated Agent:
 - Imported resume tokens remain unchanged. If the latest Claude transcript
   cannot be made available, the normal runtime resume attempt surfaces the
   failure to the user.
-- A symlinked v1 Agent root is treated as an external user workspace: identity
-  may be read from its resolved directory, but the target is never removed.
-- Identity symlinks are followed only when they resolve inside the source
-  workspace and are materialized as ordinary files/directories.
-- Ordinary workspace symlinks remain links. Targets under identity entries are
-  rewritten to Agent data; other internal targets are rewritten to the new
-  Session workspace; external and dangling targets retain their meaning.
+- A symlinked v1 Agent root is skipped without following or removing it.
+- Identity and ordinary workspace symlinks are skipped. Migration copies only
+  regular files and directories so link permissions or unsupported link targets
+  cannot block the rest of the migration.
 - Ordinary workspace content is scanned once. The first verified private
   staging copy is reused as the regular-content source for later Sessions, so
-  migration does not need an additional full-size template. Symlinks are
-  omitted while cloning and recreated with each Session's rewritten target.
+  migration does not need an additional full-size template.
 
 Before reading or copying Agent identity and workspace content, migration
 validates every exact v2 target against every v1 source, then clears the final

--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -36,8 +36,6 @@ const { copyMutation, platformState } = vi.hoisted(() => ({
   copyMutation: {
     afterCopyFile: undefined as undefined | ((sourcePath: string, destinationPath: string) => Promise<void>),
     beforeCpEntry: undefined as undefined | ((sourcePath: string, destinationPath: string) => Promise<void>),
-    beforeRealpath: undefined as undefined | ((sourcePath: string) => Promise<void>),
-    beforeSymlink: undefined as undefined | ((target: string, path: string, type?: string | null) => Promise<void>),
     copyFileCalls: [] as Array<[sourcePath: string, destinationPath: string]>,
     symlinkCalls: [] as Array<[target: string, path: string, type?: string | null]>
   },
@@ -83,13 +81,8 @@ vi.mock('node:fs/promises', async (importOriginal) => {
       await copyMutation.afterCopyFile?.(String(args[0]), String(args[1]))
       return result
     },
-    realpath: async (...args: Parameters<typeof original.realpath>) => {
-      await copyMutation.beforeRealpath?.(String(args[0]))
-      return original.realpath(...args)
-    },
     symlink: async (...args: Parameters<typeof original.symlink>) => {
       copyMutation.symlinkCalls.push([String(args[0]), String(args[1]), args[2]])
-      await copyMutation.beforeSymlink?.(String(args[0]), String(args[1]), args[2])
       return original.symlink(...args)
     }
   }
@@ -156,8 +149,6 @@ describe('agentsFilesystemMigration', () => {
   afterEach(async () => {
     copyMutation.afterCopyFile = undefined
     copyMutation.beforeCpEntry = undefined
-    copyMutation.beforeRealpath = undefined
-    copyMutation.beforeSymlink = undefined
     copyMutation.copyFileCalls.length = 0
     copyMutation.symlinkCalls.length = 0
     platformState.isMac = false
@@ -276,6 +267,22 @@ describe('agentsFilesystemMigration', () => {
     }
 
     await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(false)
+  })
+
+  it.runIf(process.platform !== 'win32')('skips a symlinked legacy Claude config root', async () => {
+    const { tempRoot, agentsDataRoot } = await createFixture()
+    const sourceTarget = path.join(tempRoot, 'external-claude')
+    const source = path.join(tempRoot, '.claude')
+    const destination = path.join(agentsDataRoot, '.claude')
+    await mkdir(sourceTarget)
+    await writeFile(path.join(sourceTarget, 'settings.json'), '{"source":true}')
+    await symlink(sourceTarget, source, 'dir')
+
+    await expect(copyLegacyClaudeConfig(source, destination)).resolves.toBe(false)
+
+    await expect(access(destination)).rejects.toThrow()
+    expect(await readFile(path.join(sourceTarget, 'settings.json'), 'utf8')).toBe('{"source":true}')
+    expect((await lstat(source)).isSymbolicLink()).toBe(true)
   })
 
   it('skips an existing identical Claude config destination on retry', async () => {
@@ -590,43 +597,7 @@ describe('agentsFilesystemMigration', () => {
   })
 
   it.runIf(process.platform !== 'win32')(
-    'recreates copied directory links as Windows junctions without asking fs.cp to copy the link',
-    async () => {
-      const { tempRoot, agentsDataRoot, legacyWorkspace } = await createFixture()
-      const skillSource = path.join(tempRoot, 'Data', 'Skills', 'find-skills')
-      const sourceLink = path.join(legacyWorkspace, 'skills', 'find-skills')
-      await mkdir(skillSource, { recursive: true })
-      await writeFile(path.join(skillSource, 'SKILL.md'), '# Find Skills')
-      await mkdir(path.dirname(sourceLink), { recursive: true })
-      await symlink(skillSource, sourceLink, 'dir')
-      copyMutation.symlinkCalls.length = 0
-      platformState.isWin = true
-
-      const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
-        sourceSessionId: 'session_latest',
-        finalSessionId: FINAL_LATEST_SESSION_ID,
-        createdAt: Date.parse('2026-07-22T00:00:00Z'),
-        updatedAt: Date.parse('2026-07-23T00:00:00Z')
-      })
-
-      await stageLegacyAgentFiles({
-        agentsDataRoot,
-        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-        sessions: [latestSession]
-      })
-
-      const destinationLink = path.join(latestSession.systemWorkspacePath!, 'skills', 'find-skills')
-      expect(await readlink(destinationLink)).toBe(skillSource)
-      expect(copyMutation.symlinkCalls).toContainEqual([
-        skillSource,
-        expect.stringMatching(/[\\/]\.01257168-34a7-5ff9-994d-bf78596c777c\.migration-[^\\/]+[\\/]find-skills$/),
-        'junction'
-      ])
-    }
-  )
-
-  it.runIf(process.platform !== 'win32')(
-    'falls back to a directory symlink when publishing a top-level Windows junction fails',
+    'skips top-level workspace symlinks without attempting to recreate them on Windows',
     async () => {
       const { tempRoot, agentsDataRoot, legacyWorkspace } = await createFixture()
       const sharedDirectory = path.join(tempRoot, 'shared-directory')
@@ -636,12 +607,6 @@ describe('agentsFilesystemMigration', () => {
       await mkdir(legacyWorkspace, { recursive: true })
       await symlink(sharedDirectory, sourceLink, 'dir')
       copyMutation.symlinkCalls.length = 0
-      copyMutation.beforeSymlink = async (_target, _linkPath, type) => {
-        if (type !== 'junction') return
-        const error = new Error('junction target is not supported')
-        Object.assign(error, { code: 'EPERM', syscall: 'symlink' })
-        throw error
-      }
       platformState.isWin = true
 
       const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
@@ -657,120 +622,98 @@ describe('agentsFilesystemMigration', () => {
         sessions: [latestSession]
       })
 
-      const destinationLink = path.join(latestSession.systemWorkspacePath!, 'shared-directory')
-      const stagingLinkPattern = /[\\/]\.01257168-34a7-5ff9-994d-bf78596c777c\.migration-[^\\/]+$/
-      expect(await readlink(destinationLink)).toBe(sharedDirectory)
-      expect(copyMutation.symlinkCalls).toEqual(
-        expect.arrayContaining([
-          [sharedDirectory, expect.stringMatching(stagingLinkPattern), 'junction'],
-          [sharedDirectory, expect.stringMatching(stagingLinkPattern), 'dir'],
-          [sharedDirectory, destinationLink, 'junction'],
-          [sharedDirectory, destinationLink, 'dir']
-        ])
-      )
+      await expect(access(path.join(latestSession.systemWorkspacePath!, 'shared-directory'))).rejects.toThrow()
+      expect(copyMutation.symlinkCalls).toEqual([])
     }
   )
 
-  it.runIf(process.platform !== 'win32')(
-    'splits identity from workspace content, materializes internal identity links, and preserves ordinary links',
-    async () => {
-      const { tempRoot, agentsDataRoot, legacyWorkspace } = await createFixture()
-      await mkdir(path.join(legacyWorkspace, 'memory'), { recursive: true })
-      await writeFile(path.join(legacyWorkspace, 'identity-source.md'), 'agent soul')
-      await symlink('identity-source.md', path.join(legacyWorkspace, 'SOUL.md'))
-      await writeFile(path.join(legacyWorkspace, 'USER.md'), 'agent user')
-      await symlink('SOUL.md', path.join(legacyWorkspace, 'soul-link'))
-      await symlink(path.join(legacyWorkspace, 'USER.md'), path.join(legacyWorkspace, 'absolute-user-link'))
-      await writeFile(path.join(legacyWorkspace, 'fact-source.md'), 'remember this')
-      await symlink('../fact-source.md', path.join(legacyWorkspace, 'memory', 'FACT.md'))
-      await symlink('memory/FACT.md', path.join(legacyWorkspace, 'memory-link'))
-      await writeFile(path.join(legacyWorkspace, 'ordinary.txt'), 'workspace content')
-      await symlink('ordinary.txt', path.join(legacyWorkspace, 'relative-link'))
-      const sharedTarget = path.join(agentsDataRoot, 'shared', 'target.txt')
-      await mkdir(path.dirname(sharedTarget), { recursive: true })
-      await writeFile(sharedTarget, 'shared target')
-      await symlink('../shared/target.txt', path.join(legacyWorkspace, 'external-relative-link'))
-      await mkdir(path.join(legacyWorkspace, 'nested'))
-      await symlink('../../shared/target.txt', path.join(legacyWorkspace, 'nested', 'external-relative-link'))
-      const absoluteTarget = path.join(tempRoot, 'absolute-target.txt')
-      await writeFile(absoluteTarget, 'external target')
-      await symlink(absoluteTarget, path.join(legacyWorkspace, 'absolute-link'))
-      await symlink('missing-target', path.join(legacyWorkspace, 'dangling-link'))
+  it.runIf(process.platform !== 'win32')('splits identity from workspace content and skips every symlink', async () => {
+    const { tempRoot, agentsDataRoot, legacyWorkspace } = await createFixture()
+    await mkdir(path.join(legacyWorkspace, 'memory'), { recursive: true })
+    await writeFile(path.join(legacyWorkspace, 'identity-source.md'), 'agent soul')
+    await symlink('identity-source.md', path.join(legacyWorkspace, 'SOUL.md'))
+    await writeFile(path.join(legacyWorkspace, 'USER.md'), 'agent user')
+    await symlink('SOUL.md', path.join(legacyWorkspace, 'soul-link'))
+    await symlink(path.join(legacyWorkspace, 'USER.md'), path.join(legacyWorkspace, 'absolute-user-link'))
+    await writeFile(path.join(legacyWorkspace, 'fact-source.md'), 'remember this')
+    await symlink('../fact-source.md', path.join(legacyWorkspace, 'memory', 'FACT.md'))
+    await symlink('memory/FACT.md', path.join(legacyWorkspace, 'memory-link'))
+    await writeFile(path.join(legacyWorkspace, 'ordinary.txt'), 'workspace content')
+    await symlink('ordinary.txt', path.join(legacyWorkspace, 'relative-link'))
+    const sharedTarget = path.join(agentsDataRoot, 'shared', 'target.txt')
+    await mkdir(path.dirname(sharedTarget), { recursive: true })
+    await writeFile(sharedTarget, 'shared target')
+    await symlink('../shared/target.txt', path.join(legacyWorkspace, 'external-relative-link'))
+    await mkdir(path.join(legacyWorkspace, 'nested'))
+    await symlink('../../shared/target.txt', path.join(legacyWorkspace, 'nested', 'external-relative-link'))
+    const absoluteTarget = path.join(tempRoot, 'absolute-target.txt')
+    await writeFile(absoluteTarget, 'external target')
+    await symlink(absoluteTarget, path.join(legacyWorkspace, 'absolute-link'))
+    await symlink('missing-target', path.join(legacyWorkspace, 'dangling-link'))
 
-      const oldSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
-        sourceSessionId: 'session_old',
-        finalSessionId: FINAL_OLD_SESSION_ID,
-        createdAt: Date.parse('2026-07-20T00:00:00Z'),
-        updatedAt: Date.parse('2026-07-21T00:00:00Z')
-      })
-      const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
-        sourceSessionId: 'session_latest',
-        finalSessionId: FINAL_LATEST_SESSION_ID,
-        createdAt: Date.parse('2026-07-22T00:00:00Z'),
-        updatedAt: Date.parse('2026-07-23T00:00:00Z')
-      })
+    const oldSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
+      sourceSessionId: 'session_old',
+      finalSessionId: FINAL_OLD_SESSION_ID,
+      createdAt: Date.parse('2026-07-20T00:00:00Z'),
+      updatedAt: Date.parse('2026-07-21T00:00:00Z')
+    })
+    const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
+      sourceSessionId: 'session_latest',
+      finalSessionId: FINAL_LATEST_SESSION_ID,
+      createdAt: Date.parse('2026-07-22T00:00:00Z'),
+      updatedAt: Date.parse('2026-07-23T00:00:00Z')
+    })
 
-      const input = {
-        agentsDataRoot,
-        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-        sessions: [oldSession, latestSession]
-      }
-      await stageLegacyAgentFiles(input)
-
-      const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
-      expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('agent soul')
-      expect((await lstat(path.join(agentDataPath, 'SOUL.md'))).isSymbolicLink()).toBe(false)
-      expect(await readFile(path.join(agentDataPath, 'USER.md'), 'utf8')).toBe('agent user')
-      expect(await readFile(path.join(agentDataPath, 'memory', 'FACT.md'), 'utf8')).toBe('remember this')
-      expect((await lstat(path.join(agentDataPath, 'memory', 'FACT.md'))).isSymbolicLink()).toBe(false)
-
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
-        'workspace content'
-      )
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'relative-link'))).toBe('ordinary.txt')
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'external-relative-link'), 'utf8')).toBe(
-        'shared target'
-      )
-      expect(
-        await readFile(path.join(latestSession.systemWorkspacePath!, 'nested', 'external-relative-link'), 'utf8')
-      ).toBe('shared target')
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'absolute-link'))).toBe(absoluteTarget)
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'dangling-link'))).toBe('missing-target')
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'soul-link'), 'utf8')).toBe('agent soul')
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'absolute-user-link'))).toBe(
-        path.join(agentDataPath, 'USER.md')
-      )
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'memory-link'), 'utf8')).toBe('remember this')
-      // The shared v1 workspace is materialized only into the latest session; the
-      // older session keeps an empty system workspace (issue #17830).
-      expect((await lstat(oldSession.systemWorkspacePath!)).isDirectory()).toBe(true)
-      expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
-
-      // The complete v1 workspace remains available for downgrade compatibility
-      // even after the v2 destinations have been verified and published.
-      expect(await readFile(path.join(legacyWorkspace, 'SOUL.md'), 'utf8')).toBe('agent soul')
-      expect((await lstat(path.join(legacyWorkspace, 'SOUL.md'))).isSymbolicLink()).toBe(true)
-      expect(await readFile(path.join(legacyWorkspace, 'USER.md'), 'utf8')).toBe('agent user')
-      expect(await readFile(path.join(legacyWorkspace, 'memory', 'FACT.md'), 'utf8')).toBe('remember this')
-      expect(await readFile(path.join(legacyWorkspace, 'ordinary.txt'), 'utf8')).toBe('workspace content')
-
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'soul-link'), 'utf8')).toBe('agent soul')
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'absolute-user-link'), 'utf8')).toBe(
-        'agent user'
-      )
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'memory-link'), 'utf8')).toBe('remember this')
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'external-relative-link'), 'utf8')).toBe(
-        'shared target'
-      )
-
-      // Stable remapped IDs make a retry converge on the same destinations.
-      await expect(stageLegacyAgentFiles(input)).resolves.toBeUndefined()
-      expect(await readFile(path.join(legacyWorkspace, 'ordinary.txt'), 'utf8')).toBe('workspace content')
-      expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
-        'workspace content'
-      )
+    const input = {
+      agentsDataRoot,
+      agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+      sessions: [oldSession, latestSession]
     }
-  )
+    await stageLegacyAgentFiles(input)
+
+    const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
+    expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('')
+    expect((await lstat(path.join(agentDataPath, 'SOUL.md'))).isSymbolicLink()).toBe(false)
+    expect(await readFile(path.join(agentDataPath, 'USER.md'), 'utf8')).toBe('agent user')
+    await expect(access(path.join(agentDataPath, 'memory', 'FACT.md'))).rejects.toThrow()
+
+    expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
+      'workspace content'
+    )
+    for (const skippedEntry of [
+      'relative-link',
+      'external-relative-link',
+      'absolute-link',
+      'dangling-link',
+      'soul-link',
+      'absolute-user-link',
+      'memory-link'
+    ]) {
+      await expect(access(path.join(latestSession.systemWorkspacePath!, skippedEntry))).rejects.toThrow()
+    }
+    await expect(
+      access(path.join(latestSession.systemWorkspacePath!, 'nested', 'external-relative-link'))
+    ).rejects.toThrow()
+    // The shared v1 workspace is materialized only into the latest session; the
+    // older session keeps an empty system workspace (issue #17830).
+    expect((await lstat(oldSession.systemWorkspacePath!)).isDirectory()).toBe(true)
+    expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
+
+    // The complete v1 workspace remains available for downgrade compatibility
+    // even after the v2 destinations have been verified and published.
+    expect(await readFile(path.join(legacyWorkspace, 'SOUL.md'), 'utf8')).toBe('agent soul')
+    expect((await lstat(path.join(legacyWorkspace, 'SOUL.md'))).isSymbolicLink()).toBe(true)
+    expect(await readFile(path.join(legacyWorkspace, 'USER.md'), 'utf8')).toBe('agent user')
+    expect(await readFile(path.join(legacyWorkspace, 'memory', 'FACT.md'), 'utf8')).toBe('remember this')
+    expect(await readFile(path.join(legacyWorkspace, 'ordinary.txt'), 'utf8')).toBe('workspace content')
+
+    // Stable remapped IDs make a retry converge on the same destinations.
+    await expect(stageLegacyAgentFiles(input)).resolves.toBeUndefined()
+    expect(await readFile(path.join(legacyWorkspace, 'ordinary.txt'), 'utf8')).toBe('workspace content')
+    expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'ordinary.txt'), 'utf8')).toBe(
+      'workspace content'
+    )
+  })
 
   it('copies the shared workspace content only into the most recently active managed session', async () => {
     const { agentsDataRoot, legacyWorkspace } = await createFixture()
@@ -931,7 +874,7 @@ describe('agentsFilesystemMigration', () => {
   })
 
   it.runIf(process.platform !== 'win32')(
-    'materializes a directory that contains symlinks into the latest session',
+    'copies regular directory content while skipping nested symlinks',
     async () => {
       const { agentsDataRoot, legacyWorkspace } = await createFixture()
       const sourceBundle = path.join(legacyWorkspace, 'bundle')
@@ -965,12 +908,10 @@ describe('agentsFilesystemMigration', () => {
       expect(await readFile(path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload.txt'), 'utf8')).toBe(
         'workspace content'
       )
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload-link'))).toBe(
-        'payload.txt'
-      )
-      expect(await readlink(path.join(latestSession.systemWorkspacePath!, 'bundle', 'absolute-payload-link'))).toBe(
-        path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload.txt')
-      )
+      await expect(access(path.join(latestSession.systemWorkspacePath!, 'bundle', 'payload-link'))).rejects.toThrow()
+      await expect(
+        access(path.join(latestSession.systemWorkspacePath!, 'bundle', 'absolute-payload-link'))
+      ).rejects.toThrow()
       expect(await readdir(oldSession.systemWorkspacePath!)).toEqual([])
     }
   )
@@ -1129,7 +1070,7 @@ describe('agentsFilesystemMigration', () => {
   })
 
   it.runIf(process.platform !== 'win32')(
-    'aborts instead of falling back when identity changes after its snapshot',
+    'skips a symlinked identity entry and falls back to an older real identity file',
     async () => {
       const { tempRoot, agentsDataRoot } = await createFixture()
       const olderWorkspace = path.join(tempRoot, 'older-workspace')
@@ -1142,13 +1083,6 @@ describe('agentsFilesystemMigration', () => {
       await writeFile(newestIdentitySource, 'newest soul')
       await symlink('identity-source.md', newestSoulPath)
       await writeFile(olderSoulPath, 'older soul')
-
-      let newestSoulRealpathCalls = 0
-      copyMutation.beforeRealpath = async (sourcePath) => {
-        if (sourcePath !== newestSoulPath || ++newestSoulRealpathCalls !== 2) return
-        await rm(newestSoulPath)
-        await symlink('missing-source.md', newestSoulPath)
-      }
 
       const olderSession = sessionPlan(agentsDataRoot, olderWorkspace, {
         sourceSessionId: 'session_old',
@@ -1165,18 +1099,16 @@ describe('agentsFilesystemMigration', () => {
         managed: false
       })
 
-      await expect(
-        stageLegacyAgentFiles({
-          agentsDataRoot,
-          agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
-          sessions: [olderSession, newestSession]
-        })
-      ).rejects.toThrow(/identity changed while being copied/i)
+      await stageLegacyAgentFiles({
+        agentsDataRoot,
+        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+        sessions: [olderSession, newestSession]
+      })
 
       const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
-      await expect(access(path.join(agentDataPath, 'SOUL.md'))).rejects.toThrow()
+      expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('older soul')
       expect((await readdir(agentDataPath)).every((entry) => !entry.startsWith('.SOUL.md.migration-'))).toBe(true)
-      expect(await readlink(newestSoulPath)).toBe('missing-source.md')
+      expect(await readlink(newestSoulPath)).toBe('identity-source.md')
       expect(await readFile(newestIdentitySource, 'utf8')).toBe('newest soul')
       expect(await readFile(olderSoulPath, 'utf8')).toBe('older soul')
     }
@@ -1862,7 +1794,7 @@ describe('agentsFilesystemMigration', () => {
   })
 
   it.runIf(process.platform !== 'win32')(
-    'treats a symlinked v1 root as an external user workspace without following or deleting it',
+    'skips a symlinked v1 workspace root without following or deleting it',
     async () => {
       const { tempRoot, agentsDataRoot, legacyWorkspace } = await createFixture()
       const externalWorkspace = path.join(tempRoot, 'external-workspace')
@@ -1890,7 +1822,7 @@ describe('agentsFilesystemMigration', () => {
       expect((await lstat(legacyWorkspace)).isSymbolicLink()).toBe(true)
       expect(await readFile(path.join(externalWorkspace, 'SOUL.md'), 'utf8')).toBe('external soul')
       expect(await readFile(path.join(externalWorkspace, 'ordinary.txt'), 'utf8')).toBe('external ordinary')
-      expect(await readFile(path.join(agentsDataRoot, FINAL_AGENT_ID, 'SOUL.md'), 'utf8')).toBe('external soul')
+      expect(await readFile(path.join(agentsDataRoot, FINAL_AGENT_ID, 'SOUL.md'), 'utf8')).toBe('')
     }
   )
 

--- a/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
+++ b/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
@@ -1,20 +1,6 @@
 import { createHash, type Hash, randomUUID } from 'node:crypto'
 import { type BigIntStats, constants, createReadStream } from 'node:fs'
-import {
-  copyFile,
-  cp,
-  link,
-  lstat,
-  mkdir,
-  readdir,
-  readlink,
-  realpath,
-  rename,
-  rmdir,
-  stat,
-  symlink,
-  unlink
-} from 'node:fs/promises'
+import { copyFile, cp, link, lstat, mkdir, readdir, readlink, realpath, rename, rmdir, unlink } from 'node:fs/promises'
 import path from 'node:path'
 
 import { loggerService } from '@logger'
@@ -185,21 +171,9 @@ function createClaudeConfigProgressTracker(
 
 interface CopyEntryResult {
   copied: boolean
+  skipped?: boolean
   fileCount: number
   byteCount: number
-}
-
-function canonicalIdentityEntryName(name: string): string | undefined {
-  switch (name.toLowerCase()) {
-    case 'soul.md':
-      return 'SOUL.md'
-    case 'user.md':
-      return 'USER.md'
-    case 'memory':
-      return 'memory'
-    default:
-      return undefined
-  }
 }
 
 async function lstatIfExists(targetPath: string) {
@@ -301,53 +275,20 @@ async function findCaseInsensitiveEntry(dir: string, name: string): Promise<stri
   return match ? path.join(dir, match) : undefined
 }
 
-async function materializeIdentityEntry(
-  sourcePath: string,
-  destinationPath: string,
-  sourceWorkspaceRoot: string,
-  visitedRealPaths = new Set<string>()
-): Promise<boolean> {
+async function materializeIdentityEntry(sourcePath: string, destinationPath: string): Promise<boolean> {
   const sourceStat = await lstat(sourcePath)
   if (sourceStat.isSymbolicLink()) {
-    let resolved: string
-    try {
-      resolved = await realpath(sourcePath)
-    } catch (error) {
-      logger.warn('Skipping unresolved identity symlink during agent migration', { sourcePath, error })
-      return false
-    }
-    const realWorkspaceRoot = await realpath(sourceWorkspaceRoot)
-    if (!isPathInsideOrEqual(resolved, realWorkspaceRoot) || resolved === realWorkspaceRoot) {
-      logger.warn('Skipping identity symlink that points outside the legacy workspace', {
-        sourcePath,
-        resolved
-      })
-      return false
-    }
-    if (visitedRealPaths.has(resolved)) {
-      logger.warn('Skipping cyclic identity symlink during agent migration', { sourcePath, resolved })
-      return false
-    }
-    visitedRealPaths.add(resolved)
-    const copied = await materializeIdentityEntry(resolved, destinationPath, sourceWorkspaceRoot, visitedRealPaths)
-    visitedRealPaths.delete(resolved)
-    return copied
+    logger.warn('Skipping identity symlink during Agent migration', { sourcePath })
+    return false
   }
 
   if (sourceStat.isDirectory()) {
     await mkdir(destinationPath)
 
-    let complete = true
     for (const entry of await readdir(sourcePath)) {
-      const copied = await materializeIdentityEntry(
-        path.join(sourcePath, entry),
-        path.join(destinationPath, entry),
-        sourceWorkspaceRoot,
-        visitedRealPaths
-      )
-      complete = copied && complete
+      await materializeIdentityEntry(path.join(sourcePath, entry), path.join(destinationPath, entry))
     }
-    return complete
+    return true
   }
 
   if (!sourceStat.isFile()) {
@@ -359,12 +300,8 @@ async function materializeIdentityEntry(
   return true
 }
 
-async function copyIdentityEntry(
-  sourcePath: string,
-  destinationPath: string,
-  sourceWorkspaceRoot: string
-): Promise<CopyEntryResult | undefined> {
-  const sourceSnapshot = await identityCopySourceSnapshot(sourcePath, sourceWorkspaceRoot)
+async function copyIdentityEntry(sourcePath: string, destinationPath: string): Promise<CopyEntryResult | undefined> {
+  const sourceSnapshot = await identityCopySourceSnapshot(sourcePath)
   if (!sourceSnapshot) return undefined
 
   const existingDestination = await filesystemEntrySnapshot(destinationPath)
@@ -387,7 +324,7 @@ async function copyIdentityEntry(
   const stagingPath = path.join(path.dirname(destinationPath), `${stagingPrefix}${randomUUID()}`)
 
   try {
-    if (!(await materializeIdentityEntry(sourcePath, stagingPath, sourceWorkspaceRoot))) {
+    if (!(await materializeIdentityEntry(sourcePath, stagingPath))) {
       throw new Error(`Legacy Agent identity changed while being copied: ${sourcePath}`)
     }
 
@@ -445,24 +382,9 @@ async function copyIdentityFromWorkspace(
   const sourceStat = await lstatIfExists(sourceWorkspacePath)
   if (!sourceStat) return { fileCount: 0, byteCount: 0 }
 
-  let effectiveWorkspacePath = sourceWorkspacePath
   if (sourceStat.isSymbolicLink()) {
-    try {
-      effectiveWorkspacePath = await realpath(sourceWorkspacePath)
-      const resolvedStat = await lstat(effectiveWorkspacePath)
-      if (!resolvedStat.isDirectory() || resolvedStat.isSymbolicLink()) {
-        logger.warn('Skipping identity copy from symlinked legacy workspace whose target is not a real directory', {
-          sourceWorkspacePath,
-          effectiveWorkspacePath
-        })
-        return { fileCount: 0, byteCount: 0 }
-      }
-      // A symlinked v1 root is an external user workspace. Read identity from
-      // its resolved target without modifying the user-owned workspace.
-    } catch (error) {
-      logger.warn('Skipping unresolved symlinked legacy workspace root', { sourceWorkspacePath, error })
-      return { fileCount: 0, byteCount: 0 }
-    }
+    logger.warn('Skipping symlinked legacy workspace root during Agent migration', { sourceWorkspacePath })
+    return { fileCount: 0, byteCount: 0 }
   } else if (!sourceStat.isDirectory()) {
     return { fileCount: 0, byteCount: 0 }
   }
@@ -471,10 +393,10 @@ async function copyIdentityFromWorkspace(
   let byteCount = 0
   for (const name of ['SOUL.md', 'USER.md', 'memory']) {
     if (claimedIdentityEntries.has(name)) continue
-    const sourcePath = await findCaseInsensitiveEntry(effectiveWorkspacePath, name)
+    const sourcePath = await findCaseInsensitiveEntry(sourceWorkspacePath, name)
     if (!sourcePath) continue
     const destinationPath = path.join(agentDataPath, name)
-    const result = await copyIdentityEntry(sourcePath, destinationPath, effectiveWorkspacePath)
+    const result = await copyIdentityEntry(sourcePath, destinationPath)
     if (result) {
       claimedIdentityEntries.add(name)
       fileCount += result.fileCount
@@ -530,7 +452,11 @@ export async function copyLegacyClaudeConfig(
 
   const sourceStat = await lstatIfExists(sourcePath)
   if (!sourceStat) return false
-  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink()) {
+  if (sourceStat.isSymbolicLink()) {
+    logger.warn('Skipping symlinked legacy Claude config root during Agent migration', { sourcePath })
+    return false
+  }
+  if (!sourceStat.isDirectory()) {
     throw new Error(`Legacy Claude config source is not a directory: ${sourcePath}`)
   }
 
@@ -1003,67 +929,6 @@ export async function copyLegacyClaudeSessionData(input: {
   })
 }
 
-function migratedLinkTarget(
-  sourceLinkPath: string,
-  destinationLinkPath: string,
-  linkTarget: string,
-  sourceWorkspaceRoot: string,
-  destinationWorkspaceRoot: string,
-  agentDataPath: string
-): string {
-  const sourceTarget = path.isAbsolute(linkTarget)
-    ? path.normalize(linkTarget)
-    : path.resolve(path.dirname(sourceLinkPath), linkTarget)
-  let migratedTarget = sourceTarget
-  if (isPathInsideOrEqual(sourceTarget, sourceWorkspaceRoot)) {
-    const relativeTarget = path.relative(sourceWorkspaceRoot, sourceTarget)
-    const [firstSegment, ...remainingSegments] = relativeTarget.split(path.sep)
-    const identityEntryName = canonicalIdentityEntryName(firstSegment)
-    migratedTarget = identityEntryName
-      ? path.join(agentDataPath, identityEntryName, ...remainingSegments)
-      : path.join(destinationWorkspaceRoot, relativeTarget)
-  }
-
-  if (path.isAbsolute(linkTarget)) return migratedTarget
-  const relativeTarget = path.relative(path.dirname(destinationLinkPath), migratedTarget)
-  return path.isAbsolute(relativeTarget) ? migratedTarget : relativeTarget || '.'
-}
-
-type WorkspaceLinkType = 'dir' | 'file'
-
-async function workspaceLinkType(sourcePath: string): Promise<WorkspaceLinkType> {
-  try {
-    return (await stat(sourcePath)).isDirectory() ? 'dir' : 'file'
-  } catch {
-    // Dangling links retain their text and use the file default on Windows.
-    return 'file'
-  }
-}
-
-function copiedWorkspaceLinkTarget(
-  migratedTarget: string,
-  finalDestinationPath: string,
-  linkType: WorkspaceLinkType
-): string {
-  if (!isWin || linkType !== 'dir') return migratedTarget
-  return path.resolve(path.dirname(finalDestinationPath), migratedTarget)
-}
-
-async function createWorkspaceLink(linkTarget: string, linkPath: string, linkType: WorkspaceLinkType): Promise<void> {
-  if (!isWin || linkType !== 'dir') {
-    await symlink(linkTarget, linkPath, linkType)
-    return
-  }
-
-  try {
-    await symlink(linkTarget, linkPath, 'junction')
-  } catch {
-    // Junctions avoid Windows symlink privileges but cannot represent every
-    // directory target, including network shares. Preserve those as dir links.
-    await symlink(linkTarget, linkPath, 'dir')
-  }
-}
-
 type FilesystemEntryKind = 'directory' | 'file' | 'symlink'
 
 interface FilesystemEntrySnapshot {
@@ -1078,24 +943,11 @@ interface CopySourceSnapshot {
   copiedFingerprint: string
   fileCount: number
   byteCount: number
-  destinationIndependent: boolean
 }
 
 interface WorkspaceSourceSnapshot {
-  sourcePath: string
-  kind: FilesystemEntryKind
-  copiedFingerprint?: string
-  linkTarget?: string
-  linkType?: WorkspaceLinkType
-  children: Array<{ name: string; snapshot: WorkspaceSourceSnapshot }>
-  hasSymlinks: boolean
-  fileCount: number
-  byteCount: number
-}
-
-interface WorkspaceDestinationSnapshot {
+  kind: Exclude<FilesystemEntryKind, 'symlink'>
   copiedFingerprint: string
-  linkType?: WorkspaceLinkType
   fileCount: number
   byteCount: number
 }
@@ -1247,12 +1099,7 @@ async function filesystemEntryStatsWithQueue(
   return { fileCount, byteCount }
 }
 
-async function identityCopySourceSnapshot(
-  targetPath: string,
-  sourceWorkspaceRoot: string,
-  visitedRealPaths = new Set<string>(),
-  realWorkspaceRoot?: string
-): Promise<CopySourceSnapshot | undefined> {
+async function identityCopySourceSnapshot(targetPath: string): Promise<CopySourceSnapshot | undefined> {
   const targetStat = await lstatBigIntIfExists(targetPath)
   if (!targetStat) return undefined
 
@@ -1260,37 +1107,13 @@ async function identityCopySourceSnapshot(
   const copiedHash = createHash('sha256')
 
   if (kind === 'symlink') {
-    let resolved: string
-    try {
-      resolved = await realpath(targetPath)
-    } catch {
-      return undefined
-    }
-    const workspaceRoot = realWorkspaceRoot ?? (await realpath(sourceWorkspaceRoot))
-    if (!isPathInsideOrEqual(resolved, workspaceRoot) || resolved === workspaceRoot || visitedRealPaths.has(resolved)) {
-      return undefined
-    }
-    visitedRealPaths.add(resolved)
-    const resolvedSnapshot = await identityCopySourceSnapshot(
-      resolved,
-      sourceWorkspaceRoot,
-      visitedRealPaths,
-      workspaceRoot
-    )
-    visitedRealPaths.delete(resolved)
-    if (!resolvedSnapshot) return undefined
-    return {
-      copiedFingerprint: resolvedSnapshot.copiedFingerprint,
-      fileCount: resolvedSnapshot.fileCount,
-      byteCount: resolvedSnapshot.byteCount,
-      destinationIndependent: true
-    }
+    logger.warn('Skipping identity symlink while snapshotting Agent migration source', { targetPath })
+    return undefined
   }
 
   updateFingerprintField(copiedHash, kind)
   let fileCount = 0
   let byteCount = 0
-  let destinationIndependent = true
   if (kind === 'file') {
     fileCount = 1
     byteCount = Number(targetStat.size)
@@ -1301,26 +1124,24 @@ async function identityCopySourceSnapshot(
     const entries = await readdir(targetPath)
     entries.sort()
     for (const entry of entries) {
-      const childSnapshot = await identityCopySourceSnapshot(
-        path.join(targetPath, entry),
-        sourceWorkspaceRoot,
-        visitedRealPaths,
-        realWorkspaceRoot
-      )
-      if (!childSnapshot) return undefined
+      const childPath = path.join(targetPath, entry)
+      const childSnapshot = await identityCopySourceSnapshot(childPath)
+      if (!childSnapshot) {
+        const childStat = await lstatBigIntIfExists(childPath)
+        if (childStat?.isSymbolicLink()) continue
+        throw new Error(`Legacy Agent identity source changed while being scanned: ${childPath}`)
+      }
       updateFingerprintField(copiedHash, entry)
       updateFingerprintField(copiedHash, childSnapshot.copiedFingerprint)
       fileCount += childSnapshot.fileCount
       byteCount += childSnapshot.byteCount
-      destinationIndependent = destinationIndependent && childSnapshot.destinationIndependent
     }
   }
 
   return {
     copiedFingerprint: copiedHash.digest('hex'),
     fileCount,
-    byteCount,
-    destinationIndependent
+    byteCount
   }
 }
 
@@ -1338,20 +1159,8 @@ async function workspaceSourceSnapshotWithQueue(
 
   const kind = filesystemEntryKind(sourceStat)
   if (kind === 'symlink') {
-    const { linkTarget, linkType } = await queueFilesystemOperation(queue, async () => ({
-      linkTarget: await readlink(sourcePath),
-      linkType: await workspaceLinkType(sourcePath)
-    }))
-    return {
-      sourcePath,
-      kind,
-      linkTarget,
-      linkType,
-      children: [],
-      hasSymlinks: true,
-      fileCount: 0,
-      byteCount: 0
-    }
+    logger.warn('Skipping workspace symlink while snapshotting Agent migration source', { sourcePath })
+    return undefined
   }
 
   const copiedHash = createHash('sha256')
@@ -1364,23 +1173,20 @@ async function workspaceSourceSnapshotWithQueue(
     })
     const copiedFingerprint = copiedHash.digest('hex')
     return {
-      sourcePath,
       kind,
       copiedFingerprint,
-      children: [],
-      hasSymlinks: false,
       fileCount: 1,
       byteCount: Number(sourceStat.size)
     }
   }
 
-  const children: WorkspaceSourceSnapshot['children'] = []
-  let hasSymlinks = false
   let fileCount = 0
   let byteCount = 0
   const entries = await queueFilesystemOperation(queue, () => readdir(sourcePath))
   entries.sort()
-  const childSnapshots: Array<{ name: string; snapshot: WorkspaceSourceSnapshot }> = new Array(entries.length)
+  const childSnapshots: Array<{ name: string; snapshot: WorkspaceSourceSnapshot } | undefined> = new Array(
+    entries.length
+  )
   await processFilesystemEntriesWithWorkers(
     entries,
     scheduler,
@@ -1388,6 +1194,8 @@ async function workspaceSourceSnapshotWithQueue(
       const childPath = path.join(sourcePath, entry)
       const snapshot = await workspaceSourceSnapshotWithQueue(childPath, queue, scheduler)
       if (!snapshot) {
+        const childStat = await queueFilesystemOperation(queue, () => lstatBigIntIfExists(childPath))
+        if (childStat?.isSymbolicLink()) return undefined
         throw new Error(`Agent migration fingerprint source disappeared: ${childPath}`)
       }
       return { name: entry, snapshot }
@@ -1397,90 +1205,19 @@ async function workspaceSourceSnapshotWithQueue(
     }
   )
   for (const child of childSnapshots) {
+    if (!child) continue
     const { name: entry, snapshot: childSnapshot } = child
-    children.push({ name: entry, snapshot: childSnapshot })
-    if (childSnapshot.copiedFingerprint !== undefined) {
-      updateFingerprintField(copiedHash, entry)
-      updateFingerprintField(copiedHash, childSnapshot.copiedFingerprint)
-    }
-    hasSymlinks = hasSymlinks || childSnapshot.hasSymlinks
+    updateFingerprintField(copiedHash, entry)
+    updateFingerprintField(copiedHash, childSnapshot.copiedFingerprint)
     fileCount += childSnapshot.fileCount
     byteCount += childSnapshot.byteCount
   }
 
   return {
-    sourcePath,
     kind,
-    copiedFingerprint: hasSymlinks ? undefined : copiedHash.digest('hex'),
-    children,
-    hasSymlinks,
+    copiedFingerprint: copiedHash.digest('hex'),
     fileCount,
     byteCount
-  }
-}
-
-function workspaceDestinationFingerprint(
-  sourceSnapshot: WorkspaceSourceSnapshot,
-  finalDestinationPath: string,
-  sourceWorkspaceRoot: string,
-  destinationWorkspaceRoot: string,
-  agentDataPath: string
-): string {
-  if (sourceSnapshot.copiedFingerprint !== undefined) return sourceSnapshot.copiedFingerprint
-
-  const copiedHash = createHash('sha256')
-  updateFingerprintField(copiedHash, sourceSnapshot.kind)
-  if (sourceSnapshot.kind === 'symlink') {
-    const linkType = sourceSnapshot.linkType!
-    const copiedLinkTarget = copiedWorkspaceLinkTarget(
-      migratedLinkTarget(
-        sourceSnapshot.sourcePath,
-        finalDestinationPath,
-        sourceSnapshot.linkTarget!,
-        sourceWorkspaceRoot,
-        destinationWorkspaceRoot,
-        agentDataPath
-      ),
-      finalDestinationPath,
-      linkType
-    )
-    updateFingerprintField(copiedHash, copiedLinkTarget)
-  } else {
-    for (const child of sourceSnapshot.children) {
-      updateFingerprintField(copiedHash, child.name)
-      updateFingerprintField(
-        copiedHash,
-        workspaceDestinationFingerprint(
-          child.snapshot,
-          path.join(finalDestinationPath, child.name),
-          sourceWorkspaceRoot,
-          destinationWorkspaceRoot,
-          agentDataPath
-        )
-      )
-    }
-  }
-  return copiedHash.digest('hex')
-}
-
-function workspaceDestinationSnapshot(
-  sourceSnapshot: WorkspaceSourceSnapshot,
-  finalDestinationPath: string,
-  sourceWorkspaceRoot: string,
-  destinationWorkspaceRoot: string,
-  agentDataPath: string
-): WorkspaceDestinationSnapshot {
-  return {
-    copiedFingerprint: workspaceDestinationFingerprint(
-      sourceSnapshot,
-      finalDestinationPath,
-      sourceWorkspaceRoot,
-      destinationWorkspaceRoot,
-      agentDataPath
-    ),
-    linkType: sourceSnapshot.linkType,
-    fileCount: sourceSnapshot.fileCount,
-    byteCount: sourceSnapshot.byteCount
   }
 }
 
@@ -1496,17 +1233,8 @@ async function requiredFilesystemEntrySnapshot(
   return snapshot
 }
 
-async function publishStagedWorkspaceEntry(
-  stagingPath: string,
-  destinationPath: string,
-  sourceLinkType?: WorkspaceLinkType
-): Promise<void> {
+async function publishStagedWorkspaceEntry(stagingPath: string, destinationPath: string): Promise<void> {
   const stagingStat = await lstat(stagingPath)
-  if (stagingStat.isSymbolicLink()) {
-    const linkType = sourceLinkType ?? (await workspaceLinkType(stagingPath))
-    await createWorkspaceLink(await readlink(stagingPath), destinationPath, linkType)
-    return
-  }
   if (stagingStat.isFile()) {
     // A hard-link publish is atomic and fails if the target appears concurrently.
     // The staging entry is on the same managed volume and is unlinked in `finally`.
@@ -1533,21 +1261,18 @@ interface PendingWorkspacePublication {
   stagingPath: string
   destinationPath: string
   copiedFingerprint: string
-  sourceLinkType?: WorkspaceLinkType
 }
 
 async function sourceSnapshotForWorkspaceEntry(
   context: WorkspaceCopyContext,
   sourcePath: string
-): Promise<WorkspaceSourceSnapshot> {
+): Promise<WorkspaceSourceSnapshot | undefined> {
   const sourceKey = path.resolve(sourcePath)
   const cachedSnapshot = context.sourceSnapshots.get(sourceKey)
   if (cachedSnapshot) return cachedSnapshot
 
   const sourceSnapshot = await workspaceSourceSnapshot(sourcePath)
-  if (!sourceSnapshot) {
-    throw new Error(`Agent migration fingerprint source disappeared: ${sourcePath}`)
-  }
+  if (!sourceSnapshot) return undefined
   context.sourceSnapshots.set(sourceKey, sourceSnapshot)
   return sourceSnapshot
 }
@@ -1557,8 +1282,8 @@ async function sourceSnapshotForWorkspaceEntry(
  * COPYFILE_FICLONE uses copy-on-write where the volume supports it and
  * otherwise performs a regular kernel copy. The first private staging entry
  * becomes the reusable source for later Sessions, so migration never needs an
- * additional full-size template. Links are materialized separately for each
- * Session before the complete private staging tree is fingerprinted.
+ * additional full-size template. Symlinks are discarded before the complete
+ * private staging tree is fingerprinted.
  */
 async function cloneWorkspaceRegularContent(sourcePath: string, destinationPath: string): Promise<void> {
   await cloneWorkspaceRegularContentWithQueue(
@@ -1582,6 +1307,7 @@ async function cloneWorkspaceRegularContentWithQueue(
 
   const kind = filesystemEntryKind(sourceStat)
   if (kind === 'symlink') {
+    logger.warn('Skipping workspace symlink while copying Agent migration source', { sourcePath })
     return
   }
   if (kind === 'file') {
@@ -1604,63 +1330,15 @@ async function cloneWorkspaceRegularContentWithQueue(
   }
 }
 
-async function materializeWorkspaceLinks(
-  sourceSnapshot: WorkspaceSourceSnapshot,
-  stagingPath: string,
-  finalDestinationPath: string,
-  sourceWorkspaceRoot: string,
-  destinationWorkspaceRoot: string,
-  agentDataPath: string
-): Promise<void> {
-  if (!sourceSnapshot.hasSymlinks) return
-
-  if (sourceSnapshot.kind === 'symlink') {
-    const linkType = sourceSnapshot.linkType!
-    const migratedTarget = migratedLinkTarget(
-      sourceSnapshot.sourcePath,
-      finalDestinationPath,
-      sourceSnapshot.linkTarget!,
-      sourceWorkspaceRoot,
-      destinationWorkspaceRoot,
-      agentDataPath
-    )
-    await createWorkspaceLink(
-      copiedWorkspaceLinkTarget(migratedTarget, finalDestinationPath, linkType),
-      stagingPath,
-      linkType
-    )
-    return
-  }
-
-  for (const child of sourceSnapshot.children) {
-    if (!child.snapshot.hasSymlinks) continue
-    await materializeWorkspaceLinks(
-      child.snapshot,
-      path.join(stagingPath, child.name),
-      path.join(finalDestinationPath, child.name),
-      sourceWorkspaceRoot,
-      destinationWorkspaceRoot,
-      agentDataPath
-    )
-  }
-}
-
 async function copyWorkspaceEntry(
   context: WorkspaceCopyContext,
   sourcePath: string,
   destinationPath: string,
-  sourceWorkspaceRoot: string,
-  destinationWorkspaceRoot: string,
-  agentDataPath: string
+  destinationWorkspaceRoot: string
 ): Promise<CopyEntryResult> {
   const sourceTree = await sourceSnapshotForWorkspaceEntry(context, sourcePath)
-  const sourceSnapshot = workspaceDestinationSnapshot(
-    sourceTree,
-    destinationPath,
-    sourceWorkspaceRoot,
-    destinationWorkspaceRoot,
-    agentDataPath
-  )
+  if (!sourceTree) return { copied: false, skipped: true, fileCount: 0, byteCount: 0 }
+  const sourceSnapshot = sourceTree
 
   const existingDestination = await filesystemEntrySnapshot(destinationPath)
   if (existingDestination) {
@@ -1685,23 +1363,13 @@ async function copyWorkspaceEntry(
   try {
     const sourceKey = path.resolve(sourcePath)
     const reusableStagingPath = context.reusableStagingPaths.get(sourceKey)
-    if (sourceTree.kind !== 'symlink') {
-      await cloneWorkspaceRegularContent(reusableStagingPath ?? sourcePath, stagingPath)
-    }
-    await materializeWorkspaceLinks(
-      sourceTree,
-      stagingPath,
-      destinationPath,
-      sourceWorkspaceRoot,
-      destinationWorkspaceRoot,
-      agentDataPath
-    )
+    await cloneWorkspaceRegularContent(reusableStagingPath ?? sourcePath, stagingPath)
 
     const stagingSnapshot = await requiredFilesystemEntrySnapshot(stagingPath)
     if (stagingSnapshot.fingerprint !== sourceSnapshot.copiedFingerprint) {
       throw new Error(`Legacy Agent workspace copy verification failed: ${sourcePath}`)
     }
-    if (sourceTree.kind !== 'symlink' && !reusableStagingPath) {
+    if (!reusableStagingPath) {
       context.reusableStagingPaths.set(sourceKey, stagingPath)
     }
 
@@ -1711,8 +1379,7 @@ async function copyWorkspaceEntry(
       sourcePath,
       stagingPath,
       destinationPath,
-      copiedFingerprint: sourceSnapshot.copiedFingerprint,
-      sourceLinkType: sourceSnapshot.linkType
+      copiedFingerprint: sourceSnapshot.copiedFingerprint
     })
     pendingPublication = true
     return {
@@ -1731,8 +1398,7 @@ async function copyOrdinaryWorkspaceContent(
   context: WorkspaceCopyContext,
   agentsDataRoot: string,
   sourceWorkspacePath: string,
-  destinationWorkspacePath: string,
-  agentDataPath: string
+  destinationWorkspacePath: string
 ): Promise<{ copiedEntries: number; reusedEntries: number; fileCount: number; byteCount: number }> {
   const sourceStat = await lstatIfExists(sourceWorkspacePath)
   if (!sourceStat?.isDirectory() || sourceStat.isSymbolicLink()) {
@@ -1753,10 +1419,9 @@ async function copyOrdinaryWorkspaceContent(
       context,
       path.join(sourceWorkspacePath, entry),
       destinationPath,
-      sourceWorkspacePath,
-      destinationWorkspacePath,
-      agentDataPath
+      destinationWorkspacePath
     )
+    if (result.skipped) continue
     if (result.copied) copiedEntries++
     else reusedEntries++
     fileCount += result.fileCount
@@ -1786,11 +1451,7 @@ async function publishPreparedWorkspaceEntries(
     }
 
     try {
-      await publishStagedWorkspaceEntry(
-        publication.stagingPath,
-        publication.destinationPath,
-        publication.sourceLinkType
-      )
+      await publishStagedWorkspaceEntry(publication.stagingPath, publication.destinationPath)
       publishedEntries++
     } catch (error) {
       const racedDestinationSnapshot = await filesystemEntrySnapshot(publication.destinationPath)
@@ -2116,8 +1777,7 @@ export async function stageLegacyAgentFiles(input: {
         workspaceCopyContext,
         input.agentsDataRoot,
         contentSession.sourceWorkspacePath,
-        contentSession.systemWorkspacePath,
-        agentDataPath
+        contentSession.systemWorkspacePath
       )
       copiedWorkspaceEntries += workspaceStats.copiedEntries
       reusedWorkspaceEntries += workspaceStats.reusedEntries


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR: Agent migration followed or recreated identity and workspace symlinks, so Windows link permissions and unsupported targets could block the migration.

After this PR: migration skips symlinked Agent roots, identity entries, workspace entries, and legacy Claude configuration entries while continuing to copy regular files and directories.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: migration completion takes priority over preserving linked entries, while the original v1 sources remain untouched for downgrade compatibility.

The following alternatives were considered: recreating links as Windows junctions or symbolic links, but both retain platform permissions and target compatibility failure modes.

Links to places where the discussion took place: N/A

### Breaking changes

Symlinked entries are no longer reproduced in migrated v2 Agent data; users who require linked content must materialize it as regular files or directories before migration.

### Special notes for your reviewer

Focused Agent filesystem migration tests passed with 56 passed and 1 skipped; `pnpm lint` and `pnpm format` also passed. Full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent data migration failures caused by symbolic links on Windows. Symlinked entries are skipped so the remaining regular data can migrate successfully; action required only if linked content must be retained, in which case materialize it before migration.
```
