### PR TITLE
chore: release v2.0.2

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -156,140 +156,54 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.1 - Refinements and Fixes
+    Cherry Studio 2.0.2 - New Features and Fixes
 
     ✨ New Features
-    - [Agent] Built-in document conversion for workspace files
-    - [Chat] Show the generating model's identity on single replies
-    - [Chat] Assistant picker keeps the create row visible while searching
-    - [Chat] Permission mode submenu indicator in the composer
-    - [Tab Bar] Chrome-style divider between adjacent tabs
-    - [Tab Bar] Settings opens as a focused tab that can be detached to a window
-    - [Assistant] Drag to reorder conversation sidebar assistant groups
-    - [Settings] Privacy-focused diagnostic bundle export in About
-    - [Models] DeepSeek V4 Flash built-in web search
-    - [Providers] Embedding endpoint type for NEWAPI model configuration
-    - [Provider Settings] Persist provider filter across visits and restarts
+    - [Import] Import Claude (Anthropic) conversation history; ChatGPT and Claude imports now preserve message branches
+    - [Providers] Built-in web search and URL context support for DeepSeek, OpenRouter, and Dashscope
+    - [Settings] Selective cache cleanup with per-item and total size estimates, plus optional removal of old-version leftover data
+    - [Settings] Workflow to safely rerun retained v1 data migration with risk acknowledgement and optional backup
+    - [Chat] Branches now persist empty input nodes, stay stable in the branch canvas, and can be removed from the node context menu
 
     🐛 Bug Fixes
