### PR TITLE
fix(doubao): normalize missing Responses annotations

### DIFF
--- a/src/main/ai/provider/__tests__/ark.test.ts
+++ b/src/main/ai/provider/__tests__/ark.test.ts
@@ -1,8 +1,39 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
 import { describe, expect, it } from 'vitest'
 
-import { stripArkUnsupportedIncludes } from '../ark'
+import { normalizeArkResponsesResponse, stripArkUnsupportedIncludes } from '../ark'
 
 const parse = (body: BodyInit | null | undefined) => JSON.parse(body as string)
+
+const prompt: LanguageModelV3CallOptions['prompt'] = [{ role: 'user', content: [{ type: 'text', text: 'Say hi.' }] }]
+
+const arkResponseBody = {
+  id: 'resp_ark',
+  created_at: 1786440279,
+  model: 'doubao-seed-2-0-code-preview-260215',
+  output: [
+    {
+      type: 'message',
+      role: 'assistant',
+      id: 'msg_ark',
+      content: [{ type: 'output_text', text: 'Hi there!' }]
+    }
+  ],
+  service_tier: 'default',
+  usage: {
+    input_tokens: 3,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens: 2,
+    output_tokens_details: { reasoning_tokens: 0 }
+  }
+}
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json; charset=utf-8', 'x-request-id': 'ark-request' }
+  })
 
 describe('stripArkUnsupportedIncludes', () => {
   it('drops the include the Responses adapter pairs with the web_search tool', () => {
@@ -23,5 +54,100 @@ describe('stripArkUnsupportedIncludes', () => {
     const body = JSON.stringify({ include: ['reasoning.encrypted_content'] })
     expect(stripArkUnsupportedIncludes(body)).toBe(body)
     expect(stripArkUnsupportedIncludes(undefined)).toBeUndefined()
+  })
+})
+
+describe('normalizeArkResponsesResponse', () => {
+  it('lets the OpenAI Responses parser consume Ark output_text without annotations', async () => {
+    const model = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+      fetch: async (input) => normalizeArkResponsesResponse(input, jsonResponse(arkResponseBody))
+    }).responses('doubao-seed-2-0-code-preview-260215')
+
+    const result = await model.doGenerate({ prompt })
+
+    expect(result.content).toContainEqual(expect.objectContaining({ type: 'text', text: 'Hi there!' }))
+  })
+
+  it('keeps an existing annotations array and the original response', async () => {
+    const annotations = [
+      {
+        type: 'url_citation',
+        start_index: 0,
+        end_index: 9,
+        url: 'https://example.com',
+        title: 'Example'
+      }
+    ]
+    const response = jsonResponse({
+      ...arkResponseBody,
+      output: [
+        {
+          ...arkResponseBody.output[0],
+          content: [{ ...arkResponseBody.output[0].content[0], annotations }]
+        }
+      ]
+    })
+
+    const normalized = await normalizeArkResponsesResponse(
+      'https://ark.cn-beijing.volces.com/api/v3/responses',
+      response
+    )
+
+    expect(normalized).toBe(response)
+    expect((await normalized.json()).output[0].content[0].annotations).toEqual(annotations)
+  })
+
+  it('preserves response metadata without stale compressed-body headers', async () => {
+    const response = new Response(JSON.stringify(arkResponseBody), {
+      status: 200,
+      statusText: 'OK',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'content-encoding': 'gzip',
+        'content-length': '1786',
+        'x-request-id': 'ark-request'
+      }
+    })
+
+    const normalized = await normalizeArkResponsesResponse(
+      'https://ark.cn-beijing.volces.com/api/v3/responses',
+      response
+    )
+
+    expect(normalized.status).toBe(200)
+    expect(normalized.statusText).toBe('OK')
+    expect(normalized.headers.get('content-type')).toBe('application/json; charset=utf-8')
+    expect(normalized.headers.get('x-request-id')).toBe('ark-request')
+    expect(normalized.headers.has('content-encoding')).toBe(false)
+    expect(normalized.headers.has('content-length')).toBe(false)
+  })
+
+  it.each([
+    {
+      name: 'streaming responses',
+      url: 'https://ark.cn-beijing.volces.com/api/v3/responses',
+      response: () => new Response('data: [DONE]\n\n', { headers: { 'content-type': 'text/event-stream' } })
+    },
+    {
+      name: 'other endpoints',
+      url: 'https://ark.cn-beijing.volces.com/api/v3/chat/completions',
+      response: () => jsonResponse(arkResponseBody)
+    },
+    {
+      name: 'failed responses',
+      url: 'https://ark.cn-beijing.volces.com/api/v3/responses',
+      response: () => jsonResponse({ error: { message: 'bad request' } }, 400)
+    },
+    {
+      name: 'invalid JSON',
+      url: 'https://ark.cn-beijing.volces.com/api/v3/responses',
+      response: () => new Response('not-json', { headers: { 'content-type': 'application/json' } })
+    }
+  ])('passes through $name', async ({ url, response: createResponse }) => {
+    const response = createResponse()
+
+    expect(await normalizeArkResponsesResponse(url, response)).toBe(response)
   })
 })

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -1017,6 +1017,55 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
       expect(config.providerId).toBe('openai-compatible')
     })
 
