### PR TITLE
fix(app-startup): apply launch-on-boot preference to system

### DIFF
--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -26,6 +26,7 @@ import { KnowledgeService, KnowledgeVectorStoreService } from '@main/features/kn
 import { IpcApiService } from '@main/ipc/IpcApiService'
 import { AnalyticsService } from '@main/services/AnalyticsService'
 import { AppMenuService } from '@main/services/AppMenuService'
+import { AppService } from '@main/services/AppService'
 import { AppUpdaterService } from '@main/services/AppUpdaterService'
 import { AutoBackupService } from '@main/services/AutoBackupService'
 import { BinaryManager } from '@main/services/BinaryManager'
@@ -91,6 +92,7 @@ export const services = {
   TesseractRuntimeService,
   AnalyticsService,
   AppMenuService,
+  AppService,
   CodeCliService,
   CommandService,
   CitationPreviewService,

--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -25,6 +25,7 @@ import { KnowledgeService, KnowledgeVectorStoreService } from '@main/features/kn
 import { IpcApiService } from '@main/ipc/IpcApiService'
 import { AnalyticsService } from '@main/services/AnalyticsService'
 import { AppMenuService } from '@main/services/AppMenuService'
+import { AppService } from '@main/services/AppService'
 import { AppUpdaterService } from '@main/services/AppUpdaterService'
 import { AutoBackupService } from '@main/services/AutoBackupService'
 import { BinaryManager } from '@main/services/BinaryManager'
@@ -86,6 +87,7 @@ export const services = {
   TesseractRuntimeService,
   AnalyticsService,
   AppMenuService,
+  AppService,
   CodeCliService,
   CommandService,
   CitationPreviewService,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,7 +11,6 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { BrowserWindow, dialog, ipcMain } from 'electron'
 
 import { skillService } from './ai/skills/SkillService'
-import { appService } from './services/AppService'
 import { copilotService } from './services/CopilotService'
 import { externalAppsService } from './services/ExternalAppsService'
 import { fileStorage as fileManager } from './services/FileStorage'
@@ -49,11 +48,6 @@ export async function registerIpc() {
       window.webContents.session.setSpellCheckerLanguages(languages)
     })
     void application.get('PreferenceService').set('app.spell_check.languages', languages)
-  })
-
-  // launch on boot
-  ipcMain.handle(IpcChannel.App_SetLaunchOnBoot, async (_, isLaunchOnBoot: boolean) => {
-    await appService.setAppLaunchOnBoot(isLaunchOnBoot)
   })
 
   // // theme

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -12,7 +12,6 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { BrowserWindow, dialog } from 'electron'
 
 import { skillService } from './ai/skills/SkillService'
-import { appService } from './services/AppService'
 import { copilotService } from './services/CopilotService'
 import { externalAppsService } from './services/ExternalAppsService'
 import { fileStorage as fileManager } from './services/FileStorage'
@@ -50,11 +49,6 @@ export async function registerIpc() {
       window.webContents.session.setSpellCheckerLanguages(languages)
     })
     void application.get('PreferenceService').set('app.spell_check.languages', languages)
-  })
-
-  // launch on boot
-  handleGuarded(IpcChannel.App_SetLaunchOnBoot, async (_, isLaunchOnBoot: boolean) => {
-    await appService.setAppLaunchOnBoot(isLaunchOnBoot)
   })
 
   // // theme

--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -1,5 +1,6 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isDev, isLinux, isMac, isWin } from '@main/core/platform'
 import { app } from 'electron'
 import fs from 'fs'
@@ -7,7 +8,19 @@ import path from 'path'
 
 const logger = loggerService.withContext('AppService')
 
-export class AppService {
+@Injectable('AppService')
+@ServicePhase(Phase.WhenReady)
+export class AppService extends BaseService {
+  protected async onInit(): Promise<void> {
+    const preferenceService = application.get('PreferenceService')
+    this.registerDisposable(
+      preferenceService.subscribeChange('app.launch_on_boot', (isLaunchOnBoot) => {
+        void this.setAppLaunchOnBoot(isLaunchOnBoot)
+      })
+    )
+    await this.setAppLaunchOnBoot(preferenceService.get('app.launch_on_boot'))
+  }
+
   public async setAppLaunchOnBoot(isLaunchOnBoot: boolean): Promise<void> {
     // Set login item settings for windows and mac
     // linux is not supported because it requires more file operations
@@ -65,5 +78,3 @@ export class AppService {
     }
   }
 }
-
-export const appService = new AppService()

--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -1,5 +1,6 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { createLatestReconciler, type LatestReconciler } from '@main/core/concurrency/latestReconciler'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isDev, isLinux, isMac, isWin } from '@main/core/platform'
 import { app } from 'electron'