-    - [Chat] Preserve conversation branches when deleting messages
-    - [Chat] Restore missing assistant names and avatars in migrated conversations
-    - [Chat] Restore default reasoning effort option after selecting a level
-    - [Chat] Prevent reference context leaks in collapsed message previews
-    - [Chat] Fix Exa web search not sending the configured API key
-    - [Chat] Fix chats failing with HTTP 400 when attaching files
-    - [Chat] Fix Gemini tool calls failing via OpenAI-compatible endpoints
-    - [Chat] Fix model selector crash when a capability filter is active
-    - [Chat] Fix model selector rebuilding model lists and causing slowdowns
-    - [Chat] Fix nested scroll regions affecting the chat viewport position
-    - [Chat] Fix right-click copying of rendered math formulas to preserve TeX
-    - [Chat] Fix Claude Code requests through the API Gateway failing with Responses API providers
-    - [Chat] Fix Claude Agent sessions on no-prefill Claude models
-    - [Chat] Fix Claude Code MCP servers failing to start on Windows when Node provides npx.cmd
-    - [Chat] Fix Claude Code Agent system prompts being overwritten by Cherry Studio instructions
-    - [Chat] Fix DeepSeek V4 model routing and OpenCode Go model API protocols
-    - [Chat] Fix Agent requests failing with HTTP 400 after gateway conversion
-    - [Chat] Fix Exa web search crashing on non-string queries
-    - [Chat] Fix translating button contrast on Windows
-    - [Tab Bar] Fix assistant and agent conversation tabs reverting their titles or losing identity
-    - [Sidebar] Normalize mini-app icons and conversation list typography and selection states
-    - [Sidebar] Fix OpenClaw dashboards staying blank or unresponsive after a gateway restart
-    - [Models] Fix missing Kimi model avatars for custom providers using K3 IDs
-    - [Models] Clarify the multi-select control with a localized button
-    - [Models] Add left/right scroll controls when model type categories overflow
-    - [Models] Fix new painting drafts not applying the default painting model
-    - [Models] Fix migration of TokenFlux painting history
-    - [Agent] Restore context usage indicator for Gateway-routed agent models
-    - [Agent] Restore normal Cherry Assistant agent capabilities
-    - [Agent] Hide disabled MCP tools from agents
-    - [Agent] Fix agent follow-ups being lost while background tasks report results
-    - [Agent] Fix localhost/loopback gateway connections bypassing configured proxies
-    - [Agent] Fix agent-session turn ordering during reconnects
-    - [Agent] Hide the prompt variable help popover in the agent prompt editor
-    - [Agent] Keep agent edit dialogs open after save failures
-    - [Migration] Fix crashes and out-of-memory failures during v1→v2 migration
-    - [Migration] Fix Agent v2 migration failing when a legacy workspace shares the Agent data path
-    - [Migration] Fix agent filesystem migration failing on cloud-storage metadata churn
-    - [Migration] Fix v2 migration failures caused by unusable legacy API keys
-    - [Notes] Fix empty notes retaining content from the previously selected note
-    - [Notes] Fix pasted markdown tables and code blocks rendering as plain text
-    - [Code] Fix custom code fonts being ignored in conversation code blocks
-    - [Code] Fix provider enabling before CLI installation
-    - [Settings] Fix AI error diagnosis using the default assistant model instead of the free Qwen model
-    - [Skills] Raise imported skill ZIP entry limit from 1,000 to 2,000
-    - [Tasks] Fix scheduled task deletion showing a misleading load failure
-    - [Export] Clarify Export menu grouping and preserve per-message local file saving
-    - [Profile] Allow WebP avatar uploads
+    - [Local Model] Local embedding model downloads fall back to the other mirror when one is unreachable, keep inference fully offline once weights are on disk, and explain an incomplete cache instead of reporting a generic connection error
+    - [Local Model] Local model downloads failing behind a SOCKS proxy, and proxy bypass rules are now honored for every redirect hop
+    - [Migration] Agent data migration no longer fails on Windows symbolic links; symlinked entries are skipped so the rest migrates successfully
+    - [Migration] V1 users can upgrade directly to any v2.0.x release while v2.1.0 and later remain gated
+    - [Providers] New API providers no longer require a URL for every protocol: one API host now serves the OpenAI, Anthropic, Gemini, and Responses endpoints, each with its correct version segment
+    - [MCP] MCP server settings no longer lose unsaved edits during refreshes, and tool details show full descriptions with clearer nested input schemas
+    - [Agent] WeChat channel QR login now starts when the channel is bound to an agent, and the channel reconnects automatically after app restart
+    - [Composer] Image attachment tokens open the shared full-size image preview when clicked or activated with the keyboard
+    - [Agent] Agent right pane Files tree no longer shows empty when the workspace already contained files; directory-tree updates were being lost during subscription setup
+    - [Chat] Tool-heavy tasks no longer stop early at 20 tool-call rounds: the default "Max tool call rounds" is raised to 100 and the maximum to 1000
+    - [Claude Code] Claude agent CLI subprocesses are no longer left running in the background after quitting the app
 
     ⚡ Performance
-    - [Agent] Improve conversation loading responsiveness and avoid unrelated session row updates
+    - [Chat] Switching back to a chat tab no longer re-highlights expanded tool responses, re-loads generated images, re-runs error diagnosis, rebuilds file-tree watchers, or re-polls finished traces — tab switches are smoother and previously loaded content stays in place
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.1 - 体验优化与问题修复
+    Cherry Studio 2.0.2 - 新功能与问题修复
 
     ✨ 新功能
-    - [Agent] 内置工作区文档格式转换
-    - [Chat] 单模型回复显示当前生成模型的头像与名称
-    - [Chat] 助手选择器在搜索时保持创建行可见
-    - [Chat] 输入框权限模式显示子菜单指示
-    - [Tab Bar] 相邻标签页之间绘制 Chrome 风格分割线
-    - [Tab Bar] 设置作为独立标签页打开，可分离为单独窗口
-    - [Assistant] 侧边栏助手分组支持拖拽排序
-    - [Settings] 关于页新增隐私优先的本地诊断包导出
-    - [Models] DeepSeek V4 Flash 内置联网搜索
-    - [Providers] NEWAPI 模型配置新增 embedding 端点类型
-    - [Provider Settings] 服务商筛选在切换页面和重启后保持
+    - [Import] 支持 Claude（Anthropic）对话历史导入；ChatGPT 和 Claude 导入现在会保留消息分支
+    - [Providers] DeepSeek、OpenRouter、Dashscope 新增内置联网搜索与 URL 上下文支持
+    - [Settings] 缓存清理支持按项查看占用大小，可选清理旧版本残留数据
+    - [Settings] 新增 v1 数据重新迁移流程，含风险确认与可选完整备份
+    - [Chat] 对话分支现在会持久化空输入节点，在分支画布中保持稳定，并支持从节点右键菜单删除
 
     🐛 问题修复
