### PR TITLE
ci: reduce pre-merge test runtime

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,14 +3,10 @@
 1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
 -->
 
-> ### 🚨 Branch strategy — read before opening this PR
+> ### Branch strategy
 >
-> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
->
-> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
-> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
->
-> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.
+> - Active development targets `main`.
+> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.
 
 ### What this PR does
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
               - 'vitest.config.ts'
               - 'patches/**'
 
-  repository-checks:
+  basic-checks:
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -86,7 +86,14 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
+          # The PR merge commit and its parents are enough for changeset comparison.
+          fetch-depth: ${{ github.event_name == 'pull_request' && '2' || '1' }}
+
+      - name: Prepare base reference
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git update-ref "refs/remotes/origin/$BASE_REF" "$(git rev-parse HEAD^1)"
 
       # provider-registry data/*.json are generated from src/creators + src/providers.
       # The daily catalog workflow regenerates data without source changes, so exempt only
@@ -149,17 +156,16 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: pnpm changeset status --since="origin/$BASE_REF"
 
-      - name: Format Check
-        run: pnpm format:check
-
-      - name: Builtin Knowledge Check
-        run: pnpm build:builtin-knowledge:check
-
-      - name: i18n Check
-        run: pnpm i18n:check
-
-      - name: Skills Check
-        run: pnpm skills:check
+      - name: Read-only Checks
+        run: |
+          # Share one checkout/install while keeping independent checks parallel.
+          # Do not kill sibling checks on failure so every failure is reported.
+          pnpm exec concurrently \
+            --names "Lint,Type and Hardcoded Strings,Format and Repository" \
+            --prefix-colors "blue,yellow,cyan" \
+            "pnpm test:lint" \
+            "pnpm typecheck && pnpm i18n:hardcoded:strict" \
+            "pnpm format:check && pnpm build:builtin-knowledge:check && pnpm i18n:check && pnpm skills:check"
 
       - name: DB Migrations Check
         run: |
@@ -185,100 +191,6 @@ jobs:
             git --no-pager diff -- src/shared/utils/systemProviderId.ts
             exit 1
           fi
-
-  type-check:
-    runs-on: ubuntu-latest
-    env:
-      CI: true
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v6
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".node-version"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm dependencies
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Type Check
-        run: pnpm typecheck
-
-      - name: Hardcoded Strings Check
-        run: pnpm i18n:hardcoded:strict
-
-  lint-check:
-    runs-on: ubuntu-latest
-    env:
-      CI: true
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v6
-
-      - name: Install Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: ".node-version"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Restore pnpm dependencies
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Lint Check
-        run: pnpm test:lint
-
-  basic-checks:
-    runs-on: ubuntu-latest
-    needs: [repository-checks, type-check, lint-check]
-    if: >-
-      always() &&
-      (github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.draft == false)
-    steps:
-      - name: Verify basic checks
-        env:
-          REPOSITORY_RESULT: ${{ needs.repository-checks.result }}
-          TYPE_RESULT: ${{ needs.type-check.result }}
-          LINT_RESULT: ${{ needs.lint-check.result }}
-        run: |
-          test "$REPOSITORY_RESULT" = "success"
-          test "$TYPE_RESULT" = "success"
-          test "$LINT_RESULT" = "success"
 
   main-test-shard:
     name: main-test (${{ matrix.shard }}/3)
@@ -417,7 +329,7 @@ jobs:
         run: pnpm test:scripts
 
   renderer-test-shard:
