### PR TITLE
refactor(file-utils): split path spec from filename convention, add RelativeFilePath brands

### DIFF
--- a/src/shared/types/file/common.ts
+++ b/src/shared/types/file/common.ts
@@ -85,6 +85,27 @@ export type AbsoluteFilePath = z.infer<typeof AbsoluteFilePathSchema>
  * counterpart at all. See that module's JSDoc for the full contract.
  */
 
+/**
+ * The relative counterpart lives in `@shared/utils/file/relativeFilePath`:
+ * `PosixRelativeFilePath` / `WindowsRelativeFilePath`, with `RelativeFilePath`
+ * as their union. Not re-exported here.
+ *
+ * It is shape-only in the same sense as `AbsoluteFilePath` — assert-only parse,
+ * no normalization — but proves strictly less, because a relative path is not
+ * self-sufficient: `docs/notes.md` means nothing without its base, so the brand
+ * certifies shape and never correspondence to a particular base.
+ *
+ * Note the asymmetry in how the two handle platforms. The absolute schema above
+ * hand-rolls a union of POSIX / drive / UNC shapes inline; the relative side
+ * factors that question out into `@shared/utils/file/pathSpec`
+ * (`isPosixPath` / `isWindowsPath`) and composes it, so a consumer can ask
+ * "legal on Windows?" — the question a cross-platform migration needs. This
+ * schema should eventually be rebuilt on the same layer, which is why the
+ * inline union is left alone rather than half-migrated: its output feeds
+ * `canonicalizeFilePath` and the persisted `file_entry.externalPath`, so
+ * changing it requires a paired migration.
+ */
+
 // TODO: Add schema for them
 export type Base64String = `data:${string};base64,${string}`
 export type UrlString = `http://${string}` | `https://${string}`

--- a/src/shared/utils/file/__tests__/pathSpec.test.ts
+++ b/src/shared/utils/file/__tests__/pathSpec.test.ts
@@ -1,0 +1,121 @@
+import { isPosixPath, isWindowsPath, parsePosixPath, parseWindowsPath } from '@shared/utils/file/pathSpec'
+import { describe, expect, it } from 'vitest'
+
+describe('parsePosixPath', () => {
+  it.each([
+    ['a/b', { isAbsolute: false, root: '', segments: ['a', 'b'] }],
+    ['a//b', { isAbsolute: false, root: '', segments: ['a', 'b'] }],
+    ['docs/', { isAbsolute: false, root: '', segments: ['docs'] }],
+    ['./a/../b', { isAbsolute: false, root: '', segments: ['.', 'a', '..', 'b'] }],
+    ['/a/b', { isAbsolute: true, root: '/', segments: ['a', 'b'] }],
+    ['/', { isAbsolute: true, root: '/', segments: [] }],
+    ['', { isAbsolute: false, root: '', segments: [] }]
+  ])('parses %s', (value, expected) => {
+    expect(parsePosixPath(value)).toEqual(expected)
+  })
+
+  it('treats backslash and colon as ordinary filename characters', () => {
+    expect(parsePosixPath('a/b/c\\d.txt').segments).toEqual(['a', 'b', 'c\\d.txt'])
+    expect(parsePosixPath('C:\\a').segments).toEqual(['C:\\a'])
+    expect(parsePosixPath('C:\\a').isAbsolute).toBe(false)
+  })
+})
+
+describe('parseWindowsPath', () => {
+  it.each([
+    ['a\\b', { isAbsolute: false, root: '', segments: ['a', 'b'] }],
+    ['a/b', { isAbsolute: false, root: '', segments: ['a', 'b'] }],
+    ['a\\b/c', { isAbsolute: false, root: '', segments: ['a', 'b', 'c'] }],
+    ['C:\\a\\b', { isAbsolute: true, root: 'C:\\', segments: ['a', 'b'] }],
+    ['C:/a', { isAbsolute: true, root: 'C:/', segments: ['a'] }],
+    ['\\a', { isAbsolute: true, root: '\\', segments: ['a'] }],
+    ['/a', { isAbsolute: true, root: '/', segments: ['a'] }],
+    ['\\\\server\\share\\a', { isAbsolute: true, root: '\\\\server\\share', segments: ['a'] }]
+  ])('parses %s', (value, expected) => {
+    expect(parseWindowsPath(value)).toEqual(expected)
+  })
+
+  it('reports a drive-relative path as non-absolute but rooted', () => {
+    // `C:foo` means "foo, relative to the working directory on drive C" — not a
+    // portable relative path, and `C:` must not be mistaken for a segment.
+    expect(parseWindowsPath('C:foo')).toEqual({ isAbsolute: false, root: 'C:', segments: ['foo'] })
+  })
+
+  it('reads any single letter before a colon as a drive, because Windows does', () => {
+    // `a:b.txt` is drive A's `b.txt`, not a file named `a:b.txt` — so a colon
+    // only looks like an illegal filename character when it is NOT in drive
+    // position.
+    expect(parseWindowsPath('a:b.txt')).toEqual({ isAbsolute: false, root: 'a:', segments: ['b.txt'] })
+    expect(parseWindowsPath('ab:c.txt')).toEqual({ isAbsolute: false, root: '', segments: ['ab:c.txt'] })
+  })
+})
+
+describe('the same string, two platforms', () => {
+  it('splits a backslash-containing name differently', () => {
+    expect(parsePosixPath('a/b/c\\d.txt').segments).toEqual(['a', 'b', 'c\\d.txt'])
+    expect(parseWindowsPath('a/b/c\\d.txt').segments).toEqual(['a', 'b', 'c', 'd.txt'])
+  })
+})
+
+describe('isPosixPath', () => {
+  it.each([['a/b.txt'], ['a\\b.txt'], ['a:b.txt'], ['a<b'], ['CON.txt'], ['name.'], ['name '], ['./a/../b'], ['/abs']])(
+    'accepts %s — POSIX forbids only / and NUL in a name',
+    (value) => {
+      expect(isPosixPath(value)).toBe(true)
+    }
+  )
+
+  it('rejects a null byte', () => {
+    expect(isPosixPath('a/b\0c')).toBe(false)
+  })
+
+  it('accepts an over-long segment — length is a capacity limit, not a syntax rule', () => {
+    // Enforcing it here would make a value already stored in SQLite stop parsing on
+    // read; too long fails at write time like a full disk does.
+    expect(isPosixPath(`a/${'x'.repeat(256)}`)).toBe(true)
+    expect(isWindowsPath(`a\\${'x'.repeat(256)}`)).toBe(true)
+  })
+})
+
+describe('isWindowsPath', () => {
+  it.each([['a\\b.txt'], ['a/b.txt'], ['C:\\a'], ['\\\\server\\share\\a'], ['./a/../b']])('accepts %s', (value) => {
+    expect(isWindowsPath(value)).toBe(true)
+  })
+
+  it.each([
+    ['a colon in a segment', 'ab:c.txt'],
+    ['an angle bracket', 'a<b'],
+    ['a reserved device name', 'CON.txt'],
+    ['a reserved device name in a subdirectory', 'docs/COM1'],
+    ['a trailing dot', 'name.'],
+    ['a trailing space', 'name '],
+    ['a null byte', 'a\0b'],
+    ['a start-of-heading control char', 'ab'],
+    ['a tab', 'a\tb'],
+    ['a unit separator, the top of the control range', 'ab']
+  ])('rejects %s', (_label, value) => {
+    expect(isWindowsPath(value)).toBe(false)
+  })
+
+  it('rejects the whole ASCII control range, which POSIX allows', () => {
+    // Win32 forbids U+0001–U+001F in a filename on top of NUL; POSIX forbids
+    // only `/` and NUL, so the two predicates must disagree here.
+    for (let code = 1; code <= 0x1f; code++) {
+      const name = `a${String.fromCharCode(code)}b.txt`
+      expect(isWindowsPath(name), `U+${code.toString(16).padStart(4, '0')}`).toBe(false)
+      expect(isPosixPath(name), `U+${code.toString(16).padStart(4, '0')}`).toBe(true)
+    }
+  })
+
+  it('does not mistake a drive root or UNC root for an illegal segment', () => {
+    // `C:` and `\\server\share` are roots, not names — name rules must not apply.
+    expect(isWindowsPath('C:\\docs\\a.txt')).toBe(true)
+    expect(isWindowsPath('\\\\server\\share\\a.txt')).toBe(true)
+  })
+
+  it('does not name-check . or ..', () => {
+    // `.` would fail the trailing-dot rule if treated as a filename.
+    expect(isWindowsPath('a\\..\\b')).toBe(true)
+    expect(isWindowsPath('.\\a')).toBe(true)
+  })
+})

