### PR TITLE
fix(ai-sdk): add status to inline assistant input items for Doubao

### DIFF
--- a/patches/@ai-sdk__openai@3.0.53.patch
+++ b/patches/@ai-sdk__openai@3.0.53.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11edd1ce23d8 100644
+index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..d437f67d1875cf8e7cca1f5741fb35632b7480ac 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -1753,13 +1753,15 @@ var modelMaxImagesPerCall = {
@@ -19,7 +19,15 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3778,6 +3780,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
+@@ -2759,6 +2761,7 @@ async function convertToOpenAIResponsesInput({
+                 role: "assistant",
+                 content: [{ type: "output_text", text: part.text }],
+                 id,
++                status: "completed",
+                 ...phase != null && { phase }
+               });
+               break;
+@@ -3778,6 +3781,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
          summary_index: import_v421.z.number(),
          delta: import_v421.z.string()
        }),
@@ -31,7 +39,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
        import_v421.z.object({
          type: import_v421.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v421.z.string(),
-@@ -6105,6 +6112,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6105,6 +6113,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -50,7 +58,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
                if (store) {
                  controller.enqueue({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c9341f5dd81 100644
+index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..ff37de048bc94cd20c9f15791370e08fdfacb6a0 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -1768,13 +1768,15 @@ var modelMaxImagesPerCall = {
@@ -70,7 +78,15 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3855,6 +3857,11 @@ var openaiResponsesChunkSchema = lazySchema19(
+@@ -2836,6 +2838,7 @@ async function convertToOpenAIResponsesInput({
+                 role: "assistant",
+                 content: [{ type: "output_text", text: part.text }],
+                 id,
++                status: "completed",
+                 ...phase != null && { phase }
+               });
+               break;
+@@ -3855,6 +3858,11 @@ var openaiResponsesChunkSchema = lazySchema19(
          summary_index: z21.number(),
          delta: z21.string()
        }),
@@ -82,7 +98,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
        z21.object({
          type: z21.literal("response.reasoning_summary_part.done"),
          item_id: z21.string(),
-@@ -6184,6 +6191,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6184,6 +6192,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -101,7 +117,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e2f314180 100644
+index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..aef30754373e2470fd05760742024645b5f61790 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
 @@ -1780,13 +1780,15 @@ var modelMaxImagesPerCall = {
@@ -121,7 +137,15 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3720,6 +3722,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
+@@ -2701,6 +2703,7 @@ async function convertToOpenAIResponsesInput({
+                 role: "assistant",
+                 content: [{ type: "output_text", text: part.text }],
+                 id,
++                status: "completed",
+                 ...phase != null && { phase }
+               });
+               break;
+@@ -3720,6 +3723,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
          summary_index: import_v417.z.number(),
          delta: import_v417.z.string()
        }),
@@ -133,7 +157,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
        import_v417.z.object({
          type: import_v417.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v417.z.string(),
-@@ -6366,6 +6373,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6366,6 +6374,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -152,7 +176,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb8df5a965 100644
+index db50beda01459008c836cd5648e024340fe31e90..f4b416a80ec50f5fcb1551f17858055839d92ea2 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
 @@ -1760,13 +1760,15 @@ var modelMaxImagesPerCall = {
@@ -172,7 +196,15 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3746,6 +3748,11 @@ var openaiResponsesChunkSchema = lazySchema15(
+@@ -2727,6 +2729,7 @@ async function convertToOpenAIResponsesInput({
+                 role: "assistant",
+                 content: [{ type: "output_text", text: part.text }],
+                 id,
++                status: "completed",
+                 ...phase != null && { phase }
+               });
+               break;
+@@ -3746,6 +3749,11 @@ var openaiResponsesChunkSchema = lazySchema15(
          summary_index: z17.number(),
          delta: z17.string()
        }),
@@ -184,7 +216,7 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
        z17.object({
          type: z17.literal("response.reasoning_summary_part.done"),
          item_id: z17.string(),
-@@ -6422,6 +6429,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6422,6 +6430,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -202,11 +234,31 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
              } else if (value.type === "response.reasoning_summary_part.done") {
                if (store) {
                  controller.enqueue({
+diff --git a/src/responses/convert-to-openai-responses-input.ts b/src/responses/convert-to-openai-responses-input.ts
+index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..aef3a98db6cd0e0ede6e96158144d3f4fc08eaf5 100644
+--- a/src/responses/convert-to-openai-responses-input.ts
++++ b/src/responses/convert-to-openai-responses-input.ts
+@@ -194,6 +194,7 @@ export async function convertToOpenAIResponsesInput({
+                 role: 'assistant',
+                 content: [{ type: 'output_text', text: part.text }],
+                 id,
++                status: 'completed',
+                 ...(phase != null && { phase }),
+               });
+ 
 diff --git a/src/responses/openai-responses-api.ts b/src/responses/openai-responses-api.ts
-index 53a3f242d81d0b52d9126b0f4580a30778373606..715f51cb5d5cc3a2f5cbd537e8d508936d7cb2df 100644
+index 53a3f242d81d0b52d9126b0f4580a30778373606..688b58f87c0640e26a393a4fcec077b51fd079bc 100644
 --- a/src/responses/openai-responses-api.ts
 +++ b/src/responses/openai-responses-api.ts
-@@ -985,6 +985,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
+@@ -86,6 +86,7 @@ export type OpenAIResponsesAssistantMessage = {
+   role: 'assistant';
+   content: Array<{ type: 'output_text'; text: string }>;
+   id?: string;
++  status?: 'completed';
+   phase?: 'commentary' | 'final_answer' | null;
+ };
+ 
+@@ -985,6 +986,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
          summary_index: z.number(),
          delta: z.string(),
        }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ patchedDependencies:
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/openai-compatible@2.0.62': 751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773
-  '@ai-sdk/openai@3.0.53': b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17
+  '@ai-sdk/openai@3.0.53': 10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@napi-rs/system-ocr@1.1.0': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
   '@openrouter/ai-sdk-provider@2.10.0': fe61d9ff590828fc0fd3f8b3b8b88a4a1b736a99b595a276c8df9e12c9498009
@@ -222,7 +222,7 @@ importers:
         version: 3.0.30(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+        version: 3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.3.4)
@@ -1312,7 +1312,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.4.3)
@@ -1349,7 +1349,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+        version: 3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.3.4)
@@ -14210,7 +14210,7 @@ snapshots:
 
   '@ai-sdk/azure@3.0.54(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+      '@ai-sdk/openai': 3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
@@ -14327,13 +14327,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)':
+  '@ai-sdk/openai@3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.53(patch_hash=10e20f0106dd48dcd19e3aa65a6a5383314fe92d9f98a92ea29be8ef3801ee7e)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)

--- a/src/main/ai/provider/__tests__/openaiResponsesAssistantStatusPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesAssistantStatusPatch.test.ts
@@ -1,0 +1,83 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { describe, expect, it } from 'vitest'
+
+// Guards patches/@ai-sdk__openai@3.0.53.patch. When `store` is disabled the SDK
+// inlines previous assistant turns (with their `itemId`) into the request body
+// as `{ role: 'assistant', content: [...], id }`. Volcengine Ark's Doubao models
+// reject such items with `MissingParameter: input.status`, so the patch adds
+// `status: 'completed'` to keep second-and-later turns working.
+describe('patched @ai-sdk/openai Responses assistant input status', () => {
+  it('adds status "completed" to inline assistant items when store is disabled', async () => {
+    let capturedBody: unknown
+    const model = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input, init) => {
+        capturedBody = JSON.parse(String(init?.body))
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            object: 'response',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+            status: 'completed'
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      }
+    }).responses('doubao-seed-2-0-pro')
+
+    await model.doGenerate({
+      providerOptions: { openai: { store: false } },
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hello', providerOptions: { openai: { itemId: 'msg_0217' } } }]
+        },
+        { role: 'user', content: [{ type: 'text', text: 'again' }] }
+      ]
+    })
+
+    const input = (capturedBody as { input: Array<Record<string, unknown>> }).input
+    const assistant = input.find((item) => item.role === 'assistant')
+    expect(assistant).toBeDefined()
+    expect(assistant?.id).toBe('msg_0217')
+    expect(assistant?.status).toBe('completed')
+  })
+
+  it('keeps using item_reference for stored assistant items by default', async () => {
+    let capturedBody: unknown
+    const model = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input, init) => {
+        capturedBody = JSON.parse(String(init?.body))
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            object: 'response',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+            status: 'completed'
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+      }
+    }).responses('doubao-seed-2-0-pro')
+
+    await model.doGenerate({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'hello', providerOptions: { openai: { itemId: 'msg_0217' } } }]
+        },
+        { role: 'user', content: [{ type: 'text', text: 'again' }] }
+      ]
+    })
+
+    const input = (capturedBody as { input: Array<Record<string, unknown>> }).input
+    expect(input).toContainEqual({ type: 'item_reference', id: 'msg_0217' })
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR: `@ai-sdk/openai@3.0.53` built inline assistant items as
`{ role: 'assistant', content: [...], id }` with no `status` when
`store: false`. OpenAI tolerates the omission, but Volcengine Ark's
Doubao seed-2-0-pro models reject such items on the second conversation
turn with `400 MissingParameter: input.status`, so the second round of
chat fails.

After this PR: Extend the pinned `@ai-sdk/openai` patch so inline
assistant input items carry `status: 'completed'`, and the
`OpenAIResponsesAssistantMessage` type declares the optional `status`
field. A regression test covers the inline item body and confirms the
default `store: true` path still emits `item_reference`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18253

### Why we need it and why it was done in this way

The temporary dependency patch fixes the boundary for every
OpenAI-compatible Responses provider that requires `status` on input
message items, without adding a provider-specific routing exception.
`status: 'completed'` is valid for OpenAI and required by Ark.

The following tradeoffs were made:

- Cherry Studio must temporarily maintain this addition in the existing
  `@ai-sdk/openai@3.0.53` patch.
- The patch should be removed when the planned `@ai-sdk/open-responses`
  migration in #13462 lands.

The following alternatives were considered:

- Route Doubao to Chat Completions: leaves the Responses converter
  broken for other strict providers.
- Gate `status` on `id != null`: Ark requires status on all assistant
  input items, so the field is added unconditionally.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

- Passed: `npx vitest run src/main/ai/provider` (535 tests)
- Passed: `pnpm lint`, `pnpm format`
- `pnpm build:check` on this Windows machine reports pre-existing,
  unrelated failures in symlink/POSIX-path-dependent tests (verified they
  fail identically with these changes stashed); the provider area is fully
  green and CI remains the full gate.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed a `400 MissingParameter: input.status` error on the second conversation turn when using Doubao seed-2-0-pro via Volcengine Ark (OpenAI Responses API).
```
