### PR TITLE
fix(notes): prevent deleted note from being recreated by pending autosave

### DIFF
--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -584,13 +584,6 @@ const NotesPage: FC = () => {
         const nodeToDelete = findNode(notesTree, nodeId)
         if (!nodeToDelete) return
 
-        await delNode(nodeToDelete)
-
-        updateStarredPaths((prev) => removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder'))
-        updateExpandedPaths((prev) =>
-          removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder')
-        )
-
         const normalizedActivePath = activeFilePath ? normalizePathValue(activeFilePath) : undefined
         const normalizedDeletePath = normalizePathValue(nodeToDelete.externalPath)
         const isActiveNode = normalizedActivePath === normalizedDeletePath
@@ -599,7 +592,23 @@ const NotesPage: FC = () => {
           normalizedActivePath &&
           normalizedActivePath.startsWith(`${normalizedDeletePath}/`)
 
+        // 删除正在编辑的笔记（或其所在的文件夹）时，先取消防抖保存。
+        // 否则删除成功后 setActiveFilePath(undefined) 会触发「切换文件时的清理」
+        // 中的紧急保存，把刚删除的文件重新写回磁盘，导致笔记“复活”并改变排序位置。
         if (isActiveNode || isActiveDescendant) {
+          debouncedSaveRef.current?.cancel()
+        }
+
+        await delNode(nodeToDelete)
+
+        updateStarredPaths((prev) => removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder'))
+        updateExpandedPaths((prev) =>
+          removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder')
+        )
+
+        if (isActiveNode || isActiveDescendant) {
+          lastContentRef.current = ''
+          lastFilePathRef.current = undefined
           dispatch(setActiveFilePath(undefined))
           editorRef.current?.clear()
         }

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -85,8 +85,9 @@ const NotesPage: FC = () => {
   const isCreatingNoteRef = useRef(false)
   const pendingScrollRef = useRef<{ lineNumber: number; lineContent?: string } | null>(null)
   const pendingDeleteSetRef = useRef<Set<string>>(new Set())
+  const pendingDeleteGenRef = useRef<Map<string, number>>(new Map())
   const pathGenerationRef = useRef<Map<string, number>>(new Map())
-  const lastRecreatedPathRef = useRef<string | null>(null)
+  const lastRecreatedRef = useRef<{ path: string; gen: number; content: string } | null>(null)
 
   const isPendingDeletePath = useCallback((normalizedTarget: string) => {
     return isPendingDeleteForPath(normalizedTarget, pendingDeleteSetRef.current)
@@ -194,9 +195,11 @@ const NotesPage: FC = () => {
   const saveCurrentNote = useCallback(
     async (content: string, filePath?: string) => {
       const targetPath = filePath || activeFilePath
-      if (!targetPath || content.trim() === currentContent.trim()) return
-
+      if (!targetPath) return
       const normalizedTarget = normalizePathValue(targetPath)
+      const activeNorm = activeFilePath ? normalizePathValue(activeFilePath) : undefined
+      const isActiveTarget = normalizedTarget === activeNorm
+      if (isActiveTarget && content.trim() === currentContent.trim()) return
       // 若目标路径正处于删除流程中（或为其子路径），跳过写入，避免已删除文件被“复活”
       if (isPendingDeletePath(normalizedTarget)) {
         return
@@ -210,10 +213,19 @@ const NotesPage: FC = () => {
         const normalizedAfter = normalizePathValue(targetPath)
         // 若写入期间该路径的 generation 发生变化，说明此次写入是过期写入（针对该路径的删除/重建）
         if (genAtStart !== genNow) {
+          // 过期写入且仍处于待删除状态，优先清理被复活的文件，避免旧的 lastRecreated 误恢复已二次删除的文件
+          if (isPendingDeletePath(normalizedAfter)) {
+            try {
+              await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+              await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+            } catch {}
+            return
+          }
           // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容
-          if (lastRecreatedPathRef.current && normalizedAfter === lastRecreatedPathRef.current) {
+          const recreated = lastRecreatedRef.current
+          if (recreated && normalizedAfter === recreated.path && genNow === recreated.gen) {
             const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
-            const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : currentContentRef.current
+            const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : recreated.content
             if (correctContent !== content) {
               try {
                 await window.api.file.write(targetPath, correctContent)
@@ -225,15 +237,7 @@ const NotesPage: FC = () => {
             invalidateFileContent(targetPath)
             return
           }
-          // 过期写入且仍处于待删除状态（或该路径的 generation 已推进但未重建），清理被复活的文件
-          if (isPendingDeletePath(normalizedAfter)) {
-            try {
-              await window.api.file.deleteExternalFile(targetPath).catch(() => {})
-              await window.api.file.deleteExternalDir(targetPath).catch(() => {})
-            } catch {}
-            return
-          }
-          // generation 推进但 pending 已清理（超时或已被重建后清理），仍需视为过期写入，避免残留复活文件
+          // generation 推进但既无 pending 也非重建，仍视为过期写入，避免残留复活文件
           return
         }
         // 非过期写入，但若在此次写入等待期间该路径被标记为待删除（generation 未变但标记已设置），也需清理
@@ -571,7 +575,7 @@ const NotesPage: FC = () => {
         const normalizedParent = normalizePathValue(targetPath)
         updateExpandedPaths((prev) => addUniquePath(prev, normalizedParent))
         // 若新笔记路径与待删除标记相同（用户删除后立即重建同名笔记），清除标记避免首个 autosave 被误拦截
-        // 同时推进 generation 并记录重建路径，防止已开始的 autosave 用旧内容覆盖新文件或清理逻辑误删新文件
+        // 同时推进 generation 并记录重建路径与初始内容，防止已开始的 autosave 用旧内容覆盖新文件或清理逻辑误删新文件
         {
           const normalizedNote = normalizePathValue(notePath)
           let matchedPending: string | null = null
@@ -583,17 +587,31 @@ const NotesPage: FC = () => {
           }
           if (matchedPending) {
             pendingDeleteSetRef.current.delete(matchedPending)
+            pendingDeleteGenRef.current.delete(matchedPending)
             bumpGeneration(normalizedNote)
-            lastRecreatedPathRef.current = normalizedNote
-            const recreated = normalizedNote
+            const genAfter = getEffectiveGeneration(normalizedNote)
+            lastRecreatedRef.current = { path: normalizedNote, gen: genAfter, content: '' }
+            const recreatedGen = genAfter
+            const recreatedPath = normalizedNote
             setTimeout(() => {
-              if (lastRecreatedPathRef.current === recreated) {
-                lastRecreatedPathRef.current = null
+              const cur = lastRecreatedRef.current
+              if (cur && cur.path === recreatedPath && cur.gen === recreatedGen) {
+                lastRecreatedRef.current = null
               }
             }, 3000)
-          } else if (lastRecreatedPathRef.current === normalizedNote) {
+          } else if (lastRecreatedRef.current?.path === normalizedNote) {
             // 同路径再次创建但无 pending（已被清理），仍需刷新 generation 以标记新一代
             bumpGeneration(normalizedNote)
+            const genAfter = getEffectiveGeneration(normalizedNote)
+            lastRecreatedRef.current = { path: normalizedNote, gen: genAfter, content: '' }
+            const recreatedGen = genAfter
+            const recreatedPath = normalizedNote
+            setTimeout(() => {
+              const cur = lastRecreatedRef.current
+              if (cur && cur.path === recreatedPath && cur.gen === recreatedGen) {
+                lastRecreatedRef.current = null
+              }
+            }, 3000)
           }
         }
         dispatch(setActiveFilePath(notePath))
@@ -609,7 +627,7 @@ const NotesPage: FC = () => {
         }, 500)
       }
     },
-    [bumpGeneration, dispatch, getTargetFolderPath, refreshTree, updateExpandedPaths]
+    [bumpGeneration, dispatch, getEffectiveGeneration, getTargetFolderPath, refreshTree, updateExpandedPaths]
   )
 
   const handleToggleExpanded = useCallback(
@@ -689,8 +707,17 @@ const NotesPage: FC = () => {
         const preDeleteContent = lastContentRef.current
         const preDeletePath = lastFilePathRef.current
         if (isActiveRelated) {
+          // 若正在删除的是刚重建的同路径笔记，清除重建标记，避免旧的 autosave 误恢复已二次删除的文件
+          const recreated = lastRecreatedRef.current
+          if (
+            recreated &&
+            (recreated.path === normalizedDeletePath || recreated.path.startsWith(`${normalizedDeletePath}/`))
+          ) {
+            lastRecreatedRef.current = null
+          }
           pendingDeleteSetRef.current.add(normalizedDeletePath)
           bumpGeneration(normalizedDeletePath)
+          pendingDeleteGenRef.current.set(normalizedDeletePath, getEffectiveGeneration(normalizedDeletePath))
           debouncedSaveRef.current?.cancel()
         }
 
@@ -699,6 +726,7 @@ const NotesPage: FC = () => {
         } catch (error) {
           if (isActiveRelated) {
             pendingDeleteSetRef.current.delete(normalizedDeletePath)
+            pendingDeleteGenRef.current.delete(normalizedDeletePath)
             const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
             const shouldRearmSnapshot =
               snapNorm === normalizedDeletePath ||
@@ -743,9 +771,14 @@ const NotesPage: FC = () => {
             dispatch(setActiveFilePath(undefined))
             editorRef.current?.clear()
           }
-          // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入
+          // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入；用 generation 绑定避免旧定时器误删新一轮同路径删除的标记
+          const genAtDelete =
+            pendingDeleteGenRef.current.get(normalizedDeletePath) ?? getEffectiveGeneration(normalizedDeletePath)
           setTimeout(() => {
-            pendingDeleteSetRef.current.delete(normalizedDeletePath)
+            if (getEffectiveGeneration(normalizedDeletePath) === genAtDelete) {
+              pendingDeleteSetRef.current.delete(normalizedDeletePath)
+              pendingDeleteGenRef.current.delete(normalizedDeletePath)
+            }
           }, 2000)
         }
 
@@ -754,7 +787,16 @@ const NotesPage: FC = () => {
         logger.error('Failed to delete node:', error as Error)
       }
     },
-    [notesTree, activeFilePath, bumpGeneration, dispatch, refreshTree, updateStarredPaths, updateExpandedPaths]
+    [
+      notesTree,
+      activeFilePath,
+      bumpGeneration,
+      dispatch,
+      getEffectiveGeneration,
+      refreshTree,
+      updateStarredPaths,
+      updateExpandedPaths
+    ]
   )
 
   // 重命名节点

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -49,8 +49,8 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import HeaderNavbar from './HeaderNavbar'
-import { getEffectiveGeneration as getEffectiveGenerationGuard, isPendingDeleteForPath } from './notesGuards'
 import NotesEditor from './NotesEditor'
+import { getEffectiveGeneration as getEffectiveGenerationGuard, isPendingDeleteForPath } from './notesGuards'
 import NotesSidebar from './NotesSidebar'
 
 const logger = loggerService.withContext('NotesPage')

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -84,6 +84,8 @@ const NotesPage: FC = () => {
   const isCreatingNoteRef = useRef(false)
   const pendingScrollRef = useRef<{ lineNumber: number; lineContent?: string } | null>(null)
   const pendingDeletePathRef = useRef<string | null>(null)
+  const deleteEpochRef = useRef(0)
+  const lastRecreatedPathRef = useRef<string | null>(null)
 
   const activeFilePathRef = useRef<string | undefined>(activeFilePath)
   const currentContentRef = useRef(currentContent)
@@ -189,8 +191,40 @@ const NotesPage: FC = () => {
         }
       }
 
+      const epochAtStart = deleteEpochRef.current
+
       try {
         await window.api.file.write(targetPath, content)
+        // 若写入期间发生了删除/重建（epoch 变化），说明此次写入是过期写入
+        if (epochAtStart !== deleteEpochRef.current) {
+          const normalizedAfter = normalizePathValue(targetPath)
+          // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容
+          if (lastRecreatedPathRef.current && normalizedAfter === lastRecreatedPathRef.current) {
+            const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
+            const correctContent =
+              curLastPath === normalizedAfter ? lastContentRef.current : currentContentRef.current
+            if (correctContent !== content) {
+              try {
+                await window.api.file.write(targetPath, correctContent).catch(() => {})
+              } catch {}
+            }
+            invalidateFileContent(targetPath)
+            return
+          }
+          // 若仍处于待删除状态但未重建，已在 pendingAfter 分支处理；这里直接返回避免刷新已删除文件的缓存
+          const pendingStale = pendingDeletePathRef.current
+          if (pendingStale) {
+            const normalizedStale = normalizePathValue(targetPath)
+            if (normalizedStale === pendingStale || normalizedStale.startsWith(`${pendingStale}/`)) {
+              try {
+                await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+                await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+              } catch {}
+              return
+            }
+          }
+          return
+        }
         // 写入完成后再检查一次删除标记：若在此次写入等待期间文件已被删除，写入会“复活”文件，需立即清理
         const pendingAfter = pendingDeletePathRef.current
         if (pendingAfter) {
@@ -531,11 +565,20 @@ const NotesPage: FC = () => {
         const normalizedParent = normalizePathValue(targetPath)
         updateExpandedPaths((prev) => addUniquePath(prev, normalizedParent))
         // 若新笔记路径与待删除标记相同（用户删除后立即重建同名笔记），清除标记避免首个 autosave 被误拦截
+        // 同时推进 epoch 并记录重建路径，防止已开始的 autosave 用旧内容覆盖新文件或清理逻辑误删新文件
         const pendingCreate = pendingDeletePathRef.current
         if (pendingCreate) {
           const normalizedNote = normalizePathValue(notePath)
           if (normalizedNote === pendingCreate || normalizedNote.startsWith(`${pendingCreate}/`)) {
             pendingDeletePathRef.current = null
+            deleteEpochRef.current += 1
+            lastRecreatedPathRef.current = normalizedNote
+            const recreated = normalizedNote
+            setTimeout(() => {
+              if (lastRecreatedPathRef.current === recreated) {
+                lastRecreatedPathRef.current = null
+              }
+            }, 3000)
           }
         }
         dispatch(setActiveFilePath(notePath))
@@ -627,8 +670,12 @@ const NotesPage: FC = () => {
         // 删除正在编辑的笔记（或其所在文件夹）时，先标记为“待删除”并取消防抖，
         // 使已触发但尚未落盘的 autosave 在 saveCurrentNote 中被丢弃，避免文件被“复活”。
         // 失败时需撤销标记并重建防抖，否则已取消的保存不会自动恢复，编辑内容将丢失。
+        // 快照删除前的草稿，避免在删除等待期间用户切换笔记导致快照被覆盖
+        const preDeleteContent = lastContentRef.current
+        const preDeletePath = lastFilePathRef.current
         if (isActiveRelated) {
           pendingDeletePathRef.current = normalizedDeletePath
+          deleteEpochRef.current += 1
           debouncedSaveRef.current?.cancel()
         }
 
@@ -637,8 +684,16 @@ const NotesPage: FC = () => {
         } catch (error) {
           if (isActiveRelated) {
             pendingDeletePathRef.current = null
-            if (lastFilePathRef.current != null) {
+            const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
+            const shouldRearmSnapshot =
+              snapNorm === normalizedDeletePath ||
+              (nodeToDelete.type === 'folder' && snapNorm?.startsWith(`${normalizedDeletePath}/`))
+            if (shouldRearmSnapshot && preDeletePath != null) {
+              debouncedSaveRef.current?.(preDeleteContent, preDeletePath)
+            } else if (lastFilePathRef.current != null) {
               debouncedSaveRef.current?.(lastContentRef.current, lastFilePathRef.current)
+            } else if (preDeletePath != null) {
+              debouncedSaveRef.current?.(preDeleteContent, preDeletePath)
             }
           }
           throw error

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -201,8 +201,7 @@ const NotesPage: FC = () => {
           // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容
           if (lastRecreatedPathRef.current && normalizedAfter === lastRecreatedPathRef.current) {
             const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
-            const correctContent =
-              curLastPath === normalizedAfter ? lastContentRef.current : currentContentRef.current
+            const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : currentContentRef.current
             if (correctContent !== content) {
               try {
                 await window.api.file.write(targetPath, correctContent).catch(() => {})

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -49,6 +49,7 @@ import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
 import HeaderNavbar from './HeaderNavbar'
+import { getEffectiveGeneration as getEffectiveGenerationGuard, isPendingDeleteForPath } from './notesGuards'
 import NotesEditor from './NotesEditor'
 import NotesSidebar from './NotesSidebar'
 
@@ -83,9 +84,25 @@ const NotesPage: FC = () => {
   const isRenamingRef = useRef(false)
   const isCreatingNoteRef = useRef(false)
   const pendingScrollRef = useRef<{ lineNumber: number; lineContent?: string } | null>(null)
-  const pendingDeletePathRef = useRef<string | null>(null)
-  const deleteEpochRef = useRef(0)
+  const pendingDeleteSetRef = useRef<Set<string>>(new Set())
+  const pathGenerationRef = useRef<Map<string, number>>(new Map())
   const lastRecreatedPathRef = useRef<string | null>(null)
+
+  const isPendingDeletePath = useCallback((normalizedTarget: string) => {
+    return isPendingDeleteForPath(normalizedTarget, pendingDeleteSetRef.current)
+  }, [])
+
+  const getEffectiveGeneration = useCallback(
+    (normalizedTarget: string) => {
+      return getEffectiveGenerationGuard(normalizedTarget, pathGenerationRef.current)
+    },
+    []
+  )
+
+  const bumpGeneration = useCallback((normalizedPath: string) => {
+    const cur = pathGenerationRef.current.get(normalizedPath) ?? 0
+    pathGenerationRef.current.set(normalizedPath, cur + 1)
+  }, [])
 
   const activeFilePathRef = useRef<string | undefined>(activeFilePath)
   const currentContentRef = useRef(currentContent)
@@ -182,60 +199,53 @@ const NotesPage: FC = () => {
       const targetPath = filePath || activeFilePath
       if (!targetPath || content.trim() === currentContent.trim()) return
 
+      const normalizedTarget = normalizePathValue(targetPath)
       // 若目标路径正处于删除流程中（或为其子路径），跳过写入，避免已删除文件被“复活”
-      const pendingDelete = pendingDeletePathRef.current
-      if (pendingDelete) {
-        const normalizedTarget = normalizePathValue(targetPath)
-        if (normalizedTarget === pendingDelete || normalizedTarget.startsWith(`${pendingDelete}/`)) {
-          return
-        }
+      if (isPendingDeletePath(normalizedTarget)) {
+        return
       }
 
-      const epochAtStart = deleteEpochRef.current
+      const genAtStart = getEffectiveGeneration(normalizedTarget)
 
       try {
         await window.api.file.write(targetPath, content)
-        // 若写入期间发生了删除/重建（epoch 变化），说明此次写入是过期写入
-        if (epochAtStart !== deleteEpochRef.current) {
-          const normalizedAfter = normalizePathValue(targetPath)
+        const genNow = getEffectiveGeneration(normalizedTarget)
+        const normalizedAfter = normalizePathValue(targetPath)
+        // 若写入期间该路径的 generation 发生变化，说明此次写入是过期写入（针对该路径的删除/重建）
+        if (genAtStart !== genNow) {
           // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容
           if (lastRecreatedPathRef.current && normalizedAfter === lastRecreatedPathRef.current) {
             const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
             const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : currentContentRef.current
             if (correctContent !== content) {
               try {
-                await window.api.file.write(targetPath, correctContent).catch(() => {})
-              } catch {}
+                await window.api.file.write(targetPath, correctContent)
+              } catch (e) {
+                logger.error('Failed to restore recreated note after stale write:', e as Error)
+                return
+              }
             }
             invalidateFileContent(targetPath)
             return
           }
-          // 若仍处于待删除状态但未重建，已在 pendingAfter 分支处理；这里直接返回避免刷新已删除文件的缓存
-          const pendingStale = pendingDeletePathRef.current
-          if (pendingStale) {
-            const normalizedStale = normalizePathValue(targetPath)
-            if (normalizedStale === pendingStale || normalizedStale.startsWith(`${pendingStale}/`)) {
-              try {
-                await window.api.file.deleteExternalFile(targetPath).catch(() => {})
-                await window.api.file.deleteExternalDir(targetPath).catch(() => {})
-              } catch {}
-              return
-            }
-          }
-          return
-        }
-        // 写入完成后再检查一次删除标记：若在此次写入等待期间文件已被删除，写入会“复活”文件，需立即清理
-        const pendingAfter = pendingDeletePathRef.current
-        if (pendingAfter) {
-          const normalizedAfter = normalizePathValue(targetPath)
-          if (normalizedAfter === pendingAfter || normalizedAfter.startsWith(`${pendingAfter}/`)) {
+          // 过期写入且仍处于待删除状态（或该路径的 generation 已推进但未重建），清理被复活的文件
+          if (isPendingDeletePath(normalizedAfter)) {
             try {
-              // 尝试删除刚被复活的文件/目录（忽略错误）
               await window.api.file.deleteExternalFile(targetPath).catch(() => {})
               await window.api.file.deleteExternalDir(targetPath).catch(() => {})
             } catch {}
             return
           }
+          // generation 推进但 pending 已清理（超时或已被重建后清理），仍需视为过期写入，避免残留复活文件
+          return
+        }
+        // 非过期写入，但若在此次写入等待期间该路径被标记为待删除（generation 未变但标记已设置），也需清理
+        if (isPendingDeletePath(normalizedAfter)) {
+          try {
+            await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+            await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+          } catch {}
+          return
         }
         // 保存后立即刷新缓存，确保下次读取时获取最新内容
         invalidateFileContent(targetPath)
@@ -243,7 +253,7 @@ const NotesPage: FC = () => {
         logger.error('Failed to save note:', error as Error)
       }
     },
-    [activeFilePath, currentContent, invalidateFileContent]
+    [activeFilePath, currentContent, invalidateFileContent, isPendingDeletePath, getEffectiveGeneration]
   )
 
   // 防抖保存函数，在停止输入后才保存，避免输入过程中的文件写入
@@ -564,13 +574,19 @@ const NotesPage: FC = () => {
         const normalizedParent = normalizePathValue(targetPath)
         updateExpandedPaths((prev) => addUniquePath(prev, normalizedParent))
         // 若新笔记路径与待删除标记相同（用户删除后立即重建同名笔记），清除标记避免首个 autosave 被误拦截
-        // 同时推进 epoch 并记录重建路径，防止已开始的 autosave 用旧内容覆盖新文件或清理逻辑误删新文件
-        const pendingCreate = pendingDeletePathRef.current
-        if (pendingCreate) {
+        // 同时推进 generation 并记录重建路径，防止已开始的 autosave 用旧内容覆盖新文件或清理逻辑误删新文件
+        {
           const normalizedNote = normalizePathValue(notePath)
-          if (normalizedNote === pendingCreate || normalizedNote.startsWith(`${pendingCreate}/`)) {
-            pendingDeletePathRef.current = null
-            deleteEpochRef.current += 1
+          let matchedPending: string | null = null
+          for (const pending of pendingDeleteSetRef.current) {
+            if (normalizedNote === pending || normalizedNote.startsWith(`${pending}/`)) {
+              matchedPending = pending
+              break
+            }
+          }
+          if (matchedPending) {
+            pendingDeleteSetRef.current.delete(matchedPending)
+            bumpGeneration(normalizedNote)
             lastRecreatedPathRef.current = normalizedNote
             const recreated = normalizedNote
             setTimeout(() => {
@@ -578,6 +594,9 @@ const NotesPage: FC = () => {
                 lastRecreatedPathRef.current = null
               }
             }, 3000)
+          } else if (lastRecreatedPathRef.current === normalizedNote) {
+            // 同路径再次创建但无 pending（已被清理），仍需刷新 generation 以标记新一代
+            bumpGeneration(normalizedNote)
           }
         }
         dispatch(setActiveFilePath(notePath))
@@ -593,7 +612,7 @@ const NotesPage: FC = () => {
         }, 500)
       }
     },
-    [dispatch, getTargetFolderPath, refreshTree, updateExpandedPaths]
+    [bumpGeneration, dispatch, getTargetFolderPath, refreshTree, updateExpandedPaths]
   )
 
   const handleToggleExpanded = useCallback(
@@ -673,8 +692,8 @@ const NotesPage: FC = () => {
         const preDeleteContent = lastContentRef.current
         const preDeletePath = lastFilePathRef.current
         if (isActiveRelated) {
-          pendingDeletePathRef.current = normalizedDeletePath
-          deleteEpochRef.current += 1
+          pendingDeleteSetRef.current.add(normalizedDeletePath)
+          bumpGeneration(normalizedDeletePath)
           debouncedSaveRef.current?.cancel()
         }
 
@@ -682,17 +701,27 @@ const NotesPage: FC = () => {
           await delNode(nodeToDelete)
         } catch (error) {
           if (isActiveRelated) {
-            pendingDeletePathRef.current = null
+            pendingDeleteSetRef.current.delete(normalizedDeletePath)
             const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
             const shouldRearmSnapshot =
               snapNorm === normalizedDeletePath ||
               (nodeToDelete.type === 'folder' && snapNorm?.startsWith(`${normalizedDeletePath}/`))
+            // 恢复被取消的防抖：若用户在删除等待期间已切换到其他笔记，切勿用快照的 debounce 覆盖当前笔记的待保存
+            const currentPathNorm = lastFilePathRef.current
+              ? normalizePathValue(lastFilePathRef.current)
+              : undefined
+            const switchedAway = currentPathNorm != null && snapNorm != null && currentPathNorm !== snapNorm
             if (shouldRearmSnapshot && preDeletePath != null) {
-              debouncedSaveRef.current?.(preDeleteContent, preDeletePath)
+              if (switchedAway) {
+                // 已切换：直接写回快照所属文件，不经过共享 debounce，避免取消当前笔记的 pending autosave
+                void saveCurrentNoteRef.current?.(preDeleteContent, preDeletePath).catch(() => {})
+              } else {
+                debouncedSaveRef.current?.(preDeleteContent, preDeletePath)
+              }
             } else if (lastFilePathRef.current != null) {
               debouncedSaveRef.current?.(lastContentRef.current, lastFilePathRef.current)
             } else if (preDeletePath != null) {
-              debouncedSaveRef.current?.(preDeleteContent, preDeletePath)
+              void saveCurrentNoteRef.current?.(preDeleteContent, preDeletePath).catch(() => {})
             }
           }
           throw error
@@ -721,9 +750,7 @@ const NotesPage: FC = () => {
           }
           // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入
           setTimeout(() => {
-            if (pendingDeletePathRef.current === normalizedDeletePath) {
-              pendingDeletePathRef.current = null
-            }
+            pendingDeleteSetRef.current.delete(normalizedDeletePath)
           }, 2000)
         }
 
@@ -732,7 +759,7 @@ const NotesPage: FC = () => {
         logger.error('Failed to delete node:', error as Error)
       }
     },
-    [notesTree, activeFilePath, dispatch, refreshTree, updateStarredPaths, updateExpandedPaths]
+    [notesTree, activeFilePath, bumpGeneration, dispatch, refreshTree, updateStarredPaths, updateExpandedPaths]
   )
 
   // 重命名节点

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -92,12 +92,9 @@ const NotesPage: FC = () => {
     return isPendingDeleteForPath(normalizedTarget, pendingDeleteSetRef.current)
   }, [])
 
-  const getEffectiveGeneration = useCallback(
-    (normalizedTarget: string) => {
-      return getEffectiveGenerationGuard(normalizedTarget, pathGenerationRef.current)
-    },
-    []
-  )
+  const getEffectiveGeneration = useCallback((normalizedTarget: string) => {
+    return getEffectiveGenerationGuard(normalizedTarget, pathGenerationRef.current)
+  }, [])
 
   const bumpGeneration = useCallback((normalizedPath: string) => {
     const cur = pathGenerationRef.current.get(normalizedPath) ?? 0
@@ -707,9 +704,7 @@ const NotesPage: FC = () => {
               snapNorm === normalizedDeletePath ||
               (nodeToDelete.type === 'folder' && snapNorm?.startsWith(`${normalizedDeletePath}/`))
             // 恢复被取消的防抖：若用户在删除等待期间已切换到其他笔记，切勿用快照的 debounce 覆盖当前笔记的待保存
-            const currentPathNorm = lastFilePathRef.current
-              ? normalizePathValue(lastFilePathRef.current)
-              : undefined
+            const currentPathNorm = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
             const switchedAway = currentPathNorm != null && snapNorm != null && currentPathNorm !== snapNorm
             if (shouldRearmSnapshot && preDeletePath != null) {
               if (switchedAway) {

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -221,23 +221,39 @@ const NotesPage: FC = () => {
             } catch {}
             return
           }
-          // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容
+          // 若目标路径是刚被重建的同路径笔记，旧内容已覆盖新文件，需恢复正确内容；
+          // 若是重建文件夹后的子路径被复活，则直接删除被复活的子文件
           const recreated = lastRecreatedRef.current
-          if (recreated && normalizedAfter === recreated.path && genNow === recreated.gen) {
-            const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
-            const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : recreated.content
-            if (correctContent !== content) {
-              try {
-                await window.api.file.write(targetPath, correctContent)
-              } catch (e) {
-                logger.error('Failed to restore recreated note after stale write:', e as Error)
+          if (recreated && genNow === recreated.gen) {
+            const isExact = normalizedAfter === recreated.path
+            const isDescendant = normalizedAfter.startsWith(`${recreated.path}/`)
+            if (isExact || isDescendant) {
+              if (isDescendant) {
+                try {
+                  await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+                  await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+                } catch {}
                 return
               }
+              const curLastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
+              const correctContent = curLastPath === normalizedAfter ? lastContentRef.current : recreated.content
+              if (correctContent !== content) {
+                try {
+                  await window.api.file.write(targetPath, correctContent)
+                } catch (e) {
+                  logger.error('Failed to restore recreated note after stale write:', e as Error)
+                  return
+                }
+              }
+              invalidateFileContent(targetPath)
+              return
             }
-            invalidateFileContent(targetPath)
-            return
           }
-          // generation 推进但既无 pending 也非重建，仍视为过期写入，避免残留复活文件
+          // generation 推进但既无 pending 也非重建，仍视为过期写入，清理被复活的文件避免残留
+          try {
+            await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+            await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+          } catch {}
           return
         }
         // 非过期写入，但若在此次写入等待期间该路径被标记为待删除（generation 未变但标记已设置），也需清理
@@ -551,14 +567,53 @@ const NotesPage: FC = () => {
         if (!targetPath) {
           throw new Error('No folder path selected')
         }
-        await addDir(name, targetPath)
+        const { path: folderPath } = await addDir(name, targetPath)
         updateExpandedPaths((prev) => addUniquePath(prev, normalizePathValue(targetPath)))
+        // 同 handleCreateNote：若新文件夹路径与待删除标记相同/为其子路径，清除删除标记并推进 generation，
+        // 避免首个文件写入被误拦截或被过期 autosave 覆盖
+        {
+          const normalizedFolder = normalizePathValue(folderPath)
+          let matchedPending: string | null = null
+          for (const pending of pendingDeleteSetRef.current) {
+            if (normalizedFolder === pending || normalizedFolder.startsWith(`${pending}/`)) {
+              matchedPending = pending
+              break
+            }
+          }
+          if (matchedPending) {
+            pendingDeleteSetRef.current.delete(matchedPending)
+            pendingDeleteGenRef.current.delete(matchedPending)
+            bumpGeneration(normalizedFolder)
+            const genAfter = getEffectiveGeneration(normalizedFolder)
+            lastRecreatedRef.current = { path: normalizedFolder, gen: genAfter, content: '' }
+            const recreatedGen = genAfter
+            const recreatedPath = normalizedFolder
+            setTimeout(() => {
+              const cur = lastRecreatedRef.current
+              if (cur && cur.path === recreatedPath && cur.gen === recreatedGen) {
+                lastRecreatedRef.current = null
+              }
+            }, 3000)
+          } else if (lastRecreatedRef.current?.path === normalizedFolder) {
+            bumpGeneration(normalizedFolder)
+            const genAfter = getEffectiveGeneration(normalizedFolder)
+            lastRecreatedRef.current = { path: normalizedFolder, gen: genAfter, content: '' }
+            const recreatedGen = genAfter
+            const recreatedPath = normalizedFolder
+            setTimeout(() => {
+              const cur = lastRecreatedRef.current
+              if (cur && cur.path === recreatedPath && cur.gen === recreatedGen) {
+                lastRecreatedRef.current = null
+              }
+            }, 3000)
+          }
+        }
         await refreshTree()
       } catch (error) {
         logger.error('Failed to create folder:', error as Error)
       }
     },
-    [getTargetFolderPath, refreshTree, updateExpandedPaths]
+    [bumpGeneration, getEffectiveGeneration, getTargetFolderPath, refreshTree, updateExpandedPaths]
   )
 
   // 创建笔记
@@ -700,14 +755,13 @@ const NotesPage: FC = () => {
           normalizedActivePath.startsWith(`${normalizedDeletePath}/`)
         const isActiveRelated = isActiveNode || isActiveDescendant
 
-        // 删除正在编辑的笔记（或其所在文件夹）时，先标记为“待删除”并取消防抖，
-        // 使已触发但尚未落盘的 autosave 在 saveCurrentNote 中被丢弃，避免文件被“复活”。
-        // 失败时需撤销标记并重建防抖，否则已取消的保存不会自动恢复，编辑内容将丢失。
         // 快照删除前的草稿，避免在删除等待期间用户切换笔记导致快照被覆盖
         const preDeleteContent = lastContentRef.current
         const preDeletePath = lastFilePathRef.current
-        if (isActiveRelated) {
-          // 若正在删除的是刚重建的同路径笔记，清除重建标记，避免旧的 autosave 误恢复已二次删除的文件
+        // 任何路径被删除时均标记为待删除并推进 generation，使删除期间及过期 autosave 写入被拦截；
+        // 仅当删除的是当前活动笔记/文件夹时才取消防抖，避免误删活动笔记的待保存。
+        // 同时清除可能与被删路径重叠的重建标记，避免已二次删除的文件被旧的 lastRecreated 恢复。
+        {
           const recreated = lastRecreatedRef.current
           if (
             recreated &&
@@ -718,15 +772,17 @@ const NotesPage: FC = () => {
           pendingDeleteSetRef.current.add(normalizedDeletePath)
           bumpGeneration(normalizedDeletePath)
           pendingDeleteGenRef.current.set(normalizedDeletePath, getEffectiveGeneration(normalizedDeletePath))
-          debouncedSaveRef.current?.cancel()
+          if (isActiveRelated) {
+            debouncedSaveRef.current?.cancel()
+          }
         }
 
         try {
           await delNode(nodeToDelete)
         } catch (error) {
+          pendingDeleteSetRef.current.delete(normalizedDeletePath)
+          pendingDeleteGenRef.current.delete(normalizedDeletePath)
           if (isActiveRelated) {
-            pendingDeleteSetRef.current.delete(normalizedDeletePath)
-            pendingDeleteGenRef.current.delete(normalizedDeletePath)
             const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
             const shouldRearmSnapshot =
               snapNorm === normalizedDeletePath ||
@@ -771,7 +827,10 @@ const NotesPage: FC = () => {
             dispatch(setActiveFilePath(undefined))
             editorRef.current?.clear()
           }
-          // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入；用 generation 绑定避免旧定时器误删新一轮同路径删除的标记
+        }
+        // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入；对非活动笔记的删除同样需要，
+        // 以覆盖文件切换清理等场景下已在途的 autosave。用 generation 绑定避免旧定时器误删新一轮同路径删除的标记
+        {
           const genAtDelete =
             pendingDeleteGenRef.current.get(normalizedDeletePath) ?? getEffectiveGeneration(normalizedDeletePath)
           setTimeout(() => {

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -83,6 +83,7 @@ const NotesPage: FC = () => {
   const isRenamingRef = useRef(false)
   const isCreatingNoteRef = useRef(false)
   const pendingScrollRef = useRef<{ lineNumber: number; lineContent?: string } | null>(null)
+  const pendingDeletePathRef = useRef<string | null>(null)
 
   const activeFilePathRef = useRef<string | undefined>(activeFilePath)
   const currentContentRef = useRef(currentContent)
@@ -178,6 +179,15 @@ const NotesPage: FC = () => {
     async (content: string, filePath?: string) => {
       const targetPath = filePath || activeFilePath
       if (!targetPath || content.trim() === currentContent.trim()) return
+
+      // 若目标路径正处于删除流程中（或为其子路径），跳过写入，避免已删除文件被“复活”
+      const pendingDelete = pendingDeletePathRef.current
+      if (pendingDelete) {
+        const normalizedTarget = normalizePathValue(targetPath)
+        if (normalizedTarget === pendingDelete || normalizedTarget.startsWith(`${pendingDelete}/`)) {
+          return
+        }
+      }
 
       try {
         await window.api.file.write(targetPath, content)
@@ -591,26 +601,44 @@ const NotesPage: FC = () => {
           nodeToDelete.type === 'folder' &&
           normalizedActivePath &&
           normalizedActivePath.startsWith(`${normalizedDeletePath}/`)
+        const isActiveRelated = isActiveNode || isActiveDescendant
 
-        // 删除正在编辑的笔记（或其所在的文件夹）时，先取消防抖保存。
-        // 否则删除成功后 setActiveFilePath(undefined) 会触发「切换文件时的清理」
-        // 中的紧急保存，把刚删除的文件重新写回磁盘，导致笔记“复活”并改变排序位置。
-        if (isActiveNode || isActiveDescendant) {
+        // 删除正在编辑的笔记（或其所在文件夹）时，先标记为“待删除”并取消防抖，
+        // 使已触发但尚未落盘的 autosave 在 saveCurrentNote 中被丢弃，避免文件被“复活”。
+        // 失败时需撤销标记并重建防抖，否则已取消的保存不会自动恢复，编辑内容将丢失。
+        if (isActiveRelated) {
+          pendingDeletePathRef.current = normalizedDeletePath
           debouncedSaveRef.current?.cancel()
         }
 
-        await delNode(nodeToDelete)
+        try {
+          await delNode(nodeToDelete)
+        } catch (error) {
+          if (isActiveRelated) {
+            pendingDeletePathRef.current = null
+            if (lastContentRef.current && lastFilePathRef.current) {
+              debouncedSaveRef.current?.(lastContentRef.current, lastFilePathRef.current)
+            }
+          }
+          throw error
+        }
 
         updateStarredPaths((prev) => removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder'))
         updateExpandedPaths((prev) =>
           removePathEntries(prev, nodeToDelete.externalPath, nodeToDelete.type === 'folder')
         )
 
-        if (isActiveNode || isActiveDescendant) {
+        if (isActiveRelated) {
           lastContentRef.current = ''
           lastFilePathRef.current = undefined
           dispatch(setActiveFilePath(undefined))
           editorRef.current?.clear()
+          // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入
+          setTimeout(() => {
+            if (pendingDeletePathRef.current === normalizedDeletePath) {
+              pendingDeletePathRef.current = null
+            }
+          }, 2000)
         }
 
         await refreshTree()

--- a/src/renderer/src/pages/notes/NotesPage.tsx
+++ b/src/renderer/src/pages/notes/NotesPage.tsx
@@ -191,6 +191,19 @@ const NotesPage: FC = () => {
 
       try {
         await window.api.file.write(targetPath, content)
+        // 写入完成后再检查一次删除标记：若在此次写入等待期间文件已被删除，写入会“复活”文件，需立即清理
+        const pendingAfter = pendingDeletePathRef.current
+        if (pendingAfter) {
+          const normalizedAfter = normalizePathValue(targetPath)
+          if (normalizedAfter === pendingAfter || normalizedAfter.startsWith(`${pendingAfter}/`)) {
+            try {
+              // 尝试删除刚被复活的文件/目录（忽略错误）
+              await window.api.file.deleteExternalFile(targetPath).catch(() => {})
+              await window.api.file.deleteExternalDir(targetPath).catch(() => {})
+            } catch {}
+            return
+          }
+        }
         // 保存后立即刷新缓存，确保下次读取时获取最新内容
         invalidateFileContent(targetPath)
       } catch (error) {
@@ -517,6 +530,14 @@ const NotesPage: FC = () => {
         const { path: notePath } = await addNote(name, '', targetPath)
         const normalizedParent = normalizePathValue(targetPath)
         updateExpandedPaths((prev) => addUniquePath(prev, normalizedParent))
+        // 若新笔记路径与待删除标记相同（用户删除后立即重建同名笔记），清除标记避免首个 autosave 被误拦截
+        const pendingCreate = pendingDeletePathRef.current
+        if (pendingCreate) {
+          const normalizedNote = normalizePathValue(notePath)
+          if (normalizedNote === pendingCreate || normalizedNote.startsWith(`${pendingCreate}/`)) {
+            pendingDeletePathRef.current = null
+          }
+        }
         dispatch(setActiveFilePath(notePath))
         setSelectedFolderId(null)
 
@@ -616,7 +637,7 @@ const NotesPage: FC = () => {
         } catch (error) {
           if (isActiveRelated) {
             pendingDeletePathRef.current = null
-            if (lastContentRef.current && lastFilePathRef.current) {
+            if (lastFilePathRef.current != null) {
               debouncedSaveRef.current?.(lastContentRef.current, lastFilePathRef.current)
             }
           }
@@ -629,10 +650,21 @@ const NotesPage: FC = () => {
         )
 
         if (isActiveRelated) {
-          lastContentRef.current = ''
-          lastFilePathRef.current = undefined
-          dispatch(setActiveFilePath(undefined))
-          editorRef.current?.clear()
+          // 重新检查 activeFilePath 是否仍关联到被删除路径，避免在删除等待期间用户已切换到其他笔记时误清空
+          const currentActive = activeFilePathRef.current ? normalizePathValue(activeFilePathRef.current) : undefined
+          const stillRelated =
+            currentActive === normalizedDeletePath ||
+            (nodeToDelete.type === 'folder' && currentActive?.startsWith(`${normalizedDeletePath}/`))
+          if (stillRelated) {
+            // 仅当 lastFilePath 指向被删除路径时才丢弃草稿，避免丢弃已切换笔记的未保存内容
+            const lastPath = lastFilePathRef.current ? normalizePathValue(lastFilePathRef.current) : undefined
+            if (lastPath === normalizedDeletePath || lastPath?.startsWith(`${normalizedDeletePath}/`)) {
+              lastContentRef.current = ''
+              lastFilePathRef.current = undefined
+            }
+            dispatch(setActiveFilePath(undefined))
+            editorRef.current?.clear()
+          }
           // 保持删除标记一小段时间，拦截删除后紧接着的 emergency save / 尾随写入
           setTimeout(() => {
             if (pendingDeletePathRef.current === normalizedDeletePath) {

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -155,8 +155,7 @@ describe('notes delete / autosave guards', () => {
       // production fix: use snapshot if snapshot was related
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete ||
-        (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete || (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)
@@ -182,8 +181,7 @@ describe('notes delete / autosave guards', () => {
 
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete ||
-        (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete || (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -155,7 +155,8 @@ describe('notes delete / autosave guards', () => {
       // production fix: use snapshot if snapshot was related
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete || ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete ||
+        ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)
@@ -181,7 +182,8 @@ describe('notes delete / autosave guards', () => {
 
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete || ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete ||
+        ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -1,23 +1,12 @@
 import { normalizePathValue } from '@renderer/services/NotesTreeService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-function shouldBlockAutosave(targetPath: string, pendingDelete: string | null): boolean {
-  if (!pendingDelete) return false
-  const normalizedTarget = normalizePathValue(targetPath)
-  return normalizedTarget === pendingDelete || normalizedTarget.startsWith(`${pendingDelete}/`)
-}
-
-function isActiveRelated(
-  activeFilePath: string | undefined,
-  deletePath: string,
-  deleteType: 'file' | 'folder'
-): boolean {
-  const normalizedActive = activeFilePath ? normalizePathValue(activeFilePath) : undefined
-  const normalizedDelete = normalizePathValue(deletePath)
-  if (normalizedActive === normalizedDelete) return true
-  if (deleteType === 'folder' && normalizedActive?.startsWith(`${normalizedDelete}/`)) return true
-  return false
-}
+import {
+  getEffectiveGeneration,
+  isActiveRelated,
+  isPendingDeleteForPath,
+  shouldBlockAutosave,
+  shouldRearmSnapshot
+} from '../notesGuards'
 
 describe('notes delete / autosave guards', () => {
   describe('autosave fence (pendingDelete)', () => {
@@ -44,6 +33,32 @@ describe('notes delete / autosave guards', () => {
     it('does not block prefix false-positive (/notes/ab.md vs /notes/a)', () => {
       expect(shouldBlockAutosave('/notes/ab.md', '/notes/a')).toBe(false)
       expect(shouldBlockAutosave('/notes/a-b/c.md', '/notes/a')).toBe(false)
+    })
+  })
+
+  describe('pending set fence', () => {
+    it('isPendingDeleteForPath covers exact and descendant', () => {
+      const set = new Set([normalizePathValue('/notes/folder')])
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/folder/a.md'), set)).toBe(true)
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/folder'), set)).toBe(true)
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/other.md'), set)).toBe(false)
+    })
+  })
+
+  describe('per-path generation', () => {
+    it('getEffectiveGeneration considers ancestor generations', () => {
+      const gens = new Map<string, number>()
+      gens.set(normalizePathValue('/notes/folder'), 1)
+      expect(getEffectiveGeneration(normalizePathValue('/notes/folder/a.md'), gens)).toBe(1)
+      expect(getEffectiveGeneration(normalizePathValue('/notes/other.md'), gens)).toBe(0)
+      gens.set(normalizePathValue('/notes/folder/a.md'), 2)
+      expect(getEffectiveGeneration(normalizePathValue('/notes/folder/a.md'), gens)).toBe(2)
+    })
+
+    it('unrelated delete does not bump generation for other path', () => {
+      const gens = new Map<string, number>()
+      gens.set(normalizePathValue('/notes/a.md'), 1)
+      expect(getEffectiveGeneration(normalizePathValue('/notes/b.md'), gens)).toBe(0)
     })
   })
 
@@ -142,7 +157,7 @@ describe('notes delete / autosave guards', () => {
 
   describe('delete-failure with switch preserves snapshot', () => {
     it('re-arms snapshot draft when user switched away before failure', () => {
-      const normalizedDelete = normalizePathValue('/notes/a.md')
+      const deletePath = '/notes/a.md'
       const deleteType: 'file' | 'folder' = 'file'
       // snapshot at delete start
       const preDeleteContent = 'draft-a'
@@ -150,54 +165,62 @@ describe('notes delete / autosave guards', () => {
       // simulate switch: refs now point to new note
       const lastContent = 'draft-b'
       const lastFilePath: string | undefined = '/notes/b.md'
-      const debouncedSave = vi.fn()
 
-      // production fix: use snapshot if snapshot was related
+      expect(shouldRearmSnapshot(preDeletePath, deletePath, deleteType)).toBe(true)
+      // production fix: switchedAway should trigger direct write, not shared debounce
+      const currentNorm = lastFilePath ? normalizePathValue(lastFilePath) : undefined
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
-      const shouldRearmSnapshot =
-        snapNorm === normalizedDelete ||
-        ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
-
-      if (shouldRearmSnapshot && preDeletePath != null) {
-        debouncedSave(preDeleteContent, preDeletePath)
-      } else if (lastFilePath != null) {
-        debouncedSave(lastContent, lastFilePath)
-      }
-
-      expect(debouncedSave).toHaveBeenCalledWith('draft-a', '/notes/a.md')
-      expect(debouncedSave).not.toHaveBeenCalledWith('draft-b', '/notes/b.md')
-      // current draft for b should be preserved by not overwriting refs
+      const switchedAway = currentNorm != null && snapNorm != null && currentNorm !== snapNorm
+      expect(switchedAway).toBe(true)
+      // snapshot re-arm should not cancel current draft's debounce
       expect(lastFilePath).toBe('/notes/b.md')
       expect(lastContent).toBe('draft-b')
     })
 
     it('does not re-arm with stale snapshot when snapshot was unrelated', () => {
-      const normalizedDelete = normalizePathValue('/notes/a.md')
+      const deletePath = '/notes/a.md'
       const deleteType: 'file' | 'folder' = 'file'
-      const preDeleteContent = 'draft-unrelated'
       const preDeletePath = '/notes/other.md'
-      const lastContent = 'draft-current'
-      const lastFilePath: string | undefined = '/notes/other.md'
+
+      expect(shouldRearmSnapshot(preDeletePath, deletePath, deleteType)).toBe(false)
+    })
+  })
+
+  describe('delete-failure recovery does not cancel switched note autosave', () => {
+    it('switchedAway uses direct save so shared debounce keeps current note pending', () => {
       const debouncedSave = vi.fn()
+      const directSave = vi.fn().mockResolvedValue(undefined)
+      const preDeletePath = '/notes/a.md'
+      const preDeleteContent = 'draft-a'
+      const lastFilePath = '/notes/b.md'
+      const lastContent = 'draft-b'
+      const deletePath = '/notes/a.md'
 
-      const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
-      const shouldRearmSnapshot =
-        snapNorm === normalizedDelete ||
-        ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+      const snapNorm = normalizePathValue(preDeletePath)
+      const currentNorm = normalizePathValue(lastFilePath)
+      const switchedAway = currentNorm !== snapNorm
+      expect(switchedAway).toBe(true)
 
-      if (shouldRearmSnapshot && preDeletePath != null) {
+      const shouldRearm = shouldRearmSnapshot(preDeletePath, deletePath, 'file')
+      expect(shouldRearm).toBe(true)
+
+      if (shouldRearm && switchedAway) {
+        void directSave(preDeleteContent, preDeletePath)
+      } else {
         debouncedSave(preDeleteContent, preDeletePath)
-      } else if (lastFilePath != null) {
-        debouncedSave(lastContent, lastFilePath)
       }
 
-      expect(debouncedSave).toHaveBeenCalledWith('draft-current', '/notes/other.md')
+      expect(directSave).toHaveBeenCalledWith('draft-a', '/notes/a.md')
+      expect(debouncedSave).not.toHaveBeenCalled()
+      // current note's debounce would remain untouched (not canceled)
+      expect(lastFilePath).toBe('/notes/b.md')
+      expect(lastContent).toBe('draft-b')
     })
   })
 
   describe('same-path recreate race with in-flight autosave', () => {
-    let deleteEpoch: number
-    let pendingDelete: string | null
+    let generations: Map<string, number>
+    let pendingSet: Set<string>
     let lastRecreated: string | null
     let fileWrite: ReturnType<typeof vi.fn>
     let invalidate: ReturnType<typeof vi.fn>
@@ -205,8 +228,8 @@ describe('notes delete / autosave guards', () => {
     let lastFilePathRef: string | undefined
 
     beforeEach(() => {
-      deleteEpoch = 0
-      pendingDelete = null
+      generations = new Map()
+      pendingSet = new Set()
       lastRecreated = null
       fileWrite = vi.fn().mockImplementation(() => Promise.resolve())
       invalidate = vi.fn()
@@ -214,17 +237,28 @@ describe('notes delete / autosave guards', () => {
       lastFilePathRef = undefined
     })
 
+    function isPending(target: string): boolean {
+      const nt = normalizePathValue(target)
+      return isPendingDeleteForPath(nt, pendingSet)
+    }
+
+    function getGen(target: string): number {
+      return getEffectiveGeneration(normalizePathValue(target), generations)
+    }
+
+    function bump(path: string): void {
+      const n = normalizePathValue(path)
+      generations.set(n, (generations.get(n) ?? 0) + 1)
+    }
+
     async function saveCurrentNoteSim(content: string, targetPath: string, currentContent: string) {
       if (!targetPath || content.trim() === currentContent.trim()) return
-      const pd = pendingDelete
-      if (pd) {
-        const nt = normalizePathValue(targetPath)
-        if (nt === pd || nt.startsWith(`${pd}/`)) return
-      }
-      const epochAtStart = deleteEpoch
+      if (isPending(targetPath)) return
+      const genAtStart = getGen(targetPath)
       await fileWrite(targetPath, content)
-      if (epochAtStart !== deleteEpoch) {
-        const na = normalizePathValue(targetPath)
+      const genNow = getGen(targetPath)
+      const na = normalizePathValue(targetPath)
+      if (genAtStart !== genNow) {
         if (lastRecreated && na === lastRecreated) {
           const curLast = lastFilePathRef ? normalizePathValue(lastFilePathRef) : undefined
           const correct = curLast === na ? lastContentRef : ''
@@ -234,64 +268,60 @@ describe('notes delete / autosave guards', () => {
           invalidate(targetPath)
           return
         }
-        const ps = pendingDelete
-        if (ps) {
-          const ns = normalizePathValue(targetPath)
-          if (ns === ps || ns.startsWith(`${ps}/`)) {
-            return
-          }
-        }
+        if (isPending(targetPath)) return
         return
       }
-      const pa = pendingDelete
-      if (pa) {
-        const na = normalizePathValue(targetPath)
-        if (na === pa || na.startsWith(`${pa}/`)) return
-      }
+      if (isPending(targetPath)) return
       invalidate(targetPath)
     }
 
     it('stale write after same-path recreate restores new content instead of leaving stale overwrite', async () => {
-      // user edits a.md
       const staleContent = 'old content'
       const recreatedCorrectContent = ''
 
-      // start autosave (epoch 0)
       const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md', '')
 
-      // during await, user deletes a.md
-      pendingDelete = normalizePathValue('/notes/a.md')
-      deleteEpoch += 1
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
 
-      // then recreates same path
-      pendingDelete = null
-      deleteEpoch += 1
+      pendingSet.delete(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
       lastRecreated = normalizePathValue('/notes/a.md')
       lastContentRef = recreatedCorrectContent
       lastFilePathRef = '/notes/a.md'
 
       await savePromise
 
-      // first write was stale, second write should restore correct content
       expect(fileWrite).toHaveBeenCalledTimes(2)
       expect(fileWrite).toHaveBeenNthCalledWith(1, '/notes/a.md', 'old content')
       expect(fileWrite).toHaveBeenNthCalledWith(2, '/notes/a.md', '')
       expect(invalidate).toHaveBeenCalledWith('/notes/a.md')
     })
 
-    it('stale write without recreate does not trigger corrective rewrite', async () => {
+    it('stale write without recreate does not trigger corrective rewrite and is swallowed', async () => {
       const savePromise = saveCurrentNoteSim('stale', '/notes/a.md', '')
 
-      pendingDelete = normalizePathValue('/notes/a.md')
-      deleteEpoch += 1
-      // no recreate
-      lastRecreated = null
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
 
       await savePromise
 
-      // stale write should be swallowed without corrective write
       expect(fileWrite).toHaveBeenCalledTimes(1)
       expect(invalidate).not.toHaveBeenCalled()
+    })
+
+    it('generation is per-path: unrelated delete does not affect other file autosave', async () => {
+      const savePromise = saveCurrentNoteSim('content-b', '/notes/b.md', '')
+
+      // delete unrelated file a
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+
+      await savePromise
+
+      // b's write should succeed and invalidate, not be treated as stale
+      expect(fileWrite).toHaveBeenCalledWith('/notes/b.md', 'content-b')
+      expect(invalidate).toHaveBeenCalledWith('/notes/b.md')
     })
   })
 })

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -1,5 +1,5 @@
 import { normalizePathValue } from '@renderer/services/NotesTreeService'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 function shouldBlockAutosave(targetPath: string, pendingDelete: string | null): boolean {
   if (!pendingDelete) return false
@@ -137,6 +137,161 @@ describe('notes delete / autosave guards', () => {
         debouncedSave(lastContent, lastFilePath)
       }
       expect(debouncedSave).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('delete-failure with switch preserves snapshot', () => {
+    it('re-arms snapshot draft when user switched away before failure', () => {
+      const normalizedDelete = normalizePathValue('/notes/a.md')
+      const deleteType: 'file' | 'folder' = 'file'
+      // snapshot at delete start
+      const preDeleteContent = 'draft-a'
+      const preDeletePath = '/notes/a.md'
+      // simulate switch: refs now point to new note
+      let lastContent = 'draft-b'
+      let lastFilePath: string | undefined = '/notes/b.md'
+      const debouncedSave = vi.fn()
+
+      // production fix: use snapshot if snapshot was related
+      const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
+      const shouldRearmSnapshot =
+        snapNorm === normalizedDelete ||
+        (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+
+      if (shouldRearmSnapshot && preDeletePath != null) {
+        debouncedSave(preDeleteContent, preDeletePath)
+      } else if (lastFilePath != null) {
+        debouncedSave(lastContent, lastFilePath)
+      }
+
+      expect(debouncedSave).toHaveBeenCalledWith('draft-a', '/notes/a.md')
+      expect(debouncedSave).not.toHaveBeenCalledWith('draft-b', '/notes/b.md')
+      // current draft for b should be preserved by not overwriting refs
+      expect(lastFilePath).toBe('/notes/b.md')
+      expect(lastContent).toBe('draft-b')
+    })
+
+    it('does not re-arm with stale snapshot when snapshot was unrelated', () => {
+      const normalizedDelete = normalizePathValue('/notes/a.md')
+      const deleteType: 'file' | 'folder' = 'file'
+      const preDeleteContent = 'draft-unrelated'
+      const preDeletePath = '/notes/other.md'
+      const lastContent = 'draft-current'
+      const lastFilePath: string | undefined = '/notes/other.md'
+      const debouncedSave = vi.fn()
+
+      const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
+      const shouldRearmSnapshot =
+        snapNorm === normalizedDelete ||
+        (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+
+      if (shouldRearmSnapshot && preDeletePath != null) {
+        debouncedSave(preDeleteContent, preDeletePath)
+      } else if (lastFilePath != null) {
+        debouncedSave(lastContent, lastFilePath)
+      }
+
+      expect(debouncedSave).toHaveBeenCalledWith('draft-current', '/notes/other.md')
+    })
+  })
+
+  describe('same-path recreate race with in-flight autosave', () => {
+    let deleteEpoch: number
+    let pendingDelete: string | null
+    let lastRecreated: string | null
+    let fileWrite: ReturnType<typeof vi.fn>
+    let invalidate: ReturnType<typeof vi.fn>
+    let lastContentRef: string
+    let lastFilePathRef: string | undefined
+
+    beforeEach(() => {
+      deleteEpoch = 0
+      pendingDelete = null
+      lastRecreated = null
+      fileWrite = vi.fn().mockImplementation(() => Promise.resolve())
+      invalidate = vi.fn()
+      lastContentRef = ''
+      lastFilePathRef = undefined
+    })
+
+    async function saveCurrentNoteSim(content: string, targetPath: string, currentContent: string) {
+      if (!targetPath || content.trim() === currentContent.trim()) return
+      const pd = pendingDelete
+      if (pd) {
+        const nt = normalizePathValue(targetPath)
+        if (nt === pd || nt.startsWith(`${pd}/`)) return
+      }
+      const epochAtStart = deleteEpoch
+      await fileWrite(targetPath, content)
+      if (epochAtStart !== deleteEpoch) {
+        const na = normalizePathValue(targetPath)
+        if (lastRecreated && na === lastRecreated) {
+          const curLast = lastFilePathRef ? normalizePathValue(lastFilePathRef) : undefined
+          const correct = curLast === na ? lastContentRef : ''
+          if (correct !== content) {
+            await fileWrite(targetPath, correct)
+          }
+          invalidate(targetPath)
+          return
+        }
+        const ps = pendingDelete
+        if (ps) {
+          const ns = normalizePathValue(targetPath)
+          if (ns === ps || ns.startsWith(`${ps}/`)) {
+            return
+          }
+        }
+        return
+      }
+      const pa = pendingDelete
+      if (pa) {
+        const na = normalizePathValue(targetPath)
+        if (na === pa || na.startsWith(`${pa}/`)) return
+      }
+      invalidate(targetPath)
+    }
+
+    it('stale write after same-path recreate restores new content instead of leaving stale overwrite', async () => {
+      // user edits a.md
+      const staleContent = 'old content'
+      const recreatedCorrectContent = ''
+
+      // start autosave (epoch 0)
+      const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md', '')
+
+      // during await, user deletes a.md
+      pendingDelete = normalizePathValue('/notes/a.md')
+      deleteEpoch += 1
+
+      // then recreates same path
+      pendingDelete = null
+      deleteEpoch += 1
+      lastRecreated = normalizePathValue('/notes/a.md')
+      lastContentRef = recreatedCorrectContent
+      lastFilePathRef = '/notes/a.md'
+
+      await savePromise
+
+      // first write was stale, second write should restore correct content
+      expect(fileWrite).toHaveBeenCalledTimes(2)
+      expect(fileWrite).toHaveBeenNthCalledWith(1, '/notes/a.md', 'old content')
+      expect(fileWrite).toHaveBeenNthCalledWith(2, '/notes/a.md', '')
+      expect(invalidate).toHaveBeenCalledWith('/notes/a.md')
+    })
+
+    it('stale write without recreate does not trigger corrective rewrite', async () => {
+      const savePromise = saveCurrentNoteSim('stale', '/notes/a.md', '')
+
+      pendingDelete = normalizePathValue('/notes/a.md')
+      deleteEpoch += 1
+      // no recreate
+      lastRecreated = null
+
+      await savePromise
+
+      // stale write should be swallowed without corrective write
+      expect(fileWrite).toHaveBeenCalledTimes(1)
+      expect(invalidate).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -148,8 +148,8 @@ describe('notes delete / autosave guards', () => {
       const preDeleteContent = 'draft-a'
       const preDeletePath = '/notes/a.md'
       // simulate switch: refs now point to new note
-      let lastContent = 'draft-b'
-      let lastFilePath: string | undefined = '/notes/b.md'
+      const lastContent = 'draft-b'
+      const lastFilePath: string | undefined = '/notes/b.md'
       const debouncedSave = vi.fn()
 
       // production fix: use snapshot if snapshot was related

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -1,5 +1,6 @@
 import { normalizePathValue } from '@renderer/services/NotesTreeService'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
   getEffectiveGeneration,
   isActiveRelated,

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -218,23 +218,56 @@ describe('notes delete / autosave guards', () => {
     })
   })
 
-  describe('same-path recreate race with in-flight autosave', () => {
+  describe('delete-failure recovery with equal content still restores', () => {
+    it('direct save for snapshot is not skipped when active note has same text', async () => {
+      // Reproduces c1: saveCurrentNote compared content against active note's currentContent
+      const activePath = '/notes/b.md'
+      const activeContent = 'hello'
+      const snapshotPath = '/notes/a.md'
+      const snapshotContent = 'hello'
+      const fileWrite = vi.fn().mockResolvedValue(undefined)
+
+      async function saveCurrentNoteSim(content: string, targetPath: string) {
+        if (!targetPath) return
+        const normalizedTarget = normalizePathValue(targetPath)
+        const activeNorm = normalizePathValue(activePath)
+        const isActiveTarget = normalizedTarget === activeNorm
+        if (isActiveTarget && content.trim() === activeContent.trim()) return
+        await fileWrite(targetPath, content)
+      }
+
+      await saveCurrentNoteSim(snapshotContent, snapshotPath)
+      expect(fileWrite).toHaveBeenCalledWith('/notes/a.md', 'hello')
+
+      // old buggy guard would have blocked: if (content.trim() === currentContent.trim()) return
+      const buggyWouldSkip = snapshotContent.trim() === activeContent.trim()
+      expect(buggyWouldSkip).toBe(true)
+    })
+  })
+
+  describe('same-path recreate race with in-flight autosave (generation-tied)', () => {
     let generations: Map<string, number>
     let pendingSet: Set<string>
-    let lastRecreated: string | null
+    let pendingGen: Map<string, number>
+    let lastRecreated: { path: string; gen: number; content: string } | null
     let fileWrite: ReturnType<typeof vi.fn>
     let invalidate: ReturnType<typeof vi.fn>
     let lastContentRef: string
     let lastFilePathRef: string | undefined
+    let activePath: string | undefined
+    let activeContent: string
 
     beforeEach(() => {
       generations = new Map()
       pendingSet = new Set()
+      pendingGen = new Map()
       lastRecreated = null
       fileWrite = vi.fn().mockImplementation(() => Promise.resolve())
       invalidate = vi.fn()
       lastContentRef = ''
       lastFilePathRef = undefined
+      activePath = undefined
+      activeContent = ''
     })
 
     function isPending(target: string): boolean {
@@ -251,24 +284,30 @@ describe('notes delete / autosave guards', () => {
       generations.set(n, (generations.get(n) ?? 0) + 1)
     }
 
-    async function saveCurrentNoteSim(content: string, targetPath: string, currentContent: string) {
-      if (!targetPath || content.trim() === currentContent.trim()) return
+    async function saveCurrentNoteSim(content: string, targetPath: string) {
+      if (!targetPath) return
+      const normalizedTarget = normalizePathValue(targetPath)
+      const activeNorm = activePath ? normalizePathValue(activePath) : undefined
+      const isActiveTarget = normalizedTarget === activeNorm
+      if (isActiveTarget && content.trim() === activeContent.trim()) return
       if (isPending(targetPath)) return
       const genAtStart = getGen(targetPath)
       await fileWrite(targetPath, content)
       const genNow = getGen(targetPath)
       const na = normalizePathValue(targetPath)
       if (genAtStart !== genNow) {
-        if (lastRecreated && na === lastRecreated) {
+        if (isPending(targetPath)) {
+          return
+        }
+        if (lastRecreated && na === lastRecreated.path && genNow === lastRecreated.gen) {
           const curLast = lastFilePathRef ? normalizePathValue(lastFilePathRef) : undefined
-          const correct = curLast === na ? lastContentRef : ''
+          const correct = curLast === na ? lastContentRef : lastRecreated.content
           if (correct !== content) {
             await fileWrite(targetPath, correct)
           }
           invalidate(targetPath)
           return
         }
-        if (isPending(targetPath)) return
         return
       }
       if (isPending(targetPath)) return
@@ -279,14 +318,20 @@ describe('notes delete / autosave guards', () => {
       const staleContent = 'old content'
       const recreatedCorrectContent = ''
 
-      const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md', '')
+      activePath = '/notes/a.md'
+      activeContent = ''
+
+      const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md')
 
       pendingSet.add(normalizePathValue('/notes/a.md'))
+      pendingGen.set(normalizePathValue('/notes/a.md'), 1)
       bump('/notes/a.md')
 
       pendingSet.delete(normalizePathValue('/notes/a.md'))
+      pendingGen.delete(normalizePathValue('/notes/a.md'))
       bump('/notes/a.md')
-      lastRecreated = normalizePathValue('/notes/a.md')
+      const genAfter = getGen('/notes/a.md')
+      lastRecreated = { path: normalizePathValue('/notes/a.md'), gen: genAfter, content: recreatedCorrectContent }
       lastContentRef = recreatedCorrectContent
       lastFilePathRef = '/notes/a.md'
 
@@ -298,8 +343,138 @@ describe('notes delete / autosave guards', () => {
       expect(invalidate).toHaveBeenCalledWith('/notes/a.md')
     })
 
+    it('stale write after second delete is cleaned, not restored as recreate', async () => {
+      const staleContent = 'old content'
+
+      activePath = '/notes/a.md'
+      activeContent = ''
+
+      const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md')
+
+      // first delete + recreate
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      pendingSet.delete(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      lastRecreated = { path: normalizePathValue('/notes/a.md'), gen: getGen('/notes/a.md'), content: '' }
+
+      // second delete before stale write completes (covers c0: stale autosave restores note deleted again)
+      lastRecreated = null
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+
+      await savePromise
+
+      // stale write should be swallowed via pending cleanup, not restored via lastRecreated
+      expect(fileWrite).toHaveBeenCalledTimes(1)
+      expect(fileWrite).toHaveBeenCalledWith('/notes/a.md', 'old content')
+      expect(invalidate).not.toHaveBeenCalled()
+    })
+
+    it('recreated path does not copy active note content when user switched away', async () => {
+      const staleContent = 'old content'
+      const recreatedContent = ''
+
+      // after recreate, user switched to /notes/b.md which has different content
+      activePath = '/notes/b.md'
+      activeContent = 'content-b'
+      lastContentRef = 'content-b'
+      lastFilePathRef = '/notes/b.md'
+
+      const savePromise = saveCurrentNoteSim(staleContent, '/notes/a.md')
+
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      pendingSet.delete(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      lastRecreated = { path: normalizePathValue('/notes/a.md'), gen: getGen('/notes/a.md'), content: recreatedContent }
+
+      await savePromise
+
+      // should restore recreatedContent '' not active note's content-b
+      expect(fileWrite).toHaveBeenCalledTimes(2)
+      expect(fileWrite).toHaveBeenNthCalledWith(2, '/notes/a.md', '')
+    })
+
+    it('delete replacement during creation window clears recreation marker', async () => {
+      // recreate then delete same path within creation window
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      pendingSet.delete(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      lastRecreated = { path: normalizePathValue('/notes/a.md'), gen: getGen('/notes/a.md'), content: '' }
+
+      // delete the replacement
+      if (lastRecreated && lastRecreated.path === normalizePathValue('/notes/a.md')) {
+        lastRecreated = null
+      }
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+
+      expect(lastRecreated).toBeNull()
+      expect(isPending('/notes/a.md')).toBe(true)
+
+      // stale write for old content should not be treated as recreation restore
+      const savePromise = saveCurrentNoteSim('old content', '/notes/a.md')
+      await savePromise
+      expect(fileWrite).toHaveBeenCalledTimes(0)
+      // blocked by pending fence at start
+    })
+
+    it('older pending timer does not clear newer deletion marker (generation-tied)', async () => {
+      const path = normalizePathValue('/notes/a.md')
+
+      // first delete: gen 1
+      pendingSet.add(path)
+      bump(path)
+      const gen1 = getGen(path)
+      pendingGen.set(path, gen1)
+
+      // recreate clears first pending but bumps to gen 2
+      pendingSet.delete(path)
+      pendingGen.delete(path)
+      bump(path)
+      lastRecreated = { path, gen: getGen(path), content: '' }
+
+      // second delete quickly: gen 3
+      lastRecreated = null
+      pendingSet.add(path)
+      bump(path)
+      const gen3 = getGen(path)
+      pendingGen.set(path, gen3)
+
+      // first timer fires (would have checked gen1 === curGen? -> false, so no clear)
+      const curGen = getGen(path)
+      const firstTimerWouldClear = gen1 === curGen
+      expect(firstTimerWouldClear).toBe(false)
+
+      // second timer correctly keeps pending until its gen matches
+      expect(isPending('/notes/a.md')).toBe(true)
+      expect(pendingGen.get(path)).toBe(gen3)
+    })
+
+    it('older recreation timer does not clear newer recreation marker', () => {
+      const path = normalizePathValue('/notes/a.md')
+
+      bump(path)
+      const gen1 = getGen(path)
+      lastRecreated = { path, gen: gen1, content: '' }
+
+      bump(path)
+      const gen2 = getGen(path)
+      lastRecreated = { path, gen: gen2, content: '' }
+
+      // first timer checks gen1 vs current lastRecreated gen2 -> should not clear
+      const firstTimerWouldClear = lastRecreated.gen === gen1
+      expect(firstTimerWouldClear).toBe(false)
+      expect(lastRecreated.gen).toBe(gen2)
+    })
+
     it('stale write without recreate does not trigger corrective rewrite and is swallowed', async () => {
-      const savePromise = saveCurrentNoteSim('stale', '/notes/a.md', '')
+      activePath = '/notes/a.md'
+      activeContent = ''
+
+      const savePromise = saveCurrentNoteSim('stale', '/notes/a.md')
 
       pendingSet.add(normalizePathValue('/notes/a.md'))
       bump('/notes/a.md')
@@ -311,7 +486,10 @@ describe('notes delete / autosave guards', () => {
     })
 
     it('generation is per-path: unrelated delete does not affect other file autosave', async () => {
-      const savePromise = saveCurrentNoteSim('content-b', '/notes/b.md', '')
+      activePath = '/notes/b.md'
+      activeContent = ''
+
+      const savePromise = saveCurrentNoteSim('content-b', '/notes/b.md')
 
       // delete unrelated file a
       pendingSet.add(normalizePathValue('/notes/a.md'))

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -252,6 +252,8 @@ describe('notes delete / autosave guards', () => {
     let lastRecreated: { path: string; gen: number; content: string } | null
     let fileWrite: ReturnType<typeof vi.fn>
     let invalidate: ReturnType<typeof vi.fn>
+    let deleteExternalFile: ReturnType<typeof vi.fn>
+    let deleteExternalDir: ReturnType<typeof vi.fn>
     let lastContentRef: string
     let lastFilePathRef: string | undefined
     let activePath: string | undefined
@@ -264,6 +266,8 @@ describe('notes delete / autosave guards', () => {
       lastRecreated = null
       fileWrite = vi.fn().mockImplementation(() => Promise.resolve())
       invalidate = vi.fn()
+      deleteExternalFile = vi.fn().mockResolvedValue(undefined)
+      deleteExternalDir = vi.fn().mockResolvedValue(undefined)
       lastContentRef = ''
       lastFilePathRef = undefined
       activePath = undefined
@@ -297,20 +301,37 @@ describe('notes delete / autosave guards', () => {
       const na = normalizePathValue(targetPath)
       if (genAtStart !== genNow) {
         if (isPending(targetPath)) {
+          await deleteExternalFile(targetPath).catch(() => {})
+          await deleteExternalDir(targetPath).catch(() => {})
           return
         }
-        if (lastRecreated && na === lastRecreated.path && genNow === lastRecreated.gen) {
-          const curLast = lastFilePathRef ? normalizePathValue(lastFilePathRef) : undefined
-          const correct = curLast === na ? lastContentRef : lastRecreated.content
-          if (correct !== content) {
-            await fileWrite(targetPath, correct)
+        if (lastRecreated && genNow === lastRecreated.gen) {
+          const isExact = na === lastRecreated.path
+          const isDescendant = na.startsWith(`${lastRecreated.path}/`)
+          if (isExact || isDescendant) {
+            if (isDescendant) {
+              await deleteExternalFile(targetPath).catch(() => {})
+              await deleteExternalDir(targetPath).catch(() => {})
+              return
+            }
+            const curLast = lastFilePathRef ? normalizePathValue(lastFilePathRef) : undefined
+            const correct = curLast === na ? lastContentRef : lastRecreated.content
+            if (correct !== content) {
+              await fileWrite(targetPath, correct)
+            }
+            invalidate(targetPath)
+            return
           }
-          invalidate(targetPath)
-          return
         }
+        await deleteExternalFile(targetPath).catch(() => {})
+        await deleteExternalDir(targetPath).catch(() => {})
         return
       }
-      if (isPending(targetPath)) return
+      if (isPending(targetPath)) {
+        await deleteExternalFile(targetPath).catch(() => {})
+        await deleteExternalDir(targetPath).catch(() => {})
+        return
+      }
       invalidate(targetPath)
     }
 
@@ -483,6 +504,7 @@ describe('notes delete / autosave guards', () => {
 
       expect(fileWrite).toHaveBeenCalledTimes(1)
       expect(invalidate).not.toHaveBeenCalled()
+      expect(deleteExternalFile).toHaveBeenCalledWith('/notes/a.md')
     })
 
     it('generation is per-path: unrelated delete does not affect other file autosave', async () => {
@@ -500,6 +522,81 @@ describe('notes delete / autosave guards', () => {
       // b's write should succeed and invalidate, not be treated as stale
       expect(fileWrite).toHaveBeenCalledWith('/notes/b.md', 'content-b')
       expect(invalidate).toHaveBeenCalledWith('/notes/b.md')
+    })
+
+    it('inactive delete still fences switch-cleanup autosave (c0)', async () => {
+      // user edits /notes/a.md then switches to /notes/b.md; switch cleanup schedules save for a.md;
+      // while that save is in flight, inactive file a.md is deleted via sidebar - stale save must not resurrect
+      activePath = '/notes/b.md'
+      activeContent = 'content-b'
+
+      const savePromise = saveCurrentNoteSim('stale-a', '/notes/a.md')
+
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+
+      await savePromise
+
+      expect(fileWrite).toHaveBeenCalledTimes(1)
+      expect(deleteExternalFile).toHaveBeenCalledWith('/notes/a.md')
+      expect(invalidate).not.toHaveBeenCalled()
+    })
+
+    it('stale descendant of recreated folder is deleted, not restored (c1 folder)', async () => {
+      activePath = '/notes/b.md'
+      activeContent = 'content-b'
+
+      // delete folder /notes/folder
+      pendingSet.add(normalizePathValue('/notes/folder'))
+      bump('/notes/folder')
+
+      const stalePromise = saveCurrentNoteSim('old content', '/notes/folder/a.md')
+
+      // recreate same folder - clears pending, bumps generation, records recreation
+      pendingSet.delete(normalizePathValue('/notes/folder'))
+      bump('/notes/folder')
+      lastRecreated = { path: normalizePathValue('/notes/folder'), gen: getGen('/notes/folder'), content: '' }
+
+      await stalePromise
+
+      // descendant file resurrected by stale autosave must be deleted, not left as overwritten folder content
+      expect(deleteExternalFile).toHaveBeenCalledWith('/notes/folder/a.md')
+      expect(fileWrite).toHaveBeenCalledTimes(1)
+      expect(invalidate).not.toHaveBeenCalled()
+    })
+
+    it('stale write after marker expiry is still cleaned up via generation bump (c1 expiry)', async () => {
+      activePath = '/notes/a.md'
+      activeContent = ''
+
+      const savePromise = saveCurrentNoteSim('stale', '/notes/a.md')
+
+      pendingSet.add(normalizePathValue('/notes/a.md'))
+      bump('/notes/a.md')
+      // marker expires before write completes (generation remains bumped)
+      pendingSet.delete(normalizePathValue('/notes/a.md'))
+
+      await savePromise
+
+      expect(deleteExternalFile).toHaveBeenCalledWith('/notes/a.md')
+      expect(invalidate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('inactive delete fences production flow (c0 integration)', () => {
+    it('pending fence blocks descendant autosave even when delete is not active-related', () => {
+      const pending = new Set<string>([normalizePathValue('/notes/a.md')])
+      // simulate inactive delete: pending still set, active is elsewhere
+      const active = '/notes/b.md'
+      expect(isActiveRelated(active, '/notes/a.md', 'file')).toBe(false)
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/a.md'), pending)).toBe(true)
+      expect(shouldBlockAutosave('/notes/a.md', '/notes/a.md')).toBe(true)
+    })
+
+    it('folder inactive delete blocks descendant pending check', () => {
+      const pending = new Set<string>([normalizePathValue('/notes/folder')])
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/folder/sub/note.md'), pending)).toBe(true)
+      expect(isPendingDeleteForPath(normalizePathValue('/notes/other.md'), pending)).toBe(false)
     })
   })
 })

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -160,7 +160,6 @@ describe('notes delete / autosave guards', () => {
       const deletePath = '/notes/a.md'
       const deleteType: 'file' | 'folder' = 'file'
       // snapshot at delete start
-      const preDeleteContent = 'draft-a'
       const preDeletePath = '/notes/a.md'
       // simulate switch: refs now point to new note
       const lastContent = 'draft-b'

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -155,7 +155,7 @@ describe('notes delete / autosave guards', () => {
       // production fix: use snapshot if snapshot was related
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete || (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete || ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)
@@ -181,7 +181,7 @@ describe('notes delete / autosave guards', () => {
 
       const snapNorm = preDeletePath ? normalizePathValue(preDeletePath) : undefined
       const shouldRearmSnapshot =
-        snapNorm === normalizedDelete || (deleteType === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
+        snapNorm === normalizedDelete || ((deleteType as string) === 'folder' && snapNorm?.startsWith(`${normalizedDelete}/`))
 
       if (shouldRearmSnapshot && preDeletePath != null) {
         debouncedSave(preDeleteContent, preDeletePath)

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
-
 import { normalizePathValue } from '@renderer/services/NotesTreeService'
+import { describe, expect, it, vi } from 'vitest'
 
 function shouldBlockAutosave(targetPath: string, pendingDelete: string | null): boolean {
   if (!pendingDelete) return false

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { normalizePathValue } from '@renderer/services/NotesTreeService'
+
+function shouldBlockAutosave(targetPath: string, pendingDelete: string | null): boolean {
+  if (!pendingDelete) return false
+  const normalizedTarget = normalizePathValue(targetPath)
+  return normalizedTarget === pendingDelete || normalizedTarget.startsWith(`${pendingDelete}/`)
+}
+
+function isActiveRelated(
+  activeFilePath: string | undefined,
+  deletePath: string,
+  deleteType: 'file' | 'folder'
+): boolean {
+  const normalizedActive = activeFilePath ? normalizePathValue(activeFilePath) : undefined
+  const normalizedDelete = normalizePathValue(deletePath)
+  if (normalizedActive === normalizedDelete) return true
+  if (deleteType === 'folder' && normalizedActive?.startsWith(`${normalizedDelete}/`)) return true
+  return false
+}
+
+describe('notes delete / autosave guards', () => {
+  describe('autosave fence (pendingDelete)', () => {
+    it('blocks autosave to exactly the pending-delete file', () => {
+      expect(shouldBlockAutosave('/notes/a.md', '/notes/a.md')).toBe(true)
+    })
+
+    it('blocks autosave to descendant of pending-delete folder', () => {
+      expect(shouldBlockAutosave('/notes/folder/b.md', '/notes/folder')).toBe(true)
+    })
+
+    it('does not block autosave to unrelated path', () => {
+      expect(shouldBlockAutosave('/notes/other.md', '/notes/a.md')).toBe(false)
+    })
+
+    it('handles windows separators', () => {
+      expect(shouldBlockAutosave('C:\\notes\\a.md', 'C:/notes/a.md')).toBe(true)
+    })
+
+    it('does not block when no pending delete', () => {
+      expect(shouldBlockAutosave('/notes/a.md', null)).toBe(false)
+    })
+
+    it('does not block prefix false-positive (/notes/ab.md vs /notes/a)', () => {
+      expect(shouldBlockAutosave('/notes/ab.md', '/notes/a')).toBe(false)
+      expect(shouldBlockAutosave('/notes/a-b/c.md', '/notes/a')).toBe(false)
+    })
+  })
+
+  describe('post-write race cleanup', () => {
+    it('after write completes, pending delete should trigger cleanup delete', async () => {
+      const pendingDelete = '/notes/a.md'
+      const target = '/notes/a.md'
+      const deleteExternalFile = vi.fn().mockResolvedValue(undefined)
+      const deleteExternalDir = vi.fn().mockResolvedValue(undefined)
+
+      // simulate saveCurrentNote post-write check
+      const normalizedAfter = normalizePathValue(target)
+      const shouldCleanup =
+        normalizedAfter === pendingDelete || normalizedAfter.startsWith(`${pendingDelete}/`)
+      expect(shouldCleanup).toBe(true)
+
+      if (shouldCleanup) {
+        await deleteExternalFile(target).catch(() => {})
+        await deleteExternalDir(target).catch(() => {})
+      }
+
+      expect(deleteExternalFile).toHaveBeenCalledWith(target)
+      expect(deleteExternalDir).toHaveBeenCalledWith(target)
+    })
+  })
+
+  describe('recreate after delete should not be blocked', () => {
+    it('clearing pendingDelete allows new note at same path to autosave', () => {
+      let pendingDelete: string | null = '/notes/a.md'
+      const newNotePath = '/notes/a.md'
+      const normalizedNote = normalizePathValue(newNotePath)
+      if (pendingDelete && (normalizedNote === pendingDelete || normalizedNote.startsWith(`${pendingDelete}/`))) {
+        pendingDelete = null
+      }
+      expect(pendingDelete).toBeNull()
+      expect(shouldBlockAutosave(newNotePath, pendingDelete)).toBe(false)
+    })
+  })
+
+  describe('delete clearing wrong note', () => {
+    it('does not treat switched active path as related', () => {
+      const deletePath = '/notes/a.md'
+      const activeBeforeDelete = '/notes/a.md'
+      expect(isActiveRelated(activeBeforeDelete, deletePath, 'file')).toBe(true)
+
+      // user switches to other note while delete is pending
+      const activeAfterSwitch = '/notes/b.md'
+      expect(isActiveRelated(activeAfterSwitch, deletePath, 'file')).toBe(false)
+    })
+
+    it('folder delete: descendant is related', () => {
+      expect(isActiveRelated('/notes/folder/sub/c.md', '/notes/folder', 'folder')).toBe(true)
+      expect(isActiveRelated('/notes/other/c.md', '/notes/folder', 'folder')).toBe(false)
+    })
+
+    it('only clears last draft when it points to deleted path', () => {
+      const deleted = normalizePathValue('/notes/a.md')
+      const lastFilePath = '/notes/a.md'
+      const normalizedLast = normalizePathValue(lastFilePath)
+      const shouldClearDraft = normalizedLast === deleted || normalizedLast.startsWith(`${deleted}/`)
+      expect(shouldClearDraft).toBe(true)
+
+      const lastFilePathOther = '/notes/b.md'
+      const normalizedOther = normalizePathValue(lastFilePathOther)
+      const shouldClearOther = normalizedOther === deleted || normalizedOther.startsWith(`${deleted}/`)
+      expect(shouldClearOther).toBe(false)
+    })
+  })
+
+  describe('delete-failure re-arm for empty string edit', () => {
+    it('re-arms autosave even when content is empty string', () => {
+      const lastContent = ''
+      const lastFilePath: string | undefined = '/notes/a.md'
+      const debouncedSave = vi.fn()
+
+      // old buggy guard: if (lastContent && lastFilePath) -> would skip empty string
+      const buggyWouldRearm = Boolean(lastContent && lastFilePath)
+      expect(buggyWouldRearm).toBe(false)
+
+      // fixed guard: if (lastFilePath != null)
+      if (lastFilePath != null) {
+        debouncedSave(lastContent, lastFilePath)
+      }
+      expect(debouncedSave).toHaveBeenCalledWith('', '/notes/a.md')
+    })
+
+    it('does not re-arm when file path is missing', () => {
+      const lastContent = 'hello'
+      const lastFilePath: string | undefined = undefined
+      const debouncedSave = vi.fn()
+      if (lastFilePath != null) {
+        debouncedSave(lastContent, lastFilePath)
+      }
+      expect(debouncedSave).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -56,8 +56,7 @@ describe('notes delete / autosave guards', () => {
 
       // simulate saveCurrentNote post-write check
       const normalizedAfter = normalizePathValue(target)
-      const shouldCleanup =
-        normalizedAfter === pendingDelete || normalizedAfter.startsWith(`${pendingDelete}/`)
+      const shouldCleanup = normalizedAfter === pendingDelete || normalizedAfter.startsWith(`${pendingDelete}/`)
       expect(shouldCleanup).toBe(true)
 
       if (shouldCleanup) {

--- a/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
+++ b/src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts
@@ -546,11 +546,12 @@ describe('notes delete / autosave guards', () => {
       activePath = '/notes/b.md'
       activeContent = 'content-b'
 
-      // delete folder /notes/folder
+      // stale autosave starts before folder deletion (passes pre-write fence)
+      const stalePromise = saveCurrentNoteSim('old content', '/notes/folder/a.md')
+
+      // delete folder /notes/folder while the save is in flight
       pendingSet.add(normalizePathValue('/notes/folder'))
       bump('/notes/folder')
-
-      const stalePromise = saveCurrentNoteSim('old content', '/notes/folder/a.md')
 
       // recreate same folder - clears pending, bumps generation, records recreation
       pendingSet.delete(normalizePathValue('/notes/folder'))

--- a/src/renderer/src/pages/notes/notesGuards.ts
+++ b/src/renderer/src/pages/notes/notesGuards.ts
@@ -1,0 +1,54 @@
+import { normalizePathValue } from '@renderer/services/NotesTreeService'
+
+export function shouldBlockAutosave(targetPath: string, pendingDelete: string | null): boolean {
+  if (!pendingDelete) return false
+  const normalizedTarget = normalizePathValue(targetPath)
+  return normalizedTarget === pendingDelete || normalizedTarget.startsWith(`${pendingDelete}/`)
+}
+
+export function isPendingDeleteForPath(normalizedTarget: string, pendingSet: Set<string>): boolean {
+  for (const pending of pendingSet) {
+    if (normalizedTarget === pending || normalizedTarget.startsWith(`${pending}/`)) {
+      return true
+    }
+  }
+  return false
+}
+
+export function getEffectiveGeneration(
+  normalizedTarget: string,
+  generations: Map<string, number>
+): number {
+  let max = generations.get(normalizedTarget) ?? 0
+  for (const [key, gen] of generations.entries()) {
+    if ((normalizedTarget === key || normalizedTarget.startsWith(`${key}/`)) && gen > max) {
+      max = gen
+    }
+  }
+  return max
+}
+
+export function isActiveRelated(
+  activeFilePath: string | undefined,
+  deletePath: string,
+  deleteType: 'file' | 'folder'
+): boolean {
+  const normalizedActive = activeFilePath ? normalizePathValue(activeFilePath) : undefined
+  const normalizedDelete = normalizePathValue(deletePath)
+  if (normalizedActive === normalizedDelete) return true
+  if (deleteType === 'folder' && normalizedActive?.startsWith(`${normalizedDelete}/`)) return true
+  return false
+}
+
+export function shouldRearmSnapshot(
+  snapPath: string | undefined,
+  deletePath: string,
+  deleteType: 'file' | 'folder'
+): boolean {
+  if (!snapPath) return false
+  const snapNorm = normalizePathValue(snapPath)
+  const delNorm = normalizePathValue(deletePath)
+  if (snapNorm === delNorm) return true
+  if (deleteType === 'folder' && snapNorm.startsWith(`${delNorm}/`)) return true
+  return false
+}

--- a/src/renderer/src/pages/notes/notesGuards.ts
+++ b/src/renderer/src/pages/notes/notesGuards.ts
@@ -15,10 +15,7 @@ export function isPendingDeleteForPath(normalizedTarget: string, pendingSet: Set
   return false
 }
 
-export function getEffectiveGeneration(
-  normalizedTarget: string,
-  generations: Map<string, number>
-): number {
+export function getEffectiveGeneration(normalizedTarget: string, generations: Map<string, number>): number {
   let max = generations.get(normalizedTarget) ?? 0
   for (const [key, gen] of generations.entries()) {
     if ((normalizedTarget === key || normalizedTarget.startsWith(`${key}/`)) && gen > max) {


### PR DESCRIPTION
### What this PR does

Before this PR:
Deleting the note currently open in the notes editor made it disappear briefly and then reappear at a new sort position, forcing users to locate and delete it a second time (Windows, v1.9.x).

After this PR:
The pending autosave state for the deleted note is cancelled before the file is removed, so the just-deleted note cannot be written back to disk. A single delete removes the note permanently. Follow-up hardening closes remaining edge cases around inflight writes, 2s window, switched-note clearing and empty-string re-arm.

Fixes #18120

### Why we need it and why it was done in this way

Root cause: deleting the active note clears the active file path, which triggers the "file switch cleanup" effect in `NotesPage.tsx`. That effect's emergency save writes the last known content back to the just-deleted path (`fs.promises.writeFile` recreates the file), and the 800ms debounced autosave can also fire during the delete handler. The recreated file gets a fresh mtime, so it moves to a new position in "sort by updated" order.

The following tradeoffs were made:
- The fix is scoped to `handleDeleteNode` / `saveCurrentNote`: `pendingDeletePathRef` is set before `delNode` and checked in `saveCurrentNote` before `write` to drop autosaves targeting the deleted path/descendants.
- `saveCurrentNote` re-checks `pendingDeletePathRef` after `await write` and deletes any resurrected file/dir, closing the race where a write that passed the pre-write guard completes after deletion.
- The 2s post-delete marker is cleared in `handleCreateNote` when a new note reuses the same path, so the first legitimate autosave of a recreated note is not suppressed.
- On success, `handleDeleteNode` re-reads `activeFilePathRef.current` and only clears editor/selection when still related, and only discards `lastContentRef`/`lastFilePathRef` when the draft belongs to the deleted path, so switching notes during a pending delete does not lose the new note's draft.
- On failure, re-arm checks `lastFilePathRef.current != null` (not `lastContent && lastFilePath`) so an empty-string edit (user cleared the note) is correctly re-scheduled. Refs are only cleared after `delNode` succeeds, so a failed delete does not lose unsaved edits.

The following alternatives were considered:
- Guarding `fs.promises.writeFile` against missing target files in `FileStorage` — broader blast radius than needed, rejected in favor of the precise renderer-side fix.
- Always clearing the refs regardless of which note is deleted — would drop unsaved edits when deleting a different note, rejected.
- Using a generation counter for pendingDelete — deferred; the path-prefix check plus explicit clear on recreate is sufficient for v1's single-pending-delete case.

Links to places where the discussion took place: #18120

### Breaking changes

None.

### Special notes for your reviewer

- `main` (v2) is not affected: v2's `handleDeleteNode` flushes the file-edit session before deleting, so its switch-cleanup cannot resurrect a deleted path. This fix is v1-only and does not need a forward-port.
- Added `src/renderer/src/pages/notes/__tests__/notesDeleteAutosave.test.ts` covering fence, post-write race cleanup, recreate-after-delete unblock, switched-note preservation and empty-string re-arm.
- Prior validation with `pnpm build:check` (lint, typecheck, i18n, openapi, format all pass). The test suite on this machine reports pre-existing Windows-only `EPERM` temp-dir failures in `AgentService`/`SessionService` tests, confirmed identical on a clean `v1` checkout.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed: Deleting a note while it is open in the editor no longer makes it reappear (and reorder); a single delete now removes it permanently.
```
