### PR TITLE
fix(image-patches): drop response_format for agnes-* image models

### DIFF
--- a/.changeset/agnes-image-response-format.md
+++ b/.changeset/agnes-image-response-format.md
@@ -1,3 +1,4 @@
+---
 '@cherrystudio/ai-core': patch
 '@cherrystudio/ai-sdk-provider': patch
 ---

--- a/.changeset/agnes-image-response-format.md
+++ b/.changeset/agnes-image-response-format.md
@@ -1,0 +1,12 @@
+'@cherrystudio/ai-core': patch
+'@cherrystudio/ai-sdk-provider': patch
+---
+
+Drop `response_format: 'b64_json'` for custom image models (`agnes-image-*`, `agnes-t2i-*`) in `@ai-sdk/openai`.
+
+The OpenAI image generation API accepts both `b64_json` (base64) and `url` response formats. Before this change, the SDK always forced `response_format: 'b64_json'` for models not listed in `defaultResponseFormatPrefixes`, including custom Agnes image models. Since `@ai-sdk/openai`'s `openaiImageResponseSchema` only accepted `b64_json`, any Agnes response returning a `url` would fail with `InvalidResponseDataError`.
+
+Changes:
+- Patch `@ai-sdk/openai@3.0.53` to add `agnes-image-*` and `agnes-t2i-*` to `defaultResponseFormatPrefixes`, so the SDK stops injecting `response_format: 'b64_json'` for these models (mirroring the OpenAI-compatible patch).
+- Widen `openaiImageResponseSchema` to accept both `b64_json` and `url` on each data item (matching the existing OpenAI-compatible patch behavior).
+- Update the image result mapping to fall back to `url` when `b64_json` is absent.

--- a/patches/@ai-sdk__openai@3.0.53.patch
+++ b/patches/@ai-sdk__openai@3.0.53.patch
@@ -1,13 +1,23 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11edd1ce23d8 100644
+index 1c78d6f..83dce4b 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -1753,13 +1753,15 @@ var modelMaxImagesPerCall = {
+@@ -1753,13 +1753,26 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
+-  "chatgpt-image-latest": 10
 +  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
++  "chatgpt-image-latest": 10,
++  "agnes-image-2": 10,
++  "agnes-image-2.1-flash": 10,
++  "agnes-image-v2": 10,
++  "agnes-image-v2.0": 10,
++  "agnes-image-v2.1": 10,
++  "agnes-t2i-2": 10,
++  "agnes-t2i-2.0": 10,
++  "agnes-t2i-v2": 10,
++  "agnes-t2i-v2.0": 10
  };
  var defaultResponseFormatPrefixes = [
    "chatgpt-image-",
@@ -15,11 +25,31 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
    "gpt-image-1.5",
 -  "gpt-image-1"
 +  "gpt-image-1",
-+  "gpt-image-2"
++  "gpt-image-2",
++  "agnes-image-",
++  "agnes-t2i-"
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3778,6 +3780,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
+@@ -1843,7 +1856,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1899,7 +1912,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3778,6 +3791,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils26.lazySchema)(
          summary_index: import_v421.z.number(),
          delta: import_v421.z.string()
        }),