-    - [Chat] 删除消息时正确保留对话分支
-    - [Chat] 恢复迁移后对话中缺失的助手名称和头像
-    - [Chat] 恢复选择推理强度后的"跟随模型默认"选项
-    - [Chat] 修复折叠消息预览中引用上下文泄露的问题
-    - [Chat] 修复 Exa 联网搜索未发送已配置 API Key 的问题
-    - [Chat] 修复附件上传导致 400 错误的问题
-    - [Chat] 修复通过 OpenAI 兼容端点调用 Gemini 工具失败的问题
-    - [Chat] 修复在能力筛选激活时选择模型崩溃的问题
-    - [Chat] 修复模型选择器重复重建模型列表导致的卡顿
-    - [Chat] 修复嵌套滚动区域影响外层聊天视口位置的问题
-    - [Chat] 修复右键复制数学公式时丢失 TeX 源码的问题
-    - [Chat] 修复通过 API Gateway 调用 Claude Code 在 Responses API 服务商下失败的问题
-    - [Chat] 修复无 prefill 的 Claude 模型上 Agent 会话异常的问题
-    - [Chat] 修复 Windows 上 Node 提供 npx.cmd 时 Claude Code MCP 服务器启动失败
-    - [Chat] 修复 Claude Code Agent 系统提示被 Cherry Studio 指令覆盖的问题
-    - [Chat] 修复 DeepSeek V4 模型路由和 OpenCode Go 模型 API 协议
-    - [Chat] 修复网关转换后 Agent 请求返回 HTTP 400 的问题
-    - [Chat] 修复 Exa 联网搜索在非字符串查询时崩溃的问题
-    - [Chat] 修复翻译按钮在 Windows 上的对比度
-    - [Tab Bar] 修复助手和 Agent 对话标签页标题回退或身份丢失的问题
-    - [Sidebar] 统一小程序图标和会话列表的字号字重与选中态
-    - [Sidebar] 修复 OpenClaw 仪表盘在网关重启后空白或无响应的问题
-    - [Models] 修复自定义服务商使用 K3 模型 ID 时 Kimi 头像缺失
-    - [Models] 用本地化按钮明确多选控件
-    - [Models] 模型类型分类溢出时增加左右滚动控件
-    - [Models] 修复新绘画草稿未应用默认绘画模型的问题
-    - [Models] 修复 TokenFlux 绘画历史迁移丢失的问题
-    - [Agent] 恢复网关路由 Agent 模型的上下文用量指示
-    - [Agent] 恢复 Cherry Assistant 正常的 Agent 能力
-    - [Agent] 不再将已禁用的 MCP 工具暴露给 Agent
-    - [Agent] 修复后台任务回报期间 Agent 追问消息丢失的问题
-    - [Agent] 修复 localhost/环回网关绕过已配置代理的问题
-    - [Agent] 修复重连时 Agent 会话回合顺序错乱的问题
-    - [Agent] 隐藏 Agent 提示词编辑器中的系统变量帮助弹窗
-    - [Agent] 修复保存失败时 Agent 编辑对话框异常关闭的问题
-    - [Migration] 修复 v1→v2 迁移过程中的崩溃和内存溢出问题
-    - [Migration] 修复旧工作区与 Agent 数据路径重叠时 Agent v2 迁移失败
-    - [Migration] 修复云存储元数据变化导致 Agent 文件系统迁移失败
-    - [Migration] 修复旧 API Key 不可用导致 v2 迁移失败
-    - [Notes] 修复空笔记残留上一个笔记内容的问题
-    - [Notes] 修复粘贴的 Markdown 表格和代码块被渲染为纯文本的问题
-    - [Code] 修复对话代码块忽略自定义代码字体的问题
-    - [Code] 修复 CLI 安装前无法启用服务商的问题
-    - [Settings] 修复 AI 错误诊断使用默认助手模型而非免费 Qwen 模型的问题
-    - [Skills] 导入技能 ZIP 条目上限从 1,000 提升到 2,000
-    - [Tasks] 修复定时任务删除后显示误导性加载失败的问题
-    - [Export] 厘清导出菜单分组并保留单条消息本地保存
-    - [Profile] 支持 WebP 头像上传
+    - [Local Model] 修复本地 Embedding 模型下载：单个镜像不可用时自动切换到备用镜像，模型缓存到本地后推理完全离线，缓存损坏时给出明确提示而非笼统的网络错误
+    - [Local Model] 修复 SOCKS 代理环境下本地模型下载失败的问题，并对下载过程中的每次重定向跳转应用代理绕过规则
+    - [Migration] 修复 Windows 上符号链接导致 Agent 数据迁移失败的问题：跳过符号链接项，确保其余数据正常迁移
+    - [Migration] v1 用户可直接升级到任意 v2.0.x 版本，v2.1.0 及之后版本仍受迁移网关保护
+    - [Providers] New API 服务商不再需要为每个协议分别填写 URL：一个 API Host 即可同时承载 OpenAI、Anthropic、Gemini、Responses 端点，并各自使用正确的版本段
+    - [MCP] 修复 MCP 服务器设置在刷新时丢失未保存编辑的问题，工具详情展示完整描述并清晰呈现嵌套输入 schema
+    - [Agent] 修复微信渠道绑定到 Agent 后才启动二维码登录的问题，并支持应用重启后自动重连
+    - [Composer] 图片附件 Token 支持点击或键盘激活时打开共享的全屏图片预览
+    - [Agent] 修复 Agent 右侧面板在工作区已有文件时仍显示为空的问题：目录树更新在订阅建立过程中被丢失
+    - [Chat] 工具密集型任务不再在 20 轮工具调用后提前停止：默认"最大工具调用轮数"提升到 100，上限提升到 1000
+    - [Claude Code] 修复退出应用后 Claude Agent CLI 子进程仍在后台残留的问题
 
     ⚡ 性能优化
