### PR TITLE
fix(topic-naming): inherit the quick model by default

### DIFF
--- a/src/main/data/db/seeding/seeders/__tests__/cherryaiDefaultModelSeeder.test.ts
+++ b/src/main/data/db/seeding/seeders/__tests__/cherryaiDefaultModelSeeder.test.ts
@@ -74,6 +74,7 @@ describe('CherryAiDefaultModelSeeder', () => {
       isHidden: false
     })
     await expectSeededDefaultModelPreferences()
+    expect(await readPreferenceValue('topic.naming.model_id')).toBeUndefined()
     expect(mockMainLoggerService.warn).toHaveBeenCalledWith('Self-healed missing CherryAI default provider', {
       providerId: CHERRYAI_PROVIDER_ID
     })

--- a/src/main/data/db/seeding/seeders/cherryaiDefaultModelSeeder.ts
+++ b/src/main/data/db/seeding/seeders/cherryaiDefaultModelSeeder.ts
@@ -26,7 +26,6 @@ const logger = loggerService.withContext('CherryAiDefaultModelSeeder')
 const DEFAULT_MODEL_PREFERENCE_SCOPE = 'default' as const
 export const DEFAULT_MODEL_PREFERENCE_KEYS = [
   'chat.default_model_id',
-  'topic.naming.model_id',
   'feature.quick_assistant.model_id',
   'feature.translate.model_id'
 ] as const

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -7,7 +7,6 @@ import { loggerService } from '@logger'
 import type { AiGenerateRequest } from '@main/ai/AiService'
 import { WindowType } from '@main/core/window/types'
 import { messageService } from '@main/data/services/MessageService'
-import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import type { Message, MessageData, UIMessage } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId, UniqueModelIdSchema } from '@shared/data/types/model'
 import type { Topic } from '@shared/data/types/topic'
@@ -208,6 +207,7 @@ export class TopicNamingService {
       ]
 
       const uniqueModelId = this.resolveNamingModelId()
