### PR TITLE
fix(agent-right-pane): move declared outputs under the task plan

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -318,7 +318,7 @@
         }
       },
       "info": {
-        "artifacts": "Deliverables",
+        "artifacts": "Outputs",
         "context_categories": {
           "autocompact_buffer": "Autocompact buffer",
           "custom_agents": "Custom agents",
@@ -334,7 +334,7 @@
         "context_usage": "Context usage",
         "label": "Session information",
         "more": "+{{count}} more",
-        "no_artifacts": "No declared deliverables",
+        "no_artifacts": "No declared outputs",
         "no_subagents": "No sub-agents",
         "shell_tasks": "Background commands",
         "subagents": "Sub-agents",

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -74,6 +74,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useAgentMessageListProviderValue } from '../../messages/agentMessageListAdapter'
 import {
+  type AgentArtifactFile,
   type AgentRightPaneStatus,
   type AgentRunLiveness,
   type AgentRunTask,
@@ -997,11 +998,13 @@ function useAgentRightPaneStatus(active = true): AgentRightPaneStatus {
 
 function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPanelScope>) {
   const meta = useAgentRightPaneMeta()
+  const actions = useAgentRightPaneActions()
   const { t } = useTranslation()
   const status = useAgentRightPaneStatus(active)
   const { usage, percentage } = useAgentSessionContextUsage(meta.sessionId)
   const compaction = useAgentSessionCompaction(meta.sessionId)
   const isCompacting = compaction.status === 'compacting'
+  const artifacts = actions.canOpenArtifactFile ? status.artifacts : []
 
   return (
     <div className="h-full space-y-4 overflow-auto p-3 text-sm">
@@ -1037,13 +1040,15 @@ function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPa
         </section>
       )}
 
+      {artifacts.length > 0 && <AgentRightPaneArtifactsSection artifacts={artifacts} compact={false} />}
+
       <AgentContextUsageSummary
         usage={usage}
         percentage={percentage}
         isCompacting={isCompacting}
         className="rounded-md border border-border-subtle px-3 py-2"
       />
-      <AgentRightPaneHighlights status={status} includeTasks={false} />
+      <AgentRightPaneHighlights status={status} includeTasks={false} includeArtifacts={false} />
     </div>
   )
 }
@@ -1151,14 +1156,43 @@ function AgentRightPaneHighlightSection({
   )
 }
 
