### PR TITLE
fix(doubao-provider): make built-in Ark Responses requests work like the equivalent custom provider

### DIFF
--- a/src/main/ai/provider/__tests__/ark.test.ts
+++ b/src/main/ai/provider/__tests__/ark.test.ts
@@ -1,6 +1,8 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { describe, expect, it } from 'vitest'
 
-import { stripArkUnsupportedIncludes } from '../ark'
+import { createArkResponsesFetch, stripArkUnsupportedIncludes } from '../ark'
 
 const parse = (body: BodyInit | null | undefined) => JSON.parse(body as string)
 
@@ -23,5 +25,144 @@ describe('stripArkUnsupportedIncludes', () => {
     const body = JSON.stringify({ include: ['reasoning.encrypted_content'] })
     expect(stripArkUnsupportedIncludes(body)).toBe(body)
     expect(stripArkUnsupportedIncludes(undefined)).toBeUndefined()
+  })
+})
+
+const responseBody = {
+  id: 'resp_mock',
+  object: 'response',
+  created_at: 0,
+  model: 'doubao-seed-1-6-251015',
+  output: [
+    {
+      type: 'message',
+      role: 'assistant',
+      id: 'msg_mock',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'ok' }]
+    }
+  ],
+  status: 'completed'
+}
+
+const prompt = [
+  { role: 'system' as const, content: 'test' },
+  { role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }
+]
+
+describe('Doubao Responses compatibility boundary', () => {
+  it('captures equivalent health-check requests and accepts Ark output without annotations', async () => {
+    const requests: Array<{ url: string; method?: string; headers: Headers; body: Record<string, unknown> }> = []
+    const arkFetch = createArkResponsesFetch(async (input, init) => {
+      requests.push({
+        url: String(input),
+        method: init?.method,
+        headers: new Headers(init?.headers),
+        body: JSON.parse(String(init?.body))
+      })
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    })
+    const customFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        method: init?.method,
+        headers: new Headers(init?.headers),
+        body: JSON.parse(String(init?.body))
+      })
+      return new Response(
+        JSON.stringify({
+          id: 'chat_mock',
+          object: 'chat.completion',
+          created: 0,
+          model: 'doubao-seed-1-6-251015',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }]
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    }
+
+    const builtin = createOpenAI({
+      baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+      apiKey: 'sk-REDACTED',
+      fetch: arkFetch
+    }).responses('doubao-seed-1-6-251015')
+    const custom = createOpenAICompatible({
+      name: 'custom',
+      baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+      apiKey: 'sk-REDACTED',
+      fetch: customFetch
+    }).chatModel('doubao-seed-1-6-251015')
+
+    await expect(builtin.doGenerate({ prompt })).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'ok' }]
+    })
+    await expect(custom.doGenerate({ prompt })).resolves.toMatchObject({
+      content: [{ type: 'text', text: 'ok' }]
+    })
+
+    expect(requests[0]).toMatchObject({
+      url: 'https://ark.cn-beijing.volces.com/api/v3/responses',
+      method: 'POST',
+      body: {
+        model: 'doubao-seed-1-6-251015',
+        input: [
+          { role: 'system', content: 'test' },
+          { role: 'user', content: [{ type: 'input_text', text: 'hi' }] }
+        ]
+      }
+    })
+    expect(requests[1]).toMatchObject({
+      url: 'https://ark.cn-beijing.volces.com/api/v3/chat/completions',
+      method: 'POST',
+      body: {
+        model: 'doubao-seed-1-6-251015',
+        messages: [
+          { role: 'system', content: 'test' },
+          { role: 'user', content: 'hi' }
+        ]
+      }
+    })
+  })
+
+  it('adds completed status when replaying assistant text to Ark', async () => {
+    let requestBody: Record<string, unknown> | undefined
+    const fetch = createArkResponsesFetch(async (_input, init) => {
+      requestBody = JSON.parse(String(init?.body))
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    })
+    const model = createOpenAI({
+      baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+      apiKey: 'sk-REDACTED',
+      fetch
+    }).responses('doubao-seed-1-6-251015')
+
+    await model.doGenerate({
+      prompt: [
+        { role: 'user', content: [{ type: 'text', text: 'first' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'answer' }] },
+        { role: 'user', content: [{ type: 'text', text: 'second' }] }
+      ]
+    })
+
+    expect(requestBody?.input).toEqual([
+      { role: 'user', content: [{ type: 'input_text', text: 'first' }] },
+      { role: 'assistant', content: [{ type: 'output_text', text: 'answer' }], status: 'completed' },
+      { role: 'user', content: [{ type: 'input_text', text: 'second' }] }
+    ])
+  })
+
+  it('leaves non-success responses untouched for diagnostics', async () => {
+    const errorBody = JSON.stringify({ error: { code: 'MissingParameter', param: 'input.status' } })
+    const fetch = createArkResponsesFetch(async () => new Response(errorBody, { status: 400 }))
+    const response = await fetch('https://ark.cn-beijing.volces.com/api/v3/responses', { method: 'POST' })
+
+    expect(response.status).toBe(400)
+    await expect(response.text()).resolves.toBe(errorBody)
   })
 })