+      if (!uniqueModelId) return
       const title = await this.generateSummaryTitle(
         assistantId,
         uniqueModelId,
@@ -306,6 +306,7 @@ export class TopicNamingService {
       if (session.isNameManuallyEdited) return
       if (!canAutoRenameAgentSessionName(session.name, userText)) return
       const uniqueModelId = this.resolveNamingModelId()
+      if (!uniqueModelId) return
 
       const structuredConversation: StructuredMessage[] = [
         { role: 'user', mainText: cleanMarkdownImages(userText) },
@@ -405,7 +406,7 @@ export class TopicNamingService {
     return (configuredPrompt || FALLBACK_PROMPT).replaceAll('{{language}}', language)
   }
 
-  private resolveNamingModelId(): UniqueModelId {
+  private resolveNamingModelId(): UniqueModelId | null {
     const preferenceService = application.get('PreferenceService')
 
     const configured = preferenceService.get('topic.naming.model_id')
@@ -418,20 +419,19 @@ export class TopicNamingService {
       )
     }
 
-    // A title is a lightweight summary, so prefer the user's own quick-assistant model over the
-    // managed CherryAI default whenever the dedicated naming model is unset or unusable.
     const quickModelId = this.toUsableNamingModelId(preferenceService.get('feature.quick_assistant.model_id'))
     if (quickModelId) return quickModelId
 
-    return CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
+    const defaultModelId = this.toUsableNamingModelId(preferenceService.get('chat.default_model_id'))
+    if (defaultModelId) return defaultModelId
+
+    return null
   }
 
   /**
    * Validate a `providerId::modelId` candidate for topic naming. Returns the id when usable, else
-   * `null`. A candidate is rejected when it fails to parse, its model no longer exists, or its
-   * provider is an external-CLI (agent-only) provider — those reuse a CLI's own login, hold no
-   * app-side credential, and cannot serve a generation request, so they can never name a topic
-   * (capability-derived, so any such provider is covered without keying on a specific id).
+   * `null`. A candidate is rejected when it fails to parse, its provider or model is missing, or
+   * its provider is external-CLI-only.
    */
   private toUsableNamingModelId(candidate: string | null | undefined): UniqueModelId | null {
     const parsed = UniqueModelIdSchema.safeParse(candidate)

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -2,7 +2,6 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 
 import { WindowType } from '@main/core/window/types'
-import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -113,6 +112,7 @@ describe('TopicNamingService', () => {
     mockMainLoggerService.warn.mockClear()
     mockMainLoggerService.debug.mockClear()
     MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.enabled', true)
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'openai::gpt-4o-mini')
     mocks.getModelByKey.mockReturnValue({ id: 'openai::gpt-4o-mini' })
     mocks.getProviderByProviderId.mockReturnValue({ authMethods: ['api-key'] })
     mockRenameInputs()
@@ -154,8 +154,9 @@ describe('TopicNamingService', () => {
     })
   })
 
-  it('falls back to the managed CherryAI default when topic naming model preference is empty', async () => {
+  it('inherits the quick model when topic naming model preference is empty', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', null)
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'minimax::MiniMax-M3')
 
     await createService().maybeRenameFromConversationSummary('topic-1', undefined, 'message-1', {
       role: 'assistant',
@@ -165,13 +166,15 @@ describe('TopicNamingService', () => {
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
         assistantId: undefined,
-        uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
+        uniqueModelId: 'minimax::MiniMax-M3'
       })
     )
   })
 
-  it('falls back to the managed CherryAI default when topic naming model preference is invalid', async () => {
-    MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', 'bad-value')
+  it('inherits the default model when the quick model preference is empty', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', null)
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', null)
+    MockMainPreferenceServiceUtils.setPreferenceValue('chat.default_model_id', 'openai::gpt-4o')
 
     await createService().maybeRenameFromConversationSummary('topic-1', undefined, 'message-1', {
       role: 'assistant',
@@ -180,7 +183,37 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
+        uniqueModelId: 'openai::gpt-4o'
+      })
+    )
+  })
+
+  it('skips topic naming when no configured, quick, or default model is usable', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', null)
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', null)
+    MockMainPreferenceServiceUtils.setPreferenceValue('chat.default_model_id', null)
+
+    await createService().maybeRenameFromConversationSummary('topic-1', undefined, 'message-1', {
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Assistant response' }]
+    } as never)
+
+    expect(mocks.generateText).not.toHaveBeenCalled()
+    expect(mocks.broadcastToType).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the quick model when topic naming model preference is invalid', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', 'bad-value')
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'minimax::MiniMax-M3')
+
+    await createService().maybeRenameFromConversationSummary('topic-1', undefined, 'message-1', {
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Assistant response' }]
+    } as never)
+
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uniqueModelId: 'minimax::MiniMax-M3'
       })
     )
     expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
@@ -189,10 +222,12 @@ describe('TopicNamingService', () => {
     )
   })
 
