### PR TITLE
fix(knowledge-search): drop zero-token guard, let BM25 store handle it (#18328)

### DIFF
--- a/src/main/features/knowledge/query/KnowledgeQueryService.ts
+++ b/src/main/features/knowledge/query/KnowledgeQueryService.ts
@@ -13,7 +13,6 @@ import { assertBaseCanRunRuntimeOperation } from '../base/baseGuards'
 import { getKnowledgeBaseFilePath } from '../pathStorage'
 import { embedKnowledgeQuery } from '../pipeline/indexing/embed'
 import { rerankKnowledgeSearchResults } from '../pipeline/indexing/rerank'
-import { extractFtsTokens } from '../pipeline/vectorstore/indexStore/ftsQuery'
 import type { KnowledgeIndexSearchMatch } from '../pipeline/vectorstore/indexStore/model'
 import {
   type KnowledgeBaseDiscoveryOptions,
@@ -51,14 +50,6 @@ export class KnowledgeQueryService {
   @TraceMethod({ spanName: 'Knowledge.search', tag: 'Knowledge' })
   async search(baseId: string, query: string): Promise<KnowledgeSearchResult[]> {
     const base = assertBaseCanRunRuntimeOperation(baseId, 'search')
-
-    // Same tokenization the FTS layer uses: no token means no BM25 hit is even possible.
-    if (extractFtsTokens(query).length === 0) {
-      throw DataApiErrorFactory.validation(
-        { query: ['Query has no searchable tokens'] },
-        'Query has no searchable tokens'
-      )
-    }
 
     // Vector/hybrid retrieval needs an embedding model; a base without one is
     // BM25-only. This is a fixed runtime policy, not a stored preference — mode is


### PR DESCRIPTION
## Updates per @eeee0717's review

The original implementation short-circuited zero-token queries to `[]` inside `KnowledgeQueryService.search`. That was wrong on two counts (both caught by the review):

1. **The guard was redundant for BM25.** `KnowledgeIndexStore.bm25Search` already returns `[]` when `toFtsMatchQuery` produces `null` (KnowledgeIndexStore.ts:524-527), and that path is already covered by a real-SQLite test (`KnowledgeIndexStore.search.test.ts` — `bm25 mode returns nothing when the query has no usable token`). The duplicated check added nothing.
2. **The guard was wrong for `hybrid`.** `extractFtsTokens(query).length === 0` only proves BM25 has no lexical terms. For hybrid bases the query may still produce a meaningful embedding (e.g. emoji such as 🔥), and the vector lane needs no lexical token to answer. Throwing silently disabled an existing capability.

### What this PR now does

Deletes the entire guard branch in `KnowledgeQueryService.search` and the now-orphaned `extractFtsTokens` import. The store layer — which the maintainer pointed to — handles the contract: BM25 lane returns `[]`, hybrid lane answers via the vector path, RRF fuses the rest.

### What about the 503?

With the guard gone, a zero-token query no longer produces a `validation` throw from inside every targeted base, so the route's all-bases-failed → 503 path is no longer reachable for this input. The orchestrator returns `[]` per base; the route stays on the 200 + empty-results path. The 503 path is preserved for genuine infra failures (broken embedding/vector-store config) and is still covered by the existing `POST /search → 503 when every targeted base search fails` test.

### What about the new test I added originally?

Removed. Mocking `KnowledgeService.search` to return `[]` exercised the route's existing aggregation behavior, not the changed code — the maintainer verified the test passes against unmodified `main` too. Per AGENTS.md ("No behavior-pinning tests"), it caught nothing. The real coverage lives one layer down in `KnowledgeIndexStore.search.test.ts`, which already pins the contract end-to-end against real SQLite.

Couldn't run `pnpm lint` / `pnpm test` / `pnpm format` locally: `pnpm install` is OOM-killed on this 1.8GB RAM box (2526 packages). CI should pass clean; please verify.

Closes #18328