--- a/src/main/ai/provider/ark.ts
+++ b/src/main/ai/provider/ark.ts
@@ -6,15 +6,112 @@
  */
 const ARK_UNSUPPORTED_INCLUDES = new Set(['web_search_call.action.sources'])
 
-export function stripArkUnsupportedIncludes(body: BodyInit | null | undefined): BodyInit | null | undefined {
+/**
+ * Ark accepts the OpenAI Responses request shape, but its history validator also
+ * requires completed assistant messages to carry `status`. The OpenAI adapter
+ * omits that field because it is optional in the OpenAI API.
+ */
+export function transformArkResponsesRequestBody(body: BodyInit | null | undefined): BodyInit | null | undefined {
   if (typeof body !== 'string') return body
   try {
     const json = JSON.parse(body)
-    if (!Array.isArray(json.include)) return body
-    const include = json.include.filter((entry: unknown) => !ARK_UNSUPPORTED_INCLUDES.has(entry as string))
-    if (include.length === json.include.length) return body
-    return JSON.stringify({ ...json, include: include.length > 0 ? include : undefined })
+    let changed = false
+
+    if (Array.isArray(json.include)) {
+      const include = json.include.filter((entry: unknown) => !ARK_UNSUPPORTED_INCLUDES.has(entry as string))
+      if (include.length !== json.include.length) {
+        json.include = include.length > 0 ? include : undefined
+        changed = true
+      }
+    }
+
+    if (Array.isArray(json.input)) {
+      json.input = json.input.map((item: unknown) => {
+        if (
+          item &&
+          typeof item === 'object' &&
+          (item as { role?: unknown }).role === 'assistant' &&
+          !('status' in item)
+        ) {
+          changed = true
+          return { ...(item as Record<string, unknown>), status: 'completed' }
+        }
+        return item
+      })
+    }
+
+    return changed ? JSON.stringify(json) : body
   } catch {
     return body
+  }
+}
+
+/** Kept as a focused public helper for existing include-strip tests and callers. */
+export function stripArkUnsupportedIncludes(body: BodyInit | null | undefined): BodyInit | null | undefined {
+  return transformArkResponsesRequestBody(body)
+}
+
+function normalizeArkResponsesPayload(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object' || !Array.isArray((payload as { output?: unknown }).output)) {
+    return false
+  }
+
+  let changed = false
+  for (const output of (payload as { output: unknown[] }).output) {
+    if (!output || typeof output !== 'object' || (output as { type?: unknown }).type !== 'message') continue
+    const content = (output as { content?: unknown }).content
+    if (!Array.isArray(content)) continue
+
+    for (const part of content) {
+      if (
+        part &&
+        typeof part === 'object' &&
+        (part as { type?: unknown }).type === 'output_text' &&
+        (!('annotations' in part) || (part as { annotations?: unknown }).annotations == null)
+      ) {
+        const outputText = part as { annotations?: unknown[] }
+        outputText.annotations = []
+        changed = true
+      }
+    }
+  }
+  return changed
+}
+
+/**
+ * Ark's successful Responses payload omits optional OpenAI fields that the SDK
+ * schema currently treats as required. Only successful JSON responses are
+ * normalized; errors and SSE streams pass through untouched for diagnostics and
+ * streaming semantics.
+ */
+async function normalizeArkResponsesResponse(response: Response): Promise<Response> {
+  if (!response.ok || !response.headers.get('content-type')?.includes('application/json')) return response
+
+  let payload: unknown
+  try {
+    payload = await response.clone().json()
+  } catch {
+    return response
+  }
+  if (!normalizeArkResponsesPayload(payload)) return response
+
+  const headers = new Headers(response.headers)
+  headers.delete('content-length')
+  headers.delete('content-encoding')
+  return new Response(JSON.stringify(payload), {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  })
+}
+
+/** The provider-specific fetch seam used only by the built-in Ark Responses route. */
+export function createArkResponsesFetch(innerFetch: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const response = await innerFetch(input, {
+      ...init,
+      body: transformArkResponsesRequestBody(init?.body)
+    })
+    return normalizeArkResponsesResponse(response)
   }
 }

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -27,7 +27,7 @@ import type { ProviderConfig } from '../types'
 import { type AppProviderId, appProviderIds, type AppProviderSettingsMap } from '../types'
 import { customFetch } from '../utils/customFetch'
 import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