-  it('falls back to the managed CherryAI default when topic naming model no longer exists', async () => {
+  it('falls back to the quick model when topic naming model no longer exists', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', 'ghost::missing')
-    mocks.getModelByKey.mockImplementation(() => {
-      throw new Error('missing model')
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'minimax::MiniMax-M3')
+    mocks.getModelByKey.mockImplementation((providerId: string, modelId: string) => {
+      if (providerId === 'ghost') throw new Error('missing model')
+      return { id: `${providerId}::${modelId}`, providerId, capabilities: [], isEnabled: true }
     })
 
     await createService().maybeRenameFromConversationSummary('topic-1', undefined, 'message-1', {
@@ -203,7 +238,7 @@ describe('TopicNamingService', () => {
     expect(mocks.getModelByKey).toHaveBeenCalledWith('ghost', 'missing')
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
+        uniqueModelId: 'minimax::MiniMax-M3'
       })
     )
     expect(mockMainLoggerService.warn).toHaveBeenCalledWith(
@@ -577,7 +612,10 @@ describe('TopicNamingService', () => {
 
   it('falls back when topic naming model points to an external-CLI (agent-only) provider', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('topic.naming.model_id', 'claude-code::haiku')
-    mocks.getProviderByProviderId.mockReturnValue({ authMethods: ['external-cli'] })
+    MockMainPreferenceServiceUtils.setPreferenceValue('feature.quick_assistant.model_id', 'openai::gpt-4o-mini')
+    mocks.getProviderByProviderId.mockImplementation((providerId: string) =>
+      providerId === 'claude-code' ? { authMethods: ['external-cli'] } : { authMethods: ['api-key'] }
+    )
     mocks.getSession.mockReturnValue({
       id: 'session-1',
       agentId: 'agent-1',
@@ -593,7 +631,7 @@ describe('TopicNamingService', () => {
     expect(mocks.getModelByKey).not.toHaveBeenCalledWith('claude-code', 'haiku')
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
+        uniqueModelId: 'openai::gpt-4o-mini'
       })
     )
     expect(mockMainLoggerService.warn).toHaveBeenCalledWith(

--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -279,6 +279,7 @@ export function ModelSelector(props: ModelSelectorProps) {
   // `emitSelection` / `normalizeSelectedIdsFromValue`).
   const multiple = props.multiple
   const noneOptionLabel = props.multiple ? undefined : props.noneOptionLabel
+  const noneOptionIcon = props.multiple ? undefined : props.noneOptionIcon
   const selectionType = props.selectionType
   const selectedValue = props.value
   const [internalOpen, setInternalOpen] = useState(false)
@@ -851,7 +852,7 @@ export function ModelSelector(props: ModelSelectorProps) {
     if (noneOptionLabel) {
       actions.push({
         type: 'selectable',
-        icon: <CircleSlash className="size-3.5" />,
+        icon: noneOptionIcon ?? <CircleSlash className="size-3.5" />,
         label: noneOptionLabel,
         selected: rawSelectedModelIds.length === 0,
         onClick: handleSelectNone
@@ -859,7 +860,14 @@ export function ModelSelector(props: ModelSelectorProps) {
     }
 
     return actions
-  }, [handleNavigateToCustomModelSettings, handleSelectNone, noneOptionLabel, rawSelectedModelIds.length, t])
+  }, [
+    handleNavigateToCustomModelSettings,
+    handleSelectNone,
+    noneOptionIcon,
+    noneOptionLabel,
+    rawSelectedModelIds.length,
+    t
+  ])
 
   const initialListHeight = Math.min(listHeight, MODEL_SELECTOR_CONTENT_HEIGHT)
 

--- a/src/renderer/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/src/renderer/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -364,11 +364,14 @@ describe('ModelSelector', () => {
   })
 
   it('marks the empty option selected after the configure action', () => {
+    const customIcon = <span data-testid="custom-empty-option-icon" />
+
     render(
       <ModelSelector
         open
         multiple={false}
         noneOptionLabel="No model"
+        noneOptionIcon={customIcon}
         trigger={<button type="button">open</button>}
         onSelect={vi.fn()}
       />
@@ -376,6 +379,7 @@ describe('ModelSelector', () => {
 
     expect(mocks.bottomActions.map((action) => action.label)).toEqual(['models.action.configure_custom', 'No model'])
     expect(mocks.bottomActions[1]).toMatchObject({ type: 'selectable', selected: true })
+    expect(mocks.bottomActions[1].icon).toBe(customIcon)
   })
 
   it('omits the empty option from required single and multi selectors', () => {

--- a/src/renderer/components/ModelSelector/types.ts
+++ b/src/renderer/components/ModelSelector/types.ts
@@ -40,6 +40,7 @@ export interface ModelSelectorSingleModelProps extends ModelSelectorCommonProps 
   selectionType?: 'model'
   value?: Model
   noneOptionLabel?: string
+  noneOptionIcon?: ReactNode
   onSelect: (model: Model | undefined) => void
 }
 
@@ -48,6 +49,7 @@ export interface ModelSelectorSingleIdProps extends ModelSelectorCommonProps {
   selectionType: 'id'
   value?: UniqueModelId
   noneOptionLabel?: string
+  noneOptionIcon?: ReactNode
   onSelect: (modelId: UniqueModelId | undefined) => void
 }
 

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -7537,6 +7537,7 @@
       },
       "topic_naming": {
         "auto": "Conversation Auto Naming",
+        "follow_quick": "Follow Quick Model",
         "label": "Conversation naming",
         "model": "Naming Model",
         "prompt": "Conversation Naming Prompt"

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -7537,6 +7537,7 @@
       },
       "topic_naming": {
         "auto": "对话自动重命名",
+        "follow_quick": "跟随快速模型",
         "label": "对话命名",
         "model": "命名模型",
         "prompt": "对话命名提示词"

--- a/src/renderer/pages/settings/ModelSettings/DefaultModelSelector.tsx
+++ b/src/renderer/pages/settings/ModelSettings/DefaultModelSelector.tsx
@@ -6,7 +6,7 @@ import { cn } from '@renderer/utils/style'
 import { type Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { ChevronDown } from 'lucide-react'
-import type { ComponentProps, FC } from 'react'
+import type { ComponentProps, FC, ReactNode } from 'react'
 
 export interface ModelSelectorTriggerProps extends Omit<ComponentProps<typeof Button>, 'children' | 'onSelect'> {
   model?: Model
@@ -17,6 +17,8 @@ export interface ModelSelectorTriggerProps extends Omit<ComponentProps<typeof Bu
 
 export interface DefaultModelSelectorProps extends ModelSelectorTriggerProps {
   filter: (model: Model) => boolean
+  noneOptionLabel?: string
+  noneOptionIcon?: ReactNode
   onSelect: (model: Model | undefined) => void
 }
 
@@ -67,11 +69,15 @@ export const DefaultModelSelector: FC<DefaultModelSelectorProps> = ({
   placeholder,
   compact,
   filter,
+  noneOptionLabel,
+  noneOptionIcon,
   onSelect
 }) => (
   <ModelSelector
     multiple={false}
     value={model}
+    noneOptionLabel={noneOptionLabel}
+    noneOptionIcon={noneOptionIcon}
     onSelect={onSelect}
     filter={filter}
     trigger={

--- a/src/renderer/pages/settings/ModelSettings/TopicNamingSettings.tsx
+++ b/src/renderer/pages/settings/ModelSettings/TopicNamingSettings.tsx
@@ -17,7 +17,7 @@ import { useModelById } from '@renderer/hooks/useModel'
 import { useProviders } from '@renderer/hooks/useProvider'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { isNonChatModel } from '@shared/utils/model'
-import { CircleHelp } from 'lucide-react'
+import { CircleHelp, Rocket } from 'lucide-react'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -36,8 +36,7 @@ export const TopicNamingSettings = () => {
 
   const handleSelectModel = useCallback(
     (selected: Model | undefined) => {
-      if (!selected) return
-      void setTopicNamingModelId(selected.id)
+      void setTopicNamingModelId(selected?.id ?? null)
     },
     [setTopicNamingModelId]
   )
@@ -66,7 +65,13 @@ export const TopicNamingSettings = () => {
               providers={providers}
               filter={chatModelFilter}
               onSelect={handleSelectModel}
-              placeholder={t('settings.models.empty')}
+              noneOptionLabel={t('settings.models.topic_naming.follow_quick')}
+              noneOptionIcon={<Rocket className="size-3.5" />}
+              placeholder={
+                topicNamingModelId === null
+                  ? t('settings.models.topic_naming.follow_quick')
+                  : t('settings.models.empty')
+              }
             />
           </div>
         </RowFlex>

--- a/src/renderer/pages/settings/ModelSettings/__tests__/TopicNamingSettings.test.tsx
+++ b/src/renderer/pages/settings/ModelSettings/__tests__/TopicNamingSettings.test.tsx
@@ -1,0 +1,106 @@
+import type { Model } from '@shared/data/types/model'
+import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const explicitModel = {
+  id: 'openai::gpt-4o-mini',
+  providerId: 'openai',
+  name: 'GPT-4o Mini',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+} satisfies Model
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('@renderer/hooks/useModel', () => ({
+  useModelById: (id: string | null) => ({ model: id === explicitModel.id ? explicitModel : undefined })
+}))
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviders: () => ({ providers: [] })
+}))
+
+vi.mock('@renderer/components/icons/ResetIcon', () => ({
+  default: () => null
+}))
+
+vi.mock('@renderer/components/SettingsPrimitives', () => ({
+  SettingSubtitle: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, type = 'button', ...props }: ComponentProps<'button'>) => (
+    <button type={type} {...props}>
+      {children}
+    </button>
+  ),
+  ColFlex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Divider: () => <hr />,
+  Flex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  RowFlex: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Switch: ({
+    onCheckedChange,
+    ...props
+  }: ComponentProps<'input'> & { onCheckedChange?: (checked: boolean) => void }) => (
+    <input type="checkbox" {...props} onChange={(event) => onCheckedChange?.(event.currentTarget.checked)} />
+  ),
+  Textarea: { Input: (props: ComponentProps<'textarea'>) => <textarea {...props} /> }
+}))
+
+vi.mock('../DefaultModelSelector', () => ({
+  DefaultModelSelector: ({
+    noneOptionLabel,
+    placeholder,
+    model,
+    onSelect
+  }: {
+    noneOptionLabel?: string
+    placeholder: string
+    model?: Model
+    onSelect: (model: Model | undefined) => void
+  }) =>
+    noneOptionLabel ? (
+      <>
+        <span data-testid="model-selector-trigger-label">{model?.name ?? placeholder}</span>
+        <button type="button" onClick={() => onSelect(undefined)}>
+          {noneOptionLabel}
+        </button>
+      </>
+    ) : null
+}))
+
+import { TopicNamingSettings } from '../TopicNamingSettings'
+
+describe('TopicNamingSettings', () => {
+  beforeEach(() => {
+    MockUsePreferenceUtils.resetMocks()
+    MockUsePreferenceUtils.setPreferenceValue('topic.naming.model_id', explicitModel.id)
+  })
+
+  it('lets the user make topic naming follow the quick model', async () => {
+    render(<TopicNamingSettings />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'settings.models.topic_naming.follow_quick' }))
+
+    await waitFor(() => expect(MockUsePreferenceUtils.getPreferenceValue('topic.naming.model_id')).toBeNull())
+  })
+
+  it('shows follow quick model in the selector when it is selected', () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.naming.model_id', null)
+
+    render(<TopicNamingSettings />)
+
+    expect(screen.getByTestId('model-selector-trigger-label')).toHaveTextContent(
+      'settings.models.topic_naming.follow_quick'
+    )
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

Fresh installations persisted CherryAI as the dedicated topic-naming model. Choosing another quick model during onboarding did not update that preference, so automatic naming could still call an unconfigured CherryAI model and report a naming failure.

After this PR:

Fresh installations leave the dedicated naming model unset. An unset naming model follows the quick model, then falls back to the default chat model, and skips AI naming when no valid candidate exists. Settings expose an explicit "Follow Quick Model" option with a rocket icon while preserving dedicated model overrides.

Fixes #18088

### Why we need it and why it was done in this way

The naming-model preference should represent only an explicit user override. Inheritance is resolved at use time so changing the quick model immediately affects topic naming without synchronizing duplicate preference values.

The following tradeoffs were made:

- Candidate resolution only validates model IDs, model/provider existence, and excludes external-CLI-only providers. Authentication, network, and generation failures remain visible instead of silently retrying another provider.
- Existing explicit naming-model preferences are preserved; only fresh default seeding changes.

The following alternatives were considered:

- Copying the quick-model ID into the naming preference during onboarding. This would persist inherited state as an explicit override and become stale after later quick-model changes.
- Adding provider-specific credential and login readiness checks. This would duplicate request-layer behavior and add complexity beyond the initialization bug.

Links to places where the discussion took place: #18088

### Breaking changes

None.

### Special notes for your reviewer

- Focused tests: 63 passed (41 topic-naming service, 15 model selector, 2 topic-naming settings, and 5 CherryAI seeder tests).
- `pnpm typecheck:web`
- `pnpm typecheck:node`
- Biome checks for all changed files
- `pnpm i18n:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Topic naming now follows the configured quick model by default on fresh installations. Users can select a dedicated naming model at any time; action required: none.
```