--- a/src/shared/utils/file/__tests__/relativeFilePath.test.ts
+++ b/src/shared/utils/file/__tests__/relativeFilePath.test.ts
@@ -1,0 +1,233 @@
+import type { PosixPath, WindowsPath } from '@shared/utils/file/pathSpec'
+import {
+  type PosixRelativeFilePath,
+  PosixRelativeFilePathSchema,
+  type RelativeFilePath,
+  resolvePosixRelativeSegments,
+  resolveWindowsRelativeSegments,
+  type WindowsRelativeFilePath,
+  WindowsRelativeFilePathSchema
+} from '@shared/utils/file/relativeFilePath'
+import { describe, expect, it } from 'vitest'
+
+const accepts = (schema: { safeParse: (v: string) => { success: boolean } }, value: string) =>
+  schema.safeParse(value).success
+
+describe('PosixRelativeFilePathSchema — structure', () => {
+  it.each([
+    ['single segment', 'a.pdf'],
+    ['multi segment', 'docs/a.pdf'],
+    ['the base itself', '.'],
+    ['a climb landing back on the base', 'a/..'],
+    ['an interior climb', 'a/../b'],
+    ['an explicit here-prefix', './a'],
+    ['repeated separators', 'a//b'],
+    ['a trailing separator', 'docs/'],
+    ['non-ASCII segments', '中文/文件.pdf'],
+    ['a leading space, which is a legal filename character', ' a.pdf'],
+    ['a backslash, legal in a POSIX filename', 'a\\b.txt'],
+    ['a name that is only legal on POSIX', 'a<b'],
+    // Containment is not this brand's business — see the block below.
+    ['a climb above the base', '../x'],
+    ['a bare climb', '..'],
+    ['a climb that escapes after descending', 'a/../../b'],
+    ['a leading backslash, one POSIX filename', '\\foo'],
+    ['a drive-looking prefix, one POSIX filename', 'C:foo']
+  ])('accepts %s', (_label, value) => {
+    expect(accepts(PosixRelativeFilePathSchema, value)).toBe(true)
+  })
+
+  it.each([
+    ['the empty string', ''],
+    ['a POSIX absolute path', '/x'],
+    ['the POSIX root', '/']
+  ])('rejects %s', (_label, value) => {
+    expect(accepts(PosixRelativeFilePathSchema, value)).toBe(false)
+  })
+
+  it('does not judge containment — `../x` is a relative path that points outside', () => {
+    // The brands answer "is this anchored to a root", nothing more. Whether a
+    // climb-out is allowed belongs to whoever owns the base; `resolve*Segments`
+    // returns null so that owner has something to check.
+    expect(accepts(PosixRelativeFilePathSchema, '../x')).toBe(true)
+    expect(resolvePosixRelativeSegments('../x')).toBeNull()
+  })
+
+  it('accepts a control character, which is a legal POSIX filename byte', () => {
+    // The Windows leaf refuses these; POSIX forbids only `/` and NUL.
+    expect(accepts(PosixRelativeFilePathSchema, 'a\u0001b.txt')).toBe(true)
+    expect(accepts(WindowsRelativeFilePathSchema, 'a\u0001b.txt')).toBe(false)
+  })
+
+  it('rejects a NUL byte, which no filesystem could hold', () => {
+    // The reason there is no standalone "structurally relative" brand: `a\0b` is
+    // non-empty and unanchored, yet cannot exist on any filesystem. Segment
+    // legality only exists per platform, so only a leaf can rule it out.
+    expect(accepts(PosixRelativeFilePathSchema, 'a\0b')).toBe(false)
+  })
+
+  it('accepts an over-long segment, which is a capacity limit rather than a syntax error', () => {
+    expect(accepts(PosixRelativeFilePathSchema, 'x'.repeat(300))).toBe(true)
+  })
+
+  it('returns the input unchanged — no trimming, no normalization', () => {
+    expect(PosixRelativeFilePathSchema.parse(' a.pdf')).toBe(' a.pdf')
+    expect(PosixRelativeFilePathSchema.parse('a//b')).toBe('a//b')
+    expect(PosixRelativeFilePathSchema.parse('a/../b')).toBe('a/../b')
+    expect(PosixRelativeFilePathSchema.parse('docs\\a.pdf')).toBe('docs\\a.pdf')
+  })
+})
+
+describe('PosixRelativeFilePathSchema — segment legality', () => {
+  it.each([
+    ['a backslash as one filename', 'a\\b.txt'],
+    ['a colon, legal on macOS and Linux alike', 'a:b.txt'],
+    ['a Windows-illegal character', 'a<b'],
+    ['a Windows reserved device name', 'CON.txt'],
+    ['a trailing dot', 'name.'],
+    ['a nested path', 'docs/sub/a.pdf']
+  ])('accepts %s', (_label, value) => {
+    expect(accepts(PosixRelativeFilePathSchema, value)).toBe(true)
+  })
+
+  it.each([
+    ['an absolute path', '/x'],
+    ['the empty string', ''],
+    ['a null byte', 'a\0b']
+  ])('rejects %s', (_label, value) => {
+    expect(accepts(PosixRelativeFilePathSchema, value)).toBe(false)
+  })
+
+  it('accepts a climb-out, which is a relative path like any other', () => {
+    expect(accepts(PosixRelativeFilePathSchema, '../x')).toBe(true)
+  })
+})
+
+describe('WindowsRelativeFilePathSchema', () => {
+  it.each([
+    ['a backslash-separated path', 'a\\b.txt'],
+    ['a forward-slash path', 'docs/a.pdf'],
+    ['an interior climb', 'a\\..\\b'],
+    ['a climb out, which containment — not this brand — would refuse', '..\\x']
+  ])('accepts %s', (_label, value) => {
+    expect(accepts(WindowsRelativeFilePathSchema, value)).toBe(true)
+  })
+
+  it.each([
+    ['a leading separator, absolute on the current drive', '\\foo'],
+    ['a drive-relative path', 'C:foo'],
+    ['a drive-absolute path', 'C:\\foo'],
+    ['a single letter before a colon, which Windows reads as a drive', 'a:b.txt'],
+    ['a colon inside a segment', 'ab:c.txt'],
+    ['a Windows-illegal character', 'a<b'],
+    ['a reserved device name', 'CON.txt'],
+    ['a trailing dot', 'name.'],
+    ['a trailing space', 'name ']
+  ])('rejects %s', (_label, value) => {
+    expect(accepts(WindowsRelativeFilePathSchema, value)).toBe(false)
+  })
+})
+
+describe('where the two sub-brands disagree', () => {
+  // Each of these is the reason the union brand alone is not a useful guarantee.
+  it.each([
+    ['\\foo', 'one POSIX filename; current-drive-absolute on Windows'],
+    ['C:foo', 'one POSIX filename; drive-relative, so anchored, on Windows'],
+    ['a<b', 'a POSIX filename; an illegal character on Windows'],
+    ['CON.txt', 'a POSIX filename; a reserved device name on Windows'],
+    ['name.', 'a POSIX filename; a trailing dot on Windows'],
+    ['ab:c.txt', 'a POSIX filename; an illegal character on Windows']
+  ])('%s is POSIX-only — %s', (value) => {
+    expect(accepts(PosixRelativeFilePathSchema, value)).toBe(true)
+    expect(accepts(WindowsRelativeFilePathSchema, value)).toBe(false)
+  })
+
+  it('nests as value sets but not as types — the brand records the reading', () => {
+    // Every Windows-relative string is also POSIX-relative: POSIX only refuses the
+    // empty string, a leading `/`, and NUL, all of which Windows refuses too. The
+    // brands stay distinct because they mean different readings of the same string.
+    const both = 'a\\b.txt'
+    expect(accepts(WindowsRelativeFilePathSchema, both)).toBe(true)
+    expect(accepts(PosixRelativeFilePathSchema, both)).toBe(true)
+    expect(resolveWindowsRelativeSegments(both)).toEqual(['a', 'b.txt'])
+    expect(resolvePosixRelativeSegments(both)).toEqual(['a\\b.txt'])
+  })
+
+  it('nests as value sets but not as types — the brand records the reading', () => {
+    // Every Windows-relative string is also POSIX-relative: POSIX only refuses the
+    // empty string, a leading `/`, and NUL, all of which Windows refuses too. The
+    // brands stay distinct because they mean different readings of the same string.
+    const both = 'a\\b.txt'
+    expect(accepts(WindowsRelativeFilePathSchema, both)).toBe(true)
+    expect(accepts(PosixRelativeFilePathSchema, both)).toBe(true)
+    expect(resolveWindowsRelativeSegments(both)).toEqual(['a', 'b.txt'])
+    expect(resolvePosixRelativeSegments(both)).toEqual(['a\\b.txt'])
+  })
+
+  it('splits a backslash name into two segments only on Windows', () => {
+    expect(resolvePosixRelativeSegments('a/b/c\\d.txt')).toEqual(['a', 'b', 'c\\d.txt'])
+    expect(resolveWindowsRelativeSegments('a/b/c\\d.txt')).toEqual(['a', 'b', 'c', 'd.txt'])
+  })
+})
+
+describe('resolvePosixRelativeSegments', () => {
+  it.each([
+    ['a/b', ['a', 'b']],
+    ['a//b', ['a', 'b']],
+    ['./a', ['a']],
+    ['a/./b', ['a', 'b']],
+    ['a/../b', ['b']],
+    ['docs/', ['docs']],
+    ['.', []],
+    ['a/..', []]
+  ])('resolves %s', (value, expected) => {
+    expect(resolvePosixRelativeSegments(value)).toEqual(expected)
+  })
+
+  it.each([['../a'], ['..'], ['a/../../b'], ['/a'], [''], ['a\0b']])('returns null for %s', (value) => {
+    expect(resolvePosixRelativeSegments(value)).toBeNull()
+  })
+
+  it('distinguishes the base itself from an escape', () => {
+    // Empty array = "the base"; null = "not a relative path at all".
+    expect(resolvePosixRelativeSegments('.')).toEqual([])
+    expect(resolvePosixRelativeSegments('..')).toBeNull()
+  })
+})
+
+describe('brand assignability', () => {
+  it('lets either leaf stand in for the union type', () => {
+    const fromPosix: RelativeFilePath = PosixRelativeFilePathSchema.parse('docs/a.pdf')
+    const fromWindows: RelativeFilePath = WindowsRelativeFilePathSchema.parse('docs\\a.pdf')
+    expect([fromPosix, fromWindows]).toEqual(['docs/a.pdf', 'docs\\a.pdf'])
+  })
+
+  it('lets a leaf stand in for the bare spec brand it refines', () => {
+    // The reason each leaf refines its platform's schema instead of getting a lone
+    // brand: a consumer that only cares about syntax takes these without re-parsing.
+    const asPosixPath: PosixPath = PosixRelativeFilePathSchema.parse('docs/a.pdf')
+    const asWindowsPath: WindowsPath = WindowsRelativeFilePathSchema.parse('docs\\a.pdf')
+    expect([asPosixPath, asWindowsPath]).toEqual(['docs/a.pdf', 'docs\\a.pdf'])
+  })
+
+  it('does not let the union stand in for either leaf', () => {
+    // Taken as a parameter, not a `const` initialised from a leaf: control flow
+    // analysis would narrow the latter straight back and the check would pass
+    // vacuously.
+    const takesUnion = (union: RelativeFilePath) => {
+      // @ts-expect-error — the union does not say which reading validated it.
+      const asPosix: PosixRelativeFilePath = union
+      return asPosix
+    }
+    expect(takesUnion(PosixRelativeFilePathSchema.parse('docs/a.pdf'))).toBe('docs/a.pdf')
+  })
+
+  it('keeps the two leaves mutually exclusive', () => {
+    const posix = PosixRelativeFilePathSchema.parse('a\\b.txt')
+    // @ts-expect-error — POSIX legality says nothing about Windows legality.
+    const asWindows: WindowsRelativeFilePath = posix
+    // @ts-expect-error — likewise for the bare spec brand.
+    const asWindowsPath: WindowsPath = posix
+    expect([asWindows, asWindowsPath]).toEqual(['a\\b.txt', 'a\\b.txt'])
+  })
+})