+    it('composes Doubao Responses request and response compatibility in its fetch wrapper', async () => {
+      vi.mocked(net.fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'resp_ark',
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                id: 'msg_ark',
+                content: [{ type: 'output_text', text: 'Hi there!' }]
+              }
+            ]
+          }),
+          { status: 200, headers: { 'content-type': 'application/json; charset=utf-8' } }
+        )
+      )
+      const provider = makeProvider({
+        id: 'doubao',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_RESPONSES]: {
+            baseUrl: 'https://ark.cn-beijing.volces.com/api/v3/',
+            adapterFamily: 'openai'
+          }
+        }
+      })
+      const model = makeModel({
+        providerId: 'doubao',
+        apiModelId: 'doubao-seed-2-0-code-preview-260215',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES]
+      })
+      const config = await providerToAiSdkConfig(provider, model)
+      const settings = config.providerSettings as Record<string, unknown>
+      const fetch = settings.fetch as typeof globalThis.fetch
+
+      const response = await fetch('https://ark.cn-beijing.volces.com/api/v3/responses', {
+        method: 'POST',
+        body: JSON.stringify({ include: ['web_search_call.action.sources'] })
+      })
+
+      const requestBody = JSON.parse(vi.mocked(net.fetch).mock.calls[0][1]?.body as string)
+      const responseBody = (await response.json()) as {
+        output: Array<{ content: Array<{ annotations?: unknown[] }> }>
+      }
+      expect(requestBody).not.toHaveProperty('include')
+      expect(responseBody.output[0].content[0].annotations).toEqual([])
+    })
+
     it('routes DMXAPI bespoke-family IMAGE models (e.g. qwen-image) through DMXAPI config', async () => {
       const provider = makeProvider({
         id: 'dmxapi',

--- a/src/main/ai/provider/ark.ts
+++ b/src/main/ai/provider/ark.ts
@@ -6,6 +6,50 @@
  */
 const ARK_UNSUPPORTED_INCLUDES = new Set(['web_search_call.action.sources'])
 
+type JsonObject = Record<string, unknown>
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isResponsesRequest(input: RequestInfo | URL): boolean {
+  const target = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+  try {
+    return new URL(target).pathname.replace(/\/+$/, '').endsWith('/responses')
+  } catch {
+    return false
+  }
+}
+
+function addMissingOutputTextAnnotations(value: unknown): unknown {
+  if (!isJsonObject(value) || !Array.isArray(value.output)) return value
+
+  let outputChanged = false
+  const output = value.output.map((item) => {
+    if (!isJsonObject(item) || item.type !== 'message' || !Array.isArray(item.content)) return item
+
+    let contentChanged = false
+    const content = item.content.map((part) => {
+      if (
+        !isJsonObject(part) ||
+        part.type !== 'output_text' ||
+        Object.prototype.hasOwnProperty.call(part, 'annotations')
+      ) {
+        return part
+      }
+
+      contentChanged = true
+      return { ...part, annotations: [] }
+    })
+
+    if (!contentChanged) return item
+    outputChanged = true
+    return { ...item, content }
+  })
+
+  return outputChanged ? { ...value, output } : value
+}
+
 export function stripArkUnsupportedIncludes(body: BodyInit | null | undefined): BodyInit | null | undefined {
   if (typeof body !== 'string') return body
   try {
@@ -16,5 +60,28 @@ export function stripArkUnsupportedIncludes(body: BodyInit | null | undefined): 
     return JSON.stringify({ ...json, include: include.length > 0 ? include : undefined })
   } catch {
     return body
+  }
+}
+
+export async function normalizeArkResponsesResponse(input: RequestInfo | URL, response: Response): Promise<Response> {
+  const contentType = response.headers.get('content-type')?.toLowerCase()
+  if (!response.ok || !isResponsesRequest(input) || contentType?.includes('text/event-stream')) return response
+
+  try {
+    const json: unknown = await response.clone().json()
+    const normalized = addMissingOutputTextAnnotations(json)
+    if (normalized === json) return response
+
+    const headers = new Headers(response.headers)
+    headers.delete('content-encoding')
+    headers.delete('content-length')
+
+    return new Response(JSON.stringify(normalized), {
+      status: response.status,
+      statusText: response.statusText,
+      headers
+    })
+  } catch {
+    return response
   }
 }

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -27,7 +27,7 @@ import type { ProviderConfig } from '../types'
 import { type AppProviderId, appProviderIds, type AppProviderSettingsMap } from '../types'
 import { customFetch } from '../utils/customFetch'
 import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
-import { stripArkUnsupportedIncludes } from './ark'
+import { normalizeArkResponsesResponse, stripArkUnsupportedIncludes } from './ark'
 import { generateSignature } from './cherryai'
 import { buildCodexRequestHeaders, coerceCodexRequestBody } from './codex'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
@@ -251,8 +251,10 @@ export async function resolveProviderAiSdkConfig(
       match: (p, id) => id === 'openai' && matchesPreset(p, SystemProviderIds.doubao),
       build: withSelectedApiKey((ctx) => {
         const config = buildGenericProviderConfig(ctx)
-        config.providerSettings.fetch = (input: RequestInfo | URL, init?: RequestInit) =>
-          customFetch(input, { ...init, body: stripArkUnsupportedIncludes(init?.body) })
+        config.providerSettings.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+          const response = await customFetch(input, { ...init, body: stripArkUnsupportedIncludes(init?.body) })
+          return normalizeArkResponsesResponse(input, response)
+        }
         return config
       })
     },


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Doubao models using Ark's Responses endpoint could return HTTP 200 with valid output text but omit `output_text.annotations`. The strict OpenAI Responses schema rejected that payload as `Invalid JSON response`, causing model connection checks to fail.

After this PR:

The Doubao fetch wrapper adds an empty `annotations` array only when it is missing from successful non-streaming `/responses` output text. Existing annotations, streaming responses, error responses, invalid JSON, and other endpoints pass through unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Ark's response is usable and accepted once the missing optional collection is normalized. Keeping the compatibility logic at the existing Doubao provider boundary fixes the vendor-specific protocol difference without changing the shared OpenAI adapter contract.

The following tradeoffs were made:

- Successful non-streaming Responses JSON is cloned and parsed once. A new response is created only when normalization is required, and stale `content-encoding` and `content-length` headers are removed after reserialization.
- The normalizer deliberately preserves an existing `annotations` property, even if malformed, so new upstream contract changes are not silently hidden.

The following alternatives were considered:

- Patch `@ai-sdk/openai` globally to make `annotations` optional. This would broaden an Ark-specific workaround to every Responses provider.
- Prefer Chat Completions for Doubao. This avoids the parser mismatch but removes Responses-only capabilities and does not address the protocol difference.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Targeted main-process tests: 70 passed across `ark.test.ts` and `config.test.ts`.
- `pnpm typecheck:node`, targeted Biome, ESLint, and Oxlint checks passed.
- The full test suite and `pnpm build:check` were not run at the requester's direction because `build:check` invokes `pnpm test`.
- A persistent isolated development window was launched for manual verification; the manual result has not been reported yet.
- No user-guide update is required because this restores expected provider behavior; a user-facing release note is included below.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Doubao model connection checks failing with "Invalid JSON response" when Ark omits output text annotations.
```
