### PR TITLE
fix(import): import API-style Claude exports without silent message loss

### DIFF
--- a/src/renderer/services/import/importers/AnthropicImporter.ts
+++ b/src/renderer/services/import/importers/AnthropicImporter.ts
@@ -1,11 +1,23 @@
 import { loggerService } from '@logger'
 import i18n from '@renderer/i18n/resolver'
-import type { DynamicToolUIPart, ReasoningUIPart } from '@shared/data/types/message'
+import type { DynamicToolUIPart, ModelSnapshot, ReasoningUIPart } from '@shared/data/types/message'
 import { withCherryMeta } from '@shared/data/types/uiParts'
 
 import type { ConversationImporter, ImportConversation, ImportMessageNode, ImportResult } from '../types'
 
 const logger = loggerService.withContext('AnthropicImporter')
+
+/**
+ * Fallback model tagged onto assistant messages when the export carries no
+ * usable model id, purely so the Claude logo renders.
+ * Mirrors ChatgptImporter's hard-coded gpt-5 default.
+ */
+const DEFAULT_MODEL: ModelSnapshot = {
+  id: 'claude-sonnet-4-6',
+  provider: 'anthropic',
+  name: 'Claude Sonnet 4.6',
+  group: 'Claude 4.6'
+}
 
 interface AnthropicToolResultContent {
   text: string
@@ -13,7 +25,7 @@ interface AnthropicToolResultContent {
 
 interface AnthropicTextBlock {
   type: 'text'
-  text: string
+  text?: string
 }
 
 interface AnthropicThinkingBlock {
@@ -51,8 +63,8 @@ type AnthropicContentBlock =
 interface AnthropicMessage {
   uuid: string
   parent_message_uuid?: string | null
-  text: string
-  content: AnthropicContentBlock[]
+  text?: string
+  content?: AnthropicContentBlock[]
   sender: 'human' | 'assistant'
 }
 
@@ -61,27 +73,48 @@ interface AnthropicConversation {
   name: string
   summary: string
   created_at: string
+  model?: string | null
+  current_leaf_message_uuid?: string | null
   chat_messages: AnthropicMessage[]
 }
 
 /**
  * Anthropic Claude conversation importer
- * Handles importing conversations from Claude's conversations.json export format
+ * Handles importing conversations from Claude's conversations.json export format,
+ * as well as the raw claude.ai API responses that browser-extension exporters dump
+ * (a single conversation object, empty flattened `text`, and a real model id).
  */
 export class AnthropicImporter implements ConversationImporter {
   readonly name = 'Claude'
   readonly emoji = '🍒'
 
   /**
-   * Validate if the file content is a valid Anthropic Claude export
+   * Validate if the file content is a valid Anthropic Claude export.
+   * The official conversations.json holds an array of conversations, while
+   * browser-extension exporters dump a single conversation object.
    */
   validate(fileContent: string): boolean {
     try {
       const parsed = JSON.parse(fileContent)
+      const conversations = Array.isArray(parsed) ? parsed : [parsed]
       return (
-        Array.isArray(parsed) &&
-        parsed.length > 0 &&
-        parsed.every(({ uuid, created_at, chat_messages }) => uuid && created_at && Array.isArray(chat_messages))
+        conversations.length > 0 &&
+        conversations.every(
+          (conversation) =>
+            conversation &&
+            typeof conversation === 'object' &&
+            conversation.uuid &&
+            conversation.created_at &&
+            Array.isArray(conversation.chat_messages) &&
+            // Fingerprint the messages themselves so unrelated JSON that happens to
+            // carry these three field names is not claimed by this importer.
+            conversation.chat_messages.every(
+              (message: { uuid?: unknown; sender?: unknown }) =>
+                message &&
+                typeof message.uuid === 'string' &&
+                (message.sender === 'human' || message.sender === 'assistant')
+            )
+        )
       )
     } catch {
       return false
@@ -94,7 +127,8 @@ export class AnthropicImporter implements ConversationImporter {
   async parse(fileContent: string): Promise<ImportResult> {
     logger.info('Starting Anthropic Claude import...')
 
-    const conversations = JSON.parse(fileContent) as AnthropicConversation[]
+    const parsed = JSON.parse(fileContent)
+    const conversations = (Array.isArray(parsed) ? parsed : [parsed]) as AnthropicConversation[]
 
     if (conversations.length === 0) {
       throw new Error(i18n.t('import.claude.error.no_conversations'))
@@ -123,12 +157,19 @@ export class AnthropicImporter implements ConversationImporter {
   }
 
   /**
-   * Check if a message has any usable content (text, thinking, or tool calls)
+   * Check if a message has any usable content (text, thinking, or tool calls).
+   * API-style exports always leave the flattened `text` empty, so text content
+   * blocks have to count on their own.
    */
   private hasUsableContent(message: AnthropicMessage): boolean {
     return (
-      message.text.trim().length > 0 ||
-      message.content.some((block) => block.type === 'tool_use' || block.type === 'thinking')
+      (message.text ?? '').trim().length > 0 ||
+      (message.content ?? []).some(
+        (block) =>
+          block.type === 'tool_use' ||
+          block.type === 'thinking' ||
+          (block.type === 'text' && (block.text ?? '').trim().length > 0)
+      )
     )
   }
 
@@ -140,13 +181,69 @@ export class AnthropicImporter implements ConversationImporter {
   }
 
   /**
+   * Split a Claude model id into family and version, handling both naming
+   * schemes: `claude-3-5-sonnet-20241022` and `claude-sonnet-4-5-20250929`.
+   * Returns an empty result for ids that match neither.
+   */
+  private parseModelId(modelId: string): {
+    family?: string
+    version?: string
+    ordering?: 'version-first' | 'family-first'
+  } {
+    // Drop the provider prefix, any deployment suffix, and the trailing release date
+    const base = modelId
+      .toLowerCase()
+      .trim()
+      .replace(/^anthropic[/.:]/, '')
+      .split('@')[0]
+      .split(':')[0]
+      .replace(/-\d{8}$/, '')
+
+    const versionFirst = base.match(/^claude-(\d+(?:[.-]\d+)?)-(opus|sonnet|haiku)/)
+    if (versionFirst) {
+      return { version: versionFirst[1].replace('-', '.'), family: versionFirst[2], ordering: 'version-first' }
+    }
+
+    const familyFirst = base.match(/^claude-(opus|sonnet|haiku)-(\d+(?:[.-]\d+)?)/)
+    if (familyFirst) {
+      return { version: familyFirst[2].replace('-', '.'), family: familyFirst[1], ordering: 'family-first' }
+    }
+
+    return {}
+  }
+
+  /**
+   * Turn a raw claude.ai model id into a model snapshot. Unrecognised ids keep the
+   * raw string as their display name so nothing is silently lost.
+   */
+  private toModelSnapshot(modelId: string): ModelSnapshot {
+    const { family, version, ordering } = this.parseModelId(modelId)
+
+    if (!family || !version) {
+      return { id: modelId, provider: 'anthropic', name: modelId, group: 'Claude' }
+    }
+
+    const familyLabel = family.charAt(0).toUpperCase() + family.slice(1)
+    return {
+      id: modelId,
+      provider: 'anthropic',
+      name: ordering === 'version-first' ? `Claude ${version} ${familyLabel}` : `Claude ${familyLabel} ${version}`,
+      group: `Claude ${version}`
+    }
+  }
+
+  /**
    * Create a v2 import message from an Anthropic message.
    * Handles text, thinking, tool_use, and tool_result content blocks.
    */
-  private createMessage(anthropicMessage: AnthropicMessage, parentSourceId?: string): ImportMessageNode {
+  private createMessage(
+    anthropicMessage: AnthropicMessage,
+    model: ModelSnapshot,
+    parentSourceId?: string
+  ): ImportMessageNode {
     const role = anthropicMessage.sender === 'human' ? 'user' : 'assistant'
     const parts: ImportMessageNode['parts'] = []
-    const contentBlocks = anthropicMessage.content
+    const contentBlocks = anthropicMessage.content ?? []
 
     // Index tool_result blocks by their tool_use_id for O(1) lookup
     const toolResultMap = new Map<string, AnthropicToolResultBlock>()
@@ -166,7 +263,7 @@ export class AnthropicImporter implements ConversationImporter {
     for (const contentBlock of contentBlocks) {
       switch (contentBlock.type) {
         case 'text': {
-          const content = contentBlock.text.trim()
+          const content = (contentBlock.text ?? '').trim()
           if (!content) break
 
           parts.push({ type: 'text', text: content })
@@ -218,7 +315,7 @@ export class AnthropicImporter implements ConversationImporter {
       }
     }
 
-    const messageText = anthropicMessage.text.trim()
+    const messageText = (anthropicMessage.text ?? '').trim()
     if (!hasTextBlock && messageText) {
       parts.push({ type: 'text', text: messageText })
     }
@@ -228,18 +325,11 @@ export class AnthropicImporter implements ConversationImporter {
       ...(parentSourceId ? { parentSourceId } : {}),
       role,
       parts,
-      // Anthropic's conversations.json export carries no per-message model field
-      // (chat_messages only expose uuid/text/content/sender/timestamps/attachments/files),
-      // so assistant messages are tagged with a default Claude model purely so the
-      // Claude logo renders. Mirrors ChatgptImporter's hard-coded gpt-5 default.
-      ...(role === 'assistant' && {
-        model: {
-          id: 'claude-sonnet-4-6',
-          provider: 'anthropic',
-          name: 'Claude Sonnet 4.6',
-          group: 'Claude 4.6'
-        }
-      })
+      // Neither export shape carries a per-message model field (chat_messages only
+      // expose uuid/text/content/sender/timestamps/attachments/files), so every
+      // assistant message in a conversation shares the conversation-level model —
+      // the real id when the export records one, the default Claude model otherwise.
+      ...(role === 'assistant' && { model })
     }
   }
 
@@ -261,20 +351,33 @@ export class AnthropicImporter implements ConversationImporter {
 
     const messagesById = new Map(conversation.chat_messages.map((message) => [message.uuid, message]))
     const usableMessageIds = new Set(usableMessages.map((message) => message.uuid))
-    const resolveParentSourceId = (message: AnthropicMessage): string | undefined => {
-      let parentSourceId = message.parent_message_uuid ?? undefined
-      while (parentSourceId && !usableMessageIds.has(parentSourceId)) {
-        parentSourceId = messagesById.get(parentSourceId)?.parent_message_uuid ?? undefined
+    // Walk up the parent chain until an imported message is reached, so filtered-out
+    // messages (and the export's root sentinel) never leak into the imported tree.
+    // The visited set keeps cyclic parent pointers in malformed exports from hanging.
+    const resolveUsableSourceId = (sourceId: string | null | undefined): string | undefined => {
+      const visited = new Set<string>()
+      let candidate = sourceId ?? undefined
+      while (candidate && !usableMessageIds.has(candidate)) {
+        if (visited.has(candidate)) return undefined
+        visited.add(candidate)
+        candidate = messagesById.get(candidate)?.parent_message_uuid ?? undefined
       }
-      return parentSourceId
+      return candidate
     }
 
-    const messages = usableMessages.map((message) => this.createMessage(message, resolveParentSourceId(message)))
+    const modelId = typeof conversation.model === 'string' ? conversation.model.trim() : ''
+    const model = modelId ? this.toModelSnapshot(modelId) : DEFAULT_MODEL
+
+    const messages = usableMessages.map((message) =>
+      this.createMessage(message, model, resolveUsableSourceId(message.parent_message_uuid))
+    )
 
     return {
       name,
       messages,
-      activeSourceId: messages.at(-1)?.sourceId
+      // API-style exports name the active branch leaf, which is not always the last
+      // exported message; fall back to export order when it is missing or unusable.
+      activeSourceId: resolveUsableSourceId(conversation.current_leaf_message_uuid) ?? messages.at(-1)?.sourceId
     }
   }
 }

--- a/src/renderer/services/import/importers/__tests__/AnthropicImporter.test.ts
+++ b/src/renderer/services/import/importers/__tests__/AnthropicImporter.test.ts
@@ -26,6 +26,46 @@ const conversation = (overrides = {}) => ({
   ...overrides
 })
 
+// The claude.ai API response that browser-extension exporters dump: a single
+// conversation object whose messages always leave the flattened `text` empty.
+const ROOT_SENTINEL = '00000000-0000-4000-8000-000000000000'
+
+const apiMessage = (sender: 'human' | 'assistant', uuid: string, text: string, overrides = {}) => ({
+  uuid,
+  text: '',
+  content: [{ type: 'text', text }],
+  sender,
+  index: 0,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:01.000Z',
+  truncated: false,
+  attachments: [],
+  files: [],
+  files_v2: [],
+  sync_sources: [],
+  parent_message_uuid: ROOT_SENTINEL,
+  ...overrides
+})
+
+const apiConversation = (overrides = {}) => ({
+  uuid: 'api-conv-1',
+  name: 'API Export Chat',
+  summary: '',
+  model: 'claude-sonnet-4-5-20250929',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:01:00.000Z',
+  settings: {},
+  is_starred: false,
+  is_temporary: false,
+  platform: 'web',
+  current_leaf_message_uuid: 'api-assistant-1',
+  chat_messages: [
+    apiMessage('human', 'api-user-1', 'What is the capital of France?'),
+    apiMessage('assistant', 'api-assistant-1', 'Paris.', { parent_message_uuid: 'api-user-1' })
+  ],
+  ...overrides
+})
+
 describe('AnthropicImporter', () => {
   let importer: AnthropicImporter
 
@@ -45,8 +85,28 @@ describe('AnthropicImporter', () => {
       expect(importer.validate(JSON.stringify([conversation()]))).toBe(true)
     })
 
-    it('rejects a conversation object that is not in the exported array format', () => {
-      expect(importer.validate(JSON.stringify(conversation()))).toBe(false)
+    it('accepts a single conversation object, as browser-extension exporters emit', () => {
+      expect(importer.validate(JSON.stringify(conversation()))).toBe(true)
+      expect(importer.validate(JSON.stringify(apiConversation()))).toBe(true)
+    })
+
+    it('rejects single objects that are not Claude conversations', () => {
+      expect(importer.validate(JSON.stringify({ title: 'ChatGPT chat', create_time: 1, mapping: {} }))).toBe(false)
+      expect(importer.validate(JSON.stringify({ uuid: 'x', created_at: 'now' }))).toBe(false)
+      expect(importer.validate(JSON.stringify({ hello: 'world' }))).toBe(false)
+      expect(importer.validate('null')).toBe(false)
+      expect(importer.validate('42')).toBe(false)
+      expect(importer.validate('"a string"')).toBe(false)
+    })
+
+    it('rejects unrelated JSON whose chat_messages entries are not Claude messages', () => {
+      const lookalike = {
+        uuid: 'batch-7',
+        created_at: '2026-01-01T00:00:00.000Z',
+        chat_messages: [{ id: 1, body: 'not a claude message' }]
+      }
+      expect(importer.validate(JSON.stringify(lookalike))).toBe(false)
+      expect(importer.validate(JSON.stringify([lookalike]))).toBe(false)
     })
 
     it('rejects the ChatGPT export format', () => {
@@ -293,6 +353,201 @@ describe('AnthropicImporter', () => {
       await expect(importer.parse(JSON.stringify([empty]))).rejects.toThrow(
         'import.claude.error.no_valid_conversations'
       )
+    })
+  })
+
+  describe('parse (API-style exports)', () => {
+    it('imports messages whose text lives only in content blocks', async () => {
+      const result = await importer.parse(JSON.stringify(apiConversation()))
+
+      const importedConversation = result.conversations[0]
+      expect(importedConversation.name).toBe('API Export Chat')
+      expect(importedConversation.messages).toHaveLength(2)
+
+      const [userMessage, assistantMessage] = importedConversation.messages
+      expect(userMessage.role).toBe('user')
+      expect(userMessage.parts).toEqual([{ type: 'text', text: 'What is the capital of France?' }])
+      expect(assistantMessage.role).toBe('assistant')
+      expect(assistantMessage.parts).toEqual([{ type: 'text', text: 'Paris.' }])
+    })
+
+    it('parses the array form of an API-style export', async () => {
+      const result = await importer.parse(JSON.stringify([apiConversation(), apiConversation({ uuid: 'api-conv-2' })]))
+      expect(result.conversations).toHaveLength(2)
+      expect(result.conversations[0].messages).toHaveLength(2)
+    })
+
+    it('tolerates messages missing the text and content fields', async () => {
+      const result = await importer.parse(
+        JSON.stringify(
+          apiConversation({
+            current_leaf_message_uuid: undefined,
+            chat_messages: [
+              apiMessage('human', 'q1', 'What is the capital of France?'),
+              { uuid: 'partial', sender: 'assistant', parent_message_uuid: 'q1' }
+            ]
+          })
+        )
+      )
+
+      expect(result.conversations[0].messages.map((message) => message.sourceId)).toEqual(['q1'])
+    })
+
+    it('keeps tool-only turns with an omitted text key and skips text blocks missing their text', async () => {
+      const result = await importer.parse(
+        JSON.stringify(
+          apiConversation({
+            current_leaf_message_uuid: undefined,
+            chat_messages: [
+              apiMessage('human', 'q1', 'What is the capital of France?'),
+              {
+                uuid: 'tool-turn',
+                sender: 'assistant',
+                parent_message_uuid: 'q1',
+                content: [
+                  { type: 'text' }, // malformed block without a text property
+                  { type: 'tool_use', id: 'call-1', name: 'lookup', input: { q: 'capital' } }
+                ]
+              }
+            ]
+          })
+        )
+      )
+
+      const messages = result.conversations[0].messages
+      expect(messages.map((message) => message.sourceId)).toEqual(['q1', 'tool-turn'])
+      expect(messages[1].parts).toEqual([
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'call-1',
+          toolName: 'lookup',
+          input: { q: 'capital' },
+          state: 'input-available'
+        }
+      ])
+    })
+
+    it('honors current_leaf_message_uuid when the active leaf is not the last exported message', async () => {
+      const result = await importer.parse(
+        JSON.stringify(
+          apiConversation({
+            current_leaf_message_uuid: 'reply-a',
+            chat_messages: [
+              apiMessage('human', 'q1', 'What is the capital of France?'),
+              apiMessage('assistant', 'reply-a', 'Paris.', { parent_message_uuid: 'q1' }),
+              apiMessage('assistant', 'reply-b', 'The capital is Paris.', { parent_message_uuid: 'q1' })
+            ]
+          })
+        )
+      )
+
+      const importedConversation = result.conversations[0]
+      expect(importedConversation.activeSourceId).toBe('reply-a')
+      // The root sentinel is not an exported message, so it resolves to no parent
+      expect(
+        importedConversation.messages.map(({ sourceId, parentSourceId }) => ({ sourceId, parentSourceId }))
+      ).toEqual([
+        { sourceId: 'q1', parentSourceId: undefined },
+        { sourceId: 'reply-a', parentSourceId: 'q1' },
+        { sourceId: 'reply-b', parentSourceId: 'q1' }
+      ])
+    })
+
+    it('walks up to the nearest usable ancestor when the active leaf was filtered out', async () => {
+      const result = await importer.parse(
+        JSON.stringify(
+          apiConversation({
+            current_leaf_message_uuid: 'empty-leaf',
+            chat_messages: [
+              apiMessage('human', 'q1', 'What is the capital of France?'),
+              apiMessage('assistant', 'a1', 'Paris.', { parent_message_uuid: 'q1' }),
+              apiMessage('human', 'empty-leaf', '   ', { parent_message_uuid: 'a1' })
+            ]
+          })
+        )
+      )
+
+      expect(result.conversations[0].messages.map((message) => message.sourceId)).toEqual(['q1', 'a1'])
+      expect(result.conversations[0].activeSourceId).toBe('a1')
+    })
+
+    it('survives cyclic parent pointers in malformed exports instead of hanging', async () => {
+      const result = await importer.parse(
+        JSON.stringify(
+          apiConversation({
+            current_leaf_message_uuid: 'cycle-a',
+            chat_messages: [
+              apiMessage('human', 'cycle-a', '   ', { parent_message_uuid: 'cycle-b' }),
+              apiMessage('assistant', 'cycle-b', '   ', { parent_message_uuid: 'cycle-a' }),
+              apiMessage('human', 'q1', 'What is the capital of France?', { parent_message_uuid: 'cycle-a' }),
+              apiMessage('assistant', 'a1', 'Paris.', { parent_message_uuid: 'q1' })
+            ]
+          })
+        )
+      )
+
+      const conversation = result.conversations[0]
+      expect(conversation.messages.map((message) => message.sourceId)).toEqual(['q1', 'a1'])
+      // q1's parent chain enters the cycle and resolves to a root, not a dangling id
+      expect(conversation.messages[0].parentSourceId).toBeUndefined()
+      // the leaf pointer into the cycle falls back to export order
+      expect(conversation.activeSourceId).toBe('a1')
+    })
+
+    it('falls back to the last exported message for missing or unknown leaf pointers', async () => {
+      const withoutPointer = await importer.parse(
+        JSON.stringify(apiConversation({ current_leaf_message_uuid: undefined }))
+      )
+      expect(withoutPointer.conversations[0].activeSourceId).toBe('api-assistant-1')
+
+      const danglingPointer = await importer.parse(
+        JSON.stringify(apiConversation({ current_leaf_message_uuid: 'not-in-this-export' }))
+      )
+      expect(danglingPointer.conversations[0].activeSourceId).toBe('api-assistant-1')
+    })
+
+    it.each([
+      ['claude-3-5-sonnet-20241022', 'Claude 3.5 Sonnet', 'Claude 3.5'],
+      ['claude-3-opus-20240229', 'Claude 3 Opus', 'Claude 3'],
+      ['claude-opus-4-1-20250805', 'Claude Opus 4.1', 'Claude 4.1'],
+      ['claude-sonnet-4-5-20250929', 'Claude Sonnet 4.5', 'Claude 4.5'],
+      ['claude-3-5-haiku-latest', 'Claude 3.5 Haiku', 'Claude 3.5'],
+      ['claude-next-9000', 'claude-next-9000', 'Claude']
+    ])('preserves the exported model id %s', async (model, name, group) => {
+      const result = await importer.parse(JSON.stringify(apiConversation({ model })))
+
+      expect(result.conversations[0].messages[1].model).toEqual({ id: model, provider: 'anthropic', name, group })
+      expect(result.conversations[0].messages[0].model).toBeUndefined()
+    })
+
+    it('falls back to the default model when the export carries no model id', async () => {
+      const defaultModel = {
+        id: 'claude-sonnet-4-6',
+        provider: 'anthropic',
+        name: 'Claude Sonnet 4.6',
+        group: 'Claude 4.6'
+      }
+
+      const nullModel = await importer.parse(JSON.stringify(apiConversation({ model: null })))
+      expect(nullModel.conversations[0].messages[1].model).toEqual(defaultModel)
+
+      const blankModel = await importer.parse(JSON.stringify(apiConversation({ model: '   ' })))
+      expect(blankModel.conversations[0].messages[1].model).toEqual(defaultModel)
+    })
+
+    it('keeps the default model for official exports, which have no model field', async () => {
+      const official = conversation()
+      expect('model' in official).toBe(false)
+
+      const result = await importer.parse(JSON.stringify([official]))
+
+      expect(result.conversations[0].messages[1].model).toEqual({
+        id: 'claude-sonnet-4-6',
+        provider: 'anthropic',
+        name: 'Claude Sonnet 4.6',
+        group: 'Claude 4.6'
+      })
+      expect(result.conversations[0].messages[1].parts).toEqual([{ type: 'text', text: 'Hi there' }])
     })
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

- **Silent user-message loss**: `hasUsableContent()` in `AnthropicImporter` only checks the flattened `text` field and `thinking`/`tool_use` blocks — never `text` content blocks. Any message whose text lives only in `content[]` is dropped. In API-style Claude exports (the raw claude.ai API response saved by browser-extension exporters such as [Claude-Conversation-Exporter](https://github.com/socketteer/Claude-Conversation-Exporter)), the flattened `text` is *always* empty, so **every human turn is discarded while assistant turns survive** — the import appears to succeed and the user has no way to notice the loss.
- **Format rejection**: those exports are a single conversation object, so `validate()` (which requires a top-level array) reports "Unsupported file format"; users who array-wrap the file by hand then hit the message loss above.
- **Metadata discarded**: these exports carry data the official export lacks — the conversation's real `model` id, the complete branch tree (the extension fetches `?tree=True`), and the `current_leaf_message_uuid` active-branch pointer — none of it usable today.

After this PR:

- Both export shapes import through the same importer:
  - `validate()`/`parse()` accept the single-object form, with a fingerprint check on `chat_messages` entries (`uuid` + `human|assistant` sender) so unrelated JSON is not claimed.
  - Text content blocks count as usable content; `text`/`content` field access is guarded for messages that omit them.
  - `model`, when present, becomes the real `ModelSnapshot` (e.g. `claude-3-5-sonnet-20241022` → "Claude 3.5 Sonnet") instead of the placeholder; unrecognized ids keep the raw id as display name; absent/null keeps the existing default.
  - `current_leaf_message_uuid`, when present, selects `activeSourceId`, walking up to the nearest usable ancestor if the leaf was filtered.
  - The shared parent-chain walk gains a cycle guard so malformed exports cannot hang the renderer.
- Official-export behavior is unchanged (regression-tested; official exports never carry these fields/shapes).

Fixes # N/A (follow-up to #16164)

### Why we need it and why it was done in this way

Users export with these extensions because the official export cannot provide the model that each conversation used (including models no longer on claude.ai) or an instant per-conversation download. #16164 noted this exact gap — the code comment reads "the export carries no per-message model field … so assistant messages are tagged with a default Claude model purely so the Claude logo renders." For the extension format that limitation is not inherent: the model id is right there in the file, and the v2 import contract already supports it (`ImportMessageNode.model` → `messageSnapshot`), so this PR feeds it real data. The full-tree branch persistence from #16164 likewise already handles the branched trees these exports contain.

The following tradeoffs were made:

- **Extend `AnthropicImporter` instead of adding a second importer** — the registry is keyed by importer name, the two shapes overlap in auto-detection, and a separate importer would duplicate ~90% of the parsing for four optional-field deltas.
- **Model is conversation-level and best-effort** — neither export shape records per-message models, so a mid-conversation model switch shows one model throughout, and claude.ai returns `model: null` for some conversations (these keep the existing default). Labels reflect what the data actually contains, no more.
- **Scope kept to this importer** — pre-existing quirks elsewhere in the import subsystem (e.g. `ChatgptImporter.validate('[]')` returning true) are left for a separate issue.

The following alternatives were considered:

- A separate importer for extension exports — rejected for the reasons above.
- Importing branches as separate topics (the approach of pre-v2 PR #12506, closed) — obsolete; the v2 message tree is strictly better.

Links to places where the discussion took place: #16164, #12506

### Breaking changes

None.

### Special notes for your reviewer

- This is a direct follow-up to @Pleasurecruise's #16164 and stays entirely within the importer it introduced — no changes to `ImportService`, the `ImportMessageNode` contract, or the UI.
- Claude.ai is not reachable in some regions, so the test fixtures are synthetic; their shapes were taken from real extension exports. A minimal redacted example of the shape this PR adds support for:

  <details>
  <summary>Redacted API-style export (what the extension saves)</summary>

  ```jsonc
  {
    "uuid": "f1e2d3c4-…",
    "name": "Example conversation",
    "model": "claude-3-5-sonnet-20241022",          // real model id — the official export has no model field
    "created_at": "2025-01-15T10:00:00.000000Z",
    "current_leaf_message_uuid": "b2c3d4e5-…",       // the branch the user last had active
    "chat_messages": [
      {
        "uuid": "a1b2c3d4-…",
        "parent_message_uuid": "00000000-0000-4000-8000-000000000000",  // root sentinel
        "sender": "human",
        "text": "",                                   // always empty in this shape —
        "content": [{ "type": "text", "text": "…" }]  // real text lives in content blocks
      },
      {
        "uuid": "b2c3d4e5-…",
        "parent_message_uuid": "a1b2c3d4-…",          // multiple children of one parent = branches
        "sender": "assistant",
        "text": "",
        "content": [
          { "type": "thinking", "thinking": "…", "start_timestamp": "…", "stop_timestamp": "…" },
          { "type": "text", "text": "…" },
          { "type": "tool_use", "id": "toolu_…", "name": "…", "input": {} },
          { "type": "tool_result", "content": [{ "type": "text", "text": "…", "uuid": "…" }], "is_error": false }
        ]
      }
    ]
  }
  ```

  </details>

- The change was additionally checked locally against a personal corpus of ~2,200 real exports (all imported without message loss) — that corpus is private, so this claim is stated once here and not offered as reviewable evidence.
- One existing test was replaced: `validate > rejects a conversation object that is not in the exported array format` asserted the array-only restriction this PR lifts, so the two could not both hold. Its replacement asserts single-object acceptance plus rejection of non-Claude single objects. All other pre-existing tests pass unchanged.
- `resolveParentSourceId` was generalized to `resolveUsableSourceId` (same upward walk, now also used for the leaf pointer, plus the cycle guard) — this function is on the shared path for both export shapes, which is why the regression suite matters here.
- Test totals: 36 importer tests (18 pre-existing + 18 new/updated) + 5 ImportService + 3 ChatGPT importer, all passing; `tsgo`, biome, oxlint, eslint clean on touched files.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required — not required (extends the existing import entry point; no new UI)
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Claude conversation import now also accepts API-style exports from browser-extension exporters, preserving each conversation's model information and active branch.
```