--- a/src/shared/utils/file/filename.ts
+++ b/src/shared/utils/file/filename.ts
@@ -5,13 +5,28 @@
  * plan: this module is the SoT; `legacyFile.ts` re-exports for back-compat
  * during the consumer-migration window.
  *
+ * Two layers, deliberately separated:
+ *
+ * - **Spec** — `isValidPosixFileName` / `isValidWindowsFileName`: can this name
+ *   exist on that filesystem? Ask this about a path you ALREADY HAVE (a scanned
+ *   file, a stored row, a cross-platform migration check). `@shared/utils/file/pathSpec`
+ *   builds on these.
+ * - **Convention** — `validateFileName`: should we let a user CREATE this name?
+ *   Spec rules plus judgement calls, notably macOS's `:`, which is a Finder
+ *   display convention and not a filesystem limit (`touch 'a:b.txt'` works).
+ *
+ * Conflating the two silently rejects real files: a macOS file honestly named
+ * `a:b.txt` is legal on disk and must not fail a shape check just because the
+ * UI would refuse to create it.
+ *
  * Platform notes:
  * - Windows: rejects `< > : " / \ | ? *` and reserved names (CON / PRN /
  *   AUX / NUL / COM1-9 / LPT1-9), plus filenames ending in `.` or space.
