### PR TITLE
fix(provider): normalize reasoning_effort for GitHub Copilot (#11140)

### DIFF
--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -145,7 +145,6 @@ describe('mergeCustomProviderParameters', () => {
     // to `reasoningEffort` before being merged into the `copilot` provider namespace.
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
-      { copilot: {} } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
@@ -158,9 +157,6 @@ describe('mergeCustomProviderParameters', () => {
     // Mirror the openai-compatible clobber test: when the user's custom params carry BOTH
     // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
     // the existing camelCase wins and the snake_case form is dropped.
-    const result = mergeCustomProviderParameters(
-      { copilot: {} } as unknown as Record<string, Record<string, never>>,
-      { reasoning_effort: 'high', reasoningEffort: 'low' },
     const result = mergeCustomProviderParameters(
       { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -158,8 +158,8 @@ describe('mergeCustomProviderParameters', () => {
     // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
     // the existing camelCase wins and the snake_case form is dropped.
     const result = mergeCustomProviderParameters(
-      { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
-      { reasoning_effort: 'high' },
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high', reasoningEffort: 'low' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
     )

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -145,6 +145,7 @@ describe('mergeCustomProviderParameters', () => {
     // to `reasoningEffort` before being merged into the `copilot` provider namespace.
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { copilot: {} } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
@@ -160,6 +161,9 @@ describe('mergeCustomProviderParameters', () => {
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
       { reasoning_effort: 'high', reasoningEffort: 'low' },
+    const result = mergeCustomProviderParameters(
+      { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
     )

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -139,6 +139,34 @@ describe('mergeCustomProviderParameters', () => {
     expect((result['openai-compatible'] as Record<string, unknown>).reasoningEffort).toBe('low')
   })
 
+  it('normalizes reasoning_effort → reasoningEffort for github-copilot-openai-compatible (#11140)', () => {
+    // Mirror the OpenAI-compatible path: AI SDK silently drops snake_case keys, so a
+    // user's custom parameter dictionary carrying `reasoning_effort` must be renamed
+    // to `reasoningEffort` before being merged into the `copilot` provider namespace.
+    const result = mergeCustomProviderParameters(
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high' },
+      'github-copilot-openai-compatible',
+      'github-copilot-openai-compatible'
+    )
+    expect(result).toEqual({ copilot: { reasoningEffort: 'high' } })
+    expect(result.copilot.reasoning_effort).toBeUndefined()
+  })
+
+  it('does NOT clobber existing reasoningEffort with renamed reasoning_effort for github-copilot (#11140)', () => {
+    // Mirror the openai-compatible clobber test: when the user's custom params carry BOTH
+    // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
+    // the existing camelCase wins and the snake_case form is dropped.
+    const result = mergeCustomProviderParameters(
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high', reasoningEffort: 'low' },
+      'github-copilot-openai-compatible',
+      'github-copilot-openai-compatible'
+    )
+    expect((result['copilot'] as Record<string, unknown>).reasoningEffort).toBe('low')
+    expect((result['copilot'] as Record<string, unknown>).reasoning_effort).toBeUndefined()
+  })
+
   it('normalizes reasoning_effort into a concrete provider namespace for an openai-compatible adapter', () => {
     const result = mergeCustomProviderParameters(
       { dashscope: {} } as Record<string, Record<string, never>>,

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -287,9 +287,12 @@ export function isCustomProviderNamespace(
 }
 
 /**
- * For `openai-compatible`, rename `reasoning_effort` → `reasoningEffort` —
+ * For OpenAI-compatible adapter families, rename `reasoning_effort` → `reasoningEffort` —
  * AI SDK silently drops the snake_case form.
- * See https://github.com/CherryHQ/cherry-studio/issues/11987.
+ *
+ * Covers both `'openai-compatible'` (custom OpenAI-compatible providers, see #11987) and
+ * `'github-copilot-openai-compatible'` (GitHub Copilot, see #11140) — both speak the
+ * OpenAI Chat Completions dialect and silently drop snake_case reasoning keys.
  */
 export function mergeCustomProviderParameters(
   providerOptions: Record<string, Record<string, JSONValue>>,
@@ -300,13 +303,15 @@ export function mergeCustomProviderParameters(
   const actualAiSdkProviderIds = Object.keys(providerOptions)
   const primaryAiSdkProviderId = actualAiSdkProviderIds[0]
   const normalizedProviderParams =
-    adapterFamily === 'openai-compatible' ? normalizeOpenAICompatibleParams(providerParams) : providerParams
+    adapterFamily === 'openai-compatible' || adapterFamily === 'github-copilot-openai-compatible'
+      ? normalizeOpenAICompatibleParams(providerParams)
+      : providerParams
 
   let result = providerOptions
   for (const key of Object.keys(normalizedProviderParams)) {
     const isProviderNamespace = isCustomProviderNamespace(key, providerOptions, rawProviderId)
     const value =
-      adapterFamily === 'openai-compatible' &&
+      (adapterFamily === 'openai-compatible' || adapterFamily === 'github-copilot-openai-compatible') &&
       isProviderNamespace &&
       normalizedProviderParams[key] !== null &&
       typeof normalizedProviderParams[key] === 'object' &&


### PR DESCRIPTION
## Summary

Fixes #11140: GitHub Copilot reasoning level settings silently dropped.

## Root cause

`mergeCustomProviderParameters` in `src/main/ai/utils/options.ts` only normalized snake_case `reasoning_effort` parameters when `adapterFamily === 'openai-compatible'`.

GitHub Copilot uses adapter family `'github-copilot-openai-compatible'`, so user-configured `reasoning_effort` custom parameters bypassed the `normalizeOpenAICompatibleParams` rename and reached the AI SDK unchanged. AI SDK silently drops unknown snake_case keys → reasoning level not applied.

This mirrors the fix for #11987 (OpenAI-compatible), which was correctly limited to `'openai-compatible'` and missed Copilot's variant.

## Changes

- `src/main/ai/utils/options.ts`: extend the normalize gate in `mergeCustomProviderParameters` to also match `'github-copilot-openai-compatible'` — both families speak the OpenAI Chat Completions dialect.
- `src/main/ai/utils/__tests__/options.test.ts`: add two tests mirroring the existing openai-compatible parity tests: normalization and clobber-guard for Copilot.

## Verification

Cannot run `pnpm test` locally due to 1.8G RAM limit (full install OOM). PR includes 2 targeted unit tests that mirror the existing openai-compatible parity — should pass on CI.

Refs: #11987 (original fix for openai-compatible), #11140 (this report)