### PR TITLE
fix(selection-toolbar): re-apply alwaysOnTop on Windows to prevent toolbar going behind other windows

### DIFF
--- a/src/main/core/window/__tests__/WindowManager.quirks.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.quirks.test.ts
@@ -207,7 +207,8 @@ vi.mock('../windowRegistry', () => {
       quirks: {
         macRestoreFocusOnHide: true,
         macClearHoverOnHide: true,
-        macReapplyAlwaysOnTop: true
+        macReapplyAlwaysOnTop: true,
+        winReapplyAlwaysOnTop: true
       }
     },
     // Pooled action with only restoreFocusOnHide (like SelectionAction)
@@ -234,6 +235,14 @@ vi.mock('../windowRegistry', () => {
       htmlPath: 'floatingTop/index.html',
       windowOptions: {},
       quirks: { macReapplyAlwaysOnTop: true }
+    },
+    // Windows variant of floatingTop
+    winFloatingTop: {
+      type: 'winFloatingTop',
+      lifecycle: 'default',
+      htmlPath: 'winFloatingTop/index.html',
+      windowOptions: {},
+      quirks: { winReapplyAlwaysOnTop: true }
     },
     // behavior.hideOnBlur — singleton, declarative blur→hide
     blurHider: {
@@ -569,23 +578,102 @@ describe('WindowManager quirks — applyQuirks monkey-patching', () => {
     })
   })
 
+  // ─── winReapplyAlwaysOnTop ──────────────────────────────────
+
+  describe('winReapplyAlwaysOnTop', () => {
+    beforeEach(() => {
+      platform.isMac = false
+      platform.isWin = true
+    })
+
+    it('re-applies setAlwaysOnTop(true, level) after show()', () => {
+      wm.open('toolbar' as never)
+      const toolbar = firstWindow()
+      toolbar.setAlwaysOnTop.mockClear()
+
+      toolbar.show()
+
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+    })
+
+    it('re-applies setAlwaysOnTop(true, level) after showInactive()', () => {
+      wm.open('toolbar' as never)
+      const toolbar = firstWindow()
+      toolbar.setAlwaysOnTop.mockClear()
+
+      toolbar.showInactive()
+
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+    })
+
+    it('does NOT wrap hide/close', () => {
+      wm.open('toolbar' as never)
+      const toolbar = firstWindow()
+
+      const hideMock = toolbar.hide
+      const closeMock = toolbar.close
+
+      expect(toolbar.hide).toBe(hideMock)
+      expect(toolbar.close).toBe(closeMock)
+    })
+
+    it('does NOT fire when quirk is absent', () => {
+      wm.open('plain' as never)
+      const plain = firstWindow()
+
+      plain.show()
+      plain.showInactive()
+
+      expect(plain.setAlwaysOnTop).not.toHaveBeenCalled()
+    })
+
+    it('defaults level to "floating" when flag is true', () => {
+      wm.open('winFloatingTop' as never)
+      const win = firstWindow()
+      win.setAlwaysOnTop.mockClear()
+
+      win.show()
+
+      expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating')
+    })
+  })
+
   // ─── Non-mac identity check ─────────────────────────────────
 
   describe('non-mac platforms', () => {
-    it('does NOT patch any method when isMac=false — identity preserved', () => {
+    it('patches show/showInactive on Windows when winReapplyAlwaysOnTop is set', () => {
+      platform.isMac = false
+      platform.isWin = true
+
+      wm.open('toolbar' as never)
+      const toolbar = firstWindow()
+
+      // hide/close must remain untouched (mac-only quirks)
+      toolbar.hide()
+      expect(toolbar.webContents.sendInputEvent).not.toHaveBeenCalled()
+
+      // show/showInactive must trigger re-apply
+      toolbar.setAlwaysOnTop.mockClear()
+      toolbar.show()
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+
+      toolbar.setAlwaysOnTop.mockClear()
+      toolbar.showInactive()
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+    })
+
+    it('does NOT patch any method on Linux — identity preserved', () => {
       platform.isMac = false
       platform.isLinux = true
 
       wm.open('toolbar' as never)
       const toolbar = firstWindow()
 
-      // Capture the mock fn refs stored at construction time
       const hideMock = toolbar.hide
       const closeMock = toolbar.close
       const showMock = toolbar.show
       const showInactiveMock = toolbar.showInactive
 
-      // After applyQuirks on non-mac: methods must remain the original mock fns
       expect(toolbar.hide).toBe(hideMock)
       expect(toolbar.close).toBe(closeMock)
       expect(toolbar.show).toBe(showMock)

--- a/src/main/core/window/quirks.ts
+++ b/src/main/core/window/quirks.ts
@@ -1,4 +1,4 @@
-import { isMac } from '@main/core/platform'
+import { isMac, isWin } from '@main/core/platform'
 import type { WindowBehavior, WindowQuirks } from '@main/core/window/types'
 import { BrowserWindow } from 'electron'
 
@@ -97,6 +97,38 @@ export function applyWindowQuirks(
       if (window.isDestroyed()) return
       // Pass relativeLevel only when declared — avoids polluting the call
       // site with a trailing `undefined` that changes spy signatures.
+      if (relativeLevel !== undefined) {
+        window.setAlwaysOnTop(true, level, relativeLevel)
+      } else {
+        window.setAlwaysOnTop(true, level)
+      }
+    }
+    window.show = () => {
+      originalShow()
+      reapply()
+    }
+    window.showInactive = () => {
+      originalShowInactive()
+      reapply()
+    }
+  }
+
+  // ── winReapplyAlwaysOnTop ───────────────────────────────────────────
+  // Why:   On Windows, other floating windows (e.g. translation toolbars)
+  //        may also use alwaysOnTop, and the toolbar's stacking level can
+  //        be lost after hide/show cycles, causing it to appear behind them.
+  // Does:  Same as macReapplyAlwaysOnTop — re-applies the level after every
+  //        show()/showInactive() call.
+  // When:  Windows floating toolbar overlays that must stay above other
+  //        always-on-top windows. No-op when `behavior.alwaysOnTop.level`
+  //        is unset.
+  if (isWin && quirks.winReapplyAlwaysOnTop) {
+    const level = behavior?.alwaysOnTop?.level ?? 'floating'
+    const relativeLevel = behavior?.alwaysOnTop?.relativeLevel
+    const originalShow = window.show.bind(window)
+    const originalShowInactive = window.showInactive.bind(window)
+    const reapply = () => {
+      if (window.isDestroyed()) return
       if (relativeLevel !== undefined) {
         window.setAlwaysOnTop(true, level, relativeLevel)
       } else {

--- a/src/main/core/window/types.ts
+++ b/src/main/core/window/types.ts
@@ -268,6 +268,15 @@ export interface WindowQuirks {
    * No-op when `behavior.alwaysOnTop.level` is unset.
    */
   macReapplyAlwaysOnTop?: boolean
+
+  /**
+   * [Windows] Re-apply `setAlwaysOnTop(true, level, relativeLevel)` after every
+   * `show()`/`showInactive()` call, ensuring the toolbar stays above other
+   * floating windows that also use alwaysOnTop. Pure boolean switch — the actual
+   * level/relativeLevel are read from `behavior.alwaysOnTop` (single source of
+   * truth). No-op when `behavior.alwaysOnTop.level` is unset.
+   */
+  winReapplyAlwaysOnTop?: boolean
 }
 
 /** Common fields shared by all window type metadata variants */

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -431,7 +431,8 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
     quirks: {
       macRestoreFocusOnHide: true,
       macClearHoverOnHide: true,
-      macReapplyAlwaysOnTop: true
+      macReapplyAlwaysOnTop: true,
+      winReapplyAlwaysOnTop: true
     }
   },
 


### PR DESCRIPTION
### Branch strategy

> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:
The Selection Assistant toolbar on Windows could appear behind other floating windows (e.g., LunaTranslator) that also use `alwaysOnTop`. This happened because the `setAlwaysOnTop(true, 'screen-saver')` level was not re-applied after hide/show cycles, causing the toolbar to lose its z-order position.

After this PR:
A new `winReapplyAlwaysOnTop` quirk re-applies `setAlwaysOnTop(true, level, relativeLevel)` after every `show()`/`showInactive()` call on Windows, identical to the existing `macReapplyAlwaysOnTop` quirk for macOS. This ensures the toolbar stays above other always-on-top windows.

Fixes #18092

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Added a new `winReapplyAlwaysOnTop` flag rather than extending `macReapplyAlwaysOnTop` to all platforms, keeping the platform-specific quirk declarations explicit and matching the existing pattern.

The following alternatives were considered:
- Removing the `isMac` guard from `macReapplyAlwaysOnTop` to make it cross-platform — rejected because it would change the semantics of an existing flag and conflate two distinct platform workarounds.

### Breaking changes

None.

### Special notes for your reviewer

- The implementation is a mechanical port of the macOS quirk (`quirks.ts:88-114` → `quirks.ts:125-146`)
- The `windowRegistry.ts` change adds `winReapplyAlwaysOnTop: true` to `SelectionToolbar` quirks
- 6 new tests added covering: show re-apply, showInactive re-apply, hide/close not wrapped, absent quirk no-op, floating fallback, and Windows platform identity

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: Selection Assistant toolbar now stays above other floating windows on Windows
```