- * - macOS: additionally rejects `:` (HFS / Finder convention).
+ * - macOS: additionally rejects `:` — convention only, see above.
  * - Linux / other Unix: additionally rejects `/`.
- * - All platforms: rejects empty strings, lengths > 255, and embedded
- *   `NUL` (`\0`) characters.
+ * - All platforms: rejects empty strings and embedded `NUL` (`\0`) characters.
+ * - Length (> 255) is refused by the CONVENTION layer only; see
+ *   {@link FILE_NAME_MAX_LENGTH} for why the spec predicates leave it out.
  *
  * The legacy implementation lived in `legacyFile.ts:400` (validate) and
  * `legacyFile.ts:473` (sanitize); their behaviour is preserved verbatim.
@@ -23,11 +38,123 @@
 export type ValidateFileNameResult = { valid: true } | { valid: false; error: string }
 
 /**
- * Validate a filename against the host platform's rules.
+ * Filesystem limit, in UTF-16 code units.
+ *
+ * Deliberately imprecise and left as-is: Linux caps `NAME_MAX` at 255 **bytes**,
+ * so 85 CJK characters already exceed it while `.length` reports 85. macOS and
+ * Windows count UTF-16 units, where this is exact. Tightening it would reject
+ * names that current code accepts, which needs its own assessment.
+ *
+ * Best-effort, and used only where a name is being PRODUCED
+ * (`sanitizeFilename` truncates) or PRE-FLIGHTED (`validateFileName` warns). The
+ * spec predicates below deliberately do NOT apply it.
+ *
+ * The line those predicates draw is namespace vs capacity:
+ *
+ * - A **namespace** rule belongs to the platform's path parser and holds on every
+ *   volume it mounts. NTFS itself stores `a<b` and trailing dots quite happily —
+ *   it is Win32 that refuses to name them. A string can be judged against these.
+ * - A **capacity** rule belongs to the FILESYSTEM. `NAME_MAX` is 255 bytes on
+ *   ext4 and 255 UTF-16 units on APFS, and the same Linux box mounting a FAT32
+ *   stick gets a third answer. Nothing in the string says which volume it will
+ *   land on, so no string-only predicate can decide it — and one that pretends to
+ *   would reject real files (255 CJK characters is 765 bytes: fine on APFS,
+ *   impossible on ext4).
+ *
+ * Windows happens to be uniform at 255 UTF-16 units across NTFS / FAT32 / exFAT /
+ * ReFS, so a Windows-only check would be accurate today — but it would still be a
+ * volume property being asserted by a name predicate, and it is what made a value
+ * already sitting in the database stop parsing on read (see the
+ * `KnowledgeRelativePathSchema` read path). Too long is `ENAMETOOLONG` at write
+ * time, in the same bucket as a full disk.
+ */
+const FILE_NAME_MAX_LENGTH = 255
+
+/**
+ * Characters Windows forbids anywhere in a filename. Includes both separators.
+ *
+ * Deliberately excludes the control range, which Windows also forbids: this
+ * constant backs `validateFileName`'s user-facing message, and that message
+ * enumerates these nine characters literally. {@link WINDOWS_CONTROL_CHARS}
+ * carries the rest.
+ */
+const WINDOWS_INVALID_CHARS = /[<>:"/\\|?*]/
+
+/**
+ * ASCII control characters, which Win32 forbids in a filename (U+0001–U+001F on
+ * top of NUL). POSIX has no such rule — every byte but `/` and `\0` is an
+ * ordinary filename character there — so this belongs only to the Windows
+ * predicate.
+ */
+// oxlint-disable-next-line no-control-regex
+const WINDOWS_CONTROL_CHARS = /[\x00-\x1f]/
+
+/** Windows device names, reserved with or without an extension (`CON`, `COM1.txt`). */
+const WINDOWS_RESERVED_NAMES = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)/i
+
+/**
+ * Whether a single path SEGMENT can exist on a POSIX filesystem.
+ *
+ * POSIX forbids exactly two things in a filename — `/` and `\0`. Everything
+ * else (`:`, `\`, `<`, trailing dots and spaces, `CON`) is an ordinary
+ * character sequence.
+ *
+ * macOS and Linux agree on all of that: the `:` rule in `validateFileName` is a
+ * Finder display convention, not a filesystem rule, so it lives there and not
+ * here. They do NOT agree on `NAME_MAX` — bytes on ext4, UTF-16 units on APFS —
+ * which is why this predicate is the two platforms' shared subset and says
+ * nothing about length ({@link FILE_NAME_MAX_LENGTH} explains why no layer here
+ * can). Splitting into per-OS predicates would not fix that: the limit is a
+ * property of the mounted volume, not of the OS.
+ *
+ * This is the SPEC half — "could this name exist on disk" — as opposed to the
+ * CONVENTION half in `validateFileName`, which additionally refuses names that
+ * are legal but a bad idea to create. Consumers validating an EXISTING path
+ * (migration checks, path-shape schemas) want this one; UI validating a name a
+ * user is about to type wants `validateFileName`.
+ */
+export function isValidPosixFileName(name: string): boolean {
+  return name.length > 0 && !name.includes('\0') && !name.includes('/')
+}
+
+/**
+ * Whether a single path SEGMENT can exist on a Windows filesystem.
+ *
+ * Strictly narrower than {@link isValidPosixFileName}: Windows forbids
+ * `< > : " / \ | ? *`, every ASCII control character, the reserved device
+ * names, and trailing `.` or space. A name legal on POSIX is therefore often
+ * illegal here — which is exactly the question a cross-platform migration has to
+ * ask before restoring a Linux backup onto Windows.
+ *
+ * Every rule here is a Win32 NAMESPACE rule, so the answer holds on any volume
+ * Windows mounts. Length is a volume property and is left out for the reason
+ * given at {@link FILE_NAME_MAX_LENGTH}, so this proves "Win32 will not refuse
+ * to name it", not "it will fit".
+ *
+ * Spec half, same as above — no convention rules.
+ */
+export function isValidWindowsFileName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    !WINDOWS_CONTROL_CHARS.test(name) &&
+    !WINDOWS_INVALID_CHARS.test(name) &&
+    !WINDOWS_RESERVED_NAMES.test(name) &&
+    !name.endsWith('.') &&
+    !name.endsWith(' ')
+  )
+}
+
+/**
+ * Validate a filename against the host platform's rules, for a name about to be
+ * CREATED — spec rules plus conventions (see {@link isValidPosixFileName}).
  *
  * Pass an explicit `platform` to validate against a different OS than the
  * runtime — used by tests and by the migration path that has to honour the
  * source OS's filename conventions.
+ *
+ * Kept as its own control flow rather than delegating to the predicates above,
+ * because each branch returns a distinct user-facing message; the predicates and
+ * this function share the RULE definitions, not the checks.
  */
 export function validateFileName(
   fileName: string,
@@ -37,7 +164,7 @@ export function validateFileName(
     return { valid: false, error: 'File name cannot be empty' }
   }
 
-  if (fileName.length === 0 || fileName.length > 255) {
+  if (fileName.length === 0 || fileName.length > FILE_NAME_MAX_LENGTH) {
     return { valid: false, error: 'File name length must be between 1 and 255 characters' }
   }
 
@@ -46,12 +173,10 @@ export function validateFileName(
   }
 
   if (platform === 'win32') {
-    const winInvalidChars = /[<>:"/\\|?*]/
-    if (winInvalidChars.test(fileName)) {
+    if (WINDOWS_INVALID_CHARS.test(fileName)) {
       return { valid: false, error: 'File name contains characters not supported by Windows: < > : " / \\ | ? *' }
     }
-    const reservedNames = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)/i
-    if (reservedNames.test(fileName)) {
+    if (WINDOWS_RESERVED_NAMES.test(fileName)) {
       return { valid: false, error: 'File name is a Windows reserved name.' }
     }
     if (fileName.endsWith('.') || fileName.endsWith(' ')) {
@@ -90,11 +215,13 @@ export function sanitizeFilename(fileName: string, replacement = '_'): string {
   if (!fileName) return ''
 
   let sanitized = fileName
+    // Not `WINDOWS_INVALID_CHARS`: this one also strips ASCII control characters
+    // and is global.
     // oxlint-disable-next-line no-control-regex
     .replace(/[<>:"/\\|?*\x00-\x1f]/g, replacement)
-    .replace(/^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)/i, `${replacement}$2`)
+    .replace(WINDOWS_RESERVED_NAMES, `${replacement}$2`)
     .replace(/[\s.]+$/, '')
-    .substring(0, 255)
+    .substring(0, FILE_NAME_MAX_LENGTH)
 
   if (!sanitized) {
     sanitized = 'untitled'

--- a/src/shared/utils/file/index.ts
+++ b/src/shared/utils/file/index.ts
@@ -15,6 +15,15 @@ export { sanitizeFilename, validateFileName, type ValidateFileNameResult } from 
 export { fileTypeMap, getFileTypeByExt } from './fileType'
 export { createFileEntryHandle, createFilePathHandle, isFileEntryHandle, isFilePathHandle } from './handle'
 export {
+  type PosixRelativeFilePath,
+  PosixRelativeFilePathSchema,
+  type RelativeFilePath,
+  resolvePosixRelativeSegments,
+  resolveWindowsRelativeSegments,
+  type WindowsRelativeFilePath,
+  WindowsRelativeFilePathSchema
+} from './relativeFilePath'
+export {
   type CreateTreeIpcResult,
   type DirectoryTreeOptions,
   DirectoryTreeOptionsSchema,

--- a/src/shared/utils/file/pathSpec.ts
+++ b/src/shared/utils/file/pathSpec.ts
@@ -1,0 +1,163 @@
+/**
+ * Per-platform path SYNTAX — how a path string decomposes, and whether every
+ * piece is legal on that platform's filesystem.
+ *
+ * Lives in shared (no `node:*`), so renderer code can ask these questions too.
+ *
+ * ## Why platform is a parameter and not an inference
+ *
+ * The same string is genuinely two different paths. `a/b/c\d.txt` is three
+ * segments on POSIX — `c\d.txt` being one filename — and four on Windows.
+ * Nothing about the string decides which; only the context it came from does.
+ * So the platform is chosen by the caller, never read from `process.platform`
+ * (which would make one value validate differently in main, renderer, and the
+ * test runner) and never hardcoded (which would impose one platform's syntax on
+ * the other's values).
+ *
+ * ## Layering
+ *
+ * ```text
+ * filename.ts   isValidPosixFileName / isValidWindowsFileName   ← one segment
+ * pathSpec.ts   parsePosixPath / parseWindowsPath               ← decomposition
+ *               PosixPathSchema / WindowsPathSchema             ← whole path
+ * ```
+ *
+ * This module answers "is this a well-formed path for that platform", NOT "is it
+ * relative" or "does it escape its base" — those are structural questions layered
+ * on top (see `relativeFilePath.ts`, and eventually the absolute counterpart:
+ * `AbsoluteFilePathSchema` currently hand-rolls a union of POSIX / drive / UNC
+ * shapes that belongs here).
+ *
+ * Nothing here is re-exported from the directory barrel: `relativeFilePath.ts` is
+ * the only consumer so far, and the syntax layer stays internal until something
+ * outside `utils/file` genuinely needs it.
+ *
+ * ## `.` and `..` are structure, not filenames
+ *
+ * Both are refused by `isValidWindowsFileName` (it rejects a trailing `.`), yet
+ * both are legal navigation segments in a path on either platform. Parsing keeps
+ * them in `segments` and validation skips them, leaving `..` handling to the
+ * structural layer, which is the only place that knows what the path is relative
+ * to.
+ */
+
+import { isValidPosixFileName, isValidWindowsFileName } from '@shared/utils/file/filename'
+import * as z from 'zod'
+
+/** A path decomposed by one platform's syntax rules. */
+export interface ParsedPath {
+  /** Whether the path is anchored to a root (`/…`, `C:\…`, `\\server\share\…`, `\…`). */
+  isAbsolute: boolean
+  /**
+   * The root, verbatim and un-normalized (`''` when relative). Retained so a
+   * caller can tell `C:\a` from `\\server\share\a` without re-parsing.
+   */
+  root: string
+  /**
+   * Segments after the root, in order, with `.`/`..` kept and empty segments
+   * (from repeated or trailing separators) dropped. NOT `..`-resolved.
+   */
+  segments: string[]
+}
+
+/**
+ * `C:` / `c:` — a Windows drive designator, with or without a following separator.
+ *
+ * Any single letter counts, so `a:b.txt` parses as drive A's `b.txt` rather than
+ * a file named `a:b.txt`. That is Windows' actual reading, and it means a colon
+ * only reads as an illegal filename character when it is NOT in drive position
+ * (`ab:c.txt`).
+ */
+const WINDOWS_DRIVE_PATTERN = /^[A-Za-z]:/
+/** `\\server\share` — both components required, matching `AbsoluteFilePathSchema`. */
+const WINDOWS_UNC_PATTERN = /^\\\\[^\\/]+[\\/][^\\/]+/
+
+const toSegments = (body: string, separator: RegExp): string[] =>
+  body.split(separator).filter((segment) => segment !== '')
+
+/**
+ * Decompose `value` as a POSIX path: `/` separates, everything else — including
+ * `\` and `:` — is an ordinary filename character.
+ */
+export function parsePosixPath(value: string): ParsedPath {
+  const isAbsolute = value.startsWith('/')
+  return {
+    isAbsolute,
+    root: isAbsolute ? '/' : '',
+    segments: toSegments(isAbsolute ? value.slice(1) : value, /\//)
+  }
+}
+
+/**
+ * Decompose `value` as a Windows path: `/` and `\` both separate, and a root may
+ * be a drive (`C:\`), a UNC share (`\\server\share`), or a bare separator
+ * (`\foo`, which is absolute on the current drive).
+ *
+ * A drive with no separator (`C:foo`) is drive-RELATIVE — a real Windows shape
+ * meaning "foo, relative to the working directory on drive C". It reports
+ * `isAbsolute: false` with the drive as `root`, so a caller demanding a portable
+ * relative path can reject it on the non-empty root rather than mistaking `C:`
+ * for a segment.
+ */
+export function parseWindowsPath(value: string): ParsedPath {
+  const uncMatch = WINDOWS_UNC_PATTERN.exec(value)
+  if (uncMatch) {
+    return { isAbsolute: true, root: uncMatch[0], segments: toSegments(value.slice(uncMatch[0].length), /[/\\]/) }
+  }
+
+  const driveMatch = WINDOWS_DRIVE_PATTERN.exec(value)
+  if (driveMatch) {
+    const rest = value.slice(driveMatch[0].length)
+    const rooted = /^[/\\]/.test(rest)
+    return {
+      isAbsolute: rooted,
+      root: rooted ? `${driveMatch[0]}${rest[0]}` : driveMatch[0],
+      segments: toSegments(rooted ? rest.slice(1) : rest, /[/\\]/)
+    }
+  }
+
+  const rooted = /^[/\\]/.test(value)
+  return {
+    isAbsolute: rooted,
+    root: rooted ? value[0] : '',
+    segments: toSegments(rooted ? value.slice(1) : value, /[/\\]/)
+  }
+}
+
+/** `.` and `..` navigate; they are not filenames and are not name-checked. */
+const isNavigationSegment = (segment: string) => segment === '.' || segment === '..'
+
+const hasOnlyValidSegments = (parsed: ParsedPath, isValidName: (name: string) => boolean) =>
+  parsed.segments.every((segment) => isNavigationSegment(segment) || isValidName(segment))
+
+/** True iff every segment of `value`, read as a POSIX path, could exist on a POSIX filesystem. */
+export function isPosixPath(value: string): boolean {
+  return !value.includes('\0') && hasOnlyValidSegments(parsePosixPath(value), isValidPosixFileName)
+}
+
+/** True iff every segment of `value`, read as a Windows path, could exist on a Windows filesystem. */
+export function isWindowsPath(value: string): boolean {
+  return !value.includes('\0') && hasOnlyValidSegments(parseWindowsPath(value), isValidWindowsFileName)
+}
+
+/**
+ * A path whose every segment is legal on a POSIX filesystem. Says nothing about
+ * whether it is absolute or relative — that is the structural layer's question.
+ *
+ * Branded so the two layers compose into one type: intersecting this with a
+ * structural brand yields a value that satisfies BOTH, so a `PosixRelativeFilePath`
+ * is directly usable wherever a plain `PosixPath` is wanted. Keeping the brand
+ * here rather than restating the literal at each composition site also makes this
+ * schema the single definition of what `PosixPath` means.
+ */
+export const PosixPathSchema = z.string().refine(isPosixPath, 'must be a well-formed POSIX path').brand<'PosixPath'>()
+
+export type PosixPath = z.infer<typeof PosixPathSchema>
+
+/** A path whose every segment is legal on a Windows filesystem. See {@link PosixPathSchema}. */
+export const WindowsPathSchema = z
+  .string()
+  .refine(isWindowsPath, 'must be a well-formed Windows path')
+  .brand<'WindowsPath'>()
+
+export type WindowsPath = z.infer<typeof WindowsPathSchema>

--- a/src/shared/utils/file/relativeFilePath.ts
+++ b/src/shared/utils/file/relativeFilePath.ts
@@ -1,0 +1,204 @@
+/**
+ * Relative filesystem paths: the structural layer (is it anchored to a root?)
+ * crossed with the per-platform syntax layer in `pathSpec.ts`.
+ *
+ * Lives in shared (no `node:*`), which is the point: the knowledge
+ * `relativePath` fields each carried a prose copy of this invariant precisely
+ * because a schema there "cannot use `node:path` since this module also runs in
+ * the renderer". Pure-string parsing removes that objection.
+ *
+ * ## Two leaves and a union
+ *
+ * ```text
+ *   PosixPathSchema                     WindowsPathSchema        ← syntax (pathSpec.ts)
+ *          │ + not anchored (POSIX)            │ + not anchored (Windows)
+ *          ▼                                   ▼
+ *   PosixRelativeFilePath              WindowsRelativeFilePath
+ *          └──────────────┬────────────────────┘
+ *                RelativeFilePath (type only)
+ * ```
+ *
+ * Each leaf refines its platform's syntax schema with a structural check, so it
+ * carries **two brands**: the spec brand it inherits and its own. The spec brand
+ * is what lets a `PosixRelativeFilePath` drop into a consumer that only asks for
+ * a `PosixPath` — no re-parse, no re-assertion.
+ *
+ * Which leaf a consumer wants follows from what it does with the value:
+ *
+ * - Storing it in a `/`-separated in-app convention → `PosixRelativeFilePath`.
+ * - Asking whether it survives a move to Windows → `WindowsRelativeFilePathSchema.safeParse`.
+ *   A failure is the answer, not an error: it means that path needs renaming or
+ *   conflict handling before it can exist there.
+ *
+ * `RelativeFilePath` is their union and exists only as a type — see its own doc
+ * for why it is not a brand.
+ *
+ * The structural check is a plain helper rather than a schema of its own,
+ * because it is never meaningful alone: "unanchored" says nothing about whether
+ * the segments could exist anywhere.
+ *
+ * ## What none of them prove
+ *
+ * - **Containment.** `../x` carries these brands. It is a relative path; it just
+ *   points outside its base. Whether that is allowed belongs to whoever owns the
+ *   base — for the knowledge material root, `assertSafeKnowledgeRelativePath`.
+ *   `resolvePosixRelativeSegments` returns `null` on a climb-out so that rule has
+ *   something to check without writing a second parser.
+ * - **Correspondence.** `docs/notes.md` means nothing without its base. These
+ *   brands certify shape, never that a value is relative to any particular base.
+ *   Base+relative pairs express that locally, where the base is in scope.
+ * - **Normalization.** `parse()` returns the input unchanged — no trim, no
+ *   `.`/`..` collapse, no separator folding. Matches `AbsoluteFilePathSchema`,
+ *   which is likewise assert-only.
+ *
+ * ## `.` is a relative path; the empty string is not
+ *
+ * `.` and `a/..` denote the base itself, which is a legal relative path. "Must
+ * point *below* the base" is a business rule, left to the consumers that need it.
+ *
+ * The empty string is rejected. It is not "the path to the current directory" —
+ * it is the absence of a path (`open("")` is `ENOENT`, while `.` resolves fine).
+ * Since `.` already denotes the base unambiguously, admitting `''` as a second
+ * spelling would only push an "empty means base" special case onto every
+ * consumer. `AbsoluteFilePathSchema` draws the same line with its `.min(1)`.
+ */
+
+import {
+  isPosixPath,
+  isWindowsPath,
+  type ParsedPath,
+  parsePosixPath,
+  parseWindowsPath,
+  PosixPathSchema,
+  WindowsPathSchema
+} from '@shared/utils/file/pathSpec'
+import type * as z from 'zod'
+
+/**
+ * `segments` with `.` and `..` applied, or `null` if the path is anchored to a
+ * root or climbs above its base.
+ *
+ * An empty array means the path denotes the base itself. Underflow returns `null`
+ * — unlike `canonicalizeFilePath`, which absorbs it because an absolute root has
+ * nowhere above it to escape to. Note this is stricter than the brands, which do
+ * not judge containment; see {@link resolvePosixRelativeSegments}.
+ */
+function resolveRelativeSegments(parsed: ParsedPath): string[] | null {
+  if (parsed.isAbsolute || parsed.root !== '') return null
+
+  const stack: string[] = []
+  for (const segment of parsed.segments) {
+    if (segment === '.') continue
+    if (segment === '..') {
+      if (stack.length === 0) return null
+      stack.pop()
+      continue
+    }
+    stack.push(segment)
+  }
+  return stack
+}
+
+/**
+ * `value` read as a POSIX path and resolved against its base, or `null` if it is
+ * not a POSIX-legal relative path **or climbs out of that base**.
+ *
+ * The containment check lives here rather than in the brands: `../x` is a
+ * perfectly good `PosixRelativeFilePath`, so a consumer that must keep values
+ * inside a base needs somewhere to ask, and `null` is that answer. Consumers
+ * enforcing "points below the base" or "occupies a reserved prefix" also want the
+ * resolved segments, which is why this returns them rather than a boolean.
+ */
+export function resolvePosixRelativeSegments(value: string): string[] | null {
+  if (value.length === 0 || !isPosixPath(value)) return null
+  return resolveRelativeSegments(parsePosixPath(value))
+}
+
+/** Windows counterpart of {@link resolvePosixRelativeSegments}. */
+export function resolveWindowsRelativeSegments(value: string): string[] | null {
+  if (value.length === 0 || !isWindowsPath(value)) return null
+  return resolveRelativeSegments(parseWindowsPath(value))
+}
+
+/**
+ * Not anchored to a root under this platform's reading, and non-empty.
+ *
+ * `..` is not consulted. `../x` is a relative path — it is simply one that points
+ * outside its base, and whether that is allowed is the base owner's rule, not a
+ * property of the path.
+ */
+const isRelativeUnder = (parse: (value: string) => ParsedPath) => (value: string) => {
+  if (value.length === 0) return false
+  const parsed = parse(value)
+  return !parsed.isAbsolute && parsed.root === ''
+}
+
+const RELATIVE_ERROR = 'must be a relative filesystem path'
+
+/**
+ * A relative path in POSIX syntax whose every segment could exist on a POSIX
+ * filesystem. `\` and `:` are ordinary filename characters here, so `a\b.txt` is
+ * one segment and stays intact.
+ *
+ * Carries two brands: `PosixPath` from the schema it refines, plus its own. The
+ * first means it drops straight into a consumer that only cares about syntax,
+ * with no re-parse. Notably it does NOT claim containment; `../x` parses fine.
+ *
+ * Both brands are phantom — zero runtime cost, dropped on IPC serialization, so
+ * receivers re-assert at the trusted boundary. Construction:
+ * - Production: `PosixRelativeFilePathSchema.parse(raw)` / `.safeParse(raw)`
+ * - Tests / fixtures: `'…' as PosixRelativeFilePath` for readability
+ */
+export const PosixRelativeFilePathSchema = PosixPathSchema.refine(
+  isRelativeUnder(parsePosixPath),
+  RELATIVE_ERROR
+).brand<'PosixRelativeFilePath'>()
+
+export type PosixRelativeFilePath = z.infer<typeof PosixRelativeFilePathSchema>
+
+/**
+ * A relative path in Windows syntax whose every segment could exist on a Windows
+ * filesystem: `\` separates, and no segment may use `< > : " | ? *`, a reserved
+ * device name, or a trailing `.` / space.
+ *
+ * `a<b`, `CON.txt` and `name.` are ordinary POSIX filenames with no Windows
+ * spelling, so parsing a stored POSIX path through this schema is how a
+ * migration finds out what cannot be restored onto Windows as-is.
+ *
+ * Built the same way as its POSIX counterpart, but on `WindowsPathSchema` and
+ * with the structural check reading roots Windows' way — `\foo` is
+ * current-drive-absolute and `C:foo` is drive-relative, both anchored, though
+ * each is a single unanchored filename when read as POSIX.
+ */
+export const WindowsRelativeFilePathSchema = WindowsPathSchema.refine(
+  isRelativeUnder(parseWindowsPath),
+  RELATIVE_ERROR
+).brand<'WindowsRelativeFilePath'>()
+
+export type WindowsRelativeFilePath = z.infer<typeof WindowsRelativeFilePathSchema>
+
+/**
+ * A relative path under one platform's reading — which one, this type does not
+ * say. Use it exactly when that is true: a consumer that cares whether a value is
+ * POSIX- or Windows-shaped should name the branch it means and validate with that
+ * branch's schema.
+ *
+ * A union rather than a brand of its own, so it cannot be minted without first
+ * picking a reading. A standalone "structurally relative" brand would admit
+ * `a\0b` — non-empty, unanchored, and storable on no filesystem — because
+ * segment legality only exists per platform.
+ *
+ * As VALUE SETS the branches nest: every Windows-relative string is also
+ * POSIX-relative, since POSIX only refuses the empty string, a leading `/`, and
+ * NUL, all three of which Windows refuses too. They stay distinct TYPES because
+ * a brand records the READING that was applied, not set membership. `a\b.txt`
+ * carrying `WindowsRelativeFilePath` means "two segments, `a` then `b.txt`";
+ * the same string carrying `PosixRelativeFilePath` means "one filename".
+ * Interchanging them would silently reinterpret the path, which is the entire
+ * hazard this module exists to prevent.
+ *
+ * No schema is exported. `z.union([Posix, Windows])` would build one in a line,
+ * but nothing parses at this level yet, and a union's `invalid_union` error
+ * buries both branch messages under a bare "Invalid input".
+ */
+export type RelativeFilePath = PosixRelativeFilePath | WindowsRelativeFilePath


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

**Bottom layer of a 2-PR stack.** Type refactor only — no consumers change here. #18230 sits on top and wires knowledge to it.

Before this PR:

- `validateFileName(name, platform)` answered two different questions at once: *can this name exist on that filesystem* and *should we let a user create it*. The macOS branch shows the cost — it rejects `:`, which is a Finder display convention, not a filesystem rule (`touch 'a:b.txt'` works fine). Any caller validating an **existing** path against it silently rejects real files.
- There was no type for relative paths at all, next to `AbsoluteFilePath` and `CanonicalFilePath`.

After this PR:

- **`filename.ts`** — spec predicates `isValidPosixFileName` / `isValidWindowsFileName` extracted. `validateFileName` keeps its own control flow (each branch returns a distinct user-facing message) and now shares only the rule *definitions*, so its output is byte-for-byte unchanged.
- **`pathSpec.ts`** (new) — per-platform path syntax: `parsePosixPath` / `parseWindowsPath` (decomposition into root + segments) and `PosixPathSchema` / `WindowsPathSchema` (whole-path legality, branded `PosixPath` / `WindowsPath`). None of it is re-exported from the directory barrel — `relativeFilePath.ts` is the only consumer so far, so the syntax layer stays internal until something outside `utils/file` needs it.
- **`relativeFilePath.ts`** (new) — each platform's syntax schema refined with a structural check:

  ```
    PosixPathSchema                     WindowsPathSchema        ← syntax (pathSpec.ts)
           │ + not anchored (POSIX)            │ + not anchored (Windows)
           ▼                                   ▼
    PosixRelativeFilePath              WindowsRelativeFilePath
           └──────────────┬────────────────────┘
                 RelativeFilePath (type only)
  ```

  Each leaf carries **two brands** — the spec brand it inherits plus its own — so a `PosixRelativeFilePath` drops straight into a consumer that only asks for a `PosixPath`, with no re-parse. Assignability is pinned by tests in both directions, `@ts-expect-error` included.

  `RelativeFilePath` is their **union, and a type only**. A standalone "structurally relative" brand would admit values no filesystem can hold: `a\0b` and a 300-character segment are both non-empty and unanchored, because segment legality only exists per platform. Making it a union means it cannot be minted without first choosing a reading — and a consumer that does care which one should name the branch and validate with that branch's schema. The two branches differ in both directions: `a<b` is POSIX-only, and `150 chars` + `\` + `150 chars` is Windows-only (two legal segments there, one over-long segment on POSIX).

  The structural check is a plain helper, not a schema, since "unanchored" is never meaningful alone. It has to be applied per platform regardless: `\foo` is one ordinary POSIX filename but current-drive-absolute on Windows, and `C:foo` is one POSIX filename but drive-relative — anchored either way.

Renderer-safe throughout (no `node:path`).

Fixes #

Refs #18209

### Why we need it and why it was done in this way

The knowledge `relativePath` fields carry four prose copies of the same invariant, each explaining that a schema is impossible because the module "cannot use `node:path` since this module also runs in the renderer". Pure-string parsing removes that objection — but only if the types are honest about platforms first, which is what this layer does.

**The platform is a required parameter, never inferred.** `a/b/c\d.txt` is three segments on POSIX (`c\d.txt` being one filename) and four on Windows. Nothing about the string decides which; only the context it came from does. Reading `process.platform` would make one value validate differently in main, renderer and the test runner; hardcoding either reading would impose one platform's syntax on the other's values.

The following tradeoffs were made:

- **`WindowsRelativeFilePath` has no in-repo consumer yet.** It is the check a cross-platform migration needs (`safeParse` failing *is* the answer: that path needs renaming before it can exist on Windows), and `validateFileName`'s existing `platform` parameter documents that intent — its JSDoc already says it is "used by ... the migration path that has to honour the source OS's filename conventions". Landing both halves of the lattice now avoids a second refactor when that work starts.
- **`FILE_NAME_MAX_LENGTH` stays at 255 UTF-16 units.** Linux caps `NAME_MAX` at 255 *bytes*, so 85 CJK characters already exceed it while `.length` reports 85. This imprecision is pre-existing; tightening it would reject names current code accepts and needs its own assessment.
- **`.` and `..` are not name-checked.** Both are legal navigation segments but `isValidWindowsFileName` rejects a trailing `.`, so parsing keeps them and validation skips them.
- **Containment is not part of the brand.** `../x` is a relative path — it just points outside its base — so refusing it here would be a base owner's policy smuggled into the definition of "relative". The brands answer "is this anchored to a root"; `resolvePosixRelativeSegments` returns `null` on a climb-out so an owner (the knowledge material root, in #18230) can enforce containment where the base is actually known.

The following alternatives were considered:

- **A single `RelativeFilePath` reading the strictest platform.** Rejected: it makes the brand quietly refuse `\foo` and `a<b`, both legal POSIX filenames, and gives consumers no way to ask the Windows question when they actually need to.
- **`RelativeFilePath` as its own brand, with the leaves intersecting it.** Rejected: a brand for "structurally relative" can only be earned without knowing the platform, so it certifies a value that may be unrepresentable on every filesystem (`a\0b`). It also forced the shared brand to be minted twice — once per reading — with nothing in the type recording which one ran.
- **Exporting `z.union([Posix, Windows])` as `RelativeFilePathSchema`.** Deferred, not rejected: it is a one-liner, but nothing parses at this level yet, and `invalid_union` buries both branch messages under a bare `"Invalid input"`. Added when a caller needs it.
- **A `style` parameter on the brand itself.** Rejected: a brand meaning "relative under whichever platform validated it" guarantees nothing at the far end of an IPC hop or a database read.
- **Writing the segment rules fresh in `relativeFilePath.ts`.** Rejected: it would duplicate the Windows ruleset (invalid chars, reserved device names, trailing dot/space) that `filename.ts` already implements.

Links to places where the discussion took place: #18209

### Breaking changes

None. No behavior changes — `validateFileName` and `sanitizeFilename` produce identical output, and nothing consumes the new types yet.

### Special notes for your reviewer

`AbsoluteFilePathSchema` still hand-rolls its own POSIX / drive / UNC union inline and is deliberately left alone: its output feeds `canonicalizeFilePath` and the persisted `file_entry.externalPath`, so rebuilding it on `pathSpec` requires a paired migration. A signpost comment in `common.ts` records that.

Worth a look: the drive-letter ambiguity in `parseWindowsPath`. Any single letter before a colon parses as a drive, because that is Windows' actual reading — `a:b.txt` is drive A's `b.txt`, not a file named `a:b.txt`. A colon therefore only reads as an illegal filename character outside drive position (`ab:c.txt`).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```




