### PR TITLE
fix(assistant-editor): send only changed assistant fields

### DIFF
--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -1,3 +1,4 @@
+import { UpdateAssistantSchema } from '@shared/data/api/schemas/assistants'
 import type { Assistant, AssistantSettings } from '@shared/data/types/assistant'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { describe, expect, it } from 'vitest'
@@ -83,28 +84,33 @@ describe('diffAssistantUpdate', () => {
     expect(diffAssistantUpdate(baseline, baseline, assistant)).toBeNull()
   })
 
-  it('emits the full columns+settings block when any column field changes', () => {
+  it('emits only the changed assistant column', () => {
     const assistant = createAssistant({ name: 'Original' })
     const baseline = initialAssistantFormState(assistant)
     const form = { ...baseline, description: 'edited' }
 
     const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result).not.toBeNull()
-    expect(result!.dto).toMatchObject({
-      name: 'Original',
-      emoji: assistant.emoji,
-      description: 'edited',
-      modelId: assistant.modelId,
-      prompt: assistant.prompt,
-      settings: expect.objectContaining({
-        temperature: baseline.temperature,
-        mcpMode: baseline.mcpMode
-      })
-    })
-    expect(result!.dto.groupId).toBeUndefined()
+    expect(result?.dto).toEqual({ description: 'edited' })
   })
 
-  it('emits a valid MCP mode when editing an unrelated field on a legacy assistant', () => {
+  it('keeps unrelated legacy settings out of a name-only PATCH', () => {
+    const assistant = createAssistant({
+      name: 'Original',
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        maxTokens: 0
+      } as unknown as AssistantSettings
+    })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, name: 'Renamed' }
+
+    const result = diffAssistantUpdate(form, baseline, assistant)
+
+    expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
+    expect(result?.dto).toEqual({ name: 'Renamed' })
+  })
+
+  it('emits a valid MCP mode when changing settings on a legacy assistant', () => {
     const assistant = createAssistant({
       settings: {
         ...DEFAULT_ASSISTANT_SETTINGS,
@@ -112,7 +118,7 @@ describe('diffAssistantUpdate', () => {
       } as unknown as AssistantSettings
     })
     const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, description: 'edited' }
+    const form = { ...baseline, enableTemperature: true }
 
     const result = diffAssistantUpdate(form, baseline, assistant)
 
@@ -133,12 +139,12 @@ describe('diffAssistantUpdate', () => {
       settings: {
         ...DEFAULT_ASSISTANT_SETTINGS,
         // `reasoning_effort` is a settings key the library dialog never
-        // touches — it MUST survive a columns PATCH.
+        // touches — it MUST survive a settings PATCH.
         reasoning_effort: 'high'
       } as AssistantSettings
     })
     const baseline = initialAssistantFormState(assistant)
-    const form = { ...baseline, prompt: 'updated' }
+    const form = { ...baseline, enableTemperature: true }
 
     const result = diffAssistantUpdate(form, baseline, assistant)
     expect(result?.dto.settings).toMatchObject({ reasoning_effort: 'high' })
@@ -188,7 +194,7 @@ describe('diffAssistantUpdate', () => {
     expect(result?.dto.name).toBeUndefined()
   })
 
-  it('treats custom parameter changes as a column-block edit', () => {
+  it('treats custom parameter changes as a settings edit', () => {
     const assistant = createAssistant()
     const baseline = initialAssistantFormState(assistant)
     const form = {

--- a/src/renderer/utils/resourceCatalog/assistantForm.ts
+++ b/src/renderer/utils/resourceCatalog/assistantForm.ts
@@ -142,10 +142,10 @@ export type AssistantSaveIntent = {
 /**
  * Compute the minimal Assistant PATCH payload.
  *
- * - Columns block: when ANY of name/emoji/description/modelId/prompt
- *   or any settings field differs, the dto carries all five column
- *   keys + a full `settings` object spread over `assistant.settings`
- *   (preserves unrelated settings keys the UI doesn't surface).
+ * - Top-level columns ship independently when their value differs.
+ * - Settings ship only when an editable settings field differs. The full
+ *   object is spread over `assistant.settings` to preserve keys the UI
+ *   doesn't surface.
  * - Relation arrays (knowledgeBaseIds / mcpServerIds) ship only when
  *   their set differs — order-insensitive, matches junction semantics.
  * - Group: placed directly on the DTO as the canonical `groupId`.
@@ -159,12 +159,12 @@ export function diffAssistantUpdate(
 ): AssistantDiffResult | null {
   const customParametersChanged = JSON.stringify(baseline.customParameters) !== JSON.stringify(form.customParameters)
 
-  const columnsChanged =
-    baseline.name !== form.name ||
-    baseline.emoji !== form.emoji ||
-    baseline.description !== form.description ||
-    baseline.modelId !== form.modelId ||
-    baseline.prompt !== form.prompt ||
+  const nameChanged = baseline.name !== form.name
+  const emojiChanged = baseline.emoji !== form.emoji
+  const descriptionChanged = baseline.description !== form.description
+  const modelIdChanged = baseline.modelId !== form.modelId
+  const promptChanged = baseline.prompt !== form.prompt
+  const settingsChanged =
     baseline.temperature !== form.temperature ||
     baseline.enableTemperature !== form.enableTemperature ||
     baseline.topP !== form.topP ||
@@ -188,21 +188,27 @@ export function diffAssistantUpdate(
   const knowledgeBaseIdsChanged = !sameIdSet(baseline.knowledgeBaseIds, form.knowledgeBaseIds)
   const mcpServerIdsChanged = !sameIdSet(baseline.mcpServerIds, form.mcpServerIds)
 
-  if (!columnsChanged && !groupChanged && !knowledgeBaseIdsChanged && !mcpServerIdsChanged) {
+  if (
+    !nameChanged &&
+    !emojiChanged &&
+    !descriptionChanged &&
+    !modelIdChanged &&
+    !promptChanged &&
+    !settingsChanged &&
+    !groupChanged &&
+    !knowledgeBaseIdsChanged &&
+    !mcpServerIdsChanged
+  ) {
     return null
   }
 
   const dto: UpdateAssistantDto = {
-    ...(columnsChanged
-      ? {
-          name: form.name.trim() || assistant.name,
-          emoji: form.emoji,
-          description: form.description,
-          modelId: form.modelId,
-          prompt: form.prompt,
-          settings: buildAssistantSettingsFromForm(form, assistant.settings)
-        }
-      : {}),
+    ...(nameChanged ? { name: form.name.trim() || assistant.name } : {}),
+    ...(emojiChanged ? { emoji: form.emoji } : {}),
+    ...(descriptionChanged ? { description: form.description } : {}),
+    ...(modelIdChanged ? { modelId: form.modelId } : {}),
+    ...(promptChanged ? { prompt: form.prompt } : {}),
+    ...(settingsChanged ? { settings: buildAssistantSettingsFromForm(form, assistant.settings) } : {}),
     ...(knowledgeBaseIdsChanged ? { knowledgeBaseIds: form.knowledgeBaseIds } : {}),
     ...(mcpServerIdsChanged ? { mcpServerIds: form.mcpServerIds } : {}),
     ...(groupChanged ? { groupId: form.groupId } : {})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

Editing one top-level assistant field sent all assistant columns and the full stored settings object. A name-only edit could therefore be rejected by current validation when unrelated legacy settings were present, leaving the edit dialog unable to save.

After this PR:

Assistant updates send only the top-level fields that changed. Settings are sent only when an editable setting changes, while still preserving settings that the dialog does not expose.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The assistant update schema is a partial PATCH contract, and the neighboring agent form already emits changed fields independently. Applying the same pattern fixes the source of the validation failure without weakening main-process validation or rewriting persisted user data.

The following tradeoffs were made:

Settings still use a complete merged object when a setting actually changes so keys not exposed by the dialog remain intact. Knowledge-base, MCP-server, and group relation updates keep their existing behavior.

The following alternatives were considered:

Special-casing name edits would leave other top-level edits vulnerable to unrelated legacy settings. Relaxing the schema or migrating historical settings would broaden the change and weaken or rewrite unrelated data.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Focused verification covered the assistant form helper, edit-dialog integration, renderer type checking, and changed-file static checks. The full repository test suite was not run. A user-guide update is not required because this restores the intended edit behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix assistant edits failing when unrelated legacy settings are present.
```