+function AgentRightPaneArtifactsSection({ artifacts, compact }: { artifacts: AgentArtifactFile[]; compact: boolean }) {
+  const actions = useAgentRightPaneActions()
+  const { t } = useTranslation()
+
+  return (
+    <AgentRightPaneHighlightSection
+      title={t('agent.right_pane.info.artifacts')}
+      icon={<Package size={14} className="text-muted-foreground" />}
+      compact={compact}>
+      <ul className="space-y-0.5">
+        {artifacts.map((artifact) => (
+          <li key={`${artifact.toolCallId}-${artifact.path}`}>
+            <button
+              type="button"
+              onClick={() => actions.openArtifactFile(artifact.path)}
+              title={artifact.path}
+              className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-1 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
+              <FileText size={14} className="shrink-0" />
+              <span className="min-w-0 flex-1 truncate text-xs">{artifact.name}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </AgentRightPaneHighlightSection>
+  )
+}
+
 function AgentRightPaneHighlights({
   status,
   compact = false,
-  includeTasks = true
+  includeTasks = true,
+  includeArtifacts = true
 }: {
   status: AgentRightPaneStatus
   compact?: boolean
   includeTasks?: boolean
+  includeArtifacts?: boolean
 }) {
   const actions = useAgentRightPaneActions()
   const { t } = useTranslation()
@@ -1167,7 +1201,7 @@ function AgentRightPaneHighlights({
   const workflowRunTasks = status.runTasks.filter(isLocalWorkflowRunTask)
   const agentRunTasks = status.runTasks.filter((task) => !isShellRunTask(task) && !isLocalWorkflowRunTask(task))
   const tasks = includeTasks ? status.tasks : []
-  const artifacts = actions.canOpenArtifactFile ? status.artifacts : []
+  const artifacts = includeArtifacts && actions.canOpenArtifactFile ? status.artifacts : []
   const hasHighlights = tasks.length > 0 || status.runTasks.length > 0 || artifacts.length > 0
 
   if (!hasHighlights) return null
@@ -1196,6 +1230,8 @@ function AgentRightPaneHighlights({
         </AgentRightPaneHighlightSection>
       )}
 
+      {artifacts.length > 0 && <AgentRightPaneArtifactsSection artifacts={artifacts} compact={compact} />}
+
       {workflowRunTasks.length > 0 && (
         <AgentRightPaneHighlightSection
           title={t('agent.right_pane.info.workflows')}
@@ -1220,28 +1256,6 @@ function AgentRightPaneHighlights({
           icon={<Terminal size={14} className="text-muted-foreground" />}
           compact={compact}>
           <RunTaskList tasks={shellRunTasks} sessionId={meta.sessionId} />
-        </AgentRightPaneHighlightSection>
-      )}
-
-      {artifacts.length > 0 && (
-        <AgentRightPaneHighlightSection
-          title={t('agent.right_pane.info.artifacts')}
-          icon={<Package size={14} className="text-muted-foreground" />}
-          compact={compact}>
-          <ul className="space-y-0.5">
-            {artifacts.map((artifact) => (
-              <li key={`${artifact.toolCallId}-${artifact.path}`}>
-                <button
-                  type="button"
-                  onClick={() => actions.openArtifactFile(artifact.path)}
-                  title={artifact.path}
-                  className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-1 py-1 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
-                  <FileText size={14} className="shrink-0" />
-                  <span className="min-w-0 flex-1 truncate text-xs">{artifact.name}</span>
-                </button>
-              </li>
-            ))}
-          </ul>
         </AgentRightPaneHighlightSection>
       )}
     </div>

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -1063,6 +1063,91 @@ describe('AgentRightPane', () => {
     expect(screen.queryByTestId('workflow-dag-panel')).toBeNull()
   })
 
+  it('keeps declared artifacts directly under the task plan instead of below the run sections', () => {
+    const parts = [
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'task-1',
+        toolName: 'TaskCreate',
+        state: 'input-available',
+        input: { subject: 'Build the deck' }
+      },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'artifacts-1',
+        toolName: 'report_artifacts',
+        state: 'output-available',
+        input: { artifacts: [{ path: 'docs/index.html' }] }
+      },
+      {
+        type: 'data-agent-task-event',
+        data: {
+          event: 'notification',
+          taskId: 'shell-1',
+          taskType: 'shell',
+          status: 'in_progress',
+          title: 'Screenshot each page'
+        }
+      }
+    ] as unknown as CherryMessagePart[]
+    const messages = [{ id: 'm1', role: 'assistant', parts, metadata: { status: 'pending' } }] as CherryUIMessage[]
+
+    render(
+      <TestAgentRightPane
+        sessionId="session-a"
+        workspacePath="/workspace"
+        messages={messages}
+        partsByMessageId={{ m1: parts }}>
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
+
+    const sectionOrder = [
+      screen.getByText('agent.right_pane.status.tasks'),
+      screen.getByText('agent.right_pane.info.artifacts'),
+      screen.getByTestId('context-usage'),
+      screen.getByText('agent.right_pane.info.shell_tasks')
+    ]
+
+    for (const [index, node] of sectionOrder.slice(0, -1).entries()) {
+      expect(node.compareDocumentPosition(sectionOrder[index + 1]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    }
+    expect(screen.getByText('index.html')).toBeInTheDocument()
+  })
+
+  it('hides the artifacts section when the workspace cannot open files', () => {
+    const parts = [
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'task-1',
+        toolName: 'TaskCreate',
+        state: 'input-available',
+        input: { subject: 'Build the deck' }
+      },
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'artifacts-1',
+        toolName: 'report_artifacts',
+        state: 'output-available',
+        input: { artifacts: [{ path: 'docs/index.html' }] }
+      }
+    ] as unknown as CherryMessagePart[]
+    const messages = [{ id: 'm1', role: 'assistant', parts, metadata: { status: 'pending' } }] as CherryUIMessage[]
+
+    render(
+      <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: parts }}>
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
+
+    expect(screen.getByText('agent.right_pane.status.tasks')).toBeInTheDocument()
+    expect(screen.queryByText('agent.right_pane.info.artifacts')).toBeNull()
+  })
+
   it('restores the stop button and reports an error when the runtime cannot stop the task', async () => {
     ipcRequestMock.mockResolvedValue(false)
     renderStatusTasks([{ id: 'subagent-1', status: 'in_progress', title: 'Inspect task state' }])


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

In an agent session's **Status** panel, the declared-outputs section was rendered last, after Workflows, Sub-agents and Background commands:

```
Tasks
Context usage
Workflows
Sub-agents
Background commands   <- often dozens of rows on a long run
Outputs               <- the file the task actually produced, at the very bottom
```

A run that shells out repeatedly pushes the outputs section far below the fold, so the one section reporting what the task produced is the hardest thing to find in a panel about that task.

After this PR:

```
Tasks
Outputs               <- directly under the task plan
Context usage
Workflows
Sub-agents
Background commands
```

The hover preview behind the Status shortcut keeps outputs adjacent to the task list for the same reason. The English label is also renamed `Deliverables` -> `Outputs` (zh-cn keeps 产物).

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The panel is read top-down as "what was planned -> what came out of it -> how much context it cost -> what is still running". Outputs belong with the plan, not after the run-progress sections whose length is unbounded.

The following tradeoffs were made:

- The context usage summary stays exactly where it was, so outputs are inserted between it and the task plan rather than reordering the whole column. This keeps the diff to the positioning fix.
- The outputs section was extracted into its own component so the Status tab can render it between those two sections, and `AgentRightPaneHighlights` gained an `includeArtifacts` flag mirroring the existing `includeTasks` one. Both call sites keep the `canOpenArtifactFile` gate exactly once.

The following alternatives were considered:

- Reordering only inside `AgentRightPaneHighlights` (moving outputs to the top of that block). Rejected: in the Status tab the task plan is rendered outside that component, so outputs would have landed below the context usage summary instead of under the tasks.
- Moving the context usage summary to the bottom of the Status tab so the whole highlights block could shift up. Rejected as a larger behavior change than the reported problem needs.
- Collapsing `includeTasks` + `includeArtifacts` into one flag, or extracting a Tasks section too. The Status tab renders tasks with a different design (count badge, bordered rows) than the compact highlights list, so the components would not collapse into one; not worth the churn for a positioning fix.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

Reported internally with a screenshot of a long agent run where the outputs section had been pushed off-screen.

### Breaking changes

None.

### Special notes for your reviewer

- Section order is pinned by a new test that asserts DOM order via `compareDocumentPosition` (Tasks -> Outputs -> Context usage -> Background commands), plus a negative test that the outputs section stays hidden when the session has no openable workspace. Both fail if the ordering or the gate regresses.
- i18n: only `locales/en-us.json` changed. The 10 machine-translated locales under `i18n/translate/` still carry the older "deliverable" wording (de `Liefergegenstände`, fr `Livrables`, ja `納品物`, ...), because the daily auto-i18n job only fills keys marked `[to be translated]` — a *changed* base value never repropagates. Left alone to match how other PRs treat `translate/`; happy to reword them or mark them for retranslation if maintainers prefer.
- `agent.right_pane.info.no_artifacts` was reworded for consistency; it currently has no call site. `chat.artifacts.title` still reads "Deliverables" but belongs to the chat HTML-artifact pane and is also unused, so it was deliberately left untouched.
- Docs: no user-guide update needed — this is a section reorder plus a label rename inside an existing panel, with no new feature or flow.
- Verified manually in a dev build against a session declaring an output plus background commands, and via `pnpm test` (22013 passed), `pnpm test:lint` and `pnpm build:check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent Status panel: declared outputs now appear directly under the task list instead of at the bottom below background commands, and the English section label is now "Outputs".
```
