### PR TITLE
fix(attachments): send long pasted text in full

### DIFF
--- a/src/main/ai/messages/__tests__/attachmentRouting.test.ts
+++ b/src/main/ai/messages/__tests__/attachmentRouting.test.ts
@@ -199,6 +199,25 @@ describe('prepareChatMessages — routing', () => {
     expect(text).toContain('read_file("a.txt", offset=5)')
   })
 
+  it('fully inlines pasted text without a read_file pointer', async () => {
+    const pastedText = '0123456789'.repeat(1_000)
+    getByIdMock.mockResolvedValueOnce({ ext: 'txt' })
+    extractMock.mockResolvedValueOnce(pastedText)
+    const pastedPart = {
+      ...fileWithEntry('e1', 'pasted text.txt', 'text/plain'),
+      providerMetadata: {
+        cherry: { fileEntryId: 'e1', fileTokenSourceId: 'source-1', composerFileKind: 'pasted-text' }
+      }
+    } as CherryMessagePart
+
+    const [out] = await run([pastedPart], NONE, { isToolCapable: true, cap: 5 })
+    const text = textOf(out.parts)[0]
+
+    expect(text).toBe(`Attached file "pasted text.txt":\n${pastedText}`)
+    expect(text).not.toContain('[Truncated')
+    expect(text).not.toContain('read_file')
+  })
+
   it('caps long text without a read_file pointer for non-tool models', async () => {
     getByIdMock.mockResolvedValueOnce({ ext: 'txt' })
     extractMock.mockResolvedValueOnce('0123456789')

--- a/src/main/ai/messages/attachmentRouting.ts
+++ b/src/main/ai/messages/attachmentRouting.ts
@@ -233,9 +233,11 @@ async function prepareChatMessage<T extends UIMessage>(message: T, ctx: PrepareC
         continue
       }
 
-      // Non-native first-party attachment → inline its (capped) text.
+      // Pasted text stays complete; ordinary non-native attachments keep the inline cap.
+      const isPastedText = fileType === FILE_TYPE.TEXT && readCherryMeta(part)?.composerFileKind === 'pasted-text'
       const body = await extractNonNativeText(fileEntryId, bareExt, fileType, handle, ctx.signal)
-      const text = `Attached file "${handle}":\n${capInlineText(handle, body, ctx.isToolCapable, ctx.cap)}`
+      const visibleBody = isPastedText ? body : capInlineText(handle, body, ctx.isToolCapable, ctx.cap)
+      const text = `Attached file "${handle}":\n${visibleBody}`
       kept.push({ type: 'text', text } as UIMessage['parts'][number])
     } catch (error) {
       if (ctx.signal?.aborted || isAbortError(error)) throw error

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -1142,12 +1142,10 @@ function applySteerReminder(content: SDKUserMessage['message']['content']): SDKU
 }
 
 /**
- * Build SDK user content from a message entity. Non-image attachments are sent as
- * current local paths so the Agent decides how to inspect them with its tools. Images
- * keep the capability-aware path: supported formats become native Anthropic image
- * blocks, while first-party images use shared OCR/native-fallback routing when vision
- * is unavailable. Assistant attachment handles remain an additional compatibility
- * interface; external files and images that cannot be materialized fall back to paths.
+ * Build SDK user content from a message entity. Pasted text is fully inlined, while
+ * other non-image attachments are sent as current local paths for the Agent's tools.
+ * Images keep the capability-aware native/OCR path. Assistant attachment handles remain
+ * an additional compatibility interface; unavailable files fall back to visible notes.
  *
  * **Side effect**: performs file I/O via {@link materializeNativeFilePart}.
  */
@@ -1160,12 +1158,12 @@ async function materializeUserContent(
   const firstPartyFileParts = parts.filter(
     (part): part is FileUIPart => part.type === 'file' && Boolean(readCherryMeta(part)?.fileEntryId)
   )
-  const firstPartyImageParts = firstPartyFileParts.filter(isImageFilePart)
-  const firstPartyPathParts = firstPartyFileParts.filter((part) => !isImageFilePart(part))
+  const firstPartyRoutedParts = firstPartyFileParts.filter(
+    (part) => isImageFilePart(part) || isPastedTextFilePart(part)
+  )
+  const firstPartyPathParts = firstPartyFileParts.filter((part) => !firstPartyRoutedParts.includes(part))
   const routedParts = parts.filter(
-    (part) =>
-      part.type === 'text' ||
-      (part.type === 'file' && Boolean(readCherryMeta(part)?.fileEntryId) && isImageFilePart(part))
+    (part) => part.type === 'text' || (part.type === 'file' && firstPartyRoutedParts.includes(part))
   )
   const externalFileParts = parts.filter(
     (part): part is FileUIPart => part.type === 'file' && !readCherryMeta(part)?.fileEntryId
@@ -1180,10 +1178,14 @@ async function materializeUserContent(
   let turnAttachments: ReturnType<typeof collectAssistantFileAttachments> = []
   if (supportsAttachmentReads && firstPartyFileParts.length > 0) {
     turnAttachments = collectAssistantFileAttachments([
-      { id: message.id, role: 'user', parts: firstPartyFileParts } as CherryUIMessage
+      {
+        id: message.id,
+        role: 'user',
+        parts: firstPartyFileParts.filter((part) => !isPastedTextFilePart(part))
+      } as CherryUIMessage
     ])
   }
-  if (firstPartyImageParts.length > 0) {
+  if (firstPartyRoutedParts.length > 0) {
     const userMessage = { id: message.id, role: 'user', parts: routedParts } as CherryUIMessage
     const attachments = supportsAttachmentReads ? turnAttachments : collectFileAttachments([userMessage])
     const [prepared] = await prepareChatMessages([userMessage], {
@@ -1332,6 +1334,10 @@ function isImageFilePart(part: FileUIPart): boolean {
   const filename = part.filename?.toLowerCase()
   const url = part.url && !part.url.startsWith('data:') ? part.url.toLowerCase().split(/[?#]/, 1)[0] : undefined
   return imageExts.some((extension) => filename?.endsWith(extension) || url?.endsWith(extension))
+}
+
+function isPastedTextFilePart(part: FileUIPart): boolean {
+  return readCherryMeta(part)?.composerFileKind === 'pasted-text'
 }
 
 function canBeClaudeImage(part: FileUIPart): boolean {

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -662,6 +662,60 @@ describe('ClaudeCodeRuntimeDriver', () => {
     void connection.close()
   })
 
+  it('fully inlines pasted text for ordinary Agents instead of exposing a file path', async () => {
+    const pastedText = 'x'.repeat(10_000)
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    mocks.prepareChatMessages.mockImplementationOnce(async ([message]) => [
+      {
+        ...message,
+        parts: message.parts.map((part: any) =>
+          part.type === 'file' ? { type: 'text', text: `Attached file "pasted text.txt":\n${pastedText}` } : part
+        )
+      }
+    ])
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+    const nextInput = sdkInput[Symbol.asyncIterator]().next()
+
+    await connection.send({
+      message: {
+        ...userMessage(),
+        data: {
+          parts: [
+            { type: 'text', text: 'summarize this' },
+            {
+              type: 'file',
+              url: 'file:///tmp/pasted.txt',
+              mediaType: 'text/plain',
+              filename: 'pasted text.txt',
+              providerMetadata: {
+                cherry: { fileEntryId: 'entry-pasted', composerFileKind: 'pasted-text' }
+              }
+            }
+          ]
+        }
+      }
+    })
+
+    await expect(nextInput).resolves.toMatchObject({
+      value: {
+        message: {
+          role: 'user',
+          content: `summarize this\nAttached file "pasted text.txt":\n${pastedText}`
+        }
+      },
+      done: false
+    })
+    expect(mocks.getPhysicalPath).not.toHaveBeenCalled()
+    void connection.close()
+  })
+
   it('reuses first-party image data URLs prepared by shared attachment routing', async () => {
     const queryQueue = createAsyncQueue<any>()
     const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
@@ -1050,6 +1104,79 @@ describe('ClaudeCodeRuntimeDriver', () => {
       done: false
     })
     expect(mocks.prepareChatMessages).not.toHaveBeenCalled()
+    void connection.close()
+  })
+
+  it('fully inlines pasted text for Cherry Assistant while keeping ordinary attachment tools', async () => {
+    const pastedText = 'y'.repeat(10_000)
+    const queryQueue = createAsyncQueue<any>()
+    const query = { ...queryQueue.iterable, interrupt: vi.fn(), close: vi.fn() }
+    mocks.createClaudeQuery.mockReturnValue(query)
+    mocks.buildRequest.mockResolvedValueOnce({
+      connectionConfig: {
+        rebuildSignature: 'sig-1',
+        live: { toolPolicy: { permissionMode: null, disabledTools: [], mcps: [] } }
+      },
+      key: 'warm-key',
+      options: { model: 'sonnet' },
+      settings: { mcpServers: { 'assistant-files': { type: 'sdk' } } },
+      sdkModelId: 'sonnet-sdk',
+      initializeTimeoutMs: 100
+    })
+    mocks.prepareChatMessages.mockImplementationOnce(async ([message]) => [
+      {
+        ...message,
+        parts: message.parts.map((part: any) =>
+          part.type === 'file' ? { type: 'text', text: `Attached file "pasted text.txt":\n${pastedText}` } : part
+        )
+      }
+    ])
+    const connection = await new ClaudeCodeRuntimeDriver().connect({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      modelId: 'claude-code::sonnet' as any
+    })
+    const sdkInput = mocks.createClaudeQuery.mock.calls[0][0].prompt
+    const nextInput = sdkInput[Symbol.asyncIterator]().next()
+
+    await connection.send({
+      message: {
+        ...userMessage(),
+        data: {
+          parts: [
+            { type: 'text', text: 'summarize this' },
+            {
+              type: 'file',
+              url: 'file:///tmp/pasted.txt',
+              mediaType: 'text/plain',
+              filename: 'pasted text.txt',
+              providerMetadata: {
+                cherry: { fileEntryId: 'entry-pasted', composerFileKind: 'pasted-text' }
+              }
+            },
+            {
+              type: 'file',
+              url: 'file:///tmp/spec.pdf',
+              mediaType: 'application/pdf',
+              filename: 'spec.pdf',
+              providerMetadata: { cherry: { fileEntryId: 'entry-spec' } }
+            }
+          ]
+        }
+      }
+    })
+
+    const specHandle = createAssistantFileAttachmentHandle('entry-spec')
+    await expect(nextInput).resolves.toMatchObject({
+      value: {
+        message: {
+          role: 'user',
+          content: `summarize this\nAttached file "pasted text.txt":\n${pastedText}\n\nAttached files (read them with your tools using these absolute paths):\n- "spec.pdf": /managed/entry-spec\n\nAttachment manifest:\n- "spec.pdf" (handle: ${specHandle})`
+        }
+      },
+      done: false
+    })
+    expect(mocks.getPhysicalPath).toHaveBeenCalledWith('entry-spec')
     void connection.close()
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Long text pasted into the composer could be converted into an attachment and limited to the normal 8,000-character inline preview. Claude Code Agents could also receive the pasted text as a file path or attachment handle instead of the complete content in the initial request.

After this PR:

Composer-generated pasted-text attachments are fully inlined in the initial model request. Ordinary attachments retain their existing inline caps, local paths, and attachment handles.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Models should receive all text that the user explicitly pasted without depending on a follow-up file tool call. The shared attachment router owns the inline-cap policy, while the Claude Code runtime owns whether first-party parts are routed as model content or exposed as file paths.

The following tradeoffs were made:

Only attachments marked as composer-generated `pasted-text` bypass the inline cap. This can increase prompt size for very large pastes, while keeping ordinary attachment limits unchanged.

The following alternatives were considered:

Raising the global attachment cap or continuing to expose pasted text through file tools was rejected because it would either expand every attachment or still depend on the Agent choosing to read the remaining content.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Pasted text is excluded from the Claude Code attachment manifest after it is inlined. Mixed turns still expose ordinary files through their existing absolute paths and assistant-file handles.

Verification:

- `pnpm lint` (passed; reported 38 existing non-blocking warnings)
- Tests and `pnpm build:check` were not run per workspace verification policy

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Long pasted text converted into an attachment is now sent to Assistants and Agents in full instead of being truncated to the first 8,000 characters.
```