-    - [Agent] 提升 Agent 对话加载响应速度，避免无关会话行的额外更新
+    - [Chat] 切换回聊天标签页时不再重新高亮工具响应、重新加载生成图片、重新运行错误诊断、重建文件树监听或重新轮询已完成的 trace，标签切换更顺滑，已加载内容保持不变
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "package": {
     "name": "CherryStudio",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A powerful AI assistant for producer.",
     "homepage": "https://github.com/CherryHQ/cherry-studio"
   },


### PR DESCRIPTION
> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:
- The app was at `v2.0.1`.

After this PR:
- Bumps the version to `v2.0.2` and ships the bilingual release notes for the release.
- Updates `package.json`, `electron-builder.yml` (release notes), and the generated `resources/builtin-agents/cherry-assistant/product-manifest.json` (via `pnpm build:builtin-knowledge`).

This is the release PR for `v2.0.2`. Generated by the `prepare-release` skill.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The release notes aggregate user-facing changes from commits since `v2.0.1`. Non-user-facing items (internal refactors, build/CI, dependency bumps) are excluded per the release-notes policy. The generated product manifest is refreshed by the build script rather than edited by hand.

The following tradeoffs were made:

- The release commit is `chore: release v2.0.2` with `--signoff` (DCO). GPG signing was not available in the CI environment, so the commit will not show as "Verified" on GitHub.

The following alternatives were considered:

- Waiting to include more commits — rejected; `v2.0.2` is being cut now from the current `main` HEAD.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None. This PR only bumps the version and refreshes release notes / generated manifest.

### Special notes for your reviewer

Included commits (since `v2.0.1`):

