### PR TITLE
fix(window-manager): hide Dock icon on close-to-tray (#18186)

### DIFF
--- a/src/main/core/window/__tests__/WindowManager.quirks.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.quirks.test.ts
@@ -133,6 +133,16 @@ function createMockBrowserWindow(): MockBrowserWindow {
 
 const createdWindows: MockBrowserWindow[] = []
 
+// ─── Mock: electron (app.dock spied so Dock-visibility assertions work) ──
+
+// vi.hoisted: vi.mock factories are hoisted above imports, so the dock spies
+// must be created in a hoisted block too (same pattern as `platform` above) —
+// otherwise the factory references them before initialization.
+const dockSpies = vi.hoisted(() => ({
+  show: vi.fn(() => Promise.resolve()),
+  hide: vi.fn()
+}))
+
 vi.mock('electron', () => {
   class BrowserWindowMock {
     constructor() {
@@ -152,7 +162,7 @@ vi.mock('electron', () => {
   }
 
   return {
-    app: { dock: { show: () => Promise.resolve(), hide: () => {} } },
+    app: { dock: { show: dockSpies.show, hide: dockSpies.hide } },
     BrowserWindow: BrowserWindowMock,
     screen: {
       getCursorScreenPoint: vi.fn(() => ({ x: 0, y: 0 })),
@@ -269,6 +279,15 @@ vi.mock('../windowRegistry', () => {
       htmlPath: 'dockHidden/index.html',
       windowOptions: {},
       behavior: { macShowInDock: false }
+    },
+    // behavior.macShowInDock: true — Main-like window that keeps the Dock alive.
+    // Paired with dockHidden for the Dock-aggregation regression tests below.
+    dockVisible: {
+      type: 'dockVisible',
+      lifecycle: 'default',
+      htmlPath: 'dockVisible/index.html',
+      windowOptions: {},
+      behavior: { macShowInDock: true }
     }
   }
   return {
@@ -727,6 +746,60 @@ describe('WindowManager quirks — applyQuirks monkey-patching', () => {
       const win = firstWindow()
 
       expect(win.setVisibleOnAllWorkspaces).not.toHaveBeenCalled()
+    })
+  })
+
+  // ─── macOS Dock visibility aggregation ─────────────────────
+  //
+  // Regression coverage for issue #18186: a resident SubWindow-like window
+  // (behavior.macShowInDock: false) must NOT keep the Dock icon alive when the
+  // Main-like window opts out via setMacShowInDockByType(Main, false). Before the
+  // registry fix, SubWindow omitted the flag and windowContributesToDock() fell
+  // through to the `!== false` default (true), so updateDockVisibility()'s some()
+  // never resolved to hide. These tests exercise the real aggregation path that
+  // MainWindowService.test.ts cannot (it mocks WindowManager entirely).
+  describe('Dock visibility aggregation (macShowInDock + setMacShowInDockByType)', () => {
+    beforeEach(() => {
+      // isMac already true for this suite (resetPlatform in outer beforeEach).
+      // Clear any dock calls captured during window creation so assertions target
+      // the explicit setMacShowInDockByType transitions below.
+      dockSpies.show.mockClear()
+      dockSpies.hide.mockClear()
+    })
+
+    it('hides the Dock when the only contributing type opts out (baseline)', () => {
+      // Single Main-like window contributes by default.
+      wm.open('dockVisible' as never)
+      dockSpies.hide.mockClear()
+
+      // Close-to-tray: Main opts out of Dock contribution.
+      wm.behavior.setMacShowInDockByType('dockVisible' as never, false)
+
+      // No window contributes anymore → Dock must hide.
+      expect(dockSpies.hide).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the Dock visible while a contributing window still exists', () => {
+      wm.open('dockVisible' as never)
+      dockSpies.hide.mockClear()
+
+      // No override change → Main still contributes → Dock stays visible.
+      expect(dockSpies.hide).not.toHaveBeenCalled()
+    })
+
+    it('hides the Dock even with a resident SubWindow-like (macShowInDock:false) present (#18186)', () => {
+      // The regression scenario: Main-like + a resident hidden SubWindow-like.
+      // SubWindow-like declares macShowInDock:false, so it must not pin the Dock.
+      wm.open('dockVisible' as never)
+      wm.open('dockHidden' as never)
+      dockSpies.hide.mockClear()
+
+      // Main-like enters tray mode (close-to-tray).
+      wm.behavior.setMacShowInDockByType('dockVisible' as never, false)
+
+      // Despite the resident SubWindow-like existing, its macShowInDock:false means
+      // it does not contribute — Dock aggregates to hidden.
+      expect(dockSpies.hide).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/main/core/window/__tests__/windowRegistry.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.test.ts
@@ -264,3 +264,16 @@ describe('WINDOW_TYPE_REGISTRY Print window — domain-loaded print surface', ()
     expect(metadata?.behavior?.macShowInDock).toBe(false)
   })
 })
+
+// Regression guard for issue #18186: a warm-created standby SubWindow is always
+// resident (pooled + standbySize:1 + warmup:'eager'). If it does not opt out of
+// Dock contribution, windowContributesToDock() returns true for it and the Dock
+// icon can never be hidden on close-to-tray / tray-on-launch.
+describe('WINDOW_TYPE_REGISTRY SubWindow — must not keep the Dock icon alive', () => {
+  it('opts out of macOS Dock contribution (macShowInDock: false)', () => {
+    const metadata = WINDOW_TYPE_REGISTRY[WindowType.SubWindow]
+
+    expect(metadata).toBeDefined()
+    expect(metadata?.behavior?.macShowInDock).toBe(false)
+  })
+})

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -240,6 +240,14 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
         // focus switches. Mirrors the Main window's choice above; do not remove.
         backgroundThrottling: false
       }
+    },
+    behavior: {
+      // SubWindow must NOT contribute to the macOS Dock — a warm-created standby
+      // instance (standbySize:1 + warmup:'eager') is always resident and hidden.
+      // Without this flag, windowContributesToDock() returns true for it, so
+      // updateDockVisibility()'s some() never resolves to hide, and the Dock icon
+      // stays visible on close-to-tray / tray-on-launch (see issue #18186).
+      macShowInDock: false
     }
     // NOTE: Fields intentionally NOT set here, injected per-call via wm.open({ options }):
     //   - title (per-tab dynamic)


### PR DESCRIPTION
### What this PR does

Before this PR:
On macOS, with "Minimize to Tray on Close" (`app.tray.on_close`) enabled, closing the main window hides the window but the **Dock icon stays visible**. v1 hid the Dock icon too; v2 regressed. Same for tray-on-launch (`app.tray.on_launch`).

After this PR:
Closing to tray (or launching to tray) now hides the Dock icon as well, matching v1 and macOS user expectation.

Fixes #18186

### Why we need it and why it was done in this way

**Root cause:** `SubWindow` was the only non-main window type in `WINDOW_TYPE_REGISTRY` that omitted a `behavior` block, so its `macShowInDock` defaulted to `!== false` → `true`. SubWindow is `pooled` with `standbySize: 1` + `warmup: 'eager'`, so WindowManager warm-creates a hidden standby instance at app start and never GCs it below `standbyFloor`. That resident hidden instance made `windowContributesToDock()` always return `true` for SubWindow, so `updateDockVisibility()`'s `some()` never resolved to hide — `app.dock?.hide()` was unreachable on close-to-tray and tray-on-launch.

The close/tray handlers themselves (`MainWindowService`), the Dock algorithm (`WindowManager.updateDockVisibility`), and `TrayService` are all correct. The bug is purely the missing registry field. The existing `MainWindowService` unit tests did not catch it because they mock `WindowManager`, so `setMacShowInDockByType` is a `vi.fn()` and the real `windowContributesToDock` interaction never runs.

The following tradeoffs were made:
- Surgical one-field fix at the exact root cause (registry `behavior.macShowInDock: false`) over touching the Dock algorithm or close logic. This fixes both the close-to-tray and tray-on-launch paths simultaneously and matches every other non-main window type (Print, McpBrowser, QuickAssistant, SelectionToolbar, SelectionAction).

The following alternatives were considered:
- Hard-coding `app.dock?.hide()` back into the close handler — rejected: the WM-based mechanism (commit bafed0d0e) exists precisely to replace those racing manual calls; re-adding one would reintroduce the multi-window races it fixed.
- Making the Dock predicate visibility-based — rejected: the design is intentionally existence-based (a hidden main window must not remove the Dock icon, per macOS Cmd+W semantics); changing it would break native behavior.

### Breaking changes

None.

### Special notes for your reviewer

- No regression for visible SubWindows: when a SubWindow is open, the Main window is present and contributes `macShowInDock: true`, so the Dock stays visible via `some()`. SubWindow not contributing only becomes decisive when Main is in tray mode (override `false`) — exactly the case we want to fix.
- Windows/Linux are unaffected: `updateDockVisibility()` early-returns on `if (!isMac)`.
- A regression test is added in `windowRegistry.test.ts` mirroring the existing `Print` assertion; verified red→green (flipping the field to `true` fails the test).

### Checklist

- [x] Branch: targets `main`
- [x] PR: description covers root cause, fix, and alternatives
- [x] Code: minimal, single-field change at the root cause
- [x] Refactor: left the registry consistent (SubWindow now matches all sibling types)
- [x] Upgrade: no schema/migration impact
- [x] Documentation: no user-guide change needed (restores documented v1 behavior)
- [x] Self-review: ran `/gh-pr-review` local-review → no issues found

```release-note
Hide the macOS Dock icon when minimizing to tray on close (and on launch-to-tray), restoring v1 behavior.
```
