### PR TITLE
fix(topic-naming): keep auto-rename requests free of assistant tool config

### DIFF
--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -208,11 +208,7 @@ export class TopicNamingService {
       ]
 
       const uniqueModelId = this.resolveNamingModelId()
-      const title = await this.generateSummaryTitle(
-        assistantId,
-        uniqueModelId,
-        buildStructuredConversation(structuredConversation)
-      )
+      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
       if (!title) return
 
       this.renameTopicIfStillAuto(topic.id, title, userText)
@@ -270,9 +266,11 @@ export class TopicNamingService {
    * Mirrors {@link maybeRenameFromConversationSummary} but targets the agents
    * DB (`session.name`) rather than `topics.name`. Uses the shared topic
    * naming model preference (`topic.naming.model_id`) for summarization,
-   * matching normal chat topic naming behavior.
+   * matching normal chat topic naming behavior. The agent id is deliberately
+   * NOT passed to the generation request — that would attach the agent's tool
+   * configuration (MCP tools, web search, knowledge bases) to the title.
    *
-   * @param agentId    Agent id used as AI generation context.
+   * @param agentId    Agent id, used for failure logging context only.
    * @param sessionId  Cherry Studio session id.
    * @param userText   Plain text of the persisted user turn, extracted by
    *                   AgentSessionRuntimeService from the saved user message.
@@ -312,11 +310,7 @@ export class TopicNamingService {
         { role: finalMessage.role, mainText: cleanMarkdownImages(getMainTextContentFromUiMessage(finalMessage)) }
       ]
 
-      const title = await this.generateSummaryTitle(
-        agentId,
-        uniqueModelId,
-        buildStructuredConversation(structuredConversation)
-      )
+      const title = await this.generateSummaryTitle(uniqueModelId, buildStructuredConversation(structuredConversation))
       if (!title) return
 
       const nextName = sanitizeConversationTitle(title)
@@ -364,14 +358,13 @@ export class TopicNamingService {
     }
   }
 
-  private async generateSummaryTitle(
-    assistantId: string | undefined,
-    uniqueModelId: UniqueModelId,
-    prompt: string
-  ): Promise<string | null> {
+  private async generateSummaryTitle(uniqueModelId: UniqueModelId, prompt: string): Promise<string | null> {
     const systemPrompt = this.resolveNamingPrompt()
+    // A title is a throwaway 10-word summary: never carry the source assistant /
+    // agent id, or buildAgentParams resolves its tool configuration (MCP tools,
+    // web search, knowledge bases) onto this request — the manual rename path in
+    // the renderer omits assistantId for the same reason.
     const request: AiGenerateRequest = {
-      assistantId,
       uniqueModelId,
       system: systemPrompt,
       prompt,

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -128,10 +128,13 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        assistantId: 'assistant-1',
         uniqueModelId: 'openai::gpt-4o-mini'
       })
     )
+    // A naming request must never carry the assistant id — buildAgentParams would
+    // otherwise attach the assistant's tool configuration (MCP / web search /
+    // knowledge bases) onto the throwaway title request.
+    expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty('assistantId')
     expect(mocks.updateTopic).toHaveBeenCalledWith('topic-1', {
       name: 'Generated Title',
       isNameManuallyEdited: false
@@ -164,10 +167,10 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        assistantId: undefined,
         uniqueModelId: CHERRYAI_DEFAULT_UNIQUE_MODEL_ID
       })
     )
+    expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty('assistantId')
   })
 
   it('falls back to the managed CherryAI default when topic naming model preference is invalid', async () => {
@@ -228,10 +231,10 @@ describe('TopicNamingService', () => {
 
     expect(mocks.generateText).toHaveBeenCalledWith(
       expect.objectContaining({
-        assistantId: 'agent-1',
         uniqueModelId: 'openai::gpt-4o-mini'
       })
     )
+    expect(mocks.generateText.mock.calls[0][0]).not.toHaveProperty('assistantId')
     expect(mocks.updateSession).toHaveBeenCalledWith('session-1', {
       name: 'Generated Title',
       isNameManuallyEdited: false


### PR DESCRIPTION
### What this PR does

Before this PR:

Auto-generated topic / agent-session titles were broken in two ways by inheriting the source assistant's configuration:

1. The naming request carried the assistant's **tool configuration** (MCP tools, web search, knowledge bases), because `TopicNamingService.generateSummaryTitle` passed `assistantId` into `AiService.generateText` and `buildAgentParams` resolved tools from it. Manual renaming (`renderer/utils/aiGeneration.ts`) never passes `assistantId`, so only the auto path was polluted.
2. A concrete failure mode: with an assistant that has **web search enabled** and a naming model that cannot combine a **disabled thinking budget with a web tool** (e.g. `qwen-3.7-plus` rejects `web_extractor` alongside `reasoningEffort: 'none'`), auto topic naming **failed outright** — no title was generated.

After this PR:

The naming request is deliberately assistant-free:

- `generateSummaryTitle` no longer takes `assistantId` and `AiGenerateRequest` no longer carries it, so `buildAgentParams` never resolves the source assistant's tools (MCP / web search / knowledge bases) onto the throwaway title request — matching the manual rename path.
- The public `maybeRename*` method signatures are unchanged; `assistantId` / `agentId` are still threaded for failure-logging context only.
- The naming model is still resolved independently via `resolveNamingModelId()` (`topic.naming.model_id` → quick-assistant model → CherryAI default), so the fix does not affect which model names the topic.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Dropping `assistantId` from the request also drops the assistant's custom sampling params (temperature/topP), fallback models, and usage-source attribution on naming calls. These are all acceptable for a throwaway 10-word title request — the same tradeoff already applied to the manual rename path.
- The public method signatures were kept (rather than deleting the params) because `assistantId` / `agentId` are still used in failure-logging context, keeping the change surgical.

The following alternatives were considered:

- Explicitly passing `mcpToolIds: []` — insufficient, because web-search routing is driven directly by `assistant.settings.enableWebSearch` in `resolveRequestWebToolRoutes`, independent of MCP ids.
- Adding a "no tools" flag to `AiBaseRequest` — a larger API surface than needed; omitting `assistantId` is the existing, already-proven mechanism the manual path relies on.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

None. Auto-naming behavior is restored to match manual renaming; no settings or data change.

### Special notes for your reviewer

- `fs_read` will still appear on naming requests — it is an unconditionally-registered builtin tool (no `applies` gate, `registerBuiltinTools.ts`), present on every request including the manual path, and confined to an empty persisted-output allow-list so every read is denied. It is infrastructure, not assistant configuration.
- Unit tests updated to assert the request carries no `assistantId` (regression guard).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed auto-generated conversation / agent-session titles: the naming request no longer carries the assistant's tool configuration (MCP tools, web search, knowledge bases), so auto-naming no longer fails when the assistant has web search enabled and the naming model cannot combine disabled thinking with a web tool (e.g. qwen-3.7-plus).
```