- `d6cb469525` fix(local-model): survive mirror failures and keep embedding inference offline (#18016)
- `8ec2a9a7dd` fix(agent-migration): skip symlinks during migration (#18101)
- `a502b21c3e` fix(new-api): serve every endpoint from one host with per-route versions (#18033)
- `9598946fe9` fix(mcp-settings): preserve form edits and improve tool details (#17647)
- `351fe3d92d` feat(data-migration): allow rerunning v1 migration (#18002)
- `84a33e88bc` feat(cli-config): support detailed models through unified gateway (#18014)
- `f8fb3752da` feat: add Claude (Anthropic) conversation import support (#16164)
- `95a2f8736a` refactor(proxy): make ProxyService own worker routing policy (#18095)
- `8e7311ade0` fix(agent-channels): start WeChat QR login (#18071)
- `dc70813d39` fix(composer): open image tokens in shared preview (#18082)
- `222e5e62ca` feat(cache-cleanup): add selective cache and legacy data cleanup (#17377)
- `9dc66831ec` fix(v2-migration): allow direct upgrades to v2.0.x (#18093)
- `da3b5f1921` feat(providers): built-in web search for DeepSeek/OpenRouter/Dashscope + distinguishable resolved model names (#17983)
- `f39b17d04c` fix(directory-tree): close the snapshot-to-stream delivery gap (#18009)
- `c992af0222` fix(tool-loop): raise the default tool-call round cap (#18072)
- `2e2ae86e44` fix(claude-code): reap sdk cli subprocesses on shutdown (#17969)
- `25156324945` perf(chat-tabs): skip redundant re-show work in message tools, artifact pane, and trace page (#18038)
- `ad0ce9cd04` feat(chat-branch): persist empty branch nodes (#17667)

Release notes (English):

Cherry Studio 2.0.2 - New Features and Fixes

✨ New Features
- [Import] Import Claude (Anthropic) conversation history; ChatGPT and Claude imports now preserve message branches
- [Providers] Built-in web search and URL context support for DeepSeek, OpenRouter, and Dashscope
- [Settings] Selective cache cleanup with per-item and total size estimates, plus optional removal of old-version leftover data
- [Settings] Workflow to safely rerun retained v1 data migration with risk acknowledgement and optional backup
- [Chat] Branches now persist empty input nodes, stay stable in the branch canvas, and can be removed from the node context menu

🐛 Bug Fixes
- [Local Model] Local embedding model downloads fall back to the other mirror when one is unreachable, keep inference fully offline once weights are on disk, and explain an incomplete cache instead of reporting a generic connection error
- [Local Model] Local model downloads failing behind a SOCKS proxy, and proxy bypass rules are now honored for every redirect hop
- [Migration] Agent data migration no longer fails on Windows symbolic links; symlinked entries are skipped so the rest migrates successfully
- [Migration] V1 users can upgrade directly to any v2.0.x release while v2.1.0 and later remain gated
- [Providers] New API providers no longer require a URL for every protocol: one API host now serves the OpenAI, Anthropic, Gemini, and Responses endpoints, each with its correct version segment
- [MCP] MCP server settings no longer lose unsaved edits during refreshes, and tool details show full descriptions with clearer nested input schemas
- [Agent] WeChat channel QR login now starts when the channel is bound to an agent, and the channel reconnects automatically after app restart
- [Composer] Image attachment tokens open the shared full-size image preview when clicked or activated with the keyboard
- [Agent] Agent right pane Files tree no longer shows empty when the workspace already contained files; directory-tree updates were being lost during subscription setup
- [Chat] Tool-heavy tasks no longer stop early at 20 tool-call rounds: the default "Max tool call rounds" is raised to 100 and the maximum to 1000
- [Claude Code] Claude agent CLI subprocesses are no longer left running in the background after quitting the app

⚡ Performance
- [Chat] Switching back to a chat tab no longer re-highlights expanded tool responses, re-loads generated images, re-runs error diagnosis, rebuilds file-tree watchers, or re-polls finished traces — tab switches are smoother and previously loaded content stays in place

Review checklist:

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] Verify generated product manifest uses the release version
- [ ] CI passes
- [ ] Merge to trigger release build

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: [You have left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
