### PR TITLE
refactor(knowledge): type material paths as PosixRelativeFilePath

### DIFF
--- a/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
+++ b/src/main/data/migration/v2/migrators/mappings/KnowledgeMappings.ts
@@ -9,7 +9,8 @@ import {
   KNOWLEDGE_ITEM_ERROR_DIRECTORY_NOT_MIGRATED,
   KNOWLEDGE_NOTE_CONTENT_MAX,
   type KnowledgeItemData,
-  type KnowledgeItemStatus
+  type KnowledgeItemStatus,
+  KnowledgeRelativePathSchema
 } from '@shared/data/types/knowledge'
 import type { FileMetadata } from '@shared/data/types/legacyFile'
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
@@ -313,7 +314,11 @@ export const transformKnowledgeItem = (
     // carry foreign separators after a cross-platform restore, so the migrator
     // dedupes and copies the file (located via `storageName`) in `execute`.
     const sanitizedName = sanitizeFilename(file.origin_name)
-    const relativePath = sanitizedName || sanitizeFilename(file.name) || item.id
+    // Every branch already clears the schema — `sanitizeFilename` strips separators
+    // and trailing dots, and `item.id` is a uuid — so `parse` brands rather than
+    // filters. It throws only if that guarantee breaks, which beats writing a row
+    // the read path would then reject.
+    const relativePath = KnowledgeRelativePathSchema.parse(sanitizedName || sanitizeFilename(file.name) || item.id)
     if (!sanitizedName) {
       onWarning?.(
         `Knowledge file item ${item.id} has a blank v1 filename; falling back to ${JSON.stringify(relativePath)}`
@@ -639,7 +644,9 @@ export const expandLegacyDirectoryItem = (
       baseId,
       groupId: containerId,
       type: 'file',
-      data: { source, relativePath },
+      // `parse` brands; it cannot reject. Every segment came through `toSafePathSegment`,
+      // which is what the invariant above asserts.
+      data: { source, relativePath: KnowledgeRelativePathSchema.parse(relativePath) },
       status: 'completed',
       error: null,
       createdAt,
@@ -657,7 +664,7 @@ export const expandLegacyDirectoryItem = (
     baseId,
     groupId: null,
     type: 'directory',
-    data: { source: item.content, relativePath: pathPrefix },
+    data: { source: item.content, relativePath: KnowledgeRelativePathSchema.parse(pathPrefix) },
     status: 'completed',
     error: null,
     createdAt,

--- a/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeBaseService.test.ts
@@ -7,6 +7,7 @@ import { generateOrderKeySequence } from '@data/services/utils/orderKey'
 import { ErrorCode } from '@shared/data/api/errors'
 import { type CreateKnowledgeBaseDto, KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL } from '@shared/data/types/knowledge'
 import { createUniqueModelId } from '@shared/data/types/model'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -121,7 +122,7 @@ describe('KnowledgeBaseService', () => {
       type: 'file',
       data: {
         source: '/docs/source-file.md',
-        relativePath: 'source-file.md'
+        relativePath: 'source-file.md' as PosixRelativeFilePath
       },
       status: 'completed',
       error: null,
@@ -392,7 +393,9 @@ describe('KnowledgeBaseService', () => {
       await seedKnowledgeBase({ name: 'General', createdAt: 3 })
       await seedKnowledgeBase({ id: BETA_KNOWLEDGE_BASE_ID, name: 'Operations', createdAt: 2 })
       await seedKnowledgeBase({ id: ALPHA_KNOWLEDGE_BASE_ID, name: 'Invoice Archive', createdAt: 1 })
-      await seedFileKnowledgeItem({ data: { source: '/docs/invoice.pdf', relativePath: 'invoice.pdf' } })
+      await seedFileKnowledgeItem({
+        data: { source: '/docs/invoice.pdf', relativePath: 'invoice.pdf' as PosixRelativeFilePath }
+      })
 
       const first = service.listForDiscovery({ limit: 1, query: 'invoice' })
       const second = service.listForDiscovery({ limit: 1, query: 'invoice', cursor: first.nextCursor })

--- a/src/main/data/services/__tests__/KnowledgeItemService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeItemService.test.ts
@@ -6,6 +6,7 @@ import { generateOrderKeyBetween } from '@data/services/utils/orderKey'
 import { ErrorCode } from '@shared/data/api/errors'
 import type { CreateKnowledgeItemDto } from '@shared/data/types/knowledge'
 import { createUniqueModelId } from '@shared/data/types/model'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { setupTestDatabase } from '@test-helpers/db'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { eq } from 'drizzle-orm'
@@ -91,7 +92,7 @@ describe('KnowledgeItemService', () => {
     const slug = id.slice(0, 8)
     return {
       source: `/docs/${slug}.md`,
-      relativePath: `${slug}.md`
+      relativePath: `${slug}.md` as PosixRelativeFilePath
     }
   }
 
@@ -669,7 +670,7 @@ describe('KnowledgeItemService', () => {
         type: 'file',
         data: {
           source: '/docs/a.md',
-          relativePath: 'a.md'
+          relativePath: 'a.md' as PosixRelativeFilePath
         }
       })
 
@@ -677,7 +678,7 @@ describe('KnowledgeItemService', () => {
         type: 'file',
         data: {
           source: '/docs/a.md',
-          relativePath: 'a.md'
+          relativePath: 'a.md' as PosixRelativeFilePath
         }
       })
     })
@@ -1269,7 +1270,7 @@ describe('KnowledgeItemService', () => {
         data: {
           source: `/docs/${FILE_A_ID.slice(0, 8)}.md`,
           relativePath: `${FILE_A_ID.slice(0, 8)}.md`,
-          indexedRelativePath: 'processed.md'
+          indexedRelativePath: 'processed.md' as PosixRelativeFilePath
         }
       })
     })
@@ -1321,7 +1322,7 @@ describe('KnowledgeItemService', () => {
         data: {
           source: 'https://example.com',
           url: 'https://example.com',
-          relativePath: 'example.md'
+          relativePath: 'example.md' as PosixRelativeFilePath
         }
       })
     })
@@ -1341,7 +1342,7 @@ describe('KnowledgeItemService', () => {
         data: {
           source: 'Meeting notes',
           content: '# Meeting\n\nbody',
-          relativePath: 'Meeting notes.md'
+          relativePath: 'Meeting notes.md' as PosixRelativeFilePath
         }
       })
     })
@@ -1410,7 +1411,7 @@ describe('KnowledgeItemService', () => {
         type: 'directory',
         data: {
           source: '/docs',
-          relativePath: 'docs'
+          relativePath: 'docs' as PosixRelativeFilePath
         }
       })
     })

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -9,6 +9,7 @@ import {
   type KnowledgeItemOf
 } from '@shared/data/types/knowledge'
 import type { AbsoluteFilePath } from '@shared/types/file'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as PathStorage from '../pathStorage'
@@ -287,7 +288,7 @@ function createFileItem(
     baseId,
     groupId: null,
     type: 'file',
-    data: { source, relativePath: source.split('/').pop() ?? source },
+    data: { source, relativePath: (source.split('/').pop() ?? source) as PosixRelativeFilePath },
     ...lifecycle,
     createdAt: '2026-04-08T00:00:00.000Z',
     updatedAt: '2026-04-08T00:00:00.000Z'
@@ -648,7 +649,7 @@ describe('KnowledgeService', () => {
           fileProcessingJobId: 'fp-job-1',
           pollRound: 0,
           firstScheduledAt: 1779811200000,
-          processedRelativePath: 'source.md'
+          processedRelativePath: 'source.md' as PosixRelativeFilePath
         }
       }
     ])
