### PR TITLE
fix(assistant-editor): recover from legacy save failures

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AssistantEditDialog.tsx
@@ -235,7 +235,7 @@ function AssistantEditDialogContent({
   )
 
   // Tracks the exact form snapshot that failed so it cannot be retried until
-  // the user changes the form.
+  // the user changes the form, while a later close can explicitly discard it.
   const failedSaveKeyRef = useRef<string | null>(null)
 
   const wasOpenRef = useRef(false)
@@ -308,6 +308,7 @@ function AssistantEditDialogContent({
     }
     if (failedSaveKeyRef.current === changeKey) {
       toast.error(saveFailedMessage)
+      onOpenChange(false)
       return
     }
     void (async () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -3,6 +3,7 @@ import { toast } from '@renderer/services/toast'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import type { Assistant } from '@shared/data/types/assistant'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import type * as ReactI18next from 'react-i18next'
@@ -1436,15 +1437,23 @@ describe('edit dialogs', () => {
     expect(screen.getByLabelText('Name')).toHaveValue('Draft Agent')
   })
 
-  it('keeps the dialog open and shows an error when save fails', async () => {
+  it('shows an auto-save error and still allows the dialog to close', async () => {
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
+    const user = userEvent.setup()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Broken Assistant' } })
+    const nameInput = screen.getByLabelText('Name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Broken Assistant')
     expect(await screen.findByText('Save failed')).toBeInTheDocument()
+    expect(toast.error).toHaveBeenCalledWith('Save failed')
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('keeps the dialog open after a successful auto-save', async () => {
@@ -1504,13 +1513,16 @@ describe('edit dialogs', () => {
     })
   })
 
-  it('prompts without closing or retrying an unchanged failed assistant save', async () => {
+  it('allows discarding an unchanged failed assistant save without retrying it', async () => {
     updateAssistantMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
+    const user = userEvent.setup()
     render(<AssistantEditDialog open resource={ASSISTANT} onOpenChange={onOpenChange} />)
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Closing Edit' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    const nameInput = screen.getByLabelText('Name')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Closing Edit')
+    await user.click(screen.getByRole('button', { name: 'Close' }))
 
     expect(await screen.findByText('Save failed')).toBeInTheDocument()
     expect(toast.error).toHaveBeenCalledWith('Save failed')
@@ -1518,13 +1530,12 @@ describe('edit dialogs', () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
     const saveAttemptsAfterFailure = updateAssistantMock.mock.calls.length
 
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    await user.click(screen.getByRole('button', { name: 'Close' }))
     await new Promise((resolve) => setTimeout(resolve, 700))
 
     expect(toast.error).toHaveBeenCalledTimes(2)
     expect(updateAssistantMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
-    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
   it('retries saving when the form changes after a failed close', async () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1037,6 +1037,33 @@ describe('edit dialogs', () => {
     )
   })
 
+  it('repairs invalid legacy max tokens when enabling the limit', async () => {
+    render(
+      <AssistantEditDialog
+        open
+        resource={{
+          ...ASSISTANT,
+          settings: { ...ASSISTANT.settings, maxTokens: 0, enableMaxTokens: false }
+        }}
+        onOpenChange={vi.fn()}
+      />
+    )
+
+    selectTab('Model')
+    fireEvent.click(await screen.findByRole('switch', { name: 'Max tokens' }))
+
+    await waitFor(() =>
+      expect(updateAssistantMock).toHaveBeenCalledWith({
+        body: {
+          settings: {
+            maxTokens: 4096,
+            enableMaxTokens: true
+          }
+        }
+      })
+    )
+  })
+
   it('shows the default tool-call cap and clamps custom rounds at 1000', async () => {
     render(
       <AssistantEditDialog

--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -1,3 +1,4 @@
+import { UpdateAssistantSchema } from '@shared/data/api/schemas/assistants'
 import type { Assistant, AssistantSettings } from '@shared/data/types/assistant'
 import { DEFAULT_ASSISTANT_SETTINGS } from '@shared/data/types/assistant'
 import { describe, expect, it } from 'vitest'
@@ -83,28 +84,16 @@ describe('diffAssistantUpdate', () => {
     expect(diffAssistantUpdate(baseline, baseline, assistant)).toBeNull()
   })
 
-  it('emits the full columns+settings block when any column field changes', () => {
+  it('emits only the changed column field', () => {
     const assistant = createAssistant({ name: 'Original' })
     const baseline = initialAssistantFormState(assistant)
     const form = { ...baseline, description: 'edited' }
 
     const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result).not.toBeNull()
-    expect(result!.dto).toMatchObject({
-      name: 'Original',
-      emoji: assistant.emoji,
-      description: 'edited',
-      modelId: assistant.modelId,
-      prompt: assistant.prompt,
-      settings: expect.objectContaining({
-        temperature: baseline.temperature,
-        mcpMode: baseline.mcpMode
-      })
-    })
-    expect(result!.dto.groupId).toBeUndefined()
+    expect(result?.dto).toEqual({ description: 'edited' })
   })
 
-  it('emits a valid MCP mode when editing an unrelated field on a legacy assistant', () => {
+  it('does not resend an invalid legacy MCP mode when editing an unrelated field', () => {
     const assistant = createAssistant({
       settings: {
         ...DEFAULT_ASSISTANT_SETTINGS,
@@ -116,7 +105,40 @@ describe('diffAssistantUpdate', () => {
 
     const result = diffAssistantUpdate(form, baseline, assistant)
 
-    expect(result?.dto.settings?.mcpMode).toBe(DEFAULT_ASSISTANT_SETTINGS.mcpMode)
+    expect(result?.dto).toEqual({ description: 'edited' })
+    expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
+  })
+
+  it('renames an assistant without resending invalid legacy settings', () => {
+    const assistant = createAssistant({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        maxTokens: 0
+      } as AssistantSettings
+    })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, name: 'Renamed' }
+
+    const result = diffAssistantUpdate(form, baseline, assistant)
+
+    expect(result?.dto).toEqual({ name: 'Renamed' })
+    expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
+  })
+
+  it('emits only the changed settings key', () => {
+    const assistant = createAssistant({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        maxTokens: 0
+      } as AssistantSettings
+    })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, temperature: 0.5 }
+
+    const result = diffAssistantUpdate(form, baseline, assistant)
+
+    expect(result?.dto).toEqual({ settings: { temperature: 0.5 } })
+    expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
   })
 
   it('falls back to the server name when the form name is blank', () => {
@@ -128,7 +150,7 @@ describe('diffAssistantUpdate', () => {
     expect(result?.dto.name).toBe('Original')
   })
 
-  it('preserves server-side settings keys the UI does not surface', () => {
+  it('leaves server-side settings keys the UI does not surface out of column patches', () => {
     const assistant = createAssistant({
       settings: {
         ...DEFAULT_ASSISTANT_SETTINGS,
@@ -141,7 +163,7 @@ describe('diffAssistantUpdate', () => {
     const form = { ...baseline, prompt: 'updated' }
 
     const result = diffAssistantUpdate(form, baseline, assistant)
-    expect(result?.dto.settings).toMatchObject({ reasoning_effort: 'high' })
+    expect(result?.dto).toEqual({ prompt: 'updated' })
   })
 
   it('writes group changes directly into the DTO', () => {

--- a/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
+++ b/src/renderer/utils/resourceCatalog/__tests__/assistantForm.test.ts
@@ -125,6 +125,33 @@ describe('diffAssistantUpdate', () => {
     expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
   })
 
+  it('repairs invalid legacy max tokens when enabling the limit', () => {
+    const assistant = createAssistant({
+      settings: {
+        ...DEFAULT_ASSISTANT_SETTINGS,
+        maxTokens: 0,
+        enableMaxTokens: false
+      } as AssistantSettings
+    })
+    const baseline = initialAssistantFormState(assistant)
+    const form = { ...baseline, enableMaxTokens: true }
+
+    const result = diffAssistantUpdate(form, baseline, assistant)
+
+    expect(baseline.maxTokens).toBe(DEFAULT_ASSISTANT_SETTINGS.maxTokens)
+    expect(result?.dto).toEqual({
+      settings: {
+        maxTokens: DEFAULT_ASSISTANT_SETTINGS.maxTokens,
+        enableMaxTokens: true
+      }
+    })
+    expect(UpdateAssistantSchema.safeParse(result?.dto).success).toBe(true)
+    expect({ ...assistant.settings, ...result?.dto.settings }).toMatchObject({
+      maxTokens: DEFAULT_ASSISTANT_SETTINGS.maxTokens,
+      enableMaxTokens: true
+    })
+  })
+
   it('emits only the changed settings key', () => {
     const assistant = createAssistant({
       settings: {

--- a/src/renderer/utils/resourceCatalog/assistantForm.ts
+++ b/src/renderer/utils/resourceCatalog/assistantForm.ts
@@ -59,34 +59,6 @@ export interface AssistantFormState {
   mcpServerIds: string[]
 }
 
-function buildAssistantSettingsFromForm(
-  form: AssistantFormState,
-  baseSettings: AssistantSettings = DEFAULT_ASSISTANT_SETTINGS
-): AssistantSettings {
-  return {
-    ...baseSettings,
-    temperature: form.temperature,
-    enableTemperature: form.enableTemperature,
-    topP: form.topP,
-    enableTopP: form.enableTopP,
-    maxTokens: form.maxTokens,
-    enableMaxTokens: form.enableMaxTokens,
-    streamOutput: form.streamOutput,
-    maxToolCalls: form.maxToolCalls,
-    enableMaxToolCalls: form.enableMaxToolCalls,
-    customParameters: form.customParameters,
-    mcpMode: form.mcpMode,
-    // null = clear the override (inherit globals). The `enabled` kill-switch
-    // is deliberately not written here — it stays a global/topic-layer concern.
-    contextSettings: form.contextOverrideEnabled
-      ? {
-          truncateThreshold: form.contextTruncateThreshold,
-          compress: { enabled: form.contextCompressEnabled, modelId: form.contextCompressModelId }
-        }
-      : null
-  }
-}
-
 export function initialAssistantFormState(assistant: Assistant): AssistantFormState {
   const settings = assistant.settings ?? ({} as AssistantSettings)
   const mcpMode = McpModeSchema.safeParse(settings.mcpMode)
@@ -142,10 +114,9 @@ export type AssistantSaveIntent = {
 /**
  * Compute the minimal Assistant PATCH payload.
  *
- * - Columns block: when ANY of name/emoji/description/modelId/prompt
- *   or any settings field differs, the dto carries all five column
- *   keys + a full `settings` object spread over `assistant.settings`
- *   (preserves unrelated settings keys the UI doesn't surface).
+ * - Columns and settings carry only the keys that changed. The service merges
+ *   a partial `settings` object onto the stored value, so untouched historical
+ *   settings are neither revalidated nor overwritten.
  * - Relation arrays (knowledgeBaseIds / mcpServerIds) ship only when
  *   their set differs — order-insensitive, matches junction semantics.
  * - Group: placed directly on the DTO as the canonical `groupId`.
@@ -158,51 +129,73 @@ export function diffAssistantUpdate(
   assistant: Assistant
 ): AssistantDiffResult | null {
   const customParametersChanged = JSON.stringify(baseline.customParameters) !== JSON.stringify(form.customParameters)
-
-  const columnsChanged =
-    baseline.name !== form.name ||
-    baseline.emoji !== form.emoji ||
-    baseline.description !== form.description ||
-    baseline.modelId !== form.modelId ||
-    baseline.prompt !== form.prompt ||
-    baseline.temperature !== form.temperature ||
-    baseline.enableTemperature !== form.enableTemperature ||
-    baseline.topP !== form.topP ||
-    baseline.enableTopP !== form.enableTopP ||
-    baseline.maxTokens !== form.maxTokens ||
-    baseline.enableMaxTokens !== form.enableMaxTokens ||
-    baseline.streamOutput !== form.streamOutput ||
-    baseline.maxToolCalls !== form.maxToolCalls ||
-    baseline.enableMaxToolCalls !== form.enableMaxToolCalls ||
-    baseline.mcpMode !== form.mcpMode ||
+  const contextSettingsChanged =
     baseline.contextOverrideEnabled !== form.contextOverrideEnabled ||
     // Sub-fields only matter while the override is on, so an ON→OFF→ON round
     // trip that lands back on the baseline values fires no spurious PATCH.
     (form.contextOverrideEnabled &&
       (baseline.contextCompressEnabled !== form.contextCompressEnabled ||
         baseline.contextTruncateThreshold !== form.contextTruncateThreshold ||
-        baseline.contextCompressModelId !== form.contextCompressModelId)) ||
-    customParametersChanged
+        baseline.contextCompressModelId !== form.contextCompressModelId))
+
+  const settings: NonNullable<UpdateAssistantDto['settings']> = {
+    ...(baseline.temperature !== form.temperature ? { temperature: form.temperature } : {}),
+    ...(baseline.enableTemperature !== form.enableTemperature ? { enableTemperature: form.enableTemperature } : {}),
+    ...(baseline.topP !== form.topP ? { topP: form.topP } : {}),
+    ...(baseline.enableTopP !== form.enableTopP ? { enableTopP: form.enableTopP } : {}),
+    ...(baseline.maxTokens !== form.maxTokens ? { maxTokens: form.maxTokens } : {}),
+    ...(baseline.enableMaxTokens !== form.enableMaxTokens ? { enableMaxTokens: form.enableMaxTokens } : {}),
+    ...(baseline.streamOutput !== form.streamOutput ? { streamOutput: form.streamOutput } : {}),
+    ...(baseline.maxToolCalls !== form.maxToolCalls ? { maxToolCalls: form.maxToolCalls } : {}),
+    ...(baseline.enableMaxToolCalls !== form.enableMaxToolCalls ? { enableMaxToolCalls: form.enableMaxToolCalls } : {}),
+    ...(baseline.mcpMode !== form.mcpMode ? { mcpMode: form.mcpMode } : {}),
+    ...(customParametersChanged ? { customParameters: form.customParameters } : {}),
+    ...(contextSettingsChanged
+      ? {
+          // null = clear the override (inherit globals). The `enabled` kill-switch
+          // is deliberately not written here — it stays a global/topic-layer concern.
+          contextSettings: form.contextOverrideEnabled
+            ? {
+                truncateThreshold: form.contextTruncateThreshold,
+                compress: { enabled: form.contextCompressEnabled, modelId: form.contextCompressModelId }
+              }
+            : null
+        }
+      : {})
+  }
+
+  const nameChanged = baseline.name !== form.name
+  const emojiChanged = baseline.emoji !== form.emoji
+  const descriptionChanged = baseline.description !== form.description
+  const modelIdChanged = baseline.modelId !== form.modelId
+  const promptChanged = baseline.prompt !== form.prompt
+  const settingsChanged = Object.keys(settings).length > 0
 
   const groupChanged = baseline.groupId !== form.groupId
   const knowledgeBaseIdsChanged = !sameIdSet(baseline.knowledgeBaseIds, form.knowledgeBaseIds)
   const mcpServerIdsChanged = !sameIdSet(baseline.mcpServerIds, form.mcpServerIds)
 
-  if (!columnsChanged && !groupChanged && !knowledgeBaseIdsChanged && !mcpServerIdsChanged) {
+  if (
+    !nameChanged &&
+    !emojiChanged &&
+    !descriptionChanged &&
+    !modelIdChanged &&
+    !promptChanged &&
+    !settingsChanged &&
+    !groupChanged &&
+    !knowledgeBaseIdsChanged &&
+    !mcpServerIdsChanged
+  ) {
     return null
   }
 
   const dto: UpdateAssistantDto = {
-    ...(columnsChanged
-      ? {
-          name: form.name.trim() || assistant.name,
-          emoji: form.emoji,
-          description: form.description,
-          modelId: form.modelId,
-          prompt: form.prompt,
-          settings: buildAssistantSettingsFromForm(form, assistant.settings)
-        }
-      : {}),
+    ...(nameChanged ? { name: form.name.trim() || assistant.name } : {}),
+    ...(emojiChanged ? { emoji: form.emoji } : {}),
+    ...(descriptionChanged ? { description: form.description } : {}),
+    ...(modelIdChanged ? { modelId: form.modelId } : {}),
+    ...(promptChanged ? { prompt: form.prompt } : {}),
+    ...(settingsChanged ? { settings } : {}),
     ...(knowledgeBaseIdsChanged ? { knowledgeBaseIds: form.knowledgeBaseIds } : {}),
     ...(mcpServerIdsChanged ? { mcpServerIds: form.mcpServerIds } : {}),
     ...(groupChanged ? { groupId: form.groupId } : {})

--- a/src/renderer/utils/resourceCatalog/assistantForm.ts
+++ b/src/renderer/utils/resourceCatalog/assistantForm.ts
@@ -1,6 +1,6 @@
 import type { UpdateAssistantDto } from '@shared/data/api/schemas/assistants'
 import type { Assistant, AssistantSettings } from '@shared/data/types/assistant'
-import { DEFAULT_ASSISTANT_SETTINGS, McpModeSchema } from '@shared/data/types/assistant'
+import { AssistantSettingsSchema, DEFAULT_ASSISTANT_SETTINGS, McpModeSchema } from '@shared/data/types/assistant'
 import { DEFAULT_CONTEXT_SETTINGS } from '@shared/data/types/contextSettings'
 
 // ---------------------------------------------------------------------------
@@ -62,6 +62,7 @@ export interface AssistantFormState {
 export function initialAssistantFormState(assistant: Assistant): AssistantFormState {
   const settings = assistant.settings ?? ({} as AssistantSettings)
   const mcpMode = McpModeSchema.safeParse(settings.mcpMode)
+  const maxTokens = AssistantSettingsSchema.shape.maxTokens.safeParse(settings.maxTokens)
   const ctx = settings.contextSettings
   return {
     name: assistant.name,
@@ -73,7 +74,7 @@ export function initialAssistantFormState(assistant: Assistant): AssistantFormSt
     enableTemperature: settings.enableTemperature ?? false,
     topP: settings.topP ?? UI_DEFAULT_TOP_P,
     enableTopP: settings.enableTopP ?? false,
-    maxTokens: settings.maxTokens ?? UI_DEFAULT_MAX_TOKENS,
+    maxTokens: maxTokens.success ? maxTokens.data : UI_DEFAULT_MAX_TOKENS,
     enableMaxTokens: settings.enableMaxTokens ?? false,
     streamOutput: settings.streamOutput ?? true,
     maxToolCalls: settings.maxToolCalls ?? DEFAULT_ASSISTANT_SETTINGS.maxToolCalls,
@@ -129,6 +130,8 @@ export function diffAssistantUpdate(
   assistant: Assistant
 ): AssistantDiffResult | null {
   const customParametersChanged = JSON.stringify(baseline.customParameters) !== JSON.stringify(form.customParameters)
+  const maxTokensChanged = baseline.maxTokens !== form.maxTokens
+  const enableMaxTokensChanged = baseline.enableMaxTokens !== form.enableMaxTokens
   const contextSettingsChanged =
     baseline.contextOverrideEnabled !== form.contextOverrideEnabled ||
     // Sub-fields only matter while the override is on, so an ON→OFF→ON round
@@ -143,8 +146,8 @@ export function diffAssistantUpdate(
     ...(baseline.enableTemperature !== form.enableTemperature ? { enableTemperature: form.enableTemperature } : {}),
     ...(baseline.topP !== form.topP ? { topP: form.topP } : {}),
     ...(baseline.enableTopP !== form.enableTopP ? { enableTopP: form.enableTopP } : {}),
-    ...(baseline.maxTokens !== form.maxTokens ? { maxTokens: form.maxTokens } : {}),
-    ...(baseline.enableMaxTokens !== form.enableMaxTokens ? { enableMaxTokens: form.enableMaxTokens } : {}),
+    ...(maxTokensChanged || (enableMaxTokensChanged && form.enableMaxTokens) ? { maxTokens: form.maxTokens } : {}),
+    ...(enableMaxTokensChanged ? { enableMaxTokens: form.enableMaxTokens } : {}),
     ...(baseline.streamOutput !== form.streamOutput ? { streamOutput: form.streamOutput } : {}),
     ...(baseline.maxToolCalls !== form.maxToolCalls ? { maxToolCalls: form.maxToolCalls } : {}),
     ...(baseline.enableMaxToolCalls !== form.enableMaxToolCalls ? { enableMaxToolCalls: form.enableMaxToolCalls } : {}),


### PR DESCRIPTION
### What this PR does

Before this PR:

- Editing an assistant column, including only its name, sent the entire persisted `settings` object. Older v2 rows containing historically tolerated values such as `maxTokens: 0` therefore failed PATCH validation.
- Once that save snapshot failed, every later close attempt returned before `onOpenChange(false)`, leaving the edit dialog impossible to exit.

After this PR:

- Assistant updates send only the changed columns and individual settings keys, so unrelated legacy settings are not revalidated or overwritten.
- Invalid historical maximum-token values are normalized for editing, and enabling the limit atomically saves both a valid value and its enable flag.
- Save failures remain visible through the existing error/toast feedback, while a later explicit close can discard the failed snapshot and exit without retrying it.

Fixes #18160

### Why we need it and why it was done in this way

At `upstream/main@12498d68ec`, `assistantForm.ts:203` called `buildAssistantSettingsFromForm()` for any changed assistant column. That resent `maxTokens: 0`, which `AssistantSettingsSchema` rejects at `src/shared/data/types/assistant.ts:56`. After the rejected save, `AssistantEditDialog.tsx:309-311` showed the error and returned for the same failed snapshot forever, preventing the close callback at line 316.

The update schema and service already support deep-partial settings and merge them onto the stored row. Aligning the renderer payload with that contract fixes the original validation failure without weakening the schema. The failed-snapshot guard still prevents an accidental retry, but the user's next explicit close now acts as a discard action.

The following tradeoffs were made:

- A second explicit close after a failed save discards the unsaved snapshot; the first failure remains visible and keeps the dialog open.
- Enabling the maximum-token limit sends its valid companion value even when the displayed value itself was not edited, keeping the persisted pair internally consistent.

The following alternatives were considered:

- Relaxing the positive-token schema was rejected because `0` is not a valid model output limit.
- Repairing only migration code was insufficient because affected databases have already shipped.
- Closing immediately on the first failed final save was rejected because it would silently discard the user's edit.

Links to places where the discussion took place:

- GitHub issue: https://github.com/CherryHQ/cherry-studio/issues/18160
- Original Feishu feedback record: https://mcnnox2fhjfq.feishu.cn/record/BJ3ervpldeX8VIcwsCdcEB56n6l

### Breaking changes

None.

### Special notes for your reviewer

Original feedback:

- Source: dev table `v2 预览版问题反馈`, base `NM62bC0Epaqy0JsKjZYcQCn7nVd`, table `tblbuPFvvugxC8My`
- Record ID: `recvrFT0Pm7jtd`
- Direct Feishu link: https://cherry-studio.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrFT0Pm7jtd
- Submitted/transcribed by: 许思寅
- Original summary: 「Windows v2.0.2 右键编辑任意助手，在基础信息中修改名称后操作失败，弹窗无法退出，只能重启 Cherry Studio。」

Red/green evidence and validation:

- On clean baseline commit `2ac3dd4c15`, the new legacy-token test failed with the form retaining `maxTokens: 0` (23 passed, 1 failed).
- On fix commit `02ade8b77c`, the helper and component regression suites pass (69/69) from a clean worktree.
- `pnpm typecheck:web`
- Changed files: `oxlint --deny-warnings` (0 warnings, 0 errors)
- `pnpm lint`
- `pnpm format`
- `pnpm test` (main: 10,847 passed / 66 skipped; renderer: 8,551 passed; other projects: 2,674 passed)
- `pnpm test:lint`
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed assistant edits that could fail and trap users in the edit dialog when legacy settings were present.
```
