### PR TITLE
fix(html-preview): honor app fonts in unstyled artifact previews

### DIFF
--- a/src/renderer/components/CodeBlockView/HtmlPreviewFrame.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlPreviewFrame.tsx
@@ -86,6 +86,55 @@ export function injectHtmlPreviewCsp(html: string, csp: string): string {
   )
 }
 
+// Default font stacks mirroring `font.css` (`--font-family` / `--code-font-family`).
+// They are used when the parent document's resolved stacks are unavailable (e.g. jsdom),
+// and as the fallback tail once the user's chosen font is prepended.
+export const HTML_PREVIEW_DEFAULT_BODY_FONT =
+  "Ubuntu, -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, Roboto, Oxygen, Cantarell, 'Open Sans', 'Helvetica Neue', Arial, 'Noto Sans', sans-serif"
+export const HTML_PREVIEW_DEFAULT_CODE_FONT = "'Cascadia Code', 'Fira Code', Consolas, Menlo, Courier, monospace"
+
+// The injected `<style>` lives inside an RCDATA element, so `<` / `>` must be stripped
+// (escaping as `&lt;` would surface literally in CSS). Font names never contain them.
+const sanitizeFontFamily = (value: string): string => value.replace(/[<>]/g, '')
+
+export function getPreviewFontStacks(): { body: string; code: string } {
+  if (typeof document === 'undefined') {
+    return { body: HTML_PREVIEW_DEFAULT_BODY_FONT, code: HTML_PREVIEW_DEFAULT_CODE_FONT }
+  }
+  const target = document.body ?? document.documentElement
+  const read = (property: string): string => {
+    try {
+      return getComputedStyle(target).getPropertyValue(property).trim()
+    } catch {
+      return ''
+    }
+  }
+  // CSS custom properties do not cross the iframe/webview document boundary, so resolve the
+  // parent's font stacks to concrete values. `--font-family` / `--code-font-family` are
+  // defined on `:root` (and re-declared on `body[os='windows']`), so reading them from the
+  // body yields the fully-resolved stacks including the user's font preference.
+  const body = read('--font-family')
+  const code = read('--code-font-family')
+  return {
+    body: body || HTML_PREVIEW_DEFAULT_BODY_FONT,
+    code: code || HTML_PREVIEW_DEFAULT_CODE_FONT
+  }
+}
+
+// Injects low-specificity element-selector defaults so unstyled preview documents inherit the
+// app's fonts instead of Chromium's UA serif default. Because these rules are injected before
+// any page styles and have (0,0,1) specificity, a generated page's own font rules and inline
+// styles always win — this only fills the gap when the document declares no font.
+export function injectHtmlPreviewDefaultFonts(html: string, stacks?: { body?: string; code?: string }): string {
+  if (!html.trim()) return html
+  const { body: bodyFont, code: codeFont } = { ...getPreviewFontStacks(), ...stacks }
+  const styleContent = [
+    `html, body { font-family: ${sanitizeFontFamily(bodyFont)}; }`,
+    `pre, code, kbd, samp { font-family: ${sanitizeFontFamily(codeFont)}; }`
+  ].join('\n  ')
+  return injectHtmlPreviewHeadElement(html, `<style>\n  ${styleContent}\n</style>`)
+}
+
 export const HtmlPreviewFrame = memo<HtmlPreviewFrameProps>(
   ({
     html,
@@ -97,7 +146,8 @@ export const HtmlPreviewFrame = memo<HtmlPreviewFrameProps>(
     iframeRef
   }) => {
     const withBase = injectHtmlPreviewBase(html, baseUrl)
-    const srcDoc = csp ? injectHtmlPreviewCsp(withBase, csp) : withBase
+    const withDefaultFonts = injectHtmlPreviewDefaultFonts(withBase)
+    const srcDoc = csp ? injectHtmlPreviewCsp(withDefaultFonts, csp) : withDefaultFonts
     return (
       <div className="h-full w-full overflow-hidden bg-white">
         {html.trim() ? (

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlPreviewFrame.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlPreviewFrame.test.tsx
@@ -6,7 +6,8 @@ import {
   HTML_PREVIEW_RESTRICTED_SANDBOX,
   HtmlPreviewFrame,
   injectHtmlPreviewBase,
-  injectHtmlPreviewCsp
+  injectHtmlPreviewCsp,
+  injectHtmlPreviewDefaultFonts
 } from '../HtmlPreviewFrame'
 
 describe('HtmlPreviewFrame', () => {
@@ -96,6 +97,63 @@ describe('HtmlPreviewFrame', () => {
 
     expect(result.match(/<base\b/gi)).toHaveLength(1)
     expect(result).toContain('<base href="https://example.com/posts/">')
+  })
+
+  it('injects low-specificity default font styles into the preview head', () => {
+    const html = '<html><head><title>t</title></head><body><pre>code()</pre><p>text</p></body></html>'
+
+    const result = injectHtmlPreviewDefaultFonts(html, {
+      body: "'Roboto', sans-serif",
+      code: "'Fira Code', monospace"
+    })
+
+    expect(result).toMatch(/^<html><head><style>/)
+    expect(result).toContain("html, body { font-family: 'Roboto', sans-serif; }")
+    expect(result).toContain("pre, code, kbd, samp { font-family: 'Fira Code', monospace; }")
+    expect(result).not.toContain('!important')
+  })
+
+  it('falls back to default font stacks when none are provided', () => {
+    const result = injectHtmlPreviewDefaultFonts('<body>hi</body>')
+
+    expect(result).toMatch(/^<head><style>/)
+    expect(result).toMatch(/html, body \{ font-family: /)
+    expect(result).toMatch(/pre, code, kbd, samp \{ font-family: /)
+  })
+
+  it('strips angle brackets from font values so they cannot break out of the style tag', () => {
+    const result = injectHtmlPreviewDefaultFonts('<body>x</body>', {
+      body: "'Roboto'</style><script>alert(1)</script>",
+      code: 'monospace'
+    })
+
+    // The malicious `</style><script>` inside the font value must be stripped, leaving only the
+    // injected style block's own single closing tag.
+    expect(result.match(/<\/style>/g)).toHaveLength(1)
+    expect(result).not.toContain('<script>')
+    expect(result).toContain("html, body { font-family: 'Roboto'/stylescriptalert(1)/script; }")
+  })
+
+  it('skips font injection for empty HTML', () => {
+    expect(injectHtmlPreviewDefaultFonts('   ')).toBe('   ')
+  })
+
+  it('renders srcdoc containing the injected default fonts alongside base and CSP', () => {
+    render(
+      <HtmlPreviewFrame
+        html="<main>Preview</main>"
+        title="common.html_preview"
+        sandbox={HTML_PREVIEW_RESTRICTED_SANDBOX}
+        csp={HTML_PREVIEW_RESTRICTED_CSP}
+      />
+    )
+    const iframe = screen.getByTitle('common.html_preview')
+
+    const srcdoc = iframe?.getAttribute('srcdoc') ?? ''
+    expect(srcdoc).toContain('<base href="about:srcdoc">')
+    expect(srcdoc).toContain('html, body { font-family:')
+    expect(srcdoc).toContain('pre, code, kbd, samp { font-family:')
+    expect(srcdoc).toContain("default-src 'none'")
   })
 
   it('renders empty preview text when provided', () => {

--- a/src/renderer/components/chat/HtmlArtifactView.tsx
+++ b/src/renderer/components/chat/HtmlArtifactView.tsx
@@ -14,6 +14,7 @@ import {
 import type { HtmlArtifactKind } from '@renderer/components/chat/messages/markdown/plugins/remarkHtmlArtifact'
 import HtmlPreviewFrame, {
   HTML_PREVIEW_RESTRICTED_CSP,
+  injectHtmlPreviewDefaultFonts,
   injectHtmlPreviewHeadElement
 } from '@renderer/components/CodeBlockView/HtmlPreviewFrame'
 import CodeViewer from '@renderer/components/CodeViewer'
@@ -530,7 +531,7 @@ const InteractiveHtmlPreview = memo(function InteractiveHtmlPreview({
   const src = useMemo(() => {
     const scrollActivationDelay = forwardBoundaryWheel ? SCROLL_ACTIVATION_DELAY_MS : 0
     const bridgeScript = `<script>${getHtmlArtifactBridgeScript(messagePrefix, scrollActivationDelay)}</script>`
-    const instrumentedHtml = injectHtmlPreviewHeadElement(html, bridgeScript)
+    const instrumentedHtml = injectHtmlPreviewDefaultFonts(injectHtmlPreviewHeadElement(html, bridgeScript))
     return `${HTML_ARTIFACT_PREVIEW_DATA_URL_PREFIX}${encodeURIComponent(instrumentedHtml)}`
   }, [forwardBoundaryWheel, html, messagePrefix])
 

--- a/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
+++ b/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
@@ -69,6 +69,7 @@ vi.mock('@renderer/components/CodeBlockView/HtmlArtifactsPopup', () => ({ defaul
 vi.mock('@renderer/components/CodeBlockView/HtmlPreviewFrame', () => ({
   HTML_PREVIEW_RESTRICTED_CSP: mocks.htmlPreviewRestrictedCsp,
   injectHtmlPreviewHeadElement: (html: string, element: string) => `${element}${html}`,
+  injectHtmlPreviewDefaultFonts: (html: string) => html,
   default: mocks.HtmlPreviewFrame
 }))
 vi.mock('@logger', () => ({


### PR DESCRIPTION
### What this PR does

Before this PR:

HTML artifact previews render AI-generated HTML inside a separate iframe/webview document (`about:srcdoc` / `data:` URL) that does not inherit the app's CSS custom properties or fonts. When the generated HTML declares no `font-family`, Chromium's UA default — **serif (Times New Roman on Windows)** — is used, so a configured code font such as JetBrains Mono renders as a serif font. All app-side code surfaces (`.shiki`, `.code-editor`, `.markdown code/pre`) already honor the code-font preference; the preview document was the only uncovered surface.

After this PR:

A low-specificity default-font `<style>` is injected into the preview document's `<head>` via the existing `injectHtmlPreviewHeadElement` helper:

```html
<style>
  html, body { font-family: <body stack>; }
  pre, code, kbd, samp { font-family: <code stack>; }
</style>
```

The stacks are resolved from the parent document's computed `--font-family` / `--code-font-family`, honoring the user's configured body and code fonts (including the Windows-specific stacks), with the `font.css` defaults as fallback. Because these element rules are injected before page styles at (0,0,1) specificity, a generated page's own `font-family` rules and inline styles always win — the injection only fills the gap when the document declares no font.

Fixes #18105

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Fonts must be resolved to concrete values because CSS custom properties do not cross the iframe/webview document boundary.
- Element-selector defaults (`(0,0,1)` specificity, injected before page styles) are the least invasive way to fill the gap: they can never override a generated page's own styles, only supply a sane default where none exists.

The following alternatives were considered:

- Injecting static generic stacks (`system-ui, ...` / `'Cascadia Code', ... monospace`) — simpler, but ignores the user's configured font preferences.
- Styling only the parent document — impossible, since the preview is an isolated browsing context.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- The same injection is applied to the interactive `<webview>` preview path in `HtmlArtifactView`.
- Covers all `HtmlPreviewFrame` callers: artifact popup preview, in-chat adaptive/static previews, and local-file HTML previews.
- Unit tests added in `HtmlPreviewFrame.test.tsx` (injection, fallback stacks, style-tag breakout sanitization, srcdoc composition). The renderer test project passes (842 files / 8510 tests). `pnpm lint` and `pnpm format` pass. `pnpm build:check` is blocked only by pre-existing main-process test failures unrelated to this change (verified identical on a clean checkout).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed HTML artifact previews (and other HTML previews) rendering in the system serif font instead of the app's configured fonts — unstyled preview documents now use the app's body and code fonts.
```

