### PR TITLE
fix(resource-catalog): save assistant and agent fields independently

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/EditDialogShared.tsx
@@ -31,12 +31,13 @@ import { useModelById } from '@renderer/hooks/useModel'
 import { toast } from '@renderer/services/toast'
 import { isUniqueModelId, type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import { ArrowUpRight, ChevronDown, Database, HelpCircle, Trash2, X } from 'lucide-react'
-import { type ComponentProps, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ComponentProps, type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { type FieldValues, type Path, type UseFormReturn, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import { AddCatalogPopover, type CatalogItem } from './CatalogPicker'
 import { DialogModelFrame, DialogModelTrigger, EmojiAvatarPicker } from './DialogFormFields'
+import type { DirectSaveStatus } from './useDirectFieldSave'
 
 // Vertical submenu / nav item preset — kept in sync with the settings sidebar's
 // settingsSubmenuItemClassName so the edit-dialog rail and settings nav read identically.
@@ -114,81 +115,6 @@ export function getSelectedModelLabel(selection: UniqueModelId | Model | undefin
   if (!selection) return null
   if (typeof selection === 'string') return selection
   return selection.name
-}
-
-export function setFormValues<TValues extends FieldValues>(form: UseFormReturn<TValues>, patch: Partial<TValues>) {
-  Object.entries(patch).forEach(([key, value]) => {
-    form.setValue(key as never, value as never, { shouldDirty: true })
-  })
-}
-
-/**
- * Debounced auto-save for the edit dialogs. Re-arms whenever `changeKey` changes
- * (a serialized snapshot of the pending diff) and fires `onSave` after `delay`ms
- * of quiet. `changeKey === null` means nothing to save.
- *
- * Saves are serialized: only one runs at a time. If the state moves on while a
- * save is in flight, a single follow-up pass is queued and runs (with the latest
- * `onSave`) once the current save settles — so the last edit is never dropped.
- *
- * Returns a `flush()` that runs/awaits the serialized save immediately; callers
- * (e.g. the close path) await it to persist pending edits before proceeding,
- * reusing the same queue instead of racing a second concurrent save.
- */
-export function useDebouncedAutoSave({
-  enabled,
-  changeKey,
-  onSave,
-  delay = 500
-}: {
-  enabled: boolean
-  changeKey: string | null
-  onSave: () => void | Promise<void>
-  delay?: number
-}): () => Promise<void> {
-  const onSaveRef = useRef(onSave)
-  const changeKeyRef = useRef(changeKey)
-  const savingRef = useRef(false)
-  // `changeKey` captured when the in-flight save started; a follow-up pass is
-  // only queued when the state has moved past it.
-  const savedKeyRef = useRef<string | null>(null)
-  const pendingRef = useRef(false)
-  const inFlightRef = useRef<Promise<void>>(Promise.resolve())
-
-  useEffect(() => {
-    onSaveRef.current = onSave
-    changeKeyRef.current = changeKey
-  })
-
-  const flush = useCallback((): Promise<void> => {
-    if (savingRef.current) {
-      // A save is already running; queue one more pass only if the latest state
-      // differs from what that save captured (otherwise it already covers it).
-      if (changeKeyRef.current !== savedKeyRef.current) pendingRef.current = true
-      return inFlightRef.current
-    }
-    savingRef.current = true
-    inFlightRef.current = (async () => {
-      try {
-        do {
-          pendingRef.current = false
-          savedKeyRef.current = changeKeyRef.current
-          await onSaveRef.current()
-        } while (pendingRef.current)
-      } finally {
-        savingRef.current = false
-      }
-    })()
-    return inFlightRef.current
-  }, [])
-
-  useEffect(() => {
-    if (!enabled || changeKey === null) return
-    const handle = setTimeout(() => void flush(), delay)
-    return () => clearTimeout(handle)
-  }, [enabled, changeKey, delay, flush])
-
-  return flush
 }
 
 const HelpIconButton = ({
@@ -269,13 +195,16 @@ export function KnowledgeBaseField<TValues extends KnowledgeBaseFieldValues>({
   portalContainer,
   formLabel = true,
   disabled = false,
-  onOpenKnowledgePage
+  onOpenKnowledgePage,
+  onValueChange
 }: {
   form: UseFormReturn<TValues>
   portalContainer: HTMLElement | null
   formLabel?: boolean
   disabled?: boolean
   onOpenKnowledgePage?: () => void
+  /** Takes over the write so a property editor can persist the new binding itself. */
+  onValueChange?: (knowledgeBaseIds: string[]) => void
 }) {
   const { t } = useTranslation()
   const { data, isLoading } = useQuery('/knowledge-bases', {
@@ -286,6 +215,8 @@ export function KnowledgeBaseField<TValues extends KnowledgeBaseFieldValues>({
   const fieldName = 'knowledgeBaseIds' as Path<TValues>
   const watchedValue = useWatch({ control: form.control, name: fieldName })
   const value = useMemo(() => (watchedValue ?? []) as string[], [watchedValue])
+  const setKnowledgeBaseIds = (nextValue: string[]) =>
+    onValueChange ? onValueChange(nextValue) : form.setValue(fieldName, nextValue as never, { shouldDirty: true })
 
   const { catalog, linkedItems } = useMemo(() => {
     const byId = new Map(bases.map((base) => [base.id, base]))
@@ -306,8 +237,6 @@ export function KnowledgeBaseField<TValues extends KnowledgeBaseFieldValues>({
     return { catalog: items, linkedItems: linked }
   }, [bases, t, value])
 
-  const setKnowledgeBaseIds = (nextValue: string[]) =>
-    form.setValue(fieldName, nextValue as never, { shouldDirty: true })
   const remove = (id: string) => setKnowledgeBaseIds(value.filter((itemId) => itemId !== id))
   const add = (id: string) => setKnowledgeBaseIds([...value, id])
 
@@ -396,8 +325,9 @@ export function EditDialogShell<TValues extends FieldValues>({
   form,
   onActiveTabChange,
   onOpenChange,
+  onRetrySave,
   open,
-  rootError,
+  saveStatus,
   setDialogContentElement,
   tabs,
   title,
@@ -406,17 +336,24 @@ export function EditDialogShell<TValues extends FieldValues>({
 }: {
   activeTab: string
   children: ReactNode
+  /**
+   * Draft store for the controls inside. The shell has no submit path — each
+   * field persists itself — so this only supplies the `FormItem`/`FormMessage`
+   * context the field primitives read.
+   */
   form: UseFormReturn<TValues>
   groupExpansion?: EditDialogGroupExpansion
   groupPresentation?: EditDialogGroupPresentation
   onActiveTabChange: (tab: string) => void
   onOpenChange: (open: boolean) => void
+  onRetrySave?: () => void
   open: boolean
-  rootError?: string
+  saveStatus?: DirectSaveStatus
   setDialogContentElement: (element: HTMLDivElement | null) => void
   tabs: EditDialogTab[]
   title: string
 }) {
+  const { t } = useTranslation()
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const [expandedGroupIds, setExpandedGroupIds] = useState<Set<string>>(() =>
     getDefaultExpandedGroupIds(tabs, groupExpansion)
@@ -463,13 +400,10 @@ export function EditDialogShell<TValues extends FieldValues>({
         ref={setDialogContentElement}
         className={cn('flex h-[min(600px,76vh)] flex-col gap-0 p-0 sm:max-w-180', resourceDialogCloseButtonClassName)}>
         <Form {...form}>
-          {/* Clipping lives on the form (rounded-[inherit]), not DialogContent: the dialog's
+          {/* Clipping lives here (rounded-[inherit]), not on DialogContent: the dialog's
               transform makes it the containing block for portaled fixed poppers (model selector),
               so overflow-hidden on DialogContent would clip them. */}
-          <form
-            id="resource-edit-dialog-form"
-            onSubmit={(event) => event.preventDefault()}
-            className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[inherit]">
             {/* Header — title, matching the create wizard's top bar. */}
             <div className={resourceDialogHeaderClassName}>
               <div className="min-w-0">
@@ -553,13 +487,25 @@ export function EditDialogShell<TValues extends FieldValues>({
                 </Scrollbar>
                 {/* Always-present bottom band: insets scrolling lists from the dialog's
                     rounded-3xl corners so content never clips into them mid-scroll, and
-                    surfaces the save error inline when present. */}
-                <div className="flex min-h-6 shrink-0 items-center px-6 pb-4" aria-live="polite">
-                  {rootError ? <p className="text-destructive text-xs">{rootError}</p> : null}
+                    reports a failed field save without ever trapping the user in the dialog. */}
+                <div className="flex min-h-6 shrink-0 items-center gap-2 px-6 pb-4" aria-live="polite">
+                  {saveStatus === 'failed' ? (
+                    <>
+                      <p className="text-destructive text-xs">{t('library.config.dialogs.edit.save_failed')}</p>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={onRetrySave}
+                        className="h-auto min-h-0 px-1 py-0 text-xs underline-offset-2 hover:underline">
+                        {t('common.retry')}
+                      </Button>
+                    </>
+                  ) : null}
                 </div>
               </div>
             </Tabs>
-          </form>
+          </div>
         </Form>
       </DialogContent>
     </Dialog>
@@ -573,7 +519,8 @@ export function AvatarField({
   fallback,
   portalContainer,
   size,
-  layout = 'stacked'
+  layout = 'stacked',
+  onValueChange
 }: {
   form: UseFormReturn<any>
   emojiPickerOpen: boolean
@@ -582,6 +529,8 @@ export function AvatarField({
   portalContainer: HTMLElement | null
   size?: 'sm' | 'md'
   layout?: 'stacked' | 'row'
+  /** Takes over the write so a property editor can persist the new avatar itself. */
+  onValueChange?: (avatar: string) => void
 }) {
   const { t } = useTranslation()
   const avatar = form.watch('avatar')
@@ -600,7 +549,7 @@ export function AvatarField({
             fallback={fallback}
             open={emojiPickerOpen}
             onOpenChange={setEmojiPickerOpen}
-            onChange={field.onChange}
+            onChange={onValueChange ?? field.onChange}
             ariaLabel={t('library.config.dialogs.create.avatar_aria')}
             portalContainer={portalContainer}
             size={size}
@@ -619,7 +568,8 @@ export function TextInputField({
   description,
   placeholder,
   required = false,
-  layout = 'stacked'
+  layout = 'stacked',
+  onValueChange
 }: {
   form: UseFormReturn<any>
   name: 'name' | 'description'
@@ -628,6 +578,8 @@ export function TextInputField({
   placeholder?: string
   required?: boolean
   layout?: 'stacked' | 'row'
+  /** Takes over the write so a property editor can persist each keystroke itself. */
+  onValueChange?: (value: string) => void
 }) {
   const { t } = useTranslation()
 
@@ -651,11 +603,15 @@ export function TextInputField({
                 value={field.value}
                 rows={2}
                 placeholder={placeholder}
-                onValueChange={field.onChange}
+                onValueChange={onValueChange ?? field.onChange}
                 className="min-h-16"
               />
             ) : (
-              <Input {...field} placeholder={placeholder} />
+              <Input
+                {...field}
+                placeholder={placeholder}
+                onChange={onValueChange ? (event) => onValueChange(event.target.value) : field.onChange}
+              />
             )}
           </FormControl>
           {description ? (

--- a/src/renderer/components/resourceCatalog/dialogs/components/__tests__/useDirectFieldSave.test.ts
+++ b/src/renderer/components/resourceCatalog/dialogs/components/__tests__/useDirectFieldSave.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useDirectFieldSave } from '../useDirectFieldSave'
+
+type Patch = { name?: string; description?: string }
+
+const merge = (base: Patch, next: Patch): Patch => ({ ...base, ...next })
+
+function setup(save: (patch: Patch) => Promise<unknown>, onError = vi.fn()) {
+  return renderHook(() => useDirectFieldSave<Patch>({ save, merge, onError, delay: 10 }))
+}
+
+/** Resolves once every already-queued microtask has run. */
+const settle = () => act(async () => await Promise.resolve())
+
+describe('useDirectFieldSave', () => {
+  it('sends a committed patch immediately', async () => {
+    const save = vi.fn().mockResolvedValue(undefined)
+    const { result } = setup(save)
+
+    act(() => result.current.commit({ name: 'a' }))
+    await settle()
+
+    expect(save).toHaveBeenCalledExactlyOnceWith({ name: 'a' })
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('collapses rapid scheduled patches into one request', async () => {
+    vi.useFakeTimers()
+    try {
+      const save = vi.fn().mockResolvedValue(undefined)
+      const { result } = setup(save)
+
+      act(() => result.current.schedule({ name: 'a' }))
+      act(() => result.current.schedule({ name: 'ab' }))
+      expect(save).not.toHaveBeenCalled()
+      expect(result.current.status).toBe('pending')
+
+      await act(async () => {
+        vi.advanceTimersByTime(10)
+        await Promise.resolve()
+      })
+      expect(save).toHaveBeenCalledExactlyOnceWith({ name: 'ab' })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('serializes writes and merges everything queued behind an in-flight one', async () => {
+    let releaseFirst: (() => void) | undefined
+    const save = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<void>((resolve) => (releaseFirst = resolve)))
+      .mockResolvedValue(undefined)
+    const { result } = setup(save)
+
+    act(() => result.current.commit({ name: 'a' }))
+    await settle()
+    expect(save).toHaveBeenCalledTimes(1)
+
+    act(() => result.current.commit({ name: 'b' }))
+    act(() => result.current.commit({ description: 'd' }))
+    expect(save).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      releaseFirst?.()
+      await Promise.resolve()
+    })
+    await settle()
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save).toHaveBeenLastCalledWith({ name: 'b', description: 'd' })
+  })
+
+  it('keeps a rejected patch buffered and resends it on retry', async () => {
+    const onError = vi.fn()
+    const save = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined)
+    const { result } = setup(save, onError)
+
+    act(() => result.current.commit({ name: 'a' }))
+    await settle()
+
+    expect(result.current.status).toBe('failed')
+    expect(onError).toHaveBeenCalledExactlyOnceWith(expect.any(Error))
+
+    act(() => result.current.retry())
+    await settle()
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save).toHaveBeenLastCalledWith({ name: 'a' })
+    expect(result.current.status).toBe('idle')
+  })
+
+  it('lets a newer value win over the rejected one', async () => {
+    const save = vi.fn().mockRejectedValueOnce(new Error('offline')).mockResolvedValue(undefined)
+    const { result } = setup(save)
+
+    act(() => result.current.commit({ name: 'stale' }))
+    await settle()
+    expect(result.current.status).toBe('failed')
+
+    act(() => result.current.commit({ name: 'fresh' }))
+    await settle()
+
+    expect(save).toHaveBeenLastCalledWith({ name: 'fresh' })
+  })
+
+  it('flushes a scheduled patch without waiting for the debounce', async () => {
+    const save = vi.fn().mockResolvedValue(undefined)
+    const { result } = setup(save)
+
+    act(() => result.current.schedule({ name: 'a' }))
+    await act(async () => await result.current.flush())
+
+    expect(save).toHaveBeenCalledExactlyOnceWith({ name: 'a' })
+  })
+
+  it('does not resend a patch that a failure already reported after unmount', async () => {
+    const save = vi.fn().mockRejectedValue(new Error('offline'))
+    const { result, unmount } = setup(save)
+
+    act(() => result.current.commit({ name: 'a' }))
+    unmount()
+    await settle()
+
+    // One attempt, and no state update on the unmounted hook.
+    expect(save).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/resourceCatalog/dialogs/components/useDirectFieldSave.ts
+++ b/src/renderer/components/resourceCatalog/dialogs/components/useDirectFieldSave.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+export type DirectSaveStatus = 'idle' | 'pending' | 'saving' | 'failed'
+
+export interface DirectFieldSave<TPatch> {
+  /** Latest queue state — drives the editor's inline save indicator. */
+  status: DirectSaveStatus
+  /** Buffer `patch` and send it now (behind any in-flight request). */
+  commit: (patch: TPatch) => void
+  /** Buffer `patch` and send it once typing settles; later calls re-arm the timer. */
+  schedule: (patch: TPatch) => void
+  /** Send everything buffered right away; resolves when the queue drains. */
+  flush: () => Promise<void>
+  /** Re-send the buffered patch whose last attempt failed. */
+  retry: () => void
+}
+
+/**
+ * Per-field save queue for the resource editors.
+ *
+ * These dialogs are property editors, not submit-style forms: every control
+ * persists only the field it owns, so a stale or invalid value elsewhere on the
+ * resource can never block an unrelated edit.
+ *
+ * Writes to one resource are strictly serialized, and patches that pile up while
+ * a request is in flight are merged (via `merge`) into a single follow-up — so
+ * an older response can never overwrite a newer value.
+ *
+ * A rejected patch stays buffered instead of being dropped: the next edit to the
+ * same field replaces it, and {@link DirectFieldSave.retry} re-sends it. Failure
+ * is surfaced through `onError` and `status` only; it never blocks the dialog.
+ */
+export function useDirectFieldSave<TPatch extends object>({
+  save,
+  merge,
+  onError,
+  delay = 500
+}: {
+  save: (patch: TPatch) => Promise<unknown>
+  /** Combine a buffered patch with a newer one; `next` wins on conflicts. */
+  merge: (base: TPatch, next: TPatch) => TPatch
+  onError?: (error: Error) => void
+  delay?: number
+}): DirectFieldSave<TPatch> {
+  const [status, setStatus] = useState<DirectSaveStatus>('idle')
+
+  const saveRef = useRef(save)
+  const mergeRef = useRef(merge)
+  const onErrorRef = useRef(onError)
+  useEffect(() => {
+    saveRef.current = save
+    mergeRef.current = merge
+    onErrorRef.current = onError
+  })
+
+  const pendingRef = useRef<TPatch | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const drainingRef = useRef(false)
+  const inFlightRef = useRef<Promise<void>>(Promise.resolve())
+  const mountedRef = useRef(true)
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false
+      if (timerRef.current) clearTimeout(timerRef.current)
+    },
+    []
+  )
+
+  // The queue outlives the dialog (a close flushes and returns immediately), so
+  // late settlements must not push state into an unmounted tree.
+  const publishStatus = useCallback((next: DirectSaveStatus) => {
+    if (mountedRef.current) setStatus(next)
+  }, [])
+
+  const drain = useCallback((): Promise<void> => {
+    if (drainingRef.current) return inFlightRef.current
+    drainingRef.current = true
+    inFlightRef.current = (async () => {
+      try {
+        while (pendingRef.current) {
+          const patch = pendingRef.current
+          pendingRef.current = null
+          publishStatus('saving')
+          try {
+            await saveRef.current(patch)
+          } catch (error) {
+            // Keep the rejected patch buffered so an explicit retry — or the
+            // user's next edit, which merges on top — can resend it.
+            pendingRef.current = pendingRef.current ? mergeRef.current(patch, pendingRef.current) : patch
+            publishStatus('failed')
+            onErrorRef.current?.(error instanceof Error ? error : new Error(String(error)))
+            return
+          }
+        }
+        publishStatus('idle')
+      } finally {
+        drainingRef.current = false
+      }
+    })()
+    return inFlightRef.current
+  }, [publishStatus])
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  const enqueue = useCallback((patch: TPatch) => {
+    pendingRef.current = pendingRef.current ? mergeRef.current(pendingRef.current, patch) : patch
+  }, [])
+
+  const commit = useCallback(
+    (patch: TPatch) => {
+      clearTimer()
+      enqueue(patch)
+      void drain()
+    },
+    [clearTimer, drain, enqueue]
+  )
+
+  const schedule = useCallback(
+    (patch: TPatch) => {
+      clearTimer()
+      enqueue(patch)
+      publishStatus('pending')
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        void drain()
+      }, delay)
+    },
+    [clearTimer, delay, drain, enqueue, publishStatus]
+  )
+
+  const flush = useCallback((): Promise<void> => {
+    clearTimer()
+    return drain()
+  }, [clearTimer, drain])
+
+  const retry = useCallback(() => {
+    clearTimer()
+    void drain()
+  }, [clearTimer, drain])
+
+  // Stable except when the reported status changes, so the field tree built on
+  // top of it doesn't re-render on every keystroke.
+  return useMemo(() => ({ status, commit, schedule, flush, retry }), [commit, flush, retry, schedule, status])
+}

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -29,11 +29,10 @@ import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import { toast } from '@renderer/services/toast'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import { permissionModeCards } from '@renderer/utils/agent'
+import { normalizePermissionMode } from '@renderer/utils/agent/permissionMode'
 import {
-  type AgentFormState,
-  applyAgentFormPatch,
+  agentEnvVarsFromText,
   buildInitialAgentFormState,
-  diffAgentSaveIntent,
   RESOURCE_PROMPT_POLISH_SYSTEM_PROMPT
 } from '@renderer/utils/resourceCatalog'
 import {
@@ -43,12 +42,13 @@ import {
   claudeUserFacingTools
 } from '@shared/ai/claudecode/toolRegistry'
 import { AGENT_PROMPT } from '@shared/ai/prompts'
-import type { UpdateAgentDto } from '@shared/data/api/schemas/agents'
+import type { AgentSkillUpdateDto, UpdateAgentDto } from '@shared/data/api/schemas/agents'
+import type { AgentConfiguration } from '@shared/data/types/agent'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import type { InstalledSkill } from '@shared/types/skill'
 import { ToolCase, Wrench } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useForm, type UseFormReturn, useWatch } from 'react-hook-form'
+import { type Path, useForm, type UseFormReturn, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import { type CatalogItem, CatalogToggleGrid } from '../components/CatalogPicker'
@@ -66,11 +66,11 @@ import {
   KnowledgeBaseField,
   type ModelLabels,
   PromptVariablesPopover,
-  TextInputField,
-  useDebouncedAutoSave
+  TextInputField
 } from '../components/EditDialogShared'
 import { McpServerCatalogGrid } from '../components/McpServerCatalogGrid'
 import { PromptPolishActions } from '../components/PromptPolishActions'
+import { useDirectFieldSave } from '../components/useDirectFieldSave'
 
 export type AgentEditDialogProps = EditDialogBaseProps & {
   resource: AgentDetail | null
@@ -159,73 +159,41 @@ function modelLabelsForAgent(resource: AgentDetail): ModelLabels {
   }
 }
 
-function buildAgentFormState(baseline: AgentFormState, values: AgentEditFormValues): AgentFormState {
-  return {
-    ...baseline,
-    avatar: values.avatar,
-    name: values.name,
-    description: values.description,
-    model: values.modelId ?? '',
-    planModel: values.planModelId || '',
-    smallModel: values.smallModelId || '',
-    instructions: values.instructions,
-    mcps: [...values.mcps],
-    knowledgeBaseIds: [...values.knowledgeBaseIds],
-    skillIds: [...values.skillIds],
-    disabledTools: [...values.disabledTools],
-    permissionMode: values.permissionMode,
-    envVarsText: values.envVarsText,
-    heartbeatEnabled: values.heartbeatEnabled,
-    heartbeatInterval: values.heartbeatInterval
+/**
+ * Combine a queued PATCH with a newer one. `configuration` is merged key-by-key
+ * (main merges the sub-keys it receives onto the persisted object) and
+ * `skillUpdates` is deduplicated per skill so the last toggle wins.
+ */
+function mergeAgentPatch(base: UpdateAgentDto, next: UpdateAgentDto): UpdateAgentDto {
+  const merged: UpdateAgentDto = { ...base, ...next }
+  if (base.configuration || next.configuration) {
+    merged.configuration = { ...base.configuration, ...next.configuration }
   }
-}
-
-function serializeAgentSaveAttempt(values: AgentEditFormValues, payload: UpdateAgentDto): string {
-  return JSON.stringify({ values, payload })
-}
-
-function advanceAgentFormBaseline(
-  latest: AgentFormState,
-  submitted: AgentFormState,
-  payload: UpdateAgentDto
-): AgentFormState {
-  const next = { ...latest }
-  const hasOwn = (value: object, key: PropertyKey) => Object.prototype.hasOwnProperty.call(value, key)
-
-  if (hasOwn(payload, 'name')) next.name = submitted.name
-  if (hasOwn(payload, 'description')) next.description = submitted.description
-  if (hasOwn(payload, 'model')) next.model = submitted.model
-  if (hasOwn(payload, 'planModel')) next.planModel = submitted.planModel
-  if (hasOwn(payload, 'smallModel')) next.smallModel = submitted.smallModel
-  if (hasOwn(payload, 'instructions')) next.instructions = submitted.instructions
-  if (hasOwn(payload, 'mcps')) next.mcps = [...submitted.mcps]
-  if (hasOwn(payload, 'knowledgeBaseIds')) next.knowledgeBaseIds = [...submitted.knowledgeBaseIds]
-  if (hasOwn(payload, 'skillUpdates')) next.skillIds = [...submitted.skillIds]
-  if (hasOwn(payload, 'disabledTools')) next.disabledTools = [...submitted.disabledTools]
-
-  const configuration = payload.configuration
-  if (configuration) {
-    if (hasOwn(configuration, 'avatar')) next.avatar = submitted.avatar
-    if (hasOwn(configuration, 'permission_mode')) next.permissionMode = submitted.permissionMode
-    if (hasOwn(configuration, 'env_vars')) next.envVarsText = submitted.envVarsText
-    if (hasOwn(configuration, 'heartbeat_enabled')) next.heartbeatEnabled = submitted.heartbeatEnabled
-    if (hasOwn(configuration, 'heartbeat_interval')) next.heartbeatInterval = submitted.heartbeatInterval
+  if (base.skillUpdates || next.skillUpdates) {
+    const bySkillId = new Map<string, AgentSkillUpdateDto>()
+    for (const update of [...(base.skillUpdates ?? []), ...(next.skillUpdates ?? [])]) {
+      bySkillId.set(update.skillId, update)
+    }
+    merged.skillUpdates = [...bySkillId.values()]
   }
-
-  return next
+  return merged
 }
 
-function syncAgentFormState(form: UseFormReturn<AgentEditFormValues>, next: AgentFormState) {
-  form.setValue('modelId', next.model || null, { shouldDirty: true })
-  form.setValue('planModelId', next.planModel, { shouldDirty: true })
-  form.setValue('smallModelId', next.smallModel, { shouldDirty: true })
-  form.setValue('mcps', next.mcps, { shouldDirty: true })
-  form.setValue('knowledgeBaseIds', next.knowledgeBaseIds, { shouldDirty: true })
-  form.setValue('skillIds', next.skillIds, { shouldDirty: true })
-  form.setValue('disabledTools', next.disabledTools, { shouldDirty: true })
-  form.setValue('permissionMode', next.permissionMode, { shouldDirty: true })
-  form.setValue('heartbeatEnabled', next.heartbeatEnabled, { shouldDirty: true })
-  form.setValue('heartbeatInterval', next.heartbeatInterval, { shouldDirty: true })
+/**
+ * `max_turns` is a retired field this dialog never surfaces; clear it whenever
+ * we touch the configuration so it cannot linger on the persisted object.
+ */
+function agentConfigurationPatch(configuration: AgentConfiguration): UpdateAgentDto {
+  return { configuration: { ...configuration, max_turns: undefined } }
+}
+
+/**
+ * Writes one draft field and persists just that field. Same contract as the
+ * assistant editor — every control owns its own PATCH.
+ */
+type AgentEditor = {
+  form: UseFormReturn<AgentEditFormValues>
+  set: (values: Partial<AgentEditFormValues>, patch: UpdateAgentDto, mode?: 'now' | 'debounced') => void
 }
 
 export function AgentEditDialog({ resource, open, onOpenChange, modelFilter, initialTab }: AgentEditDialogProps) {
@@ -254,28 +222,33 @@ function AgentEditDialogContent({
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false)
   const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAgent(resource))
-  const [formBaseline, setFormBaseline] = useState<AgentFormState>(() => buildInitialAgentFormState(resource))
-  const formBaselineRef = useRef(formBaseline)
-  const failedSaveKeyRef = useRef<string | null>(null)
-  const [baselineSkillAgentId, setBaselineSkillAgentId] = useState<string | null>(null)
+  const [skillsSeededForAgentId, setSkillsSeededForAgentId] = useState<string | null>(null)
   const defaultValues = useMemo(() => defaultValuesForAgent(resource), [resource])
   const form = useForm<AgentEditFormValues>({ defaultValues })
-  const values = form.watch()
-  const { model: selectedAgentModel } = useModelById(values.modelId)
-  const promptModelName =
-    selectedAgentModel?.name ?? (values.modelId === resource.model ? resource.modelName : undefined)
-  const replaceFormBaseline = useCallback((next: AgentFormState) => {
-    formBaselineRef.current = next
-    setFormBaseline(next)
-  }, [])
-  const patchAgentForm = useCallback(
-    (patch: Partial<AgentFormState>) => {
-      const current = buildAgentFormState(formBaselineRef.current, form.getValues())
-      syncAgentFormState(form, applyAgentFormPatch(current, patch))
-    },
-    [form]
-  )
+  const modelId = form.watch('modelId')
+  const { model: selectedAgentModel } = useModelById(modelId)
+  const promptModelName = selectedAgentModel?.name ?? (modelId === resource.model ? resource.modelName : undefined)
   const { updateAgent } = useAgentMutationsById(resource.id)
+  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
+  const save = useDirectFieldSave<UpdateAgentDto>({
+    save: updateAgent,
+    merge: mergeAgentPatch,
+    onError: (error) => {
+      logger.error('Failed to save agent edit dialog', error, { agentId: resource.id })
+      toast.error(saveFailedMessage)
+    }
+  })
+  const setField = useCallback<AgentEditor['set']>(
+    (values, patch, mode = 'now') => {
+      for (const [key, value] of Object.entries(values)) {
+        form.setValue(key as Path<AgentEditFormValues>, value as never, { shouldDirty: true })
+      }
+      if (mode === 'debounced') save.schedule(patch)
+      else save.commit(patch)
+    },
+    [form, save]
+  )
+  const editor = useMemo<AgentEditor>(() => ({ form, set: setField }), [form, setField])
   const { bases: knowledgeBases, isLoading: knowledgeBasesLoading } = useKnowledgeBases()
   const availableKnowledgeBaseIds = useMemo(() => new Set(knowledgeBases.map((base) => base.id)), [knowledgeBases])
   const {
@@ -298,10 +271,6 @@ function AgentEditDialogContent({
     () => (skillIdsFromQueryKey ? skillIdsFromQueryKey.split('\0') : []),
     [skillIdsFromQueryKey]
   )
-  const currentFormState = useMemo(() => buildAgentFormState(formBaseline, values), [formBaseline, values])
-  const saveIntent = useMemo(() => {
-    return diffAgentSaveIntent(currentFormState, formBaseline)
-  }, [currentFormState, formBaseline])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -333,118 +302,40 @@ function AgentEditDialogContent({
     setActiveTab(initialTab ?? 'basic')
     setEmojiPickerOpen(false)
     setModelLabels(modelLabelsForAgent(resource))
-    replaceFormBaseline(buildInitialAgentFormState(resource))
-    setBaselineSkillAgentId(null)
-    failedSaveKeyRef.current = null
-  }, [defaultValues, form, initialTab, open, replaceFormBaseline, resource])
+    setSkillsSeededForAgentId(null)
+  }, [defaultValues, form, initialTab, open, resource])
 
-  // Cached skill rows may render during revalidation, but the editable skill
-  // baseline must come from the authoritative projection so later toggles diff
-  // correctly.
+  // Cached skill rows may render during revalidation, so seed the draft only
+  // from the authoritative projection — a toggle diffs against what it shows.
   useEffect(() => {
-    if (!open || skillsLoading || skillsRefreshing || baselineSkillAgentId === resource.id) return
-    replaceFormBaseline({ ...formBaselineRef.current, skillIds: [...skillIdsFromQuery] })
+    if (!open || skillsLoading || skillsRefreshing || skillsSeededForAgentId === resource.id) return
     form.setValue('skillIds', skillIdsFromQuery, { shouldDirty: false })
-    setBaselineSkillAgentId(resource.id)
-  }, [
-    baselineSkillAgentId,
-    form,
-    open,
-    replaceFormBaseline,
-    resource.id,
-    skillIdsFromQuery,
-    skillsLoading,
-    skillsRefreshing
-  ])
+    setSkillsSeededForAgentId(resource.id)
+  }, [form, open, resource.id, skillIdsFromQuery, skillsLoading, skillsRefreshing, skillsSeededForAgentId])
 
   useEffect(() => {
     if (!open || knowledgeBasesLoading) return
 
-    // Keep unrelated local edits while removing bindings that disappeared from
-    // the knowledge-base directory after a delete. Agent projection refreshes
-    // caused by this dialog's own saves must not overwrite newer form edits.
+    // Drop bindings that disappeared from the knowledge-base directory after a
+    // delete. Draft-only: the agent row already lost them, so there is nothing
+    // left to persist.
     const currentIds = form.getValues('knowledgeBaseIds')
     const convergedIds = currentIds.filter((id) => availableKnowledgeBaseIds.has(id))
     if (convergedIds.length !== currentIds.length) {
-      replaceFormBaseline({
-        ...formBaselineRef.current,
-        knowledgeBaseIds: formBaselineRef.current.knowledgeBaseIds.filter((id) => availableKnowledgeBaseIds.has(id))
-      })
       form.setValue('knowledgeBaseIds', convergedIds, { shouldDirty: false })
     }
-  }, [availableKnowledgeBaseIds, form, knowledgeBasesLoading, open, replaceFormBaseline])
+  }, [availableKnowledgeBaseIds, form, knowledgeBasesLoading, open])
 
   useEffect(() => {
     if (leafTabIds.has(activeTab)) return
     setActiveTab('basic')
   }, [activeTab, leafTabIds])
 
-  const rootError = form.formState.errors.root?.message
-  const autoSaveChangeKey =
-    saveIntent && values.name.trim().length > 0 ? serializeAgentSaveAttempt(values, saveIntent.payload) : null
-  const canPersist = autoSaveChangeKey !== null
-  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
-
-  const persist = async () => {
-    // Recompute from refs at execution time: the serialized autosave queue may
-    // start its follow-up pass before React has rendered the baseline state
-    // advanced by the previous pass.
-    const submittedValues = form.getValues()
-    const submittedFormState = buildAgentFormState(formBaselineRef.current, submittedValues)
-    const pending = diffAgentSaveIntent(submittedFormState, formBaselineRef.current)
-    if (!pending) return
-    const attemptedKey = serializeAgentSaveAttempt(submittedValues, pending.payload)
-
-    // A close-triggered flush does not cancel the already scheduled debounce.
-    // Keep both paths from resending an unchanged payload that already failed.
-    if (failedSaveKeyRef.current === attemptedKey) return
-
-    form.clearErrors('root')
-    failedSaveKeyRef.current = null
-
-    try {
-      await updateAgent(pending.payload)
-    } catch (error) {
-      logger.error('Failed to auto-save agent edit dialog', error as Error, { agentId: resource.id })
-      failedSaveKeyRef.current = attemptedKey
-      form.setError('root', { message: saveFailedMessage })
-      toast.error(saveFailedMessage)
-      return
-    }
-
-    // Commit only fields this request actually submitted. Baseline updates that
-    // landed while it was in flight (such as authoritative skill initialization)
-    // must survive so queued edits still diff against the persisted state.
-    replaceFormBaseline(advanceAgentFormBaseline(formBaselineRef.current, submittedFormState, pending.payload))
-  }
-
-  // Include the pending payload so a baseline update during an in-flight save
-  // can queue a newly meaningful diff even when form values return to the
-  // snapshot that save captured. Values remain in the key to distinguish DTO
-  // clears represented by explicit `undefined`.
-  const flush = useDebouncedAutoSave({
-    enabled: open,
-    changeKey: autoSaveChangeKey,
-    onSave: persist
-  })
-
-  // On close with a pending edit, flush through the same serialized save queue and
-  // only close once it settles — so a failed final save stays visible instead of
-  // being silently dropped, and we never race a second concurrent save.
+  // Send whatever is still debounced, then close regardless of the outcome: a
+  // rejected field save is reported by the queue, never by trapping the user.
   const handleOpenChange = (next: boolean) => {
-    if (next || !canPersist) {
-      onOpenChange(next)
-      return
-    }
-    if (failedSaveKeyRef.current === autoSaveChangeKey) {
-      toast.error(saveFailedMessage)
-      return
-    }
-    void (async () => {
-      await flush()
-      if (failedSaveKeyRef.current !== null) return
-      onOpenChange(false)
-    })()
+    if (!next) void save.flush()
+    onOpenChange(next)
   }
   // Route the settings-navigate close through handleOpenChange so it flushes too.
   const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
@@ -455,8 +346,9 @@ function AgentEditDialogContent({
       form={form}
       onActiveTabChange={setActiveTab}
       onOpenChange={handleOpenChange}
+      onRetrySave={save.retry}
       open={open}
-      rootError={rootError}
+      saveStatus={save.status}
       setDialogContentElement={setDialogContentElement}
       groupPresentation="inline"
       tabs={tabs}
@@ -464,12 +356,11 @@ function AgentEditDialogContent({
       <>
         <TabsContent value="basic" forceMount hidden={activeTab !== 'basic'} className="m-0">
           <AgentBasicFields
-            form={form}
+            editor={editor}
             modelFilter={modelFilter}
             portalContainer={dialogContentElement}
             modelLabels={modelLabels}
             setModelLabels={setModelLabels}
-            patchAgentForm={patchAgentForm}
             emojiPickerOpen={emojiPickerOpen}
             setEmojiPickerOpen={setEmojiPickerOpen}
             onSettingsNavigate={closeBeforeAction}
@@ -480,23 +371,27 @@ function AgentEditDialogContent({
           forceMount
           hidden={activeTab !== 'prompt'}
           className="m-0 flex h-full min-h-0 flex-col">
-          <AgentPromptField form={form} modelName={promptModelName ?? null} portalContainer={dialogContentElement} />
+          <AgentPromptField
+            editor={editor}
+            modelName={promptModelName ?? null}
+            portalContainer={dialogContentElement}
+          />
         </TabsContent>
         {isToolTab(activeTab) ? (
           <TabsContent value={activeTab} forceMount className="m-0">
             <AgentToolsFields
               agent={resource}
-              form={form}
+              editor={editor}
               activeToolTab={activeTab}
               portalContainer={dialogContentElement}
               skills={skills}
               skillsLoading={skillsLoading}
-              skillsReady={baselineSkillAgentId === resource.id}
+              skillsReady={skillsSeededForAgentId === resource.id}
             />
           </TabsContent>
         ) : null}
         <TabsContent value="advanced" forceMount hidden={activeTab !== 'advanced'} className="m-0">
-          <AgentAdvancedFields form={form} />
+          <AgentAdvancedFields editor={editor} />
         </TabsContent>
       </>
     </EditDialogShell>
@@ -504,28 +399,38 @@ function AgentEditDialogContent({
 }
 
 function AgentBasicFields({
-  form,
+  editor,
   modelFilter,
   portalContainer,
   modelLabels,
   setModelLabels,
-  patchAgentForm,
   emojiPickerOpen,
   setEmojiPickerOpen,
   onSettingsNavigate
 }: {
-  form: UseFormReturn<AgentEditFormValues>
+  editor: AgentEditor
   modelFilter?: (model: Model) => boolean
   portalContainer: HTMLElement | null
   modelLabels: ModelLabels
   setModelLabels: (labels: ModelLabels) => void
-  patchAgentForm: (patch: Partial<AgentFormState>) => void
   emojiPickerOpen: boolean
   setEmojiPickerOpen: (open: boolean) => void
   onSettingsNavigate?: (navigate: () => void) => void
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const heartbeatEnabled = form.watch('heartbeatEnabled')
+
+  const handleNameChange = (name: string) => {
+    // An empty name is a transient editing state, not a persistable value: keep
+    // it in the draft, surface the required message, and skip the PATCH.
+    const trimmed = name.trim()
+    if (!trimmed) {
+      form.setValue('name', name, { shouldDirty: true, shouldValidate: true })
+      return
+    }
+    set({ name }, { name: trimmed }, 'debounced')
+  }
 
   return (
     <div className="divide-y divide-border-subtle border-border-subtle border-b [&>*:first-child]:pt-0">
@@ -537,6 +442,7 @@ function AgentBasicFields({
         portalContainer={portalContainer}
         size="sm"
         layout="row"
+        onValueChange={(avatar) => set({ avatar }, agentConfigurationPatch({ avatar }))}
       />
       <TextInputField
         form={form}
@@ -545,6 +451,7 @@ function AgentBasicFields({
         placeholder={t('library.config.agent.field.name.placeholder')}
         required
         layout="row"
+        onValueChange={handleNameChange}
       />
       <TextInputField
         form={form}
@@ -552,6 +459,7 @@ function AgentBasicFields({
         label={t('library.config.agent.field.description.label')}
         placeholder={t('library.config.agent.field.description.placeholder')}
         layout="row"
+        onValueChange={(description) => set({ description }, { description }, 'debounced')}
       />
       <CompactModelField
         form={form}
@@ -561,7 +469,15 @@ function AgentBasicFields({
         portalContainer={portalContainer}
         modelLabels={modelLabels}
         setModelLabels={setModelLabels}
-        onModelChange={(modelId) => patchAgentForm({ model: modelId ?? '' })}
+        onModelChange={(nextModelId) => {
+          // The primary model has no clear affordance; an empty pick is a draft
+          // state with nothing to persist.
+          if (!nextModelId) {
+            form.setValue('modelId', null, { shouldDirty: true })
+            return
+          }
+          set({ modelId: nextModelId }, { model: nextModelId })
+        }}
         onSettingsNavigate={onSettingsNavigate}
         layout="row"
         triggerClassName="h-9 rounded-md border border-input bg-transparent px-3 hover:bg-accent/50"
@@ -575,7 +491,7 @@ function AgentBasicFields({
         portalContainer={portalContainer}
         modelLabels={modelLabels}
         setModelLabels={setModelLabels}
-        onModelChange={(modelId) => patchAgentForm({ planModel: modelId ?? '' })}
+        onModelChange={(modelId) => set({ planModelId: modelId ?? '' }, { planModel: modelId ?? undefined })}
         onSettingsNavigate={onSettingsNavigate}
         layout="row"
         triggerClassName="h-9 rounded-md border border-input bg-transparent px-3 hover:bg-accent/50"
@@ -589,31 +505,26 @@ function AgentBasicFields({
         portalContainer={portalContainer}
         modelLabels={modelLabels}
         setModelLabels={setModelLabels}
-        onModelChange={(modelId) => patchAgentForm({ smallModel: modelId ?? '' })}
+        onModelChange={(modelId) => set({ smallModelId: modelId ?? '' }, { smallModel: modelId ?? undefined })}
         onSettingsNavigate={onSettingsNavigate}
         layout="row"
         triggerClassName="h-9 rounded-md border border-input bg-transparent px-3 hover:bg-accent/50"
       />
-      <PermissionModeField form={form} portalContainer={portalContainer} patchAgentForm={patchAgentForm} />
-      <HeartbeatSettingsField
-        form={form}
-        enabled={heartbeatEnabled}
-        onEnabledChange={(checked) => patchAgentForm({ heartbeatEnabled: checked })}
-      />
+      <PermissionModeField editor={editor} portalContainer={portalContainer} />
+      <HeartbeatSettingsField editor={editor} enabled={heartbeatEnabled} />
     </div>
   )
 }
 
 function PermissionModeField({
-  form,
-  portalContainer,
-  patchAgentForm
+  editor,
+  portalContainer
 }: {
-  form: UseFormReturn<AgentEditFormValues>
+  editor: AgentEditor
   portalContainer: HTMLElement | null
-  patchAgentForm: (patch: Partial<AgentFormState>) => void
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const permissionMode = useWatch({ control: form.control, name: 'permissionMode' }) || 'default'
   const selectedPermissionModeCard = permissionModeCards.find((card) => card.mode === permissionMode)
 
@@ -626,7 +537,12 @@ function PermissionModeField({
           <FormLabel className={editDialogFormRowLabelClassName}>
             {t('library.config.agent.field.permission_mode.label')}
           </FormLabel>
-          <Select value={field.value || 'default'} onValueChange={(value) => patchAgentForm({ permissionMode: value })}>
+          <Select
+            value={field.value || 'default'}
+            onValueChange={(value) => {
+              const permissionMode = normalizePermissionMode(value)
+              set({ permissionMode }, agentConfigurationPatch({ permission_mode: permissionMode }))
+            }}>
             <FormControl>
               <SelectTrigger
                 className="h-9 w-full rounded-md"
@@ -659,16 +575,9 @@ function PermissionModeField({
   )
 }
 
-function HeartbeatSettingsField({
-  form,
-  enabled,
-  onEnabledChange
-}: {
-  form: UseFormReturn<AgentEditFormValues>
-  enabled: boolean
-  onEnabledChange: (checked: boolean) => void
-}) {
+function HeartbeatSettingsField({ editor, enabled }: { editor: AgentEditor; enabled: boolean }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const label = t('library.config.agent.field.heartbeat_enabled.label')
 
   return (
@@ -681,7 +590,14 @@ function HeartbeatSettingsField({
             <FormLabel className={editDialogFormRowLabelClassName}>{label}</FormLabel>
             <FormControl>
               <div className="flex h-9 items-center">
-                <Switch size="sm" checked={field.value} onCheckedChange={onEnabledChange} aria-label={label} />
+                <Switch
+                  size="sm"
+                  checked={field.value}
+                  onCheckedChange={(checked) =>
+                    set({ heartbeatEnabled: checked }, agentConfigurationPatch({ heartbeat_enabled: checked }))
+                  }
+                  aria-label={label}
+                />
               </div>
             </FormControl>
             <FormMessage className="col-start-2" />
@@ -707,7 +623,18 @@ function HeartbeatSettingsField({
                   changeOnBlur
                   className="h-9 w-full"
                   value={field.value || null}
-                  onChange={(v) => field.onChange(typeof v === 'number' ? v : 0)}
+                  onChange={(v) => {
+                    const heartbeatInterval = typeof v === 'number' ? v : 0
+                    // An interval edit implies the feature is on — mirrors the
+                    // pairing the runtime expects.
+                    set(
+                      { heartbeatInterval },
+                      agentConfigurationPatch({
+                        ...(enabled ? { heartbeat_enabled: true } : {}),
+                        heartbeat_interval: heartbeatInterval
+                      })
+                    )
+                  }}
                 />
               </FormControl>
               <FormMessage className="col-start-2" />
@@ -720,15 +647,16 @@ function HeartbeatSettingsField({
 }
 
 function AgentPromptField({
-  form,
+  editor,
   modelName,
   portalContainer
 }: {
-  form: UseFormReturn<AgentEditFormValues>
+  editor: AgentEditor
   modelName: string | null
   portalContainer: HTMLElement | null
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const [resetPreviewKey, setResetPreviewKey] = useState(0)
   const instructions = form.watch('instructions')
   const name = form.watch('name')
@@ -738,7 +666,7 @@ function AgentPromptField({
   })
 
   const handlePromptChange = (nextInstructions: string) => {
-    form.setValue('instructions', nextInstructions, { shouldDirty: true, shouldTouch: true })
+    set({ instructions: nextInstructions }, { instructions: nextInstructions }, 'debounced')
   }
 
   const handlePromptActionChange = (nextInstructions: string) => {
@@ -784,7 +712,7 @@ function AgentPromptField({
 
 function AgentToolsFields({
   agent,
-  form,
+  editor,
   activeToolTab,
   portalContainer,
   skills,
@@ -792,7 +720,7 @@ function AgentToolsFields({
   skillsReady
 }: {
   agent: AgentDetail
-  form: UseFormReturn<AgentEditFormValues>
+  editor: AgentEditor
   activeToolTab: ToolTab
   portalContainer: HTMLElement | null
   skills: InstalledSkill[]
@@ -800,6 +728,7 @@ function AgentToolsFields({
   skillsReady: boolean
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const disabledTools = form.watch('disabledTools')
   const mcps = form.watch('mcps')
   const knowledgeBaseIds = form.watch('knowledgeBaseIds')
@@ -835,19 +764,29 @@ function AgentToolsFields({
     () => new Set(builtinSections.flatMap((s) => s.items.map((i) => i.id)).filter((id) => !disabledSet.has(id))),
     [builtinSections, disabledSet]
   )
-  const setToolEnabled = (name: string, enabled: boolean) =>
-    form.setValue('disabledTools', enabled ? disabledTools.filter((n) => n !== name) : [...disabledTools, name], {
-      shouldDirty: true
-    })
+  const setToolEnabled = (name: string, enabled: boolean) => {
+    const next = enabled ? disabledTools.filter((n) => n !== name) : [...disabledTools, name]
+    set({ disabledTools: next }, { disabledTools: next })
+  }
 
   const mcpIds = useMemo(() => new Set(mcps), [mcps])
-  const enableMCP = (id: string) => form.setValue('mcps', [...mcps, id], { shouldDirty: true })
-  const disableMCP = (id: string) =>
-    form.setValue(
-      'mcps',
-      mcps.filter((mcpId) => mcpId !== id),
-      { shouldDirty: true }
-    )
+  const setMcpEnabled = (id: string, enabled: boolean) => {
+    const next = enabled ? [...mcps, id] : mcps.filter((mcpId) => mcpId !== id)
+    set({ mcps: next }, { mcps: next })
+  }
+
+  // Skills persist as per-skill toggles, so send only the ids whose enablement
+  // actually flipped rather than the whole selection.
+  const setSkillIds = (nextSkillIds: string[]) => {
+    const before = new Set(skillIds)
+    const after = new Set(nextSkillIds)
+    const skillUpdates: AgentSkillUpdateDto[] = [
+      ...skillIds.filter((id) => !after.has(id)).map((skillId) => ({ skillId, isEnabled: false })),
+      ...nextSkillIds.filter((id) => !before.has(id)).map((skillId) => ({ skillId, isEnabled: true }))
+    ]
+    if (skillUpdates.length === 0) return
+    set({ skillIds: nextSkillIds }, { skillUpdates })
+  }
 
   return (
     <div className="grid gap-4">
@@ -868,13 +807,17 @@ function AgentToolsFields({
         </div>
       ) : null}
       {activeToolTab === 'tools.knowledge' ? (
-        <KnowledgeBaseField form={form} portalContainer={portalContainer} />
+        <KnowledgeBaseField
+          form={form}
+          portalContainer={portalContainer}
+          onValueChange={(knowledgeBaseIds) => set({ knowledgeBaseIds }, { knowledgeBaseIds })}
+        />
       ) : null}
       {activeToolTab === 'tools.mcp' ? (
         <McpServerCatalogGrid
           title={t('library.config.tools.added')}
           enabledIds={mcpIds}
-          onToggle={(id, enabled) => (enabled ? enableMCP(id) : disableMCP(id))}
+          onToggle={setMcpEnabled}
           emptyLabel={t('library.config.agent.section.tools.no_mcp_bound')}
           portalContainer={portalContainer}
         />
@@ -886,7 +829,7 @@ function AgentToolsFields({
           loading={skillsLoading}
           selectedIds={skillIds}
           disabled={!canManageSkills || !skillsReady}
-          onSelectedIdsChange={(ids) => form.setValue('skillIds', ids, { shouldDirty: true })}
+          onSelectedIdsChange={setSkillIds}
           emptyLabel={
             canManageSkills
               ? t('library.config.agent.section.tools.no_skills_enabled')
@@ -909,8 +852,9 @@ function AgentToolsFields({
   )
 }
 
-function AgentAdvancedFields({ form }: { form: UseFormReturn<AgentEditFormValues> }) {
+function AgentAdvancedFields({ editor }: { editor: AgentEditor }) {
   const { t } = useTranslation()
+  const { form, set } = editor
 
   return (
     <div>
@@ -926,7 +870,13 @@ function AgentAdvancedFields({ form }: { form: UseFormReturn<AgentEditFormValues
             <FormControl>
               <Textarea.Input
                 value={field.value}
-                onValueChange={field.onChange}
+                onValueChange={(envVarsText) =>
+                  set(
+                    { envVarsText },
+                    agentConfigurationPatch({ env_vars: agentEnvVarsFromText(envVarsText) }),
+                    'debounced'
+                  )
+                }
                 placeholder={t('library.config.agent.field.env_vars.placeholder')}
                 rows={5}
               />

--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -28,18 +28,16 @@ import { useGroupMutations, useGroups } from '@renderer/hooks/useGroups'
 import { usePromptProcessor } from '@renderer/hooks/usePromptProcessor'
 import { toast } from '@renderer/services/toast'
 import { MCP_MODE_OPTIONS, RESOURCE_PROMPT_POLISH_SYSTEM_PROMPT } from '@renderer/utils/resourceCatalog'
-import {
-  type AssistantFormState,
-  diffAssistantSaveIntent,
-  initialAssistantFormState
-} from '@renderer/utils/resourceCatalog'
+import { type AssistantFormState, initialAssistantFormState } from '@renderer/utils/resourceCatalog'
 import { AGENT_PROMPT } from '@shared/ai/prompts'
+import type { UpdateAssistantDto } from '@shared/data/api/schemas/assistants'
+import type { AssistantSettings } from '@shared/data/types/assistant'
 import { DEFAULT_ASSISTANT_SETTINGS, MAX_TOOL_CALLS, MIN_TOOL_CALLS } from '@shared/data/types/assistant'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import { isNonChatModel } from '@shared/utils/model'
 import { Sparkles, Trash2 } from 'lucide-react'
-import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react'
-import { useForm, type UseFormReturn } from 'react-hook-form'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type Path, useForm, type UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -56,13 +54,12 @@ import {
   KnowledgeBaseField,
   type ModelLabels,
   PromptVariablesPopover,
-  setFormValues,
-  TextInputField,
-  useDebouncedAutoSave
+  TextInputField
 } from '../components/EditDialogShared'
 import { GroupSelector } from '../components/GroupSelector'
 import { McpServerCatalogGrid } from '../components/McpServerCatalogGrid'
 import { PromptPolishActions } from '../components/PromptPolishActions'
+import { useDirectFieldSave } from '../components/useDirectFieldSave'
 
 export type AssistantEditDialogResource = Parameters<typeof initialAssistantFormState>[0]
 
@@ -145,33 +142,42 @@ function modelLabelsForAssistant(resource: AssistantEditDialogResource): ModelLa
   }
 }
 
-function buildAssistantFormState(baseline: AssistantFormState, values: AssistantEditFormValues): AssistantFormState {
-  return {
-    ...baseline,
-    emoji: values.avatar,
-    name: values.name,
-    description: values.description,
-    modelId: values.modelId,
-    groupId: values.groupId,
-    prompt: values.prompt,
-    temperature: values.temperature,
-    enableTemperature: values.enableTemperature,
-    topP: values.topP,
-    enableTopP: values.enableTopP,
-    maxTokens: values.maxTokens,
-    enableMaxTokens: values.enableMaxTokens,
-    streamOutput: values.streamOutput,
-    maxToolCalls: values.maxToolCalls,
-    enableMaxToolCalls: values.enableMaxToolCalls,
-    customParameters: values.customParameters,
-    mcpMode: values.mcpMode,
-    contextOverrideEnabled: values.contextOverrideEnabled,
-    contextCompressEnabled: values.contextCompressEnabled,
-    contextTruncateThreshold: values.contextTruncateThreshold,
-    contextCompressModelId: values.contextCompressModelId,
-    knowledgeBaseIds: values.knowledgeBaseIds,
-    mcpServerIds: values.mcpServerIds
+/**
+ * Combine a queued PATCH with a newer one. `settings` is a deep partial on the
+ * wire, so overlapping settings edits merge key-by-key instead of the newer
+ * fragment dropping the older one.
+ */
+function mergeAssistantPatch(base: UpdateAssistantDto, next: UpdateAssistantDto): UpdateAssistantDto {
+  const merged: UpdateAssistantDto = { ...base, ...next }
+  if (base.settings || next.settings) {
+    merged.settings = { ...base.settings, ...next.settings }
   }
+  return merged
+}
+
+/** `null` clears the per-assistant override so the globals apply again. */
+function contextSettingsFromValues(values: AssistantEditFormValues): AssistantSettings['contextSettings'] {
+  if (!values.contextOverrideEnabled) return null
+  return {
+    truncateThreshold: values.contextTruncateThreshold,
+    compress: { enabled: values.contextCompressEnabled, modelId: values.contextCompressModelId }
+  }
+}
+
+/**
+ * Writes one draft field and persists just that field.
+ *
+ * Every control owns its own PATCH, so an unrelated legacy value stored on the
+ * assistant can never invalidate the request (the cause of #18160).
+ */
+type AssistantEditor = {
+  form: UseFormReturn<AssistantEditFormValues>
+  set: (
+    values: Partial<AssistantEditFormValues>,
+    patch: UpdateAssistantDto,
+    /** `debounced` batches keystrokes; everything else saves on the spot. */
+    mode?: 'now' | 'debounced'
+  ) => void
 }
 
 export function AssistantEditDialog({
@@ -209,14 +215,29 @@ function AssistantEditDialogContent({
   const [modelLabels, setModelLabels] = useState<ModelLabels>(() => modelLabelsForAssistant(resource))
   const defaultValues = useMemo(() => defaultValuesForAssistant(resource), [resource])
   const form = useForm<AssistantEditFormValues>({ defaultValues })
-  const values = form.watch()
   const { groups, isLoading: isGroupsLoading, error: groupsError } = useGroups('assistant')
   const { createGroup } = useGroupMutations('assistant')
   const { updateAssistant } = useAssistantMutationsById(resource.id)
-  const saveIntent = useMemo(() => {
-    const baseline = initialAssistantFormState(resource)
-    return diffAssistantSaveIntent(buildAssistantFormState(baseline, values), baseline, resource)
-  }, [resource, values])
+  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
+  const save = useDirectFieldSave<UpdateAssistantDto>({
+    save: updateAssistant,
+    merge: mergeAssistantPatch,
+    onError: (error) => {
+      logger.error('Failed to save assistant edit dialog', error, { assistantId: resource.id })
+      toast.error(saveFailedMessage)
+    }
+  })
+  const setField = useCallback<AssistantEditor['set']>(
+    (values, patch, mode = 'now') => {
+      for (const [key, value] of Object.entries(values)) {
+        form.setValue(key as Path<AssistantEditFormValues>, value as never, { shouldDirty: true })
+      }
+      if (mode === 'debounced') save.schedule(patch)
+      else save.commit(patch)
+    },
+    [form, save]
+  )
+  const editor = useMemo<AssistantEditor>(() => ({ form, set: setField }), [form, setField])
   const tabs = useMemo<EditDialogTab[]>(
     () => [
       { id: 'basic', label: t('library.config.dialogs.edit.basic_tab') },
@@ -234,10 +255,6 @@ function AssistantEditDialogContent({
     [t]
   )
 
-  // Tracks the exact form snapshot that failed so it cannot be retried until
-  // the user changes the form.
-  const failedSaveKeyRef = useRef<string | null>(null)
-
   const wasOpenRef = useRef(false)
   useEffect(() => {
     const justOpened = open && !wasOpenRef.current
@@ -254,67 +271,13 @@ function AssistantEditDialogContent({
     setEmojiPickerOpen(false)
     setCreateGroupDialogOpen(false)
     setModelLabels(modelLabelsForAssistant(resource))
-    // A fresh open is a fresh editing session — a stale failure from a prior
-    // session (this instance can outlive one close, see the exit-animation
-    // hold in useResourceCatalogController) must not silently discard a new,
-    // coincidentally-identical edit as if it were a repeated close.
-    failedSaveKeyRef.current = null
   }, [defaultValues, form, initialTab, open, resource])
 
-  const rootError = form.formState.errors.root?.message
-  const canPersist = Boolean(saveIntent) && values.name.trim().length > 0
-  const changeKey = canPersist ? JSON.stringify(values) : null
-  const saveFailedMessage = t('library.config.dialogs.edit.save_failed')
-
-  const persist = async () => {
-    const pending = saveIntent
-    if (!pending || !changeKey) return
-    const attemptedKey = changeKey
-
-    // A close-triggered flush does not cancel the already scheduled debounce.
-    // Keep both paths from resending an unchanged payload that already failed.
-    if (failedSaveKeyRef.current === attemptedKey) return
-
-    form.clearErrors('root')
-    failedSaveKeyRef.current = null
-
-    try {
-      await updateAssistant(pending.payload)
-    } catch (error) {
-      logger.error('Failed to auto-save assistant edit dialog', error as Error, { assistantId: resource.id })
-      failedSaveKeyRef.current = attemptedKey
-      form.setError('root', { message: saveFailedMessage })
-      toast.error(saveFailedMessage)
-    }
-  }
-
-  // Key the debounce on the form values (user input), not on saveIntent: the
-  // update mutation refreshes /assistants/* → resource refetches → saveIntent's
-  // baseline moves, but the values are unchanged, so this never re-fires from our
-  // own save (prevents a save→refetch→save loop).
-  const flush = useDebouncedAutoSave({
-    enabled: open,
-    changeKey,
-    onSave: persist
-  })
-
-  // On close with a pending edit, flush through the same serialized save queue and
-  // only close once it settles — so a failed final save stays visible instead of
-  // being silently dropped, and we never race a second concurrent save.
+  // Send whatever is still debounced, then close regardless of the outcome: a
+  // rejected field save is reported by the queue, never by trapping the user.
   const handleOpenChange = (next: boolean) => {
-    if (next || !canPersist) {
-      onOpenChange(next)
-      return
-    }
-    if (failedSaveKeyRef.current === changeKey) {
-      toast.error(saveFailedMessage)
-      return
-    }
-    void (async () => {
-      await flush()
-      if (failedSaveKeyRef.current !== null) return
-      onOpenChange(false)
-    })()
+    if (!next) void save.flush()
+    onOpenChange(next)
   }
   // Route the settings-navigate close through handleOpenChange so it flushes too.
   const closeBeforeAction = useCloseBeforeAction(handleOpenChange)
@@ -322,7 +285,7 @@ function AssistantEditDialogContent({
   const handleCreateGroup = async (name: string) => {
     try {
       const group = await createGroup(name)
-      form.setValue('groupId', group.id, { shouldDirty: true, shouldTouch: true })
+      setField({ groupId: group.id }, { groupId: group.id })
     } catch (error) {
       logger.error(
         'Failed to create assistant group from edit dialog',
@@ -343,15 +306,16 @@ function AssistantEditDialogContent({
       groupPresentation="inline"
       onActiveTabChange={setActiveTab}
       onOpenChange={handleOpenChange}
+      onRetrySave={save.retry}
       open={open}
-      rootError={rootError}
+      saveStatus={save.status}
       setDialogContentElement={setDialogContentElement}
       tabs={tabs}
       title={t('library.config.dialogs.edit.assistant_title')}>
       <>
         <TabsContent value="basic" forceMount hidden={activeTab !== 'basic'} className="m-0">
           <AssistantBasicFields
-            form={form}
+            editor={editor}
             modelFilter={modelFilter}
             portalContainer={dialogContentElement}
             modelLabels={modelLabels}
@@ -371,7 +335,7 @@ function AssistantEditDialogContent({
           hidden={activeTab !== 'prompt'}
           className="m-0 flex h-full min-h-0 flex-col">
           <AssistantPromptField
-            form={form}
+            editor={editor}
             resource={resource}
             modelName={modelLabels.modelId}
             portalContainer={dialogContentElement}
@@ -380,17 +344,21 @@ function AssistantEditDialogContent({
         {isAssistantToolTab(activeTab) ? (
           <TabsContent value={activeTab} forceMount className="m-0">
             {activeTab === 'tools.mcp' ? (
-              <AssistantToolsFields form={form} portalContainer={dialogContentElement} />
+              <AssistantToolsFields editor={editor} portalContainer={dialogContentElement} />
             ) : (
               <div className="grid gap-4">
-                <KnowledgeBaseField form={form} portalContainer={dialogContentElement} />
+                <KnowledgeBaseField
+                  form={form}
+                  portalContainer={dialogContentElement}
+                  onValueChange={(knowledgeBaseIds) => setField({ knowledgeBaseIds }, { knowledgeBaseIds })}
+                />
               </div>
             )}
           </TabsContent>
         ) : null}
         <TabsContent value="advanced" forceMount hidden={activeTab !== 'advanced'} className="m-0">
           <AssistantAdvancedFields
-            form={form}
+            editor={editor}
             portalContainer={dialogContentElement}
             modelLabels={modelLabels}
             setModelLabels={setModelLabels}
@@ -407,7 +375,7 @@ function AssistantEditDialogContent({
 }
 
 function AssistantBasicFields({
-  form,
+  editor,
   modelFilter,
   portalContainer,
   modelLabels,
@@ -420,7 +388,7 @@ function AssistantBasicFields({
   onCreateGroup,
   onSettingsNavigate
 }: {
-  form: UseFormReturn<AssistantEditFormValues>
+  editor: AssistantEditor
   modelFilter?: (model: Model) => boolean
   portalContainer: HTMLElement | null
   modelLabels: ModelLabels
@@ -434,15 +402,32 @@ function AssistantBasicFields({
   onSettingsNavigate?: (navigate: () => void) => void
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
+
+  const handleNameChange = (name: string) => {
+    // An empty name is a transient editing state, not a persistable value: keep
+    // it in the draft, surface the required message, and skip the PATCH.
+    const trimmed = name.trim()
+    if (!trimmed) {
+      form.setValue('name', name, { shouldDirty: true, shouldValidate: true })
+      return
+    }
+    set({ name }, { name: trimmed }, 'debounced')
+  }
+
   const handleAssistantModelChange = (modelId: UniqueModelId | null, model?: Model) => {
-    const patch: Partial<AssistantEditFormValues> = { modelId }
+    const values: Partial<AssistantEditFormValues> = { modelId }
+    const patch: UpdateAssistantDto = { modelId }
     const nameLower = model?.name.toLowerCase() ?? ''
     if (nameLower.includes('kimi-k2')) {
-      patch.temperature = 0.6
+      values.temperature = 0.6
     } else if (nameLower.includes('moonshot')) {
-      patch.temperature = 0.3
+      values.temperature = 0.3
     }
-    setFormValues(form, patch)
+    if (values.temperature !== undefined) {
+      patch.settings = { temperature: values.temperature }
+    }
+    set(values, patch)
   }
 
   return (
@@ -455,6 +440,7 @@ function AssistantBasicFields({
         portalContainer={portalContainer}
         size="sm"
         layout="row"
+        onValueChange={(avatar) => set({ avatar }, { emoji: avatar })}
       />
       <TextInputField
         form={form}
@@ -463,6 +449,7 @@ function AssistantBasicFields({
         placeholder={t('library.config.basic.field.name.placeholder')}
         required
         layout="row"
+        onValueChange={handleNameChange}
       />
       <TextInputField
         form={form}
@@ -470,6 +457,7 @@ function AssistantBasicFields({
         label={t('common.description')}
         placeholder={t('library.config.basic.field.description.placeholder')}
         layout="row"
+        onValueChange={(description) => set({ description }, { description }, 'debounced')}
       />
       <CompactModelField
         form={form}
@@ -493,7 +481,7 @@ function AssistantBasicFields({
             <FormLabel className={editDialogFormRowLabelClassName}>{t('library.config.basic.group')}</FormLabel>
             <GroupSelector
               value={field.value}
-              onChange={field.onChange}
+              onChange={(groupId) => set({ groupId }, { groupId })}
               groups={groups}
               isLoading={groupsLoading}
               error={groupsError}
@@ -510,17 +498,18 @@ function AssistantBasicFields({
 }
 
 function AssistantPromptField({
-  form,
+  editor,
   resource,
   modelName,
   portalContainer
 }: {
-  form: UseFormReturn<AssistantEditFormValues>
+  editor: AssistantEditor
   resource: AssistantEditDialogResource
   modelName: string | null
   portalContainer: HTMLElement | null
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const [resetPreviewKey, setResetPreviewKey] = useState(0)
   const prompt = form.watch('prompt')
   const name = form.watch('name')
@@ -530,7 +519,7 @@ function AssistantPromptField({
   })
 
   const handlePromptChange = (nextPrompt: string) => {
-    form.setValue('prompt', nextPrompt, { shouldDirty: true, shouldTouch: true })
+    set({ prompt: nextPrompt }, { prompt: nextPrompt }, 'debounced')
   }
 
   const handlePromptActionChange = (nextPrompt: string) => {
@@ -577,24 +566,25 @@ function AssistantPromptField({
 }
 
 function AssistantToolsFields({
-  form,
+  editor,
   portalContainer
 }: {
-  form: UseFormReturn<AssistantEditFormValues>
+  editor: AssistantEditor
   portalContainer: HTMLElement | null
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const mcpMode = form.watch('mcpMode')
   const mcpServerIds = form.watch('mcpServerIds')
   const mcpModeLabel = t('library.config.basic.mcp_mode')
 
   const enabledIds = useMemo(() => new Set(mcpServerIds), [mcpServerIds])
-  const toggleMcpServer = (id: string, enabled: boolean) =>
-    form.setValue(
-      'mcpServerIds',
-      enabled ? Array.from(new Set([...mcpServerIds, id])) : mcpServerIds.filter((serverId) => serverId !== id),
-      { shouldDirty: true }
-    )
+  const toggleMcpServer = (id: string, enabled: boolean) => {
+    const next = enabled
+      ? Array.from(new Set([...mcpServerIds, id]))
+      : mcpServerIds.filter((serverId) => serverId !== id)
+    set({ mcpServerIds: next }, { mcpServerIds: next })
+  }
 
   return (
     <div className="grid gap-4">
@@ -611,7 +601,7 @@ function AssistantToolsFields({
                   className="shrink-0"
                   aria-label={mcpModeLabel}
                   value={mcpMode}
-                  onValueChange={(value) => form.setValue('mcpMode', value, { shouldDirty: true })}
+                  onValueChange={(value) => set({ mcpMode: value }, { settings: { mcpMode: value } })}
                   options={MCP_MODE_OPTIONS.map((mode) => ({
                     value: mode.id,
                     label: t(mode.labelKey)
@@ -647,17 +637,18 @@ function AssistantToolsFields({
 }
 
 function AssistantAdvancedFields({
-  form,
+  editor,
   portalContainer,
   modelLabels,
   setModelLabels
 }: {
-  form: UseFormReturn<AssistantEditFormValues>
+  editor: AssistantEditor
   portalContainer: HTMLElement | null
   modelLabels: ModelLabels
   setModelLabels: (labels: ModelLabels) => void
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const values = form.watch()
   // Global defaults, shown as the seed when the user turns the override on for
   // an assistant that has none stored yet.
@@ -682,12 +673,15 @@ function AssistantAdvancedFields({
         valueLabel={values.enableTemperature ? values.temperature.toFixed(1) : t('library.config.basic.default_value')}
         description={t('library.config.basic.field.temperature.hint')}
         enabled={values.enableTemperature}
-        onEnabledChange={(checked) => form.setValue('enableTemperature', checked, { shouldDirty: true })}>
+        onEnabledChange={(checked) =>
+          set({ enableTemperature: checked }, { settings: { enableTemperature: checked } })
+        }>
         <FormField
           control={form.control}
           name="temperature"
           render={({ field }) => (
             <div className="-mb-2 mt-3 w-full">
+              {/* Drag updates the draft; only the released value is persisted. */}
               <Slider
                 min={0}
                 max={2}
@@ -695,6 +689,7 @@ function AssistantAdvancedFields({
                 value={[field.value]}
                 marks={temperatureMarks}
                 onValueChange={([value]) => field.onChange(value)}
+                onValueCommit={([value]) => set({ temperature: value }, { settings: { temperature: value } })}
                 className="w-full"
               />
             </div>
@@ -707,7 +702,7 @@ function AssistantAdvancedFields({
         valueLabel={values.enableTopP ? values.topP.toFixed(2) : t('library.config.basic.default_value')}
         description={t('library.config.basic.field.top_p.hint')}
         enabled={values.enableTopP}
-        onEnabledChange={(checked) => form.setValue('enableTopP', checked, { shouldDirty: true })}>
+        onEnabledChange={(checked) => set({ enableTopP: checked }, { settings: { enableTopP: checked } })}>
         <FormField
           control={form.control}
           name="topP"
@@ -720,6 +715,7 @@ function AssistantAdvancedFields({
                 value={[field.value]}
                 marks={topPMarks}
                 onValueChange={([value]) => field.onChange(value)}
+                onValueCommit={([value]) => set({ topP: value }, { settings: { topP: value } })}
                 className="w-full"
               />
             </div>
@@ -732,7 +728,7 @@ function AssistantAdvancedFields({
         valueLabel={values.enableMaxTokens ? undefined : t('library.config.basic.default_value')}
         description={t('library.config.basic.field.max_tokens.hint')}
         enabled={values.enableMaxTokens}
-        onEnabledChange={(checked) => form.setValue('enableMaxTokens', checked, { shouldDirty: true })}
+        onEnabledChange={(checked) => set({ enableMaxTokens: checked }, { settings: { enableMaxTokens: checked } })}
         control={
           <FormField
             control={form.control}
@@ -747,9 +743,10 @@ function AssistantAdvancedFields({
                 changeOnBlur
                 className="h-8 rounded-lg border-border bg-transparent px-2.5 shadow-none focus-visible:border-primary"
                 value={field.value}
-                onChange={(value) =>
-                  field.onChange(typeof value === 'number' && value > 0 ? value : UI_DEFAULT_MAX_TOKENS)
-                }
+                onChange={(value) => {
+                  const maxTokens = typeof value === 'number' && value > 0 ? value : UI_DEFAULT_MAX_TOKENS
+                  set({ maxTokens }, { settings: { maxTokens } })
+                }}
               />
             )}
           />
@@ -772,7 +769,7 @@ function AssistantAdvancedFields({
                 <Switch
                   size="sm"
                   checked={field.value}
-                  onCheckedChange={field.onChange}
+                  onCheckedChange={(checked) => set({ streamOutput: checked }, { settings: { streamOutput: checked } })}
                   aria-label={t('library.config.basic.stream_output')}
                 />
               </FormControl>
@@ -795,7 +792,9 @@ function AssistantAdvancedFields({
           count: DEFAULT_ASSISTANT_SETTINGS.maxToolCalls
         })}
         enabled={values.enableMaxToolCalls}
-        onEnabledChange={(checked) => form.setValue('enableMaxToolCalls', checked, { shouldDirty: true })}
+        onEnabledChange={(checked) =>
+          set({ enableMaxToolCalls: checked }, { settings: { enableMaxToolCalls: checked } })
+        }
         control={
           <FormField
             control={form.control}
@@ -811,11 +810,11 @@ function AssistantAdvancedFields({
                 changeOnBlur
                 className="h-8 rounded-lg border-border bg-transparent px-2.5 shadow-none focus-visible:border-primary"
                 value={field.value}
-                onChange={(value) =>
-                  field.onChange(
+                onChange={(value) => {
+                  const maxToolCalls =
                     typeof value === 'number' && value > 0 ? value : DEFAULT_ASSISTANT_SETTINGS.maxToolCalls
-                  )
-                }
+                  set({ maxToolCalls }, { settings: { maxToolCalls } })
+                }}
               />
             )}
           />
@@ -823,7 +822,7 @@ function AssistantAdvancedFields({
       />
 
       <ContextManagementFields
-        form={form}
+        editor={editor}
         portalContainer={portalContainer}
         modelLabels={modelLabels}
         setModelLabels={setModelLabels}
@@ -840,7 +839,7 @@ function AssistantAdvancedFields({
         render={({ field }) => (
           <CustomParametersField
             value={field.value}
-            onChange={(customParameters) => field.onChange(customParameters)}
+            onChange={(customParameters) => set({ customParameters }, { settings: { customParameters } }, 'debounced')}
             portalContainer={portalContainer}
           />
         )}
@@ -850,32 +849,43 @@ function AssistantAdvancedFields({
 }
 
 function ContextManagementFields({
-  form,
+  editor,
   portalContainer,
   modelLabels,
   setModelLabels,
   globalDefaults
 }: {
-  form: UseFormReturn<AssistantEditFormValues>
+  editor: AssistantEditor
   portalContainer: HTMLElement | null
   modelLabels: ModelLabels
   setModelLabels: (labels: ModelLabels) => void
   globalDefaults: { compressEnabled: boolean; truncateThreshold: number; compressModelId: string | null }
 }) {
   const { t } = useTranslation()
+  const { form, set } = editor
   const values = form.watch()
   // Only re-seed from globals the first time an assistant WITHOUT a stored
   // override is customized — an ON→OFF→ON round trip on a stored override must
   // preserve the saved values.
   const hadStoredOverride = useRef(values.contextOverrideEnabled)
 
+  // The override is one stored object, so every sub-field ships the whole
+  // `contextSettings` value rebuilt from the current draft.
+  const setContextValues = (patch: Partial<AssistantEditFormValues>) => {
+    const next = { ...values, ...patch }
+    set(patch, { settings: { contextSettings: contextSettingsFromValues(next) } })
+  }
+
   const onOverrideToggle = (checked: boolean) => {
-    if (checked && !hadStoredOverride.current) {
-      form.setValue('contextCompressEnabled', globalDefaults.compressEnabled, { shouldDirty: true })
-      form.setValue('contextTruncateThreshold', globalDefaults.truncateThreshold, { shouldDirty: true })
-      form.setValue('contextCompressModelId', globalDefaults.compressModelId, { shouldDirty: true })
-    }
-    form.setValue('contextOverrideEnabled', checked, { shouldDirty: true })
+    const seed =
+      checked && !hadStoredOverride.current
+        ? {
+            contextCompressEnabled: globalDefaults.compressEnabled,
+            contextTruncateThreshold: globalDefaults.truncateThreshold,
+            contextCompressModelId: globalDefaults.compressModelId
+          }
+        : {}
+    setContextValues({ ...seed, contextOverrideEnabled: checked })
   }
 
   return (
@@ -904,7 +914,7 @@ function ContextManagementFields({
                     <Switch
                       size="sm"
                       checked={field.value}
-                      onCheckedChange={field.onChange}
+                      onCheckedChange={(checked) => setContextValues({ contextCompressEnabled: checked })}
                       aria-label={t('library.config.basic.context_compress_enabled')}
                     />
                   </FormControl>
@@ -934,7 +944,10 @@ function ContextManagementFields({
                     className="h-8 rounded-lg border-border bg-transparent px-2.5 shadow-none focus-visible:border-primary"
                     value={field.value}
                     onChange={(value) =>
-                      field.onChange(typeof value === 'number' && value > 0 ? value : globalDefaults.truncateThreshold)
+                      setContextValues({
+                        contextTruncateThreshold:
+                          typeof value === 'number' && value > 0 ? value : globalDefaults.truncateThreshold
+                      })
                     }
                   />
                 </FormControl>
@@ -954,7 +967,7 @@ function ContextManagementFields({
             portalContainer={portalContainer}
             modelLabels={modelLabels}
             setModelLabels={setModelLabels}
-            onModelChange={(modelId) => form.setValue('contextCompressModelId', modelId, { shouldDirty: true })}
+            onModelChange={(modelId) => setContextValues({ contextCompressModelId: modelId })}
           />
         </div>
       ) : null}

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -284,6 +284,7 @@ vi.mock('react-i18next', async (importOriginal) => {
           'common.preview': 'Preview',
           'common.remove': 'Remove',
           'common.required_field': 'Required',
+          'common.retry': 'Retry',
           'common.save': 'Save',
           'common.undo': 'Undo',
           'error.no_response': 'No response',
@@ -830,7 +831,7 @@ describe('edit dialogs', () => {
     )
   })
 
-  it('advances the agent form baseline before a queued follow-up save', async () => {
+  it('queues an edit made while an agent save is in flight and sends only that field', async () => {
     let resolveFirstSave: (() => void) | undefined
     updateAgentMock.mockImplementationOnce(
       () =>
@@ -854,7 +855,7 @@ describe('edit dialogs', () => {
     })
   })
 
-  it('preserves skill baseline initialization while an unrelated save is pending', async () => {
+  it('seeds the skill draft from the refreshed projection while an unrelated save is pending', async () => {
     installedSkillsState.current = {
       ...installedSkillsState.current,
       refreshing: true
@@ -1022,18 +1023,14 @@ describe('edit dialogs', () => {
     expectHelpTrigger('Max tool call rounds', 'Caps tool-call rounds at 100.')
     expectHelpTrigger('Custom parameters', 'Extra provider parameters.')
     fireEvent.click(screen.getByRole('switch', { name: 'Temperature' }))
+
+    // Each control PATCHes only the field it owns.
     await waitFor(() =>
-      expect(updateAssistantMock).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          knowledgeBaseIds: ['kb-1'],
-          mcpServerIds: ['mcp-1'],
-          settings: expect.objectContaining({
-            enableTemperature: true,
-            mcpMode: 'manual'
-          })
-        })
-      })
+      expect(updateAssistantMock).toHaveBeenCalledWith({ body: { settings: { enableTemperature: true } } })
     )
+    expect(updateAssistantMock).toHaveBeenCalledWith({ body: { knowledgeBaseIds: ['kb-1'] } })
+    expect(updateAssistantMock).toHaveBeenCalledWith({ body: { settings: { mcpMode: 'manual' } } })
+    expect(updateAssistantMock).toHaveBeenCalledWith({ body: { mcpServerIds: ['mcp-1'] } })
   })
 
   it('shows the default tool-call cap and clamps custom rounds at 1000', async () => {
@@ -1068,15 +1065,9 @@ describe('edit dialogs', () => {
 
     expect(maxToolCallsInput).toHaveValue(1000)
     await waitFor(() =>
-      expect(updateAssistantMock).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          settings: expect.objectContaining({
-            enableMaxToolCalls: true,
-            maxToolCalls: 1000
-          })
-        })
-      })
+      expect(updateAssistantMock).toHaveBeenCalledWith({ body: { settings: { maxToolCalls: 1000 } } })
     )
+    expect(updateAssistantMock).toHaveBeenCalledWith({ body: { settings: { enableMaxToolCalls: true } } })
   })
 
   it('polishes and restores assistant prompts through the shared action', async () => {
@@ -1150,16 +1141,15 @@ describe('edit dialogs', () => {
     expectHelpTrigger('Environment variables', 'One KEY=VALUE per line')
     fireEvent.change(screen.getByRole('textbox'), { target: { value: 'FOO=bar' } })
 
-    await waitFor(() => expect(updateAgentMock).toHaveBeenCalled())
-    const body = vi.mocked(updateAgentMock).mock.calls[0][0].body
-    expect(body).not.toHaveProperty('allowedTools')
-    expect(body.configuration).toHaveProperty('max_turns', undefined)
-    expect(body.configuration).toEqual(
-      expect.objectContaining({
-        env_vars: { FOO: 'bar' },
-        permission_mode: 'plan'
-      })
-    )
+    await waitFor(() => expect(updateAgentMock).toHaveBeenCalledTimes(2))
+    const bodies = vi.mocked(updateAgentMock).mock.calls.map(([call]) => call.body)
+    for (const body of bodies) {
+      expect(body).not.toHaveProperty('allowedTools')
+      // Every configuration write clears the retired field this dialog never surfaces.
+      expect(body.configuration).toHaveProperty('max_turns', undefined)
+    }
+    expect(bodies[0].configuration).toEqual({ permission_mode: 'plan', max_turns: undefined })
+    expect(bodies[1].configuration).toEqual({ env_vars: { FOO: 'bar' }, max_turns: undefined })
   })
 
   it('shows agent tool categories directly in the left tab list', async () => {
@@ -1264,7 +1254,7 @@ describe('edit dialogs', () => {
     expect(screen.getByTestId('skill-catalog-picker')).toHaveAttribute('data-mode', 'edit')
   })
 
-  it('waits for background skill refresh before initializing the editable baseline', async () => {
+  it('waits for background skill refresh before seeding the editable skill draft', async () => {
     installedSkillsState.current = {
       ...installedSkillsState.current,
       refreshing: true
@@ -1307,22 +1297,19 @@ describe('edit dialogs', () => {
     expect(screen.getByRole('tab', { name: 'MCP' })).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('auto-saves agent skill toggles after a debounce', async () => {
+  it('saves an agent skill toggle immediately as a single skill update', async () => {
     render(<AgentEditDialog open resource={AGENT} onOpenChange={vi.fn()} />)
 
     selectTab('技能')
 
     fireEvent.click(screen.getByRole('switch', { name: 'Skill One' }))
-    // Not persisted synchronously — the debounce is still pending.
-    expect(updateAgentMock).not.toHaveBeenCalled()
 
     await waitFor(() =>
       expect(updateAgentMock).toHaveBeenCalledWith({
-        body: expect.objectContaining({
-          skillUpdates: [{ skillId: 'skill-1', isEnabled: true }]
-        })
+        body: { skillUpdates: [{ skillId: 'skill-1', isEnabled: true }] }
       })
     )
+    expect(updateAgentMock).toHaveBeenCalledTimes(1)
   })
 
   it('uses the same MCP server list presentation in assistant and agent editing', async () => {
@@ -1470,8 +1457,7 @@ describe('edit dialogs', () => {
         body: expect.objectContaining({ name: 'Updated Assistant' })
       })
     )
-    // The close now awaits the flush and only closes once it settles.
-    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('persists the latest edit made while an earlier save is still in flight', async () => {
@@ -1504,7 +1490,17 @@ describe('edit dialogs', () => {
     })
   })
 
-  it('prompts without closing or retrying an unchanged failed assistant save', async () => {
+  it('flags an emptied name instead of persisting it', async () => {
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '  ' } })
+
+    expect(await screen.findByText('Required')).toBeInTheDocument()
+    await new Promise((resolve) => setTimeout(resolve, 700))
+    expect(updateAssistantMock).not.toHaveBeenCalled()
+  })
+
+  it('closes the assistant dialog even when the final save fails', async () => {
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
@@ -1512,78 +1508,55 @@ describe('edit dialogs', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Edit' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
 
-    expect(await screen.findByText('Save failed')).toBeInTheDocument()
-    expect(toast.error).toHaveBeenCalledWith('Save failed')
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-    const saveAttemptsAfterFailure = updateAssistantMock.mock.calls.length
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-    await new Promise((resolve) => setTimeout(resolve, 700))
-
-    expect(toast.error).toHaveBeenCalledTimes(2)
-    expect(updateAssistantMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    // A rejected field save is reported, never used to trap the user in the dialog.
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Save failed'))
+    expect(updateAssistantMock).toHaveBeenCalledWith({ body: { name: 'Closing Edit' } })
   })
 
-  it('retries saving when the form changes after a failed close', async () => {
-    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+  it('closes the agent dialog even when the final save fails', async () => {
+    updateAgentMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
-    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Agent' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Save failed'))
+    expect(updateAgentMock).toHaveBeenCalledWith({ body: { name: 'Closing Agent' } })
+  })
+
+  it('resends the rejected field when the user retries from the save banner', async () => {
+    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Retry Me' } })
+    await screen.findByText('Save failed')
+    expect(updateAssistantMock).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenLastCalledWith({ body: { name: 'Retry Me' } })
+    await waitFor(() => expect(screen.queryByText('Save failed')).not.toBeInTheDocument())
+  })
+
+  it('replaces a rejected field value with the next edit instead of resending it', async () => {
+    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
+    render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={vi.fn()} />)
 
     const nameInput = screen.getByLabelText('Name')
-    fireEvent.change(nameInput, { target: { value: 'First Closing Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    fireEvent.change(nameInput, { target: { value: 'Failed Edit' } })
+    await screen.findByText('Save failed')
 
-    await screen.findByText('Save failed', undefined, { timeout: 5000 })
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-    const saveAttemptsAfterFailure = updateAssistantMock.mock.calls.length
+    fireEvent.change(nameInput, { target: { value: 'Newer Edit' } })
 
-    fireEvent.change(nameInput, { target: { value: 'Retry Closing Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-
-    await waitFor(() => expect(updateAssistantMock.mock.calls.length).toBeGreaterThan(saveAttemptsAfterFailure))
-    expect(updateAssistantMock).toHaveBeenLastCalledWith({
-      body: expect.objectContaining({ name: 'Retry Closing Edit' })
-    })
-    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(2))
+    expect(updateAssistantMock).toHaveBeenLastCalledWith({ body: { name: 'Newer Edit' } })
   })
 
-  it('clears the failed assistant save snapshot when reopened within the exit-animation window', async () => {
-    // The host (useResourceCatalogController) keeps this dialog instance mounted for
-    // DIALOG_EXIT_ANIMATION_MS after `open` goes false, so a reopen within that window
-    // reuses the SAME component instance instead of remounting — simulate that with
-    // `rerender` rather than a fresh `render`.
-    updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
-    const onOpenChange = vi.fn()
-    const { rerender } = render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
-
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Repro Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-
-    await screen.findByText('Save failed', undefined, { timeout: 5000 })
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-
-    // Simulate an external close, then reopen on the same instance before it unmounts.
-    rerender(<AssistantEditDialog open={false} resource={ASSISTANT} onOpenChange={onOpenChange} />)
-    rerender(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
-    const saveAttemptsBeforeRetry = updateAssistantMock.mock.calls.length
-
-    // Make the exact same edit again. The new editing session must not mistake it
-    // for the prior session's failed snapshot and block the save.
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Repro Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-    expect(updateAssistantMock.mock.calls.length).toBeGreaterThan(saveAttemptsBeforeRetry)
-    expect(updateAssistantMock).toHaveBeenLastCalledWith({
-      body: expect.objectContaining({ name: 'Repro Edit' })
-    })
-    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
-  })
-
-  it('reuses the in-flight save when closing mid-save instead of racing a second one', async () => {
+  it('does not race a second save when closing mid-save', async () => {
     let resolveSave: (() => void) | undefined
     updateAssistantMock.mockImplementationOnce(
       () =>
@@ -1597,47 +1570,13 @@ describe('edit dialogs', () => {
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Mid Save' } })
     await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
 
-    // Close while that save is still in flight: no second concurrent save, and the
-    // dialog must not close until the in-flight save settles.
+    // Closing joins the in-flight save's queue rather than starting a second one,
+    // and does not wait for it.
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(updateAssistantMock).toHaveBeenCalledTimes(1)
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
 
     resolveSave?.()
-    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
-    expect(updateAssistantMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('prompts without closing or retrying an unchanged failed agent save', async () => {
-    updateAgentMock.mockRejectedValueOnce(new Error('Network down'))
-    const onOpenChange = vi.fn()
-    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
-
-    const nameInput = screen.getByLabelText('Name')
-    fireEvent.change(nameInput, { target: { value: 'Closing Agent' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-
-    expect(await screen.findByText('Save failed')).toBeInTheDocument()
-    expect(toast.error).toHaveBeenCalledWith('Save failed')
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-    const saveAttemptsAfterFailure = updateAgentMock.mock.calls.length
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-    await new Promise((resolve) => setTimeout(resolve, 700))
-
-    expect(toast.error).toHaveBeenCalledTimes(2)
-    expect(updateAgentMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
-
-    fireEvent.change(nameInput, { target: { value: 'Retry Agent' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
-
-    await waitFor(() => expect(updateAgentMock.mock.calls.length).toBeGreaterThan(saveAttemptsAfterFailure))
-    expect(updateAgentMock).toHaveBeenLastCalledWith({
-      body: expect.objectContaining({ name: 'Retry Agent' })
-    })
-    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false))
+    await waitFor(() => expect(updateAssistantMock).toHaveBeenCalledTimes(1))
   })
 })

--- a/src/renderer/utils/resourceCatalog/__tests__/agentForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/agentForm.test.ts
@@ -1,13 +1,7 @@
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import { describe, expect, it } from 'vitest'
 
-import {
-  type AgentFormState,
-  applyAgentFormPatch,
-  buildInitialAgentFormState,
-  diffAgentSaveIntent,
-  diffAgentUpdate
-} from '../agentForm'
+import { agentEnvVarsFromText, buildInitialAgentFormState } from '../agentForm'
 
 function createAgent(overrides: Partial<AgentDetail> = {}): AgentDetail {
   return {
@@ -85,174 +79,15 @@ describe('buildInitialAgentFormState', () => {
   })
 })
 
-describe('applyAgentFormPatch', () => {
-  it('normalizes the patched permission mode', () => {
-    const draft = buildInitialAgentFormState()
-    const next = applyAgentFormPatch(draft, { permissionMode: 'acceptEdits' })
-
-    expect(next.permissionMode).toBe('acceptEdits')
-  })
-
-  it('keeps other fields untouched when patching permission mode', () => {
-    const draft = buildInitialAgentFormState(
-      createAgent({ configuration: { permission_mode: 'bypassPermissions', avatar: '🚀' } })
-    )
-    const next = applyAgentFormPatch(draft, { permissionMode: 'default' })
-
-    expect(next.permissionMode).toBe('default')
-    expect(next.avatar).toBe('🚀')
-  })
-})
-
-describe('diffAgentSaveIntent', () => {
-  it('wraps update diffs for the edit dialog save handler', () => {
-    const agent = createAgent()
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, name: 'Renamed' }
-
-    expect(diffAgentSaveIntent(next, baseline)).toEqual({
-      kind: 'update',
-      payload: { name: 'Renamed' }
-    })
-  })
-})
-
-describe('diffAgentUpdate', () => {
-  it('returns null when nothing changed', () => {
-    const agent = createAgent()
-    const baseline = buildInitialAgentFormState(agent)
-    expect(diffAgentUpdate(baseline, baseline)).toBeNull()
-  })
-
-  it('includes only changed top-level keys in the PATCH payload', () => {
-    const agent = createAgent()
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, name: 'Renamed', instructions: 'new prompt' }
-
-    const result = diffAgentUpdate(baseline, next)
-    expect(result?.dto).toEqual({
-      name: 'Renamed',
-      instructions: 'new prompt'
+describe('agentEnvVarsFromText', () => {
+  it('parses KEY=VALUE lines, dropping blanks and keeping `=` inside values', () => {
+    expect(agentEnvVarsFromText('DEBUG=1\n\nURL=https://x?a=b\n')).toEqual({
+      DEBUG: '1',
+      URL: 'https://x?a=b'
     })
   })
 
-  it('emits knowledgeBaseIds when the bound knowledge bases change', () => {
-    const agent = createAgent({ knowledgeBaseIds: ['kb-1'] })
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, knowledgeBaseIds: ['kb-2'] }
-
-    const result = diffAgentUpdate(baseline, next)
-
-    expect(result?.dto).toEqual({ knowledgeBaseIds: ['kb-2'] })
-  })
-
-  it('does not emit knowledgeBaseIds when the bound knowledge base set is only reordered', () => {
-    const agent = createAgent({ knowledgeBaseIds: ['kb-1', 'kb-2'] })
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, knowledgeBaseIds: ['kb-2', 'kb-1'] }
-
-    expect(diffAgentUpdate(baseline, next)).toBeNull()
-  })
-
-  it('includes skillUpdates when the enabled skill set changes', () => {
-    const agent = createAgent()
-    const baseline = buildInitialAgentFormState(agent, ['skill-1'])
-    const next = { ...baseline, skillIds: ['skill-2'] }
-
-    const result = diffAgentUpdate(baseline, next)
-
-    expect(result?.dto).toEqual({
-      skillUpdates: [
-        { skillId: 'skill-1', isEnabled: false },
-        { skillId: 'skill-2', isEnabled: true }
-      ]
-    })
-  })
-
-  it('does not emit skillUpdates when the enabled skill set is only reordered', () => {
-    const agent = createAgent()
-    const baseline = buildInitialAgentFormState(agent, ['skill-1', 'skill-2'])
-    const next = { ...baseline, skillIds: ['skill-2', 'skill-1'] }
-
-    expect(diffAgentUpdate(baseline, next)).toBeNull()
-  })
-
-  it('preserves UniqueModelIds in the PATCH payload without legacy conversion', () => {
-    const agent = createAgent({
-      model: 'anthropic::claude-sonnet-4-5',
-      planModel: 'anthropic::claude-haiku-4-5',
-      smallModel: 'anthropic::claude-opus-4-5'
-    })
-    const baseline = buildInitialAgentFormState(agent)
-    const next: AgentFormState = {
-      ...baseline,
-      model: 'anthropic::claude-sonnet-4-6',
-      planModel: 'anthropic::claude-haiku-4-6',
-      smallModel: ''
-    }
-
-    const result = diffAgentUpdate(baseline, next)
-
-    expect(result?.dto).toMatchObject({
-      model: 'anthropic::claude-sonnet-4-6',
-      planModel: 'anthropic::claude-haiku-4-6',
-      smallModel: undefined
-    })
-  })
-
-  it('emits only edited configuration keys and explicitly removes max_turns', () => {
-    const agent = createAgent({
-      configuration: { avatar: '🤖', plugin_state: 'keep-me', max_turns: 10 }
-    })
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, avatar: '🚀' }
-
-    const result = diffAgentUpdate(baseline, next)
-    // Main preserves plugin_state by merging this intent into the latest row.
-    expect(result?.dto.configuration).toEqual({
-      avatar: '🚀',
-      max_turns: undefined
-    })
-  })
-
-  it('round-trips env_vars through the textarea format', () => {
-    const agent = createAgent({ configuration: { env_vars: { A: '1' } } })
-    const baseline = buildInitialAgentFormState(agent)
-    // User appends a line via the textarea control.
-    const next = { ...baseline, envVarsText: 'A=1\nB=2' }
-
-    const result = diffAgentUpdate(baseline, next)
-    expect(result?.dto.configuration).toMatchObject({
-      env_vars: {
-        A: '1',
-        B: '2'
-      }
-    })
-  })
-
-  it('preserves env var value whitespace after the first equals sign', () => {
-    const agent = createAgent({ configuration: { env_vars: {} } })
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, envVarsText: 'TOKEN= abc \nEMPTY=  \nSPACED_KEY =value=with=equals' }
-
-    const result = diffAgentUpdate(baseline, next)
-    expect(result?.dto.configuration).toMatchObject({
-      env_vars: {
-        TOKEN: ' abc ',
-        EMPTY: '  ',
-        SPACED_KEY: 'value=with=equals'
-      }
-    })
-  })
-
-  it('persists the explicit default permission mode when switching back from another mode', () => {
-    const agent = createAgent({ configuration: { permission_mode: 'plan' } })
-    const baseline = buildInitialAgentFormState(agent)
-    const next = { ...baseline, permissionMode: 'default' }
-
-    const result = diffAgentUpdate(baseline, next)
-    expect(result?.dto.configuration).toMatchObject({
-      permission_mode: 'default'
-    })
+  it('treats a line without `=` as an empty value', () => {
+    expect(agentEnvVarsFromText(' DEBUG ')).toEqual({ DEBUG: '' })
   })
 })

--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -2,7 +2,7 @@ import type { Assistant, AssistantSettings } from '@shared/data/types/assistant'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { describe, expect, it } from 'vitest'
 
-import { diffAssistantSaveIntent, diffAssistantUpdate, initialAssistantFormState } from '../assistantForm'
+import { initialAssistantFormState } from '../assistantForm'
 
 function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
   return {
@@ -76,152 +76,7 @@ describe('initialAssistantFormState', () => {
   })
 })
 
-describe('diffAssistantUpdate', () => {
-  it('returns null when nothing changed', () => {
-    const assistant = createAssistant()
-    const baseline = initialAssistantFormState(assistant)
-    expect(diffAssistantUpdate(baseline, baseline, assistant)).toBeNull()
-  })
-
-  it('emits the full columns+settings block when any column field changes', () => {
-    const assistant = createAssistant({ name: 'Original' })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, description: 'edited' }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result).not.toBeNull()
-    expect(result!.dto).toMatchObject({
-      name: 'Original',
-      emoji: assistant.emoji,
-      description: 'edited',
-      modelId: assistant.modelId,
-      prompt: assistant.prompt,
-      settings: expect.objectContaining({
-        temperature: baseline.temperature,
-        mcpMode: baseline.mcpMode
-      })
-    })
-    expect(result!.dto.groupId).toBeUndefined()
-  })
-
-  it('emits a valid MCP mode when editing an unrelated field on a legacy assistant', () => {
-    const assistant = createAssistant({
-      settings: {
-        ...DEFAULT_ASSISTANT_SETTINGS,
-        mcpMode: true
-      } as unknown as AssistantSettings
-    })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, description: 'edited' }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-
-    expect(result?.dto.settings?.mcpMode).toBe(DEFAULT_ASSISTANT_SETTINGS.mcpMode)
-  })
-
-  it('falls back to the server name when the form name is blank', () => {
-    const assistant = createAssistant({ name: 'Original' })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, name: '   ', description: 'd' }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.name).toBe('Original')
-  })
-
-  it('preserves server-side settings keys the UI does not surface', () => {
-    const assistant = createAssistant({
-      settings: {
-        ...DEFAULT_ASSISTANT_SETTINGS,
-        // `reasoning_effort` is a settings key the library dialog never
-        // touches — it MUST survive a columns PATCH.
-        reasoning_effort: 'high'
-      } as AssistantSettings
-    })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, prompt: 'updated' }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.settings).toMatchObject({ reasoning_effort: 'high' })
-  })
-
-  it('writes group changes directly into the DTO', () => {
-    const originalGroupId = '11111111-1111-4111-8111-111111111111'
-    const nextGroupId = '22222222-2222-4222-8222-222222222222'
-    const assistant = createAssistant({ groupId: originalGroupId })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, groupId: nextGroupId }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.groupId).toBe(nextGroupId)
-  })
-
-  it('writes null when clearing the assistant group', () => {
-    const assistant = createAssistant({ groupId: '11111111-1111-4111-8111-111111111111' })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, groupId: null }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.groupId).toBeNull()
-  })
-
-  it('emits knowledgeBaseIds only when the set changes, ignoring order', () => {
-    const assistant = createAssistant({ knowledgeBaseIds: ['a', 'b'] })
-    const baseline = initialAssistantFormState(assistant)
-
-    const reordered = { ...baseline, knowledgeBaseIds: ['b', 'a'] }
-    expect(diffAssistantUpdate(reordered, baseline, assistant)).toBeNull()
-
-    const added = { ...baseline, knowledgeBaseIds: ['a', 'b', 'c'] }
-    const result = diffAssistantUpdate(added, baseline, assistant)
-    expect(result?.dto.knowledgeBaseIds).toEqual(['a', 'b', 'c'])
-  })
-
-  it('emits mcpServerIds independently of the columns block', () => {
-    const assistant = createAssistant({ mcpServerIds: ['m-1'] })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, mcpServerIds: ['m-1', 'm-2'] }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.mcpServerIds).toEqual(['m-1', 'm-2'])
-    // No column changed → settings should NOT be in the dto.
-    expect(result?.dto.settings).toBeUndefined()
-    expect(result?.dto.name).toBeUndefined()
-  })
-
-  it('treats custom parameter changes as a column-block edit', () => {
-    const assistant = createAssistant()
-    const baseline = initialAssistantFormState(assistant)
-    const form = {
-      ...baseline,
-      customParameters: [{ name: 'seed', type: 'number', value: 42 } as const]
-    }
-
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.settings?.customParameters).toEqual([{ name: 'seed', type: 'number', value: 42 }])
-  })
-})
-
-describe('context-management override (P2-D)', () => {
-  it('seeds the override-off state when no contextSettings are stored', () => {
-    const form = initialAssistantFormState(createAssistant())
-    expect(form.contextOverrideEnabled).toBe(false)
-    expect(form.contextCompressModelId).toBeNull()
-  })
-
-  it('seeds the override-on state from a stored contextSettings object', () => {
-    const assistant = createAssistant({
-      settings: {
-        ...DEFAULT_ASSISTANT_SETTINGS,
-        contextSettings: { truncateThreshold: 4000, compress: { enabled: false, modelId: 'openai::c' } }
-      } as AssistantSettings
-    })
-    const form = initialAssistantFormState(assistant)
-    expect(form.contextOverrideEnabled).toBe(true)
-    expect(form.contextTruncateThreshold).toBe(4000)
-    expect(form.contextCompressEnabled).toBe(false)
-    expect(form.contextCompressModelId).toBe('openai::c')
-  })
-
+describe('initialAssistantFormState context override', () => {
   it('treats a null contextSettings as override-off (inherit)', () => {
     const assistant = createAssistant({
       settings: { ...DEFAULT_ASSISTANT_SETTINGS, contextSettings: null } as AssistantSettings
@@ -229,53 +84,19 @@ describe('context-management override (P2-D)', () => {
     expect(initialAssistantFormState(assistant).contextOverrideEnabled).toBe(false)
   })
 
-  it('writes contextSettings: null when the override is turned off', () => {
+  it('turns a stored contextSettings object into the override fields', () => {
     const assistant = createAssistant({
       settings: {
         ...DEFAULT_ASSISTANT_SETTINGS,
-        contextSettings: { truncateThreshold: 4000 }
+        contextSettings: { truncateThreshold: 8000, compress: { enabled: false, modelId: 'anthropic::c' } }
       } as AssistantSettings
     })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, contextOverrideEnabled: false }
 
-    const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.settings?.contextSettings).toBeNull()
-  })
-
-  it('builds the override object when the switch is on', () => {
-    const baseline = initialAssistantFormState(createAssistant())
-    const form = {
-      ...baseline,
+    expect(initialAssistantFormState(assistant)).toMatchObject({
       contextOverrideEnabled: true,
-      contextCompressEnabled: false,
       contextTruncateThreshold: 8000,
+      contextCompressEnabled: false,
       contextCompressModelId: 'anthropic::c'
-    }
-
-    const result = diffAssistantUpdate(form, baseline, createAssistant())
-    expect(result?.dto.settings?.contextSettings).toEqual({
-      truncateThreshold: 8000,
-      compress: { enabled: false, modelId: 'anthropic::c' }
-    })
-  })
-
-  it('does not PATCH when sub-fields change while the override is off', () => {
-    const baseline = initialAssistantFormState(createAssistant())
-    const form = { ...baseline, contextTruncateThreshold: 999 }
-    expect(diffAssistantUpdate(form, baseline, createAssistant())).toBeNull()
-  })
-})
-
-describe('diffAssistantSaveIntent', () => {
-  it('wraps update diffs for the edit dialog save handler', () => {
-    const assistant = createAssistant({ groupId: '11111111-1111-4111-8111-111111111111' })
-    const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, groupId: '22222222-2222-4222-8222-222222222222' }
-
-    expect(diffAssistantSaveIntent(form, baseline, assistant)).toEqual({
-      kind: 'update',
-      payload: { groupId: '22222222-2222-4222-8222-222222222222' }
     })
   })
 })

--- a/src/renderer/utils/resourceCatalog/agentForm.ts
+++ b/src/renderer/utils/resourceCatalog/agentForm.ts
@@ -1,10 +1,5 @@
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
-import {
-  DEFAULT_HEARTBEAT_ENABLED,
-  DEFAULT_HEARTBEAT_INTERVAL,
-  normalizePermissionMode
-} from '@renderer/utils/agent/permissionMode'
-import type { AgentSkillUpdateDto, UpdateAgentDto } from '@shared/data/api/schemas/agents'
+import { DEFAULT_HEARTBEAT_ENABLED, DEFAULT_HEARTBEAT_INTERVAL } from '@renderer/utils/agent/permissionMode'
 import type { AgentConfiguration } from '@shared/data/types/agent'
 import type { UniqueModelId } from '@shared/data/types/model'
 
@@ -16,9 +11,8 @@ import type { UniqueModelId } from '@shared/data/types/model'
  * Flat, controlled form-state for the Agent create/edit dialogs.
  *
  * Every editable field (one per `AgentBase` column + the common
- * `configuration.*` sub-keys surfaced by the dialog) lives on this object.
- * The dialog diffs it against the baseline at save time and emits a minimal
- * `UpdateAgentDto`.
+ * `configuration.*` sub-keys surfaced by the dialog) lives on this object. It
+ * seeds the dialog's draft; each control then persists its own field.
  */
 export interface AgentFormState {
   name: string
@@ -78,7 +72,7 @@ function envVarsToText(raw: unknown): string {
 }
 
 /** Reverse of `envVarsToText` — record of `KEY -> VALUE`, empty lines dropped. */
-function envVarsFromText(text: string): Record<string, string> {
+export function agentEnvVarsFromText(text: string): Record<string, string> {
   const entries = text
     .split(/\r?\n/)
     .filter((line) => line.trim().length > 0)
@@ -110,162 +104,5 @@ export function buildInitialAgentFormState(agent?: AgentDetail | null, skillIds:
     envVarsText: envVarsToText(cfg.env_vars),
     heartbeatEnabled: cfg.heartbeat_enabled ?? DEFAULT_HEARTBEAT_ENABLED,
     heartbeatInterval: asNumber(cfg.heartbeat_interval) || DEFAULT_HEARTBEAT_INTERVAL
-  }
-}
-
-export function applyAgentFormPatch(current: AgentFormState, patch: Partial<AgentFormState>): AgentFormState {
-  const next: AgentFormState = { ...current, ...patch }
-
-  if (Object.prototype.hasOwnProperty.call(patch, 'permissionMode')) {
-    next.permissionMode = normalizePermissionMode(patch.permissionMode)
-  }
-
-  return next
-}
-
-/** Result of {@link diffAgentUpdate}. */
-export interface AgentDiffResult {
-  dto: UpdateAgentDto
-}
-
-/**
- * Compute a minimal `UpdateAgentDto` by comparing `next` to `baseline`. Returns
- * `null` when no editable agent field changed.
- *
- * `configuration` contains only the keys edited by this form. Main merges those
- * keys into the latest persisted configuration inside the write transaction.
- * `max_turns` is explicitly removed whenever this form changes configuration,
- * because that retired field is intentionally not surfaced by the dialog.
- */
-export function diffAgentUpdate(baseline: AgentFormState, next: AgentFormState): AgentDiffResult | null {
-  const dto: UpdateAgentDto = {}
-  let dirty = false
-
-  if (baseline.name !== next.name) {
-    dto.name = next.name
-    dirty = true
-  }
-  if (baseline.description !== next.description) {
-    dto.description = next.description
-    dirty = true
-  }
-  if (baseline.model !== next.model) {
-    if (next.model) dto.model = next.model
-    dirty = true
-  }
-  if (baseline.planModel !== next.planModel) {
-    dto.planModel = next.planModel || undefined
-    dirty = true
-  }
-  if (baseline.smallModel !== next.smallModel) {
-    dto.smallModel = next.smallModel || undefined
-    dirty = true
-  }
-  if (baseline.instructions !== next.instructions) {
-    dto.instructions = next.instructions
-    dirty = true
-  }
-  if (!arraysEqual(baseline.mcps, next.mcps)) {
-    dto.mcps = next.mcps
-    dirty = true
-  }
-  if (!stringSetsEqual(baseline.knowledgeBaseIds, next.knowledgeBaseIds)) {
-    dto.knowledgeBaseIds = next.knowledgeBaseIds
-    dirty = true
-  }
-  const skillUpdates = diffSkillUpdates(baseline.skillIds, next.skillIds)
-  if (skillUpdates.length > 0) {
-    dto.skillUpdates = skillUpdates
-    dirty = true
-  }
-  if (!arraysEqual(baseline.disabledTools, next.disabledTools)) {
-    dto.disabledTools = next.disabledTools
-    dirty = true
-  }
-
-  const cfgPatch: AgentConfiguration = {}
-  let cfgDirty = false
-
-  if (baseline.avatar !== next.avatar) {
-    cfgPatch.avatar = next.avatar
-    cfgDirty = true
-  }
-  if (baseline.permissionMode !== next.permissionMode) {
-    cfgPatch.permission_mode = normalizePermissionMode(next.permissionMode)
-    cfgDirty = true
-  }
-  if (baseline.envVarsText !== next.envVarsText) {
-    cfgPatch.env_vars = envVarsFromText(next.envVarsText)
-    cfgDirty = true
-  }
-  if (baseline.heartbeatEnabled !== next.heartbeatEnabled) {
-    cfgPatch.heartbeat_enabled = next.heartbeatEnabled
-    cfgDirty = true
-  }
-  if (baseline.heartbeatInterval !== next.heartbeatInterval) {
-    if (next.heartbeatEnabled) {
-      cfgPatch.heartbeat_enabled = true
-    }
-    cfgPatch.heartbeat_interval = next.heartbeatInterval
-    cfgDirty = true
-  }
-
-  if (cfgDirty) {
-    dto.configuration = { ...cfgPatch, max_turns: undefined }
-    dirty = true
-  }
-
-  if (!dirty) return null
-
-  return { dto }
-}
-
-function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false
-  return true
-}
-
-function stringSetsEqual(a: readonly string[], b: readonly string[]): boolean {
-  const aSet = new Set(a)
-  const bSet = new Set(b)
-  return aSet.size === bSet.size && [...aSet].every((value) => bSet.has(value))
-}
-
-function diffSkillUpdates(baselineSkillIds: readonly string[], nextSkillIds: readonly string[]): AgentSkillUpdateDto[] {
-  const baselineSet = new Set(baselineSkillIds)
-  const nextSet = new Set(nextSkillIds)
-  const updates: AgentSkillUpdateDto[] = []
-
-  for (const skillId of baselineSkillIds) {
-    if (!nextSet.has(skillId)) updates.push({ skillId, isEnabled: false })
-  }
-  for (const skillId of nextSkillIds) {
-    if (!baselineSet.has(skillId)) updates.push({ skillId, isEnabled: true })
-  }
-
-  return updates
-}
-
-// ---------------------------------------------------------------------------
-// Unified save intent
-// ---------------------------------------------------------------------------
-
-/**
- * Single "what should save do next?" value consumed by edit dialog save
- * handlers.
- */
-export type AgentSaveIntent = { kind: 'update'; payload: UpdateAgentDto }
-
-/**
- * Resolve the current form into a save intent. Returns `null` when
- * there's nothing to do.
- */
-export function diffAgentSaveIntent(form: AgentFormState, baseline: AgentFormState): AgentSaveIntent | null {
-  const result = diffAgentUpdate(baseline, form)
-  if (!result) return null
-  return {
-    kind: 'update',
-    payload: result.dto
   }
 }

--- a/src/renderer/utils/resourceCatalog/assistantForm.ts
+++ b/src/renderer/utils/resourceCatalog/assistantForm.ts
@@ -1,4 +1,3 @@
-import type { UpdateAssistantDto } from '@shared/data/api/schemas/assistants'
 import type { Assistant, AssistantSettings } from '@shared/data/types/assistant'
 import { DEFAULT_ASSISTANT_SETTINGS, McpModeSchema } from '@shared/data/types/assistant'
 import { DEFAULT_CONTEXT_SETTINGS } from '@shared/data/types/contextSettings'
@@ -18,8 +17,8 @@ const UI_DEFAULT_TOP_P = 1
 const UI_DEFAULT_MAX_TOKENS = 4096
 
 /**
- * Flat form state for the Assistant edit dialog. Every editable field lives
- * here so the dialog commits in a single PATCH.
+ * Flat draft state for the Assistant edit dialog. Every editable field lives
+ * here; each control persists its own field.
  *
  * `groupId` stores the canonical assistant group reference. Names are resolved
  * only for display by the selector.
@@ -59,34 +58,6 @@ export interface AssistantFormState {
   mcpServerIds: string[]
 }
 
-function buildAssistantSettingsFromForm(
-  form: AssistantFormState,
-  baseSettings: AssistantSettings = DEFAULT_ASSISTANT_SETTINGS
-): AssistantSettings {
-  return {
-    ...baseSettings,
-    temperature: form.temperature,
-    enableTemperature: form.enableTemperature,
-    topP: form.topP,
-    enableTopP: form.enableTopP,
-    maxTokens: form.maxTokens,
-    enableMaxTokens: form.enableMaxTokens,
-    streamOutput: form.streamOutput,
-    maxToolCalls: form.maxToolCalls,
-    enableMaxToolCalls: form.enableMaxToolCalls,
-    customParameters: form.customParameters,
-    mcpMode: form.mcpMode,
-    // null = clear the override (inherit globals). The `enabled` kill-switch
-    // is deliberately not written here — it stays a global/topic-layer concern.
-    contextSettings: form.contextOverrideEnabled
-      ? {
-          truncateThreshold: form.contextTruncateThreshold,
-          compress: { enabled: form.contextCompressEnabled, modelId: form.contextCompressModelId }
-        }
-      : null
-  }
-}
-
 export function initialAssistantFormState(assistant: Assistant): AssistantFormState {
   const settings = assistant.settings ?? ({} as AssistantSettings)
   const mcpMode = McpModeSchema.safeParse(settings.mcpMode)
@@ -118,116 +89,4 @@ export function initialAssistantFormState(assistant: Assistant): AssistantFormSt
     knowledgeBaseIds: assistant.knowledgeBaseIds ?? [],
     mcpServerIds: assistant.mcpServerIds ?? []
   }
-}
-
-// ---------------------------------------------------------------------------
-// Diff
-// ---------------------------------------------------------------------------
-
-/**
- * Result of `diffAssistantUpdate`.
- *
- * `dto` is the complete PATCH body, including `groupId` when the assignment
- * changes.
- */
-export interface AssistantDiffResult {
-  dto: UpdateAssistantDto
-}
-
-export type AssistantSaveIntent = {
-  kind: 'update'
-  payload: UpdateAssistantDto
-}
-
-/**
- * Compute the minimal Assistant PATCH payload.
- *
- * - Columns block: when ANY of name/emoji/description/modelId/prompt
- *   or any settings field differs, the dto carries all five column
- *   keys + a full `settings` object spread over `assistant.settings`
- *   (preserves unrelated settings keys the UI doesn't surface).
- * - Relation arrays (knowledgeBaseIds / mcpServerIds) ship only when
- *   their set differs — order-insensitive, matches junction semantics.
- * - Group: placed directly on the DTO as the canonical `groupId`.
- *
- * Returns `null` when nothing changed.
- */
-export function diffAssistantUpdate(
-  form: AssistantFormState,
-  baseline: AssistantFormState,
-  assistant: Assistant
-): AssistantDiffResult | null {
-  const customParametersChanged = JSON.stringify(baseline.customParameters) !== JSON.stringify(form.customParameters)
-
-  const columnsChanged =
-    baseline.name !== form.name ||
-    baseline.emoji !== form.emoji ||
-    baseline.description !== form.description ||
-    baseline.modelId !== form.modelId ||
-    baseline.prompt !== form.prompt ||
-    baseline.temperature !== form.temperature ||
-    baseline.enableTemperature !== form.enableTemperature ||
-    baseline.topP !== form.topP ||
-    baseline.enableTopP !== form.enableTopP ||
-    baseline.maxTokens !== form.maxTokens ||
-    baseline.enableMaxTokens !== form.enableMaxTokens ||
-    baseline.streamOutput !== form.streamOutput ||
-    baseline.maxToolCalls !== form.maxToolCalls ||
-    baseline.enableMaxToolCalls !== form.enableMaxToolCalls ||
-    baseline.mcpMode !== form.mcpMode ||
-    baseline.contextOverrideEnabled !== form.contextOverrideEnabled ||
-    // Sub-fields only matter while the override is on, so an ON→OFF→ON round
-    // trip that lands back on the baseline values fires no spurious PATCH.
-    (form.contextOverrideEnabled &&
-      (baseline.contextCompressEnabled !== form.contextCompressEnabled ||
-        baseline.contextTruncateThreshold !== form.contextTruncateThreshold ||
-        baseline.contextCompressModelId !== form.contextCompressModelId)) ||
-    customParametersChanged
-
-  const groupChanged = baseline.groupId !== form.groupId
-  const knowledgeBaseIdsChanged = !sameIdSet(baseline.knowledgeBaseIds, form.knowledgeBaseIds)
-  const mcpServerIdsChanged = !sameIdSet(baseline.mcpServerIds, form.mcpServerIds)
-
-  if (!columnsChanged && !groupChanged && !knowledgeBaseIdsChanged && !mcpServerIdsChanged) {
-    return null
-  }
-
-  const dto: UpdateAssistantDto = {
-    ...(columnsChanged
-      ? {
-          name: form.name.trim() || assistant.name,
-          emoji: form.emoji,
-          description: form.description,
-          modelId: form.modelId,
-          prompt: form.prompt,
-          settings: buildAssistantSettingsFromForm(form, assistant.settings)
-        }
-      : {}),
-    ...(knowledgeBaseIdsChanged ? { knowledgeBaseIds: form.knowledgeBaseIds } : {}),
-    ...(mcpServerIdsChanged ? { mcpServerIds: form.mcpServerIds } : {}),
-    ...(groupChanged ? { groupId: form.groupId } : {})
-  }
-
-  return { dto }
-}
-
-export function diffAssistantSaveIntent(
-  form: AssistantFormState,
-  baseline: AssistantFormState,
-  assistant: Assistant
-): AssistantSaveIntent | null {
-  const diff = diffAssistantUpdate(form, baseline, assistant)
-  if (!diff) return null
-
-  return {
-    kind: 'update',
-    payload: diff.dto
-  }
-}
-
-/** Order-insensitive id-set equality; junction tables don't carry ordering. */
-function sameIdSet(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false
-  const set = new Set(a)
-  return b.every((id) => set.has(id))
 }

--- a/src/renderer/utils/resourceCatalog/index.ts
+++ b/src/renderer/utils/resourceCatalog/index.ts
@@ -1,20 +1,5 @@
-export {
-  type AgentDiffResult,
-  type AgentFormState,
-  type AgentSaveIntent,
-  applyAgentFormPatch,
-  buildInitialAgentFormState,
-  diffAgentSaveIntent,
-  diffAgentUpdate
-} from './agentForm'
-export {
-  type AssistantDiffResult,
-  type AssistantFormState,
-  type AssistantSaveIntent,
-  diffAssistantSaveIntent,
-  diffAssistantUpdate,
-  initialAssistantFormState
-} from './assistantForm'
+export { agentEnvVarsFromText, type AgentFormState, buildInitialAgentFormState } from './agentForm'
+export { type AssistantFormState, initialAssistantFormState } from './assistantForm'
 export {
   type AssistantConfigMcpMode,
   MCP_MODE_OPTIONS,


### PR DESCRIPTION
### What this PR does

Before this PR:

Renaming an assistant re-sent the whole row on every save — `name`, `emoji`, `modelId`, `prompt`, and a full `settings` object rebuilt on top of whatever was already stored. If any of those historical values no longer validated, the entire PATCH was rejected and the rename never landed. The dialog then refused to close, because a failed save was treated as unsaved changes with no discard path — the only way out was restarting the app.

After this PR:

Both resource editors are property editors instead of auto-submitting forms. Every control PATCHes only the field it owns, so renaming sends `{ name }` and a stale value elsewhere on the resource cannot block it. A failed save is reported inline with a retry action, and closing the dialog always closes it.

- New `useDirectFieldSave` per-resource save queue: writes are strictly serialized, and patches that pile up behind an in-flight request are merged into a single follow-up (`settings` / `configuration` key-by-key, `skillUpdates` deduplicated per skill), so a late response can never overwrite a newer value. A rejected patch stays buffered for retry instead of being dropped.
- Save timing per control type: toggles, selects, avatar, group and relation lists save on change; name / description / prompt / env vars debounce and flush on close; sliders save on `onValueCommit` so dragging doesn't write on every frame.
- Removes the whole-form diff (`diffAssistantSaveIntent` / `diffAgentSaveIntent`), the failed-snapshot guard (`failedSaveKeyRef`), and the agent baseline bookkeeping (`formBaseline` / `advanceAgentFormBaseline`) that the old model required. Net −525 lines.

Fixes #18160

### Why we need it and why it was done in this way

The root cause is not the name input — it is that a single control's edit was expressed as a full-resource submit. `UpdateAssistantSchema` already accepts a deep-partial `settings` precisely so a client can change one setting without re-validating the others, but the dialog was re-sending the whole object anyway. Sending minimal patches makes an unrelated corrupt field structurally unable to fail a rename, rather than papering over one specific bad field.

The close-guard regression is the second half of the bug. #17261 (Jul 24) had added an escape hatch — a second close attempt discarded and exited. #17977 (Aug 6) removed it to prevent silently losing edits, and both shipped in v2.0.2, so the later PR reinstated the trap. Restoring the old two-click escape would re-introduce the silent-loss problem it was removed for. Non-blocking close plus an explicit retry affordance satisfies both: nothing is silently discarded, and the user is never stuck.

The following tradeoffs were made:

- **React Hook Form is kept, but only as the draft store.** All form semantics are gone (no `<form>`, no submit, no whole-form diff, no root error, no close guard). `FormField` / `FormItem` / `FormLabel` / `FormMessage` remain because they carry the entire layout and validation surface of both dialogs and are shared with the create wizard; removing them would mean rewriting ~2000 lines of unrelated JSX for no change in save correctness. The four shared field components (`AvatarField`, `TextInputField`, `CompactModelField`, `KnowledgeBaseField`) gained an optional `onValueChange` so a property editor can take over the write; the create wizard is untouched.
- **One PATCH per field means more requests.** Changing MCP mode and then toggling a server now sends two requests instead of one. That is the point — request granularity now matches edit granularity — and identical debounced edits still coalesce into one request.
- **Failure handling is deliberately not uniform across field types.** Short fields roll forward on the next edit; long text keeps its draft. A single unified failure state would force one of the two to behave wrongly.

The following alternatives were considered:

- Fixing only the invalid field (as #17261 did for `mcpMode`): treats the symptom. The next legacy field to fall out of schema reproduces the same bug.
- A unified form-level auto-save controller: keeps the wrong model. These dialogs have no submit step, so a form state machine only adds ceremony around a per-field problem.
- Restoring the pre-#17977 two-click discard: reintroduces the silent data loss that #17977 fixed.

Links to places where the discussion took place: #18160, #17261, #17977

### Breaking changes

None. No schema, DTO, or persisted-shape changes — only which subset of fields the renderer sends per edit.

### Special notes for your reviewer

- The interesting file is `useDirectFieldSave.ts` (serialization, merge-on-conflict, failure buffering). It has its own unit tests covering ordering, coalescing, retry, newer-value-wins, flush, and unmount.
- `EditDialogs.test.tsx`: five tests encoding the old blocking contract were rewritten against the new one (close always closes; retry resends; a newer edit replaces a rejected value). Expectations that asserted one combined PATCH now assert the individual per-field PATCHes.
- Clearing the name is now a draft-only state: it shows the `Required` message and sends nothing, instead of silently blocking every other field's save as it used to.
- Not manually verified in Electron — this is renderer-only and covered by the full renderer suite, but a reviewer exercising rename → offline → retry → close would be welcome.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed renaming an assistant or agent failing to save and leaving the edit dialog impossible to close. Each field in the editor is now saved on its own, so an outdated setting elsewhere on the resource no longer blocks unrelated edits, and a failed save shows a retry action instead of trapping the dialog open.
```