@@ -930,13 +931,21 @@ describe('KnowledgeService', () => {
 
     const processedSourceFile = {
       ...createFileItem('src-file', 'source-kb', '/docs/report.pdf'),
-      data: { source: '/docs/report.pdf', relativePath: 'report.pdf', indexedRelativePath: 'report.md' }
+      data: {
+        source: '/docs/report.pdf',
+        relativePath: 'report.pdf' as PosixRelativeFilePath,
+        indexedRelativePath: 'report.md' as PosixRelativeFilePath
+      }
     }
     knowledgeItemGetRootItemsByBaseIdMock.mockReturnValueOnce([processedSourceFile])
 
     const restoredFile = {
       ...createFileItem('restored-file', 'restored-kb', '/docs/report.pdf', 'processing'),
-      data: { source: '/docs/report.pdf', relativePath: 'report.pdf', indexedRelativePath: 'report.md' }
+      data: {
+        source: '/docs/report.pdf',
+        relativePath: 'report.pdf' as PosixRelativeFilePath,
+        indexedRelativePath: 'report.md' as PosixRelativeFilePath
+      }
     }
     knowledgeItemCreateActiveMock.mockReturnValueOnce(restoredFile)
     knowledgeItemGetByIdMock.mockReturnValue(restoredFile)
@@ -958,7 +967,11 @@ describe('KnowledgeService', () => {
       'restored-kb',
       expect.objectContaining({
         type: 'file',
-        data: { source: '/docs/report.pdf', relativePath: 'report.pdf', indexedRelativePath: 'report.md' }
+        data: {
+          source: '/docs/report.pdf',
+          relativePath: 'report.pdf' as PosixRelativeFilePath,
+          indexedRelativePath: 'report.md' as PosixRelativeFilePath
+        }
       })
     )
     // The file processor is skipped and indexing runs straight from the artifact (re-embedding still happens).
@@ -980,7 +993,11 @@ describe('KnowledgeService', () => {
     const sourceUrl = {
       ...createNoteItem('source-url', 'source-kb'),
       type: 'url' as const,
-      data: { source: 'https://example.com', url: 'https://example.com', relativePath: 'example-page.md' }
+      data: {
+        source: 'https://example.com',
+        url: 'https://example.com',
+        relativePath: 'example-page.md' as PosixRelativeFilePath
+      }
     }
     knowledgeItemGetRootItemsByBaseIdMock.mockReturnValueOnce([sourceUrl])
 
@@ -1002,7 +1019,11 @@ describe('KnowledgeService', () => {
       'restored-kb',
       expect.objectContaining({
         type: 'url',
-        data: { source: 'https://example.com', url: 'https://example.com', relativePath: 'example-page.md' }
+        data: {
+          source: 'https://example.com',
+          url: 'https://example.com',
+          relativePath: 'example-page.md' as PosixRelativeFilePath
+        }
       })
     )
   })
@@ -1189,7 +1210,7 @@ describe('KnowledgeService', () => {
         fileProcessingJobId: 'fp-job-1',
         pollRound: 0,
         firstScheduledAt: expect.any(Number),
-        processedRelativePath: 'source.md'
+        processedRelativePath: 'source.md' as PosixRelativeFilePath
       },
       expect.objectContaining({
         idempotencyKey: 'knowledge:kb-1:file-1:fp-check:fp-job-1:0',
@@ -1253,7 +1274,11 @@ describe('KnowledgeService', () => {
       {
         ...createNoteItem('existing-url', 'kb-1'),
         type: 'url' as const,
-        data: { source: 'https://example.com/old', url: 'https://example.com/old', relativePath: 'example-page.md' }
+        data: {
+          source: 'https://example.com/old',
+          url: 'https://example.com/old',
+          relativePath: 'example-page.md' as PosixRelativeFilePath
+        }
       }
     ])
 
@@ -1280,7 +1305,11 @@ describe('KnowledgeService', () => {
       'kb-1',
       expect.objectContaining({
         type: 'url',
-        data: { source: 'https://example.com/new', url: 'https://example.com/new', relativePath: 'example-page_1.md' }
+        data: {
+          source: 'https://example.com/new',
+          url: 'https://example.com/new',
+          relativePath: 'example-page_1.md' as PosixRelativeFilePath
+        }
       })
     )
   })
@@ -1312,7 +1341,12 @@ describe('KnowledgeService', () => {
     // later hard-failed on the orphan.
     expect(deleteKnowledgeItemFilesBestEffortMock).toHaveBeenCalledWith(
       'kb-1',
-      [expect.objectContaining({ type: 'url', data: expect.objectContaining({ relativePath: 'example-page.md' }) })],
+      [
+        expect.objectContaining({
+          type: 'url',
+          data: expect.objectContaining({ relativePath: 'example-page.md' as PosixRelativeFilePath })
+        })
+      ],
       expect.anything()
     )
   })
@@ -1325,7 +1359,7 @@ describe('KnowledgeService', () => {
       {
         ...createNoteItem('existing-note', 'kb-1'),
         type: 'note' as const,
-        data: { source: 'Meeting notes', content: 'hello', relativePath: 'Meeting notes.md' }
+        data: { source: 'Meeting notes', content: 'hello', relativePath: 'Meeting notes.md' as PosixRelativeFilePath }
       }
     ])
     knowledgeItemCreateActiveMock.mockReturnValueOnce(
@@ -1354,7 +1388,7 @@ describe('KnowledgeService', () => {
       'kb-1',
       expect.objectContaining({
         type: 'file',
-        data: { source: '/Users/me/Meeting notes.md', relativePath: 'Meeting notes_1.md' }
+        data: { source: '/Users/me/Meeting notes.md', relativePath: 'Meeting notes_1.md' as PosixRelativeFilePath }
       })
     )
   })
@@ -1369,7 +1403,7 @@ describe('KnowledgeService', () => {
       {
         ...createNoteItem('existing-note', 'kb-1'),
         type: 'note' as const,
-        data: { source: 'Source', content: 'hello', relativePath: 'source.md' }
+        data: { source: 'Source', content: 'hello', relativePath: 'source.md' as PosixRelativeFilePath }
       }
     ])
 
@@ -1469,7 +1503,7 @@ describe('KnowledgeService', () => {
         fileProcessingJobId: 'fp-job-1',
         pollRound: 0,
         firstScheduledAt: expect.any(Number),
-        processedRelativePath: 'source.md'
+        processedRelativePath: 'source.md' as PosixRelativeFilePath
       },
       expect.objectContaining({
         idempotencyKey: 'knowledge:kb-1:file-1:fp-check:fp-job-1:0',
@@ -1577,7 +1611,7 @@ describe('KnowledgeService', () => {
       pollRound: 1,
       firstScheduledAt: Date.parse('2026-04-08T00:00:00.000Z'),
       parentJobId: 'check-job-0',
-      processedRelativePath: 'source.md'
+      processedRelativePath: 'source.md' as PosixRelativeFilePath
     })
 
     expect(enqueueMock).toHaveBeenCalledWith(
@@ -1588,7 +1622,7 @@ describe('KnowledgeService', () => {
         fileProcessingJobId: 'fp-job-1',
         pollRound: 1,
         firstScheduledAt: Date.parse('2026-04-08T00:00:00.000Z'),
-        processedRelativePath: 'source.md'
+        processedRelativePath: 'source.md' as PosixRelativeFilePath
       },
       expect.objectContaining({
         idempotencyKey: 'knowledge:kb-1:file-1:fp-check:fp-job-1:1',
@@ -1770,7 +1804,7 @@ describe('KnowledgeService', () => {
     const migratedChild: KnowledgeItemOf<'file'> = {
       ...createFileItem('file-1', 'kb-1', '/legacy/abs/x.md', 'completed'),
       groupId: 'dir-1',
-      data: { source: '/legacy/abs/x.md', relativePath: 'file-1' }
+      data: { source: '/legacy/abs/x.md', relativePath: 'file-1' as PosixRelativeFilePath }
     }
     probeKnowledgeSourcePathMock.mockResolvedValue('missing')
     knowledgeItemGetByIdMock.mockReturnValue(root)
@@ -1886,8 +1920,8 @@ describe('KnowledgeService', () => {
       ...item,
       data: {
         ...item.data,
-        relativePath: 'stored-report.pdf',
-        indexedRelativePath: 'stored-report.md'
+        relativePath: 'stored-report.pdf' as PosixRelativeFilePath,
+        indexedRelativePath: 'stored-report.md' as PosixRelativeFilePath
       }
     })
 
@@ -1904,7 +1938,7 @@ describe('KnowledgeService', () => {
       data: {
         source: 'https://example.com/product-docs',
         url: 'https://example.com/product-docs',
-        relativePath: 'Product Docs.md'
+        relativePath: 'Product Docs.md' as PosixRelativeFilePath
       },
       status: 'completed',
       error: null,
@@ -1949,7 +1983,7 @@ describe('KnowledgeService', () => {
     const directory = createDirectoryItem('directory-1', null, 'completed')
     knowledgeItemGetByIdMock.mockReturnValue({
       ...directory,
-      data: { ...directory.data, relativePath: 'stored-directory' }
+      data: { ...directory.data, relativePath: 'stored-directory' as PosixRelativeFilePath }
     })
 
     expect(() => service.getFilePath('directory-1')).toThrow(

--- a/src/main/features/knowledge/__tests__/items.test.ts
+++ b/src/main/features/knowledge/__tests__/items.test.ts
@@ -1,4 +1,5 @@
 import type { KnowledgeItem, KnowledgeItemOf } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MaterialFieldSource } from '../items'
@@ -37,7 +38,7 @@ function createItem(type: KnowledgeItem['type']): KnowledgeItem {
       return {
         ...base,
         type,
-        data: { source: '/docs/file.md', relativePath: 'file.md' }
+        data: { source: '/docs/file.md', relativePath: 'file.md' as PosixRelativeFilePath }
       }
     case 'url':
       return { ...base, type, data: { source: 'https://example.com', url: 'https://example.com' } }
@@ -74,7 +75,11 @@ describe('classifyKnowledgeItemSource', () => {
   it('checks a file against its material file, preferring indexedRelativePath', async () => {
     const file: KnowledgeItemOf<'file'> = {
       ...(createItem('file') as KnowledgeItemOf<'file'>),
-      data: { source: '/docs/file.md', relativePath: 'file.md', indexedRelativePath: 'processed/file.md' }
+      data: {
+        source: '/docs/file.md',
+        relativePath: 'file.md' as PosixRelativeFilePath,
+        indexedRelativePath: 'processed/file.md' as PosixRelativeFilePath
+      }
     }
 
     await expect(classifyKnowledgeItemSource('kb-1', file)).resolves.toBe('rebuildable')
@@ -121,7 +126,7 @@ describe('toMaterialRelativePath', () => {
     const file: MaterialFieldSource = {
       id: 'file-1',
       type: 'file',
-      data: { source: '/docs/report.pdf', relativePath: 'report.pdf' }
+      data: { source: '/docs/report.pdf', relativePath: 'report.pdf' as PosixRelativeFilePath }
     }
     expect(toMaterialRelativePath(file)).toBe('report.pdf')
   })
@@ -130,7 +135,11 @@ describe('toMaterialRelativePath', () => {
     const file: MaterialFieldSource = {
       id: 'file-2',
       type: 'file',
-      data: { source: '/docs/report.pdf', relativePath: 'report.pdf', indexedRelativePath: 'report.md' }
+      data: {
+        source: '/docs/report.pdf',
+        relativePath: 'report.pdf' as PosixRelativeFilePath,
+        indexedRelativePath: 'report.md' as PosixRelativeFilePath
+      }
     }
     expect(toMaterialRelativePath(file)).toBe('report.md')
   })
@@ -139,7 +148,11 @@ describe('toMaterialRelativePath', () => {
     const url: MaterialFieldSource = {
       id: 'url-1',
       type: 'url',
-      data: { source: 'https://example.com', url: 'https://example.com', relativePath: 'example-page.md' }
+      data: {
+        source: 'https://example.com',
+        url: 'https://example.com',
+        relativePath: 'example-page.md' as PosixRelativeFilePath
+      }
     }
     expect(toMaterialRelativePath(url)).toBe('example-page.md')
   })
@@ -148,7 +161,7 @@ describe('toMaterialRelativePath', () => {
     const note: MaterialFieldSource = {
       id: 'note-1',
       type: 'note',
-      data: { source: 'My note', content: 'hello', relativePath: 'My note.md' }
+      data: { source: 'My note', content: 'hello', relativePath: 'My note.md' as PosixRelativeFilePath }
     }
     expect(toMaterialRelativePath(note)).toBe('My note.md')
   })

--- a/src/main/features/knowledge/__tests__/pathStorage.test.ts
+++ b/src/main/features/knowledge/__tests__/pathStorage.test.ts
@@ -4,7 +4,13 @@
 // helpers (the guard itself is private).
 import path from 'node:path'
 
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Legitimately branded, not a type lie: `../escape.md` IS a relative POSIX path.
+// Containment is the knowledge layer's rule, so a traversal reaches these helpers
+// fully typed and the runtime guard is the only thing standing in its way.
+const UNSAFE_RELATIVE_PATH = '../escape.md' as PosixRelativeFilePath
 
 const { copyMock, writeMock, ensureDirMock, removeMock, removeDirMock, rmdirMock, lstatMock, errorMock, warnMock } =
   vi.hoisted(() => ({
@@ -87,6 +93,13 @@ describe('pathStorage relative-path safety', () => {
 
     it('accepts a safe nested relative path', () => {
       expect(getKnowledgeBaseFilePath(BASE_ID, 'sub/dir/file.md')).toBe(path.join(MATERIAL_DIR, 'sub/dir/file.md'))
+    })
+
+    it('reads the reserved-prefix rule as POSIX, so a backslash cannot fake the boundary', () => {
+      // `.cherry\x` is one legal Linux filename sitting directly under raw/, not
+      // something inside `.cherry/`. The old guard folded `\` unconditionally
+      // and rejected it (#17429).
+      expect(getKnowledgeBaseFilePath(BASE_ID, '.cherry\\x')).toBe(path.join(MATERIAL_DIR, '.cherry\\x'))
     })
   })
 
@@ -191,14 +204,14 @@ describe('pathStorage relative-path safety', () => {
     })
 
     it('rejects an unsafe target relative path before any filesystem write', async () => {
-      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', '../escape.md')).rejects.toThrow(
+      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', UNSAFE_RELATIVE_PATH)).rejects.toThrow(
         'Invalid knowledge relative path'
       )
       expect(copyMock).not.toHaveBeenCalled()
     })
 
     it('creates parent directories and copies for a nested target', async () => {
-      const relativePath = 'docs/sub/a.md'
+      const relativePath = 'docs/sub/a.md' as PosixRelativeFilePath
       await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', relativePath)).resolves.toBe(relativePath)
       const destPath = path.join(MATERIAL_DIR, relativePath)
       expect(ensureDirMock).toHaveBeenCalledWith(path.dirname(destPath))
@@ -208,7 +221,7 @@ describe('pathStorage relative-path safety', () => {
 
     it('throws when the target already exists', async () => {
       lstatMock.mockResolvedValueOnce({})
-      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md')).rejects.toThrow(
+      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md' as PosixRelativeFilePath)).rejects.toThrow(
         'Knowledge file already exists'
       )
       expect(copyMock).not.toHaveBeenCalled()
@@ -217,14 +230,18 @@ describe('pathStorage relative-path safety', () => {
     it('overwrites an existing target without throwing when overwrite is set', async () => {
       // overwrite skips the availability guard entirely (lstat is never consulted), so a
       // retry can re-copy over its own orphan from a prior aborted directory expansion.
-      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md', { overwrite: true })).resolves.toBe('a.md')
+      await expect(
+        copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md' as PosixRelativeFilePath, { overwrite: true })
+      ).resolves.toBe('a.md')
       expect(lstatMock).not.toHaveBeenCalled()
       expect(copyMock).toHaveBeenCalledWith('/src/a.md', path.join(MATERIAL_DIR, 'a.md'), undefined)
     })
 
     it('forwards the abort signal to copy', async () => {
       const signal = new AbortController().signal
-      await expect(copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md', { signal })).resolves.toBe('a.md')
+      await expect(
+        copyFileIntoKnowledgeBaseAt(BASE_ID, '/src/a.md', 'a.md' as PosixRelativeFilePath, { signal })
+      ).resolves.toBe('a.md')
       expect(copyMock).toHaveBeenCalledWith('/src/a.md', path.join(MATERIAL_DIR, 'a.md'), signal)
     })
   })
@@ -238,14 +255,14 @@ describe('pathStorage relative-path safety', () => {
     })
 
     it('rejects an unsafe target relative path before any filesystem write', async () => {
-      await expect(writeFileIntoKnowledgeBaseAt(BASE_ID, '../escape.md', 'hi')).rejects.toThrow(
+      await expect(writeFileIntoKnowledgeBaseAt(BASE_ID, UNSAFE_RELATIVE_PATH, 'hi')).rejects.toThrow(
         'Invalid knowledge relative path'
       )
       expect(writeMock).not.toHaveBeenCalled()
     })
 
     it('creates parent directories and writes the content for a nested target', async () => {
-      const relativePath = 'docs/sub/page.md'
+      const relativePath = 'docs/sub/page.md' as PosixRelativeFilePath
       await expect(writeFileIntoKnowledgeBaseAt(BASE_ID, relativePath, '# hi')).resolves.toBe(relativePath)
       const destPath = path.join(MATERIAL_DIR, relativePath)
       expect(ensureDirMock).toHaveBeenCalledWith(path.dirname(destPath))
@@ -254,7 +271,7 @@ describe('pathStorage relative-path safety', () => {
 
     it('throws when the target already exists', async () => {
       lstatMock.mockResolvedValueOnce({})
-      await expect(writeFileIntoKnowledgeBaseAt(BASE_ID, 'page.md', '# hi')).rejects.toThrow(
+      await expect(writeFileIntoKnowledgeBaseAt(BASE_ID, 'page.md' as PosixRelativeFilePath, '# hi')).rejects.toThrow(
         'Knowledge file already exists'
       )
       expect(writeMock).not.toHaveBeenCalled()
@@ -264,9 +281,12 @@ describe('pathStorage relative-path safety', () => {
   describe('collectKnowledgeReservedRelativePaths', () => {
     it('collects file source and indexed-artifact paths and url/note snapshot paths', () => {
       const reserved = collectKnowledgeReservedRelativePaths([
-        { type: 'file', data: { relativePath: 'a.pdf', indexedRelativePath: 'a.md' } },
-        { type: 'url', data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' } },
-        { type: 'note', data: { source: 'n', content: 'body', relativePath: 'n.md' } },
+        {
+          type: 'file',
+          data: { relativePath: 'a.pdf' as PosixRelativeFilePath, indexedRelativePath: 'a.md' as PosixRelativeFilePath }
+        },
+        { type: 'url', data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' as PosixRelativeFilePath } },
+        { type: 'note', data: { source: 'n', content: 'body', relativePath: 'n.md' as PosixRelativeFilePath } },
         { type: 'note', data: { source: 'uncaptured', content: 'body' } },
         { type: 'directory', data: { source: 'd', path: '/d' } }
       ])
@@ -286,7 +306,7 @@ describe('pathStorage relative-path safety', () => {
 
     it('reserves the prospective processed-markdown slot for an unprocessed file when a processor is set', () => {
       const reserved = collectKnowledgeReservedRelativePaths(
-        [{ id: 'i1', type: 'file', data: { relativePath: 'paper.pdf' } }],
+        [{ id: 'i1', type: 'file', data: { relativePath: 'paper.pdf' as PosixRelativeFilePath } }],
         {
           fileProcessorId: 'some-processor'
         }
@@ -297,14 +317,14 @@ describe('pathStorage relative-path safety', () => {
 
     it('does not reserve a prospective slot without a processor', () => {
       const noProcessor = collectKnowledgeReservedRelativePaths([
-        { id: 'i1', type: 'file', data: { relativePath: 'paper.pdf' } }
+        { id: 'i1', type: 'file', data: { relativePath: 'paper.pdf' as PosixRelativeFilePath } }
       ])
       expect(noProcessor).toEqual(new Set(['paper.pdf']))
     })
 
     it('does not reserve a prospective slot for a non-processed source extension', () => {
       const reserved = collectKnowledgeReservedRelativePaths(
-        [{ id: 'i1', type: 'file', data: { relativePath: 'notes.md' } }],
+        [{ id: 'i1', type: 'file', data: { relativePath: 'notes.md' as PosixRelativeFilePath } }],
         { fileProcessorId: 'some-processor' }
       )
 
@@ -326,7 +346,7 @@ describe('pathStorage relative-path safety', () => {
       // `.xls` reaches the index through AnydocReader, not a document_to_markdown
       // processor, so it never emits a `.md` artifact and needs no slot.
       const reserved = collectKnowledgeReservedRelativePaths(
-        [{ id: 'i1', type: 'file', data: { relativePath: 'report.xls' } }],
+        [{ id: 'i1', type: 'file', data: { relativePath: 'report.xls' as PosixRelativeFilePath } }],
         { fileProcessorId: 'some-processor' }
       )
 
@@ -335,7 +355,7 @@ describe('pathStorage relative-path safety', () => {
 
     it('does not reserve a prospective slot for an OpenDocument source the base cannot process', () => {
       const reserved = collectKnowledgeReservedRelativePaths(
-        [{ id: 'i1', type: 'file', data: { relativePath: 'legacy.odt' } }],
+        [{ id: 'i1', type: 'file', data: { relativePath: 'legacy.odt' as PosixRelativeFilePath } }],
         { fileProcessorId: 'some-processor' }
       )
 
@@ -346,7 +366,16 @@ describe('pathStorage relative-path safety', () => {
       // The pinned artifact has a name that is NOT the prospective slot, so the set
       // proves the prospective branch was suppressed (paper.md must be absent).
       const reserved = collectKnowledgeReservedRelativePaths(
-        [{ id: 'i1', type: 'file', data: { relativePath: 'paper.pdf', indexedRelativePath: 'paper-out.md' } }],
+        [
+          {
+            id: 'i1',
+            type: 'file',
+            data: {
+              relativePath: 'paper.pdf' as PosixRelativeFilePath,
+              indexedRelativePath: 'paper-out.md' as PosixRelativeFilePath
+            }
+          }
+        ],
         { fileProcessorId: 'some-processor' }
       )
 
@@ -357,8 +386,12 @@ describe('pathStorage relative-path safety', () => {
     it('skips the excluded item so a candidate path can be tested against the rest', () => {
       const reserved = collectKnowledgeReservedRelativePaths(
         [
-          { id: 'self', type: 'url', data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' } },
-          { id: 'other', type: 'file', data: { relativePath: 'a.pdf' } }
+          {
+            id: 'self',
+            type: 'url',
+            data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' as PosixRelativeFilePath }
+          },
+          { id: 'other', type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }
         ],
         { excludeItemId: 'self' }
       )
@@ -377,11 +410,11 @@ describe('deleteKnowledgeItemFiles', () => {
 
   it('removes file and captured url/note snapshot paths, skipping directories and uncaptured notes', async () => {
     await deleteKnowledgeItemFiles(BASE_ID, [
-      { type: 'note', data: { source: 'n', content: 'x', relativePath: 'n.md' } },
-      { type: 'url', data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' } },
+      { type: 'note', data: { source: 'n', content: 'x', relativePath: 'n.md' as PosixRelativeFilePath } },
+      { type: 'url', data: { source: 'https://x', url: 'https://x', relativePath: 'x.md' as PosixRelativeFilePath } },
       { type: 'note', data: { source: 'uncaptured', content: 'y' } },
       { type: 'directory', data: { source: 'd', path: '/d' } },
-      { type: 'file', data: { relativePath: 'a.pdf' } }
+      { type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }
     ])
 
     expect(removeMock).toHaveBeenCalledTimes(3)
@@ -392,7 +425,10 @@ describe('deleteKnowledgeItemFiles', () => {
 
   it('removes both relativePath and indexedRelativePath when they differ', async () => {
     await deleteKnowledgeItemFiles(BASE_ID, [
-      { type: 'file', data: { relativePath: 'a.pdf', indexedRelativePath: 'a.md' } }
+      {
+        type: 'file',
+        data: { relativePath: 'a.pdf' as PosixRelativeFilePath, indexedRelativePath: 'a.md' as PosixRelativeFilePath }
+      }
     ])
 
     expect(removeMock).toHaveBeenCalledTimes(2)
@@ -402,7 +438,10 @@ describe('deleteKnowledgeItemFiles', () => {
 
   it('deduplicates identical relativePath and indexedRelativePath', async () => {
     await deleteKnowledgeItemFiles(BASE_ID, [
-      { type: 'file', data: { relativePath: 'a.pdf', indexedRelativePath: 'a.pdf' } }
+      {
+        type: 'file',
+        data: { relativePath: 'a.pdf' as PosixRelativeFilePath, indexedRelativePath: 'a.pdf' as PosixRelativeFilePath }
+      }
     ])
 
     expect(removeMock).toHaveBeenCalledTimes(1)
@@ -411,21 +450,21 @@ describe('deleteKnowledgeItemFiles', () => {
 
   it('resolves when every removal succeeds (ENOENT idempotency is handled inside remove)', async () => {
     await expect(
-      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' } }])
+      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }])
     ).resolves.toBeUndefined()
   })
 
   it('propagates a non-ENOENT removal error', async () => {
     removeMock.mockRejectedValue(Object.assign(new Error('busy'), { code: 'EBUSY' }))
     await expect(
-      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' } }])
+      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }])
     ).rejects.toThrow('busy')
   })
 
   it('prunes now-empty ancestor directories deepest-first (the directory data source shell)', async () => {
     await deleteKnowledgeItemFiles(BASE_ID, [
-      { type: 'file', data: { relativePath: 'docs/sub/a.pdf' } },
-      { type: 'file', data: { relativePath: 'docs/b.pdf' } }
+      { type: 'file', data: { relativePath: 'docs/sub/a.pdf' as PosixRelativeFilePath } },
+      { type: 'file', data: { relativePath: 'docs/b.pdf' as PosixRelativeFilePath } }
     ])
 
     const prunedDirs = rmdirMock.mock.calls.map((call) => call[0])
@@ -433,7 +472,9 @@ describe('deleteKnowledgeItemFiles', () => {
   })
 
   it('leaves a top-level file with no ancestor directory to prune', async () => {
-    await deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' } }])
+    await deleteKnowledgeItemFiles(BASE_ID, [
+      { type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }
+    ])
 
     expect(rmdirMock).not.toHaveBeenCalled()
   })
@@ -442,7 +483,9 @@ describe('deleteKnowledgeItemFiles', () => {
     rmdirMock.mockRejectedValue(Object.assign(new Error('not empty'), { code: 'ENOTEMPTY' }))
 
     await expect(
-      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'docs/a.pdf' } }])
+      deleteKnowledgeItemFiles(BASE_ID, [
+        { type: 'file', data: { relativePath: 'docs/a.pdf' as PosixRelativeFilePath } }
+      ])
     ).resolves.toBeUndefined()
     expect(rmdirMock).toHaveBeenCalledWith(path.join(MATERIAL_DIR, 'docs'))
     // ENOTEMPTY/ENOENT are expected outcomes — they must not produce log noise.
@@ -453,7 +496,9 @@ describe('deleteKnowledgeItemFiles', () => {
     rmdirMock.mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
 
     await expect(
-      deleteKnowledgeItemFiles(BASE_ID, [{ type: 'file', data: { relativePath: 'docs/a.pdf' } }])
+      deleteKnowledgeItemFiles(BASE_ID, [
+        { type: 'file', data: { relativePath: 'docs/a.pdf' as PosixRelativeFilePath } }
+      ])
     ).resolves.toBeUndefined()
     expect(warnMock).toHaveBeenCalledWith(
       'Failed to prune empty knowledge material directory',
@@ -469,9 +514,13 @@ describe('deleteKnowledgeItemFilesBestEffort', () => {
   })
 
   it('delegates to deleteKnowledgeItemFiles on the happy path without logging', async () => {
-    await deleteKnowledgeItemFilesBestEffort(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' } }], {
-      baseId: BASE_ID
-    })
+    await deleteKnowledgeItemFilesBestEffort(
+      BASE_ID,
+      [{ type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }],
+      {
+        baseId: BASE_ID
+      }
+    )
 
     expect(removeMock).toHaveBeenCalledWith(path.join(MATERIAL_DIR, 'a.pdf'))
     expect(errorMock).not.toHaveBeenCalled()
@@ -481,18 +530,26 @@ describe('deleteKnowledgeItemFilesBestEffort', () => {
     removeMock.mockRejectedValue(Object.assign(new Error('busy'), { code: 'EBUSY' }))
 
     await expect(
-      deleteKnowledgeItemFilesBestEffort(BASE_ID, [{ type: 'file', data: { relativePath: 'a.pdf' } }], {
-        baseId: BASE_ID
-      })
+      deleteKnowledgeItemFilesBestEffort(
+        BASE_ID,
+        [{ type: 'file', data: { relativePath: 'a.pdf' as PosixRelativeFilePath } }],
+        {
+          baseId: BASE_ID
+        }
+      )
     ).resolves.toBeUndefined()
     expect(errorMock).toHaveBeenCalledTimes(1)
   })
 
   it('swallows and logs a reserved/unsafe relative path that would throw before any removal', async () => {
     await expect(
-      deleteKnowledgeItemFilesBestEffort(BASE_ID, [{ type: 'file', data: { relativePath: '../escape.pdf' } }], {
-        baseId: BASE_ID
-      })
+      deleteKnowledgeItemFilesBestEffort(
+        BASE_ID,
+        [{ type: 'file', data: { relativePath: '../escape.pdf' as PosixRelativeFilePath } }],
+        {
+          baseId: BASE_ID
+        }
+      )
     ).resolves.toBeUndefined()
     expect(removeMock).not.toHaveBeenCalled()
     expect(errorMock).toHaveBeenCalledTimes(1)

--- a/src/main/features/knowledge/ingestion/__tests__/addConflicts.test.ts
+++ b/src/main/features/knowledge/ingestion/__tests__/addConflicts.test.ts
@@ -1,5 +1,6 @@
 import type { KnowledgeAddItemInput, KnowledgeItem } from '@shared/data/types/knowledge'
 import type { AbsoluteFilePath } from '@shared/types/file'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
 import { resolveKnowledgeAddConflicts } from '../addConflicts'
@@ -30,7 +31,10 @@ describe('resolveKnowledgeAddConflicts', () => {
   it('reports no conflicts and keeps all inputs when nothing collides', () => {
     const inputs = [fileInput('/a/report.pdf'), urlInput('https://x.com')]
     const existing = [
-      existingItem('e1', { type: 'file', data: { source: '/old/other.pdf', relativePath: 'other.pdf' } })
+      existingItem('e1', {
+        type: 'file',
+        data: { source: '/old/other.pdf', relativePath: 'other.pdf' as PosixRelativeFilePath }
+      })
     ]
 
     const result = resolveKnowledgeAddConflicts(inputs, existing)
@@ -43,7 +47,10 @@ describe('resolveKnowledgeAddConflicts', () => {
   it('detects a collision against an existing root and reports the existing display title', () => {
     const inputs = [fileInput('/folderA/report.pdf')]
     const existing = [
-      existingItem('e1', { type: 'file', data: { source: '/old/report.pdf', relativePath: 'report.pdf' } })
+      existingItem('e1', {
+        type: 'file',
+        data: { source: '/old/report.pdf', relativePath: 'report.pdf' as PosixRelativeFilePath }
+      })
     ]
 
     const result = resolveKnowledgeAddConflicts(inputs, existing)
@@ -68,7 +75,11 @@ describe('resolveKnowledgeAddConflicts', () => {
     const existing = [
       existingItem('e1', {
         type: 'url',
-        data: { source: 'https://x.com', url: 'https://x.com', relativePath: 'Captured Title.md' }
+        data: {
+          source: 'https://x.com',
+          url: 'https://x.com',
+          relativePath: 'Captured Title.md' as PosixRelativeFilePath
+        }
       })
     ]
 
@@ -95,7 +106,10 @@ describe('resolveKnowledgeAddConflicts', () => {
   it('dedupes the reported conflicts by type and key', () => {
     const inputs = [fileInput('/folderA/report.pdf'), fileInput('/folderB/report.pdf')]
     const existing = [
-      existingItem('e1', { type: 'file', data: { source: '/old/report.pdf', relativePath: 'report.pdf' } })
+      existingItem('e1', {
+        type: 'file',
+        data: { source: '/old/report.pdf', relativePath: 'report.pdf' as PosixRelativeFilePath }
+      })
     ]
 
     const result = resolveKnowledgeAddConflicts(inputs, existing)
@@ -110,9 +124,18 @@ describe('resolveKnowledgeAddConflicts', () => {
     // leaving test_2.md / test_3.md intact — they are distinct, deliberately-kept copies.
     const inputs = [fileInput('/incoming/test.md')]
     const existing = [
-      existingItem('e1', { type: 'file', data: { source: '/a/test.md', relativePath: 'test.md' } }),
-      existingItem('e2', { type: 'file', data: { source: '/b/test.md', relativePath: 'test_2.md' } }),
-      existingItem('e3', { type: 'file', data: { source: '/c/test.md', relativePath: 'test_3.md' } })
+      existingItem('e1', {
+        type: 'file',
+        data: { source: '/a/test.md', relativePath: 'test.md' as PosixRelativeFilePath }
+      }),
+      existingItem('e2', {
+        type: 'file',
+        data: { source: '/b/test.md', relativePath: 'test_2.md' as PosixRelativeFilePath }
+      }),
+      existingItem('e3', {
+        type: 'file',
+        data: { source: '/c/test.md', relativePath: 'test_3.md' as PosixRelativeFilePath }
+      })
     ]
 
     const result = resolveKnowledgeAddConflicts(inputs, existing)
@@ -128,7 +151,7 @@ describe('resolveKnowledgeAddConflicts', () => {
     const existing = [
       existingItem('e1', {
         type: 'note',
-        data: { source: 'Q4: plan', content: 'old body', relativePath: 'Q4_ plan.md' }
+        data: { source: 'Q4: plan', content: 'old body', relativePath: 'Q4_ plan.md' as PosixRelativeFilePath }
       })
     ]
 

--- a/src/main/features/knowledge/pathStorage.ts
+++ b/src/main/features/knowledge/pathStorage.ts
@@ -6,8 +6,13 @@ import { loggerService } from '@logger'
 import { copy, ensureDir, type PathReadability, probeReadable, remove, removeDir, write } from '@main/utils/file'
 import { nextFreeKnowledgeRelativePath } from '@main/utils/knowledge'
 import { getFileExt } from '@main/utils/legacyFile'
+import { KnowledgeRelativePathSchema } from '@shared/data/types/knowledge'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
-import { knowledgeFileProcessingExts } from '@shared/utils/file'
+import {
+  knowledgeFileProcessingExts,
+  type PosixRelativeFilePath,
+  resolvePosixRelativeSegments
+} from '@shared/utils/file'
 
 const logger = loggerService.withContext('Knowledge:PathStorage')
 
@@ -86,16 +91,22 @@ export async function probeKnowledgeSourcePath(absolutePath: string): Promise<Pa
   return probeReadable(AbsoluteFilePathSchema.parse(absolutePath))
 }
 
-export function getKnowledgeSourceRelativePath(sourcePath: string): string {
+export function getKnowledgeSourceRelativePath(sourcePath: string): PosixRelativeFilePath {
   const fileName = path.basename(sourcePath)
   assertSafeKnowledgeRelativePath(fileName)
   return fileName
 }
 
-export function getProcessedMarkdownRelativePath(relativePath: string): string {
+export function getProcessedMarkdownRelativePath(relativePath: string): PosixRelativeFilePath {
   assertSafeKnowledgeRelativePath(relativePath)
   const parsed = path.parse(relativePath)
-  return normalizeRelativePath(path.join(parsed.dir, `${parsed.name}.md`))
+  // Re-asserted rather than inheriting the input's brand: swapping the extension
+  // builds a NEW string, and `path.parse` on a dotfile (`.env` → name `.env`,
+  // ext '') can turn one into `.env.md` — a different path that has to clear the
+  // guard on its own.
+  const processed = normalizeRelativePath(path.join(parsed.dir, `${parsed.name}.md`))
+  assertSafeKnowledgeRelativePath(processed)
+  return processed
 }
 
 /**
@@ -111,7 +122,7 @@ export function reserveImportedFileRelativePath(
   sourceRelativePath: string,
   reserveProcessedArtifact: boolean,
   reservedPaths: Set<string>
-): string {
+): PosixRelativeFilePath {
   const chosen = nextFreeKnowledgeRelativePath(sourceRelativePath, (candidate) => {
     if (reservedPaths.has(candidate)) {
       return false
@@ -119,6 +130,10 @@ export function reserveImportedFileRelativePath(
     return !reserveProcessedArtifact || !reservedPaths.has(getProcessedMarkdownRelativePath(candidate))
   })
 
+  // `nextFreeKnowledgeRelativePath` derives the suffixed name itself, so the
+  // result is a new string that has not been through the guard — assert before
+  // handing it out as a branded value.
+  assertSafeKnowledgeRelativePath(chosen)
   reservedPaths.add(chosen)
   if (reserveProcessedArtifact) {
     reservedPaths.add(getProcessedMarkdownRelativePath(chosen))
@@ -129,9 +144,9 @@ export function reserveImportedFileRelativePath(
 export async function copyFileIntoKnowledgeBaseAt(
   baseId: string,
   sourcePath: string,
-  relativePath: string,
+  relativePath: PosixRelativeFilePath,
   options: { signal?: AbortSignal; overwrite?: boolean } = {}
-): Promise<string> {
+): Promise<PosixRelativeFilePath> {
   const destPath = getKnowledgeBaseFilePath(baseId, relativePath)
   // `overwrite` lets directory expansion re-copy over its own orphans from a prior
   // aborted attempt (the prefix is unique per container, so a same-named dest can
@@ -147,9 +162,9 @@ export async function copyFileIntoKnowledgeBaseAt(
 /** Write in-memory content (e.g. a captured URL snapshot) to a base-relative file. */
 export async function writeFileIntoKnowledgeBaseAt(
   baseId: string,
-  relativePath: string,
+  relativePath: PosixRelativeFilePath,
   content: string
-): Promise<string> {
+): Promise<PosixRelativeFilePath> {
   const destPath = getKnowledgeBaseFilePath(baseId, relativePath)
   await assertTargetAvailable(destPath)
   await ensureDir(AbsoluteFilePathSchema.parse(path.dirname(destPath)))
@@ -304,21 +319,52 @@ export async function deleteKnowledgeBaseDir(baseId: string): Promise<void> {
   await removeDir(getKnowledgeBaseDir(baseId))
 }
 
-export function assertSafeKnowledgeRelativePath(relativePath: string): void {
-  if (!relativePath || path.isAbsolute(relativePath) || relativePath.includes('\0')) {
+/**
+ * The filesystem-boundary guard for every material path, layered over the shape
+ * rules rather than restating them:
+ *
+ * - **Shape** (not anchored to a root, no null byte, POSIX-legal segments) and
+ *   **containment under `raw/`** both come from `KnowledgeRelativePathSchema`,
+ *   the same gate on the four persisted `relativePath` fields. Kept here as
+ *   defence in depth: paths derived *after* that schema ran
+ *   (`getProcessedMarkdownRelativePath`, `nextFreeKnowledgeRelativePath`) reach
+ *   the filesystem through this function without being re-parsed.
+ * - **Reserved prefix** stays here, because it is about `raw/` specifically and
+ *   not about relative paths in general.
+ *
+ * Reading the first POSIX segment rather than folding separators is what takes
+ * this function off `normalizeRelativePath`, and it fixes a false rejection:
+ * `.cherry\x` is one legal Linux filename sitting directly under `raw/`, not
+ * something inside the reserved `.cherry/` directory. The old unconditional
+ * `\`→`/` fold said otherwise (#17429).
+ *
+ * Declared as an assertion function, which makes it the sole producer of
+ * `PosixRelativeFilePath` on this side: the helpers below return branded values
+ * simply by asserting, with no cast anywhere.
+ */
+export function assertSafeKnowledgeRelativePath(relativePath: string): asserts relativePath is PosixRelativeFilePath {
+  const parsed = KnowledgeRelativePathSchema.safeParse(relativePath)
+  if (!parsed.success) {
     throw new Error(`Invalid knowledge relative path: ${relativePath}`)
   }
 
-  const normalized = normalizeRelativePath(relativePath)
-  if (normalized === '.' || normalized === '..' || normalized.startsWith('../')) {
-    throw new Error(`Invalid knowledge relative path: ${relativePath}`)
-  }
-
-  if (normalized.startsWith(`${CHERRY_META_DIR}/`) || normalized === CHERRY_META_DIR) {
+  // Non-null: the schema above already proved it resolves.
+  const segments = resolvePosixRelativeSegments(relativePath) ?? []
+  if (segments[0] === CHERRY_META_DIR) {
     throw new Error(`Knowledge relative path is reserved: ${relativePath}`)
   }
 }
 
+/**
+ * Producer-side POSIX spelling for a path this module builds with `path.join`,
+ * which emits `\` on Windows while material paths are stored `/`-separated.
+ *
+ * The fold is unconditional and therefore lossy on POSIX, where `\` is an
+ * ordinary filename character: a source truly named `a\b.xls` yields `a/b.md`
+ * here, one segment too deep. Tracked in #17429 — fixing it means teaching this
+ * function the platform distinction that `pathSpec` now draws, which is out of
+ * scope for the type work that removed its other caller.
+ */
 function normalizeRelativePath(relativePath: string): string {
   return path.normalize(relativePath).replace(/\\/g, '/')
 }

--- a/src/main/features/knowledge/pipeline/readers/__tests__/KnowledgeReaderMetadata.test.ts
+++ b/src/main/features/knowledge/pipeline/readers/__tests__/KnowledgeReaderMetadata.test.ts
@@ -1,4 +1,5 @@
 import type * as FsUtils from '@main/utils/file'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { loadDataMock, readFileMock } = vi.hoisted(() => ({
@@ -64,7 +65,7 @@ describe('knowledge reader metadata', () => {
       type: 'file',
       data: {
         source: '/tmp/original.txt',
-        relativePath: 'original.txt'
+        relativePath: 'original.txt' as PosixRelativeFilePath
       },
       status: 'processing',
       error: null,
@@ -89,7 +90,11 @@ describe('knowledge reader metadata', () => {
         baseId: 'kb-1',
         groupId: null,
         type: 'url',
-        data: { source: 'https://example.com', url: 'https://example.com', relativePath: 'example.md' },
+        data: {
+          source: 'https://example.com',
+          url: 'https://example.com',
+          relativePath: 'example.md' as PosixRelativeFilePath
+        },
         status: 'processing',
         error: null,
         createdAt: '2026-04-08T00:00:00.000Z',
@@ -134,7 +139,11 @@ describe('knowledge reader metadata', () => {
         baseId: 'kb-1',
         groupId: null,
         type: 'note',
-        data: { source: 'My note', content: '# Note title\n\nbody', relativePath: 'My note.md' },
+        data: {
+          source: 'My note',
+          content: '# Note title\n\nbody',
+          relativePath: 'My note.md' as PosixRelativeFilePath
+        },
         status: 'processing',
         error: null,
         createdAt: '2026-04-08T00:00:00.000Z',

--- a/src/main/features/knowledge/pipeline/readers/__tests__/ReaderFactory.test.ts
+++ b/src/main/features/knowledge/pipeline/readers/__tests__/ReaderFactory.test.ts
@@ -1,6 +1,7 @@
 import type * as FsUtils from '@main/utils/file'
 import type { KnowledgeItemOf } from '@shared/data/types/knowledge'
 import type { AbsoluteFilePath } from '@shared/types/file'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const fetchMock = vi.hoisted(() => vi.fn())
@@ -133,12 +134,12 @@ function createFileItem(ext: string, sourcePath?: string): KnowledgeItemOf<'file
     updatedAt: '2026-04-03T00:00:00.000Z',
     data: {
       source: sourcePath ?? `/tmp/sample${ext}`,
-      relativePath: `sample${ext}`
+      relativePath: `sample${ext}` as PosixRelativeFilePath
     }
   }
 }
 
-function createNoteItem(content: string, relativePath = 'note-1.md'): KnowledgeItemOf<'note'> {
+function createNoteItem(content: string, relativePath = 'note-1.md' as PosixRelativeFilePath): KnowledgeItemOf<'note'> {
   return {
     id: 'note-1',
     baseId: 'base-1',
@@ -169,7 +170,7 @@ function createUrlItem(): KnowledgeItemOf<'url'> {
     data: {
       source: 'https://example.com',
       url: 'https://example.com',
-      relativePath: 'example-page.md'
+      relativePath: 'example-page.md' as PosixRelativeFilePath
     }
   }
 }
@@ -236,8 +237,8 @@ describe('loadKnowledgeItemDocuments', () => {
       ...createFileItem('.pdf', '/tmp/source.pdf'),
       data: {
         source: '/tmp/source.pdf',
-        relativePath: 'source.pdf',
-        indexedRelativePath: 'source.md'
+        relativePath: 'source.pdf' as PosixRelativeFilePath,
+        indexedRelativePath: 'source.md' as PosixRelativeFilePath
       }
     }
 
@@ -304,7 +305,7 @@ describe('loadKnowledgeItemDocuments', () => {
 
   it('creates a note reader that returns a single Document from its snapshot', async () => {
     readFileMock.mockResolvedValueOnce('hello world')
-    const item = createNoteItem('hello world', 'my-note.md')
+    const item = createNoteItem('hello world', 'my-note.md' as PosixRelativeFilePath)
     const docs = await loadKnowledgeItemDocuments(item)
 
     expect(readFileMock).toHaveBeenCalledWith('/mock/feature.knowledgebase.data/base-1/raw/my-note.md')

--- a/src/main/features/knowledge/pipeline/sources/__tests__/sourcePlanning.test.ts
+++ b/src/main/features/knowledge/pipeline/sources/__tests__/sourcePlanning.test.ts
@@ -1,4 +1,5 @@
 import type { KnowledgeBase, KnowledgeItemOf } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
 import { planKnowledgeItemSource } from '../sourcePlanning'
@@ -30,7 +31,7 @@ function createFileItem(source: string): KnowledgeItemOf<'file'> {
     baseId: 'kb-1',
     groupId: null,
     type: 'file',
-    data: { source, relativePath: source.split('/').pop() ?? source },
+    data: { source, relativePath: (source.split('/').pop() ?? source) as PosixRelativeFilePath },
     status: 'processing',
     error: null,
     createdAt: '2026-04-08T00:00:00.000Z',
@@ -62,7 +63,7 @@ describe('planKnowledgeItemSource', () => {
 
   it('indexes a file that already carries a processed artifact directly, skipping the processor', () => {
     const item = createFileItem('/docs/source.pdf')
-    item.data.indexedRelativePath = 'source.md'
+    item.data.indexedRelativePath = 'source.md' as PosixRelativeFilePath
     expect(planKnowledgeItemSource(createBase(), item)).toEqual({ kind: 'index-documents' })
   })
 })

--- a/src/main/features/knowledge/pipeline/sources/directory.ts
+++ b/src/main/features/knowledge/pipeline/sources/directory.ts
@@ -90,10 +90,15 @@ async function expandDirectoryNode(
     // basename across subdirectories don't collide and the hierarchy survives.
     // The whole tree resolves under the base material root (raw/) via the helper.
     const subtreePath = node.treePath.replace(/^\/+/, '')
+    // Both halves were guarded on their own (`pathPrefix` in expandDirectory,
+    // `treePath` by the tree layer), but the join is a new path — assert it here,
+    // which is also what brands it for `copyFileIntoKnowledgeBaseAt`.
+    const materialPath = `${pathPrefix}/${subtreePath}`
+    assertSafeKnowledgeRelativePath(materialPath)
     // Thread the abort signal so a hung single-file copy can be interrupted, and allow
     // overwrite so a retry after a mid-scan abort re-copies over its own leftover files
     // instead of failing on the pre-existing dest (see prepareRoot retry idempotency).
-    const relativePath = await copyFileIntoKnowledgeBaseAt(baseId, node.externalPath, `${pathPrefix}/${subtreePath}`, {
+    const relativePath = await copyFileIntoKnowledgeBaseAt(baseId, node.externalPath, materialPath, {
       signal,
       overwrite: true
     })

--- a/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
@@ -1,4 +1,5 @@
 import { LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { MockMainCacheServiceExport } from '@test-mocks/main/CacheService'
 import { describe, expect, it } from 'vitest'
 
@@ -346,7 +347,7 @@ describe('index-documents job handler', () => {
   it('uses the processed-artifact path (indexedRelativePath) as the material relative path', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
     const fileItem = createFileItem(FILE_ITEM_ID)
-    fileItem.data.indexedRelativePath = 'source.md'
+    fileItem.data.indexedRelativePath = 'source.md' as PosixRelativeFilePath
     knowledgeItemGetByIdMock.mockReturnValue(fileItem)
     knowledgeItemUpdateStatusMock.mockReturnValue(fileItem)
 
@@ -439,7 +440,10 @@ describe('index-documents job handler', () => {
     expect(knowledgeItemUpdateSnapshotRelativePathMock).toHaveBeenCalledWith('url-1', 'url', 'example-page.md')
     // The reader receives the item carrying the freshly captured snapshot path.
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'url-1', data: expect.objectContaining({ relativePath: 'example-page.md' }) })
+      expect.objectContaining({
+        id: 'url-1',
+        data: expect.objectContaining({ relativePath: 'example-page.md' as PosixRelativeFilePath })
+      })
     )
     // The material's relative_path is the real snapshot path under `raw/`, not the
     // item-id virtual placeholder — so it points at the bytes captureUrlSnapshotFile
@@ -454,7 +458,7 @@ describe('index-documents job handler', () => {
 
   it('does not fetch a URL that already has a captured snapshot', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
-    knowledgeItemGetByIdMock.mockReturnValue(createUrlItem('url-1', 'cached.md'))
+    knowledgeItemGetByIdMock.mockReturnValue(createUrlItem('url-1', 'cached.md' as PosixRelativeFilePath))
 
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: 'url-1' }))
 
@@ -462,7 +466,7 @@ describe('index-documents job handler', () => {
     expect(captureUrlSnapshotFileMock).not.toHaveBeenCalled()
     expect(knowledgeItemUpdateSnapshotRelativePathMock).not.toHaveBeenCalled()
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'cached.md' }) })
+      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'cached.md' as PosixRelativeFilePath }) })
     )
   })
 
@@ -471,7 +475,7 @@ describe('index-documents job handler', () => {
     // Load sees no snapshot; the in-lock re-read sees one a concurrent job wrote.
     knowledgeItemGetByIdMock
       .mockReturnValueOnce(createUrlItem('url-1'))
-      .mockReturnValueOnce(createUrlItem('url-1', 'raced.md'))
+      .mockReturnValueOnce(createUrlItem('url-1', 'raced.md' as PosixRelativeFilePath))
 
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: 'url-1' }))
 
@@ -480,7 +484,7 @@ describe('index-documents job handler', () => {
     expect(captureUrlSnapshotFileMock).not.toHaveBeenCalled()
     expect(knowledgeItemUpdateSnapshotRelativePathMock).not.toHaveBeenCalled()
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'raced.md' }) })
+      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'raced.md' as PosixRelativeFilePath }) })
     )
     // The material is stamped with the raced snapshot path too — the concurrently
     // captured file, not the item-id placeholder.
@@ -525,7 +529,10 @@ describe('index-documents job handler', () => {
     expect(knowledgeItemUpdateSnapshotRelativePathMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'note', 'My note.md')
     // The reader receives the item carrying the freshly captured snapshot path.
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ id: NOTE_ITEM_ID, data: expect.objectContaining({ relativePath: 'My note.md' }) })
+      expect.objectContaining({
+        id: NOTE_ITEM_ID,
+        data: expect.objectContaining({ relativePath: 'My note.md' as PosixRelativeFilePath })
+      })
     )
     // The material's relative_path is the real snapshot path under `raw/`, not the
     // item-id virtual placeholder — so it points at the bytes captureNoteSnapshotFile wrote.
@@ -534,14 +541,18 @@ describe('index-documents job handler', () => {
 
   it('does not capture a note that already has a snapshot', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
-    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID, null, 'processing', 'cached-note.md'))
+    knowledgeItemGetByIdMock.mockReturnValue(
+      createNoteItem(NOTE_ITEM_ID, null, 'processing', 'cached-note.md' as PosixRelativeFilePath)
+    )
 
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
 
     expect(captureNoteSnapshotFileMock).not.toHaveBeenCalled()
     expect(knowledgeItemUpdateSnapshotRelativePathMock).not.toHaveBeenCalled()
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'cached-note.md' }) })
+      expect.objectContaining({
+        data: expect.objectContaining({ relativePath: 'cached-note.md' as PosixRelativeFilePath })
+      })
     )
   })
 
@@ -551,14 +562,16 @@ describe('index-documents job handler', () => {
     const noSnapshotNote = { ...createNoteItem(NOTE_ITEM_ID), data: { source: 'My note', content: 'note body' } }
     knowledgeItemGetByIdMock
       .mockReturnValueOnce(noSnapshotNote)
-      .mockReturnValueOnce(createNoteItem(NOTE_ITEM_ID, null, 'processing', 'raced-note.md'))
+      .mockReturnValueOnce(createNoteItem(NOTE_ITEM_ID, null, 'processing', 'raced-note.md' as PosixRelativeFilePath))
 
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
 
     expect(captureNoteSnapshotFileMock).not.toHaveBeenCalled()
     expect(knowledgeItemUpdateSnapshotRelativePathMock).not.toHaveBeenCalled()
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ relativePath: 'raced-note.md' }) })
+      expect.objectContaining({
+        data: expect.objectContaining({ relativePath: 'raced-note.md' as PosixRelativeFilePath })
+      })
     )
     expect(lastRebuildInput().material.relativePath).toBe('raced-note.md')
   })

--- a/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
+++ b/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
@@ -2,6 +2,7 @@ import type { JobContext } from '@main/core/job/types'
 import type * as FsUtils from '@main/utils/file'
 import type { JobSnapshot } from '@shared/data/api/schemas/jobs'
 import type { KnowledgeBase, KnowledgeItemOf } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
 import { beforeEach, type Mocked, vi } from 'vitest'
 
@@ -199,7 +200,7 @@ export const { createReindexSubtreeJobHandler } = await import('../reindexSubtre
 
 export const NOTE_ITEM_ID = '0198f3f2-7d1a-7abc-8def-123456789abc'
 export const FILE_ITEM_ID = '0198f3f2-7d1a-7abc-8def-123456789abd'
-export const FILE_RELATIVE_PATH = 'source.pdf'
+export const FILE_RELATIVE_PATH = 'source.pdf' as PosixRelativeFilePath
 export const PROCESSED_RELATIVE_PATH = 'source.md'
 type KnowledgeJobSnapshotInput = Pick<JobSnapshot, 'type' | 'input'> & Partial<JobSnapshot>
 
@@ -232,7 +233,7 @@ export function createNoteItem(
   // Default to an already-captured snapshot so the item is a valid indexable
   // leaf that passes straight through ensureSnapshot; pass undefined (or
   // override `data`) to exercise the first-index capture path.
-  relativePath: string | undefined = `${id}.md`
+  relativePath: PosixRelativeFilePath | undefined = `${id}.md` as PosixRelativeFilePath
 ): KnowledgeItemOf<'note'> {
   return {
     id,
@@ -249,7 +250,7 @@ export function createNoteItem(
 
 export function createUrlItem(
   id = 'url-1',
-  relativePath?: string,
+  relativePath?: PosixRelativeFilePath,
   status: Exclude<KnowledgeItemOf<'url'>['status'], 'failed'> = 'processing'
 ): KnowledgeItemOf<'url'> {
   return {
@@ -381,7 +382,7 @@ beforeEach(() => {
   captureUrlSnapshotFileMock.mockResolvedValue('example-page.md')
   captureNoteSnapshotFileMock.mockResolvedValue('note-snapshot.md')
   knowledgeItemUpdateSnapshotRelativePathMock.mockImplementation(
-    (id: string, type: 'url' | 'note', relativePath: string) =>
+    (id: string, type: 'url' | 'note', relativePath: PosixRelativeFilePath) =>
       type === 'url' ? createUrlItem(id, relativePath) : createNoteItem(id, null, 'processing', relativePath)
   )
   loadKnowledgeItemDocumentsMock.mockResolvedValue([

--- a/src/main/features/knowledge/tasks/__tests__/prepareItem.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/prepareItem.test.ts
@@ -1,4 +1,5 @@
 import type { KnowledgeItem } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -93,7 +94,7 @@ function createFileItem(id = 'file-1', groupId: string | null = null): Knowledge
     type: 'file',
     data: {
       source: `/docs/${id}.md`,
-      relativePath: `${id}.md`
+      relativePath: `${id}.md` as PosixRelativeFilePath
     },
     status: 'processing',
     error: null,
@@ -202,11 +203,11 @@ describe('prepareKnowledgeItem', () => {
     // counted itself as reserved, expansion would dedupe it to `docs_1` every run.
     const root = createDirectoryItem('dir-root')
     // Pin the container's own prefix, as if it had already been indexed once.
-    root.data = { source: '/abs/docs', relativePath: 'docs' }
+    root.data = { source: '/abs/docs', relativePath: 'docs' as PosixRelativeFilePath }
     const sibling = createFileItem('file-sibling') // top-level relativePath `file-sibling.md`
     knowledgeItemGetItemsByBaseIdMock.mockReturnValueOnce([root, sibling])
     expandDirectoryOwnerToTreeMock.mockResolvedValueOnce([
-      { type: 'file', data: { source: '/abs/docs/a.md', relativePath: 'docs/a.md' } }
+      { type: 'file', data: { source: '/abs/docs/a.md', relativePath: 'docs/a.md' as PosixRelativeFilePath } }
     ])
 
     return prepareKnowledgeItem(createPrepareOptions(root)).then(() => {
@@ -248,7 +249,7 @@ describe('prepareKnowledgeItem', () => {
           type: 'file',
           data: {
             source: '/docs/file-child.md',
-            relativePath: 'file-child.md'
+            relativePath: 'file-child.md' as PosixRelativeFilePath
           }
         }
       ]

--- a/src/renderer/components/chat/messages/tools/painting/__tests__/MessageGenerateImage.test.tsx
+++ b/src/renderer/components/chat/messages/tools/painting/__tests__/MessageGenerateImage.test.tsx
@@ -1,4 +1,5 @@
 import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
+import type * as SharedFileUtils from '@shared/utils/file'
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -7,7 +8,10 @@ const { getPhysicalPath } = vi.hoisted(() => ({ getPhysicalPath: vi.fn() }))
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
-vi.mock('@shared/utils/file', () => ({
+// Partial mock: only `toSafeFileUrl` is stubbed. Replacing the whole barrel
+// breaks any module that pulls a different export from it at import time.
+vi.mock('@shared/utils/file', async (importOriginal) => ({
+  ...(await importOriginal<typeof SharedFileUtils>()),
   toSafeFileUrl: (path: string) => `file://${path}`
 }))
 vi.mock('@renderer/components/Spinner', () => ({

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -9,6 +9,7 @@ import type {
   KnowledgeItemOf,
   RestoreKnowledgeBaseResult
 } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -578,7 +579,7 @@ const createKnowledgeDirectoryItem = ({ id }: { id: string }): KnowledgeItemOf<'
   type: 'directory',
   data: {
     source: `/knowledge/${id}`,
-    relativePath: id
+    relativePath: id as PosixRelativeFilePath
   },
   status: 'completed',
   error: null,

--- a/src/renderer/pages/knowledge/hooks/__tests__/usePreviewKnowledgeSource.test.ts
+++ b/src/renderer/pages/knowledge/hooks/__tests__/usePreviewKnowledgeSource.test.ts
@@ -6,6 +6,7 @@ import {
 import { toast } from '@renderer/services/toast'
 import { IpcError } from '@shared/ipc/errors/IpcError'
 import { knowledgeErrorCodes } from '@shared/ipc/errors/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -166,7 +167,7 @@ describe('usePreviewKnowledgeSource', () => {
     const item = createUrlItem({
       id: 'url-1',
       source: 'https://example.com/product-docs',
-      relativePath: 'Product Docs.md'
+      relativePath: 'Product Docs.md' as PosixRelativeFilePath
     })
 
     await act(async () => {
@@ -261,7 +262,7 @@ describe('usePreviewKnowledgeSource', () => {
         createUrlItem({
           id: 'url-1',
           source: 'https://example.com/product-docs',
-          relativePath: 'Product Docs.md'
+          relativePath: 'Product Docs.md' as PosixRelativeFilePath
         })
       )
     })

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/dataSourcePanel.selectors.test.ts
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/dataSourcePanel.selectors.test.ts
@@ -1,3 +1,4 @@
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
 import { getItemStatus, getItemTitle } from '../utils/selectors'
@@ -14,7 +15,7 @@ describe('dataSourcePanel.selectors', () => {
         createUrlItem({
           id: 'url-1',
           source: 'https://example.com/product-docs',
-          relativePath: 'Drop-in replacements for React Native UI.md'
+          relativePath: 'Drop-in replacements for React Native UI.md' as PosixRelativeFilePath
         })
       )
     ).toBe('Drop-in replacements for React Native UI')

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/testUtils.ts
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/testUtils.ts
@@ -1,4 +1,5 @@
 import { getKnowledgeNoteFirstLine, getKnowledgePathBasename, type KnowledgeItemOf } from '@shared/data/types/knowledge'
+import type { PosixRelativeFilePath } from '@shared/utils/file'
 
 type KnowledgeItemLifecycle<TItem extends { error: unknown; status: string }> = TItem extends unknown
   ? Pick<TItem, 'error' | 'status'>
@@ -85,7 +86,7 @@ export const createFileItem = ({
   type: 'file',
   data: {
     source,
-    relativePath: getKnowledgePathBasename(source)
+    relativePath: getKnowledgePathBasename(source) as PosixRelativeFilePath
   }
 })
 
@@ -97,7 +98,7 @@ export const createUrlItem = ({
 }: {
   id: string
   source?: string
-  relativePath?: string
+  relativePath?: PosixRelativeFilePath
   status?: KnowledgeItemOf<'url'>['status']
 }): KnowledgeItemOf<'url'> => ({
   ...baseFields,

--- a/src/shared/data/types/__tests__/knowledge.test.ts
+++ b/src/shared/data/types/__tests__/knowledge.test.ts
@@ -1,12 +1,74 @@
+import { PosixRelativeFilePathSchema } from '@shared/utils/file'
 import { describe, expect, it } from 'vitest'
 
 import {
+  DirectoryItemDataSchema,
+  FileItemDataSchema,
   getKnowledgeItemConflictKey,
   getKnowledgeItemDisplayTitle,
   getKnowledgeNoteFirstLine,
   getKnowledgePathBasename,
+  KnowledgeRelativePathSchema,
   KnowledgeSearchResultSchema
 } from '../knowledge'
+
+describe('KnowledgeRelativePathSchema', () => {
+  it.each([
+    ['a deduped filename', '测试_2.pdf'],
+    ['a directory-expanded leaf', 'docs/a.pdf'],
+    ['a leading space, which sanitizeFilename does not strip', ' a.pdf'],
+    ['a backslash, which is one legal POSIX filename', 'a\\b.txt'],
+    ['a name that only Windows would refuse', 'CON.txt']
+  ])('accepts %s', (_label, value) => {
+    expect(KnowledgeRelativePathSchema.safeParse(value).success).toBe(true)
+  })
+
+  it.each([
+    ['the material root itself', '.'],
+    ['a climb landing back on the root', 'a/..'],
+    ['the empty string', ''],
+    ['an escape above the root', '../x'],
+    ['an absolute path', '/x'],
+    ['a null byte', 'a\0b']
+  ])('rejects %s', (_label, value) => {
+    expect(KnowledgeRelativePathSchema.safeParse(value).success).toBe(false)
+  })
+
+  it('returns the value unchanged — the old .trim() desynced a stored path from the file on disk', () => {
+    expect(KnowledgeRelativePathSchema.parse(' a.pdf')).toBe(' a.pdf')
+  })
+
+  it('owns the containment rule the shape brand deliberately does not', () => {
+    // `PosixRelativeFilePathSchema` accepts `../x` — it is a relative path, just one
+    // pointing outside its base. Keeping material inside the root is this layer's job.
+    expect(PosixRelativeFilePathSchema.safeParse('../escape.md').success).toBe(true)
+    expect(KnowledgeRelativePathSchema.safeParse('../escape.md').success).toBe(false)
+    expect(KnowledgeRelativePathSchema.safeParse('a/../../escape.md').success).toBe(false)
+  })
+
+  it('leaves the reserved .cherry prefix to the filesystem-boundary guard', () => {
+    // Shape is fine; `assertSafeKnowledgeRelativePath` owns the business rule.
+    expect(KnowledgeRelativePathSchema.safeParse('.cherry/index.sqlite').success).toBe(true)
+  })
+
+  it('does not judge whether the value could be restored onto Windows', () => {
+    // `CON.txt` and `a\b.txt` are storable POSIX names with no Windows spelling.
+    // That is a migration-time conflict, not a reason to refuse the row.
+    expect(KnowledgeRelativePathSchema.safeParse('CON.txt').success).toBe(true)
+    expect(KnowledgeRelativePathSchema.safeParse('a\\b.txt').success).toBe(true)
+  })
+
+  it('gates the persisted item data fields', () => {
+    expect(FileItemDataSchema.safeParse({ source: '/a/b.pdf', relativePath: 'b.pdf' }).success).toBe(true)
+    expect(FileItemDataSchema.safeParse({ source: '/a/b.pdf', relativePath: '../b.pdf' }).success).toBe(false)
+    expect(
+      FileItemDataSchema.safeParse({ source: '/a/b.pdf', relativePath: 'b.pdf', indexedRelativePath: '/tmp/b.md' })
+        .success
+    ).toBe(false)
+    expect(DirectoryItemDataSchema.safeParse({ source: '/a/docs', relativePath: 'docs_2' }).success).toBe(true)
+    expect(DirectoryItemDataSchema.safeParse({ source: '/a/docs', relativePath: '.' }).success).toBe(false)
+  })
+})
 
 describe('KnowledgeSearchResultSchema', () => {
   const result = {

--- a/src/shared/data/types/knowledge.ts
+++ b/src/shared/data/types/knowledge.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePathSchema } from '@shared/types/file'
-import { sanitizeFilename } from '@shared/utils/file'
+import { PosixRelativeFilePathSchema, resolvePosixRelativeSegments, sanitizeFilename } from '@shared/utils/file'
 import * as z from 'zod'
 
 import { GroupIdSchema } from './group'
@@ -15,6 +15,44 @@ import { GroupIdSchema } from './group'
 // ============================================================================
 // Constants and Field Schemas
 // ============================================================================
+
+/**
+ * A path to a material under a knowledge base's `raw/` directory.
+ *
+ * POSIX, not the union brand: material paths are `/`-separated by construction
+ * (main spells them that way before storing) and are read back with `path.join`,
+ * which accepts `/` on Windows too. So a `\` in a stored value is part of a
+ * filename — a file legitimately named `a\b.txt` on Linux — and must survive
+ * round-tripping rather than being re-read as a directory boundary.
+ *
+ * `PosixRelativeFilePathSchema` carries the shape rules (non-empty, not anchored
+ * to a root, every segment legal on a POSIX filesystem). Layered on top are the
+ * two rules that depend on `raw/` being the base, which the shape layer has no
+ * way to know about:
+ *
+ * - **Stays inside it.** `../x` is a perfectly good relative path; as a material
+ *   path it is a traversal out of the knowledge base.
+ * - **Points below it, never at it.** `.` and `a/..` denote `raw/` itself, which
+ *   would make the base its own material — `deleteKnowledgeItemFiles` would then
+ *   remove the entire `raw/` tree instead of one item's file.
+ *
+ * The remaining knowledge rule — the reserved `CHERRY_META_DIR` prefix — stays
+ * imperative in `assertSafeKnowledgeRelativePath` (`main/features/knowledge/
+ * pathStorage.ts`), which guards the filesystem boundary and so also covers
+ * paths derived after this schema has run.
+ *
+ * Not checked here: whether the value could be restored onto Windows. A Linux
+ * user's `a\b.txt` or `CON.txt` is storable but has no Windows spelling — that
+ * is a migration-time conflict (`WindowsRelativeFilePathSchema` is the check),
+ * not a reason to refuse the row.
+ */
+export const KnowledgeRelativePathSchema = PosixRelativeFilePathSchema.refine((value) => {
+  // `PosixRelativeFilePath` permits `../x` — a relative path that points outside
+  // its base. Containment is the base owner's rule, so the material root asserts
+  // it here: `null` is a climb-out, `[]` is the root itself.
+  const segments = resolvePosixRelativeSegments(value)
+  return segments !== null && segments.length > 0
+}, 'must stay inside the knowledge base material root and point below it')
 
 export const KNOWLEDGE_ITEM_TYPES = ['file', 'url', 'note', 'directory'] as const
 export const KnowledgeItemTypeSchema = z.enum(KNOWLEDGE_ITEM_TYPES)
@@ -264,26 +302,12 @@ const KnowledgeItemSharedSchema = z.strictObject({
  * File item data.
  */
 export const FileItemDataSchema = KnowledgeItemSharedSchema.extend({
-  // relativePath / indexedRelativePath are always produced by main-side helpers
-  // (copyFileIntoKnowledgeBaseAt, toMaterialRelativePath, ...), never raw caller
-  // input. The base-relative, POSIX-normalized, no-traversal invariant is
-  // enforced imperatively by assertSafeKnowledgeRelativePath at the filesystem
-  // boundary (getKnowledgeBaseFilePath). This schema only validates shape, so a
-  // refined path schema here would duplicate that check — and cannot use
-  // node:path since this module also runs in the renderer.
-  relativePath: z
-    .string()
-    .trim()
-    .min(1)
-    .describe('Knowledge-base-relative, POSIX-normalized path for the copied source file.'),
-  indexedRelativePath: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe(
-      'Knowledge-base-relative, POSIX-normalized path for the file actually indexed, such as a processed markdown artifact.'
-    )
+  relativePath: KnowledgeRelativePathSchema.describe(
+    'Knowledge-base-relative, POSIX-normalized path for the copied source file.'
+  ),
+  indexedRelativePath: KnowledgeRelativePathSchema.optional().describe(
+    'Knowledge-base-relative, POSIX-normalized path for the file actually indexed, such as a processed markdown artifact.'
+  )
 })
 export type FileItemData = z.infer<typeof FileItemDataSchema>
 
@@ -293,14 +317,10 @@ export type FileItemData = z.infer<typeof FileItemDataSchema>
 export const UrlItemDataSchema = KnowledgeItemSharedSchema.extend({
   url: z.string().trim().min(1).describe('URL to read and index.'),
   // Written lazily by main on first index/refresh, never by raw caller input
-  // (add omits it). Same base-relative, POSIX-normalized, no-traversal invariant
-  // as FileItemData.relativePath, enforced at the filesystem boundary.
-  relativePath: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe('Knowledge-base-relative path for the captured URL snapshot markdown, written on first index.')
+  // (add omits it).
+  relativePath: KnowledgeRelativePathSchema.optional().describe(
+    'Knowledge-base-relative path for the captured URL snapshot markdown, written on first index.'
+  )
 })
 
 /**
@@ -309,14 +329,10 @@ export const UrlItemDataSchema = KnowledgeItemSharedSchema.extend({
 export const NoteItemDataSchema = KnowledgeItemSharedSchema.extend({
   content: z.string().max(KNOWLEDGE_NOTE_CONTENT_MAX).describe('Plain text note content to index.'),
   // Written lazily by main on first index, never by raw caller input (add omits
-  // it). Same base-relative, POSIX-normalized, no-traversal invariant as
-  // FileItemData.relativePath, enforced at the filesystem boundary.
-  relativePath: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe('Knowledge-base-relative path for the captured note snapshot markdown, written on first index.')
+  // it).
+  relativePath: KnowledgeRelativePathSchema.optional().describe(
+    'Knowledge-base-relative path for the captured note snapshot markdown, written on first index.'
+  )
 })
 
 /**
@@ -327,15 +343,9 @@ export const NoteItemDataSchema = KnowledgeItemSharedSchema.extend({
 export const DirectoryItemDataSchema = KnowledgeItemSharedSchema.extend({
   // Written lazily by main on first expansion (add omits it): the deduped, base-relative
   // `raw/` directory prefix the container's files live under (e.g. `docs` or `docs_2`).
-  // Same POSIX-normalized, no-traversal invariant as FileItemData.relativePath.
-  relativePath: z
-    .string()
-    .trim()
-    .min(1)
-    .optional()
-    .describe(
-      'Knowledge-base-relative `raw/` directory prefix the expanded files are stored under, written on first expansion.'
-    )
+  relativePath: KnowledgeRelativePathSchema.optional().describe(
+    'Knowledge-base-relative `raw/` directory prefix the expanded files are stored under, written on first expansion.'
+  )
 })
 export type DirectoryItemData = z.infer<typeof DirectoryItemDataSchema>
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

**Top layer of a 2-PR stack — based on #18229, review that one first.** This layer is the consumer.

Before this PR:

- The four knowledge `relativePath` schemas were `z.string().trim().min(1)`, each carrying a prose copy of the same invariant and pointing at the real check in `assertSafeKnowledgeRelativePath`. That comment also recorded why it was not a schema: it "cannot use `node:path` since this module also runs in the renderer".
- The filesystem guard folded separators with `path.normalize().replace(/\\/g, '/')` before testing the reserved prefix.

After this PR:

- All four schemas take `KnowledgeRelativePathSchema` — `PosixRelativeFilePathSchema` plus the two rules the shape layer does not own, both of which only mean anything once `raw/` is known to be the base: the path must **stay inside** it (`../x` is a perfectly good relative path, just not a material one) and must point **below** it, never at it (`.` would make the base its own material, so `deleteKnowledgeItemFiles` would take out the whole `raw/` tree). The four duplicated comments are gone.
- `assertSafeKnowledgeRelativePath` becomes an assertion function, making it the sole producer of the brand on the main side: the path helpers return branded values by asserting, with **no cast in production code**.
- The reserved-prefix rule reads the first POSIX segment instead of folding separators.

Fixes #18209

### Why we need it and why it was done in this way

Material paths are POSIX by construction — main spells them `/`-separated before storing, and `path.join` accepts `/` on Windows — so they take the POSIX brand rather than the platform-agnostic union. A `\` in a stored value is therefore part of a filename, not a directory boundary.

**That fixes a false rejection.** `.cherry\x` is one legal Linux filename sitting directly under `raw/`, but the old unconditional fold re-read it as living inside the reserved `.cherry/` control directory and refused it. Symptom of #17429.

The following tradeoffs were made:

- **The read path is tightened too, not just writes.** A `safeParse` failure on read poisons a whole base's item-list query, so this is deliberate: every write goes through `getKnowledgeBaseFilePath` → `assertSafeKnowledgeRelativePath`, and the new rules are the same generic set the old guard enforced, so no stored value that used to load can stop loading.
- **`.trim()` is dropped.** It was a transform, and `sanitizeFilename` does not strip leading spaces, so a file genuinely named `" a.pdf"` was stored under a name that no longer matched the disk. Removing it fixes that; `parse` now returns the input verbatim.
- **Windows-restorability is deliberately NOT enforced.** A Linux user's `a\b.txt` or `CON.txt` is storable but has no Windows spelling. That is a migration-time conflict for `WindowsRelativeFilePathSchema` to detect, not a reason to refuse the row — the type layer should not do the migration layer's job.

The following alternatives were considered:

- **Tighten only the write path.** Rejected: values read back would carry no brand, so half the duplicated prose would have to stay.
- **Degrade dirty rows on read.** Rejected: introduces a silent-failure path.
- **Give knowledge its own brand.** Rejected: the two business rules narrow what this module accepts; they do not describe a different kind of string.

Links to places where the discussion took place: #18209

### Breaking changes

None user-facing. One behavior change worth naming: a material path whose first POSIX segment is not literally `.cherry` is no longer rejected, so `.cherry\x` (a legal Linux filename) now stores and resolves correctly instead of erroring.

### Special notes for your reviewer

The bulk of the diff is test fixtures taking `as PosixRelativeFilePath` — production code needs no casts. Two places do brand explicitly, both because they construct a genuinely new string: the `${pathPrefix}/${subtreePath}` join in `directory.ts`, and the two v1-migration constructions in `KnowledgeMappings.ts` (where `parse` brands rather than filters — every branch is already guaranteed to clear it).

`normalizeRelativePath` survives with a single caller, `getProcessedMarkdownRelativePath`, where the fold is a producer-side concern. Its lossiness on POSIX is now documented and left to #17429.

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```

