### PR TITLE
fix(builtin-tools): stop sending strict so knowledge bases work on Anthropic

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/AssistantFileToolsServer.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/AssistantFileToolsServer.test.ts
@@ -95,8 +95,10 @@ describe('AssistantFileToolsServer', () => {
     }))
     const server = new AssistantFileToolsServer({ sessionId: 'session-1', workspacePath: '/workspace' })
 
-    const first = await callTool(server, 'read_file', { filename: handle, offset: 0, limit: 0 })
-    const second = await callTool(server, 'read_file', { filename: handle, offset: 0, limit: 0 })
+    // offset/limit omitted: they are plain optionals now, and `limit: 0` is rejected outright
+    // (it used to be the "use the default" sentinel that `strict: true` forced on this schema).
+    const first = await callTool(server, 'read_file', { filename: handle })
+    const second = await callTool(server, 'read_file', { filename: handle })
 
     expect(first.content[0].text).toBe(handle)
     expect(second.content[0].text).toBe('(none)')

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeListTool.ts
@@ -15,12 +15,7 @@
  * non-empty, only those bases are reachable. The tool is not exposed when that scope is empty.
  */
 
-import {
-  KB_LIST_TOOL_NAME,
-  kbListOutputSchema,
-  kbListStrictInputSchema,
-  kbTreeOutputSchema
-} from '@shared/ai/builtinTools'
+import { KB_LIST_TOOL_NAME, kbListInputSchema, kbListOutputSchema, kbTreeOutputSchema } from '@shared/ai/builtinTools'
 import { tool } from 'ai'
 import * as z from 'zod'
 
@@ -39,27 +34,15 @@ export { KB_LIST_TOOL_NAME }
 // `{ error }`, so the output is a three-way union.
 const knowledgeListResultSchema = z.union([kbListOutputSchema, kbTreeOutputSchema, knowledgeLookupErrorSchema])
 