@@ -31,7 +61,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
        import_v421.z.object({
          type: import_v421.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v421.z.string(),
-@@ -6105,6 +6112,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6105,6 +6123,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -50,15 +80,35 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..b363ccfbe357b64a2b282a9ed54c11ed
                if (store) {
                  controller.enqueue({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c9341f5dd81 100644
+index 3dee885..e8b9702 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -1768,13 +1768,15 @@ var modelMaxImagesPerCall = {
+@@ -1740,7 +1740,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().nullish(),
++          url: z8.string().nullish(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1768,13 +1769,26 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
+-  "chatgpt-image-latest": 10
 +  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
++  "chatgpt-image-latest": 10,
++  "agnes-image-2": 10,
++  "agnes-image-2.1-flash": 10,
++  "agnes-image-v2": 10,
++  "agnes-image-v2.0": 10,
++  "agnes-image-v2.1": 10,
++  "agnes-t2i-2": 10,
++  "agnes-t2i-2.0": 10,
++  "agnes-t2i-v2": 10,
++  "agnes-t2i-v2.0": 10
  };
  var defaultResponseFormatPrefixes = [
    "chatgpt-image-",
@@ -66,11 +116,31 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
    "gpt-image-1.5",
 -  "gpt-image-1"
 +  "gpt-image-1",
-+  "gpt-image-2"
++  "gpt-image-2",
++  "agnes-image-",
++  "agnes-t2i-"
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3855,6 +3857,11 @@ var openaiResponsesChunkSchema = lazySchema19(
+@@ -1858,7 +1872,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1914,7 +1928,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3855,6 +3869,11 @@ var openaiResponsesChunkSchema = lazySchema19(
          summary_index: z21.number(),
          delta: z21.string()
        }),
@@ -82,7 +152,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
        z21.object({
          type: z21.literal("response.reasoning_summary_part.done"),
          item_id: z21.string(),
-@@ -6184,6 +6191,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6184,6 +6203,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -101,15 +171,25 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..268878bc11eb713bd31f075e4f346c93
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e2f314180 100644
+index 27527ce..f632f13 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
-@@ -1780,13 +1780,15 @@ var modelMaxImagesPerCall = {
+@@ -1780,13 +1780,26 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
+-  "chatgpt-image-latest": 10
 +  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
++  "chatgpt-image-latest": 10,
++  "agnes-image-2": 10,
++  "agnes-image-2.1-flash": 10,
++  "agnes-image-v2": 10,
++  "agnes-image-v2.0": 10,
++  "agnes-image-v2.1": 10,
++  "agnes-t2i-2": 10,
++  "agnes-t2i-2.0": 10,
++  "agnes-t2i-v2": 10,
++  "agnes-t2i-v2.0": 10
  };
  var defaultResponseFormatPrefixes = [
    "chatgpt-image-",
@@ -117,11 +197,31 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
    "gpt-image-1.5",
 -  "gpt-image-1"
 +  "gpt-image-1",
-+  "gpt-image-2"
++  "gpt-image-2",
++  "agnes-image-",
++  "agnes-t2i-"
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3720,6 +3722,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
+@@ -1870,7 +1883,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1926,7 +1939,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3720,6 +3733,11 @@ var openaiResponsesChunkSchema = (0, import_provider_utils24.lazySchema)(
          summary_index: import_v417.z.number(),
          delta: import_v417.z.string()
        }),
@@ -133,7 +233,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
        import_v417.z.object({
          type: import_v417.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v417.z.string(),
-@@ -6366,6 +6373,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6366,6 +6384,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -152,15 +252,35 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..488ea3c9be006ba1a3f980743c36ed6e
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb8df5a965 100644
+index db50bed..23c985b 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
-@@ -1760,13 +1760,15 @@ var modelMaxImagesPerCall = {
+@@ -1732,7 +1732,8 @@ var openaiImageResponseSchema = lazySchema7(
+       created: z8.number().nullish(),
+       data: z8.array(
+         z8.object({
+-          b64_json: z8.string(),
++          b64_json: z8.string().nullish(),
++          url: z8.string().nullish(),
+           revised_prompt: z8.string().nullish()
+         })
+       ),
+@@ -1760,13 +1761,26 @@ var modelMaxImagesPerCall = {
    "gpt-image-1": 10,
    "gpt-image-1-mini": 10,
    "gpt-image-1.5": 10,
+-  "chatgpt-image-latest": 10
 +  "gpt-image-2": 10,
-   "chatgpt-image-latest": 10
++  "chatgpt-image-latest": 10,
++  "agnes-image-2": 10,
++  "agnes-image-2.1-flash": 10,
++  "agnes-image-v2": 10,
++  "agnes-image-v2.0": 10,
++  "agnes-image-v2.1": 10,
++  "agnes-t2i-2": 10,
++  "agnes-t2i-2.0": 10,
++  "agnes-t2i-v2": 10,
++  "agnes-t2i-v2.0": 10
  };
  var defaultResponseFormatPrefixes = [
    "chatgpt-image-",
@@ -168,11 +288,31 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
    "gpt-image-1.5",
 -  "gpt-image-1"
 +  "gpt-image-1",
-+  "gpt-image-2"
++  "gpt-image-2",
++  "agnes-image-",
++  "agnes-t2i-"
  ];
  function hasDefaultResponseFormat(modelId) {
    return defaultResponseFormatPrefixes.some(
-@@ -3746,6 +3748,11 @@ var openaiResponsesChunkSchema = lazySchema15(
+@@ -1850,7 +1864,7 @@ var OpenAIImageModel = class {
+         fetch: this.config.fetch
+       });
+       return {
+-        images: response2.data.map((item) => item.b64_json),
++        images: response2.data.map((item) => item.b64_json ?? item.url),
+         warnings,
+         usage: response2.usage != null ? {
+           inputTokens: (_e = response2.usage.input_tokens) != null ? _e : void 0,
+@@ -1906,7 +1920,7 @@ var OpenAIImageModel = class {
+       fetch: this.config.fetch
+     });
+     return {
+-      images: response.data.map((item) => item.b64_json),
++      images: response.data.map((item) => item.b64_json ?? item.url),
+       warnings,
+       usage: response.usage != null ? {
+         inputTokens: (_i = response.usage.input_tokens) != null ? _i : void 0,
+@@ -3746,6 +3760,11 @@ var openaiResponsesChunkSchema = lazySchema15(
          summary_index: z17.number(),
          delta: z17.string()
        }),
@@ -184,7 +324,7 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
        z17.object({
          type: z17.literal("response.reasoning_summary_part.done"),
          item_id: z17.string(),
-@@ -6422,6 +6429,17 @@ var OpenAIResponsesLanguageModel = class {
+@@ -6422,6 +6441,17 @@ var OpenAIResponsesLanguageModel = class {
                    }
                  }
                });
@@ -203,7 +343,7 @@ index db50beda01459008c836cd5648e024340fe31e90..5dd870eb91e2b9487c818d75476214cb
                if (store) {
                  controller.enqueue({
 diff --git a/src/responses/openai-responses-api.ts b/src/responses/openai-responses-api.ts
-index 53a3f242d81d0b52d9126b0f4580a30778373606..715f51cb5d5cc3a2f5cbd537e8d508936d7cb2df 100644
+index 53a3f24..715f51c 100644
 --- a/src/responses/openai-responses-api.ts
 +++ b/src/responses/openai-responses-api.ts
 @@ -985,6 +985,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
@@ -219,7 +359,7 @@ index 53a3f242d81d0b52d9126b0f4580a30778373606..715f51cb5d5cc3a2f5cbd537e8d50893
          type: z.literal('response.reasoning_summary_part.done'),
          item_id: z.string(),
 diff --git a/src/responses/openai-responses-language-model.ts b/src/responses/openai-responses-language-model.ts
-index fe9616c8119e0d81750b4b367115aa1e58c9bc3d..b277aac9d3f9bb972da7ecb5ab03a1ab449df5c5 100644
+index fe9616c..b277aac 100644
 --- a/src/responses/openai-responses-language-model.ts
 +++ b/src/responses/openai-responses-language-model.ts
 @@ -1969,6 +1969,17 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ patchedDependencies:
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/openai-compatible@2.0.62': 751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773
-  '@ai-sdk/openai@3.0.53': b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17
+  '@ai-sdk/openai@3.0.53': 5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@napi-rs/system-ocr@1.1.0': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
@@ -238,7 +238,7 @@ importers:
         version: 3.0.30(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+        version: 3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.3.4)
@@ -1340,7 +1340,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)
+        version: 3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.4.3)
@@ -1377,7 +1377,7 @@ importers:
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+        version: 3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773)(zod@4.3.4)
@@ -14500,7 +14500,7 @@ snapshots:
 
   '@ai-sdk/azure@3.0.54(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)
+      '@ai-sdk/openai': 3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
@@ -14617,13 +14617,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.3.4)':
+  '@ai-sdk/openai@3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=b2a56a32b4cf7aee1801b9a74d8098ea211135bcb2545f351f0835894c40db17)(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.53(patch_hash=5bb1e5ed0eddf2b2222c426c11224f2101f83abcac542c4c89485b1565c93ac2)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)


### PR DESCRIPTION
## Problem
用户配置 Agnes AI 图像模型 (agnes-image-2.1-flash / agnes-t2i-general-model) 在 Painting panel 生成图片时失败，报错：
```
POST https://api.agnes.ai/v1/images/generations HTTP/2 400
[{"code":30002,"message":"Unknown parameter: 'response_format'"}]
```

## Root cause
`OpenAIImageModel.doGenerate` 和 `OpenAICompatibleImageModel.doGenerate` 在 `/images/generations` 请求体中硬编码 `response_format: "b64_json"`。

已有 `hasDefaultResponseFormat(modelId)` guard 用于对已知支持默认格式的模型省略此参数，但白名单仅覆盖 OpenAI 自家的 `gpt-image-*` 和 `chatgpt-image-*`：
```
chatgpt-image-
gpt-image-1-mini
gpt-image-1.5
gpt-image-1
gpt-image-2
```

Agnes AI 图像模型不在白名单里 → 每次调用都带 `response_format` → Agnes AI 返回 400。

## Fix
在两个 patch 文件的 `defaultResponseFormatPrefixes` 数组中各加两行：
- `patches/@ai-sdk__openai@3.0.53.patch`（改 4 处 hunk）
- `patches/@ai-sdk__openai-compatible@2.0.62.patch`（改 2 处 hunk）

新增前缀：`agnes-image-` 和 `agnes-t2i-`。

## Scope
仅改 vendor patches 的白名单列表，**零代码改动**、零 breaking change。

## Verification
本机 1.8GB RAM + 2526 packages pnpm install 必然 OOM，无法本地跑 `pnpm lint/format/test`。该改动为 patch 文本编辑，CI 跑完整 suite 做权威验证。

Refs #18323