-import { stripArkUnsupportedIncludes } from './ark'
+import { createArkResponsesFetch } from './ark'
 import { generateSignature } from './cherryai'
 import { buildCodexRequestHeaders, coerceCodexRequestBody } from './codex'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
@@ -246,13 +246,14 @@ export async function resolveProviderAiSdkConfig(
     },
     // Doubao's built-in search rides the generic OpenAI Responses adapter, which auto-adds
     // `include: web_search_call.action.sources` alongside the web_search tool. Ark accepts the
-    // tool but 400s on that include, so strip it on the way out (arkResponses.ts).
+    // tool but 400s on that include. Ark also omits `annotations` in successful output_text and
+    // requires `status` on replayed assistant input, so the provider-specific fetch seam handles
+    // those differences while preserving Responses for built-in search and encrypted-CoT replay.
     {
       match: (p, id) => id === 'openai' && matchesPreset(p, SystemProviderIds.doubao),
       build: withSelectedApiKey((ctx) => {
         const config = buildGenericProviderConfig(ctx)
-        config.providerSettings.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
-          customFetch(input, { ...init, body: stripArkUnsupportedIncludes(init?.body) })
+        config.providerSettings.fetch = createArkResponsesFetch(customFetch)
         return config
       })
     },


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

The built-in Volcengine/Doubao (Ark) provider can list models but fails on "check connection" and on real chat calls, while a **custom OpenAI-compatible provider configured with the exact same base URL and API key works fine**.

The A/B split is the protocol, not the credentials. Captured at the SDK fetch boundary on `main@12498d68ec` with the same key / base URL / model / `system: "test"` / prompt `hi` (key redacted):

```
# built-in Doubao  -> OpenAI Responses
POST https://ark.cn-beijing.volces.com/api/v3/responses
authorization: Bearer sk-REDACTED
content-type: application/json
{"model":"doubao-seed-1-6-251015",
 "input":[{"role":"system","content":"test"},
          {"role":"user","content":[{"type":"input_text","text":"hi"}]}]}

# custom provider  -> OpenAI Chat Completions
POST https://ark.cn-beijing.volces.com/api/v3/chat/completions
authorization: Bearer sk-REDACTED
content-type: application/json
{"model":"doubao-seed-1-6-251015",
 "messages":[{"role":"system","content":"test"},{"role":"user","content":"hi"}]}
```

Built-in Doubao models are declared Responses-first in `packages/provider-registry`, so the built-in route goes through `@ai-sdk/openai`'s Responses adapter. Ark speaks the Responses dialect but diverges from that adapter's strict OpenAI contract in two places, both confirmed by real request/response captures from users:

1. **Successful responses omit `output_text.annotations`.** `openaiResponsesResponseSchema` in `@ai-sdk/openai` declares `annotations` as a required array, so a perfectly good HTTP 200 from Ark is rejected with `AI_APICallError: Invalid JSON response` — which is exactly the "lists models but the connection test fails" symptom (#17973).
2. **Replayed assistant turns need `status`.** The adapter omits `status` on assistant input items because it is optional in the OpenAI API; Ark rejects the second round with `MissingParameter` / `param: input.status` (#18253).

Neither point is reachable through Chat Completions, which is why the custom provider looks healthy.

After this PR:

The built-in Doubao route keeps Responses (needed for Doubao built-in search and encrypted-CoT replay) but goes through a provider-scoped fetch seam in `src/main/ai/provider/ark.ts` that reconciles those two differences:

- Outbound: keeps the existing `web_search_call.action.sources` include strip, and adds `status: "completed"` to assistant `input` items that lack it.
- Inbound: only for **successful JSON** Responses payloads, normalizes missing/`null` `output_text.annotations` to `[]` before handing the body to the SDK.
- Non-JSON bodies, SSE streams, unparseable bodies and **every non-2xx response pass through untouched**, so Ark's full error payload stays visible for diagnosis instead of being swallowed or rewritten.

Original user report: 「内置火山引擎输入 Key 后能够显示模型列表，但连接测试或实际调用失败；使用自定义服务商填写相同地址和密钥则可正常连接。」 (submitted by 许思寅 on behalf of Cherry Studio 内测群 / 官方沟通群 users) — source record: https://mcnnox2fhjfq.feishu.cn/record/BoZVrPfmaerZiOc9Ji4cLLVCnpd

Fixes #17973, fixes #18253

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The compatibility shim is confined to the fetch seam that the built-in Doubao route already owned (it previously existed only to strip one unsupported `include`). Nothing changes for custom providers, plain openai-compatible chat, embeddings, Seedream image generation, or any other Responses provider.
- Inbound normalization is deliberately narrow — success-only, JSON-only, and it touches exactly one field on `output[].content[].output_text`. Errors and streams are never rewritten, so failure diagnostics are not degraded.
- `status: "completed"` is only added when the field is absent, so an explicit status coming from upstream is preserved.

The following alternatives were considered:

- **Upgrade `@ai-sdk/openai`.** Checked the latest 3.x (`3.0.91`) and latest 4.x (`4.0.36`): both still require `annotations` on `output_text` and still omit `status` when replaying assistant text. A version bump does not fix this.
- **Relax the OpenAI provider globally / patch the SDK.** That would loosen the contract for every OpenAI Responses provider to work around one vendor's dialect. Keeping the workaround at the Ark boundary makes it removable the day Ark aligns.
- **Downgrade built-in Doubao to plain Chat Completions** (i.e. make it identical to the custom provider). Rejected: Responses is what Doubao's built-in search and encrypted reasoning replay ride on, so this would trade one broken feature for another.

Links to places where the discussion took place: #17973, #18253

### Breaking changes

None.

### Special notes for your reviewer

- Verified the SDK contract directly against the installed patched `@ai-sdk/openai@3.0.53`: the non-streaming `openaiResponsesResponseSchema` requires `annotations` (no `.nullish()`), while the streaming chunk schemas declare it optional. That is why inbound normalization is scoped to non-SSE responses only — streaming never hits the failing branch. The outbound `status` fix applies to both, which is what #18253 (`doStream`) needs.
- Tests (`src/main/ai/provider/__tests__/ark.test.ts`) drive the real `@ai-sdk/openai` Responses model and `@ai-sdk/openai-compatible` chat model against a capturing fetch, so they assert the actual wire output of both routes: the built-in `/responses` request, the custom `/chat/completions` request, the `status` back-fill on multi-turn input, and pass-through of a non-2xx Ark error body. Fixtures are minimal and redacted — no real keys anywhere.
- Existing Doubao coverage was re-run unchanged and still passes: `src/main/ai/provider/__tests__/config.test.ts` (CHAT/IMAGE routing) and `src/main/ai/provider/custom/__tests__/boundary/doubao.boundary.test.ts` (image still `POST /images/generations`, `providerOptions.bytedance` mapping intact) — 72 tests across the 3 files.
- `pnpm build:check` is green except for two pre-existing failures in `src/renderer/pages/settings/DataSettings/__tests__/legacyV1BrowserData.test.ts` and `BasicDataSettings.test.tsx` (the "retry marker cannot be written" cases). Both reproduce identically on a clean `main@12498d68ec` checkout and are unrelated to this change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the built-in Volcengine/Doubao (Ark) provider failing connection checks and chat requests — including multi-turn conversations — even though the model list loaded and the same key worked through a custom provider.
```
