### PR TITLE
fix(agent-editor): let an explicit close discard a failed agent save

### DIFF
--- a/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/AgentEditDialog.tsx
@@ -438,6 +438,7 @@ function AgentEditDialogContent({
     }
     if (failedSaveKeyRef.current === autoSaveChangeKey) {
       toast.error(saveFailedMessage)
+      onOpenChange(false)
       return
     }
     void (async () => {

--- a/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/__tests__/EditDialogs.test.tsx
@@ -1646,7 +1646,7 @@ describe('edit dialogs', () => {
     expect(updateAssistantMock).toHaveBeenCalledTimes(1)
   })
 
-  it('prompts without closing or retrying an unchanged failed agent save', async () => {
+  it('allows discarding an unchanged failed agent save without retrying it', async () => {
     updateAgentMock.mockRejectedValueOnce(new Error('Network down'))
     const onOpenChange = vi.fn()
     render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
@@ -1666,8 +1666,21 @@ describe('edit dialogs', () => {
 
     expect(toast.error).toHaveBeenCalledTimes(2)
     expect(updateAgentMock).toHaveBeenCalledTimes(saveAttemptsAfterFailure)
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('retries saving the agent when the form changes after a failed close', async () => {
+    updateAgentMock.mockRejectedValueOnce(new Error('Network down'))
+    const onOpenChange = vi.fn()
+    render(<AgentEditDialog open resource={AGENT} onOpenChange={onOpenChange} />)
+
+    const nameInput = screen.getByLabelText('Name')
+    fireEvent.change(nameInput, { target: { value: 'Closing Agent' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    await screen.findByText('Save failed', undefined, { timeout: 5000 })
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    const saveAttemptsAfterFailure = updateAgentMock.mock.calls.length
 
     fireEvent.change(nameInput, { target: { value: 'Retry Agent' } })
     fireEvent.click(screen.getByRole('button', { name: 'Close' }))


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

- Once an agent auto-save failed, every later close attempt with the same form snapshot only re-toasted the error and returned before `onOpenChange(false)`, leaving the agent edit dialog impossible to exit without changing the form or restarting the app.
- This is the same trap #18257 fixed for the assistant edit dialog; the agent dialog kept the old behavior, and its regression test pinned the trap as expected behavior.

After this PR:

- A repeat explicit close of the same failed snapshot no longer retries the known-failing payload; it shows the failure toast once more, discards the unsaved snapshot, and closes the dialog.
- The first failed close still keeps the dialog open with the error visible, so the user's edit is never silently dropped.

Fixes: N/A (no tracking issue; assistant-side counterpart was #18160, fixed by #18257)

### Why we need it and why it was done in this way

At `main@7bb65e75d9`, `AgentEditDialog.tsx:439-442` returned after toasting whenever the close-time form snapshot matched the last failed save (`failedSaveKeyRef`). Since the snapshot only changes when the user edits the form, an unchanged failed save made every close attempt loop through that branch forever. #18257 already resolved the identical trap in `AssistantEditDialog.tsx` by treating a later explicit close as a discard action; this PR mirrors that one-line fix and aligns the agent regression tests with the assistant suite.

The following tradeoffs were made:

- A second explicit close after a failed save discards the unsaved snapshot; the first failure remains visible and keeps the dialog open. This matches the tradeoff accepted in #18257.
- The settings-navigate close path (`useCloseBeforeAction`) shares `handleOpenChange`, so navigating to settings with a failed snapshot now also discards the edit and closes — consistent with the assistant dialog's post-#18257 behavior, as both are explicit leave actions.

The following alternatives were considered:

- Closing immediately on the first failed final save was rejected because it would silently discard the user's edit.
- Keeping the dialog open forever (current behavior) was rejected because it traps the user with no exit short of reverting their edit or restarting the app.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/18257

### Breaking changes

None.

### Special notes for your reviewer

Red/green evidence and validation:

- With the component unchanged, the new discard test failed exactly on `onOpenChange` never being called with `false` (the trap); after the one-line fix, `EditDialogs.test.tsx` passes 46/46.
- The prior agent test `prompts without closing or retrying an unchanged failed agent save` asserted the trapped behavior; it is rewritten into two tests mirroring the assistant suite: `allows discarding an unchanged failed agent save without retrying it` and `retries saving the agent when the form changes after a failed close`.
- Changed files: `oxlint --deny-warnings` (0 warnings, 0 errors), `biome check` clean.
- `tsgo --noEmit -p tsconfig.web.json --composite false` clean.
- Full `pnpm test` / `pnpm build:check` left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required (bug fix restoring expected close behavior; no new feature or workflow change)
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the agent edit dialog trapping users after a failed save; a repeat explicit close now discards the unsaved change and exits.
```
