### PR TITLE
fix(knowledge-readers): reject binary Office text fallback

### DIFF
--- a/src/main/features/knowledge/pipeline/readers/KnowledgeFileReader.ts
+++ b/src/main/features/knowledge/pipeline/readers/KnowledgeFileReader.ts
@@ -31,13 +31,11 @@ export function createSupportedFileReader(filePath: AbsoluteFilePath): VectorSto
       return new AnydocReader(() => new DocxReader())
     case '.epub':
       return new AnydocReader(() => new EpubReader(), true)
-    // These binary containers use TextFileReader as the fallback when anydoc is
-    // unavailable or cannot convert them.
     case '.ppt':
     case '.pptx':
     case '.xls':
     case '.xlsx':
-      return new AnydocReader(() => new TextFileReader())
+      return new AnydocReader()
     case '.html':
     case '.htm':
       return new HTMLReader()

--- a/src/main/features/knowledge/pipeline/readers/__tests__/ReaderFactory.test.ts
+++ b/src/main/features/knowledge/pipeline/readers/__tests__/ReaderFactory.test.ts
@@ -254,11 +254,7 @@ describe('loadKnowledgeItemDocuments', () => {
   it.each([
     ['.doc', fallbackReaderSpies.doc],
     ['.docx', fallbackReaderSpies.docx],
-    ['.epub', fallbackReaderSpies.epub],
-    ['.ppt', fallbackReaderSpies.text],
-    ['.pptx', fallbackReaderSpies.text],
-    ['.xls', fallbackReaderSpies.text],
-    ['.xlsx', fallbackReaderSpies.text]
+    ['.epub', fallbackReaderSpies.epub]
   ])('routes %s files through anydoc with the intended fallback reader', async (ext, expectedFallback) => {
     const content = new Uint8Array([1, 2, 3])
     const reader = createSupportedFileReader(`/tmp/sample${ext}` as AbsoluteFilePath)
@@ -267,6 +263,19 @@ describe('loadKnowledgeItemDocuments', () => {
 
     expect(expectedFallback).toHaveBeenCalledWith(content, `sample${ext}`)
   })
+
+  it.each(['.ppt', '.pptx', '.xls', '.xlsx'])(
+    'throws instead of falling back to TextFileReader for %s when anydoc conversion fails',
+    async (ext) => {
+      const failure = new Error('anydoc conversion failed')
+      toMarkdownBytesMock.mockRejectedValueOnce(failure)
+      const content = new Uint8Array([1, 2, 3])
+      const reader = createSupportedFileReader(`/tmp/sample${ext}` as AbsoluteFilePath)
+
+      await expect(reader.loadDataAsContent(content, `sample${ext}`)).rejects.toBe(failure)
+      expect(fallbackReaderSpies.text).not.toHaveBeenCalled()
+    }
+  )
 
   it('uses the EPUB fallback when anydoc produces no text', async () => {
     toMarkdownBytesMock.mockResolvedValue('')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

When anydoc could not load on Windows ARM64, `.ppt`, `.pptx`, `.xls`, and `.xlsx` were routed through `TextFileReader`, decoding binary container bytes as UTF-8 and silently indexing garbage.

After this PR:

Those binary Office formats use `AnydocReader` without a text fallback. AnyDoc load/conversion failure now propagates as an item failure instead of producing a successful garbage document. Regression tests cover all four extensions and assert that the text fallback is not called.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18190

### Why we need it and why it was done in this way

The following tradeoffs were made:

This is the smallest safe main-process change: binary containers must never be passed to a plain-text reader. Existing valid fallbacks for `.doc`, `.docx`, and `.epub` are unchanged. On platforms without AnyDoc support, the affected item now visibly fails and retains the application error/log path.

The following alternatives were considered:

Adding a new legacy OLE2 `.ppt` parser or a wasm/native AnyDoc replacement was not included because it would be a separate dependency/platform-support project. The current repository has no legacy `.ppt` parser; `officeparser` supports ZIP-based formats such as `.pptx` and `.xlsx` only.

Links to places where the discussion took place: [source dev record](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrNae34jA6s), [upstream issue #18190](https://github.com/CherryHQ/cherry-studio/issues/18190)

### Breaking changes

Unsupported binary Office imports on platforms without AnyDoc support now fail explicitly instead of being marked completed with corrupted content.

### Special notes for your reviewer

Reviewers: DeJeune, zhangjiadi225.

Validation: targeted ReaderFactory/AnydocReader tests passed; `pnpm lint` passed; full `pnpm test` passed (main 10,847 passed, renderer 8,547 passed, other projects 2,674 passed).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge base imports for binary Office formats now fail explicitly when AnyDoc is unavailable instead of indexing binary garbage.
```