-    name: renderer-test (${{ matrix.shard }}/8)
+    name: renderer-test (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -433,7 +345,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       CI: true
 
@@ -466,7 +378,7 @@ jobs:
         run: pnpm install
 
       - name: Renderer Test
-        run: pnpm test:renderer --shard=${{ matrix.shard }}/8
+        run: pnpm test:renderer --shard=${{ matrix.shard }}/6
 
   render-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
         run: pnpm test:scripts
 
   renderer-test-shard:
-    name: renderer-test (${{ matrix.shard }}/6)
+    name: renderer-test (${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -388,7 +388,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       CI: true
 
@@ -421,7 +421,7 @@ jobs:
         run: pnpm install
 
       - name: Renderer Test
-        run: pnpm test:renderer --shard=${{ matrix.shard }}/6
+        run: pnpm test:renderer --shard=${{ matrix.shard }}/8
 
   render-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,14 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: pnpm changeset status --since="origin/$BASE_REF"
 
-      - name: Lint Check
-        run: pnpm test:lint
-
-      - name: Format Check
-        run: pnpm format:check
-
-      - name: Type Check
-        run: pnpm typecheck
+      - name: Lint, Format and Type Checks
+        run: |
+          pnpm exec concurrently \
+            --names "Lint Check,Format Check,Type Check" \
+            --prefix-colors "cyan,magenta,yellow" \
+            "pnpm test:lint" \
+            "pnpm format:check" \
+            "pnpm typecheck"
 
       - name: DB Migrations Check
         run: |
@@ -158,7 +158,8 @@ jobs:
       - name: Skills Check
         run: pnpm skills:check
 
-  general-test:
+  main-test-shard:
+    name: main-test (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -166,6 +167,10 @@ jobs:
       needs.changes.outputs.shared == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     env:
       CI: true
 
@@ -198,19 +203,38 @@ jobs:
         run: pnpm install
 
       - name: Main Process Test
-        run: pnpm test:main
+        run: pnpm test:main --shard=${{ matrix.shard }}/2
 
       - name: AI Core Test
+        if: matrix.shard == 1
         run: pnpm test:aicore
 
       - name: Shared Package Test
+        if: matrix.shard == 1
         run: pnpm test:shared
 
       - name: Provider Registry Package Test
+        if: matrix.shard == 1
         run: pnpm test:provider-registry
 
       - name: Scripts Test
+        if: matrix.shard == 1
         run: pnpm test:scripts
+
+  general-test:
+    runs-on: ubuntu-latest
+    needs: [changes, main-test-shard]
+    if: >-
+      always() &&
+      (needs.changes.outputs.main == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch')
+    steps:
+      - name: Verify general test shards
+        env:
+          SHARD_RESULT: ${{ needs.main-test-shard.result }}
+        run: test "$SHARD_RESULT" = "success"
 
   ui-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
               - 'vitest.config.ts'
               - 'patches/**'
 
-  basic-checks-worker:
+  repository-checks:
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -149,13 +149,17 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: pnpm changeset status --since="origin/$BASE_REF"
 
-      - name: Type and Repository Checks
-        run: |
-          pnpm exec concurrently \
-            --names "Type and Hardcoded Strings,Format and Repository Checks" \
-            --prefix-colors "yellow,cyan" \
-            "pnpm typecheck && pnpm i18n:hardcoded:strict" \
-            "pnpm format:check && pnpm build:builtin-knowledge:check && pnpm i18n:check && pnpm skills:check"
+      - name: Format Check
+        run: pnpm format:check
+
+      - name: Builtin Knowledge Check
+        run: pnpm build:builtin-knowledge:check
+
+      - name: i18n Check
+        run: pnpm i18n:check
+
+      - name: Skills Check
+        run: pnpm skills:check
 
       - name: DB Migrations Check
         run: |
@@ -181,6 +185,45 @@ jobs:
             git --no-pager diff -- src/shared/utils/systemProviderId.ts
             exit 1
           fi
+
+  type-check:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Restore pnpm dependencies
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Type Check
+        run: pnpm typecheck
+
+      - name: Hardcoded Strings Check
+        run: pnpm i18n:hardcoded:strict
 
   lint-check:
     runs-on: ubuntu-latest
@@ -220,7 +263,7 @@ jobs:
 
   basic-checks:
     runs-on: ubuntu-latest
-    needs: [basic-checks-worker, lint-check]
+    needs: [repository-checks, type-check, lint-check]
     if: >-
       always() &&
       (github.event_name == 'push' ||
@@ -229,10 +272,12 @@ jobs:
     steps:
       - name: Verify basic checks
         env:
-          BASIC_RESULT: ${{ needs.basic-checks-worker.result }}
+          REPOSITORY_RESULT: ${{ needs.repository-checks.result }}
+          TYPE_RESULT: ${{ needs.type-check.result }}
           LINT_RESULT: ${{ needs.lint-check.result }}
         run: |
-          test "$BASIC_RESULT" = "success"
+          test "$REPOSITORY_RESULT" = "success"
+          test "$TYPE_RESULT" = "success"
           test "$LINT_RESULT" = "success"
 
   main-test-shard:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
       main: ${{ steps.filter.outputs.main }}
       renderer: ${{ steps.filter.outputs.renderer }}
       shared: ${{ steps.filter.outputs.shared }}
+      ai-core: ${{ steps.filter.outputs.ai-core }}
+      ui: ${{ steps.filter.outputs.ui }}
+      provider-registry: ${{ steps.filter.outputs.provider-registry }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      extension-table-plus: ${{ steps.filter.outputs.extension-table-plus }}
+      test-infra: ${{ steps.filter.outputs.test-infra }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6
@@ -36,12 +42,33 @@ jobs:
             main:
               - 'src/main/**'
               - 'src/preload/**'
-              - 'scripts/**'
+              - 'tests/helpers/**'
+              - 'tests/main.setup.ts'
+              - 'tests/__mocks__/main/**'
+              - 'tests/__mocks__/MainLoggerService.ts'
+              - 'migrations/**'
             renderer:
               - 'src/renderer/**'
+              - 'src/preload/**'
+              - 'tests/renderer.setup.ts'
+              - 'tests/__mocks__/renderer/**'
+              - 'tests/__mocks__/RendererLoggerService.ts'
+              - 'tests/__mocks__/requestAnimationFrame.ts'
             shared:
-              - 'packages/**'
-              - 'tests/**'
+              - 'src/shared/**'
+            ai-core:
+              - 'packages/aiCore/**'
+              - 'packages/ai-sdk-provider/**'
+            ui:
+              - 'packages/ui/**'
+            provider-registry:
+              - 'packages/provider-registry/**'
+            scripts:
+              - 'scripts/**'
+            extension-table-plus:
+              - 'packages/extension-table-plus/**'
+            test-infra:
+              - '.github/workflows/ci.yml'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -112,14 +139,18 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: pnpm changeset status --since="origin/$BASE_REF"
 
-      - name: Lint, Format and Type Checks
+      - name: Read-only Checks
         run: |
           pnpm exec concurrently \
-            --names "Lint Check,Format Check,Type Check" \
-            --prefix-colors "cyan,magenta,yellow" \
+            --names "Lint Check,Format Check,Type Check,Builtin Knowledge Check,i18n Check,Hardcoded Strings Check,Skills Check" \
+            --prefix-colors "cyan,magenta,yellow,blue,green,red,white" \
             "pnpm test:lint" \
             "pnpm format:check" \
-            "pnpm typecheck"
+            "pnpm typecheck" \
+            "pnpm build:builtin-knowledge:check" \
+            "pnpm i18n:check" \
+            "pnpm i18n:hardcoded:strict" \
+            "pnpm skills:check"
 
       - name: DB Migrations Check
         run: |
@@ -146,18 +177,6 @@ jobs:
             exit 1
           fi
 
-      - name: Builtin Knowledge Check
-        run: pnpm build:builtin-knowledge:check
-
-      - name: i18n Check
-        run: pnpm i18n:check
-
-      - name: Hardcoded Strings Check
-        run: pnpm i18n:hardcoded:strict
-
-      - name: Skills Check
-        run: pnpm skills:check
-
   main-test-shard:
     name: main-test (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
@@ -165,6 +184,9 @@ jobs:
     if: >-
       needs.changes.outputs.main == 'true' ||
       needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.ai-core == 'true' ||
+      needs.changes.outputs.provider-registry == 'true' ||
+      needs.changes.outputs.test-infra == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch'
     strategy:
@@ -191,8 +213,8 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
+      - name: Restore pnpm dependencies
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -205,43 +227,39 @@ jobs:
       - name: Main Process Test
         run: pnpm test:main --shard=${{ matrix.shard }}/2
 
-      - name: AI Core Test
-        if: matrix.shard == 1
-        run: pnpm test:aicore
-
-      - name: Shared Package Test
-        if: matrix.shard == 1
-        run: pnpm test:shared
-
-      - name: Provider Registry Package Test
-        if: matrix.shard == 1
-        run: pnpm test:provider-registry
-
-      - name: Scripts Test
-        if: matrix.shard == 1
-        run: pnpm test:scripts
-
   general-test:
     runs-on: ubuntu-latest
-    needs: [changes, main-test-shard]
+    needs: [changes, main-test-shard, package-test]
     if: >-
       always() &&
       (needs.changes.outputs.main == 'true' ||
       needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.ai-core == 'true' ||
+      needs.changes.outputs.ui == 'true' ||
+      needs.changes.outputs.provider-registry == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
+      needs.changes.outputs.test-infra == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch')
     steps:
-      - name: Verify general test shards
+      - name: Verify main and package tests
         env:
-          SHARD_RESULT: ${{ needs.main-test-shard.result }}
-        run: test "$SHARD_RESULT" = "success"
+          MAIN_RESULT: ${{ needs.main-test-shard.result }}
+          PACKAGE_RESULT: ${{ needs.package-test.result }}
+        run: |
+          test "$MAIN_RESULT" = "success" || test "$MAIN_RESULT" = "skipped"
+          test "$PACKAGE_RESULT" = "success" || test "$PACKAGE_RESULT" = "skipped"
 
-  ui-test:
+  package-test:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      needs.changes.outputs.renderer == 'true' ||
       needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.ai-core == 'true' ||
+      needs.changes.outputs.ui == 'true' ||
+      needs.changes.outputs.provider-registry == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
+      needs.changes.outputs.test-infra == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch'
     env:
@@ -264,8 +282,8 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
+      - name: Restore pnpm dependencies
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -275,22 +293,44 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: AI Core Test
+        if: needs.changes.outputs.ai-core == 'true' || needs.changes.outputs.test-infra == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: pnpm test:aicore
+
       - name: UI Package Test
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.test-infra == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: pnpm test:pkg:ui
 
+      - name: Shared Package Test
+        if: needs.changes.outputs.shared == 'true' || needs.changes.outputs.provider-registry == 'true' || needs.changes.outputs.test-infra == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: pnpm test:shared
+
+      - name: Provider Registry Package Test
+        if: needs.changes.outputs.provider-registry == 'true' || needs.changes.outputs.shared == 'true' || needs.changes.outputs.test-infra == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: pnpm test:provider-registry
+
+      - name: Scripts Test
+        if: needs.changes.outputs.scripts == 'true' || needs.changes.outputs.provider-registry == 'true' || needs.changes.outputs.test-infra == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        run: pnpm test:scripts
+
   renderer-test-shard:
-    name: renderer-test (${{ matrix.shard }}/3)
+    name: renderer-test (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
       needs.changes.outputs.renderer == 'true' ||
       needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.ai-core == 'true' ||
+      needs.changes.outputs.ui == 'true' ||
+      needs.changes.outputs.provider-registry == 'true' ||
+      needs.changes.outputs.extension-table-plus == 'true' ||
+      needs.changes.outputs.test-infra == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     env:
       CI: true
 
@@ -311,8 +351,8 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
-      - name: Cache pnpm dependencies
-        uses: actions/cache@v5
+      - name: Restore pnpm dependencies
+        uses: actions/cache/restore@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -323,7 +363,7 @@ jobs:
         run: pnpm install
 
       - name: Renderer Test
-        run: pnpm test:renderer --shard=${{ matrix.shard }}/3
+        run: pnpm test:renderer --shard=${{ matrix.shard }}/4
 
   render-test:
     runs-on: ubuntu-latest
@@ -332,6 +372,11 @@ jobs:
       always() &&
       (needs.changes.outputs.renderer == 'true' ||
       needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.ai-core == 'true' ||
+      needs.changes.outputs.ui == 'true' ||
+      needs.changes.outputs.provider-registry == 'true' ||
+      needs.changes.outputs.extension-table-plus == 'true' ||
+      needs.changes.outputs.test-infra == 'true' ||
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch')
     steps:
@@ -342,8 +387,8 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: [basic-checks, general-test, ui-test, render-test]
-    if: always() && (needs.basic-checks.result == 'failure' || needs.general-test.result == 'failure' || needs.ui-test.result == 'failure' || needs.render-test.result == 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [basic-checks, general-test, package-test, render-test]
+    if: always() && (needs.basic-checks.result == 'failure' || needs.general-test.result == 'failure' || needs.package-test.result == 'failure' || needs.render-test.result == 'failure') && github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,8 +239,36 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Main Process Test
-        run: pnpm test:main --shard=${{ matrix.shard }}/3
+      - name: Main and Package Tests
+        shell: bash
+        env:
+          AI_CORE_CHANGED: ${{ needs.changes.outputs.ai-core }}
+          UI_CHANGED: ${{ needs.changes.outputs.ui }}
+          SHARED_CHANGED: ${{ needs.changes.outputs.shared }}
+          PROVIDER_REGISTRY_CHANGED: ${{ needs.changes.outputs.provider-registry }}
+          SCRIPTS_CHANGED: ${{ needs.changes.outputs.scripts }}
+          TEST_INFRA_CHANGED: ${{ needs.changes.outputs.test-infra }}
+        run: |
+          projects=(--project main)
+
+          if [[ "$AI_CORE_CHANGED" == "true" || "$TEST_INFRA_CHANGED" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            projects+=(--project aiCore)
+          fi
+          if [[ "$UI_CHANGED" == "true" || "$TEST_INFRA_CHANGED" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            projects+=(--project ui)
+          fi
+          if [[ "$SHARED_CHANGED" == "true" || "$PROVIDER_REGISTRY_CHANGED" == "true" || "$TEST_INFRA_CHANGED" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            projects+=(--project shared)
+          fi
+          if [[ "$PROVIDER_REGISTRY_CHANGED" == "true" || "$SHARED_CHANGED" == "true" || "$TEST_INFRA_CHANGED" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            projects+=(--project provider-registry)
+          fi
+          if [[ "$SCRIPTS_CHANGED" == "true" || "$PROVIDER_REGISTRY_CHANGED" == "true" || "$TEST_INFRA_CHANGED" == "true" || "${{ github.event_name }}" != "pull_request" ]]; then
+            projects+=(--project scripts)
+          fi
+
+          pnpm rebuild:node
+          pnpm exec vitest run "${projects[@]}" --shard=${{ matrix.shard }}/3
 
   general-test:
     runs-on: ubuntu-latest
@@ -269,14 +297,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      needs.changes.outputs.shared == 'true' ||
-      needs.changes.outputs.ai-core == 'true' ||
-      needs.changes.outputs.ui == 'true' ||
-      needs.changes.outputs.provider-registry == 'true' ||
-      needs.changes.outputs.scripts == 'true' ||
-      needs.changes.outputs.test-infra == 'true' ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      (needs.changes.outputs.ui == 'true' ||
+      needs.changes.outputs.scripts == 'true') &&
+      needs.changes.outputs.main != 'true' &&
+      needs.changes.outputs.shared != 'true' &&
+      needs.changes.outputs.ai-core != 'true' &&
+      needs.changes.outputs.provider-registry != 'true' &&
+      needs.changes.outputs.test-infra != 'true' &&
+      github.event_name == 'pull_request'
     env:
       CI: true
 
@@ -329,7 +357,7 @@ jobs:
         run: pnpm test:scripts
 
   renderer-test-shard:
-    name: renderer-test (${{ matrix.shard }}/6)
+    name: renderer-test (${{ matrix.shard }}/5)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -345,7 +373,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6]
+        shard: [1, 2, 3, 4, 5]
     env:
       CI: true
 
@@ -378,7 +406,7 @@ jobs:
         run: pnpm install
 
       - name: Renderer Test
-        run: pnpm test:renderer --shard=${{ matrix.shard }}/6
+        run: pnpm test:renderer --shard=${{ matrix.shard }}/5
 
   render-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
               - 'vitest.config.ts'
               - 'patches/**'
 
-  basic-checks:
+  basic-checks-worker:
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -122,7 +122,17 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
+      - name: Restore pnpm dependencies
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
       - name: Cache pnpm dependencies
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -139,18 +149,13 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: pnpm changeset status --since="origin/$BASE_REF"
 
-      - name: Read-only Checks
+      - name: Type and Repository Checks
         run: |
           pnpm exec concurrently \
-            --names "Lint Check,Format Check,Type Check,Builtin Knowledge Check,i18n Check,Hardcoded Strings Check,Skills Check" \
-            --prefix-colors "cyan,magenta,yellow,blue,green,red,white" \
-            "pnpm test:lint" \
-            "pnpm format:check" \
-            "pnpm typecheck" \
-            "pnpm build:builtin-knowledge:check" \
-            "pnpm i18n:check" \
-            "pnpm i18n:hardcoded:strict" \
-            "pnpm skills:check"
+            --names "Type and Hardcoded Strings,Format and Repository Checks" \
+            --prefix-colors "yellow,cyan" \
+            "pnpm typecheck && pnpm i18n:hardcoded:strict" \
+            "pnpm format:check && pnpm build:builtin-knowledge:check && pnpm i18n:check && pnpm skills:check"
 
       - name: DB Migrations Check
         run: |
@@ -177,8 +182,61 @@ jobs:
             exit 1
           fi
 
+  lint-check:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".node-version"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Restore pnpm dependencies
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Lint Check
+        run: pnpm test:lint
+
+  basic-checks:
+    runs-on: ubuntu-latest
+    needs: [basic-checks-worker, lint-check]
+    if: >-
+      always() &&
+      (github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.draft == false)
+    steps:
+      - name: Verify basic checks
+        env:
+          BASIC_RESULT: ${{ needs.basic-checks-worker.result }}
+          LINT_RESULT: ${{ needs.lint-check.result }}
+        run: |
+          test "$BASIC_RESULT" = "success"
+          test "$LINT_RESULT" = "success"
+
   main-test-shard:
-    name: main-test (${{ matrix.shard }}/2)
+    name: main-test (${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -192,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     env:
       CI: true
 
@@ -225,7 +283,7 @@ jobs:
         run: pnpm install
 
       - name: Main Process Test
-        run: pnpm test:main --shard=${{ matrix.shard }}/2
+        run: pnpm test:main --shard=${{ matrix.shard }}/3
 
   general-test:
     runs-on: ubuntu-latest
@@ -314,7 +372,7 @@ jobs:
         run: pnpm test:scripts
 
   renderer-test-shard:
-    name: renderer-test (${{ matrix.shard }}/4)
+    name: renderer-test (${{ matrix.shard }}/6)
     runs-on: ubuntu-latest
     needs: changes
     if: >-
@@ -330,7 +388,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       CI: true
 
@@ -363,7 +421,7 @@ jobs:
         run: pnpm install
 
       - name: Renderer Test
-        run: pnpm test:renderer --shard=${{ matrix.shard }}/4
+        run: pnpm test:renderer --shard=${{ matrix.shard }}/6
 
   render-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: stale-issue-management
+  cancel-in-progress: false
+
 env:
   daysBeforeStale: 30 # Number of days of inactivity before marking as stale
   daysBeforeClose: 10 # Number of days to wait after marking as stale before closing
@@ -29,6 +33,7 @@ jobs:
           days-before-close: 0 # Close immediately after stale
           stale-issue-label: 'inactive'
           close-issue-label: 'closed:no-response'
+          close-issue-reason: 'not_planned'
           exempt-all-milestones: true
           exempt-all-assignees: true
           stale-issue-message: |
@@ -37,7 +42,7 @@ jobs:
 
             该问题被标记为"需要更多信息"且已经 ${{ env.daysBeforeStale }} 天没有任何活动，将立即关闭。
           operations-per-run: 50
-          exempt-issue-labels: 'pending, Dev Team'
+          exempt-issue-labels: 'Pending, Dev Team'
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
@@ -48,15 +53,19 @@ jobs:
           days-before-stale: ${{ env.daysBeforeStale }}
           days-before-close: ${{ env.daysBeforeClose }}
           stale-issue-label: 'inactive'
+          close-issue-reason: 'not_planned'
           exempt-all-milestones: true
           exempt-all-assignees: true
           stale-issue-message: |
             This issue has been inactive for a prolonged period and will be closed automatically in ${{ env.daysBeforeClose }} days.
             该问题已长时间处于闲置状态，${{ env.daysBeforeClose }} 天后将自动关闭。
-          exempt-issue-labels: 'pending, Dev Team, kind/enhancement'
+          close-issue-message: |
+            This issue has been closed automatically after ${{ env.daysBeforeClose }} additional days without activity. If the issue is still relevant, please open a new issue with current-version reproduction details.
+            该问题在提醒后又经过 ${{ env.daysBeforeClose }} 天仍无活动，现已自动关闭。如果问题在当前版本中仍然存在，请提交包含复现信息的新 issue。
+          exempt-issue-labels: 'Pending, Dev Team, feature'
           days-before-pr-stale: -1 # Completely disable stalling for PRs
           days-before-pr-close: -1 # Completely disable closing for PRs
 
-          # Temporary to reduce the huge issues number
+          # Process the full issue backlog so eligible stale issues close on schedule.
           operations-per-run: 1000
           debug-only: false

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gen:system-provider-ids": "tsx scripts/generate-system-provider-ids.ts",
     "update:languages": "tsx scripts/update-languages.ts",
     "pretest": "pnpm rebuild:node",
-    "test": "vitest run --silent",
+    "test": "vitest run --silent --project main && vitest run --silent --project renderer && vitest run --silent --project aiCore --project ui --project shared --project provider-registry --project scripts",
     "pretest:main": "pnpm rebuild:node",
     "test:main": "vitest run --project main",
     "test:renderer": "vitest run --project renderer",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

- A full pre-merge CI run took about 5 minutes 14 seconds.
- Main and renderer Vitest projects each ran on a single runner.
- Test jobs ran even when a PR did not touch their module or its dependencies.
- Basic checks shared one long critical path.
- Local `pnpm test` ran all Vitest projects in one invocation, causing worker contention.

After this PR:

- Main tests run in 3 shards and renderer tests run in 8 shards, each behind a stable aggregate check.
- Fine-grained path filtering runs only affected main, renderer, shared, AI core, UI, provider-registry, scripts, and extension test groups.
- Small package suites share one checkout/install job but their individual steps are conditionally skipped.
- Lint, type/hardcoded-string checks, and repository integrity checks run on separate runners. The checks themselves remain explicit and no longer use `concurrently`.
- Pull-request jobs restore the pnpm cache without paying the post-job cache-save cost.
- Local `pnpm test` runs the large main and renderer projects, then the smaller package projects, in controlled sequential groups.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Recent pre-merge workflows regressed to roughly five to six minutes. Measurements showed that renderer tests became the critical path after main tests were sharded, and that GitHub checkout/cache variance could push a combined basic-check job over three minutes.

The following tradeoffs were made:

- Use 3 main shards and 8 renderer shards. The latest full run kept main shards between 2:13 and 2:23 and renderer shards between 2:04 and 2:29, including runner setup.
- Keep small package suites in one job to avoid a checkout/install job for every small project.
- Split basic checks only at the measured critical-path boundaries. Type checks can use a shallow checkout, while changeset and generated-file integrity checks retain full Git history.
- Preserve stable `general-test`, `render-test`, and `basic-checks` aggregate job names for branch protection.
- Treat workflow, lockfile, workspace, TypeScript, Electron/Vitest config, and patches as test infrastructure that intentionally triggers the complete suite.

The following alternatives were considered:

- Removing tests or validation checks was rejected; this PR keeps all existing coverage.
- Running every basic command in its own job was rejected because repeated setup would waste runner time without reducing the wall-clock critical path materially.
- Keeping renderer at four or six shards was rejected after real runs remained above the 2–3 minute target.
- Keeping all basic checks in one job was rejected after checkout and cache variance pushed that job to 3:13 despite the checks themselves taking a stable 68 seconds.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/18165

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Latest full run: https://github.com/CherryHQ/cherry-studio/actions/runs/31239330968 — 2:53, all checks passed.
- The PR's first comparable full run took 5:14, so the measured wall-clock reduction is 141 seconds (about 45%).
- Repository checks completed in 1:49, type/hardcoded checks in 2:04, and lint in 2:30.
- A normal renderer-only source change skips main and unrelated package tests. This PR changes `ci.yml` and `package.json`, which are test infrastructure, so its validation runs intentionally execute every suite.
- The optimized local `pnpm test` completed successfully in 291.05 seconds.
- No tests or checks were removed.
- All commits currently on this PR are verified signatures, including the rewritten original commit.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```