@@ -11,14 +12,43 @@ const logger = loggerService.withContext('AppService')
 @Injectable('AppService')
 @ServicePhase(Phase.WhenReady)
 export class AppService extends BaseService {
+  private acceptingPreferenceChanges = false
+  private desiredLaunchOnBoot = false
+  private appliedLaunchOnBoot: boolean | undefined
+  private readonly launchOnBootReconciler: LatestReconciler = createLatestReconciler<{
+    desired: boolean
+    applied: boolean | undefined
+  }>({
+    name: 'appLaunchOnBoot',
+    getSnapshot: () => ({ desired: this.desiredLaunchOnBoot, applied: this.appliedLaunchOnBoot }),
+    isSettled: ({ desired, applied }) => desired === applied,
+    apply: async ({ desired }) => {
+      await this.setAppLaunchOnBoot(desired)
+      this.appliedLaunchOnBoot = desired
+    },
+    onError: (error) => logger.error('Failed to reconcile launch on boot:', error as Error)
+  })
+
   protected async onInit(): Promise<void> {
+    // Force a fresh OS sync after a stop→restart in case the setting changed while stopped.
+    this.acceptingPreferenceChanges = true
+    this.appliedLaunchOnBoot = undefined
     const preferenceService = application.get('PreferenceService')
     this.registerDisposable(
       preferenceService.subscribeChange('app.launch_on_boot', (isLaunchOnBoot) => {
-        void this.setAppLaunchOnBoot(isLaunchOnBoot)
+        if (!this.acceptingPreferenceChanges) return
+        this.desiredLaunchOnBoot = isLaunchOnBoot
+        this.launchOnBootReconciler.request()
       })
     )
-    await this.setAppLaunchOnBoot(preferenceService.get('app.launch_on_boot'))
+    this.desiredLaunchOnBoot = preferenceService.get('app.launch_on_boot')
+    this.launchOnBootReconciler.request()
+    await this.launchOnBootReconciler.flush()
+  }
+
+  protected async onStop(): Promise<void> {
+    this.acceptingPreferenceChanges = false
+    await this.launchOnBootReconciler.flush()
   }
 
   public async setAppLaunchOnBoot(isLaunchOnBoot: boolean): Promise<void> {
@@ -27,27 +57,27 @@ export class AppService extends BaseService {
     if (isWin || isMac) {
       app.setLoginItemSettings({ openAtLogin: isLaunchOnBoot })
     } else if (isLinux) {
-      try {
-        const autostartDir = application.getPath('sys.appdata.autostart')
-        const desktopFile = path.join(autostartDir, isDev ? 'cherry-studio-dev.desktop' : 'cherry-studio.desktop')
+      const autostartDir = application.getPath('sys.appdata.autostart')
+      const desktopFile = path.join(autostartDir, isDev ? 'cherry-studio-dev.desktop' : 'cherry-studio.desktop')
 
-        if (isLaunchOnBoot) {
-          // Ensure autostart directory exists
-          try {
-            await fs.promises.access(autostartDir)
-          } catch {
-            await fs.promises.mkdir(autostartDir, { recursive: true })
-          }
+      if (isLaunchOnBoot) {
+        // Ensure autostart directory exists
+        try {
+          await fs.promises.access(autostartDir)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+          await fs.promises.mkdir(autostartDir, { recursive: true })
+        }
 
-          // Get executable path
-          let executablePath = application.getPath('app.exe_file')
-          if (process.env.APPIMAGE) {
-            // For AppImage packaged apps, use APPIMAGE environment variable
-            executablePath = process.env.APPIMAGE
-          }
+        // Get executable path
+        let executablePath = application.getPath('app.exe_file')
+        if (process.env.APPIMAGE) {
+          // For AppImage packaged apps, use APPIMAGE environment variable
+          executablePath = process.env.APPIMAGE
+        }
 
-          // Create desktop file content
-          const desktopContent = `[Desktop Entry]
+        // Create desktop file content
+        const desktopContent = `[Desktop Entry]
   Type=Application
   Name=Cherry Studio
   Comment=A powerful AI assistant for producer.
@@ -59,21 +89,19 @@ export class AppService extends BaseService {
   X-GNOME-Autostart-enabled=true
   Hidden=false`
 
-          // Write desktop file
-          await fs.promises.writeFile(desktopFile, desktopContent)
-          logger.info('Created autostart desktop file for Linux')
-        } else {
-          // Remove desktop file
-          try {
-            await fs.promises.access(desktopFile)
-            await fs.promises.unlink(desktopFile)
-            logger.info('Removed autostart desktop file for Linux')
-          } catch {
-            // File doesn't exist, no need to remove
-          }
+        // Write desktop file
+        await fs.promises.writeFile(desktopFile, desktopContent)
+        logger.info('Created autostart desktop file for Linux')
+      } else {
+        // Remove desktop file
+        try {
+          await fs.promises.access(desktopFile)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+          throw error
         }
-      } catch (error) {
-        logger.error('Failed to set launch on boot for Linux:', error as Error)
+        await fs.promises.unlink(desktopFile)
+        logger.info('Removed autostart desktop file for Linux')
       }
     }
   }

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,8 +1,14 @@
-import type * as LifecycleModule from '@main/core/lifecycle'
+import { BaseService } from '@main/core/lifecycle'
+import path from 'path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { setLoginItemSettingsMock } = vi.hoisted(() => ({
-  setLoginItemSettingsMock: vi.fn()
+const { setLoginItemSettingsMock, platform, accessMock, mkdirMock, writeFileMock, unlinkMock } = vi.hoisted(() => ({
+  setLoginItemSettingsMock: vi.fn(),
+  platform: { isDev: false, isLinux: false, isMac: false, isWin: true },
+  accessMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  writeFileMock: vi.fn(),
+  unlinkMock: vi.fn()
 }))
 
 vi.mock('@application', async () => {
@@ -10,24 +16,17 @@ vi.mock('@application', async () => {
   return mockApplicationFactory()
 })
 
-vi.mock('@main/core/lifecycle', async (importOriginal) => {
-  const actual = await importOriginal<typeof LifecycleModule>()
-  class MockBaseService {
-    protected readonly _disposables: Array<{ dispose: () => void } | (() => void)> = []
+vi.mock('@main/core/platform', () => platform)
 
-    protected registerDisposable<T extends { dispose: () => void } | (() => void)>(disposable: T): T {
-      this._disposables.push(disposable)
-      return disposable
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      access: accessMock,
+      mkdir: mkdirMock,
+      writeFile: writeFileMock,
+      unlink: unlinkMock
     }
   }
-  return { ...actual, BaseService: MockBaseService }
-})
-
-vi.mock('@main/core/platform', () => ({
-  isDev: false,
-  isLinux: false,
-  isMac: false,
-  isWin: true
 }))
 
 vi.mock('electron', () => ({
@@ -38,35 +37,134 @@ import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceServi
 
 const { AppService } = await import('../AppService')
 
-type AppServiceInternals = {
-  onInit: () => Promise<void> | void
+const autostartDir = '/mock/sys.appdata.autostart'
+const desktopFile = path.join(autostartDir, 'cherry-studio.desktop')
+const linuxFiles = new Set<string>()
+let autostartDirExists = false
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
 }
 
 describe('AppService', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    BaseService.resetInstances()
+    platform.isDev = false
+    platform.isLinux = false
+    platform.isMac = false
+    platform.isWin = true
+    autostartDirExists = false
+    linuxFiles.clear()
+    setLoginItemSettingsMock.mockReset()
+    accessMock.mockReset()
+    mkdirMock.mockReset()
+    writeFileMock.mockReset()
+    unlinkMock.mockReset()
+    accessMock.mockImplementation(async (target: string) => {
+      if ((target === autostartDir && autostartDirExists) || (target === desktopFile && linuxFiles.has(target))) return
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    mkdirMock.mockImplementation(async () => {
+      autostartDirExists = true
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      linuxFiles.add(target)
+    })
+    unlinkMock.mockImplementation(async (target: string) => {
+      linuxFiles.delete(target)
+    })
     MockMainPreferenceServiceUtils.resetMocks()
   })
 
   it('reconciles the persisted launch-on-boot preference during startup', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
-    const service = new AppService() as unknown as AppServiceInternals
+    const service = new AppService()
 
-    await service.onInit()
+    await service._doInit()
 
     expect(setLoginItemSettingsMock).toHaveBeenCalledOnce()
     expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
   })
 
   it('applies launch-on-boot preference changes to the system', async () => {
-    const service = new AppService() as unknown as AppServiceInternals
-    await service.onInit()
+    const service = new AppService()
+    await service._doInit()
     setLoginItemSettingsMock.mockClear()
 
     MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
-    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    await vi.waitFor(() => expect(setLoginItemSettingsMock).toHaveBeenCalledOnce())
 
-    expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(1, { openAtLogin: true })
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    await vi.waitFor(() => expect(setLoginItemSettingsMock).toHaveBeenCalledTimes(2))
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
     expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(2, { openAtLogin: false })
+  })
+
+  it('serializes Linux updates and converges to the latest preference', async () => {
+    platform.isLinux = true
+    platform.isWin = false
+    const service = new AppService()
+    await service._doInit()
+
+    const writeGate = deferred()
+    let writeStarted!: () => void
+    const writeStartedPromise = new Promise<void>((resolve) => {
+      writeStarted = resolve
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      writeStarted()
+      await writeGate.promise
+      linuxFiles.add(target)
+    })
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    await writeStartedPromise
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    writeGate.resolve()
+
+    await vi.waitFor(() => expect(unlinkMock).toHaveBeenCalledOnce())
+    expect(linuxFiles.has(desktopFile)).toBe(false)
+  })
+
+  it('waits for in-flight Linux updates before stopping and resubscribes on restart', async () => {
+    platform.isLinux = true
+    platform.isWin = false
+    const service = new AppService()
+    await service._doInit()
+
+    const writeGate = deferred()
+    let writeStarted!: () => void
+    const writeStartedPromise = new Promise<void>((resolve) => {
+      writeStarted = resolve
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      writeStarted()
+      await writeGate.promise
+      linuxFiles.add(target)
+    })
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    await writeStartedPromise
+    let stopped = false
+    const stopPromise = service._doStop().then(() => {
+      stopped = true
+    })
+    await Promise.resolve()
+    expect(stopped).toBe(false)
+
+    writeGate.resolve()
+    await stopPromise
+    expect(linuxFiles.has(desktopFile)).toBe(true)
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    expect(unlinkMock).not.toHaveBeenCalled()
+
+    await service._doInit()
+    await vi.waitFor(() => expect(unlinkMock).toHaveBeenCalledOnce())
+    expect(linuxFiles.has(desktopFile)).toBe(false)
   })
 })

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,0 +1,72 @@
+import type * as LifecycleModule from '@main/core/lifecycle'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { setLoginItemSettingsMock } = vi.hoisted(() => ({
+  setLoginItemSettingsMock: vi.fn()
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
+
+vi.mock('@main/core/lifecycle', async (importOriginal) => {
+  const actual = await importOriginal<typeof LifecycleModule>()
+  class MockBaseService {
+    protected readonly _disposables: Array<{ dispose: () => void } | (() => void)> = []
+
+    protected registerDisposable<T extends { dispose: () => void } | (() => void)>(disposable: T): T {
+      this._disposables.push(disposable)
+      return disposable
+    }
+  }
+  return { ...actual, BaseService: MockBaseService }
+})
+
+vi.mock('@main/core/platform', () => ({
+  isDev: false,
+  isLinux: false,
+  isMac: false,
+  isWin: true
+}))
+
+vi.mock('electron', () => ({
+  app: { setLoginItemSettings: setLoginItemSettingsMock }
+}))
+
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
+
+const { AppService } = await import('../AppService')
+
+type AppServiceInternals = {
+  onInit: () => Promise<void> | void
+}
+
+describe('AppService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    MockMainPreferenceServiceUtils.resetMocks()
+  })
+
+  it('reconciles the persisted launch-on-boot preference during startup', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    const service = new AppService() as unknown as AppServiceInternals
+
+    await service.onInit()
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledOnce()
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
+  })
+
+  it('applies launch-on-boot preference changes to the system', async () => {
+    const service = new AppService() as unknown as AppServiceInternals
+    await service.onInit()
+    setLoginItemSettingsMock.mockClear()
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+
+    expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(1, { openAtLogin: true })
+    expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(2, { openAtLogin: false })
+  })
+})

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -47,7 +47,6 @@ type ShortcutRegistrationConflictPayload = {
 // Custom APIs for renderer
 const api = {
   setSpellCheckLanguages: (languages: string[]) => ipcRenderer.invoke(IpcChannel.App_SetSpellCheckLanguages, languages),
-  setLaunchOnBoot: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetLaunchOnBoot, isActive),
   select: (options: Electron.OpenDialogOptions) => ipcRenderer.invoke(IpcChannel.App_Select, options),
   hasWritePermission: (path: string) => ipcRenderer.invoke(IpcChannel.App_HasWritePermission, path),
   resolvePath: (path: string) => ipcRenderer.invoke(IpcChannel.App_ResolvePath, path),

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -59,7 +59,6 @@ type ShortcutRegistrationConflictPayload = {
 // Custom APIs for renderer
 const api = {
   setSpellCheckLanguages: (languages: string[]) => ipcRenderer.invoke(IpcChannel.App_SetSpellCheckLanguages, languages),
-  setLaunchOnBoot: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetLaunchOnBoot, isActive),
   select: (options: Electron.OpenDialogOptions) => ipcRenderer.invoke(IpcChannel.App_Select, options),
   hasWritePermission: (path: string) => ipcRenderer.invoke(IpcChannel.App_HasWritePermission, path),
   resolvePath: (path: string) => ipcRenderer.invoke(IpcChannel.App_ResolvePath, path),

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -5,7 +5,6 @@
  * LAN transfer, and a handful of micro-domains.
  */
 export enum IpcChannel {
-  App_SetLaunchOnBoot = 'app:set-launch-on-boot',
   App_SetSpellCheckLanguages = 'app:set-spell-check-languages',
   App_Select = 'app:select',
   App_HasWritePermission = 'app:has-write-permission',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

The v2 Launch on Startup switch only persisted `app.launch_on_boot`. It never applied the preference to the operating system, so Cherry Studio was absent from Windows startup apps and macOS login items. Migrated preferences were also never reconciled.

After this PR:

`AppService` reconciles the persisted preference when the main-process lifecycle reaches `WhenReady` and subscribes to subsequent preference changes. The existing Windows/macOS and Linux system integrations remain responsible for applying the value. The unused v1 preload wrapper, legacy IPC handler, and channel enum are removed.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19061

### Why we need it and why it was done in this way

Preference is the v2 source of truth and already synchronizes renderer writes to the main process. Keeping the system side effect in a lifecycle service makes both live changes and startup/migration reconciliation use the same path.

Source feedback:

- Source table: 产研 dev table “V2 问题反馈”, base `NM62bC0Epaqy0JsKjZYcQCn7nVd`, table `tblbuPFvvugxC8My`
- `record_id`: `recvrHiNT6GIkh`
- Feishu link: https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrHiNT6GIkh
- Submitted by: 许思寅（集中反馈底层表 `rec27WDKB0ydQw`, 2026-08-08）
- Original feedback summary: 「在两台 Windows 电脑上启用 Cherry Studio 开机自动启动后，下一次开机应用均未自动启动，Windows 启动项管理中也没有 Cherry Studio 条目。」
- Environment: two Windows computers, Cherry Studio v2.0.2
- Reproduction: enable Launch on Startup in Settings → restart Windows → Cherry Studio does not launch → no Cherry Studio entry appears in system startup management.

The following tradeoffs were made:

- The renderer remains preference-only; the main process owns the operating-system side effect.
- Initial reconciliation intentionally reapplies the preference so migrated users and users whose system startup entry was removed are repaired.
- The existing Linux autostart implementation is unchanged.

The following alternatives were considered:

- Calling the legacy preload IPC method from the switch would fix only live toggles, not migrated preferences or missing system entries at startup. That zero-call v1 path was removed instead.

Links to places where the discussion took place: https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrHiNT6GIkh

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A.

### Special notes for your reviewer

- No visual/UI changes; the existing switch appearance and interaction are unchanged.
- Added a regression test covering startup reconciliation and runtime `true`/`false` preference changes. The test failed before the production change and passes after it.
- Verification passed: `pnpm typecheck:web`, `pnpm typecheck:node`, changed-file oxlint, `pnpm lint`, `pnpm test`, `pnpm format`, `pnpm build:check`, and `pnpm test:lint`.
- After rebasing onto the latest `upstream/main`, the focused test, `typecheck:node`, changed-file oxlint, and `git diff --check` passed again under Node v24.11.1.
- macOS manual verification: check System Settings → General → Login Items, or inspect `app.getLoginItemSettings()`.
- Windows manual verification: inspect the user Run registry entry / Startup Apps after changing the setting.
- A user-guide update is not required because the existing setting and documented user workflow are unchanged; this restores the intended behavior.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Launch on Startup so Cherry Studio now registers with the operating system and reapplies the saved preference during app startup.
```
