### PR TITLE
feat(sidebar): pin assistants and agents to the sidebar

### DIFF
--- a/src/main/data/api/handlers/__tests__/agentSessions.test.ts
+++ b/src/main/data/api/handlers/__tests__/agentSessions.test.ts
@@ -73,6 +73,25 @@ describe('agentSessionHandlers', () => {
 
       await expect(agentSessionHandlers['/agent-sessions/latest'].GET({} as never)).resolves.toEqual({ session: null })
     })
+
+    it('narrows the latest lookup to one agent when agentId is given', async () => {
+      const session = { id: 'session-agent' }
+      getLatestActiveMock.mockReturnValueOnce(session)
+
+      await expect(
+        agentSessionHandlers['/agent-sessions/latest'].GET({ query: { agentId: 'agent-1' } } as never)
+      ).resolves.toEqual({ session })
+
+      expect(getLatestActiveMock).toHaveBeenCalledWith({ agentId: 'agent-1' })
+    })
+
+    it('rejects an empty agentId', async () => {
+      await expect(
+        agentSessionHandlers['/agent-sessions/latest'].GET({ query: { agentId: '' } } as never)
+      ).rejects.toThrow()
+
+      expect(getLatestActiveMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('/agent-sessions/:sessionId', () => {

--- a/src/main/data/api/handlers/__tests__/topics.test.ts
+++ b/src/main/data/api/handlers/__tests__/topics.test.ts
@@ -110,6 +110,23 @@ describe('topicHandlers', () => {
 
       await expect(topicHandlers['/topics/latest'].GET({} as never)).resolves.toEqual({ topic: null })
     })
+
+    it('narrows the latest lookup to one assistant when assistantId is given', async () => {
+      const topic = { id: 'topic-assistant' }
+      getLatestActiveMock.mockReturnValueOnce(topic)
+
+      await expect(
+        topicHandlers['/topics/latest'].GET({ query: { assistantId: 'assistant-1' } } as never)
+      ).resolves.toEqual({ topic })
+
+      expect(getLatestActiveMock).toHaveBeenCalledWith({ assistantId: 'assistant-1' })
+    })
+
+    it('rejects an empty assistantId', async () => {
+      await expect(topicHandlers['/topics/latest'].GET({ query: { assistantId: '' } } as never)).rejects.toThrow()
+
+      expect(getLatestActiveMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('/topics/reusable-placeholder', () => {

--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -462,6 +462,9 @@ export class AgentSessionService {
    * by `orderKey ASC` (creation/manual order, newest-created first), so a
    * recently-active session is not guaranteed to be on it. This
    * `lastActivityAt DESC LIMIT 1` proves global latest independent of the rail's ordering.
+   *
+   * An optional `agentId` narrows the scan to one agent's sessions — used by
+   * per-agent sidebar entries to resume that agent's last conversation.
    */
   getLatestActive(query: LatestAgentSessionQuery = {}): AgentSessionEntity | null {
     const db = application.get('DbService').getDb()

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -156,6 +156,9 @@ export class TopicService {
    * unpinned-by-`orderKey` (manual/creation order), so the globally latest-active
    * topic is not guaranteed to be on it. This `lastActivityAt DESC LIMIT 1` proves global
    * latest independent of how the rail happens to page.
+   *
+   * An optional `assistantId` narrows the scan to one assistant's topics — used by
+   * per-assistant sidebar entries to resume that assistant's last conversation.
    */
   getLatestActive(query: LatestTopicQuery = {}): Topic | null {
     const db = application.get('DbService').getDb()

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -46,6 +46,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   const {
     favorites,
     miniAppFavoriteIds,
+    agentFavoriteIds,
     assistantFavoriteIds,
     setAppPinned,
     removeMiniApp,
@@ -55,9 +56,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   } = useSidebarFavorites()
   const { activeTab, tabs, updateTab, openTab, setActiveTab } = useTabs()
   const { miniApps, pinned } = useMiniApps({ enabled: miniAppFavoriteIds.length > 0 })
-  // Agents are few and cheap; assistants are loaded only when pinned ones exist
-  // (the list can be large, mirroring the mini app gating above).
-  const { agents } = useAgents()
+  const { agents } = useAgents({ enabled: agentFavoriteIds.length > 0 })
   const { assistants } = useAssistantsApi({ enabled: assistantFavoriteIds.length > 0 })
   const [defaultPaintingProvider] = usePreference('feature.paintings.default_provider')
 

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -242,9 +242,8 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
     [activeTab, openableMiniAppById, openTab, setActiveTab, t, tabs, updateTab]
   )
 
-  // Pinned user entities (agents / assistants) navigate through the same tab
-  // reuse rules as mini apps; the route interceptor resolves the entity's most
-  // recent conversation from the `agentId` / `assistantId` query param.
+  // Pinned entities reuse tabs like mini apps do; the route interceptor turns the
+  // `agentId` / `assistantId` param into that entity's most recent conversation.
   const handleOpenEntityTab = useCallback(
     (path: string, title: string) => {
       if (activeTab?.url === path) return

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -1,7 +1,9 @@
 import { usePersistCache } from '@data/hooks/useCache'
 import { usePreference } from '@data/hooks/usePreference'
 import { arrayMove } from '@dnd-kit/sortable'
+import { useAgents } from '@renderer/hooks/agent/useAgent'
 import { useTabs } from '@renderer/hooks/tab'
+import { useAssistantsApi } from '@renderer/hooks/useAssistant'
 import useAvatar from '@renderer/hooks/useAvatar'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
@@ -41,10 +43,29 @@ const REQUIRED_SIDEBAR_FAVORITE_SET = new Set<SidebarAppId>(REQUIRED_SIDEBAR_FAV
 export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   const { t } = useTranslation()
   const [userName] = usePreference('app.user.name')
-  const { favorites, miniAppFavoriteIds, setAppPinned, removeMiniApp, reorderFavorites } = useSidebarFavorites()
+  const {
+    favorites,
+    miniAppFavoriteIds,
+    assistantFavoriteIds,
+    setAppPinned,
+    removeMiniApp,
+    removeAgent,
+    removeAssistant,
+    reorderFavorites
+  } = useSidebarFavorites()
   const { activeTab, tabs, updateTab, openTab, setActiveTab } = useTabs()
   const { miniApps, pinned } = useMiniApps({ enabled: miniAppFavoriteIds.length > 0 })
+  // Agents are few and cheap; assistants are loaded only when pinned ones exist
+  // (the list can be large, mirroring the mini app gating above).
+  const { agents } = useAgents()
+  const { assistants } = useAssistantsApi({ enabled: assistantFavoriteIds.length > 0 })
   const [defaultPaintingProvider] = usePreference('feature.paintings.default_provider')
+
+  const installedAgents = useMemo(() => new Map(agents.map((agent) => [agent.id, agent])), [agents])
+  const installedAssistants = useMemo(
+    () => new Map(assistants.map((assistant) => [assistant.id, assistant])),
+    [assistants]
+  )
 
   // Sidebar width — persisted across restarts. Dragging through the
   // intermediate 50-120px range uses a local preview width so the UI can
@@ -217,6 +238,50 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
     [activeTab, openableMiniAppById, openTab, setActiveTab, t, tabs, updateTab]
   )
 
+  // Pinned user entities (agents / assistants) navigate through the same tab
+  // reuse rules as mini apps; the route interceptor resolves the entity's most
+  // recent conversation from the `agentId` / `assistantId` query param.
+  const handleOpenEntityTab = useCallback(
+    (path: string, title: string) => {
+      if (activeTab?.url === path) return
+
+      if (activeTab?.isPinned) {
+        openTab(path, { forceNew: true, title })
+        return
+      }
+
+      if (activeTab) {
+        updateTab(activeTab.id, {
+          url: path,
+          title,
+          icon: undefined,
+          metadata: undefined
+        })
+        return
+      }
+
+      openTab(path, { forceNew: true, title })
+    },
+    [activeTab, openTab, updateTab]
+  )
+
+  const handleOpenAgentTab = useCallback(
+    (agentId: string) => {
+      const agent = installedAgents.get(agentId)
+      if (!agent) return
+      handleOpenEntityTab(`/app/agents?agentId=${encodeURIComponent(agentId)}`, agent.name)
+    },
+    [handleOpenEntityTab, installedAgents]
+  )
+  const handleOpenAssistantTab = useCallback(
+    (assistantId: string) => {
+      const assistant = installedAssistants.get(assistantId)
+      if (!assistant) return
+      handleOpenEntityTab(`/app/chat?assistantId=${encodeURIComponent(assistantId)}`, assistant.name)
+    },
+    [handleOpenEntityTab, installedAssistants]
+  )
+
   // All per-type sidebar knowledge (icon, label, route, active-match, open, remove)
   // lives in the variant registry; the container only supplies the runtime context.
   const variantContext = useMemo<SidebarVariantContext>(
@@ -224,20 +289,32 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       t,
       defaultPaintingProvider,
       installedMiniApps: openableMiniAppById,
+      installedAgents,
+      installedAssistants,
       isRequiredApp: (id) => REQUIRED_SIDEBAR_FAVORITE_SET.has(id),
       openApp: handleNavigate,
       openMiniApp: handleOpenMiniAppTab,
+      openAgent: handleOpenAgentTab,
+      openAssistant: handleOpenAssistantTab,
       removeApp: handleRemoveSidebarFavorite,
-      removeMiniApp
+      removeMiniApp,
+      removeAgent,
+      removeAssistant
     }),
     [
       t,
       defaultPaintingProvider,
       openableMiniAppById,
+      installedAgents,
+      installedAssistants,
       handleNavigate,
       handleOpenMiniAppTab,
+      handleOpenAgentTab,
+      handleOpenAssistantTab,
       handleRemoveSidebarFavorite,
-      removeMiniApp
+      removeMiniApp,
+      removeAgent,
+      removeAssistant
     ]
   )
 

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -59,6 +59,11 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   const { agents } = useAgents({ enabled: agentFavoriteIds.length > 0 })
   const { assistants } = useAssistantsApi({ enabled: assistantFavoriteIds.length > 0 })
   const [defaultPaintingProvider] = usePreference('feature.paintings.default_provider')
+  // Pinned entity rows render through the same icon renderers as their rails, so they
+  // follow the same icon-type preferences instead of always showing the emoji.
+  const [assistantIconType] = usePreference('assistant.icon_type')
+  const [agentIconType] = usePreference('agent.icon_type')
+  const [defaultModelId] = usePreference('chat.default_model_id')
 
   const installedAgents = useMemo(() => new Map(agents.map((agent) => [agent.id, agent])), [agents])
   const installedAssistants = useMemo(
@@ -290,6 +295,9 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       installedMiniApps: openableMiniAppById,
       installedAgents,
       installedAssistants,
+      assistantIconType,
+      agentIconType,
+      defaultModelId,
       isRequiredApp: (id) => REQUIRED_SIDEBAR_FAVORITE_SET.has(id),
       openApp: handleNavigate,
       openMiniApp: handleOpenMiniAppTab,
@@ -306,6 +314,9 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       openableMiniAppById,
       installedAgents,
       installedAssistants,
+      assistantIconType,
+      agentIconType,
+      defaultModelId,
       handleNavigate,
       handleOpenMiniAppTab,
       handleOpenAgentTab,

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -1,0 +1,108 @@
+import type { Assistant } from '@renderer/types/assistant'
+import type { AgentEntity } from '@shared/data/api/schemas/agents'
+import type { SidebarFavoriteItem } from '@shared/data/preference/preferenceTypes'
+import type { MiniApp } from '@shared/data/types/miniApp'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveSidebarEntry, type SidebarVariantContext } from '../sidebarVariants'
+
+function createContext(overrides: Partial<SidebarVariantContext> = {}): SidebarVariantContext {
+  return {
+    t: (key: string) => key,
+    defaultPaintingProvider: 'aihubmix',
+    installedMiniApps: new Map<string, MiniApp>(),
+    installedAgents: new Map<string, AgentEntity>(),
+    installedAssistants: new Map<string, Assistant>(),
+    assistantIconType: 'emoji',
+    agentIconType: 'emoji',
+    defaultModelId: null,
+    isRequiredApp: () => false,
+    openApp: vi.fn(),
+    openMiniApp: vi.fn(),
+    openAgent: vi.fn(),
+    openAssistant: vi.fn(),
+    removeApp: vi.fn(),
+    removeMiniApp: vi.fn(),
+    removeAgent: vi.fn(),
+    removeAssistant: vi.fn(),
+    ...overrides
+  }
+}
+
+function createAssistant(overrides: Partial<Assistant> = {}): Assistant {
+  return { id: 'assistant-1', name: 'Alpha', emoji: '🍒', modelId: 'openai::gpt-5', ...overrides } as Assistant
+}
+
+function createAgent(configuration?: Record<string, unknown>): AgentEntity {
+  return { id: 'agent-1', name: 'Agent', configuration } as unknown as AgentEntity
+}
+
+const assistantFavorite: SidebarFavoriteItem = { type: 'assistant', id: 'assistant-1' }
+const agentFavorite: SidebarFavoriteItem = { type: 'agent', id: 'agent-1' }
+
+describe('sidebarVariants icons', () => {
+  it('renders the assistant own emoji', () => {
+    const ctx = createContext({
+      installedAssistants: new Map([['assistant-1', createAssistant()]])
+    })
+
+    const entry = resolveSidebarEntry(assistantFavorite, ctx)
+    render(<div data-testid="icon">{entry?.renderIcon(18, 'lg')}</div>)
+
+    expect(screen.getByTestId('icon')).toHaveTextContent('🍒')
+  })
+
+  it('renders the model avatar when the icon type preference is model', () => {
+    const ctx = createContext({
+      assistantIconType: 'model',
+      installedAssistants: new Map([['assistant-1', createAssistant()]])
+    })
+
+    const entry = resolveSidebarEntry(assistantFavorite, ctx)
+    render(<div data-testid="icon">{entry?.renderIcon(18, 'lg')}</div>)
+
+    // A pinned row must mirror the rail: with icon_type=model the rail shows the model
+    // avatar, so showing the (often placeholder) emoji here would not match it.
+    expect(screen.getByTestId('icon')).not.toHaveTextContent('🍒')
+  })
+
+  it('still renders a glyph when the icon type preference is none', () => {
+    const ctx = createContext({
+      assistantIconType: 'none',
+      installedAssistants: new Map([['assistant-1', createAssistant()]])
+    })
+
+    const entry = resolveSidebarEntry(assistantFavorite, ctx)
+    render(<div data-testid="icon">{entry?.renderIcon(18, 'lg')}</div>)
+
+    // The rail can drop the icon entirely; a sidebar row cannot — it is the only thing
+    // identifying the row.
+    expect(screen.getByTestId('icon')).toHaveTextContent('🍒')
+  })
+
+  it('renders the rail placeholder icon when the assistant has no emoji', () => {
+    const ctx = createContext({
+      installedAssistants: new Map([['assistant-1', createAssistant({ emoji: '' })]])
+    })
+
+    const entry = resolveSidebarEntry(assistantFavorite, ctx)
+    const { container } = render(<div data-testid="icon">{entry?.renderIcon(18, 'lg')}</div>)
+
+    // Rendering an empty emoji would leave EmojiIcon showing only its blurred '⭐️'
+    // placeholder; the shared renderer draws the same bot placeholder as the rail.
+    expect(screen.getByTestId('icon')).not.toHaveTextContent('⭐️')
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('keeps a renderable glyph for an agent with no configured avatar', () => {
+    const ctx = createContext({
+      installedAgents: new Map([['agent-1', createAgent()]])
+    })
+
+    const entry = resolveSidebarEntry(agentFavorite, ctx)
+    render(<div data-testid="icon">{entry?.renderIcon(18, 'lg')}</div>)
+
+    expect(screen.getByTestId('icon')).not.toHaveTextContent('⭐️')
+  })
+})

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -53,23 +53,21 @@ describe('sidebarVariants icons', () => {
     expect(screen.getByTestId('icon')).toHaveTextContent('🍒')
   })
 
-  it('sizes a pinned entity icon like the built-in app rows next to it', () => {
+  it.each([
+    ['lg', '24'],
+    ['md', '18']
+  ] as const)('sizes a pinned entity icon like a mini app logo (%s)', (iconSize, expected) => {
     const ctx = createContext({
       installedAssistants: new Map([['assistant-1', createAssistant()]])
     })
 
-    const appEntry = resolveSidebarEntry({ type: 'app', id: 'assistants' }, ctx)
-    const entityEntry = resolveSidebarEntry(assistantFavorite, ctx)
+    const entry = resolveSidebarEntry(assistantFavorite, ctx)
+    const { container } = render(<div>{entry?.renderIcon(18, iconSize)}</div>)
 
-    const { container: appBox } = render(<div>{appEntry?.renderIcon(18, 'lg')}</div>)
-    const { container: entityBox } = render(<div>{entityEntry?.renderIcon(18, 'lg')}</div>)
-
-    // Entity rows sit inline with the app rows, so drawing them at the mini app
-    // scale (24) instead of the row size makes the whole rail look uneven.
-    const appIcon = appBox.querySelector('svg')
-    const entityIcon = entityBox.querySelector('svg, div[style]')
-    expect(appIcon?.getAttribute('width')).toBe('18')
-    expect(entityIcon?.getAttribute('width') ?? (entityIcon as HTMLElement)?.style.width).toMatch(/^18(px)?$/)
+    // Filled discs read a size smaller than line glyphs at the same box, so entity
+    // rows follow the mini app scale rather than the lucide `size` the apps use.
+    const icon = container.querySelector('svg, div[style]')
+    expect(icon?.getAttribute('width') ?? (icon as HTMLElement)?.style.width).toMatch(new RegExp(`^${expected}(px)?$`))
   })
 
   it('renders the model avatar when the icon type preference is model', () => {

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -53,6 +53,25 @@ describe('sidebarVariants icons', () => {
     expect(screen.getByTestId('icon')).toHaveTextContent('🍒')
   })
 
+  it('sizes a pinned entity icon like the built-in app rows next to it', () => {
+    const ctx = createContext({
+      installedAssistants: new Map([['assistant-1', createAssistant()]])
+    })
+
+    const appEntry = resolveSidebarEntry({ type: 'app', id: 'assistants' }, ctx)
+    const entityEntry = resolveSidebarEntry(assistantFavorite, ctx)
+
+    const { container: appBox } = render(<div>{appEntry?.renderIcon(18, 'lg')}</div>)
+    const { container: entityBox } = render(<div>{entityEntry?.renderIcon(18, 'lg')}</div>)
+
+    // Entity rows sit inline with the app rows, so drawing them at the mini app
+    // scale (24) instead of the row size makes the whole rail look uneven.
+    const appIcon = appBox.querySelector('svg')
+    const entityIcon = entityBox.querySelector('svg, div[style]')
+    expect(appIcon?.getAttribute('width')).toBe('18')
+    expect(entityIcon?.getAttribute('width') ?? (entityIcon as HTMLElement)?.style.width).toMatch(/^18(px)?$/)
+  })
+
   it('renders the model avatar when the icon type preference is model', () => {
     const ctx = createContext({
       assistantIconType: 'model',

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -1,11 +1,10 @@
-import EmojiIcon from '@renderer/components/EmojiIcon'
+import { renderAgentEntityIcon, renderAssistantEntityIcon } from '@renderer/components/chat/resourceList/base'
 import { getSidebarIconLabelKey } from '@renderer/i18n/label'
 import type { Assistant } from '@renderer/types/assistant'
-import { getAgentAvatarFromConfiguration } from '@renderer/utils/agent'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import { getSidebarFavoriteKey, getSidebarMenuPath, isSidebarAppId } from '@renderer/utils/sidebar'
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
-import type { SidebarFavoriteItem } from '@shared/data/preference/preferenceTypes'
+import type { AssistantIconType, SidebarFavoriteItem } from '@shared/data/preference/preferenceTypes'
 import type { MiniApp } from '@shared/data/types/miniApp'
 
 import { MiniAppIcon, type ResolvedSidebarEntry } from '../Sidebar'
@@ -14,6 +13,11 @@ import { SIDEBAR_ICON_COMPONENTS } from './sidebarIcons'
 /** Exhaustiveness guard: a new `SidebarFavoriteItem` type must add a `case` below. */
 function assertNever(value: never): never {
   throw new Error(`Unhandled sidebar favorite variant: ${JSON.stringify(value)}`)
+}
+
+/** A sidebar row is only identifiable by its icon, so 'none' degrades to the emoji. */
+function sidebarIconType(iconType: AssistantIconType): AssistantIconType {
+  return iconType === 'none' ? 'emoji' : iconType
 }
 
 /**
@@ -27,6 +31,10 @@ export interface SidebarVariantContext {
   installedMiniApps: Map<string, MiniApp>
   installedAgents: Map<string, AgentEntity>
   installedAssistants: Map<string, Assistant>
+  /** Icon-type preferences, so pinned rows match what the assistant / agent rails show. */
+  assistantIconType: AssistantIconType
+  agentIconType: AssistantIconType
+  defaultModelId: string | null
   isRequiredApp: (id: SidebarAppId) => boolean
   openApp: (id: SidebarAppId) => void
   openMiniApp: (id: string) => void
@@ -116,11 +124,12 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
     // Stale agent (deleted) is dropped from the list but stays in the preference.
     if (!agent) return null
 
-    const emoji = getAgentAvatarFromConfiguration(agent.configuration)
     return {
       key: getSidebarFavoriteKey(item),
       label: agent.name,
-      renderIcon: (size) => <EmojiIcon emoji={emoji} size={size} fontSize={Math.round(size * 0.58)} className="mr-0" />,
+      // Same renderer the agent rail uses, so a pinned row matches the list it came from.
+      // 'none' would leave the row with no glyph at all, so the sidebar keeps the emoji there.
+      renderIcon: (size) => renderAgentEntityIcon(sidebarIconType(ctx.agentIconType), agent, ctx.defaultModelId, size),
       // Active-state highlight stays on the built-in agents app entry; this row
       // only navigates the conversation the interceptor resolves.
       isActive: () => false,
@@ -146,9 +155,10 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
     return {
       key: getSidebarFavoriteKey(item),
       label: assistant.name,
-      renderIcon: (size) => (
-        <EmojiIcon emoji={assistant.emoji} size={size} fontSize={Math.round(size * 0.58)} className="mr-0" />
-      ),
+      // Same renderer the assistant rail uses, so a pinned row matches the list it came from.
+      // 'none' would leave the row with no glyph at all, so the sidebar keeps the emoji there.
+      renderIcon: (size) =>
+        renderAssistantEntityIcon(sidebarIconType(ctx.assistantIconType), assistant, ctx.defaultModelId, size),
       // Active-state highlight stays on the built-in assistants app entry.
       isActive: () => false,
       onOpen: () => ctx.openAssistant(assistant.id),

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -1,6 +1,10 @@
+import EmojiIcon from '@renderer/components/EmojiIcon'
 import { getSidebarIconLabelKey } from '@renderer/i18n/label'
+import type { Assistant } from '@renderer/types/assistant'
+import { getAgentAvatarFromConfiguration } from '@renderer/utils/agent'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import { getSidebarFavoriteKey, getSidebarMenuPath, isSidebarAppId } from '@renderer/utils/sidebar'
+import type { AgentEntity } from '@shared/data/api/schemas/agents'
 import type { SidebarFavoriteItem } from '@shared/data/preference/preferenceTypes'
 import type { MiniApp } from '@shared/data/types/miniApp'
 
@@ -21,11 +25,17 @@ export interface SidebarVariantContext {
   t: (key: string) => string
   defaultPaintingProvider: string
   installedMiniApps: Map<string, MiniApp>
+  installedAgents: Map<string, AgentEntity>
+  installedAssistants: Map<string, Assistant>
   isRequiredApp: (id: SidebarAppId) => boolean
   openApp: (id: SidebarAppId) => void
   openMiniApp: (id: string) => void
+  openAgent: (id: string) => void
+  openAssistant: (id: string) => void
   removeApp: (id: SidebarAppId) => void
   removeMiniApp: (id: string) => void
+  removeAgent: (id: string) => void
+  removeAssistant: (id: string) => void
 }
 
 /**
@@ -100,6 +110,60 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
   }
 }
 
+const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 'agent' }>> = {
+  resolve: (item, ctx) => {
+    const agent = ctx.installedAgents.get(item.id)
+    // Stale agent (deleted) is dropped from the list but stays in the preference.
+    if (!agent) return null
+
+    const emoji = getAgentAvatarFromConfiguration(agent.configuration)
+    return {
+      key: getSidebarFavoriteKey(item),
+      label: agent.name,
+      renderIcon: (size) => <EmojiIcon emoji={emoji} size={size} fontSize={Math.round(size * 0.58)} className="mr-0" />,
+      // Active-state highlight stays on the built-in agents app entry; this row
+      // only navigates the conversation the interceptor resolves.
+      isActive: () => false,
+      onOpen: () => ctx.openAgent(agent.id),
+      contextMenuItems: [
+        {
+          type: 'item',
+          id: `sidebar.remove-agent.${agent.id}`,
+          label: ctx.t('launchpad.unpin_from_sidebar'),
+          onSelect: () => ctx.removeAgent(agent.id)
+        }
+      ]
+    }
+  }
+}
+
+const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 'assistant' }>> = {
+  resolve: (item, ctx) => {
+    const assistant = ctx.installedAssistants.get(item.id)
+    // Stale assistant (deleted) is dropped from the list but stays in the preference.
+    if (!assistant) return null
+
+    return {
+      key: getSidebarFavoriteKey(item),
+      label: assistant.name,
+      renderIcon: (size) => (
+        <EmojiIcon emoji={assistant.emoji} size={size} fontSize={Math.round(size * 0.58)} className="mr-0" />
+      ),
+      // Active-state highlight stays on the built-in assistants app entry.
+      isActive: () => false,
+      onOpen: () => ctx.openAssistant(assistant.id),
+      contextMenuItems: [
+        {
+          type: 'item',
+          id: `sidebar.remove-assistant.${assistant.id}`,
+          label: ctx.t('launchpad.unpin_from_sidebar'),
+          onSelect: () => ctx.removeAssistant(assistant.id)
+        }
+      ]
+    }
+  }
+}
+
 /**
  * Resolve one stored favorite into a rendered row via its variant descriptor, or
  * `null` when it is not renderable. The single dispatch here is the only place
@@ -116,6 +180,10 @@ export function resolveSidebarEntry(
       return appVariant.resolve(favorite, ctx)
     case 'mini_app':
       return miniAppVariant.resolve(favorite, ctx)
+    case 'agent':
+      return agentVariant.resolve(favorite, ctx)
+    case 'assistant':
+      return assistantVariant.resolve(favorite, ctx)
     default:
       return assertNever(favorite)
   }

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -20,6 +20,10 @@ function sidebarIconType(iconType: AssistantIconType): AssistantIconType {
   return iconType === 'none' ? 'emoji' : iconType
 }
 
+// Entity icons are filled discs like mini app logos, not line glyphs, so they follow
+// the mini app scale — the lucide `size` renders them visibly smaller than their row.
+const ENTITY_ICON_PIXEL_SIZE = { md: 18, lg: 24 } as const
+
 /**
  * Runtime context a variant needs to resolve a favorite into a rendered row:
  * i18n, route inputs, installed mini app data, and the open/remove callbacks the
@@ -129,7 +133,13 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
       label: agent.name,
       // Same renderer the agent rail uses, so a pinned row matches the list it came from.
       // 'none' would leave the row with no glyph at all, so the sidebar keeps the emoji there.
-      renderIcon: (size) => renderAgentEntityIcon(sidebarIconType(ctx.agentIconType), agent, ctx.defaultModelId, size),
+      renderIcon: (_size, iconSize) =>
+        renderAgentEntityIcon(
+          sidebarIconType(ctx.agentIconType),
+          agent,
+          ctx.defaultModelId,
+          ENTITY_ICON_PIXEL_SIZE[iconSize]
+        ),
       // Active-state highlight stays on the built-in agents app entry; this row
       // only navigates the conversation the interceptor resolves.
       isActive: () => false,
@@ -157,8 +167,13 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
       label: assistant.name,
       // Same renderer the assistant rail uses, so a pinned row matches the list it came from.
       // 'none' would leave the row with no glyph at all, so the sidebar keeps the emoji there.
-      renderIcon: (size) =>
-        renderAssistantEntityIcon(sidebarIconType(ctx.assistantIconType), assistant, ctx.defaultModelId, size),
+      renderIcon: (_size, iconSize) =>
+        renderAssistantEntityIcon(
+          sidebarIconType(ctx.assistantIconType),
+          assistant,
+          ctx.defaultModelId,
+          ENTITY_ICON_PIXEL_SIZE[iconSize]
+        ),
       // Active-state highlight stays on the built-in assistants app entry.
       isActive: () => false,
       onOpen: () => ctx.openAssistant(assistant.id),

--- a/src/renderer/components/chat/resourceList/AgentResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AgentResourceList.tsx
@@ -12,6 +12,7 @@ import { useAgents } from '@renderer/hooks/agent/useAgent'
 import type { AgentSessionsSource } from '@renderer/hooks/resourceViewSources'
 import { useCloseConversationTabs } from '@renderer/hooks/tab'
 import { usePins } from '@renderer/hooks/usePins'
+import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { ipcApi } from '@renderer/ipc'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
@@ -39,6 +40,7 @@ const AGENT_ENTITY_EDIT_ACTION_ID = 'agent-entity.edit'
 const AGENT_ENTITY_TOGGLE_PIN_ACTION_ID = 'agent-entity.toggle-pin'
 const AGENT_ENTITY_ICON_TYPE_ACTION_ID = 'agent-entity.icon-type'
 const AGENT_ENTITY_DELETE_ACTION_ID = 'agent-entity.delete'
+const AGENT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID = 'agent-entity.toggle-sidebar'
 
 type SessionListItem = AgentSessionEntity & {
   pinned?: boolean
@@ -112,6 +114,8 @@ export function AgentResourceList({
   const [editDialogTarget, setEditDialogTarget] = useState<ResourceEditDialogTarget | null>(null)
   const agentPinnedIdSet = useMemo(() => new Set(agentPinnedIds), [agentPinnedIds])
   const isAgentPinActionDisabled = isAgentPinsLoading || isAgentPinsRefreshing || isAgentPinsMutating
+  const { agentFavoriteIds: sidebarAgentFavoriteIds, toggleAgent, removeAgent } = useSidebarFavorites()
+  const sidebarAgentFavoriteIdSet = useMemo(() => new Set(sidebarAgentFavoriteIds), [sidebarAgentFavoriteIds])
   const sessionItems = useMemo<SessionListItem[]>(
     () => sessions.map((session) => ({ ...session, pinned: pinIdBySessionId.has(session.id) })),
     [pinIdBySessionId, sessions]
@@ -297,6 +301,7 @@ export function AgentResourceList({
   const getContextMenuActions = useCallback(
     (item: ResourceEntityRailItem): ResolvedAction[] => {
       const pinned = agentPinnedIdSet.has(item.id)
+      const sidebarPinned = sidebarAgentFavoriteIdSet.has(item.id)
       const deleteTasksOnly = isProtectedBuiltinAgentRole(
         agents.find((agent) => agent.id === item.id)?.configuration?.builtin_role
       )
@@ -314,6 +319,12 @@ export function AgentResourceList({
           icon: pinned ? <PinOff size={14} /> : <Pin size={14} />,
           order: 20,
           availability: { visible: true, enabled: !isAgentPinActionDisabled }
+        }),
+        buildResolvedResourceEntityMenuAction({
+          id: AGENT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID,
+          label: sidebarPinned ? t('launchpad.unpin_from_sidebar') : t('launchpad.pin_to_sidebar'),
+          icon: sidebarPinned ? <PinOff size={14} /> : <Pin size={14} />,
+          order: 22
         }),
         buildResolvedIconTypeMenuAction(
           AGENT_ENTITY_ICON_TYPE_ACTION_ID,
@@ -334,7 +345,15 @@ export function AgentResourceList({
         })
       ]
     },
-    [agentPinnedIdSet, agents, assistantIconType, deletingAgentId, isAgentPinActionDisabled, t]
+    [
+      agentPinnedIdSet,
+      agents,
+      assistantIconType,
+      deletingAgentId,
+      isAgentPinActionDisabled,
+      sidebarAgentFavoriteIdSet,
+      t
+    ]
   )
 
   const handleContextMenuAction = useCallback(
@@ -347,6 +366,11 @@ export function AgentResourceList({
         void handleToggleAgentPin(item.id)
         return
       }
+      if (action.id === AGENT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID) {
+        if (sidebarAgentFavoriteIdSet.has(item.id)) removeAgent(item.id)
+        else toggleAgent(item.id)
+        return
+      }
       if (action.id.startsWith(`${AGENT_ENTITY_ICON_TYPE_ACTION_ID}.`)) {
         void setAssistantIconType(action.id.slice(AGENT_ENTITY_ICON_TYPE_ACTION_ID.length + 1) as AssistantIconType)
         return
@@ -355,7 +379,15 @@ export function AgentResourceList({
         void handleDeleteAgent(item.id)
       }
     },
-    [handleDeleteAgent, handleToggleAgentPin, openAgentEditor, setAssistantIconType]
+    [
+      handleDeleteAgent,
+      handleToggleAgentPin,
+      openAgentEditor,
+      removeAgent,
+      setAssistantIconType,
+      sidebarAgentFavoriteIdSet,
+      toggleAgent
+    ]
   )
 
   return (

--- a/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/AssistantResourceList.tsx
@@ -14,6 +14,7 @@ import { useCloseConversationTabs } from '@renderer/hooks/tab'
 import { useAssistantMutations, useAssistantsApi } from '@renderer/hooks/useAssistant'
 import { useGroupReorder, useGroups } from '@renderer/hooks/useGroups'
 import { usePins } from '@renderer/hooks/usePins'
+import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { mapApiTopicToRendererTopic, useTopicMutations } from '@renderer/hooks/useTopic'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
@@ -42,6 +43,7 @@ const ASSISTANT_ENTITY_CLEAR_TOPICS_ACTION_ID = 'assistant-entity.clear-topics'
 const ASSISTANT_ENTITY_TOGGLE_GROUPING_ACTION_ID = 'assistant-entity.toggle-grouping'
 const ASSISTANT_ENTITY_ICON_TYPE_ACTION_ID = 'assistant-entity.icon-type'
 const ASSISTANT_ENTITY_DELETE_ACTION_ID = 'assistant-entity.delete'
+const ASSISTANT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID = 'assistant-entity.toggle-sidebar'
 const UNLINKED_ASSISTANT_ENTITY_ID = 'assistant-entity:unlinked'
 
 type AssistantResourceListProps = {
@@ -127,6 +129,11 @@ export function AssistantResourceList({
   const [editDialogTarget, setEditDialogTarget] = useState<ResourceEditDialogTarget | null>(null)
   const assistantPinnedIdSet = useMemo(() => new Set(assistantPinnedIds), [assistantPinnedIds])
   const assistantIdSet = useMemo(() => new Set(assistants.map((assistant) => assistant.id)), [assistants])
+  const { assistantFavoriteIds: sidebarAssistantFavoriteIds, toggleAssistant, removeAssistant } = useSidebarFavorites()
+  const sidebarAssistantFavoriteIdSet = useMemo(
+    () => new Set(sidebarAssistantFavoriteIds),
+    [sidebarAssistantFavoriteIds]
+  )
   const assistantGroupById = useMemo(
     () => new Map(assistantGroups.map((group) => [group.id, group] as const)),
     [assistantGroups]
@@ -427,6 +434,7 @@ export function AssistantResourceList({
       if (item.id === UNLINKED_ASSISTANT_ENTITY_ID) return []
 
       const pinned = assistantPinnedIdSet.has(item.id)
+      const sidebarPinned = sidebarAssistantFavoriteIdSet.has(item.id)
 
       return [
         buildResolvedResourceEntityMenuAction({
@@ -441,6 +449,12 @@ export function AssistantResourceList({
           icon: pinned ? <PinOffIcon size={14} /> : <PinIcon size={14} />,
           order: 20,
           availability: { visible: true, enabled: !isAssistantPinActionDisabled }
+        }),
+        buildResolvedResourceEntityMenuAction({
+          id: ASSISTANT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID,
+          label: sidebarPinned ? t('launchpad.unpin_from_sidebar') : t('launchpad.pin_to_sidebar'),
+          icon: sidebarPinned ? <PinOffIcon size={14} /> : <PinIcon size={14} />,
+          order: 22
         }),
         buildResolvedResourceEntityMenuAction({
           id: ASSISTANT_ENTITY_CLEAR_TOPICS_ACTION_ID,
@@ -481,6 +495,7 @@ export function AssistantResourceList({
       deletingAssistantId,
       isAssistantPinActionDisabled,
       isGroupGrouping,
+      sidebarAssistantFavoriteIdSet,
       t
     ]
   )
@@ -493,6 +508,11 @@ export function AssistantResourceList({
       }
       if (action.id === ASSISTANT_ENTITY_TOGGLE_PIN_ACTION_ID) {
         void handleToggleAssistantPin(item.id)
+        return
+      }
+      if (action.id === ASSISTANT_ENTITY_TOGGLE_SIDEBAR_ACTION_ID) {
+        if (sidebarAssistantFavoriteIdSet.has(item.id)) removeAssistant(item.id)
+        else toggleAssistant(item.id)
         return
       }
       if (action.id === ASSISTANT_ENTITY_CLEAR_TOPICS_ACTION_ID) {
@@ -517,8 +537,11 @@ export function AssistantResourceList({
       handleToggleAssistantPin,
       isGroupGrouping,
       openAssistantEditor,
+      removeAssistant,
       setAssistantIconType,
-      setAssistantSortType
+      setAssistantSortType,
+      sidebarAssistantFavoriteIdSet,
+      toggleAssistant
     ]
   )
 

--- a/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
+++ b/src/renderer/components/chat/resourceList/__tests__/EntityResourceListActions.test.tsx
@@ -112,6 +112,9 @@ vi.mock('@data/hooks/usePreference', () => ({
       (value: unknown) => {
         preferenceMocks.values.set(key, value)
         preferenceMocks.setPreference(key, value)
+        // Mutations through useSidebarFavorites call `.catch` on the returned
+        // promise; resolve so those toggle paths do not throw.
+        return Promise.resolve()
       }
     ]
   }
@@ -1011,5 +1014,84 @@ describe('classic layout entity resource list actions', () => {
     expect(onOpenHistoryRecords).toHaveBeenCalledTimes(1)
     expect(screen.queryByText('agent.session.group.expand_all')).not.toBeInTheDocument()
     expect(screen.queryByText('agent.session.group.collapse_all')).not.toBeInTheDocument()
+  })
+
+  it('offers toggling an agent into the sidebar from the classic rail context menu', () => {
+    render(
+      <AgentResourceList
+        activeAgentId="agent-1"
+        agentSessionsSource={createAgentSessionsSource()}
+        onSelectSession={vi.fn()}
+        onCreateSession={vi.fn()}
+        onShowMissingAgentSelection={vi.fn()}
+      />
+    )
+
+    const menu = screen.getByTestId('agent-1-context-menu')
+    expect(menu).toHaveTextContent('launchpad.pin_to_sidebar')
+    expect(menu).not.toHaveTextContent('launchpad.unpin_from_sidebar')
+
+    fireEvent.click(within(menu).getByRole('button', { name: 'launchpad.pin_to_sidebar' }))
+
+    expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+      { type: 'app', id: 'assistants' },
+      { type: 'agent', id: 'agent-1' }
+    ])
+  })
+
+  it('toggles an already-pinned agent out of the sidebar from the classic rail context menu', () => {
+    preferenceMocks.values.set('ui.sidebar.favorites', [{ type: 'agent', id: 'agent-1' }])
+
+    render(
+      <AgentResourceList
+        activeAgentId="agent-1"
+        agentSessionsSource={createAgentSessionsSource()}
+        onSelectSession={vi.fn()}
+        onCreateSession={vi.fn()}
+        onShowMissingAgentSelection={vi.fn()}
+      />
+    )
+
+    const menu = screen.getByTestId('agent-1-context-menu')
+    expect(menu).toHaveTextContent('launchpad.unpin_from_sidebar')
+
+    fireEvent.click(within(menu).getByRole('button', { name: 'launchpad.unpin_from_sidebar' }))
+
+    expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+      { type: 'app', id: 'assistants' }
+    ])
+  })
+
+  it('offers toggling an assistant into the sidebar from the classic rail context menu', () => {
+    render(
+      <TestAssistantResourceList activeAssistantId="assistant-1" onSelectTopic={vi.fn()} onCreateTopic={vi.fn()} />
+    )
+
+    const menu = screen.getByTestId('assistant-1-context-menu')
+    expect(menu).toHaveTextContent('launchpad.pin_to_sidebar')
+
+    fireEvent.click(within(menu).getByRole('button', { name: 'launchpad.pin_to_sidebar' }))
+
+    expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+      { type: 'app', id: 'assistants' },
+      { type: 'assistant', id: 'assistant-1' }
+    ])
+  })
+
+  it('toggles an already-pinned assistant out of the sidebar from the classic rail context menu', () => {
+    preferenceMocks.values.set('ui.sidebar.favorites', [{ type: 'assistant', id: 'assistant-1' }])
+
+    render(
+      <TestAssistantResourceList activeAssistantId="assistant-1" onSelectTopic={vi.fn()} onCreateTopic={vi.fn()} />
+    )
+
+    const menu = screen.getByTestId('assistant-1-context-menu')
+    expect(menu).toHaveTextContent('launchpad.unpin_from_sidebar')
+
+    fireEvent.click(within(menu).getByRole('button', { name: 'launchpad.unpin_from_sidebar' }))
+
+    expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+      { type: 'app', id: 'assistants' }
+    ])
   })
 })

--- a/src/renderer/components/chat/resourceList/base/resourceEntityIcon.tsx
+++ b/src/renderer/components/chat/resourceList/base/resourceEntityIcon.tsx
@@ -31,46 +31,58 @@ function buildModelAvatarModel(uniqueModelId: unknown, modelName: string | null 
   }
 }
 
-function renderFallbackAssistantIcon(emoji?: string | null) {
+const RESOURCE_ICON_SIZE = 24
+
+function renderFallbackAssistantIcon(emoji: string | null | undefined, size: number) {
   return emoji ? (
-    <EmojiIcon emoji={emoji} size={24} fontSize={14} className="mr-0" />
+    <EmojiIcon emoji={emoji} size={size} fontSize={Math.round(size * 0.58)} className="mr-0" />
   ) : (
-    <span className="flex size-6 items-center justify-center rounded-full bg-background-subtle">
-      <Bot size={14} />
+    <span
+      className="flex items-center justify-center rounded-full bg-background-subtle"
+      style={{ width: size, height: size }}>
+      <Bot size={Math.round(size * 0.58)} />
     </span>
   )
 }
 
+/**
+ * @param size - Rendered icon size; the sidebar renders smaller rows than the rails.
+ */
 export function renderAssistantEntityIcon(
   iconType: AssistantIconType,
   assistant: { emoji?: string | null; modelId?: string | null; modelName?: string | null },
-  fallbackModelId?: string | null
+  fallbackModelId?: string | null,
+  size: number = RESOURCE_ICON_SIZE
 ) {
   if (iconType === 'none') return undefined
 
   const modelAvatarModel = buildModelAvatarModel(assistant.modelId ?? fallbackModelId, assistant.modelName)
   if (iconType === 'model' && modelAvatarModel) {
-    return <ModelAvatar model={modelAvatarModel} size={24} className="border border-border-subtle" />
+    return <ModelAvatar model={modelAvatarModel} size={size} className="border border-border-subtle" />
   }
 
-  return renderFallbackAssistantIcon(assistant.emoji)
+  return renderFallbackAssistantIcon(assistant.emoji, size)
 }
 
+/**
+ * @param size - Rendered icon size; the sidebar renders smaller rows than the rails.
+ */
 export function renderAgentEntityIcon(
   iconType: AssistantIconType,
   agent: { configuration?: AgentConfiguration; model?: string | null; modelName?: string | null } | undefined,
-  fallbackModelId?: string | null
+  fallbackModelId?: string | null,
+  size: number = RESOURCE_ICON_SIZE
 ) {
   if (iconType === 'none') return undefined
 
   const modelAvatarModel = buildModelAvatarModel(agent?.model ?? fallbackModelId, agent?.modelName)
-  if (iconType === 'model' && modelAvatarModel) return <ModelAvatar model={modelAvatarModel} size={24} />
+  if (iconType === 'model' && modelAvatarModel) return <ModelAvatar model={modelAvatarModel} size={size} />
 
   return (
     <EmojiIcon
       emoji={getAgentAvatarFromConfiguration(agent?.configuration) || DEFAULT_ASSISTANT_EMOJI}
-      size={24}
-      fontSize={14}
+      size={size}
+      fontSize={Math.round(size * 0.58)}
       className="mr-0"
     />
   )

--- a/src/renderer/hooks/__tests__/useSidebarFavorites.test.ts
+++ b/src/renderer/hooks/__tests__/useSidebarFavorites.test.ts
@@ -25,4 +25,87 @@ describe('useSidebarFavorites', () => {
 
     expect(setFavorites).not.toHaveBeenCalled()
   })
+
+  describe('entity favorites (agents / assistants)', () => {
+    const REQUIRED_ASSISTANTS = { type: 'app', id: 'assistants' } as const
+
+    it('toggles an agent favorite on and exposes it in agentFavoriteIds', () => {
+      const setFavorites = vi.fn().mockResolvedValue(undefined)
+      MockUsePreferenceUtils.mockPreferenceReturn('ui.sidebar.favorites', [], setFavorites)
+
+      const { result } = renderHook(() => useSidebarFavorites())
+
+      act(() => {
+        result.current.toggleAgent('agent-1')
+      })
+
+      // Mutations operate on the ordered visible list, so the required
+      // assistants app is persisted alongside the newly added entity.
+      expect(setFavorites).toHaveBeenCalledWith([REQUIRED_ASSISTANTS, { type: 'agent', id: 'agent-1' }])
+    })
+
+    it('toggles an assistant favorite off and removes it from assistantFavoriteIds', () => {
+      const setFavorites = vi.fn().mockResolvedValue(undefined)
+      MockUsePreferenceUtils.mockPreferenceReturn(
+        'ui.sidebar.favorites',
+        [{ type: 'assistant', id: 'assistant-1' }],
+        setFavorites
+      )
+
+      const { result } = renderHook(() => useSidebarFavorites())
+      expect(result.current.assistantFavoriteIds).toEqual(['assistant-1'])
+
+      act(() => {
+        result.current.toggleAssistant('assistant-1')
+      })
+
+      expect(setFavorites).toHaveBeenCalledWith([REQUIRED_ASSISTANTS])
+    })
+
+    it('segregates agent and assistant favorite ids by type', () => {
+      MockUsePreferenceUtils.mockPreferenceReturn('ui.sidebar.favorites', [
+        { type: 'agent', id: 'agent-1' },
+        { type: 'assistant', id: 'assistant-1' },
+        { type: 'mini_app', id: 'calculator' }
+      ])
+
+      const { result } = renderHook(() => useSidebarFavorites())
+
+      expect(result.current.agentFavoriteIds).toEqual(['agent-1'])
+      expect(result.current.assistantFavoriteIds).toEqual(['assistant-1'])
+    })
+
+    it('removes an agent favorite via removeAgent', () => {
+      const setFavorites = vi.fn().mockResolvedValue(undefined)
+      MockUsePreferenceUtils.mockPreferenceReturn(
+        'ui.sidebar.favorites',
+        [
+          { type: 'agent', id: 'agent-1' },
+          { type: 'assistant', id: 'assistant-1' }
+        ],
+        setFavorites
+      )
+
+      const { result } = renderHook(() => useSidebarFavorites())
+
+      act(() => {
+        result.current.removeAgent('agent-1')
+      })
+
+      expect(setFavorites).toHaveBeenCalledWith([REQUIRED_ASSISTANTS, { type: 'assistant', id: 'assistant-1' }])
+    })
+
+    it('skips removing an assistant that is not favorited', () => {
+      const setFavorites = vi.fn().mockResolvedValue(undefined)
+      MockUsePreferenceUtils.mockPreferenceReturn('ui.sidebar.favorites', [], setFavorites)
+
+      const { result } = renderHook(() => useSidebarFavorites())
+
+      act(() => {
+        result.current.removeAssistant('missing-assistant')
+      })
+
+      expect(setFavorites).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/renderer/hooks/agent/useAgent.ts
+++ b/src/renderer/hooks/agent/useAgent.ts
@@ -66,10 +66,16 @@ export const useAgent = (id: string | null) => {
 /**
  * List + mutate all agents. Plain deletion removes the agent only; sessions are
  * preserved as orphaned history unless a caller explicitly requests session deletion.
+ *
+ * @param options.enabled - Skip the list query when the caller has nothing to render
+ *   for it (mutations stay usable). Defaults to `true`.
  */
-export const useAgents = () => {
+export const useAgents = (options: { enabled?: boolean } = {}) => {
   const { t } = useTranslation()
-  const { data, isLoading, error, refetch } = useQuery('/agents', { query: { limit: AGENTS_MAX_LIMIT } })
+  const { data, isLoading, error, refetch } = useQuery('/agents', {
+    enabled: options.enabled ?? true,
+    query: { limit: AGENTS_MAX_LIMIT }
+  })
   const agents = useMemo<AgentEntity[]>(() => (data?.items ?? []) as unknown as AgentEntity[], [data])
   const invalidate = useInvalidateCache()
 

--- a/src/renderer/hooks/useSidebarFavorites.ts
+++ b/src/renderer/hooks/useSidebarFavorites.ts
@@ -5,9 +5,11 @@ import {
   getOrderedVisibleSidebarFavoriteItems,
   getOrderedVisibleSidebarFavorites,
   getSidebarMiniAppFavoriteIds,
+  removeSidebarEntityFavorite,
   removeSidebarMiniApp,
   reorderSidebarFavorites,
   setSidebarAppPinned,
+  toggleSidebarEntityFavorite,
   toggleSidebarMiniApp
 } from '@renderer/utils/sidebar'
 import type { SidebarFavoriteItem } from '@shared/data/preference/preferenceTypes'
@@ -34,6 +36,14 @@ export function useSidebarFavorites() {
   const favoriteItems = useMemo(() => getOrderedVisibleSidebarFavoriteItems(favorites), [favorites])
   const appFavorites = useMemo(() => getOrderedVisibleSidebarFavorites(favorites), [favorites])
   const miniAppFavoriteIds = useMemo(() => getSidebarMiniAppFavoriteIds(favorites), [favorites])
+  const agentFavoriteIds = useMemo(
+    () => favoriteItems.flatMap((favorite) => (favorite.type === 'agent' ? [favorite.id] : [])),
+    [favoriteItems]
+  )
+  const assistantFavoriteIds = useMemo(
+    () => favoriteItems.flatMap((favorite) => (favorite.type === 'assistant' ? [favorite.id] : [])),
+    [favoriteItems]
+  )
 
   const persist = useCallback(
     (next: SidebarFavoriteItem[]) => {
@@ -56,6 +66,28 @@ export function useSidebarFavorites() {
     },
     [favorites, miniAppFavoriteIds, persist]
   )
+  const toggleAgent = useCallback(
+    (id: string) => persist(toggleSidebarEntityFavorite(favorites, 'agent', id)),
+    [favorites, persist]
+  )
+  const toggleAssistant = useCallback(
+    (id: string) => persist(toggleSidebarEntityFavorite(favorites, 'assistant', id)),
+    [favorites, persist]
+  )
+  const removeAgent = useCallback(
+    (id: string) => {
+      if (!agentFavoriteIds.includes(id)) return
+      persist(removeSidebarEntityFavorite(favorites, 'agent', id))
+    },
+    [favorites, agentFavoriteIds, persist]
+  )
+  const removeAssistant = useCallback(
+    (id: string) => {
+      if (!assistantFavoriteIds.includes(id)) return
+      persist(removeSidebarEntityFavorite(favorites, 'assistant', id))
+    },
+    [favorites, assistantFavoriteIds, persist]
+  )
   const reorderFavorites = useCallback(
     (orderedItems: readonly SidebarFavoriteItem[]) => persist(reorderSidebarFavorites(favorites, orderedItems)),
     [favorites, persist]
@@ -65,9 +97,15 @@ export function useSidebarFavorites() {
     favorites: favoriteItems,
     appFavorites,
     miniAppFavoriteIds,
+    agentFavoriteIds,
+    assistantFavoriteIds,
     setAppPinned,
     reorderFavorites,
     toggleMiniApp,
-    removeMiniApp
+    removeMiniApp,
+    toggleAgent,
+    toggleAssistant,
+    removeAgent,
+    removeAssistant
   }
 }

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -98,6 +98,7 @@ const AgentPage = () => {
   const isActiveTab = useIsActiveTab()
   const currentTabId = useCurrentTabId()
   const routeSessionId = routeSearch.sessionId
+  const routeAgentId = routeSearch.agentId
   const isMessageOnlyView = routeSearch.view === 'message' && !!routeSessionId
   const routeActiveSessionId = isMessageOnlyView ? null : (routeSessionId ?? null)
   // Shared full-list source for session UI plus exact latest/reusable lookups.
@@ -454,7 +455,10 @@ const AgentPage = () => {
     async (defaults: CreateAgentSessionDefaults = {}): Promise<AgentSessionEntity | null> => {
       if (isCreatingEmptySessionRef.current) return null
       isCreatingEmptySessionRef.current = true
-      const agentId = defaults.agentId === undefined ? (visibleSession?.agentId ?? null) : defaults.agentId
+      // A sidebar `?agentId=` entry whose agent has no sessions yet falls through to the page;
+      // create for that exact agent rather than whatever session happens to be visible.
+      const agentId =
+        defaults.agentId === undefined ? (visibleSession?.agentId ?? routeAgentId ?? null) : defaults.agentId
       try {
         closeSurface()
 
@@ -477,7 +481,7 @@ const AgentPage = () => {
         isCreatingEmptySessionRef.current = false
       }
     },
-    [activateSession, clearActiveSession, closeSurface, resolveEmptySession, t, visibleSession?.agentId]
+    [activateSession, clearActiveSession, closeSurface, resolveEmptySession, routeAgentId, t, visibleSession?.agentId]
   )
 
   const showMissingAgentSelection = useCallback(() => {
@@ -497,11 +501,15 @@ const AgentPage = () => {
       setPendingSession(null)
 
       const excluded = new Set(excludedAgentIds)
+      // A sidebar `?agentId=` entry with no sessions yet starts a fresh session for that
+      // exact agent, not whatever was last focused.
+      const routeAgent =
+        routeAgentId && !excluded.has(routeAgentId) ? agents.find((agent) => agent.id === routeAgentId) : undefined
       const rememberedAgent =
         lastUsedAgentId && !excluded.has(lastUsedAgentId)
           ? agents.find((agent) => agent.id === lastUsedAgentId)
           : undefined
-      const defaultAgent = rememberedAgent ?? agents.find((agent) => !excluded.has(agent.id))
+      const defaultAgent = routeAgent ?? rememberedAgent ?? agents.find((agent) => !excluded.has(agent.id))
       if (!defaultAgent) {
         setActiveSessionId(null)
         setPendingSessionDefaults(null)
@@ -511,7 +519,15 @@ const AgentPage = () => {
 
       return createAndActivateEmptySession({ agentId: defaultAgent.id })
     },
-    [agents, closeSurface, createAndActivateEmptySession, lastUsedAgentId, setActiveSessionId, setPendingSession]
+    [
+      agents,
+      closeSurface,
+      createAndActivateEmptySession,
+      lastUsedAgentId,
+      routeAgentId,
+      setActiveSessionId,
+      setPendingSession
+    ]
   )
 
   // Stable wrapper for the classic-layout rail's per-agent "new session" action. Adapting the

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -2471,6 +2471,36 @@ describe('AgentPage', () => {
     expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
   })
 
+  it('creates for the sidebar agentId when the pinned agent has no session yet', async () => {
+    agentPageMocks.routeSearch = { agentId: 'agent-a' }
+    agentPageMocks.agents = [
+      { id: 'agent-a', model: 'model-a', name: 'Agent A' },
+      { id: 'agent-b', model: 'model-b', name: 'Agent B' }
+    ]
+    agentPageMocks.classicLayoutSessions = []
+    agentPageMocks.dataApiPost.mockResolvedValue({
+      ...agentPageMocks.persistedSession,
+      id: 'session-pinned-agent',
+      agentId: 'agent-a',
+      name: '',
+      workspaceId: '',
+      workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+    })
+
+    render(<AgentPage />)
+
+    // The composer create path carries no agent id, so without the route fallback it
+    // would resolve to the visible session's agent (none here) and stall.
+    fireEvent.click(screen.getByRole('button', { name: 'Create empty session from composer' }))
+
+    await waitFor(() =>
+      expect(agentPageMocks.dataApiPost).toHaveBeenCalledWith(
+        '/agent-sessions',
+        expect.objectContaining({ body: expect.objectContaining({ agentId: 'agent-a' }) })
+      )
+    )
+  })
+
   it('records the visible agent reported by the chat body', async () => {
     render(<AgentPage />)
 

--- a/src/renderer/pages/agents/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/agents/__tests__/routeSearch.test.ts
@@ -5,14 +5,43 @@ import { parseAgentRouteSearch } from '../routeSearch'
 describe('parseAgentRouteSearch', () => {
   it('accepts the feedback intent alongside existing search fields', () => {
     expect(parseAgentRouteSearch({ intent: 'feedback', sessionId: 'session-1', view: 'message' })).toEqual({
+      agentId: undefined,
       intent: 'feedback',
       sessionId: 'session-1',
       view: 'message'
     })
   })
 
+  it('parses the sidebar agentId for pinned entity entries', () => {
+    expect(parseAgentRouteSearch({ agentId: 'agent-1' })).toEqual({
+      agentId: 'agent-1',
+      intent: undefined,
+      sessionId: undefined,
+      view: undefined
+    })
+  })
+
+  it('keeps agentId alongside an explicit session', () => {
+    expect(parseAgentRouteSearch({ agentId: 'agent-1', sessionId: 'session-1' })).toEqual({
+      agentId: 'agent-1',
+      intent: undefined,
+      sessionId: 'session-1',
+      view: undefined
+    })
+  })
+
+  it('drops non-string agentId values', () => {
+    expect(parseAgentRouteSearch({ agentId: 7 })).toEqual({
+      agentId: undefined,
+      intent: undefined,
+      sessionId: undefined,
+      view: undefined
+    })
+  })
+
   it('drops unknown intents', () => {
     expect(parseAgentRouteSearch({ intent: 'other' })).toEqual({
+      agentId: undefined,
       intent: undefined,
       sessionId: undefined,
       view: undefined

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -37,6 +37,7 @@ import { useConversationNavigation } from '@renderer/hooks/useConversationNaviga
 import { useImageCaptureTargets } from '@renderer/hooks/useImageCaptureTargets'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { usePins } from '@renderer/hooks/usePins'
+import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { finishTopicRenaming, startTopicRenaming } from '@renderer/hooks/useTopic'
 import { useWindowFrame } from '@renderer/hooks/useWindowFrame'
 import { ipcApi } from '@renderer/ipc'
@@ -172,6 +173,12 @@ function AgentGroupMoreMenu({
   onTogglePin: (agentId: string) => void | Promise<void>
 }) {
   const { t } = useTranslation()
+  const {
+    agentFavoriteIds: sidebarAgentFavoriteIds,
+    toggleAgent: toggleSidebarAgent,
+    removeAgent: removeSidebarAgent
+  } = useSidebarFavorites()
+  const sidebarPinned = sidebarAgentFavoriteIds.includes(agentId)
   const actionContext: AgentGroupActionContext = {
     agentId,
     assistantIconType,
@@ -181,8 +188,13 @@ function AgentGroupMoreMenu({
     onEdit,
     onSetAgentIconType,
     onTogglePin,
+    onToggleSidebar: (id) => {
+      if (sidebarPinned) removeSidebarAgent(id)
+      else toggleSidebarAgent(id)
+    },
     pinDisabled,
     pinned,
+    sidebarPinned,
     t
   }
   const actions = resolveAgentGroupActions(actionContext)
@@ -518,6 +530,19 @@ const Sessions = ({
   const { updateSession } = useUpdateSession()
 
   const agentPinnedIdSet = useMemo(() => new Set(agentPinnedIds), [agentPinnedIds])
+  const {
+    agentFavoriteIds: sidebarAgentFavoriteIds,
+    toggleAgent: toggleSidebarAgent,
+    removeAgent: removeSidebarAgent
+  } = useSidebarFavorites()
+  const sidebarAgentFavoriteIdSet = useMemo(() => new Set(sidebarAgentFavoriteIds), [sidebarAgentFavoriteIds])
+  const handleToggleAgentSidebar = useCallback(
+    (agentId: string) => {
+      if (sidebarAgentFavoriteIdSet.has(agentId)) removeSidebarAgent(agentId)
+      else toggleSidebarAgent(agentId)
+    },
+    [removeSidebarAgent, sidebarAgentFavoriteIdSet, toggleSidebarAgent]
+  )
   const agentsForDisplay = useMemo(() => {
     if (!optimisticAgentOrderIds) return agents
 
@@ -1791,8 +1816,10 @@ const Sessions = ({
           onEdit: openAgentEditor,
           onSetAgentIconType: setAssistantIconType,
           onTogglePin: handleToggleAgentPin,
+          onToggleSidebar: handleToggleAgentSidebar,
           pinDisabled: isAgentPinActionDisabled,
           pinned: agentPinnedIdSet.has(agentId),
+          sidebarPinned: sidebarAgentFavoriteIdSet.has(agentId),
           t
         }
         const actions = resolveAgentGroupActions(actionContext)
@@ -1837,10 +1864,12 @@ const Sessions = ({
       handleOpenWorkdirGroup,
       handleStartRenameWorkdirGroup,
       handleToggleAgentPin,
+      handleToggleAgentSidebar,
       isAgentPinActionDisabled,
       isUpdatingWorkspace,
       openAgentEditor,
       setAssistantIconType,
+      sidebarAgentFavoriteIdSet,
       t,
       workdirDisplay
     ]

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -159,7 +159,9 @@ function AgentGroupMoreMenu({
   onDeleteAgent,
   onEdit,
   onSetAgentIconType,
-  onTogglePin
+  onTogglePin,
+  onToggleSidebar,
+  sidebarPinned
 }: {
   agentId: string
   assistantIconType: AssistantIconType
@@ -167,18 +169,14 @@ function AgentGroupMoreMenu({
   deleteTasksOnly?: boolean
   pinDisabled?: boolean
   pinned: boolean
+  sidebarPinned: boolean
   onDeleteAgent: (agentId: string) => void | Promise<void>
   onEdit: (agentId: string) => void
   onSetAgentIconType: (iconType: AssistantIconType) => void | Promise<void>
   onTogglePin: (agentId: string) => void | Promise<void>
+  onToggleSidebar: (agentId: string) => void | Promise<void>
 }) {
   const { t } = useTranslation()
-  const {
-    agentFavoriteIds: sidebarAgentFavoriteIds,
-    toggleAgent: toggleSidebarAgent,
-    removeAgent: removeSidebarAgent
-  } = useSidebarFavorites()
-  const sidebarPinned = sidebarAgentFavoriteIds.includes(agentId)
   const actionContext: AgentGroupActionContext = {
     agentId,
     assistantIconType,
@@ -188,10 +186,7 @@ function AgentGroupMoreMenu({
     onEdit,
     onSetAgentIconType,
     onTogglePin,
-    onToggleSidebar: (id) => {
-      if (sidebarPinned) removeSidebarAgent(id)
-      else toggleSidebarAgent(id)
-    },
+    onToggleSidebar,
     pinDisabled,
     pinned,
     sidebarPinned,
@@ -1653,6 +1648,8 @@ const Sessions = ({
                 onEdit={openAgentEditor}
                 onSetAgentIconType={setAssistantIconType}
                 onTogglePin={handleToggleAgentPin}
+                onToggleSidebar={handleToggleAgentSidebar}
+                sidebarPinned={sidebarAgentFavoriteIdSet.has(agentGroupId)}
               />
             </Tooltip>
           )}
@@ -1700,6 +1697,7 @@ const Sessions = ({
       createSessionSeedIndex,
       handleDeleteAgent,
       handleToggleAgentPin,
+      handleToggleAgentSidebar,
       handleDeleteWorkdirGroup,
       handleOpenWorkdirGroup,
       handleStartRenameWorkdirGroup,
@@ -1710,6 +1708,7 @@ const Sessions = ({
       onShowMissingAgentSelection,
       requestCreateSessionFromSeed,
       setAssistantIconType,
+      sidebarAgentFavoriteIdSet,
       t,
       workdirDisplay
     ]

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -391,6 +391,7 @@ vi.mock('@renderer/data/hooks/usePreference', () => ({
     (value: unknown) => {
       preferenceMocks.values.set(key, value)
       preferenceMocks.setPreference(key, value)
+      return Promise.resolve()
     }
   ],
   useMultiplePreferences: (keys: Record<string, string>) => [
@@ -554,6 +555,8 @@ vi.mock('react-i18next', () => ({
         'agent.delete.content': 'Delete this agent and its tasks?',
         'agent.delete.error.failed': 'Failed to delete agent',
         'agent.delete.title': 'Delete Agent',
+        'launchpad.pin_to_sidebar': 'Add to sidebar',
+        'launchpad.unpin_from_sidebar': 'Remove from sidebar',
         'agent.session.agent.delete.content': 'Delete all tasks for this agent. The agent itself will not be deleted.',
         'agent.session.agent.delete.title': 'Delete agent tasks',
         'agent.session.agent.delete.trigger': 'Delete agent tasks',
@@ -3501,6 +3504,69 @@ describe('Sessions', () => {
     fireEvent.click(modelIconMenuItem as HTMLElement)
 
     await vi.waitFor(() => expect(preferenceMocks.setPreference).toHaveBeenCalledWith('agent.icon_type', 'model'))
+  })
+
+  it('pins an agent to the sidebar from the agent group menu', async () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    preferenceMocks.values.set('ui.sidebar.favorites', [])
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [{ id: 'agent-a', model: 'model-a', name: 'Alpha agent' }],
+      isLoading: false,
+      error: undefined,
+      refetch: dataApiMocks.refetchAgents
+    })
+    setupSessions({
+      sessions: [createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' })]
+    })
+
+    render(<SessionsForTest />)
+
+    const agentGroup = screen.getByRole('button', { name: 'Alpha agent' }).closest('div')
+    fireEvent.pointerDown(within(agentGroup as HTMLElement).getByRole('button', { name: 'More' }))
+    const pinMenuItem = screen
+      .getAllByRole('menuitem', { name: 'Add to sidebar' })
+      .find((button) => button.getAttribute('data-slot') === 'dropdown-menu-item')
+    expect(pinMenuItem).toBeDefined()
+
+    fireEvent.click(pinMenuItem as HTMLElement)
+
+    await vi.waitFor(() =>
+      expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+        { type: 'app', id: 'assistants' },
+        { type: 'agent', id: 'agent-a' }
+      ])
+    )
+  })
+
+  it('unpins an already pinned agent from the agent group menu', async () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    preferenceMocks.values.set('ui.sidebar.favorites', [{ type: 'agent', id: 'agent-a' }])
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [{ id: 'agent-a', model: 'model-a', name: 'Alpha agent' }],
+      isLoading: false,
+      error: undefined,
+      refetch: dataApiMocks.refetchAgents
+    })
+    setupSessions({
+      sessions: [createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' })]
+    })
+
+    render(<SessionsForTest />)
+
+    const agentGroup = screen.getByRole('button', { name: 'Alpha agent' }).closest('div')
+    fireEvent.pointerDown(within(agentGroup as HTMLElement).getByRole('button', { name: 'More' }))
+    const unpinMenuItem = screen
+      .getAllByRole('menuitem', { name: 'Remove from sidebar' })
+      .find((button) => button.getAttribute('data-slot') === 'dropdown-menu-item')
+    expect(unpinMenuItem).toBeDefined()
+
+    fireEvent.click(unpinMenuItem as HTMLElement)
+
+    await vi.waitFor(() =>
+      expect(preferenceMocks.setPreference).toHaveBeenCalledWith('ui.sidebar.favorites', [
+        { type: 'app', id: 'assistants' }
+      ])
+    )
   })
 
   it('deletes an agent from the agent group menu', async () => {

--- a/src/renderer/pages/agents/components/agentGroupActions.tsx
+++ b/src/renderer/pages/agents/components/agentGroupActions.tsx
@@ -19,8 +19,10 @@ export interface AgentGroupActionContext {
   onDeleteAgent: (agentId: string) => void | Promise<void>
   onSetAgentIconType: (iconType: AssistantIconType) => void | Promise<void>
   onTogglePin: (agentId: string) => void | Promise<void>
+  onToggleSidebar: (agentId: string) => void
   pinDisabled?: boolean
   pinned: boolean
+  sidebarPinned: boolean
   t: TFunction
 }
 
@@ -39,6 +41,11 @@ agentGroupActionRegistry.registerCommand({
   id: 'agent-group.toggle-pin',
   availability: ({ pinDisabled }) => ({ enabled: !pinDisabled }),
   run: ({ agentId, onTogglePin }) => onTogglePin(agentId)
+})
+
+agentGroupActionRegistry.registerCommand({
+  id: 'agent-group.toggle-sidebar',
+  run: ({ agentId, onToggleSidebar }) => onToggleSidebar(agentId)
 })
 
 for (const type of RESOURCE_ICON_TYPE_OPTIONS) {
@@ -71,6 +78,17 @@ agentGroupActionRegistry.registerAction(
     label: ({ pinned, t }) => (pinned ? t('agent.unpin.title') : t('agent.pin.title')),
     icon: ({ pinned }) => (pinned ? <PinOff size={14} /> : <Pin size={14} />),
     order: 20
+  })
+)
+
+agentGroupActionRegistry.registerAction(
+  buildResourceEntityMenuActionDescriptor({
+    id: 'agent-group.toggle-sidebar',
+    commandId: 'agent-group.toggle-sidebar',
+    label: ({ sidebarPinned, t }) =>
+      sidebarPinned ? t('launchpad.unpin_from_sidebar') : t('launchpad.pin_to_sidebar'),
+    icon: ({ sidebarPinned }) => (sidebarPinned ? <PinOff size={14} /> : <Pin size={14} />),
+    order: 22
   })
 )
 

--- a/src/renderer/pages/agents/routeSearch.ts
+++ b/src/renderer/pages/agents/routeSearch.ts
@@ -1,15 +1,17 @@
 export const MESSAGE_VIEW = 'message' as const
 
 export type AgentRouteSearch = {
+  agentId?: string
   intent?: 'feedback'
   sessionId?: string
   view?: typeof MESSAGE_VIEW
 }
 
 export function parseAgentRouteSearch(search: Record<string, unknown>): AgentRouteSearch {
+  const agentId = typeof search.agentId === 'string' ? search.agentId : undefined
   const intent = search.intent === 'feedback' ? 'feedback' : undefined
   const sessionId = typeof search.sessionId === 'string' ? search.sessionId : undefined
   const view = search.view === MESSAGE_VIEW ? MESSAGE_VIEW : undefined
 
-  return { intent, sessionId, view }
+  return { agentId, intent, sessionId, view }
 }

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -63,7 +63,7 @@ const ASSISTANT_CONVERSATION_RESOURCE_KINDS = [
   'assistant'
 ] as const satisfies readonly AssistantConversationResourceKind[]
 
-type NewTopicAssistantSelectionSource = 'explicit' | 'last-used' | 'first-assistant' | 'runtime-fallback'
+type NewTopicAssistantSelectionSource = 'explicit' | 'route' | 'last-used' | 'first-assistant' | 'runtime-fallback'
 type ResolvedNewTopicAssistantSelection = { assistantId?: string; source: NewTopicAssistantSelectionSource }
 
 type NewTopicAssistantTargetOptions = {
@@ -91,6 +91,7 @@ const HomePage: FC = () => {
   const routeSearch = parseChatRouteSearch(useSearch({ strict: false }) as Record<string, unknown>)
   const navigate = useNavigate()
   const routeTopicId = routeSearch.topicId
+  const routeAssistantId = routeSearch.assistantId
   const isMessageOnlyView = routeSearch.view === 'message' && !!routeTopicId
   const handleManualPaneOpen = useCallback(() => {
     requestAnimationFrame(() => {
@@ -155,6 +156,11 @@ const HomePage: FC = () => {
       if (isAvailableAssistantId(explicitAssistantId)) {
         return { assistantId: explicitAssistantId, source: 'explicit' }
       }
+      // A sidebar `?assistantId=` entry whose assistant has no topics yet creates for that exact
+      // assistant, not whatever was last focused (mirrors AgentPage's `preferredAgentId`).
+      if (isAvailableAssistantId(routeAssistantId)) {
+        return { assistantId: routeAssistantId, source: 'route' }
+      }
       if (isAvailableAssistantId(validLastUsedAssistantId)) {
         return { assistantId: validLastUsedAssistantId, source: 'last-used' }
       }
@@ -164,7 +170,7 @@ const HomePage: FC = () => {
       }
       return { source: 'runtime-fallback' }
     },
-    [assistantIdSet, assistants, validLastUsedAssistantId]
+    [assistantIdSet, assistants, routeAssistantId, validLastUsedAssistantId]
   )
 
   const routeActiveTopicId = isMessageOnlyView ? null : (routeTopicId ?? null)

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -182,12 +182,14 @@ function AssistantGroupMoreMenu({
   disabled,
   isGroupGrouping,
   pinned,
+  sidebarPinned,
   onDeleteAssistant,
   onDeleteAllTopics,
   onEdit,
   onSetAssistantIconType,
   onToggleGrouping,
-  onTogglePin
+  onTogglePin,
+  onToggleSidebar
 }: {
   assistantId: string
   assistantIconType: AssistantIconType
@@ -196,20 +198,16 @@ function AssistantGroupMoreMenu({
   disabled?: boolean
   isGroupGrouping: boolean
   pinned: boolean
+  sidebarPinned: boolean
   onDeleteAssistant: (assistantId: string) => void | Promise<void>
   onDeleteAllTopics: (assistantId: string) => void | Promise<void>
   onEdit: (assistantId: string) => void
   onSetAssistantIconType: (iconType: AssistantIconType) => void | Promise<void>
   onToggleGrouping: () => void | Promise<void>
   onTogglePin: (assistantId: string) => void | Promise<void>
+  onToggleSidebar: (assistantId: string) => void | Promise<void>
 }) {
   const { t } = useTranslation()
-  const {
-    assistantFavoriteIds: sidebarAssistantFavoriteIds,
-    toggleAssistant: toggleSidebarAssistant,
-    removeAssistant: removeSidebarAssistant
-  } = useSidebarFavorites()
-  const sidebarPinned = sidebarAssistantFavoriteIds.includes(assistantId)
   const actionContext: AssistantGroupActionContext = {
     assistantId,
     assistantIconType,
@@ -223,10 +221,7 @@ function AssistantGroupMoreMenu({
     onSetAssistantIconType,
     onToggleGrouping,
     onTogglePin,
-    onToggleSidebar: (id) => {
-      if (sidebarPinned) removeSidebarAssistant(id)
-      else toggleSidebarAssistant(id)
-    },
+    onToggleSidebar,
     pinned,
     sidebarPinned,
     t
@@ -1020,6 +1015,8 @@ export function Topics({
                 onSetAssistantIconType={setAssistantIconType}
                 onToggleGrouping={() => setAssistantSortType(isGroupGrouping ? 'list' : 'tags')}
                 onTogglePin={handleToggleAssistantPin}
+                onToggleSidebar={handleToggleAssistantSidebar}
+                sidebarPinned={sidebarAssistantFavoriteIdSet.has(assistantGroupId)}
               />
             </Tooltip>
           )}
@@ -1049,12 +1046,14 @@ export function Topics({
       handleDeleteAssistant,
       handleDeleteAssistantTopics,
       handleToggleAssistantPin,
+      handleToggleAssistantSidebar,
       isAssistantPinActionDisabled,
       isGroupGrouping,
       onNewTopic,
       openAssistantEditor,
       setAssistantIconType,
       setAssistantSortType,
+      sidebarAssistantFavoriteIdSet,
       t
     ]
   )

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -49,6 +49,7 @@ import { useGroupReorder, useGroups } from '@renderer/hooks/useGroups'
 import { useImageCaptureTargets } from '@renderer/hooks/useImageCaptureTargets'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { usePins } from '@renderer/hooks/usePins'
+import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { finishTopicRenaming, getTopicMessages, startTopicRenaming, useTopicMutations } from '@renderer/hooks/useTopic'
 import { useTopicStreamStatus } from '@renderer/hooks/useTopicStreamStatus'
 import { useWindowFrame } from '@renderer/hooks/useWindowFrame'
@@ -203,6 +204,12 @@ function AssistantGroupMoreMenu({
   onTogglePin: (assistantId: string) => void | Promise<void>
 }) {
   const { t } = useTranslation()
+  const {
+    assistantFavoriteIds: sidebarAssistantFavoriteIds,
+    toggleAssistant: toggleSidebarAssistant,
+    removeAssistant: removeSidebarAssistant
+  } = useSidebarFavorites()
+  const sidebarPinned = sidebarAssistantFavoriteIds.includes(assistantId)
   const actionContext: AssistantGroupActionContext = {
     assistantId,
     assistantIconType,
@@ -216,7 +223,12 @@ function AssistantGroupMoreMenu({
     onSetAssistantIconType,
     onToggleGrouping,
     onTogglePin,
+    onToggleSidebar: (id) => {
+      if (sidebarPinned) removeSidebarAssistant(id)
+      else toggleSidebarAssistant(id)
+    },
     pinned,
+    sidebarPinned,
     t
   }
   const actions = resolveAssistantGroupActions(actionContext)
@@ -320,6 +332,22 @@ export function Topics({
   } = usePins('assistant', { enabled: dataEnabled })
   const assistantPinnedIdSet = useMemo(() => new Set(assistantPinnedIds), [assistantPinnedIds])
   const isAssistantPinActionDisabled = isAssistantPinsLoading || isAssistantPinsRefreshing || isAssistantPinsMutating
+  const {
+    assistantFavoriteIds: sidebarAssistantFavoriteIds,
+    toggleAssistant: toggleSidebarAssistant,
+    removeAssistant: removeSidebarAssistant
+  } = useSidebarFavorites()
+  const sidebarAssistantFavoriteIdSet = useMemo(
+    () => new Set(sidebarAssistantFavoriteIds),
+    [sidebarAssistantFavoriteIds]
+  )
+  const handleToggleAssistantSidebar = useCallback(
+    (assistantId: string) => {
+      if (sidebarAssistantFavoriteIdSet.has(assistantId)) removeSidebarAssistant(assistantId)
+      else toggleSidebarAssistant(assistantId)
+    },
+    [removeSidebarAssistant, sidebarAssistantFavoriteIdSet, toggleSidebarAssistant]
+  )
   const {
     topics: apiTopics,
     orderSignature,
@@ -1052,7 +1080,9 @@ export function Topics({
         onSetAssistantIconType: setAssistantIconType,
         onToggleGrouping: () => setAssistantSortType(isGroupGrouping ? 'list' : 'tags'),
         onTogglePin: handleToggleAssistantPin,
+        onToggleSidebar: handleToggleAssistantSidebar,
         pinned: assistantPinnedIdSet.has(assistantId),
+        sidebarPinned: sidebarAssistantFavoriteIdSet.has(assistantId),
         t
       }
       const actions = resolveAssistantGroupActions(actionContext)
@@ -1072,11 +1102,13 @@ export function Topics({
       handleDeleteAssistant,
       handleDeleteAssistantTopics,
       handleToggleAssistantPin,
+      handleToggleAssistantSidebar,
       isAssistantPinActionDisabled,
       isGroupGrouping,
       openAssistantEditor,
       setAssistantIconType,
       setAssistantSortType,
+      sidebarAssistantFavoriteIdSet,
       t
     ]
   )

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -361,6 +361,8 @@ vi.mock('react-i18next', () => ({
         if (key === 'assistants.edit.title') return 'Edit Assistant'
         if (key === 'assistants.pin.title') return 'Pin Assistant'
         if (key === 'assistants.unpin.title') return 'Unpin Assistant'
+        if (key === 'launchpad.pin_to_sidebar') return 'Add to sidebar'
+        if (key === 'launchpad.unpin_from_sidebar') return 'Remove from sidebar'
         if (key === 'assistants.clear.menu_title') return 'Delete all assistant conversations'
         if (key === 'assistants.delete.title') return 'Delete Assistant'
         if (key === 'assistants.delete.content') return 'Delete this assistant and its conversations?'
@@ -3209,6 +3211,47 @@ describe('Topics', () => {
     fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'Show in groups' }))
     await vi.waitFor(() =>
       expect(MockUsePreferenceUtils.getPreferenceValue('assistant.tab.sort_type' as never)).toBe('tags')
+    )
+  })
+
+  it('pins an assistant to the sidebar from the assistant group menu', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    MockUsePreferenceUtils.setPreferenceValue('ui.sidebar.favorites' as never, [])
+
+    renderTopicList()
+
+    const assistantHeader = screen.getByRole('button', { name: 'Alpha Assistant' }).closest('div')
+    const moreButton = within(assistantHeader as HTMLElement).getByRole('button', { name: 'More' })
+    fireEvent.click(moreButton)
+
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'Add to sidebar' }))
+
+    await vi.waitFor(() =>
+      expect(MockUsePreferenceUtils.getPreferenceValue('ui.sidebar.favorites' as never)).toEqual([
+        { type: 'app', id: 'assistants' },
+        { type: 'assistant', id: 'assistant-1' }
+      ])
+    )
+  })
+
+  it('unpins an already pinned assistant from the assistant group menu', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    MockUsePreferenceUtils.setPreferenceValue('ui.sidebar.favorites' as never, [
+      { type: 'assistant', id: 'assistant-1' }
+    ])
+
+    renderTopicList()
+
+    const assistantHeader = screen.getByRole('button', { name: 'Alpha Assistant' }).closest('div')
+    const moreButton = within(assistantHeader as HTMLElement).getByRole('button', { name: 'More' })
+    fireEvent.click(moreButton)
+
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'Remove from sidebar' }))
+
+    await vi.waitFor(() =>
+      expect(MockUsePreferenceUtils.getPreferenceValue('ui.sidebar.favorites' as never)).toEqual([
+        { type: 'app', id: 'assistants' }
+      ])
     )
   })
 

--- a/src/renderer/pages/home/Tabs/components/assistantGroupActions.tsx
+++ b/src/renderer/pages/home/Tabs/components/assistantGroupActions.tsx
@@ -23,7 +23,9 @@ export interface AssistantGroupActionContext {
   onSetAssistantIconType: (iconType: AssistantIconType) => void | Promise<void>
   onToggleGrouping: () => void | Promise<void>
   onTogglePin: (assistantId: string) => void | Promise<void>
+  onToggleSidebar: (assistantId: string) => void
   pinned: boolean
+  sidebarPinned: boolean
   t: TFunction
 }
 
@@ -42,6 +44,11 @@ assistantGroupActionRegistry.registerCommand({
   id: 'assistant-group.toggle-pin',
   availability: ({ disabled }) => ({ enabled: !disabled }),
   run: ({ assistantId, onTogglePin }) => onTogglePin(assistantId)
+})
+
+assistantGroupActionRegistry.registerCommand({
+  id: 'assistant-group.toggle-sidebar',
+  run: ({ assistantId, onToggleSidebar }) => onToggleSidebar(assistantId)
 })
 
 assistantGroupActionRegistry.registerCommand({
@@ -85,6 +92,17 @@ assistantGroupActionRegistry.registerAction(
     label: ({ pinned, t }) => (pinned ? t('assistants.unpin.title') : t('assistants.pin.title')),
     icon: ({ pinned }) => (pinned ? <PinOffIcon size={14} /> : <PinIcon size={14} />),
     order: 20
+  })
+)
+
+assistantGroupActionRegistry.registerAction(
+  buildResourceEntityMenuActionDescriptor({
+    id: 'assistant-group.toggle-sidebar',
+    commandId: 'assistant-group.toggle-sidebar',
+    label: ({ sidebarPinned, t }) =>
+      sidebarPinned ? t('launchpad.unpin_from_sidebar') : t('launchpad.pin_to_sidebar'),
+    icon: ({ sidebarPinned }) => (sidebarPinned ? <PinOffIcon size={14} /> : <PinIcon size={14} />),
+    order: 22
   })
 )
 

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1954,6 +1954,31 @@ describe('HomePage', () => {
     expect(screen.getByTestId('active-topic-assistant')).toHaveTextContent('assistant-2')
   })
 
+  it('uses the sidebar-pinned route assistant before the remembered one', async () => {
+    homeMocks.routeSearch = { assistantId: 'assistant-2' }
+    homeMocks.assistants = [{ id: 'assistant-1' }, { id: 'assistant-2' }]
+    homeMocks.persistCacheValues.set('ui.chat.last_used_assistant_id', 'assistant-1')
+
+    render(<HomePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New topic' }))
+
+    await waitFor(() => expect(homeMocks.createTopic).toHaveBeenCalledWith({ assistantId: 'assistant-2' }))
+    expect(screen.getByTestId('active-topic-assistant')).toHaveTextContent('assistant-2')
+  })
+
+  it('ignores a route assistant that no longer exists', async () => {
+    homeMocks.routeSearch = { assistantId: 'assistant-deleted' }
+    homeMocks.assistants = [{ id: 'assistant-1' }, { id: 'assistant-2' }]
+    homeMocks.persistCacheValues.set('ui.chat.last_used_assistant_id', 'assistant-1')
+
+    render(<HomePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'New topic' }))
+
+    await waitFor(() => expect(homeMocks.createTopic).toHaveBeenCalledWith({ assistantId: 'assistant-1' }))
+  })
+
   it('passes URL topicId to useActiveTopic as activeTopicId', async () => {
     homeMocks.entryTopic = undefined
     homeMocks.routeSearch = { topicId: 'topic-from-url' }

--- a/src/renderer/pages/home/__tests__/routeSearch.test.ts
+++ b/src/renderer/pages/home/__tests__/routeSearch.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseChatRouteSearch } from '../routeSearch'
+
+describe('parseChatRouteSearch', () => {
+  it('parses the sidebar assistantId for pinned entity entries', () => {
+    expect(parseChatRouteSearch({ assistantId: 'assistant-1' })).toEqual({
+      assistantId: 'assistant-1',
+      topicId: undefined,
+      view: undefined
+    })
+  })
+
+  it('keeps assistantId alongside an explicit topic', () => {
+    expect(parseChatRouteSearch({ assistantId: 'assistant-1', topicId: 'topic-1' })).toEqual({
+      assistantId: 'assistant-1',
+      topicId: 'topic-1',
+      view: undefined
+    })
+  })
+
+  it('parses topic and message view', () => {
+    expect(parseChatRouteSearch({ topicId: 'topic-1', view: 'message' })).toEqual({
+      assistantId: undefined,
+      topicId: 'topic-1',
+      view: 'message'
+    })
+  })
+
+  it('drops non-string assistantId values and unknown views', () => {
+    expect(parseChatRouteSearch({ assistantId: 7, view: 'other' })).toEqual({
+      assistantId: undefined,
+      topicId: undefined,
+      view: undefined
+    })
+  })
+})

--- a/src/renderer/pages/home/routeSearch.ts
+++ b/src/renderer/pages/home/routeSearch.ts
@@ -1,13 +1,15 @@
 export const MESSAGE_VIEW = 'message' as const
 
 export type ChatRouteSearch = {
+  assistantId?: string
   topicId?: string
   view?: typeof MESSAGE_VIEW
 }
 
 export function parseChatRouteSearch(search: Record<string, unknown>): ChatRouteSearch {
+  const assistantId = typeof search.assistantId === 'string' ? search.assistantId : undefined
   const topicId = typeof search.topicId === 'string' ? search.topicId : undefined
   const view = search.view === MESSAGE_VIEW ? MESSAGE_VIEW : undefined
 
-  return { topicId, view }
+  return { assistantId, topicId, view }
 }

--- a/src/renderer/routes/app/__tests__/conversation-entry.test.ts
+++ b/src/renderer/routes/app/__tests__/conversation-entry.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   resolveAgentEntrySessionId: vi.fn(),
-  resolveChatEntryTopicId: vi.fn()
+  resolveAgentEntrySessionIdForAgent: vi.fn(),
+  resolveChatEntryTopicId: vi.fn(),
+  resolveChatEntryTopicIdForAssistant: vi.fn()
 }))
 
 vi.mock('@renderer/pages/agents/AgentPage', () => ({ default: () => null }))
@@ -23,6 +25,8 @@ beforeEach(() => {
   vi.clearAllMocks()
   mocks.resolveChatEntryTopicId.mockResolvedValue(null)
   mocks.resolveAgentEntrySessionId.mockResolvedValue(null)
+  mocks.resolveChatEntryTopicIdForAssistant.mockResolvedValue(null)
+  mocks.resolveAgentEntrySessionIdForAgent.mockResolvedValue(null)
 })
 
 describe('conversation entry route guards', () => {
@@ -53,6 +57,42 @@ describe('conversation entry route guards', () => {
   it('does not resolve a feedback-intent agent entry', async () => {
     await agentBeforeLoad({ search: { intent: 'feedback' } })
 
+    expect(mocks.resolveAgentEntrySessionId).not.toHaveBeenCalled()
+  })
+
+  it('resolves an assistant-scoped topic for a sidebar assistant entry', async () => {
+    mocks.resolveChatEntryTopicIdForAssistant.mockResolvedValue('topic-assistant')
+
+    await expect(chatBeforeLoad({ search: { assistantId: 'assistant-1' } })).rejects.toMatchObject({
+      options: { to: '/app/chat', search: { topicId: 'topic-assistant' }, replace: true }
+    })
+
+    expect(mocks.resolveChatEntryTopicIdForAssistant).toHaveBeenCalledWith('assistant-1')
+    expect(mocks.resolveChatEntryTopicId).not.toHaveBeenCalled()
+  })
+
+  it('falls through bare when the assistant has no topics', async () => {
+    await chatBeforeLoad({ search: { assistantId: 'assistant-1' } })
+
+    expect(mocks.resolveChatEntryTopicIdForAssistant).toHaveBeenCalledWith('assistant-1')
+    expect(mocks.resolveChatEntryTopicId).not.toHaveBeenCalled()
+  })
+
+  it('resolves an agent-scoped session for a sidebar agent entry', async () => {
+    mocks.resolveAgentEntrySessionIdForAgent.mockResolvedValue('session-agent')
+
+    await expect(agentBeforeLoad({ search: { agentId: 'agent-1' } })).rejects.toMatchObject({
+      options: { to: '/app/agents', search: { sessionId: 'session-agent' }, replace: true }
+    })
+
+    expect(mocks.resolveAgentEntrySessionIdForAgent).toHaveBeenCalledWith('agent-1')
+    expect(mocks.resolveAgentEntrySessionId).not.toHaveBeenCalled()
+  })
+
+  it('falls through bare when the agent has no sessions', async () => {
+    await agentBeforeLoad({ search: { agentId: 'agent-1' } })
+
+    expect(mocks.resolveAgentEntrySessionIdForAgent).toHaveBeenCalledWith('agent-1')
     expect(mocks.resolveAgentEntrySessionId).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/routes/app/agents.tsx
+++ b/src/renderer/routes/app/agents.tsx
@@ -1,17 +1,25 @@
 import AgentPage from '@renderer/pages/agents/AgentPage'
 import { parseAgentRouteSearch } from '@renderer/pages/agents/routeSearch'
-import { resolveAgentEntrySessionId } from '@renderer/utils/conversationEntry'
+import { resolveAgentEntrySessionId, resolveAgentEntrySessionIdForAgent } from '@renderer/utils/conversationEntry'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/app/agents')({
   validateSearch: (search) => parseAgentRouteSearch(search),
   // Bare entries resolve their session here, before the page mounts, so the page
   // renders the final conversation in one pass. Explicit targets and the
-  // feedback entries pass through untouched. Message-only entries already
-  // carry a session id; a stray `view=message` without one is still a bare entry.
-  // No resolvable session → fall through bare; the page creates the first session itself.
+  // feedback entries pass through untouched. A sidebar `?agentId=` entry
+  // resolves that agent's most recent session instead of the global
+  // last-focused one. Message-only entries already carry a session id; a stray
+  // `view=message` without one is still a bare entry. No resolvable session →
+  // fall through bare; the page creates the first session itself (bound to the
+  // pinned agent).
   beforeLoad: async ({ search }) => {
     if (search.sessionId || search.intent === 'feedback') return
+    if (search.agentId) {
+      const sessionId = await resolveAgentEntrySessionIdForAgent(search.agentId)
+      if (sessionId) throw redirect({ to: '/app/agents', search: { sessionId }, replace: true })
+      return
+    }
     const sessionId = await resolveAgentEntrySessionId()
     if (sessionId) throw redirect({ to: '/app/agents', search: { sessionId }, replace: true })
   },

--- a/src/renderer/routes/app/agents.tsx
+++ b/src/renderer/routes/app/agents.tsx
@@ -5,14 +5,8 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/app/agents')({
   validateSearch: (search) => parseAgentRouteSearch(search),
-  // Bare entries resolve their session here, before the page mounts, so the page
-  // renders the final conversation in one pass. Explicit targets and the
-  // feedback entries pass through untouched. A sidebar `?agentId=` entry
-  // resolves that agent's most recent session instead of the global
-  // last-focused one. Message-only entries already carry a session id; a stray
-  // `view=message` without one is still a bare entry. No resolvable session →
-  // fall through bare; the page creates the first session itself (bound to the
-  // pinned agent).
+  // Resolving before mount renders the final conversation in one pass. A sidebar
+  // `?agentId=` entry must resume that agent, not the globally last-focused session.
   beforeLoad: async ({ search }) => {
     if (search.sessionId || search.intent === 'feedback') return
     if (search.agentId) {

--- a/src/renderer/routes/app/chat.tsx
+++ b/src/renderer/routes/app/chat.tsx
@@ -1,17 +1,24 @@
 import HomePage from '@renderer/pages/home/HomePage'
 import { parseChatRouteSearch } from '@renderer/pages/home/routeSearch'
-import { resolveChatEntryTopicId } from '@renderer/utils/conversationEntry'
+import { resolveChatEntryTopicId, resolveChatEntryTopicIdForAssistant } from '@renderer/utils/conversationEntry'
 import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/app/chat')({
   validateSearch: (search) => parseChatRouteSearch(search),
   // Bare entries resolve their topic here, before the page mounts, so the page
   // renders the final conversation in one pass. Explicit targets pass through
-  // untouched. Message-only entries already carry a topic id; a stray
-  // `view=message` without one is still a bare entry. No resolvable topic → fall
-  // through bare; the page renders its empty state.
+  // untouched. A sidebar `?assistantId=` entry resolves that assistant's most
+  // recent topic instead of the global last-focused one. Message-only entries
+  // already carry a topic id; a stray `view=message` without one is still a bare
+  // entry. No resolvable topic → fall through bare; the page renders its empty
+  // state (with the pinned assistant still selected).
   beforeLoad: async ({ search }) => {
     if (search.topicId) return
+    if (search.assistantId) {
+      const topicId = await resolveChatEntryTopicIdForAssistant(search.assistantId)
+      if (topicId) throw redirect({ to: '/app/chat', search: { topicId }, replace: true })
+      return
+    }
     const topicId = await resolveChatEntryTopicId()
     if (topicId) throw redirect({ to: '/app/chat', search: { topicId }, replace: true })
   },

--- a/src/renderer/routes/app/chat.tsx
+++ b/src/renderer/routes/app/chat.tsx
@@ -5,13 +5,8 @@ import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/app/chat')({
   validateSearch: (search) => parseChatRouteSearch(search),
-  // Bare entries resolve their topic here, before the page mounts, so the page
-  // renders the final conversation in one pass. Explicit targets pass through
-  // untouched. A sidebar `?assistantId=` entry resolves that assistant's most
-  // recent topic instead of the global last-focused one. Message-only entries
-  // already carry a topic id; a stray `view=message` without one is still a bare
-  // entry. No resolvable topic → fall through bare; the page renders its empty
-  // state (with the pinned assistant still selected).
+  // Resolving before mount renders the final conversation in one pass. A sidebar
+  // `?assistantId=` entry must resume that assistant, not the globally last-focused topic.
   beforeLoad: async ({ search }) => {
     if (search.topicId) return
     if (search.assistantId) {

--- a/src/renderer/utils/__tests__/conversationEntry.test.ts
+++ b/src/renderer/utils/__tests__/conversationEntry.test.ts
@@ -14,7 +14,12 @@ vi.mock('@data/DataApiService', () => ({
   dataApiService: { get: mocks.get }
 }))
 
-import { resolveAgentEntrySessionId, resolveChatEntryTopicId } from '@renderer/utils/conversationEntry'
+import {
+  resolveAgentEntrySessionId,
+  resolveAgentEntrySessionIdForAgent,
+  resolveChatEntryTopicId,
+  resolveChatEntryTopicIdForAssistant
+} from '@renderer/utils/conversationEntry'
 
 const notFoundError = () => new DataApiError(ErrorCode.NOT_FOUND, 'not found', 404)
 
@@ -99,5 +104,53 @@ describe('resolveAgentEntrySessionId', () => {
     mocks.get.mockResolvedValue({ session: null })
 
     await expect(resolveAgentEntrySessionId()).resolves.toBeNull()
+  })
+})
+
+describe('resolveChatEntryTopicIdForAssistant', () => {
+  it('resolves the latest topic of the given assistant', async () => {
+    mocks.get.mockResolvedValue({ topic: { id: 'topic-assistant' } })
+
+    await expect(resolveChatEntryTopicIdForAssistant('assistant-1')).resolves.toBe('topic-assistant')
+    expect(mocks.get).toHaveBeenCalledWith('/topics/latest', { query: { assistantId: 'assistant-1' } })
+    expect(mocks.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the assistant has no topics', async () => {
+    mocks.get.mockResolvedValue({ topic: null })
+
+    await expect(resolveChatEntryTopicIdForAssistant('assistant-1')).resolves.toBeNull()
+  })
+
+  it('never consults the global last-focused topic cache', async () => {
+    mocks.getPersist.mockReturnValue('topic-global')
+    mocks.get.mockResolvedValue({ topic: { id: 'topic-assistant' } })
+
+    await expect(resolveChatEntryTopicIdForAssistant('assistant-1')).resolves.toBe('topic-assistant')
+    expect(mocks.getPersist).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveAgentEntrySessionIdForAgent', () => {
+  it('resolves the latest session of the given agent', async () => {
+    mocks.get.mockResolvedValue({ session: { id: 'session-agent' } })
+
+    await expect(resolveAgentEntrySessionIdForAgent('agent-1')).resolves.toBe('session-agent')
+    expect(mocks.get).toHaveBeenCalledWith('/agent-sessions/latest', { query: { agentId: 'agent-1' } })
+    expect(mocks.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when the agent has no sessions', async () => {
+    mocks.get.mockResolvedValue({ session: null })
+
+    await expect(resolveAgentEntrySessionIdForAgent('agent-1')).resolves.toBeNull()
+  })
+
+  it('never consults the global last-focused session cache', async () => {
+    mocks.getPersist.mockReturnValue('session-global')
+    mocks.get.mockResolvedValue({ session: { id: 'session-agent' } })
+
+    await expect(resolveAgentEntrySessionIdForAgent('agent-1')).resolves.toBe('session-agent')
+    expect(mocks.getPersist).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/utils/__tests__/sidebar.test.ts
+++ b/src/renderer/utils/__tests__/sidebar.test.ts
@@ -9,17 +9,21 @@ import {
   getSidebarMenuPath,
   getSidebarMiniAppFavoriteIds,
   isMessageOnlyConversationUrl,
+  removeSidebarEntityFavorite,
   removeSidebarMiniApp,
   reorderLaunchpadApps,
   reorderSidebarFavorites,
   resolveSidebarActiveItem,
   setSidebarAppPinned,
   SIDEBAR_FAVORITE_ORDER,
+  toggleSidebarEntityFavorite,
   toggleSidebarMiniApp
 } from '../sidebar'
 
 const appFavorite = (id: SidebarFavorite): SidebarFavoriteItem => ({ type: 'app', id })
 const miniAppFavorite = (id: string): SidebarFavoriteItem => ({ type: 'mini_app', id })
+const agentFavorite = (id: string): SidebarFavoriteItem => ({ type: 'agent', id })
+const assistantFavorite = (id: string): SidebarFavoriteItem => ({ type: 'assistant', id })
 
 describe('sidebar config helpers', () => {
   it('keeps the fixed sidebar app order available', () => {
@@ -198,6 +202,65 @@ describe('sidebar favorites mutations', () => {
     expect(toggleSidebarMiniApp([appFavorite('assistants'), group], 'weather')).toEqual([
       appFavorite('assistants'),
       miniAppFavorite('weather'),
+      group
+    ])
+  })
+
+  it('normalizes agent and assistant favorites into the visible list', () => {
+    expect(
+      getOrderedVisibleSidebarFavoriteItems([
+        appFavorite('assistants'),
+        agentFavorite('agent-1'),
+        assistantFavorite('assistant-1')
+      ])
+    ).toEqual([appFavorite('assistants'), agentFavorite('agent-1'), assistantFavorite('assistant-1')])
+  })
+
+  it('drops agent/assistant favorites without an id during normalization', () => {
+    expect(
+      getSidebarFavoriteItems([
+        appFavorite('assistants'),
+        { type: 'agent' } as unknown as SidebarFavoriteItem,
+        { type: 'assistant' } as unknown as SidebarFavoriteItem
+      ])
+    ).toEqual([appFavorite('assistants')])
+  })
+
+  it('toggles an entity favorite on and off, preserving apps and other entities', () => {
+    const added = toggleSidebarEntityFavorite(
+      [appFavorite('assistants'), assistantFavorite('assistant-1')],
+      'agent',
+      'agent-1'
+    )
+    expect(added).toEqual([appFavorite('assistants'), assistantFavorite('assistant-1'), agentFavorite('agent-1')])
+
+    expect(toggleSidebarEntityFavorite(added, 'assistant', 'assistant-1')).toEqual([
+      appFavorite('assistants'),
+      agentFavorite('agent-1')
+    ])
+  })
+
+  it('removes an entity favorite while preserving apps and the other entity type', () => {
+    expect(
+      removeSidebarEntityFavorite(
+        [appFavorite('assistants'), agentFavorite('agent-1'), assistantFavorite('assistant-1')],
+        'agent',
+        'agent-1'
+      )
+    ).toEqual([appFavorite('assistants'), assistantFavorite('assistant-1')])
+  })
+
+  it('does not treat known agent/assistant favorites as forward-compatible unknown items on mutation', () => {
+    const group = { type: 'group', id: 'g1', name: 'Group', items: [] } as unknown as SidebarFavoriteItem
+
+    // Mutations operate on the ordered visible list, so the required assistants
+    // app is prepended next to the preserved future-typed group item.
+    expect(toggleSidebarEntityFavorite([agentFavorite('agent-1'), group], 'agent', 'agent-1')).toEqual([
+      appFavorite('assistants'),
+      group
+    ])
+    expect(toggleSidebarEntityFavorite([assistantFavorite('assistant-1'), group], 'assistant', 'assistant-1')).toEqual([
+      appFavorite('assistants'),
       group
     ])
   })

--- a/src/renderer/utils/conversationEntry.ts
+++ b/src/renderer/utils/conversationEntry.ts
@@ -48,3 +48,19 @@ export async function resolveAgentEntrySessionId(): Promise<string | null> {
   const { session } = await dataApiService.get('/agent-sessions/latest')
   return session?.id ?? null
 }
+
+/**
+ * Entity-scoped variants used by the sidebar entries: resolve the most recent
+ * conversation of one specific assistant / agent. They intentionally ignore the
+ * global last-focused caches — a pinned entity entry is about that entity, not
+ * whatever was last focused elsewhere.
+ */
+export async function resolveChatEntryTopicIdForAssistant(assistantId: string): Promise<string | null> {
+  const { topic } = await dataApiService.get('/topics/latest', { query: { assistantId } })
+  return topic?.id ?? null
+}
+
+export async function resolveAgentEntrySessionIdForAgent(agentId: string): Promise<string | null> {
+  const { session } = await dataApiService.get('/agent-sessions/latest', { query: { agentId } })
+  return session?.id ?? null
+}

--- a/src/renderer/utils/sidebar.ts
+++ b/src/renderer/utils/sidebar.ts
@@ -171,10 +171,6 @@ function createSidebarAppFavorite(id: SidebarAppId): SidebarFavoriteItem {
   return { type: 'app', id }
 }
 
-function createSidebarMiniAppFavorite(id: string): SidebarFavoriteItem {
-  return { type: 'mini_app', id }
-}
-
 /**
  * Stable identity for a favorite — its react key and reorder-matching key.
  *
@@ -370,22 +366,44 @@ export function setSidebarAppPinned(
   return preserveForwardCompatibleSidebarFavoriteItems(favorites, [...items, createSidebarAppFavorite(id)])
 }
 
+type SidebarLeafFavoriteType = 'mini_app' | 'agent' | 'assistant'
+
+// LEAF-ONLY: recurse into group.items when a 'group' variant is added.
+const isSidebarLeafFavorite = (item: SidebarFavoriteItem, type: SidebarLeafFavoriteType, id: string) =>
+  item.type === type && item.id === id
+
+/** Toggle a leaf favorite in place: present → filtered out, absent → appended to the end. */
+function toggleSidebarLeafFavorite(
+  favorites: readonly SidebarFavoriteItem[] | undefined,
+  type: SidebarLeafFavoriteType,
+  id: string
+): SidebarFavoriteItem[] {
+  const items = getOrderedVisibleSidebarFavoriteItems(favorites)
+
+  if (items.some((item) => isSidebarLeafFavorite(item, type, id))) {
+    return removeSidebarLeafFavorite(favorites, type, id)
+  }
+  return preserveForwardCompatibleSidebarFavoriteItems(favorites, [...items, { type, id }])
+}
+
+/** Remove a leaf favorite, preserving everything else in place. */
+function removeSidebarLeafFavorite(
+  favorites: readonly SidebarFavoriteItem[] | undefined,
+  type: SidebarLeafFavoriteType,
+  id: string
+): SidebarFavoriteItem[] {
+  return preserveForwardCompatibleSidebarFavoriteItems(
+    favorites,
+    getOrderedVisibleSidebarFavoriteItems(favorites).filter((item) => !isSidebarLeafFavorite(item, type, id))
+  )
+}
+
 /** Toggle a mini app favorite, preserving everything else. Adding appends to the end. */
 export function toggleSidebarMiniApp(
   favorites: readonly SidebarFavoriteItem[] | undefined,
   id: string
 ): SidebarFavoriteItem[] {
-  const items = getOrderedVisibleSidebarFavoriteItems(favorites)
-  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
-  const isTarget = (item: SidebarFavoriteItem) => item.type === 'mini_app' && item.id === id
-
-  if (items.some(isTarget)) {
-    return preserveForwardCompatibleSidebarFavoriteItems(
-      favorites,
-      items.filter((item) => !isTarget(item))
-    )
-  }
-  return preserveForwardCompatibleSidebarFavoriteItems(favorites, [...items, createSidebarMiniAppFavorite(id)])
+  return toggleSidebarLeafFavorite(favorites, 'mini_app', id)
 }
 
 /** Remove a mini app favorite, preserving everything else in place. */
@@ -393,11 +411,7 @@ export function removeSidebarMiniApp(
   favorites: readonly SidebarFavoriteItem[] | undefined,
   id: string
 ): SidebarFavoriteItem[] {
-  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
-  return preserveForwardCompatibleSidebarFavoriteItems(
-    favorites,
-    getOrderedVisibleSidebarFavoriteItems(favorites).filter((item) => !(item.type === 'mini_app' && item.id === id))
-  )
+  return removeSidebarLeafFavorite(favorites, 'mini_app', id)
 }
 
 /**
@@ -410,17 +424,7 @@ export function toggleSidebarEntityFavorite(
   type: 'agent' | 'assistant',
   id: string
 ): SidebarFavoriteItem[] {
-  const items = getOrderedVisibleSidebarFavoriteItems(favorites)
-  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
-  const isTarget = (item: SidebarFavoriteItem) => item.type === type && item.id === id
-
-  if (items.some(isTarget)) {
-    return preserveForwardCompatibleSidebarFavoriteItems(
-      favorites,
-      items.filter((item) => !isTarget(item))
-    )
-  }
-  return preserveForwardCompatibleSidebarFavoriteItems(favorites, [...items, { type, id }])
+  return toggleSidebarLeafFavorite(favorites, type, id)
 }
 
 /** Remove a pinned user entity (agent / assistant) favorite, preserving everything else in place. */
@@ -429,11 +433,7 @@ export function removeSidebarEntityFavorite(
   type: 'agent' | 'assistant',
   id: string
 ): SidebarFavoriteItem[] {
-  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
-  return preserveForwardCompatibleSidebarFavoriteItems(
-    favorites,
-    getOrderedVisibleSidebarFavoriteItems(favorites).filter((item) => !(item.type === type && item.id === id))
-  )
+  return removeSidebarLeafFavorite(favorites, type, id)
 }
 
 // --- Launchpad app order --------------------------------------------------

--- a/src/renderer/utils/sidebar.ts
+++ b/src/renderer/utils/sidebar.ts
@@ -191,6 +191,8 @@ function isForwardCompatibleSidebarFavoriteItem(favorite: SidebarFavoriteItem): 
     typeof item.type === 'string' &&
     item.type !== 'app' &&
     item.type !== 'mini_app' &&
+    item.type !== 'agent' &&
+    item.type !== 'assistant' &&
     typeof item.id === 'string' &&
     item.id.length > 0
   )
@@ -232,6 +234,9 @@ function normalizeSidebarFavoriteItem(favorite: SidebarFavoriteItem): SidebarFav
     case 'app':
       return isSidebarAppId(favorite.id) ? { ...favorite } : undefined
     case 'mini_app':
+      return favorite.id ? { ...favorite } : undefined
+    case 'agent':
+    case 'assistant':
       return favorite.id ? { ...favorite } : undefined
     default: {
       // Untrusted storage boundary: an unknown type (corrupt or written by a newer
@@ -392,6 +397,42 @@ export function removeSidebarMiniApp(
   return preserveForwardCompatibleSidebarFavoriteItems(
     favorites,
     getOrderedVisibleSidebarFavoriteItems(favorites).filter((item) => !(item.type === 'mini_app' && item.id === id))
+  )
+}
+
+/**
+ * Toggle a pinned user entity (agent / assistant) favorite, preserving
+ * everything else in place. Adding appends to the end of the whole list,
+ * removing filters the target out — mirrors {@link toggleSidebarMiniApp}.
+ */
+export function toggleSidebarEntityFavorite(
+  favorites: readonly SidebarFavoriteItem[] | undefined,
+  type: 'agent' | 'assistant',
+  id: string
+): SidebarFavoriteItem[] {
+  const items = getOrderedVisibleSidebarFavoriteItems(favorites)
+  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
+  const isTarget = (item: SidebarFavoriteItem) => item.type === type && item.id === id
+
+  if (items.some(isTarget)) {
+    return preserveForwardCompatibleSidebarFavoriteItems(
+      favorites,
+      items.filter((item) => !isTarget(item))
+    )
+  }
+  return preserveForwardCompatibleSidebarFavoriteItems(favorites, [...items, { type, id }])
+}
+
+/** Remove a pinned user entity (agent / assistant) favorite, preserving everything else in place. */
+export function removeSidebarEntityFavorite(
+  favorites: readonly SidebarFavoriteItem[] | undefined,
+  type: 'agent' | 'assistant',
+  id: string
+): SidebarFavoriteItem[] {
+  // LEAF-ONLY: recurse into group.items when a 'group' variant is added.
+  return preserveForwardCompatibleSidebarFavoriteItems(
+    favorites,
+    getOrderedVisibleSidebarFavoriteItems(favorites).filter((item) => !(item.type === type && item.id === id))
   )
 }
 

--- a/src/shared/data/api/schemas/topics.ts
+++ b/src/shared/data/api/schemas/topics.ts
@@ -213,6 +213,7 @@ export type TopicSchemas = {
    * `assistantId=unlinked` covers topics without a live assistant.
    *
    * @example GET /topics/latest
+   * @example GET /topics/latest?assistantId=asst_123
    */
   '/topics/latest': {
     GET: {

--- a/src/shared/data/preference/preferenceTypes.ts
+++ b/src/shared/data/preference/preferenceTypes.ts
@@ -130,6 +130,14 @@ export type SidebarFavoriteItem =
       type: 'mini_app'
       id: string
     }
+  | {
+      type: 'agent'
+      id: string
+    }
+  | {
+      type: 'assistant'
+      id: string
+    }
 
 export type AssistantIconType = 'model' | 'emoji' | 'none'
 


### PR DESCRIPTION
## Summary

Pin custom **assistants** and **agents** to the sidebar, just like mini-apps. Right-click an assistant/agent in its list → "Add to sidebar"; clicking the pinned icon reopens that entity's **most recent conversation** (topic for assistants, session for agents).

Closes #14161

## Related issue

[#14161 — [Feature]: Hope assistants and agents can be pinned to the sidebar like mini-programs](https://github.com/CherryHQ/cherry-studio/issues/14161)

> 不同网站的小程序可以选择性的固定到侧边栏，太方便了，希望助手和智能体也可以做到
>
> Mini-programs from different websites can be selectively pinned to the sidebar, which is very convenient. I hope assistants and agents can also do this

## Screenshots

**Assistant — "Add to sidebar" in the right-click menu**
<img width="1564" height="1003" alt="01-context-menu" src="https://github.com/user-attachments/assets/df1ee167-61ce-42f9-a64f-46c5a2123bb5" />

**Assistant — pinned; the emoji icon appears in the sidebar**
<img width="1564" height="1003" alt="02-pinned-sidebar" src="https://github.com/user-attachments/assets/46c2575b-b09b-45a9-9d89-d55d1ce282e4" />

**Agent — the same entry in the agent list**
<img width="1655" height="1094" alt="05-agent-context-menu" src="https://github.com/user-attachments/assets/5da91f0e-089c-4f44-9bc4-9687498cc848" />

**Both pinned — assistant and agent sit in the sidebar**
<img width="1655" height="1094" alt="06-agent-pinned" src="https://github.com/user-attachments/assets/51a27e6b-1a24-4c66-bcab-b36907da45c9" />

## What changed

### Sidebar data model
- `SidebarFavoriteItem` gains `{ type: 'assistant', id }` and `{ type: 'agent', id }` variants, persisted in `ui.sidebar.favorites`
- `src/renderer/utils/sidebar.ts`: `toggleSidebarEntityFavorite` / `removeSidebarEntityFavorite` built on `getOrderedVisibleSidebarFavoriteItems` (so the required `assistants` app stays present)
- `useSidebarFavorites` exposes `toggleAssistant`/`toggleAgent`/`removeAssistant`/`removeAgent` + id lists

### Sidebar rendering (`app/Sidebar` + `sidebarVariants`)
- New `agentVariant`/`assistantVariant` descriptors render pinned entities with their own icons (agent avatar / assistant emoji)
- Stale pins (entity deleted) are dropped gracefully; context menu offers "Remove from sidebar"

### Context menu entries — both layouts
Cherry Studio has **two** assistant/agent menu implementations, and the entry had to be added to both:
- `AssistantResourceList` / `AgentResourceList` — used by the **classic** layout
- `assistantGroupActions` / `agentGroupActions` (via `HomeTabs`/`Sessions`) — used by the **default** layout

Both now register a `toggle-sidebar` action reusing the existing `launchpad.pin_to_sidebar` / `launchpad.unpin_from_sidebar` keys.

### Entry routes
- `/app/chat?assistantId=` and `/app/agents?agentId=` resolve in `beforeLoad` to the entity's most recent topic/session, then redirect to the concrete conversation (`replace: true`)

### Backend
- `/topics/latest?assistantId=` and `/agent-sessions/latest?agentId=` filter the latest-lookup to a single entity

## Verification

Unit tests: backend handler/service tests for the entity-scoped lookups, sidebar util tests, entry-route tests, and context-menu toggle tests for both assistant and agent.

Beyond unit tests, the feature was **driven end-to-end in a real Electron build** (Playwright against the packaged renderer), for **both** entity types in the default layout:

| Step | Assistant | Agent |
| --- | --- | --- |
| Context menu shows "Add to sidebar" | ✅ | ✅ |
| Clicking it pins the entity — icon appears in the sidebar | ✅ | ✅ |
| Re-opening the menu shows "Remove from sidebar" | ✅ | ✅ |
| Clicking the pinned icon reopens the entity's conversation | ✅ | ✅ |

This run is also what surfaced the second-menu gap above: the pin entry initially only existed on the classic-layout component, so it was invisible to users on the default layout even though the unit tests passed. Fixed in `fix(sidebar): expose the pin action in the default layout menus`.

`typecheck:web`, `typecheck:node`, eslint, the renderer project (849 files / 8644 tests) and the shared project (81 files / 1023 tests) are all green. The main-process project has pre-existing Windows-only failures (POSIX mock paths, external binary fixtures) that reproduce identically on a clean checkout without these changes — none touch files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

