### PR TITLE
fix(quick-assistant): finalize streaming text parts

### DIFF
--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -48,17 +48,21 @@ const EMPTY_UI_MESSAGES: CherryUIMessage[] = []
 type MiniRoute = 'home' | 'chat' | 'translate' | 'summary' | 'explanation'
 
 /**
- * Finalize a list of live assistant messages: turn any still-streaming
- * reasoning part into `state: 'done'`, deriving `thinkingMs` from
- * `startedAt` if the upstream hasn't set it yet. Called when the execution
- * transitions from active to inactive.
+ * Finalize a list of live assistant messages: turn any still-streaming text
+ * or reasoning part into `state: 'done'`, deriving `thinkingMs` for reasoning
+ * from `startedAt` if the upstream hasn't set it yet. Called when the
+ * execution transitions from active to inactive.
  */
-const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] => {
+export const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] => {
   return messages.map((msg) => {
     if (!msg.parts) return msg
     let changed = false
     const newParts = msg.parts.map((part) => {
-      if (part.type !== 'reasoning' || part.state !== 'streaming') return part
+      if ((part.type !== 'text' && part.type !== 'reasoning') || part.state !== 'streaming') return part
+
+      changed = true
+      if (part.type === 'text') return { ...part, state: 'done' as const }
+
       const cherry = readCherryMeta(part)
       const startedAt = cherry?.startedAt
       const thinkingMs = cherry?.thinkingMs
@@ -68,7 +72,6 @@ const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] =>
         patch = { thinkingMs: Math.round(Math.max(0, Date.now() - startedAt)) }
       }
 
-      changed = true
       return withCherryMeta({ ...part, state: 'done' }, patch)
     })
     return changed ? { ...msg, parts: newParts } : msg

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom/vitest'
 
+import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
 import { fireEvent, render, screen } from '@testing-library/react'
 import type React from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({
   quickAssistantId: '',
@@ -24,7 +26,7 @@ const state = vi.hoisted(() => ({
   resetTemporaryTopic: vi.fn()
 }))
 
-import HomeWindow from '../HomeWindow'
+import HomeWindow, { finalizeLiveMessages } from '../HomeWindow'
 
 vi.mock('@renderer/ipc', () => ({
   ipcApi: { request: vi.fn(), on: vi.fn(() => () => {}) },
@@ -140,6 +142,44 @@ vi.mock('../../chat/ChatWindow', () => ({
 vi.mock('../../translate/TranslateWindow', () => ({
   default: () => <div data-testid="translate-window" />
 }))
+
+describe('finalizeLiveMessages', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('finalizes streaming content parts without replacing unchanged messages', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1500)
+    const liveMessage = {
+      id: 'live-message',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'answer', state: 'streaming' },
+        {
+          type: 'reasoning',
+          text: 'thinking',
+          state: 'streaming',
+          providerMetadata: { cherry: { startedAt: 1000 } }
+        }
+      ]
+    } as CherryUIMessage
+    const unchangedMessage = {
+      id: 'done-message',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'done', state: 'done' }]
+    } as CherryUIMessage
+
+    const result = finalizeLiveMessages([liveMessage, unchangedMessage])
+
+    expect(result[0].parts[0]).toMatchObject({ type: 'text', state: 'done' })
+    expect(result[0].parts[1]).toMatchObject({ type: 'reasoning', state: 'done' })
+    expect(readCherryMeta(result[0].parts[1] as CherryMessagePart)).toMatchObject({
+      startedAt: 1000,
+      thinkingMs: 500
+    })
+    expect(result[1]).toBe(unchangedMessage)
+  })
+})
 
 describe('HomeWindow', () => {
   beforeEach(() => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

When a Quick Assistant execution transitioned from active to inactive, `finalizeLiveMessages` only finalized streaming reasoning parts. A completed text part could remain in `state: 'streaming'`, leaving completed history on the streaming Markdown path.

After this PR:

Quick Assistant finalizes both text and reasoning parts that still use the shared `streaming` state. Reasoning duration derivation is preserved, and messages without changed parts keep their original object identity.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18166

### Why we need it and why it was done in this way

The active-execution `> 0` to `0` effect moves live assistant snapshots into `completedAssistants`. Its finalizer previously returned every non-reasoning part unchanged, so a streaming text part could leak into completed history. Narrowing the finalizer to the two AI SDK content part types that share `state?: 'streaming' | 'done'` keeps the fix aligned with the main chat completion contract without touching tool parts, which have a separate state machine.

The following tradeoffs were made:

- The change is intentionally limited to Quick Assistant's terminal snapshot conversion; transport, persistence, and the main chat flow are unchanged.
- The helper is exported from the existing module solely for a focused regression test instead of introducing a new single-use module.

The following alternatives were considered:

- Adding a renderer-side fallback was rejected because it would hide the invalid completed state while leaving downstream consumers inconsistent.
- Treating every tool/data/file part as a content part was rejected because those parts do not use the shared `streaming`/`done` protocol.

Links to places where the discussion took place: [upstream issue #18166](https://github.com/CherryHQ/cherry-studio/issues/18166), [original Feishu record](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrFU2haJqo5), [shareable source record](https://mcnnox2fhjfq.feishu.cn/record/BHeorOAYReZLQJc1yXpc1ZsNnxf)

Original feedback:

- Source: Product & Engineering dev Base, `V2 问题反馈` (`base NM62bC0Epaqy0JsKjZYcQCn7nVd` / `table tblbuPFvvugxC8My`)
- Record ID: `recvrFU2haJqo5`
- Submitted by: 许思寅
- Upstream issue: CherryHQ/cherry-studio#18166 (OPEN)
- User summary: 「快速助手流式回复结束、执行状态转为 inactive 后，finalizeLiveMessages 只把 reasoning Part 置为 done，text Part 仍永久保持 streaming。完成的回复继续走 StreamingMarkdown/parseIncompleteMarkdown 渲染路径，与主聊天窗口的终态处理不一致。」
- Reproduction: Open Quick Assistant and trigger a streaming text response → wait for execution to finish → inspect the message part state → the text part remains `streaming`.

### Breaking changes

None.

### Special notes for your reviewer

- Regression test: the old guard fails because the text part remains `streaming`; the new implementation finalizes text/reasoning parts, preserves reasoning `thinkingMs`, and reuses unchanged message references.
- Manual validation: exercised a real Quick Assistant SSE streaming response in an isolated Electron profile. The terminal text part was `done`, the Markdown block was successful, and no visible before/after rendering difference was observed.
- Validation: `pnpm typecheck:web`; changed-file oxlint with zero warnings; focused Vitest (3/3); full `pnpm lint`, `pnpm test` (22,013 passed, 66 skipped), `pnpm format`, `pnpm build:check`, and `pnpm test:lint`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this internal completion-state fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Quick Assistant completed text responses remaining in a streaming state.
```
