### PR TITLE
perf(startup-memory): lazy-load five heavy main-process dependencies

### DIFF
--- a/src/main/ai/mcp/servers/fetch.ts
+++ b/src/main/ai/mcp/servers/fetch.ts
@@ -3,7 +3,6 @@
 import { fetchRemoteText } from '@main/utils/remoteFetch'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
-import { JSDOM } from 'jsdom'
 import TurndownService from 'turndown'
 import * as z from 'zod'
 
@@ -74,6 +73,8 @@ export class Fetcher {
     try {
       const html = await this._fetchText(requestPayload)
 
+      // Delayed loading: jsdom costs tens of MB of RSS, so it must load on first tool call, not at boot.
+      const { JSDOM } = await import('jsdom')
       const dom = new JSDOM(html)
       const document = dom.window.document
 

--- a/src/main/ai/messages/attachmentTextExtraction.ts
+++ b/src/main/ai/messages/attachmentTextExtraction.ts
@@ -17,7 +17,6 @@ import { decodeTextWithAutoEncoding } from '@main/utils/legacyFile'
 import { extractPdfText } from '@main/utils/pdf'
 import type { FileEntryId } from '@shared/data/types/file'
 import { documentExts } from '@shared/utils/file'
-import officeParser from 'officeparser'
 import WordExtractor from 'word-extractor'
 
 const logger = loggerService.withContext('ai:documentExtraction')
@@ -45,6 +44,8 @@ async function extract(entryId: FileEntryId, ext: string): Promise<string | null
     return extracted.getBody().trim()
   }
   if (OFFICE_PARSER_EXTS.has(ext)) {
+    // Delayed loading: officeparser (and the pdf stack it drags in) stays out of the boot path.
+    const { default: officeParser } = await import('officeparser')
     const text = await officeParser.parseOfficeAsync(buffer, { tempFilesLocation: application.getPath('app.temp') })
     return text.trim()
   }

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -1,13 +1,13 @@
 import { fileURLToPath } from 'node:url'
 
-import {
-  type Options,
-  type Query,
-  query as createClaudeQuery,
-  type SDKAssistantMessage,
-  type SDKPartialAssistantMessage,
-  type SDKResultMessage,
-  type SDKUserMessage
+import type {
+  Options,
+  Query,
+  query,
+  SDKAssistantMessage,
+  SDKPartialAssistantMessage,
+  SDKResultMessage,
+  SDKUserMessage
 } from '@anthropic-ai/claude-agent-sdk'
 import type { ImageBlockParam } from '@anthropic-ai/sdk/resources/messages'
 
@@ -355,6 +355,8 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   private sdkInputQueue = new SdkInputQueue()
   private readonly abortController = new AbortController()
   private query?: Query
+  /** SDK `query` factory captured at connect — the sync stale-resume retry cannot await the import. */
+  private createQuery?: typeof query
   private closePromise?: Promise<void>
   /** The exact spawn options of the live query — resume recovery re-spawns from these. */
   private spawnOptions?: Options
@@ -439,6 +441,9 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
     // describes the credential that will actually serve this connection.
     this._usageCapture = consumedWarmQuery?.usageCapture ?? request.usageCapture
     this.spawnOptions = options
+    // Delayed loading: the agent SDK stays out of the boot path and loads on first connection.
+    const createClaudeQuery = (await import('@anthropic-ai/claude-agent-sdk')).query
+    this.createQuery = createClaudeQuery
     this.query = consumedWarmQuery
       ? consumedWarmQuery.warmQuery.query(this.sdkInputQueue)
       : createClaudeQuery({ prompt: this.sdkInputQueue, options })
@@ -753,7 +758,14 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
 
   /** Rebuilds one failed resumed query without its corrupt or missing conversation history. */
   private tryRecoverWithoutResume(error: unknown): boolean {
-    if (this.resumeRecoveryRetried || !this.resumeToken || !this.spawnOptions || this.abortController.signal.aborted) {
+    const createClaudeQuery = this.createQuery
+    if (
+      this.resumeRecoveryRetried ||
+      !this.resumeToken ||
+      !this.spawnOptions ||
+      !createClaudeQuery ||
+      this.abortController.signal.aborted
+    ) {
       return false
     }
     const reason = getResumeRecoveryReason(error)

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeWarmQueryManager.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeWarmQueryManager.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto'
 
 import type { Options, WarmQuery } from '@anthropic-ai/claude-agent-sdk'
-import { startup } from '@anthropic-ai/claude-agent-sdk'
 import { application } from '@application'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import { loggerService } from '@logger'
@@ -160,7 +159,7 @@ export class ClaudeCodeWarmQueryManager extends BaseService {
     try {
       const warmRequest = await buildClaudeCodeWarmQueryRequestForAgentSession(sessionId)
       if (!warmRequest) return
-      this.prewarm(await this.withTraceEnv(sessionId, warmRequest))
+      await this.prewarm(await this.withTraceEnv(sessionId, warmRequest))
     } catch (error) {
       logger.warn('Failed to prewarm agent session', { sessionId, error })
     }
@@ -198,7 +197,10 @@ export class ClaudeCodeWarmQueryManager extends BaseService {
     })
   }
 
-  prewarm(request: WarmQueryRequest): void {
+  async prewarm(request: WarmQueryRequest): Promise<void> {
+    // Delayed loading: the agent SDK stays out of the boot path and loads on first prewarm. The
+    // single await sits before any `entries` access, so the body below still runs without gaps.
+    const { startup } = await import('@anthropic-ai/claude-agent-sdk')
     const warmOptions = { ...stripWarmQueryOptions(request.options), spawnClaudeCodeProcess }
     const signature = createClaudeCodeWarmQuerySignature(
       warmOptions,

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeWarmQueryManager.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeWarmQueryManager.test.ts
@@ -89,7 +89,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const abortController = new AbortController()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1', abortController } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1', abortController } as any })
 
     const consumed = await manager.consume({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1' } as any })
     const second = await manager.consume({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1' } as any })
@@ -109,7 +109,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const ignoredSpawn = vi.fn()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({
+    await manager.prewarm({
       key: 'session-1',
       options: { model: 'sonnet', spawnClaudeCodeProcess: ignoredSpawn } as any
     })
@@ -128,8 +128,8 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const firstWarm = warmQuery(firstCleanup.promise)
     const secondWarm = warmQuery(secondCleanup.promise)
     startupMock.mockResolvedValueOnce(firstWarm).mockResolvedValueOnce(secondWarm)
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
-    manager.prewarm({ key: 'session-2', options: { model: 'opus' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
+    await manager.prewarm({ key: 'session-2', options: { model: 'opus' } as any })
     await Promise.resolve()
 
     const closing = manager.closeAll()
@@ -160,7 +160,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const manager = new ClaudeCodeWarmQueryManager()
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
     await Promise.resolve()
 
     await expect(manager._doStop()).resolves.toBeUndefined()
@@ -169,9 +169,13 @@ describe('ClaudeCodeWarmQueryManager', () => {
 
   it('does not reject stop when a warm cleanup fails', async () => {
     const manager = new ClaudeCodeWarmQueryManager()
-    const warm = warmQuery(Promise.reject(new Error('dispose failed')))
+    const cleanupFailure = Promise.reject(new Error('dispose failed'))
+    // Park a handler: prewarm yields to the SDK import before the dispose chain attaches the real
+    // one, so the bare rejection would otherwise be reported as unhandled.
+    cleanupFailure.catch(() => undefined)
+    const warm = warmQuery(cleanupFailure)
     startupMock.mockResolvedValueOnce(warm)
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
     await Promise.resolve()
 
     await expect(manager._doStop()).resolves.toBeUndefined()
@@ -184,8 +188,8 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const current = warmQuery()
     startupMock.mockResolvedValueOnce(stale).mockResolvedValueOnce(current)
 
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1' } as any })
-    manager.prewarm({ key: 'session-1', options: { model: 'opus', resume: 'sdk-1' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet', resume: 'sdk-1' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'opus', resume: 'sdk-1' } as any })
 
     await Promise.resolve()
     const consumed = await manager.consume({ key: 'session-1', options: { model: 'opus', resume: 'sdk-1' } as any })
@@ -292,7 +296,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({
+    await manager.prewarm({
       key: 'session-1',
       options: { model: 'sonnet', env: { ANTHROPIC_API_KEY: 'key-a' } } as any,
       credentialsFingerprint: 'set-1'
@@ -312,7 +316,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({
+    await manager.prewarm({
       key: 'session-1',
       options: { model: 'sonnet', env: { ANTHROPIC_API_KEY: 'key-a' } } as any,
       credentialsFingerprint: 'set-1',
@@ -353,7 +357,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({
+    await manager.prewarm({
       key: 'session-1',
       options: { model: 'sonnet' } as any,
       credentialsFingerprint: 'set-1'
@@ -374,7 +378,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({
+    await manager.prewarm({
       key: 'session-1',
       options: { model: 'sonnet' } as any,
       knowledgeBaseIds: []
@@ -395,7 +399,7 @@ describe('ClaudeCodeWarmQueryManager', () => {
     const warm = warmQuery()
     startupMock.mockResolvedValueOnce(warm)
 
-    manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
+    await manager.prewarm({ key: 'session-1', options: { model: 'sonnet' } as any })
     await Promise.resolve()
     vi.advanceTimersByTime(5 * 60 * 1000)
     await Promise.resolve()

--- a/src/main/features/fileProcessing/processors/tesseract/runtime/TesseractRuntimeService.ts
+++ b/src/main/features/fileProcessing/processors/tesseract/runtime/TesseractRuntimeService.ts
@@ -9,7 +9,6 @@ import { MB } from '@shared/utils/constants'
 import PQueue from 'p-queue'
 import type { LanguageCode } from 'tesseract.js'
 import type Tesseract from 'tesseract.js'
-import { createWorker } from 'tesseract.js'
 
 import type { ImageToTextHandlerOutput } from '../../types'
 import type { PreparedTesseractContext } from '../types'
@@ -105,6 +104,8 @@ export class TesseractRuntimeService extends BaseService {
         langs
       })
 
+      // Delayed loading: tesseract.js only loads when an OCR task actually needs a worker.
+      const { createWorker } = await import('tesseract.js')
       const nextWorker = await createWorker(langs, undefined, {
         langPath: await this.getLangPath(),
         cachePath: await this.getCacheDir(),

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -36,7 +36,6 @@ import { dialog, net, shell } from 'electron'
 import * as fs from 'fs'
 import { writeFileSync } from 'fs'
 import { readFile } from 'fs/promises'
-import officeParser from 'officeparser'
 import * as path from 'path'
 import { PDFDocument } from 'pdf-lib'
 import { v4 as uuidv4 } from 'uuid'
@@ -426,6 +425,8 @@ class FileStorage {
           return extracted.getBody()
         }
 
+        // Delayed loading: officeparser (and the pdf stack it drags in) stays out of the boot path.
+        const { default: officeParser } = await import('officeparser')
         const data = await officeParser.parseOfficeAsync(filePath, {
           tempFilesLocation: this.tempDir
         })

--- a/src/main/utils/image.ts
+++ b/src/main/utils/image.ts
@@ -1,5 +1,3 @@
-import sharp from 'sharp'
-
 /** Target square dimension for normalized entity images (avatar / logo). */
 const ENTITY_IMAGE_DIMENSION = 128
 /** Decode-work bound: a small file can still declare huge dimensions (bomb). */
@@ -13,6 +11,8 @@ const MAX_ENTITY_INPUT_PIXELS = 100_000_000
  * decides how to react).
  */
 export async function transcodeToEntityWebp(bytes: Uint8Array): Promise<Buffer> {
+  // Delayed loading: a static import would map sharp's multi-MB libvips native library at boot.
+  const sharp = (await import('sharp')).default
   // Only the first frame of an animated GIF is used — fine for a 128² entity image.
   return sharp(bytes, { limitInputPixels: MAX_ENTITY_INPUT_PIXELS })
     .resize(ENTITY_IMAGE_DIMENSION, ENTITY_IMAGE_DIMENSION, { fit: 'cover' })


### PR DESCRIPTION
### What this PR does

Before this PR:

The main process eagerly loaded five heavy external dependencies at boot through top-level static imports — `jsdom`, `sharp` (which maps the multi-MB libvips native library), `officeparser`, `tesseract.js`, and `@anthropic-ai/claude-agent-sdk` — even when the corresponding feature (MCP fetch tool, entity-image transcode, document text extraction, OCR, Claude agent sessions) was never used. Measured on an idle dev instance at T+65s after launch, the main process held 134.7 MB of V8 heap and 313.6 MB of private memory.

After this PR:

All five packages are imported with `await import()` at their call sites and stay out of the boot path entirely. Verified three ways: the built `out/main/main.js` contains zero top-level `require(...)` of these packages (only deferred `import(...)` sites), a live instance's module cache contains none of them after boot, and the same T+65s measurement shows 113.0 MB V8 heap (−21.7 MB, −16%) and 282.7 MB private memory (−30.9 MB, −10%). Each package now loads on the first use of its feature.

Fixes: N/A

### Why we need it and why it was done in this way

Main-process boot RSS sits around 300 MB, and a memory audit showed a large share comes from dependencies that load at startup but are rarely or never used. Deferring them to first use is the lowest-risk slice of that work; heavier levers (re-enabling main-process code splitting, first-party lazy loading, minification) are planned as follow-ups.

The following tradeoffs were made:

- The first call into each feature pays a one-time import cost (typically tens of ms; Node caches the module afterwards).
- `ClaudeCodeWarmQueryManager.prewarm` becomes async so the SDK import is awaited before any `entries` access — the body still runs without interleaving gaps, its only caller awaits it, and the unit tests were updated to `await` it.
- `ClaudeCodeRuntimeConnection` caches the SDK `query` factory at connect time because the synchronous resume-recovery path cannot await an import.

The following alternatives were considered:

- Routing the MCP fetch server's HTML handling through the existing `readableContentWorker` (a bigger change; still possible later).
- Fixing this at the bundler level by re-enabling code splitting — deferred to a follow-up because `inlineDynamicImports` originated as a workaround in #7183 and needs its own validation; the deferrals in this PR work today because these packages are externalized `dependencies` (the same mechanism as the existing `pdf-parse` dynamic import).

Links to places where the discussion took place: N/A

### Breaking changes

None. Behavior is unchanged apart from a one-time lazy-import latency on the first use of each feature.

### Special notes for your reviewer

- A package only stays lazy if **zero** static value-imports of it remain in the eager graph — a single static site hoists the `require` for everyone. sharp demonstrated this: two call sites already used `await import('sharp')`, but the static import in `src/main/utils/image.ts` forced it eager anyway.
- `import type` imports of these packages are kept — they are erased at compile time and cost nothing.
- Verification: `pnpm build:check` green (1770 test files / 21859 tests, 0 failures); bundle grep shows only `import("pkg")` forms; runtime module-cache inspection of a live instance confirms none of the five packages load at boot.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Reduced main-process startup memory by lazy-loading heavy dependencies (jsdom, sharp, officeparser, tesseract.js, Claude agent SDK); each now loads on first use of its feature.
```
