### PR TITLE
fix(system-ocr): send image bytes on Windows so JPEG decodes

### DIFF
--- a/src/main/features/fileProcessing/processors/system/imageToText/__tests__/handler.test.ts
+++ b/src/main/features/fileProcessing/processors/system/imageToText/__tests__/handler.test.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
 import { FILE_TYPE, FileInfoSchema } from '@shared/types/file'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +18,8 @@ vi.mock('@napi-rs/system-ocr', () => ({
   },
   recognize: vi.fn()
 }))
+
+import { recognize } from '@napi-rs/system-ocr'
 
 import { systemImageToTextHandler } from '../handler'
 
@@ -65,6 +71,58 @@ describe('systemImageToTextHandler', () => {
     )
 
     warnSpy.mockRestore()
+  })
+
+  it('recognizes a JPEG on Windows by sending the image bytes instead of the path', async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'system-ocr-test-'))
+    try {
+      const jpegPath = path.join(tempDir, 'scan.jpg')
+      const jpegBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46])
+      await fs.writeFile(jpegPath, jpegBytes)
+
+      // Model the @napi-rs/system-ocr@1.1.0 Windows binding: path input is decoded with a
+      // hardcoded PNG WIC decoder (any JPEG path fails), buffer input decodes by real format.
+      let receivedImage: string | Uint8Array | undefined
+      vi.mocked(recognize).mockImplementation(async (image) => {
+        receivedImage = image
+        if (typeof image === 'string') {
+          throw Object.assign(new Error('Windows error 图像格式未知。 (0x88982F07)'), { code: 'GenericFailure' })
+        }
+        return { text: 'jpeg text', confidence: 1 }
+      })
+
+      const jpegFile = FileInfoSchema.parse({
+        path: jpegPath,
+        name: 'scan',
+        size: jpegBytes.length,
+        ext: 'jpg',
+        mime: 'image/jpeg',
+        type: FILE_TYPE.IMAGE,
+        createdAt: 1,
+        modifiedAt: 1
+      })
+
+      const prepared = await systemImageToTextHandler.prepare(
+        jpegFile,
+        {
+          id: 'system',
+          type: 'builtin',
+          capabilities: [{ feature: 'image_to_text', inputs: ['image'], output: 'text' }],
+          options: {}
+        } as never,
+        undefined
+      )
+      if (prepared.mode !== 'background') {
+        throw new Error('expected a background job')
+      }
+
+      const result = await prepared.execute({ signal: new AbortController().signal, reportProgress: () => {} })
+
+      expect(result).toEqual({ kind: 'text', text: 'jpeg text' })
+      expect(Buffer.from(receivedImage as Uint8Array)).toEqual(jpegBytes)
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/src/main/features/fileProcessing/processors/system/imageToText/handler.ts
+++ b/src/main/features/fileProcessing/processors/system/imageToText/handler.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+
 import { loggerService } from '@logger'
 import { isLinux, isWin } from '@main/core/platform'
 import type * as SystemOcrModule from '@napi-rs/system-ocr'
@@ -42,8 +44,14 @@ export const systemImageToTextHandler: FileProcessingCapabilityHandler<'image_to
 
         const { OcrAccuracy, recognize } = await loadSystemOcr()
 
+        // The binding's Windows path input is hardcoded to the PNG WIC decoder, so any JPEG path
+        // fails with 0x88982F07 (#18326); its buffer input sniffs the real format — pass bytes.
+        const image = isWin
+          ? await fs.readFile(context.file.path, { signal: executionContext.signal })
+          : context.file.path
+
         const result = await recognize(
-          context.file.path,
+          image,
           OcrAccuracy.Accurate,
           isWin ? context.langs : undefined,
           executionContext.signal


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR: on Windows, System OCR fails for **every JPEG** with `Windows error 图像格式未知。 (0x88982F07)` / `code: GenericFailure`. The image is then silently forwarded to the model, and non-vision models receive an `[Unsupported Image]` placeholder. PNG works.

After this PR: on Windows the handler reads the image file and passes its **bytes** to `@napi-rs/system-ocr` `recognize()` instead of the file path. JPEG (and BMP/TIFF/GIF/WebP/HEIF, which were broken the same way) now OCR correctly. macOS behavior is unchanged.

Fixes #18326

### Why we need it and why it was done in this way

**Root cause** (confirmed in upstream source at tag `v1.1.0`, [`src/windows.rs`](https://github.com/Brooooooklyn/system-ocr/blob/v1.1.0/src/windows.rs)): the Windows binding decodes **path** input with a hardcoded PNG WIC decoder — `BitmapDecoder::CreateWithIdAsync(BitmapDecoder::PngDecoderId(), ...)` — so any non-PNG path fails with `0x88982F07` (`WINCODEC_ERR_UNKNOWNIMAGEFORMAT`). Its **buffer** input takes a different branch that sniffs the magic bytes and selects the matching WIC decoder (PNG/JPEG/BMP/TIFF/GIF/JXR/WebP/HEIF). Buffer input is a documented input mode (`image: string | Uint8Array`), not a workaround — no revert is needed if upstream later fixes path input.

The following tradeoffs were made:

- **Bytes are passed on Windows only; macOS keeps path input.** macOS path input works today (`VNImageRequestHandler(url:)` lets Vision read the file without copying it through the JS heap), while the macOS *buffer* branch is the one spot in upstream history that had a real bug (double-free via `NSData initWithBytesNoCopy`, upstream #24 — fixed in v1.1.0). Switching macOS to buffers has zero benefit and would pull a working platform into the change, so the fix is gated on `isWin`.
- Reading the whole image into memory on Windows is an accepted cost — chat image uploads are bounded, and there is no path-based alternative that decodes JPEG.

The following alternatives were considered:

- **Transcode JPEG → temp PNG (via sharp) and retry**: rejected — heavier (transcode + temp-file lifecycle + new path-registry key), and it would fix only JPEG while the buffer branch fixes all formats the path branch breaks.
- **Fix upstream and bump the dependency**: the bug is unreported upstream and `1.1.0` is the latest release; an upstream issue is worth filing separately, but users need a fix now.
- **Prior art**: other production consumers of this library avoid the bug the same way — [aime-chat](https://github.com/DarkNoah/aime-chat/blob/main/src/main/providers/local-provider.ts) always calls `recognize()` with file bytes, and WFHelper's Windows screenshot-OCR pipeline feeds buffers.

Links to places where the discussion took place: #18326

### Breaking changes

None.

### Special notes for your reviewer

- Developed on macOS; the fix could not be run against the real Windows binding locally. The new test models the upstream `v1.1.0` Windows contract (path input rejects with `GenericFailure`, buffer input recognizes) against a real JPEG file on disk, so it fails if the handler ever reverts to passing a path. It would be great if the reporter of #18326 could verify on a real Windows machine — their standalone repro script from the issue applies directly.
- The abort signal is threaded through `fs.readFile(path, { signal })` as well as `recognize()`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed System OCR on Windows failing on every JPEG image (WIC error 0x88982F07): the native engine now receives image bytes instead of a file path, which also fixes BMP/TIFF/GIF/WebP/HEIF inputs.
```
