### PR TITLE
fix(provider-registry): resolve same-family model sizes via size-preserving key

### DIFF
--- a/packages/provider-registry/src/__tests__/registry-loader.test.ts
+++ b/packages/provider-registry/src/__tests__/registry-loader.test.ts
@@ -118,3 +118,25 @@ describe('RegistryLoader.findModel — registry-tag (colon) size/quant ids', () 
     expect(loader.findModel('gpt-oss-20b')?.id).toBe('gpt-oss-20b')
   })
 })
+
+describe('RegistryLoader.findModel — size-preserving catalog matches', () => {
+  const realCatalogLoader = () =>
+    new RegistryLoader({
+      models: join(__dirname, '../../data/models.json'),
+      providers: join(__dirname, '../../data/providers.json'),
+      providerModels: join(__dirname, '../../data/provider-models.json')
+    })
+
+  it('maps version-spelled 9b ids to the 9b row instead of a same-family 27b row', () => {
+    const loader = realCatalogLoader()
+
+    expect(loader.findModel('qwen3.5-9b')?.id).toBe('qwen3-5-9b')
+    expect(loader.findModel('qwen3.5-27b')?.id).toBe('qwen3-5-27b')
+  })
+
+  it('falls back to the family key when no size-specific catalog row exists', () => {
+    const loader = modelLoader([model('qwen3-5')])
+
+    expect(loader.findModel('qwen3.5-999b')?.id).toBe('qwen3-5')
+  })
+})

--- a/packages/provider-registry/src/registry-loader.ts
+++ b/packages/provider-registry/src/registry-loader.ts
@@ -205,6 +205,9 @@ export class RegistryLoader {
     if (colonVariantTagToHyphen(modelId) !== modelId) {
       return this.modelBySizedNorm!.get(normalizeModelId(modelId, { keepParameterSize: true })) ?? null
     }
+    // Prefer the size-preserving key before the family key so distinct catalog sizes keep their metadata.
+    const sizedHit = this.modelBySizedNorm!.get(normalizeModelId(modelId, { keepParameterSize: true }))
+    if (sizedHit) return sizedHit
     return this.modelByNormId!.get(normalizeModelId(modelId)) ?? null
   }
 


### PR DESCRIPTION
## Summary

Fixes #18389.

A custom OpenAI-compatible provider (e.g. self-hosted vLLM) returns model id `qwen3.5-9b` from `/v1/models`, but the model list showed it as `Qwen3.5 27B` — and the wrong catalog row's pricing / context window / capabilities / `presetModelId` got merged onto the 9b model.

### Root cause

`RegistryLoader.findModel` (`packages/provider-registry/src/registry-loader.ts`) resolves a fetched raw id via exact map → colon-tag sized map → **size-agnostic normalized fallback** (`modelByNormId`). The size-agnostic fallback is the bug:

`normalizeModelId('qwen3.5-9b')` strips the parameter-size suffix (`-9b`) and folds the version dot (`.`→`-`), yielding the key `qwen3-5`. Two catalog entries both normalize to `qwen3-5`:
- `qwen3-5-27b` (name: `Qwen3.5 27B`)
- `qwen3-5-9b`  (name: `Qwen: Qwen3.5-9B`)

`buildModelIndex` uses first-wins, and `qwen3-5-27b` precedes `qwen3-5-9b` in the catalog, so `findModel('qwen3.5-9b')` returned the **27b** row.

The codebase already built a size-preserving map (`modelBySizedNorm`, indexed with `keepParameterSize: true`) for this exact class of bug, but only consulted it for colon-tagged ids (`gpt-oss:20b`).

### Fix

Consult `modelBySizedNorm` before the size-agnostic fallback for **all** non-exact lookups, not only colon tags. `qwen3.5-9b` → sized key `qwen3-5-9b` → exact hit on the 9b catalog row.

Same-family different-size ids now keep their own metadata instead of collapsing onto whichever sibling happens to be indexed first.

## Verification

- `pnpm exec vitest run --project provider-registry` → 18 files / 302 tests passed (incl. the 11 `registry-loader` tests).
- `biome check` on both changed files → clean.
- Regression tests added in `packages/provider-registry/src/__tests__/registry-loader.test.ts`:
  - real-catalog: `qwen3.5-9b → qwen3-5-9b`, `qwen3.5-27b → qwen3-5-27b`.
  - sized-miss still falls through to the family key.

> Note: `pnpm --filter @cherrystudio/provider-registry test`, `pnpm lint`, and `pnpm build:check` fail to start in this environment for **pre-existing, unrelated** reasons (root `vitest.config.ts` `extends: 'packages/aiCore/vitest.config.ts'` UNRESOLVED_ENTRY under vitest 4; `.oxlintrc.json` `typeAware` rejected by oxlint 1.56; a couple of stale `tsc` errors in untouched files). None are introduced by this change — verified by running the scoped equivalents above.

## Scope

Surgical: +3 lines in `findModel`, +22 lines of tests. No catalog JSON, `normalizeModelId`, or provider source touched.

A residual edge case is intentionally out of scope: a **size the catalog doesn't list** (e.g. `qwen3.5-999b`) or a **size-less id whose family has only sized rows** (e.g. bare `qwen3.5`) still falls through to the size-agnostic first-wins row. Fixing that needs a semantic change to the size-agnostic fallback (or catalog conflict detection) and warrants a separate change.
