### PR TITLE
fix(mcp): close stale clients so ping failures stop orphaning child processes

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -114,6 +114,10 @@ export interface McpToolListChangedEvent {
 // still letting users raise it further via `server.timeout`.
 const MCP_CONNECT_TIMEOUT_FLOOR_MS = 180_000
 
+// Liveness ping before reusing a cached client. 1s falsely timed out on stdio servers busy
+// with a previous request, forcing needless reconnects.
+const PING_TIMEOUT_MS = 5_000
+
 // Order in which to attempt the URL-based transports for a given server. We try the
 // user-configured type first (no behavior change for correctly configured servers) and,
 // if that fails with a transport-level protocol error, retry with the other transport.
@@ -370,20 +374,19 @@ export class McpRuntimeService extends BaseService {
         // Check if the existing client is still connected
         const pingResult = await existingClient.ping({
           // add short timeout to prevent hanging
-          timeout: 1000
+          timeout: PING_TIMEOUT_MS
         })
         getServerLogger(server).debug(`Ping result`, { ok: !!pingResult })
-        // If the ping fails, remove the client from the cache
-        // and create a new one
+        // If the ping fails, close the client and create a new one
         if (!pingResult) {
-          this.clients.delete(serverKey)
+          await this.discardStaleClient(serverKey)
         } else {
           this.setServerStatus(server.id, 'connected')
           return existingClient
         }
       } catch (error: any) {
         getServerLogger(server).error(`Error pinging server ${server.name}`, error as Error)
-        this.clients.delete(serverKey)
+        await this.discardStaleClient(serverKey)
       }
     }
 
@@ -941,6 +944,19 @@ export class McpRuntimeService extends BaseService {
       if (result.status === 'rejected') {
         logger.error(`Failed to close client`, result.reason as Error)
       }
+    }
+  }
+
+  /**
+   * A client that failed its liveness ping must still be closed — dropping it from the map
+   * alone orphans the stdio child process (issue #18144).
+   */
+  private async discardStaleClient(serverKey: string): Promise<void> {
+    try {
+      await this.closeClient(serverKey)
+    } catch (error) {
+      logger.error(`Failed to close stale client`, error as Error)
+      this.clients.delete(serverKey)
     }
   }
 

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -323,6 +323,46 @@ describe('McpRuntimeService.closeClientsForServer', () => {
   })
 })
 
+describe('McpRuntimeService stale client cleanup (issue #18144)', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    MockMainCacheServiceUtils.resetMocks()
+    getByIdMock.mockReset()
+  })
+
+  const server = {
+    id: 'server-1',
+    name: 'srv',
+    command: 'python',
+    args: ['server.py'],
+    isActive: true
+  } as McpServer
+
+  it.each([
+    ['ping resolves falsy', vi.fn().mockResolvedValue(false)],
+    ['ping throws', vi.fn().mockRejectedValue(new Error('timeout'))]
+  ])('closes the dead client instead of orphaning its process when %s', async (_label, ping) => {
+    const service = new McpRuntimeService()
+    const close = vi.fn().mockResolvedValue(undefined)
+    ;(service as any).clients.set(service.getServerKey(server), { close, ping })
+
+    await (service as any).getOrCreateClient(server)
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reconnects when closing the dead client throws', async () => {
+    const service = new McpRuntimeService()
+    const close = vi.fn().mockRejectedValue(new Error('transport already gone'))
+    const ping = vi.fn().mockResolvedValue(false)
+    const key = service.getServerKey(server)
+    ;(service as any).clients.set(key, { close, ping })
+
+    await expect((service as any).getOrCreateClient(server)).resolves.toBeDefined()
+    expect((service as any).clients.get(key)?.ping).not.toBe(ping)
+  })
+})
+
 describe('MCP IPC payload validation (mcp-services-5)', () => {
   it('rejects a malformed callTool payload (missing serverId/name)', () => {
     expect(McpCallToolPayloadSchema.safeParse({}).success).toBe(false)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

### What this PR does

Before this PR: when a cached MCP client failed its liveness ping in `McpRuntimeService.getOrCreateClient`, it was removed from `this.clients` with a bare `delete` — `client.close()` never ran, so `StdioClientTransport` never terminated its child process. Every reconnect cycle leaked one more orphaned process (e.g. `python server.py`). The ping also used a 1s timeout, which falsely fires on a stdio server busy with a previous request.

After this PR: both ping-failure branches route through `closeClient()` — the same cleanup `checkMcpConnectivity` already used — via a small `discardStaleClient()` helper that falls back to a bare `delete` if `close()` itself throws, so a dead transport cannot block the reconnect. The ping timeout is raised from 1s to 5s.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18144

### Why we need it and why it was done in this way

The following tradeoffs were made: `closeClient()` also clears the server's tool/prompt/resource caches and log buffer, so a ping-triggered reconnect now drops that buffer — acceptable, since a successful connect repopulates the caches and `restartServer` already behaves this way. The `close()` failure path still force-deletes the map entry so a permanently wedged transport cannot make the server unreconnectable.

The following alternatives were considered: calling `existingClient.close()` inline at both sites — rejected, because it would duplicate the cache/log cleanup `closeClient()` already owns and leave the two paths free to drift apart again, which is exactly how this bug arose.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18144

### Breaking changes

None.

### Special notes for your reviewer

Three regression tests were added in `src/main/ai/mcp/__tests__/McpRuntimeService.test.ts` (falsy ping, throwing ping, and `close()` rejecting). They were verified to fail against the old `delete`-only code. `pnpm format`, `pnpm typecheck`, and oxlint on the changed files are clean; `vitest --project main` passes except for pre-existing chokidar/timing failures under `src/main/services/file/**` and `ReadableContentService.integration`, which this change does not touch.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix MCP stdio servers leaving orphaned child processes behind after a failed liveness ping or reconnect.
```