-function normalizeStrictInput(input: z.infer<typeof kbListStrictInputSchema>) {
-  // The model-facing strict schema uses primitive sentinels for Gemini/OpenAI compatibility.
-  // Keep that provider concern at the adapter boundary; the shared core receives normal optionals.
-  return {
-    query: input.query || undefined,
-    groupId: input.groupId || undefined,
-    baseId: input.baseId || undefined,
-    maxDepth: input.maxDepth < 0 ? undefined : input.maxDepth
-  }
-}
-
 const kbListTool = tool({
   description: KNOWLEDGE_LIST_DESCRIPTION,
-  inputSchema: kbListStrictInputSchema,
+  inputSchema: kbListInputSchema,
   outputSchema: knowledgeListResultSchema,
-  strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    return listOrOutlineKnowledge(normalizeStrictInput(input), request.knowledgeBaseIds ?? [])
+    return listOrOutlineKnowledge(input, request.knowledgeBaseIds ?? [])
   },
-  toModelOutput: ({ input, output }) => knowledgeListModelOutput(output, normalizeStrictInput(input))
+  toModelOutput: ({ input, output }) => knowledgeListModelOutput(output, input)
 })
 
 export function createKbListToolEntry(): ToolEntry {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeManageTool.ts
@@ -19,12 +19,7 @@
  * refuses it too (it never runs an approval-gated tool blind) — an unreachable tool either way.
  */
 
-import {
-  KB_MANAGE_TOOL_NAME,
-  KB_MANAGE_UNUSED_TYPE,
-  kbManageOutputSchema,
-  kbManageStrictInputSchema
-} from '@shared/ai/builtinTools'
+import { KB_MANAGE_TOOL_NAME, kbManageInputSchema, kbManageOutputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -44,28 +39,13 @@ const knowledgeManageResultSchema = z.union([kbManageOutputSchema, knowledgeLook
 
 const kbManageTool = tool({
   description: KNOWLEDGE_MANAGE_DESCRIPTION,
-  inputSchema: kbManageStrictInputSchema,
+  inputSchema: kbManageInputSchema,
   outputSchema: knowledgeManageResultSchema,
-  strict: true,
   // Every action (add / delete / refresh) modifies the base; gate on explicit user approval.
   needsApproval: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    // Normalize the strict schema's primitive sentinels at the provider boundary. The shared
-    // mutation core keeps its natural optional-field contract.
-    return manageKnowledge(
-      {
-        baseId: input.baseId,
-        action: input.action,
-        type: input.type === KB_MANAGE_UNUSED_TYPE ? undefined : input.type,
-        path: input.path || undefined,
-        url: input.url || undefined,
-        content: input.content || undefined,
-        title: input.title || undefined,
-        conceptIds: input.conceptIds.length > 0 ? input.conceptIds : undefined
-      },
-      request.knowledgeBaseIds ?? []
-    )
+    return manageKnowledge(input, request.knowledgeBaseIds ?? [])
   },
   toModelOutput: ({ output }) => knowledgeManageModelOutput(output)
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeReadTool.ts
@@ -16,12 +16,7 @@
  * identical logic; this file is just the AI-SDK `tool()` wrapper.
  */
 
-import {
-  KB_READ_TOOL_NAME,
-  kbGrepOutputSchema,
-  kbReadOutputSchema,
-  kbReadStrictInputSchema
-} from '@shared/ai/builtinTools'
+import { KB_READ_TOOL_NAME, kbGrepOutputSchema, kbReadInputSchema, kbReadOutputSchema } from '@shared/ai/builtinTools'
 import { type InferToolInput, type InferToolOutput, tool } from 'ai'
 import * as z from 'zod'
 
@@ -42,25 +37,11 @@ const knowledgeReadResultSchema = z.union([kbReadOutputSchema, kbGrepOutputSchem
 
 const kbReadTool = tool({
   description: KNOWLEDGE_READ_DESCRIPTION,
-  inputSchema: kbReadStrictInputSchema,
+  inputSchema: kbReadInputSchema,
   outputSchema: knowledgeReadResultSchema,
-  strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
-    // Normalize the strict schema's primitive sentinels at the provider boundary. The shared
-    // read/grep core keeps its natural optional-field contract.
-    return readOrGrepConcept(
-      {
-        baseId: input.baseId,
-        conceptId: input.conceptId,
-        charStart: input.charStart,
-        charEnd: input.charEnd || undefined,
-        pattern: input.pattern || undefined,
-        ignoreCase: input.ignoreCase,
-        maxMatches: input.maxMatches || undefined
-      },
-      request.knowledgeBaseIds ?? []
-    )
+    return readOrGrepConcept(input, request.knowledgeBaseIds ?? [])
   },
   toModelOutput: ({ output }) => knowledgeReadModelOutput(output)
 })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/KnowledgeSearchTool.ts
@@ -33,7 +33,6 @@ const kbSearchTool = tool({
   description: KNOWLEDGE_SEARCH_DESCRIPTION,
   inputSchema: kbSearchInputSchema,
   outputSchema: knowledgeSearchResultSchema,
-  strict: true,
   execute: async ({ query, baseIds }, options) => {
     const { request } = getToolCallContext(options)
     return searchKnowledge(query, baseIds, request.knowledgeBaseIds ?? [])

--- a/src/main/ai/tools/adapters/aiSdk/builtin/ReadFileTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/ReadFileTool.ts
@@ -115,8 +115,8 @@ export async function readFile(
       return textResult(`Cannot read the attached file "${entry.handle}" as text (unsupported file type).`)
     }
     if (!text.trim()) return textResult(noExtractableTextNote(entry.handle))
-    // 0 is the "use the default" sentinel for both (see `readFileInputSchema`).
-    return paginate(text, input.offset || undefined, input.limit || undefined)
+    // Both are optional; `paginate`'s parameter defaults cover an omitted one.
+    return paginate(text, input.offset, input.limit)
   } catch (error) {
     if (signal?.aborted || isAbortError(error)) throw error
     // Log the detail; return a sanitized, filename-level message (no entry ids / paths).
@@ -141,7 +141,6 @@ const readFileTool = tool({
   description: READ_FILE_DESCRIPTION,
   inputSchema: readFileInputSchema,
   outputSchema: readFileResultSchema,
-  strict: true,
   execute: async (input, options) => {
     const { request } = getToolCallContext(options)
     return readFile(input, { attachments: request.fileAttachments ?? [] }, request.abortSignal)

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebFetchTool.ts
@@ -23,7 +23,6 @@ const webFetchTool = tool({
   description: WEB_FETCH_DESCRIPTION,
   inputSchema: webFetchInputSchema,
   outputSchema: webFetchResultSchema,
-  strict: true,
   execute: async ({ urls }, options) =>
     markTrustedLocalToolTerminalFailure(await fetchWeb(urls, getToolCallContext(options).request.abortSignal)),
   toModelOutput: ({ output }) => webLookupModelOutput(output)

--- a/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/WebSearchTool.ts
@@ -30,9 +30,6 @@ const webSearchTool = tool({
   description: WEB_SEARCH_DESCRIPTION,
   inputSchema: webSearchInputSchema,
   outputSchema: webSearchResultSchema,
-  // Provider-level constrained decoding where supported. Repair fallback
-  // (in AiService) handles providers that don't honour `strict`.
-  strict: true,
   execute: async ({ query }, options) => {
     if (typeof query !== 'string' || !query.trim()) {
       return []

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
@@ -154,19 +154,14 @@ function makeProcessingFileItem(id: string): KnowledgeItem {
   } as unknown as KnowledgeItem
 }
 
-type StrictListArgs = { query: string; groupId: string; baseId: string; maxDepth: number }
-type ListArgs = Partial<StrictListArgs>
+type ListArgs = { query?: string; groupId?: string; baseId?: string; maxDepth?: number }
 
 function callExecute(args: ListArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: StrictListArgs, options: ToolExecutionOptions) => Promise<unknown>
+  const execute = entry.tool.execute as (args: ListArgs, options: ToolExecutionOptions) => Promise<unknown>
   return execute(
-    {
-      query: '',
-      groupId: '',
-      baseId: '',
-      maxDepth: -1,
-      ...args
-    },
+    // Unused filters are omitted, not sentinel-valued — kb_list runs without `strict`, so its schema
+    // is plain optionals and the model omits what it does not filter on.
+    args,
     {
       toolCallId: 'tc-1',
       messages: [],
@@ -232,7 +227,7 @@ describe('kb_list', () => {
     expect(result.map((b) => b.id)).toEqual(['kb-1'])
   })
 
-  it('normalizes strict-path empty-string filters to no filter', async () => {
+  it('treats an omitted groupId as no filter, not as "ungrouped"', async () => {
     knowledgeServiceListBases.mockReturnValue([
       makeBase({ id: 'kb-1', groupId: 'g1' }),
       makeBase({ id: 'kb-2', groupId: null })
@@ -240,7 +235,7 @@ describe('kb_list', () => {
     knowledgeServiceListRootItems.mockReturnValue([])
 
     const result = (await callExecute({}, { knowledgeBaseIds: ['kb-1', 'kb-2'] })) as Array<{ id: string }>
-    // The empty groupId sentinel must not collapse to `base.groupId === null`; both bases come back.
+    // An absent groupId must not collapse to `base.groupId === null`; both bases come back.
     expect(result.map((b) => b.id).sort()).toEqual(['kb-1', 'kb-2'])
   })
 
@@ -390,7 +385,7 @@ describe('kb_list', () => {
       expect(knowledgeServiceListBases).not.toHaveBeenCalled()
     })
 
-    it('normalizes the unlimited-depth sentinel before outlining', async () => {
+    it('outlines to unlimited depth when maxDepth is omitted', async () => {
       knowledgeServiceGetOrganizationTree.mockReturnValue(orgTree())
 
       await callExecute({ baseId: 'kb-1' }, { knowledgeBaseIds: ['kb-1'] })

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeManageTool.test.ts
@@ -42,22 +42,12 @@ type ManageArgs = {
   conceptIds?: string[]
 }
 
-type StrictManageArgs = Omit<Required<ManageArgs>, 'type'> & {
-  type: NonNullable<ManageArgs['type']> | 'none'
-}
-
 function callExecute(args: ManageArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: StrictManageArgs, options: ToolExecutionOptions) => Promise<unknown>
+  const execute = entry.tool.execute as (args: ManageArgs, options: ToolExecutionOptions) => Promise<unknown>
   return execute(
-    {
-      type: 'none',
-      path: '',
-      url: '',
-      content: '',
-      title: '',
-      conceptIds: [],
-      ...args
-    },
+    // Fields the action does not use are omitted, not sentinel-valued — kb_manage runs without
+    // `strict`, so its schema is plain optionals.
+    args,
     {
       toolCallId: 'tc-1',
       messages: [],

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeReadTool.test.ts
@@ -41,19 +41,12 @@ type ReadArgs = {
   maxMatches?: number
 }
 
-type StrictReadArgs = Required<ReadArgs>
-
 function callExecute(args: ReadArgs, ctx: { knowledgeBaseIds?: string[] } = {}): Promise<unknown> {
-  const execute = entry.tool.execute as (args: StrictReadArgs, options: ToolExecutionOptions) => Promise<unknown>
+  const execute = entry.tool.execute as (args: ReadArgs, options: ToolExecutionOptions) => Promise<unknown>
   return execute(
-    {
-      charStart: 0,
-      charEnd: 0,
-      pattern: '',
-      ignoreCase: true,
-      maxMatches: 0,
-      ...args
-    },
+    // Mode-specific fields are omitted, not sentinel-valued — kb_read runs without `strict`, so its
+    // schema is plain optionals and the model omits what the mode does not use.
+    args,
     {
       toolCallId: 'tc-1',
       messages: [],
@@ -131,13 +124,15 @@ describe('kb_read', () => {
     })
   })
 
-  it('normalizes strict-path sentinels to read-mode defaults', async () => {
+  it('reads the whole document in read mode when the optional fields are omitted', async () => {
     readConcept.mockResolvedValue(conceptContent())
 
     await callExecute({ baseId: 'kb-1', conceptId: 'docs/intro.md' }, { knowledgeBaseIds: ['kb-1'] })
 
+    // An omitted `pattern` must route to read, not grep: `readOrGrepConcept` switches on the field
+    // being present at all, so a sentinel empty string here would silently mean "grep for ''".
     expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', {
-      charStart: 0,
+      charStart: undefined,
       charEnd: undefined
     })
     expect(grepConcept).not.toHaveBeenCalled()
@@ -148,7 +143,7 @@ describe('kb_read', () => {
 
     await callExecute({ baseId: 'kb-1', conceptId: 'docs/intro.md' }, { knowledgeBaseIds: [] })
 
-    expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', { charStart: 0, charEnd: undefined })
+    expect(readConcept).toHaveBeenCalledWith('kb-1', 'docs/intro.md', { charStart: undefined, charEnd: undefined })
   })
 
   it('maps a NOT_FOUND into a steer to re-check the conceptId (not a raw throw)', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/ReadFileTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/ReadFileTool.test.ts
@@ -28,12 +28,8 @@ import { readFile, readFileModelOutput } from '../ReadFileTool'
 const att = (handle: string): FileAttachmentRef => ({ fileEntryId: 'e1', handle, displayName: handle })
 const ctx = (attachments: FileAttachmentRef[]) => ({ attachments })
 
-// offset/limit are required numbers (under `strict: true`) with 0 meaning "default"; default them here.
-const input = (rest: { filename: string; offset?: number; limit?: number }): ReadFileInput => ({
-  offset: 0,
-  limit: 0,
-  ...rest
-})
+// offset/limit are plain optionals — omitting one means "use the default", so pass `rest` through.
+const input = (rest: { filename: string; offset?: number; limit?: number }): ReadFileInput => rest
 
 afterEach(() => vi.clearAllMocks())
 

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/WebSearchTool.test.ts
@@ -307,7 +307,9 @@ describe('web_fetch', () => {
       expect(validated.success).toBe(true)
     })
 
-    it('keeps the `uri` format strict providers reject out of the provider-facing schema', () => {
+    // No builtin tool is `strict` any more, but `format: "uri"` stays out on purpose: it is what
+    // strict OpenAI-compatible endpoints reject, and `isHttpUrl` is narrower than `.url()` anyway.
+    it('keeps the `uri` format out of the provider-facing schema', () => {
       const { jsonSchema } = asSchema(fetchEntry.tool.inputSchema)
 
       // Whole-document rather than `properties.urls.items.format`: an optional chain that stops

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/registerBuiltinTools.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/registerBuiltinTools.test.ts
@@ -30,18 +30,22 @@ describe('registerBuiltinTools', () => {
     expect(reg.has(FS_READ_TOOL_NAME)).toBe(true)
   })
 
-  it('never marks a knowledge tool `strict` (binding a base would 400 the whole request)', () => {
-    // `strict` asks the provider for constrained decoding, so it compiles every strict tool schema in
-    // the request into one sampling grammar. These four turn on together the moment a knowledge base
-    // is bound, and Anthropic 400s the request ("Schema is too complex for compilation") once that
-    // combined grammar exceeds its compile budget — which broke every message, including "hi".
+  it('never marks a builtin tool `strict` (strict schemas share one compile budget)', () => {
+    // `strict` asks the provider for constrained decoding, so Anthropic compiles every strict tool
+    // schema in the request into one sampling grammar and 400s the request ("Schema is too complex
+    // for compilation") once the combined grammar exceeds its compile budget. Binding a knowledge
+    // base alone turned on four strict tools at once and broke every message, including "hi".
+    // Asserted registry-wide rather than on the kb_* four: the budget is undocumented and shared, so
+    // "this tool is small enough to be strict" is a judgement that would need re-checking on every
+    // added tool and property. A blanket rule needs none.
     // The AI SDK still validates tool calls against the zod schema, and `createAiRepair` re-asks the
     // model on a mismatch, so nothing is silently unvalidated.
     const reg = new ToolRegistry()
     registerBuiltinTools(reg)
-    for (const name of [KB_SEARCH_TOOL_NAME, KB_LIST_TOOL_NAME, KB_READ_TOOL_NAME, KB_MANAGE_TOOL_NAME]) {
-      expect(reg.getByName(name)?.tool.strict ?? false).toBe(false)
-    }
+    const strictEntries = reg.getAll().filter((e) => e.tool.strict === true)
+    expect(strictEntries.map((e) => e.name)).toEqual([])
+    // Sanity: the assertion above is only meaningful while the registry is actually populated.
+    expect(reg.getAll().length).toBeGreaterThan(0)
   })
 
   it('gates read_file on file attachments', () => {

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/registerBuiltinTools.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/registerBuiltinTools.test.ts
@@ -30,6 +30,20 @@ describe('registerBuiltinTools', () => {
     expect(reg.has(FS_READ_TOOL_NAME)).toBe(true)
   })
 
+  it('never marks a knowledge tool `strict` (binding a base would 400 the whole request)', () => {
+    // `strict` asks the provider for constrained decoding, so it compiles every strict tool schema in
+    // the request into one sampling grammar. These four turn on together the moment a knowledge base
+    // is bound, and Anthropic 400s the request ("Schema is too complex for compilation") once that
+    // combined grammar exceeds its compile budget — which broke every message, including "hi".
+    // The AI SDK still validates tool calls against the zod schema, and `createAiRepair` re-asks the
+    // model on a mismatch, so nothing is silently unvalidated.
+    const reg = new ToolRegistry()
+    registerBuiltinTools(reg)
+    for (const name of [KB_SEARCH_TOOL_NAME, KB_LIST_TOOL_NAME, KB_READ_TOOL_NAME, KB_MANAGE_TOOL_NAME]) {
+      expect(reg.getByName(name)?.tool.strict ?? false).toBe(false)
+    }
+  })
+
   it('gates read_file on file attachments', () => {
     const reg = new ToolRegistry()
     registerBuiltinTools(reg)

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -425,8 +425,8 @@ function readTree(
 /**
  * kb_list dispatch: list the user's bases, or — when a `baseId` is supplied — outline that one
  * base's structure. One tool with two modes (see KNOWLEDGE_LIST_DESCRIPTION); both cores share the
- * `{ error }` contract, so this only routes by the presence of `baseId`. AI-SDK adapters normalize
- * their strict-schema sentinels before calling this core; MCP callers omit unused fields directly.
+ * `{ error }` contract, so this only routes by the presence of `baseId`. Both callers (AI-SDK tool
+ * and MCP bridge) omit the fields their mode does not use, so no sentinel translation happens here.
  */
 export async function listOrOutlineKnowledge(
   input: { query?: string; groupId?: string; baseId?: string; maxDepth?: number },
@@ -441,7 +441,7 @@ export async function listOrOutlineKnowledge(
 /** Longest a derived note title (its first line) may be before it is truncated. */
 const NOTE_TITLE_MAX_CHARS = 80
 
-/** kb_manage input shape shared after AI-SDK strict sentinels have been normalized. */
+/** kb_manage input shape — the fields the chosen `action` does not use are simply absent. */
 type ManageKnowledgeInput = {
   baseId: string
   action: 'add' | 'delete' | 'refresh'

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -6,11 +6,8 @@ import {
   KB_LIST_TOOL_NAME,
   KB_SEARCH_TOOL_NAME,
   kbListInputSchema,
-  kbListStrictInputSchema,
   kbManageInputSchema,
-  kbManageStrictInputSchema,
   kbReadInputSchema,
-  kbReadStrictInputSchema,
   kbSearchInputSchema,
   REPORT_ARTIFACTS_DESCRIPTION,
   REPORT_ARTIFACTS_TOOL_NAME,
@@ -22,18 +19,6 @@ import {
   WEB_SEARCH_TOOL_NAME,
   webFetchInputSchema
 } from '../builtinTools'
-
-function expectDirectPropertyTypes(schema: z.ZodType) {
-  const json = z.toJSONSchema(schema) as {
-    properties?: Record<string, { type?: unknown; anyOf?: unknown }>
-  }
-  const properties = Object.values(json.properties ?? {})
-
-  // Gemini rejects nullable properties because their JSON Schema uses `anyOf` without a top-level
-  // `type`. Every strict tool property must therefore serialize as one directly typed primitive.
-  expect(properties.every((property) => typeof property.type === 'string')).toBe(true)
-  expect(properties.some((property) => property.anyOf !== undefined)).toBe(false)
-}
 
 describe('builtin tool contracts', () => {
   it('uses model-facing builtin tool names', () => {
@@ -98,82 +83,29 @@ describe('builtin tool contracts', () => {
     }
   })
 
-  it('keeps kb_list strict-path fields in `required` so strict providers accept the schema', () => {
-    // AI-SDK strict mode must satisfy both OpenAI-compatible providers (every property required) and
-    // Gemini (every property directly typed, with no nullable `anyOf`). Sentinels preserve optional
-    // semantics while meeting both contracts.
-    const json = z.toJSONSchema(kbListStrictInputSchema) as { required?: unknown }
-
-    expect(Array.isArray(json.required)).toBe(true)
-    expect(json.required).toEqual(expect.arrayContaining(['query', 'groupId', 'baseId', 'maxDepth']))
-    expect(kbListStrictInputSchema.safeParse({ query: '', groupId: '', baseId: '', maxDepth: -1 }).success).toBe(true)
-    expectDirectPropertyTypes(kbListStrictInputSchema)
-  })
-
-  it('lets the MCP kb_list path omit either filter', () => {
-    // The Claude Code bridge parses raw args with kbListInputSchema; an agent may omit filters
-    // entirely, so the optional shape must accept `{}` and a lone query without erroring. (Making it
-    // required to satisfy the strict path would break this — hence the separate sentinel variant.)
+  // The kb_* tools run without `strict`, so one optional-shaped schema serves both the AI-SDK tool
+  // and the Claude Code / MCP bridge. Every field the chosen mode does not use must be omittable —
+  // if any of these regress to required, the model has to invent a value for it.
+  it('lets kb_list omit either filter', () => {
     expect(kbListInputSchema.safeParse({}).success).toBe(true)
     expect(kbListInputSchema.safeParse({ query: 'recipes' }).success).toBe(true)
   })
 
-  it('keeps kb_manage strict-path fields in `required` so strict providers accept the schema', () => {
-    // Same cross-provider contract as kb_list. `none`, empty strings, and an empty array represent
-    // fields unused by this action and are normalized before the shared mutation core runs.
-    const json = z.toJSONSchema(kbManageStrictInputSchema) as { required?: unknown }
-
-    expect(Array.isArray(json.required)).toBe(true)
-    expect(json.required).toEqual(
-      expect.arrayContaining(['baseId', 'action', 'type', 'path', 'url', 'content', 'title', 'conceptIds'])
-    )
-    expect(
-      kbManageStrictInputSchema.safeParse({
-        baseId: 'kb-1',
-        action: 'delete',
-        type: 'none',
-        path: '',
-        url: '',
-        content: '',
-        title: '',
-        conceptIds: []
-      }).success
-    ).toBe(true)
-    expectDirectPropertyTypes(kbManageStrictInputSchema)
-  })
-
-  it('lets the MCP kb_manage path omit unused fields', () => {
-    // The Claude Code bridge parses raw args with kbManageInputSchema; an agent may omit every
-    // field but `baseId`/`action`, so the optional shape must accept that without erroring.
+  it('lets kb_manage omit the fields its action does not use', () => {
     expect(kbManageInputSchema.safeParse({ baseId: 'kb-1', action: 'delete' }).success).toBe(true)
     expect(kbManageInputSchema.safeParse({ baseId: 'kb-1', action: 'add', type: 'note', content: 'hi' }).success).toBe(
       true
     )
   })
 
-  it('keeps kb_read strict-path fields in `required` so strict providers accept the schema', () => {
-    const json = z.toJSONSchema(kbReadStrictInputSchema) as { required?: unknown }
-
-    expect(Array.isArray(json.required)).toBe(true)
-    expect(json.required).toEqual(
-      expect.arrayContaining(['baseId', 'conceptId', 'charStart', 'charEnd', 'pattern', 'ignoreCase', 'maxMatches'])
-    )
-    expect(
-      kbReadStrictInputSchema.safeParse({
-        baseId: 'kb-1',
-        conceptId: 'docs/intro.md',
-        charStart: 0,
-        charEnd: 0,
-        pattern: '',
-        ignoreCase: true,
-        maxMatches: 0
-      }).success
-    ).toBe(true)
-    expectDirectPropertyTypes(kbReadStrictInputSchema)
+  it('lets kb_read omit mode-specific fields', () => {
+    expect(kbReadInputSchema.safeParse({ baseId: 'kb-1', conceptId: 'docs/intro.md' }).success).toBe(true)
   })
 
-  it('lets the MCP kb_read path omit mode-specific fields', () => {
-    expect(kbReadInputSchema.safeParse({ baseId: 'kb-1', conceptId: 'docs/intro.md' }).success).toBe(true)
+  // `readOrGrepConcept` routes on `pattern` being present at all, so an empty-string `pattern` would
+  // mean "grep for ''" rather than "read the document". Rejecting it keeps the sentinel unreachable.
+  it('rejects an empty kb_read pattern rather than letting it mean read mode', () => {
+    expect(kbReadInputSchema.safeParse({ baseId: 'kb-1', conceptId: 'docs/intro.md', pattern: '' }).success).toBe(false)
   })
 
   it('advertises the exact to_markdown input boundary and supported extensions', () => {

--- a/src/shared/ai/__tests__/builtinTools.test.ts
+++ b/src/shared/ai/__tests__/builtinTools.test.ts
@@ -9,6 +9,7 @@ import {
   kbManageInputSchema,
   kbReadInputSchema,
   kbSearchInputSchema,
+  readFileInputSchema,
   REPORT_ARTIFACTS_DESCRIPTION,
   REPORT_ARTIFACTS_TOOL_NAME,
   reportArtifactsInputSchema,
@@ -43,10 +44,11 @@ describe('builtin tool contracts', () => {
     expect(description).not.toContain('web__search')
   })
 
-  it('keeps `format` out of the web_fetch schema so strict providers accept it', () => {
-    // WebFetchTool runs with `strict: true`. Zod's `.url()` emits `format: "uri"`, which strict
-    // OpenAI-compatible providers reject with a 400 that kills the whole request, not just this
-    // tool ("Invalid schema for function 'web_fetch': ... 'uri' is not a valid format").
+  it('keeps `format` out of the web_fetch schema so any provider accepts it', () => {
+    // Zod's `.url()` emits `format: "uri"`, which strict OpenAI-compatible providers reject with a
+    // 400 that kills the whole request, not just this tool ("Invalid schema for function
+    // 'web_fetch': ... 'uri' is not a valid format"). No builtin tool is strict any more, but the
+    // refinement is kept regardless — `isHttpUrl` is narrower than `.url()` (see the schema).
     // The http(s) contract is carried by a refinement, which `toJSONSchema` cannot express.
     // Whole-document rather than a `properties.urls.items.format` chain: an optional chain that
     // stops matching after a shape change would pass while `format` reappeared elsewhere.
@@ -106,6 +108,18 @@ describe('builtin tool contracts', () => {
   // mean "grep for ''" rather than "read the document". Rejecting it keeps the sentinel unreachable.
   it('rejects an empty kb_read pattern rather than letting it mean read mode', () => {
     expect(kbReadInputSchema.safeParse({ baseId: 'kb-1', conceptId: 'docs/intro.md', pattern: '' }).success).toBe(false)
+  })
+
+  // read_file's offset/limit were required numbers with a 0 sentinel while it ran with `strict: true`.
+  // Now that they are plain optionals, `limit: 0` has no sentinel meaning left — and taken literally
+  // it says "return zero characters", which `paginate` would answer with a 2-char page. Reject it so
+  // a model that still sends the old sentinel gets a repairable input error instead of a silent
+  // near-empty read. `offset: 0` stays valid: it genuinely means "start at the beginning".
+  it('rejects read_file limit: 0 but keeps offset: 0 meaningful', () => {
+    expect(readFileInputSchema.safeParse({ filename: 'a.txt' }).success).toBe(true)
+    expect(readFileInputSchema.safeParse({ filename: 'a.txt', offset: 0 }).success).toBe(true)
+    expect(readFileInputSchema.safeParse({ filename: 'a.txt', limit: 0 }).success).toBe(false)
+    expect(readFileInputSchema.safeParse({ filename: 'a.txt', limit: 1 }).success).toBe(true)
   })
 
   it('advertises the exact to_markdown input boundary and supported extensions', () => {

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -11,25 +11,35 @@ import * as z from 'zod'
  * place is a compile error in the other.
  */
 
-// ── Why the kb_* tools do not run with `strict: true` ────────────
+// ── Why no builtin tool runs with `strict: true` ─────────────────
 //
-// `strict` asks the provider for constrained decoding, which makes it compile every strict tool
-// schema in the request into one sampling grammar. Binding a knowledge base turns on four tools at
-// once (kb_search / kb_list / kb_read / kb_manage, all `defer: 'never'`), and Anthropic 400s the
-// whole request when that combined grammar exceeds its compile budget ("Schema is too complex for
-// compilation") — so attaching a base broke every message, including "hi".
+// `strict` asks the provider for constrained decoding, which makes Anthropic compile every strict
+// tool schema in the request into ONE sampling grammar. The compile budget is shared across those
+// strict schemas (non-strict tools do not count toward it), and the request 400s when the combined
+// grammar exceeds it ("Schema is too complex for compilation"). Binding a knowledge base turned on
+// four strict tools at once (kb_search / kb_list / kb_read / kb_manage, all `defer: 'never'`, so
+// none could even be deferred) and broke every message, including "hi".
 //
-// Dropping `strict` also removes what forced these schemas into a second, sentinel-valued shape:
-// strict mode requires every property in `required`, so optional fields had to become required
-// primitives (`''` / `0` / `-1` / `'none'`) that adapters translated back. Plain `.optional()` is
-// both what the model reads more easily and what the shared `knowledgeLookup` core already expects,
-// so one schema now serves the AI-SDK tool and the Claude Code / MCP bridge alike.
+// The web/file tools that were also strict (web_search / web_fetch / read_file — 5 properties
+// between them) would not have blown that budget on their own. They lost `strict` for the reason
+// below instead: on schemas this small it buys almost nothing, and it is not free.
+//
+// Dropping `strict` also removes what forced several of these schemas into a second, sentinel-valued
+// shape: strict mode requires every property in `required`, so optional fields had to become
+// required primitives (`''` / `0` / `-1` / `'none'`) that adapters translated back. Plain
+// `.optional()` is both what the model reads more easily and what the shared cores already expect,
+// so one schema now serves the AI-SDK tools and the Claude Code / MCP bridge alike.
 //
 // Nothing goes unvalidated: the AI SDK still checks every tool call against these schemas, and
 // `createAiRepair` re-asks the model on a mismatch — the fallback `strict` was buying us out of.
+// Provider-side, the validation keywords strict mode used to strip (`minLength`, `maximum`, …) now
+// survive; each provider's own sanitizer drops or folds what it cannot take (Anthropic turns them
+// into advisory description text), so the model sees MORE of the contract than it did before.
 //
-// Keep it this way: re-adding `strict` here reintroduces the 400 the moment a base is bound.
-// (`readFileInputSchema` below is a different case — it is still strict, and still needs sentinels.)
+// Keep it this way. `registerBuiltinTools.test.ts` asserts the whole registry stays non-strict: a
+// blanket rule needs no judgement call, whereas "is this one small enough to be strict?" has to be
+// re-answered against an undocumented budget that only Anthropic can change — and answered again
+// every time a tool or a property is added.
 
 // ── kb_list ──────────────────────────────────────────────────────
 
@@ -378,15 +388,18 @@ export const webSearchOutputItemSchema = z.object({
 export const webSearchOutputSchema = z.array(webSearchOutputItemSchema)
 
 export const webFetchInputSchema = z.object({
-  // `.refine()` rather than `.url()`: WebFetchTool runs with `strict: true`, and `.url()` emits
-  // `format: "uri"`, which strict OpenAI-compatible providers reject outright — the whole request
-  // 400s ("Invalid schema for function 'web_fetch': ... 'uri' is not a valid format"), taking every
-  // other tool in the turn down with it. A refinement is invisible to `toJSONSchema` (no `format`
-  // keyword) yet still runs locally, so the model's tool call is validated before `execute` and a
-  // malformed URL surfaces as a repairable input error instead of a bogus network failure.
-  //
-  // `isHttpUrl` is literally the predicate `normalizeWebSearchUrls` enforces service-side, so the
-  // schema and the service agree by construction instead of via two copies of one rule that drift.
+  // `.refine()` rather than `.url()`, for two reasons that both still hold now that no builtin tool
+  // runs with `strict: true` (see the note at the top of this file):
+  //   1. `isHttpUrl` is *narrower* than `.url()`, which happily accepts `file:///etc/passwd` and
+  //      `javascript:alert(1)`. It is literally the predicate `normalizeWebSearchUrls` enforces
+  //      service-side, so the schema and the service agree by construction rather than via two
+  //      copies of one rule that drift. Do not "simplify" this back to `.url()`.
+  //   2. A refinement is invisible to `toJSONSchema` (it emits no `format` keyword), so the schema
+  //      carries no `format: "uri"` — which strict OpenAI-compatible providers reject outright,
+  //      400ing the whole request and taking every other tool in the turn with it. Keeping `format`
+  //      out costs nothing and keeps this schema safe to send anywhere.
+  // Either way the refinement still runs locally, so a malformed URL surfaces as a repairable input
+  // error before `execute` instead of a bogus network failure.
   //
   // It is only a syntax gate, though. Of the two providers serving `web_fetch`, `fetch` retrieves
   // the target in this process and so runs it through `remoteUrlSafety`, which additionally rejects
@@ -507,24 +520,27 @@ export const readFileInputSchema = z.object({
     .describe(
       'Name of the attached file to read, exactly as it appears in the attachment manifest in the conversation.'
     ),
-  // Required plain numbers with a 0 sentinel, not `.optional()` / `.nullable()`: ReadFileTool runs
-  // with `strict: true`, so a strict OpenAI-compatible provider rejects a schema whose `required`
-  // omits a property (`z.toJSONSchema` drops `.optional()` fields from `required`) — while Gemini
-  // rejects the `anyOf: [number, null]` that `.nullable()` emits ("didn't specify the schema type
-  // field"). A bare `number` is the only shape both accept; `readFile` maps 0 back to the defaults.
+  // Plain optionals — omitting a field means "use the default". These were required numbers with a
+  // 0 sentinel while read_file ran with `strict: true`; see the note at the top of this file for why
+  // strict is gone. `.optional()` and not `.nullable()`: the latter emits `anyOf: [number, null]`,
+  // which Gemini rejects ("didn't specify the schema type field").
   offset: z
     .number()
     .int()
     .nonnegative()
+    .optional()
     .describe(
-      '0-based character offset to start from. Page through long documents with offset + limit. Use 0 to start at the beginning.'
+      '0-based character offset to start from. Page through long documents with offset + limit. Omit to start at the beginning.'
     ),
+  // `.positive()`, not `.nonnegative()`: with the sentinel gone, `limit: 0` would mean "return zero
+  // characters" and `paginate` would emit a 2-char page rather than the default. Reject it instead.
   limit: z
     .number()
     .int()
-    .nonnegative()
+    .positive()
     .max(200_000)
-    .describe(`Max characters to return. Use 0 to default to ${READ_FILE_PAGE_SIZE}.`)
+    .optional()
+    .describe(`Max characters to return. Omit to default to ${READ_FILE_PAGE_SIZE}.`)
 })
 
 export const readFileOutputSchema = z.object({

--- a/src/shared/ai/builtinTools.ts
+++ b/src/shared/ai/builtinTools.ts
@@ -11,6 +11,26 @@ import * as z from 'zod'
  * place is a compile error in the other.
  */
 
+// ── Why the kb_* tools do not run with `strict: true` ────────────
+//
+// `strict` asks the provider for constrained decoding, which makes it compile every strict tool
+// schema in the request into one sampling grammar. Binding a knowledge base turns on four tools at
+// once (kb_search / kb_list / kb_read / kb_manage, all `defer: 'never'`), and Anthropic 400s the
+// whole request when that combined grammar exceeds its compile budget ("Schema is too complex for
+// compilation") — so attaching a base broke every message, including "hi".
+//
+// Dropping `strict` also removes what forced these schemas into a second, sentinel-valued shape:
+// strict mode requires every property in `required`, so optional fields had to become required
+// primitives (`''` / `0` / `-1` / `'none'`) that adapters translated back. Plain `.optional()` is
+// both what the model reads more easily and what the shared `knowledgeLookup` core already expects,
+// so one schema now serves the AI-SDK tool and the Claude Code / MCP bridge alike.
+//
+// Nothing goes unvalidated: the AI SDK still checks every tool call against these schemas, and
+// `createAiRepair` re-asks the model on a mismatch — the fallback `strict` was buying us out of.
+//
+// Keep it this way: re-adding `strict` here reintroduces the 400 the moment a base is bound.
+// (`readFileInputSchema` below is a different case — it is still strict, and still needs sentinels.)
+
 // ── kb_list ──────────────────────────────────────────────────────
 
 export const KB_LIST_TOOL_NAME = 'kb_list'
@@ -22,11 +42,8 @@ export const KB_LIST_TOOL_NAME = 'kb_list'
 //                       optionally capped by `maxDepth`. Each readable leaf carries a `conceptId`
 //                       for kb_read.
 //
-// kb_list is consumed by two paths with conflicting schema needs, so it has two shapes.
-//
-// MCP / Claude Code bridge (cherryBuiltinTools): the agent parses raw args with this schema and may
-// omit any field, so they are `.optional()`. `z.toJSONSchema` legitimately drops them from
-// `required`, which the non-strict MCP schema accepts. Omit a field to skip it.
+// One shape for both consumers (AI-SDK tool + MCP / Claude Code bridge): unused fields are simply
+// omitted. See the `kb_*` note at the top of this file.
 export const kbListInputSchema = z.object({
   query: z
     .string()
@@ -56,42 +73,6 @@ export const kbListInputSchema = z.object({
     .nonnegative()
     .optional()
     .describe('Outline mode only (requires `baseId`): limit the tree to this many folder levels (0 = top level).')
-})
-
-// AI-SDK path (KnowledgeListTool) runs with `strict: true`. Strict OpenAI-compatible providers require
-// every property in `required`, while Gemini also requires every property to expose a top-level
-// primitive `type` and rejects the `anyOf` emitted by `.nullable()`. As with `readFileInputSchema`,
-// required primitives plus sentinel values satisfy both providers; the adapter maps the sentinels
-// back to optional core inputs. The MCP schema above remains optional because it has no strict-mode
-// constraint.
-export const kbListStrictInputSchema = z.object({
-  query: z
-    .string()
-    .trim()
-    .max(200)
-    .describe(
-      'List mode only: case-insensitive substring filter against base name and sample sources. Pass an empty string to list all.'
-    ),
-  groupId: z
-    .string()
-    .trim()
-    .describe(
-      'List mode only: restrict the result to a single knowledge base group. Pass an empty string to span all groups.'
-    ),
-  baseId: z
-    .string()
-    .trim()
-    .describe(
-      'Pass a base id (from a prior list-mode call) to switch to outline mode: return that base’s ' +
-        'folder/document tree instead of the list of bases. Pass an empty string to list the bases.'
-    ),
-  maxDepth: z
-    .number()
-    .int()
-    .min(-1)
-    .describe(
-      'Outline mode only (requires `baseId`): limit the tree to this many folder levels (0 = top level). Pass -1 for unlimited depth.'
-    )
 })
 
 export const kbListOutputItemSchema = z.object({
@@ -229,55 +210,6 @@ export const kbReadInputSchema = z.object({
     )
 })
 
-// AI-SDK strict schemas use required primitives and sentinels for cross-provider compatibility; see
-// `kbListStrictInputSchema`. The adapter normalizes these sentinels before calling the shared core.
-export const kbReadStrictInputSchema = z.object({
-  baseId: z
-    .string()
-    .trim()
-    .min(1)
-    .describe('ID of the knowledge base to read from — a base id from kb_list or a kb_search hit.'),
-  conceptId: z
-    .string()
-    .trim()
-    .min(1)
-    .describe('Concept ID of the document to read — the `conceptId` field of a kb_search hit (its relative path).'),
-  charStart: z
-    .number()
-    .int()
-    .nonnegative()
-    .describe('Read mode only: 0-based start offset of the slice to read. Pass 0 to start at the beginning.'),
-  charEnd: z
-    .number()
-    .int()
-    .nonnegative()
-    .describe(
-      'Read mode only: end offset (exclusive) of the slice. Pass 0 to read to the end. Long reads are capped; ' +
-        'when `totalChars` exceeds the returned `charEnd`, page on by calling again with `charStart` set to that `charEnd`.'
-    ),
-  pattern: z
-    .string()
-    .max(200)
-    .describe(
-      'Pass a JavaScript regular expression to switch to grep mode: instead of the document text, return each ' +
-        'matching line with its character offsets and a snippet (anchors `^`/`$` bind to each line; a match ' +
-        'cannot span lines). Use this for an exact lookup — a number, code symbol, term, quote. Pass an empty ' +
-        'string to read the document text; use kb_search for semantic/meaning-based lookup across documents.'
-    ),
-  ignoreCase: z
-    .boolean()
-    .describe('Grep mode only: case-insensitive matching. Pass true for the default; ignored in read mode.'),
-  maxMatches: z
-    .number()
-    .int()
-    .nonnegative()
-    .max(200)
-    .describe(
-      'Grep mode only: maximum matches to return (default 50, hard cap 200). Pass 0 to use the default. ' +
-        '`totalMatches` always reports the full count.'
-    )
-})
-
 export const kbReadOutputSchema = z.object({
   // Citation id the model echoes back as `[cite:id]`. One id per call: a read returns one
   // document slice, so the whole result is a single source. Optional because results persisted
@@ -356,16 +288,11 @@ export const KB_MANAGE_TOOL_NAME = 'kb_manage'
 
 export const KB_MANAGE_ACTIONS = ['add', 'delete', 'refresh'] as const
 export const KB_MANAGE_ADD_TYPES = ['file', 'url', 'note'] as const
-export const KB_MANAGE_UNUSED_TYPE = 'none' as const
 
 // One flat object, not a discriminated union: which fields apply depends on `action`
 // (and, for add, on `type`). The core validates the combination and returns a steer
 // string on a missing field, so the model gets a clear error rather than a schema reject.
-//
-// kb_manage is consumed by two paths with conflicting schema needs, same split as kb_list.
-//
-// MCP / Claude Code bridge (cherryBuiltinTools): the agent parses raw args with this schema and may
-// omit any field, so they are `.optional()`.
+// Fields the chosen action does not use are simply omitted.
 export const kbManageInputSchema = z.object({
   baseId: z.string().trim().min(1).describe('ID of the knowledge base to modify — a base id from kb_list.'),
   action: z
@@ -403,49 +330,6 @@ export const kbManageInputSchema = z.object({
     .optional()
     .describe(
       'For action="delete"/"refresh": Concept IDs (the `conceptId` field of a kb_search hit or a kb_list result) to operate on.'
-    )
-})
-
-// AI-SDK strict schemas use required primitives and sentinels for cross-provider compatibility; see
-// `kbListStrictInputSchema`. The adapter normalizes these sentinels before calling the shared core.
-export const kbManageStrictInputSchema = z.object({
-  baseId: z.string().trim().min(1).describe('ID of the knowledge base to modify — a base id from kb_list.'),
-  action: z
-    .enum(KB_MANAGE_ACTIONS)
-    .describe(
-      'add: import a new source (set `type` + its field). delete: remove documents by `conceptIds`. ' +
-        'refresh: re-index documents by `conceptIds`. All actions modify the base and require user approval.'
-    ),
-  type: z
-    .enum([...KB_MANAGE_ADD_TYPES, KB_MANAGE_UNUSED_TYPE])
-    .describe(
-      'For action="add" only: the source kind — "file" (set `path`), "url" (set `url`), or "note" (set `content`). ' +
-        'Pass "none" for delete or refresh.'
-    ),
-  path: z
-    .string()
-    .trim()
-    .describe(
-      'For action="add", type="file": absolute local filesystem path of the file to import. Pass an empty string otherwise.'
-    ),
-  url: z
-    .string()
-    .trim()
-    .describe('For action="add", type="url": the URL to fetch and index. Pass an empty string otherwise.'),
-  content: z
-    .string()
-    .describe('For action="add", type="note": the plain-text note content to index. Pass an empty string otherwise.'),
-  title: z
-    .string()
-    .trim()
-    .describe(
-      'For action="add", type="note": optional display title (defaults to the note\'s first line). Pass an empty string to omit.'
-    ),
-  conceptIds: z
-    .array(z.string().trim().min(1))
-    .describe(
-      'For action="delete"/"refresh": Concept IDs (the `conceptId` field of a kb_search hit or a kb_list result) ' +
-        'to operate on. Pass an empty array for add.'
     )
 })
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Attaching a Knowledge Base to an Assistant made **every** message fail on Anthropic with a 400 — even a bare `hi`:

> Schema is too complex for compilation, suggesting simplification or reduction of tools is needed.

Reported by a user on v2.0.2 (macOS, Apple Silicon; Claude Sonnet 4.6 and Haiku 4.5; SiliconFlow `BAAI/bge-m3` embeddings). Base creation, indexing and Recall Test all worked — only chatting with a base bound failed. Unbinding the base fixed it; recreating the base/assistant, restarting, switching models and removing Skills did not.

After this PR:

No builtin tool sends `strict: true`. Binding a base no longer triggers grammar compilation, so the request goes through.

Fixes # N/A — reported by email to support@cherry-ai.com, no GitHub issue was filed.

### Why we need it and why it was done in this way

`strict: true` asks the provider for constrained decoding. `@ai-sdk/anthropic` forwards it verbatim (`supportsStrictTools === true && tool.strict != null`), so Anthropic compiles every strict tool schema in the request into **one** sampling grammar and 400s the whole request when the combined grammar exceeds its compile budget.

Binding a knowledge base turns on four strict tools at once — `kb_search` / `kb_list` / `kb_read` / `kb_manage`, all `defer: 'never'`, so none can even be hidden behind `tool_search`. Measured against the emitted JSON Schema, that takes the request's strict surface from **5 properties to 25**. Nothing else a user toggles is strict (MCP and Skill tools never set it), which is exactly why removing `skill-creator` changed nothing while unbinding the base fixed it.

Commit 1 drops `strict` from the four `kb_*` tools. Commit 2 drops it from the last three (`web_search` / `web_fetch` / `read_file`).

The following tradeoffs were made:

- **Lost the hard guarantee of schema-valid tool arguments.** Tool calls are still validated — the AI SDK checks every call against the zod schema and `createAiRepair` re-asks the model on a mismatch. The cost is an occasional extra round-trip instead of a 400. `kb_manage` is the most exposed (8 fields with conditional dependencies), but its core already answers a missing field with a steer string rather than a schema reject, and it is `needsApproval: true`, so a bad call surfaces as an approval card rather than executing.
- **`read_file`'s `limit: 0` is now rejected instead of meaning "use the default".** The 0 sentinel only existed because strict requires every property in `required`. It was ambiguous: read literally it asks for zero characters, which `paginate` answers with a 2-char page. `offset: 0` stays valid — it genuinely means "start at the beginning". Grepped for other consumers; only a test relied on it.
- **The `kb_*` and `read_file` schemas lost their duplicate sentinel-valued shapes** (`''` / `0` / `-1` / `'none'` as required primitives, translated back by adapters). The AI-SDK path now uses the same plain-optional schema the MCP bridge already used, so one schema serves both. Net −250 lines in commit 1.
- **Validation keywords now reach providers.** Strict mode stripped `minLength` / `maximum` / etc. Non-strict keeps them, and each provider's own sanitizer handles what it cannot take — Anthropic's folds them into advisory description text, Gemini's converter keeps only its supported subset. Net effect: the model sees *more* of the contract than before.

The following alternatives were considered:

- **Keep `strict` on the small tools, drop it only from `kb_*`.** Anthropic's budget is shared across a request's *strict* schemas only, so `web_search` / `web_fetch` / `read_file` (5 properties between them) would not have blown it on their own. Rejected: on schemas that small, strict guarantees type and structure the model was not getting wrong anyway, while the error that does happen — a filename matching no attachment — is one strict cannot catch (`readFile`'s allow-list does). Meanwhile it forces the sentinel shape above. A blanket "no builtin tool is strict" rule also needs no judgement call, whereas "is this one small enough?" must be re-answered against an undocumented budget on every tool and property added.
- **Revert `web_fetch`'s `.refine(isHttpUrl)` back to `.url()`.** Rejected: strict was only half that refinement's rationale. `isHttpUrl` is *narrower* than `.url()`, which accepts `file:///etc/passwd` and `javascript:alert(1)`, and it is the same predicate `normalizeWebSearchUrls` enforces service-side. The schema is unchanged; only its comment was rewritten.
- **Delete the now-unreachable `STRICT_UNSUPPORTED` branch in `toolSchemaCompatibility.ts`.** Rejected: it is defensive provider-compat infrastructure with its own tests, and removing it would let whoever re-adds `strict` walk back into #18041.

Links to places where the discussion took place: N/A

### Breaking changes

None user-facing.

One internal contract change: `read_file` now rejects `limit: 0` rather than treating it as "use the default" (`offset: 0` is unaffected). This is a tool-call input contract between the model and the app, not a user setting or stored data, so no migration or user action is required. A model that still sends the old sentinel gets a repairable input error instead of a silent near-empty read.

### Special notes for your reviewer

**Not verified against the live Anthropic API — I had no API key available.** Every link in the causal chain is established from code and from the request-body dump in #18037 (which shows `"strict":true` reaching `api.anthropic.com`), but the final step — that dropping these tools lands back inside Anthropic's compile budget — is inference. **Please reproduce once before merging: create a base → bind it to an assistant → send `hi`.**

Worth a close look:

- `registerBuiltinTools.test.ts` asserts the whole registry stays non-strict. I mutation-tested it: re-adding `strict: true` to `WebFetchTool` turns it red and names `web_fetch`.
- Anthropic's complexity limit accumulates across *strict* schemas only, not all tools. An earlier draft of commit 2's message overstated this; the message and code comments were corrected before push.
- `builtinTools.ts` carries a header comment explaining why strict must not come back. That comment plus the registry-wide test are the whole guardrail.

Test status: `pnpm lint`, `pnpm test:lint` (exit 0), `pnpm typecheck` (all three projects) and the full `src/main/ai` + `src/shared/ai` suite (3517 tests) pass locally. `pnpm build:check` and the full suite were left to CI. The one full-suite failure seen locally (`file/tree/builder.test.ts`) was confirmed pre-existing flake: it passes on a clean baseline and on 3 consecutive reruns with these changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Knowledge Base assistants failing on Anthropic models with "Schema is too complex for compilation". Attaching a knowledge base to an assistant made every message fail; it now works.
```
