### PR TITLE
fix(agent-jobs): allow bounded scheduled task concurrency

### DIFF
--- a/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
+++ b/src/main/ai/agents/__tests__/agentTaskJobHandler.test.ts
@@ -92,9 +92,9 @@ describe('AgentTaskJobHandler', () => {
   })
 
   describe('metadata', () => {
-    it('declares per-agent queue + concurrency 1 + retry-on-restart policy', () => {
+    it('allows three concurrent tasks per agent while keeping retry-on-restart policy', () => {
       expect(agentTaskJobHandler.recovery).toBe('retry')
-      expect(agentTaskJobHandler.defaultConcurrency).toBe(1)
+      expect(agentTaskJobHandler.defaultConcurrency).toBe(3)
       expect(agentTaskJobHandler.defaultRetryPolicy).toEqual({
         maxAttempts: 1,
         backoff: 'none',

--- a/src/main/ai/agents/agentTaskJobHandler.ts
+++ b/src/main/ai/agents/agentTaskJobHandler.ts
@@ -38,14 +38,10 @@ export const agentTaskJobHandler: JobHandler<AgentTaskInput> = {
   /** Preserve the existing at-least-once recovery contract; reuse mode inherits its crash-replay limitation. */
   recovery: 'retry',
 
-  /**
-   * Per-agent serialization queue: a single agent never runs two scheduled
-   * tasks concurrently (Claude Code subprocess + workspace state would
-   * collide). Cross-agent parallelism is unaffected.
-   */
+  /** Bound same-agent parallelism to limit subprocess and workspace contention. */
   defaultQueue: (input) => `agent:${input.agentId}`,
 
-  defaultConcurrency: 1,
+  defaultConcurrency: 3,
 
   /**
    * Schedule-driven tasks do not retry inside the Job runtime — failure


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Scheduled tasks belonging to the same agent shared a queue with concurrency `1`, so tasks triggered together executed sequentially.

After this PR:

Up to three scheduled tasks can run concurrently per agent. The existing per-agent queue and global concurrency limit remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18306

### Why we need it and why it was done in this way

The v2 job migration changed scheduled agent tasks from fire-and-forget execution to a per-agent queue with concurrency `1`. This bounded increase restores useful overlap without returning to unbounded execution.

The following tradeoffs were made:

- Limit same-agent concurrency to three to improve throughput while bounding subprocess, workspace, provider, and token-cost pressure.
- Keep the existing global concurrency limit of 50 as the application-wide safety ceiling.

The following alternatives were considered:

- Queue jobs by schedule ID with concurrency `1`. This would isolate each schedule and preserve non-overlap per task, but it requires expanding the shared `JobHandler`/`JobManager` queue-resolution contract to expose schedule context. That complexity and broader impact are not justified for this fix, so this PR deliberately does not change schedule or queue architecture.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18306

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation completed:

- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm test:lint`
- `pnpm build:check`

No user-guide update is required; this restores expected scheduled-task behavior without adding configuration or UI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Scheduled tasks for the same agent can now run up to three jobs concurrently instead of always running sequentially. action required: none.
```
