### PR TITLE
fix(vertex-ai): restore default Vertex endpoint routing

### DIFF
--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -294,6 +294,103 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       expect(settings.location).toBe('us-central1')
     })
 
+    it.each(['https://aiplatform.googleapis.com', 'https://us-central1-aiplatform.googleapis.com'])(
+      'treats the bare Google aiplatform host %s as the SDK default (REGRESSION)',
+      async (baseUrl) => {
+        getAuthConfigMock.mockReturnValue(vertexAuth)
+        const provider = makeProvider({
+          id: 'vertex',
+          authType: 'iam-gcp',
+          defaultChatEndpoint: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+          endpointConfigs: {
+            [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: {
+              baseUrl,
+              adapterFamily: 'google-vertex'
+            }
+          }
+        })
+        const model = makeModel({
+          id: 'vertex::gemini-2.0-flash',
+          apiModelId: 'gemini-2.0-flash',
+          endpointTypes: [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]
+        })
+
+        const config = await providerToAiSdkConfig(provider, model)
+        const settings = config.providerSettings as Record<string, unknown>
+
+        expect(config.providerId).toBe('google-vertex')
+        expect(settings.baseURL).toBeUndefined()
+        expect(settings.project).toBe('my-project')
+        expect(settings.location).toBe('us-central1')
+      }
+    )
+
+    it('preserves a proxy URL whose path ends with the official hostname (REGRESSION)', async () => {
+      getAuthConfigMock.mockReturnValue(vertexAuth)
+      const provider = makeProvider({
+        id: 'vertex',
+        authType: 'iam-gcp',
+        defaultChatEndpoint: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: {
+            baseUrl: 'https://proxy.example.com/aiplatform.googleapis.com',
+            adapterFamily: 'google-vertex'
+          }
+        }
+      })
+      const model = makeModel({
+        id: 'vertex::gemini-2.0-flash',
+        apiModelId: 'gemini-2.0-flash',
+        endpointTypes: [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as Record<string, unknown>
+
+      expect(config.providerId).toBe('google-vertex')
+      expect(settings.baseURL).toBe('https://proxy.example.com/aiplatform.googleapis.com/v1beta/publishers/google')
+      expect(settings.project).toBe('my-project')
+      expect(settings.location).toBe('us-central1')
+    })
+
+    it.each([
+      ['an official URL with an API path', 'https://aiplatform.googleapis.com/v1'],
+      ['an insecure official URL', 'http://aiplatform.googleapis.com'],
+      ['an official URL with a query', 'https://aiplatform.googleapis.com?proxy=1'],
+      ['an official URL with a fragment', 'https://aiplatform.googleapis.com#proxy'],
+      ['an official URL with an empty trailing query marker', 'https://aiplatform.googleapis.com?'],
+      ['an official URL with the explicit no-version marker', 'https://aiplatform.googleapis.com#'],
+      ['an official URL with credentials', 'https://user:secret@aiplatform.googleapis.com'],
+      ['an official URL with a non-default port', 'https://aiplatform.googleapis.com:8443'],
+      ['a lookalike hostname without the regional separator', 'https://proxyaiplatform.googleapis.com']
+    ])('preserves %s as an explicit Vertex endpoint (REGRESSION)', async (_case, baseUrl) => {
+      getAuthConfigMock.mockReturnValue(vertexAuth)
+      const provider = makeProvider({
+        id: 'vertex',
+        authType: 'iam-gcp',
+        defaultChatEndpoint: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: {
+            baseUrl,
+            adapterFamily: 'google-vertex'
+          }
+        }
+      })
+      const model = makeModel({
+        id: 'vertex::gemini-2.0-flash',
+        apiModelId: 'gemini-2.0-flash',
+        endpointTypes: [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]
+      })
+
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as Record<string, unknown>
+
+      expect(config.providerId).toBe('google-vertex')
+      expect(settings.baseURL).toBeDefined()
+      expect(settings.project).toBe('my-project')
+      expect(settings.location).toBe('us-central1')
+    })
+
     it.each(['meta/llama-4-scout-17b-16e-instruct-maas', 'google/gemma-4-26b-a4b-it-maas'])(
       'routes MaaS Vertex model %s to the google-vertex-maas adapter',
       async (apiModelId) => {

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -19,7 +19,13 @@ import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { formatApiHost, formatOllamaApiHost, isWithTrailingSharp, withoutTrailingApiVersion } from '@shared/utils/api'
 import { isGenerateImageModel } from '@shared/utils/model'
-import { isAzureOpenAIProvider, isGeminiProvider, isOllamaProvider, matchesPreset } from '@shared/utils/provider'
+import {
+  isAzureOpenAIProvider,
+  isGeminiProvider,
+  isOllamaProvider,
+  isVertexProvider,
+  matchesPreset
+} from '@shared/utils/provider'
 import { SystemProviderIds } from '@shared/utils/systemProviderId'
 import { isEmpty } from 'es-toolkit/compat'
 
@@ -68,9 +74,38 @@ export interface ResolvedProviderAiSdkConfig {
   credentialReceipt: ServingCredentialReceipt
 }
 
+function isDefaultVertexApiHost(baseURL: string): boolean {
+  // URL normalizes trailing empty query/fragment markers to empty strings, but they are
+  // meaningful to the existing endpoint formatter (notably `#` disables version appending).
+  if (baseURL.includes('?') || baseURL.includes('#')) return false
+
+  try {
+    const url = new URL(baseURL)
+    const isGoogleApiHost =
+      url.hostname === 'aiplatform.googleapis.com' || url.hostname.endsWith('-aiplatform.googleapis.com')
+
+    return (
+      url.protocol === 'https:' &&
+      isGoogleApiHost &&
+      url.pathname === '/' &&
+      !url.search &&
+      !url.hash &&
+      !url.username &&
+      !url.password &&
+      !url.port
+    )
+  } catch {
+    return false
+  }
+}
+
 /** Applies endpoint-/provider-specific formatting (API version, Ollama/Gemini paths). */
 function formatBaseURL(baseURL: string, provider: Provider, endpointType?: EndpointType): string {
   if (!baseURL) return ''
+
+  // A bare Google Vertex host selects the standard service; it is not a proxy override.
+  // Leave it empty so the SDK derives the project/location resource path from iam-gcp auth.
+  if (isVertexProvider(provider) && isDefaultVertexApiHost(baseURL)) return ''
 
   const appendApiVersion = !isWithTrailingSharp(baseURL)
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### 🚨 Branch strategy — read before opening this PR
>
> The v2 refactor has merged into `main`, so **`main` is the default branch for active development** (v1 and v2 code currently coexist there — expect large, breaking changes).
>
> - **Active development** (features, refactors, optimizations, fixes for the current codebase) → target **`main`** (the default base).
> - **v1 maintenance** (hotfixes and subsequent v1 releases) → branch from and target **`v1`**, _not_ `main`.
>
> A v1 fix does **not** auto-carry to `main`: if the same bug exists on `main`, open a separate forward-port PR targeting `main`. Before touching subsystems being replaced, read `docs/references/data/` and watch for `@deprecated` markers — they flag code being deleted.

### What this PR does

Before this PR:

A bare official Vertex AI host was formatted as a custom endpoint and became a host without the required project and location resource path, causing service-account requests to return 404.

After this PR:

Bare global and regional Google Vertex hosts are delegated to the Vertex SDK so it derives the standard project/location URL. Explicit paths, proxy URLs, protocol markers, query/fragment markers, credentials, and non-default ports retain their existing endpoint behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The Vertex SDK already owns construction of standard service URLs from IAM project and location data. Main-process model listing, renderer endpoint previews, and the earlier implementation all distinguish official bare hosts from actual proxy overrides, so the runtime configuration now preserves that contract.

The following tradeoffs were made:

The official-host check is intentionally strict and local to provider configuration. Only an HTTPS bare Google Vertex hostname is treated as the default; explicit endpoint syntax remains opt-in and unchanged.

The following alternatives were considered:

Clearing the host only during migration would not fix manually entered or already migrated values. Rebuilding the complete Vertex resource URL locally would duplicate SDK version, region, and publisher rules.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The focused test matrix covers global/regional official hosts and explicit proxy/path/protocol/query/fragment/credential/port boundaries. Main-process type checking and changed-file static checks also pass. The full repository test suite was not run. A user-guide update is not required because this restores standard Vertex routing.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Vertex AI service-account requests returning 404 when the standard Google endpoint is configured.
```
