### PR TITLE
fix(notes): align sidebar note icons

### DIFF
--- a/src/renderer/pages/notes/NotesSidebar.tsx
+++ b/src/renderer/pages/notes/NotesSidebar.tsx
@@ -4,7 +4,7 @@ import { useActiveNode } from '@renderer/hooks/useNotesQuery'
 import NotesSidebarHeader from '@renderer/pages/notes/NotesSidebarHeader'
 import { findNode } from '@renderer/services/NotesTreeService'
 import type { NotesSortType, NotesTreeNode } from '@renderer/types/note'
-import { FilePlus, Folder, FolderUp, Loader2, Upload, X } from 'lucide-react'
+import { FilePlus, FileText, Folder, FolderUp, Loader2, Upload, X } from 'lucide-react'
 import type { FC } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -30,6 +30,8 @@ interface NotesSidebarProps {
   sortType: NotesSortType
   selectedFolderId?: string | null
 }
+
+const renderNoteFileIcon = () => <FileText size={16} className="shrink-0" />
 
 const collectExpandedIds = (nodes: NotesTreeNode[], result: Set<string>): Set<string> => {
   for (const node of nodes) {
@@ -382,6 +384,7 @@ const NotesSidebar: FC<NotesSidebarProps> = ({
                 selectedId={selectedId}
                 onSelectedChange={handleFileTreeSelectedChange}
                 onMove={handleMove}
+                fileIcon={renderNoteFileIcon}
                 renameSlot={renameSlot}
                 animationSlot={animationSlot}
                 renderRowExtras={renderRowExtras}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Note rows in the Notes sidebar inherited the shared file tree's Material Icon Theme document icon, which used a fixed blue fill that did not match the surrounding Lucide icons.

<img width="470" height="558" alt="image" src="https://github.com/user-attachments/assets/67d4a13a-f49d-4172-b222-4112d2b4197c" />

After this PR:

The Notes sidebar supplies a Lucide `FileText` icon through the existing `FileTree` icon override, while other file tree consumers retain their file-type-specific icons.

<img width="466" height="575" alt="image" src="https://github.com/user-attachments/assets/2c403625-9d7e-47d5-9607-61619bb9b430" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The note icon is part of the Notes interface and should follow the same visual language as the surrounding Notes controls. Using the existing `fileIcon` override keeps that presentation decision local to the Notes sidebar and avoids changing the shared file tree's behavior for artifact and workspace files.

The following tradeoffs were made:

- Note files use one consistent icon instead of exposing file-type-specific colors in this view.
- The shared file tree keeps its current Material Icon Theme default for consumers where file-type recognition is useful.

The following alternatives were considered:

- Changing the shared `FileTree` default was rejected because it would also alter the artifact and workspace file browser.
- Lucide `NotepadText` was compared, but `FileText` was selected as the clearer representation of an individual note row.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This is a presentation-only change scoped to Notes. It does not change note data, file handling, or the artifact file tree.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Updated note rows in the Notes sidebar to use an icon consistent with the rest of the interface.
```
