### PR TITLE
feat(selection-reference): structural selection anchors, FilePreview contract, and office-transform skill

### DIFF
--- a/resources/skills/office-transform/SKILL.md
+++ b/resources/skills/office-transform/SKILL.md
@@ -95,6 +95,31 @@ styles, charts, images, and macros in untouched parts survive exactly. Edit shap
   paragraph keeps its paragraph style and the first run's character style; other inline
   content within that one paragraph (mixed run styling, hyperlinks) is flattened.
 
+### Generate — write ad-hoc library code for new documents
+
+Generation (a fresh deck, workbook, or document — from scratch or from data you
+just extracted) has no source file to protect, so there is no fixed script: write a
+short Python program against the matching library (`python-pptx`, `openpyxl`,
+`python-docx`) and run it via `uv run --with <pkg> python`. The two skill
+invariants still apply: write to a new file (never a path the user's original
+occupies), and verify the output by reopening it before reporting success.
+
+### Edit pptx — use python-pptx, saving to a new path
+
+pptx edits do not go through `office_patch_copy.py`. `python-pptx` mutates the
+original lxml tree in place and preserves XML it does not understand, so it is
+round-trip safe (unlike `openpyxl`, which drops charts and drawings — that is why
+xlsx edits use patch-copy). Open the source, apply the targeted change (locate
+shapes by `shape_id` to match anchor `nodeId`), and `save()` to a NEW path:
+
+```python
+from pptx import Presentation
+p = Presentation("/abs/deck.pptx")
+shape = next(s for s in p.slides[1].shapes if s.shape_id == 4)
+shape.text_frame.text = "new text"
+p.save("/abs/deck-updated.pptx")  # never save over the source
+```
+
 ## Output conventions
 
 - Name derived files after the source with an operation suffix:
@@ -117,8 +142,9 @@ If verification fails, say so and show the error — do not present an unverifie
 
 ## Limits
 
-- pptx supports anchored text extraction only; patch-copy edits and slide-copy
-  outputs are not available yet — say so when asked for them.
+- pptx edits go through python-pptx (see "Edit pptx"), not patch-copy; slide-copy
+  into a new deck is not supported (python-pptx cannot clone slides) — say so
+  when asked for it.
 - Patched xlsx string cells become inline strings (valid OOXML; Excel reads them fine).
 - Edited XML parts lose insignificant whitespace formatting; semantics are preserved.
 - Scanned/image-only PDFs yield no text (no OCR here).

--- a/resources/skills/office-transform/SKILL.md
+++ b/resources/skills/office-transform/SKILL.md
@@ -47,6 +47,7 @@ Anchor shapes:
 | xlsx | `{"format":"xlsx","sheet":"Sheet1","range":"A1:C10"}` (range may be one cell) |
 | docx | `{"format":"docx","paragraph":3,"charRange":[0,12]}` (`charRange` optional; ordinal counts body-level paragraphs only, tables excluded) |
 | pdf | `{"format":"pdf","page":3,"charRange":[0,120]}` (`charRange` optional, applies to extracted text) |
+| pptx | `{"format":"pptx","slide":2,"nodeId":"4","paragraph":0,"tableCell":{"row":1,"col":0}}` (`slide` is one-based; `nodeId` is the OOXML shape id — omit for the whole slide; `paragraph` and `tableCell` optional) |
 
 ## Operations
 
@@ -70,6 +71,7 @@ The output format is inferred from `--out`'s extension:
 | xlsx | `openpyxl` | `xlsx`, `csv`, `md` |
 | docx | `python-docx` | `docx`, `txt`, `md` |
 | pdf | `pypdf` | `pdf` (page copy), `txt`, `md` |
+| pptx | `python-pptx` | `txt`, `md` (slide, shape, paragraph, or table-cell text) |
 
 xlsx extraction reads computed values (`data_only`), so formula cells yield their last
 saved result. docx extraction to `docx` carries text only, not run styling.
@@ -115,8 +117,8 @@ If verification fails, say so and show the error — do not present an unverifie
 
 ## Limits
 
-- pptx is not yet covered; for pptx content, extract via `to_markdown` and say that
-  targeted pptx transforms are not available yet.
+- pptx supports anchored text extraction only; patch-copy edits and slide-copy
+  outputs are not available yet — say so when asked for them.
 - Patched xlsx string cells become inline strings (valid OOXML; Excel reads them fine).
 - Edited XML parts lose insignificant whitespace formatting; semantics are preserved.
 - Scanned/image-only PDFs yield no text (no OCR here).

--- a/resources/skills/office-transform/SKILL.md
+++ b/resources/skills/office-transform/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: office-transform
+description: Derive new Office files from structural selections without touching the original. Use when the user points at part of a spreadsheet, Word document, or PDF (a worksheet range, paragraph, page, or a pasted selection-ref block) and wants it extracted, converted, or edited — the result is always a NEW file; the source file is never modified. Covers xlsx range extraction to csv/markdown/xlsx, docx paragraph extraction and text replacement, pdf page extraction, and targeted xlsx cell edits.
+version: 1.0.0
+---
+
+# Office Transform
+
+Turn a structural selection of an Office/PDF document into a new derived file.
+
+Two invariants hold for every operation:
+
+1. **The source file is read-only.** Every result is a new file; both scripts refuse to
+   write to the source path or overwrite an existing file. Never work around this with
+   ad-hoc shell edits to the original.
+2. **Anchors are structural.** Selections address the document's own coordinates —
+   worksheet + A1 range, body-level paragraph ordinal, one-based page number — never
+   screen or DOM positions.
+
+## When to use which tool
+
+- Only need to *read* a document to summarize or answer questions → use
+  `mcp__cherry-tools__to_markdown` instead (see the cherry-tool-guide skill); it is
+  lossy but built for reading.
+- The user wants a *file* out — an extracted range, a converted fragment, an edited
+  copy → this skill.
+
+## Input: selection references
+
+Chat surfaces may hand you a fenced `selection-ref` block:
+
+```selection-ref
+{"path": "/abs/report.xlsx", "anchor": {"format": "xlsx", "sheet": "Sheet1", "range": "A1:C10"}, "excerpt": "…", "fileStamp": {"size": 1024, "mtimeMs": 1700000000000}}
+```
+
+The `anchor` object is exactly what the scripts take via `--anchor`. Before acting on
+one, compare `fileStamp` against the file's current size/mtime (`stat`); if they
+differ, tell the user the file changed since they selected and ask them to re-select —
+never silently re-anchor. Users may also describe the region in words ("sheet 2,
+columns A through C"); build the anchor JSON yourself, confirming the worksheet name or
+paragraph if ambiguous.
+
+Anchor shapes:
+
+| Format | Anchor |
+| --- | --- |
+| xlsx | `{"format":"xlsx","sheet":"Sheet1","range":"A1:C10"}` (range may be one cell) |
+| docx | `{"format":"docx","paragraph":3,"charRange":[0,12]}` (`charRange` optional; ordinal counts body-level paragraphs only, tables excluded) |
+| pdf | `{"format":"pdf","page":3,"charRange":[0,120]}` (`charRange` optional, applies to extracted text) |
+
+## Operations
+
+Scripts live in this skill's `scripts/` directory; resolve paths relative to this
+skill folder. Python dependencies are per-format and provided at invocation time via
+`uv run --with <pkg>` (the bundled-shell idiom — do not `pip install` globally).
+
+### Extract — pull the anchored region into a new file
+
+```bash
+uv run --with openpyxl python scripts/office_extract.py \
+  --file /abs/report.xlsx \
+  --anchor '{"format":"xlsx","sheet":"Sheet1","range":"A1:C10"}' \
+  --out /abs/report-q1-range.csv
+```
+
+The output format is inferred from `--out`'s extension:
+
+| Source | Dependency (`--with`) | Output formats |
+| --- | --- | --- |
+| xlsx | `openpyxl` | `xlsx`, `csv`, `md` |
+| docx | `python-docx` | `docx`, `txt`, `md` |
+| pdf | `pypdf` | `pdf` (page copy), `txt`, `md` |
+
+xlsx extraction reads computed values (`data_only`), so formula cells yield their last
+saved result. docx extraction to `docx` carries text only, not run styling.
+
+### Patch-copy — derive an edited copy, standard library only
+
+```bash
+python3 scripts/office_patch_copy.py \
+  --file /abs/report.xlsx \
+  --edits '{"format":"xlsx","sheet":"Sheet1","cells":{"B2":42,"C3":"hello"}}' \
+  --out /abs/report-updated.xlsx
+```
+
+OOXML packages are ZIPs of XML parts. Patch-copy copies every part byte-for-byte and
+re-serializes only the part the edits touch (one worksheet, or `word/document.xml`), so
+styles, charts, images, and macros in untouched parts survive exactly. Edit shapes:
+
+- `{"format":"xlsx","sheet":"S","cells":{"B2":42,"C3":"text","D4":true}}` — numbers,
+  strings, and booleans; an existing formula in an edited cell is replaced by the value.
+- `{"format":"docx","replacements":[{"paragraph":3,"text":"new text"}]}` — the
+  paragraph keeps its paragraph style and the first run's character style; other inline
+  content within that one paragraph (mixed run styling, hyperlinks) is flattened.
+
+## Output conventions
+
+- Name derived files after the source with an operation suffix:
+  `report.xlsx` → `report-updated.xlsx`, `report-q1-range.csv`, `spec-p3.txt`.
+- Write into the session workspace (or where the user asked). Both scripts print the
+  written path on success — report it to the user.
+
+## Verify before reporting success
+
+Always reopen the derived file with the matching reader and check the result, e.g.:
+
+```bash
+uv run --with openpyxl python -c "
+from openpyxl import load_workbook
+ws = load_workbook('/abs/report-updated.xlsx', data_only=True)['Sheet1']
+print(ws['B2'].value)"
+```
+
+If verification fails, say so and show the error — do not present an unverified file.
+
+## Limits
+
+- pptx is not yet covered; for pptx content, extract via `to_markdown` and say that
+  targeted pptx transforms are not available yet.
+- Patched xlsx string cells become inline strings (valid OOXML; Excel reads them fine).
+- Edited XML parts lose insignificant whitespace formatting; semantics are preserved.
+- Scanned/image-only PDFs yield no text (no OCR here).

--- a/resources/skills/office-transform/scripts/office_extract.py
+++ b/resources/skills/office-transform/scripts/office_extract.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Extract an anchored region of an Office/PDF file into a NEW file.
+
+The source file is opened read-only and never modified. Anchors address the
+document's own structural coordinates (worksheet range, body-level paragraph
+ordinal, page number) — see SKILL.md for the anchor JSON shapes.
+
+Format-specific third-party readers are imported lazily, so run this with the
+dependency matching the source format, e.g.:
+
+    uv run --with openpyxl python office_extract.py \
+        --file /abs/report.xlsx \
+        --anchor '{"format":"xlsx","sheet":"Sheet1","range":"A1:C10"}' \
+        --out /abs/report-extract.csv
+
+Dependencies by source format: xlsx -> openpyxl, docx -> python-docx, pdf -> pypdf.
+"""
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+A1_CELL_RE = re.compile(r"^([A-Z]{1,3})([1-9][0-9]*)$")
+
+
+def fail(message: str) -> "sys.NoReturn":
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def column_to_index(letters: str) -> int:
+    index = 0
+    for char in letters:
+        index = index * 26 + (ord(char) - ord("A") + 1)
+    return index
+
+
+def parse_a1_cell(ref: str) -> tuple[int, int]:
+    match = A1_CELL_RE.match(ref)
+    if not match:
+        fail(f"invalid A1 cell reference: {ref!r}")
+    return column_to_index(match.group(1)), int(match.group(2))
+
+
+def parse_a1_range(ref: str) -> tuple[int, int, int, int]:
+    """Return (min_col, min_row, max_col, max_row) from 'B2' or 'A1:C10'."""
+    parts = ref.split(":")
+    if len(parts) > 2:
+        fail(f"invalid A1 range: {ref!r}")
+    start = parse_a1_cell(parts[0])
+    end = parse_a1_cell(parts[-1])
+    return (
+        min(start[0], end[0]),
+        min(start[1], end[1]),
+        max(start[0], end[0]),
+        max(start[1], end[1]),
+    )
+
+
+def slice_char_range(text: str, char_range) -> str:
+    if char_range is None:
+        return text
+    start, end = int(char_range[0]), int(char_range[1])
+    if start > end or start < 0:
+        fail(f"invalid charRange: {char_range!r}")
+    return text[start:end]
+
+
+def cell_display(value) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def write_markdown_table(rows: list[list[str]], out_path: Path) -> None:
+    if not rows:
+        fail("selection produced no rows")
+    width = max(len(row) for row in rows)
+    normalized = [row + [""] * (width - len(row)) for row in rows]
+    escaped = [[cell.replace("|", "\\|").replace("\n", " ") for cell in row] for row in normalized]
+    lines = ["| " + " | ".join(escaped[0]) + " |", "| " + " | ".join(["---"] * width) + " |"]
+    lines.extend("| " + " | ".join(row) + " |" for row in escaped[1:])
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def extract_xlsx(src: Path, anchor: dict, out_path: Path, out_format: str) -> None:
+    try:
+        from openpyxl import Workbook, load_workbook
+    except ImportError:
+        fail("openpyxl is required for xlsx sources — rerun via `uv run --with openpyxl python ...`")
+
+    sheet_name = anchor.get("sheet")
+    range_ref = anchor.get("range")
+    if not sheet_name or not range_ref:
+        fail("xlsx anchor requires 'sheet' and 'range'")
+
+    workbook = load_workbook(src, data_only=True, read_only=True)
+    if sheet_name not in workbook.sheetnames:
+        fail(f"worksheet not found: {sheet_name!r} (has: {workbook.sheetnames})")
+    worksheet = workbook[sheet_name]
+
+    min_col, min_row, max_col, max_row = parse_a1_range(range_ref)
+    values = [
+        [cell.value for cell in row]
+        for row in worksheet.iter_rows(min_row=min_row, max_row=max_row, min_col=min_col, max_col=max_col)
+    ]
+    workbook.close()
+
+    if out_format == "xlsx":
+        derived = Workbook()
+        derived_sheet = derived.active
+        derived_sheet.title = sheet_name[:31]
+        for row in values:
+            derived_sheet.append(row)
+        derived.save(out_path)
+    elif out_format == "csv":
+        with out_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.writer(handle)
+            writer.writerows([[cell_display(value) for value in row] for row in values])
+    elif out_format == "md":
+        write_markdown_table([[cell_display(value) for value in row] for row in values], out_path)
+    else:
+        fail(f"unsupported output format for xlsx source: {out_format!r} (use xlsx, csv, or md)")
+
+
+def extract_docx(src: Path, anchor: dict, out_path: Path, out_format: str) -> None:
+    try:
+        import docx
+    except ImportError:
+        fail("python-docx is required for docx sources — rerun via `uv run --with python-docx python ...`")
+
+    paragraph_index = anchor.get("paragraph")
+    if paragraph_index is None or int(paragraph_index) < 0:
+        fail("docx anchor requires a non-negative 'paragraph' ordinal")
+    paragraph_index = int(paragraph_index)
+
+    document = docx.Document(str(src))
+    paragraphs = document.paragraphs
+    if paragraph_index >= len(paragraphs):
+        fail(f"paragraph {paragraph_index} out of range (document has {len(paragraphs)} body paragraphs)")
+    text = slice_char_range(paragraphs[paragraph_index].text, anchor.get("charRange"))
+
+    if out_format in ("txt", "md"):
+        out_path.write_text(text + "\n", encoding="utf-8")
+    elif out_format == "docx":
+        derived = docx.Document()
+        derived.add_paragraph(text)
+        derived.save(str(out_path))
+    else:
+        fail(f"unsupported output format for docx source: {out_format!r} (use txt, md, or docx)")
+
+
+def extract_pdf(src: Path, anchor: dict, out_path: Path, out_format: str) -> None:
+    try:
+        from pypdf import PdfReader, PdfWriter
+    except ImportError:
+        fail("pypdf is required for pdf sources — rerun via `uv run --with pypdf python ...`")
+
+    page_number = anchor.get("page")
+    if page_number is None or int(page_number) < 1:
+        fail("pdf anchor requires a one-based 'page' number")
+    page_index = int(page_number) - 1
+
+    reader = PdfReader(str(src))
+    if page_index >= len(reader.pages):
+        fail(f"page {page_number} out of range (document has {len(reader.pages)} pages)")
+    page = reader.pages[page_index]
+
+    if out_format == "pdf":
+        writer = PdfWriter()
+        writer.add_page(page)
+        with out_path.open("wb") as handle:
+            writer.write(handle)
+    elif out_format in ("txt", "md"):
+        text = slice_char_range(page.extract_text() or "", anchor.get("charRange"))
+        out_path.write_text(text + "\n", encoding="utf-8")
+    else:
+        fail(f"unsupported output format for pdf source: {out_format!r} (use pdf, txt, or md)")
+
+
+EXTRACTORS = {"xlsx": extract_xlsx, "docx": extract_docx, "pdf": extract_pdf}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--file", required=True, help="absolute path of the source document (read-only)")
+    parser.add_argument("--anchor", required=True, help="anchor JSON, e.g. '{\"format\":\"xlsx\",...}'")
+    parser.add_argument("--out", required=True, help="absolute path of the NEW file to create; must not exist")
+    args = parser.parse_args()
+
+    src = Path(args.file)
+    out_path = Path(args.out)
+    if not src.is_file():
+        fail(f"source file not found: {src}")
+    if out_path.resolve() == src.resolve():
+        fail("output path must differ from the source file — the source is never modified")
+    if out_path.exists():
+        fail(f"output path already exists: {out_path} — pick a fresh name instead of overwriting")
+
+    try:
+        anchor = json.loads(args.anchor)
+    except json.JSONDecodeError as error:
+        fail(f"anchor is not valid JSON: {error}")
+    anchor_format = anchor.get("format")
+    extractor = EXTRACTORS.get(anchor_format)
+    if extractor is None:
+        fail(f"unsupported anchor format: {anchor_format!r} (use xlsx, docx, or pdf)")
+
+    out_format = out_path.suffix.lstrip(".").lower()
+    if not out_format:
+        fail("output path needs an extension so the output format can be inferred")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    extractor(src, anchor, out_path, out_format)
+    print(str(out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/skills/office-transform/scripts/office_extract.py
+++ b/resources/skills/office-transform/scripts/office_extract.py
@@ -13,7 +13,8 @@ dependency matching the source format, e.g.:
         --anchor '{"format":"xlsx","sheet":"Sheet1","range":"A1:C10"}' \
         --out /abs/report-extract.csv
 
-Dependencies by source format: xlsx -> openpyxl, docx -> python-docx, pdf -> pypdf.
+Dependencies by source format: xlsx -> openpyxl, docx -> python-docx,
+pdf -> pypdf, pptx -> python-pptx.
 """
 
 import argparse
@@ -181,7 +182,76 @@ def extract_pdf(src: Path, anchor: dict, out_path: Path, out_format: str) -> Non
         fail(f"unsupported output format for pdf source: {out_format!r} (use pdf, txt, or md)")
 
 
-EXTRACTORS = {"xlsx": extract_xlsx, "docx": extract_docx, "pdf": extract_pdf}
+def iter_shapes_recursive(shapes):
+    for shape in shapes:
+        yield shape
+        if shape.shape_type == 6:  # MSO_SHAPE_TYPE.GROUP
+            yield from iter_shapes_recursive(shape.shapes)
+
+
+def shape_text_lines(shape) -> list[str]:
+    if shape.has_text_frame:
+        return [paragraph.text for paragraph in shape.text_frame.paragraphs]
+    if getattr(shape, "has_table", False) and shape.has_table:
+        return [" | ".join(cell.text for cell in row.cells) for row in shape.table.rows]
+    return []
+
+
+def extract_pptx(src: Path, anchor: dict, out_path: Path, out_format: str) -> None:
+    try:
+        from pptx import Presentation
+    except ImportError:
+        fail("python-pptx is required for pptx sources — rerun via `uv run --with python-pptx python ...`")
+
+    slide_number = anchor.get("slide")
+    if slide_number is None or int(slide_number) < 1:
+        fail("pptx anchor requires a one-based 'slide' number")
+    slide_index = int(slide_number) - 1
+
+    presentation = Presentation(str(src))
+    slides = list(presentation.slides)
+    if slide_index >= len(slides):
+        fail(f"slide {slide_number} out of range (deck has {len(slides)} slides)")
+    slide = slides[slide_index]
+
+    node_id = anchor.get("nodeId")
+    if node_id is None:
+        lines = [line for shape in iter_shapes_recursive(slide.shapes) for line in shape_text_lines(shape)]
+    else:
+        shape = next(
+            (candidate for candidate in iter_shapes_recursive(slide.shapes) if str(candidate.shape_id) == str(node_id)),
+            None,
+        )
+        if shape is None:
+            fail(f"shape with nodeId {node_id!r} not found on slide {slide_number}")
+
+        table_cell = anchor.get("tableCell")
+        paragraph_index = anchor.get("paragraph")
+        if table_cell is not None:
+            if not (getattr(shape, "has_table", False) and shape.has_table):
+                fail(f"shape {node_id!r} is not a table but anchor has 'tableCell'")
+            rows = list(shape.table.rows)
+            row, col = int(table_cell.get("row", -1)), int(table_cell.get("col", -1))
+            if row < 0 or row >= len(rows) or col < 0 or col >= len(list(rows[row].cells)):
+                fail(f"tableCell {table_cell!r} out of range for shape {node_id!r}")
+            lines = [list(rows[row].cells)[col].text]
+        elif paragraph_index is not None:
+            if not shape.has_text_frame:
+                fail(f"shape {node_id!r} has no text body but anchor has 'paragraph'")
+            paragraphs = shape.text_frame.paragraphs
+            if int(paragraph_index) >= len(paragraphs):
+                fail(f"paragraph {paragraph_index} out of range (shape has {len(paragraphs)} paragraphs)")
+            lines = [paragraphs[int(paragraph_index)].text]
+        else:
+            lines = shape_text_lines(shape)
+
+    if out_format in ("txt", "md"):
+        out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    else:
+        fail(f"unsupported output format for pptx source: {out_format!r} (use txt or md)")
+
+
+EXTRACTORS = {"xlsx": extract_xlsx, "docx": extract_docx, "pdf": extract_pdf, "pptx": extract_pptx}
 
 
 def main() -> None:
@@ -207,7 +277,7 @@ def main() -> None:
     anchor_format = anchor.get("format")
     extractor = EXTRACTORS.get(anchor_format)
     if extractor is None:
-        fail(f"unsupported anchor format: {anchor_format!r} (use xlsx, docx, or pdf)")
+        fail(f"unsupported anchor format: {anchor_format!r} (use xlsx, docx, pdf, or pptx)")
 
     out_format = out_path.suffix.lstrip(".").lower()
     if not out_format:

--- a/resources/skills/office-transform/scripts/office_patch_copy.py
+++ b/resources/skills/office-transform/scripts/office_patch_copy.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Derive a new .xlsx/.docx by copying the original package and rewriting only
+the XML parts the requested edits touch.
+
+OOXML files are ZIP packages of XML parts. This script copies every part of
+the original byte-for-byte and re-serializes ONLY the affected part (one
+worksheet, or word/document.xml), so fidelity risk is confined to that part.
+The source file is never modified. Standard library only — no dependencies.
+
+Edit JSON shapes (pass via --edits):
+
+    {"format": "xlsx", "sheet": "Sheet1", "cells": {"B2": 42, "C3": "hello", "D4": true}}
+    {"format": "docx", "replacements": [{"paragraph": 3, "text": "new text"}]}
+
+xlsx: each cell is overwritten with the JSON value (number, string, or
+boolean); an existing formula in that cell is replaced by the value.
+docx: 'paragraph' is the zero-based ordinal among BODY-LEVEL paragraphs
+(tables excluded); the paragraph keeps its paragraph style and the first
+run's character style, but other inline content (extra run styling,
+hyperlinks) inside that one paragraph is flattened into the new text.
+"""
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+SPREADSHEET_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+RELATIONSHIP_ATTR_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PACKAGE_RELS_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+WORD_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+XML_NS = "http://www.w3.org/XML/1998/namespace"
+
+# Prefixes Word/Excel conventionally use; registering them keeps re-serialized
+# parts using the same prefixes the rest of the package refers to.
+OOXML_PREFIXES = {
+    "": SPREADSHEET_NS,
+    "r": RELATIONSHIP_ATTR_NS,
+    "w": WORD_NS,
+    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
+    "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing",
+    "w14": "http://schemas.microsoft.com/office/word/2010/wordml",
+    "w15": "http://schemas.microsoft.com/office/word/2012/wordml",
+    "wps": "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
+    "wpg": "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "pic": "http://schemas.openxmlformats.org/drawingml/2006/picture",
+    "m": "http://schemas.openxmlformats.org/officeDocument/2006/math",
+    "v": "urn:schemas-microsoft-com:vml",
+    "o": "urn:schemas-microsoft-com:office:office",
+    "w10": "urn:schemas-microsoft-com:office:word",
+    "x14ac": "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac",
+}
+
+A1_CELL_RE = re.compile(r"^([A-Z]{1,3})([1-9][0-9]*)$")
+
+
+def fail(message: str) -> "sys.NoReturn":
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def column_to_index(letters: str) -> int:
+    index = 0
+    for char in letters:
+        index = index * 26 + (ord(char) - ord("A") + 1)
+    return index
+
+
+def parse_a1_cell(ref: str) -> tuple[int, int]:
+    match = A1_CELL_RE.match(ref)
+    if not match:
+        fail(f"invalid A1 cell reference: {ref!r}")
+    return column_to_index(match.group(1)), int(match.group(2))
+
+
+def serialize_part(root: ET.Element) -> bytes:
+    return b'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\r\n' + ET.tostring(root, encoding="unicode").encode(
+        "utf-8"
+    )
+
+
+# ── xlsx ─────────────────────────────────────────────────────────────────────
+
+
+def resolve_worksheet_part(archive: zipfile.ZipFile, sheet_name: str) -> str:
+    workbook = ET.fromstring(archive.read("xl/workbook.xml"))
+    relationship_id = None
+    for sheet in workbook.iter(f"{{{SPREADSHEET_NS}}}sheet"):
+        if sheet.get("name") == sheet_name:
+            relationship_id = sheet.get(f"{{{RELATIONSHIP_ATTR_NS}}}id")
+            break
+    if relationship_id is None:
+        names = [sheet.get("name") for sheet in workbook.iter(f"{{{SPREADSHEET_NS}}}sheet")]
+        fail(f"worksheet not found: {sheet_name!r} (has: {names})")
+
+    rels = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+    for relationship in rels.iter(f"{{{PACKAGE_RELS_NS}}}Relationship"):
+        if relationship.get("Id") == relationship_id:
+            target = relationship.get("Target", "")
+            return target.lstrip("/") if target.startswith("/") else f"xl/{target}"
+    fail(f"workbook relationship {relationship_id!r} not found")
+    raise AssertionError  # unreachable
+
+
+def qn(namespace: str, tag: str) -> str:
+    return f"{{{namespace}}}{tag}"
+
+
+def set_cell_value(cell: ET.Element, value) -> None:
+    for child in list(cell):
+        cell.remove(child)
+    cell.attrib.pop("t", None)
+    if isinstance(value, bool):
+        cell.set("t", "b")
+        ET.SubElement(cell, qn(SPREADSHEET_NS, "v")).text = "1" if value else "0"
+    elif isinstance(value, (int, float)):
+        ET.SubElement(cell, qn(SPREADSHEET_NS, "v")).text = repr(value)
+    elif isinstance(value, str):
+        cell.set("t", "inlineStr")
+        inline = ET.SubElement(cell, qn(SPREADSHEET_NS, "is"))
+        text = ET.SubElement(inline, qn(SPREADSHEET_NS, "t"))
+        text.set(qn(XML_NS, "space"), "preserve")
+        text.text = value
+    else:
+        fail(f"unsupported cell value type: {type(value).__name__} (use number, string, or boolean)")
+
+
+def find_or_create_ordered(parent: ET.Element, tag: str, sort_key, key, attr_ref: str) -> ET.Element:
+    """Find child with attribute r == attr_ref, or insert one keeping siblings ordered."""
+    for child in parent.findall(tag):
+        if child.get("r") == attr_ref:
+            return child
+    created = ET.Element(tag, {"r": attr_ref})
+    insert_at = len(list(parent))
+    for position, child in enumerate(list(parent)):
+        child_ref = child.get("r")
+        if child.tag == tag and child_ref is not None and sort_key(child_ref) > key:
+            insert_at = position
+            break
+    parent.insert(insert_at, created)
+    return created
+
+
+def patch_xlsx(archive: zipfile.ZipFile, edits: dict) -> dict[str, bytes]:
+    sheet_name = edits.get("sheet")
+    cells = edits.get("cells")
+    if not sheet_name or not isinstance(cells, dict) or not cells:
+        fail("xlsx edits require 'sheet' and a non-empty 'cells' object")
+
+    part_name = resolve_worksheet_part(archive, sheet_name)
+    ET.register_namespace("", SPREADSHEET_NS)
+    for prefix, uri in OOXML_PREFIXES.items():
+        if prefix:
+            ET.register_namespace(prefix, uri)
+    root = ET.fromstring(archive.read(part_name))
+    sheet_data = root.find(qn(SPREADSHEET_NS, "sheetData"))
+    if sheet_data is None:
+        fail(f"{part_name} has no sheetData element")
+
+    row_tag = qn(SPREADSHEET_NS, "row")
+    cell_tag = qn(SPREADSHEET_NS, "c")
+    for ref, value in sorted(cells.items(), key=lambda item: (parse_a1_cell(item[0])[1], parse_a1_cell(item[0])[0])):
+        column, row_number = parse_a1_cell(ref)
+        row = find_or_create_ordered(sheet_data, row_tag, lambda r: int(r), row_number, str(row_number))
+        cell = find_or_create_ordered(row, cell_tag, lambda r: parse_a1_cell(r)[0], column, ref)
+        set_cell_value(cell, value)
+
+    return {part_name: serialize_part(root)}
+
+
+# ── docx ─────────────────────────────────────────────────────────────────────
+
+
+def patch_docx(archive: zipfile.ZipFile, edits: dict) -> dict[str, bytes]:
+    replacements = edits.get("replacements")
+    if not isinstance(replacements, list) or not replacements:
+        fail("docx edits require a non-empty 'replacements' array")
+
+    ET.register_namespace("", WORD_NS)
+    for prefix, uri in OOXML_PREFIXES.items():
+        if prefix and prefix != "r":
+            ET.register_namespace(prefix, uri)
+    ET.register_namespace("r", RELATIONSHIP_ATTR_NS)
+    root = ET.fromstring(archive.read("word/document.xml"))
+    body = root.find(qn(WORD_NS, "body"))
+    if body is None:
+        fail("word/document.xml has no body element")
+    paragraphs = [child for child in body if child.tag == qn(WORD_NS, "p")]
+
+    for replacement in replacements:
+        index = replacement.get("paragraph")
+        text = replacement.get("text")
+        if index is None or int(index) < 0 or not isinstance(text, str):
+            fail(f"each replacement needs a non-negative 'paragraph' and string 'text': {replacement!r}")
+        index = int(index)
+        if index >= len(paragraphs):
+            fail(f"paragraph {index} out of range (document has {len(paragraphs)} body paragraphs)")
+        paragraph = paragraphs[index]
+
+        properties = paragraph.find(qn(WORD_NS, "pPr"))
+        first_run_properties = None
+        first_run = paragraph.find(qn(WORD_NS, "r"))
+        if first_run is not None:
+            first_run_properties = first_run.find(qn(WORD_NS, "rPr"))
+
+        for child in list(paragraph):
+            if child is not properties:
+                paragraph.remove(child)
+        run = ET.SubElement(paragraph, qn(WORD_NS, "r"))
+        if first_run_properties is not None:
+            run.append(first_run_properties)
+        text_element = ET.SubElement(run, qn(WORD_NS, "t"))
+        text_element.set(qn(XML_NS, "space"), "preserve")
+        text_element.text = text
+
+    return {"word/document.xml": serialize_part(root)}
+
+
+PATCHERS = {"xlsx": patch_xlsx, "docx": patch_docx}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--file", required=True, help="absolute path of the source document (read-only)")
+    parser.add_argument("--edits", required=True, help="edit JSON — see module docstring for shapes")
+    parser.add_argument("--out", required=True, help="absolute path of the NEW file to create; must not exist")
+    args = parser.parse_args()
+
+    src = Path(args.file)
+    out_path = Path(args.out)
+    if not src.is_file():
+        fail(f"source file not found: {src}")
+    if out_path.resolve() == src.resolve():
+        fail("output path must differ from the source file — the source is never modified")
+    if out_path.exists():
+        fail(f"output path already exists: {out_path} — pick a fresh name instead of overwriting")
+
+    try:
+        edits = json.loads(args.edits)
+    except json.JSONDecodeError as error:
+        fail(f"edits is not valid JSON: {error}")
+    patcher = PATCHERS.get(edits.get("format"))
+    if patcher is None:
+        fail(f"unsupported edits format: {edits.get('format')!r} (use xlsx or docx)")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(src) as archive:
+        replaced_parts = patcher(archive, edits)
+        with zipfile.ZipFile(out_path, "w") as derived:
+            for item in archive.infolist():
+                data = replaced_parts.get(item.filename, None)
+                if data is None:
+                    data = archive.read(item.filename)
+                derived.writestr(item, data, compress_type=item.compress_type)
+    print(str(out_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/renderer/components/FilePreview/FilePreview.tsx
+++ b/src/renderer/components/FilePreview/FilePreview.tsx
@@ -15,7 +15,7 @@ import { FilePreviewLayout } from './FilePreviewLayout'
 import { filePreviewRegistry, resolveExtensionPlugin } from './filePreviewRegistry'
 import { FilePreviewToolbarPortalHost, FilePreviewToolbarPortalProvider } from './FilePreviewToolbar'
 import { textFilePreviewPlugin } from './plugins/text/textFilePreviewPlugin'
-import type { FilePreviewFileMetadata, FilePreviewPlugin, FilePreviewType } from './types'
+import type { FilePreviewFileMetadata, FilePreviewPlugin, FilePreviewPluginProps, FilePreviewType } from './types'
 
 const logger = loggerService.withContext('FilePreview')
 const TEXT_CONTENT_PLUGIN_IDS = new Set(['html', 'markdown', 'text'])
@@ -109,6 +109,7 @@ interface FilePreviewPluginRendererProps {
   fileName: string
   filePath: AbsoluteFilePath
   metadata: FilePreviewFileMetadata
+  onSelectionReference?: FilePreviewPluginProps['onSelectionReference']
   plugin: FilePreviewPlugin
   refreshKey: number
   type: FilePreviewType
@@ -141,6 +142,7 @@ function FilePreviewPluginRenderer({
   fileName,
   filePath,
   metadata,
+  onSelectionReference,
   plugin,
   refreshKey,
   type
@@ -157,6 +159,7 @@ function FilePreviewPluginRenderer({
           filePath={filePath}
           fileName={fileName}
           metadata={metadata}
+          onSelectionReference={onSelectionReference}
           refreshKey={refreshKey}
           type={type}
         />
@@ -170,6 +173,8 @@ export interface FilePreviewProps {
   header?: ReactNode
   refreshKey?: number
   type?: FilePreviewType
+  /** See {@link FilePreviewPluginProps.onSelectionReference}; forwarded to the active plugin as-is. */
+  onSelectionReference?: FilePreviewPluginProps['onSelectionReference']
 }
 
 interface NormalizedFilePreviewTarget {
@@ -189,7 +194,13 @@ type FilePreviewResolution =
       status: 'ready'
     }
 
-export function FilePreview({ filePath, header, refreshKey = 0, type = 'file' }: FilePreviewProps) {
+export function FilePreview({
+  filePath,
+  header,
+  refreshKey = 0,
+  type = 'file',
+  onSelectionReference
+}: FilePreviewProps) {
   const file = useMemo(() => {
     try {
       const normalizedPath = normalizeFilePreviewPath(filePath)
@@ -259,6 +270,7 @@ export function FilePreview({ filePath, header, refreshKey = 0, type = 'file' }:
       <FilePreviewPluginRenderer
         {...resolution.file}
         metadata={resolution.metadata}
+        onSelectionReference={onSelectionReference}
         plugin={resolution.plugin}
         refreshKey={refreshKey}
         type={type}

--- a/src/renderer/components/FilePreview/README.md
+++ b/src/renderer/components/FilePreview/README.md
@@ -168,8 +168,8 @@ export const filePreviewRegistry = createFilePreviewRegistry({
 
 ## Composition Rules
 
-Keep the public `FilePreview` props minimal: `filePath`, optional `header`, optional `refreshKey`, and optional `type`.
-Follow these boundaries when adding formats or capabilities:
+Keep the public `FilePreview` props minimal: `filePath`, optional `header`, optional `refreshKey`, optional `type`, and
+optional `onSelectionReference`. Follow these boundaries when adding formats or capabilities:
 
 - Express format differences as independent plugins. Do not add booleans such as `isPdf` or `isImage` to `FilePreview`.
 - The plugin owns its loading state, view state, and actions. Its toolbar receives only the state and callbacks required for rendering.
@@ -185,6 +185,19 @@ Follow these boundaries when adding formats or capabilities:
   centered in its own row for Tab and standalone previews.
 
 This composition lets the same plugin work in embedded and tab hosts without format-specific branches.
+
+## Selection References
+
+`onSelectionReference` is an optional pass-through channel for reporting the user's selection as a
+`SelectionReference` (`@renderer/types/selectionReference`) — an anchor into the document's own structural
+coordinates (worksheet range, paragraph ordinal, page number), never DOM or pixel coordinates.
+
+- A plugin that owns a view → structure inverse mapping calls the callback with the current reference, and with
+  `null` when the selection clears. Plugins without such a mapping ignore the prop entirely.
+- The host forwards the callback verbatim. What to do with a reference (show an action, inject it into a
+  conversation) is the embedding surface's concern; neither the host nor the plugin renders reference UI.
+- Producers must fill `excerpt` (plain-text snapshot) and `fileStamp` (size + mtime at capture); consumers reject
+  stale references via `isSelectionReferenceStale` instead of silently re-anchoring.
 
 ## File I/O, States, and Errors
 

--- a/src/renderer/components/FilePreview/__tests__/FilePreview.test.tsx
+++ b/src/renderer/components/FilePreview/__tests__/FilePreview.test.tsx
@@ -58,9 +58,15 @@ vi.mock('../plugins/text/textFilePreviewPlugin', () => ({
     id: 'text',
     extensions: [],
     load: async () => ({
-      default: () => {
+      default: ({ onSelectionReference }: { onSelectionReference?: (reference: unknown) => void }) => {
         mocks.textPreview()
-        return <div data-testid="text-file-preview" />
+        return (
+          <div data-testid="text-file-preview">
+            <button type="button" onClick={() => onSelectionReference?.(SELECTION_REFERENCE_FIXTURE)}>
+              report-selection
+            </button>
+          </div>
+        )
       }
     })
   }
@@ -71,6 +77,13 @@ vi.mock('react-i18next', () => ({
 }))
 
 import { FilePreview } from '../FilePreview'
+
+const SELECTION_REFERENCE_FIXTURE = {
+  path: '/tmp/notes.txt',
+  anchor: { format: 'docx', paragraph: 0 },
+  excerpt: 'hello',
+  fileStamp: { size: 1, mtimeMs: 1 }
+}
 
 afterEach(() => {
   cleanup()
@@ -156,5 +169,23 @@ describe('FilePreview', () => {
 
     expect(await screen.findByTestId('text-file-preview')).toBeInTheDocument()
     expect(mocks.textPreview).toHaveBeenCalledTimes(1)
+  })
+
+  it('forwards plugin selection references to the host callback verbatim', async () => {
+    mocks.ipcApiRequest.mockResolvedValueOnce({
+      kind: 'file',
+      type: 'text',
+      size: 1,
+      createdAt: 1,
+      modifiedAt: 1,
+      mime: 'text/plain'
+    })
+    const onSelectionReference = vi.fn()
+
+    render(<FilePreview filePath={'/tmp/notes.txt' as AbsoluteFilePath} onSelectionReference={onSelectionReference} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'report-selection' }))
+
+    expect(onSelectionReference).toHaveBeenCalledWith(SELECTION_REFERENCE_FIXTURE)
   })
 })

--- a/src/renderer/components/FilePreview/types.ts
+++ b/src/renderer/components/FilePreview/types.ts
@@ -1,3 +1,4 @@
+import type { SelectionReference } from '@renderer/types/selectionReference'
 import type { AbsoluteFilePath, PhysicalFileMetadata } from '@shared/types/file'
 import type { ComponentType } from 'react'
 
@@ -10,6 +11,14 @@ export interface FilePreviewPluginProps {
   metadata: FilePreviewFileMetadata
   refreshKey: number
   type?: FilePreviewType
+  /**
+   * Reports the user's current selection as a structural document anchor
+   * (`null` when the selection is cleared). Plugins that own a view → structure
+   * inverse mapping call this; plugins without one simply ignore the prop.
+   * The host forwards it verbatim — presentation of the reference is the
+   * embedding surface's concern, never the plugin's.
+   */
+  onSelectionReference?: (reference: SelectionReference | null) => void
 }
 
 export interface FilePreviewPlugin {

--- a/src/renderer/types/__tests__/selectionReference.test.ts
+++ b/src/renderer/types/__tests__/selectionReference.test.ts
@@ -31,6 +31,17 @@ describe('SelectionReferenceSchema', () => {
         anchor: { format: 'pdf', page: 3 }
       })
     ).not.toBeNull()
+    expect(
+      parseSelectionReference({
+        ...validReference,
+        path: '/workspace/deck.pptx',
+        anchor: { format: 'pptx', slide: 2, nodeId: '4', tableCell: { row: 1, col: 0 } }
+      })
+    ).not.toBeNull()
+  })
+
+  it('rejects a zero-based slide number that would address the wrong slide', () => {
+    expect(parseSelectionReference({ ...validReference, anchor: { format: 'pptx', slide: 0, nodeId: '4' } })).toBeNull()
   })
 
   it('rejects malformed A1 ranges before they can mis-address an extraction', () => {

--- a/src/renderer/types/__tests__/selectionReference.test.ts
+++ b/src/renderer/types/__tests__/selectionReference.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isSelectionReferenceStale,
+  parseSelectionReference,
+  SELECTION_EXCERPT_MAX_LENGTH,
+  type SelectionReference
+} from '../selectionReference'
+
+const validReference = {
+  path: '/workspace/report.xlsx',
+  anchor: { format: 'xlsx', sheet: 'Sheet1', range: 'A1:C10' },
+  excerpt: 'Q1 revenue table',
+  fileStamp: { size: 1024, mtimeMs: 1_700_000_000_000 }
+}
+
+describe('SelectionReferenceSchema', () => {
+  it('accepts each anchor format a producer can emit', () => {
+    expect(parseSelectionReference(validReference)).not.toBeNull()
+    expect(
+      parseSelectionReference({
+        ...validReference,
+        path: '/workspace/spec.docx',
+        anchor: { format: 'docx', paragraph: 0, charRange: [0, 12] }
+      })
+    ).not.toBeNull()
+    expect(
+      parseSelectionReference({
+        ...validReference,
+        path: '/workspace/paper.pdf',
+        anchor: { format: 'pdf', page: 3 }
+      })
+    ).not.toBeNull()
+  })
+
+  it('rejects malformed A1 ranges before they can mis-address an extraction', () => {
+    for (const range of ['a1:c10', '1A', 'A0', 'A1:', 'A1:C10:D2', '']) {
+      expect(parseSelectionReference({ ...validReference, anchor: { format: 'xlsx', sheet: 'S', range } })).toBeNull()
+    }
+  })
+
+  it('rejects an inverted charRange that would slice the wrong text', () => {
+    expect(
+      parseSelectionReference({
+        ...validReference,
+        anchor: { format: 'docx', paragraph: 2, charRange: [10, 4] }
+      })
+    ).toBeNull()
+  })
+
+  it('rejects non-absolute paths that skill scripts could not resolve', () => {
+    expect(parseSelectionReference({ ...validReference, path: 'report.xlsx' })).toBeNull()
+  })
+
+  it('caps the excerpt so a reference cannot bloat the message', () => {
+    expect(
+      parseSelectionReference({ ...validReference, excerpt: 'x'.repeat(SELECTION_EXCERPT_MAX_LENGTH + 1) })
+    ).toBeNull()
+  })
+
+  it('returns null instead of throwing on arbitrary junk', () => {
+    expect(parseSelectionReference(undefined)).toBeNull()
+    expect(parseSelectionReference('{}')).toBeNull()
+    expect(parseSelectionReference({ anchor: { format: 'xlsx' } })).toBeNull()
+  })
+})
+
+describe('isSelectionReferenceStale', () => {
+  const reference = parseSelectionReference(validReference) as SelectionReference
+
+  it('flags a changed file so a stale anchor is never silently re-used', () => {
+    expect(isSelectionReferenceStale(reference, { size: 1024, mtimeMs: 1_700_000_000_001 })).toBe(true)
+    expect(isSelectionReferenceStale(reference, { size: 2048, mtimeMs: 1_700_000_000_000 })).toBe(true)
+  })
+
+  it('accepts an unchanged file', () => {
+    expect(isSelectionReferenceStale(reference, { size: 1024, mtimeMs: 1_700_000_000_000 })).toBe(false)
+  })
+})

--- a/src/renderer/types/selectionReference.ts
+++ b/src/renderer/types/selectionReference.ts
@@ -40,11 +40,28 @@ const PdfAnchorSchema = z.object({
   charRange: CharRangeSchema.optional()
 })
 
-// pptx joins this union when its selection producer lands (slide + shape id).
+const PptxAnchorSchema = z.object({
+  format: z.literal('pptx'),
+  /** One-based slide number, matching the deck's own slide numbering. */
+  slide: z.number().int().positive(),
+  /** OOXML shape id (`p:cNvPr` id) as exposed by the renderer's model/text index. Absent = whole slide. */
+  nodeId: z.string().min(1).optional(),
+  /** Zero-based paragraph within the shape's text body. */
+  paragraph: z.number().int().nonnegative().optional(),
+  /** Zero-based table coordinates when the node is a table. */
+  tableCell: z
+    .object({
+      row: z.number().int().nonnegative(),
+      col: z.number().int().nonnegative()
+    })
+    .optional()
+})
+
 export const DocumentAnchorSchema = z.discriminatedUnion('format', [
   XlsxAnchorSchema,
   DocxAnchorSchema,
-  PdfAnchorSchema
+  PdfAnchorSchema,
+  PptxAnchorSchema
 ])
 
 export type DocumentAnchor = z.infer<typeof DocumentAnchorSchema>

--- a/src/renderer/types/selectionReference.ts
+++ b/src/renderer/types/selectionReference.ts
@@ -1,0 +1,86 @@
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import * as z from 'zod'
+
+/**
+ * Structured references from a document preview selection to the document's
+ * own structural coordinates (OOXML / PDF native addressing — never DOM or
+ * pixel coordinates, which drift with the rendering implementation).
+ *
+ * Producers are FilePreview plugins (each owns the view → structure inverse
+ * mapping for its format). The reference travels as message text, so its only
+ * runtime consumers are LLMs and skill scripts that parse the JSON back.
+ */
+
+/** Single cell (`B2`) or rectangular range (`A1:C10`) in A1 notation. */
+const XLSX_A1_RANGE_REGEX = /^[A-Z]{1,3}[1-9][0-9]*(?::[A-Z]{1,3}[1-9][0-9]*)?$/
+
+/** `[start, end)` character offsets within the anchored unit's plain text. */
+const CharRangeSchema = z
+  .tuple([z.number().int().nonnegative(), z.number().int().nonnegative()])
+  .refine(([start, end]) => start <= end, { message: 'charRange start must not exceed end' })
+
+const XlsxAnchorSchema = z.object({
+  format: z.literal('xlsx'),
+  /** Worksheet name exactly as stored in the workbook. */
+  sheet: z.string().min(1),
+  range: z.string().regex(XLSX_A1_RANGE_REGEX, 'range must be A1 notation, e.g. "B2" or "A1:C10"')
+})
+
+const DocxAnchorSchema = z.object({
+  format: z.literal('docx'),
+  /** Zero-based ordinal of the `w:p` element in document.xml body order. */
+  paragraph: z.number().int().nonnegative(),
+  charRange: CharRangeSchema.optional()
+})
+
+const PdfAnchorSchema = z.object({
+  format: z.literal('pdf'),
+  /** One-based page number, matching the PDF's own page numbering. */
+  page: z.number().int().positive(),
+  charRange: CharRangeSchema.optional()
+})
+
+// pptx joins this union when its selection producer lands (slide + shape id).
+export const DocumentAnchorSchema = z.discriminatedUnion('format', [
+  XlsxAnchorSchema,
+  DocxAnchorSchema,
+  PdfAnchorSchema
+])
+
+export type DocumentAnchor = z.infer<typeof DocumentAnchorSchema>
+
+/** Snapshot of the source file's identity at capture time, checked before use. */
+const SelectionFileStampSchema = z.object({
+  size: z.number().int().nonnegative(),
+  mtimeMs: z.number().nonnegative()
+})
+
+export type SelectionFileStamp = z.infer<typeof SelectionFileStampSchema>
+
+export const SELECTION_EXCERPT_MAX_LENGTH = 2000
+
+export const SelectionReferenceSchema = z.object({
+  path: AbsoluteFilePathSchema,
+  anchor: DocumentAnchorSchema,
+  /** Plain-text snapshot of the selection so consumers can read intent without opening the file. */
+  excerpt: z.string().max(SELECTION_EXCERPT_MAX_LENGTH),
+  fileStamp: SelectionFileStampSchema
+})
+
+export type SelectionReference = z.infer<typeof SelectionReferenceSchema>
+
+/** Fence language tag identifying a serialized reference inside message text. */
+export const SELECTION_REFERENCE_FENCE = 'selection-ref'
+
+export function parseSelectionReference(value: unknown): SelectionReference | null {
+  const parsed = SelectionReferenceSchema.safeParse(value)
+  return parsed.success ? parsed.data : null
+}
+
+/**
+ * A reference is stale when the file changed after capture. Stale references
+ * must be re-captured, never silently re-anchored — offsets may have moved.
+ */
+export function isSelectionReferenceStale(reference: SelectionReference, current: SelectionFileStamp): boolean {
+  return reference.fileStamp.size !== current.size || reference.fileStamp.mtimeMs !== current.mtimeMs
+}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

There was no way to reference *part* of an Office/PDF document precisely: previews were view-only, and an agent asked to work on "that range / that paragraph / that shape" had to guess from prose. Deriving an edited copy of an Office file meant a full parse → re-serialize round-trip, which silently drops content the parsing library does not understand (openpyxl loses charts, drawings, and pivot tables).

After this PR:

Foundation (Phase 0) for structural document selections, in three independent pieces:

- **`SelectionReference` schema** (`src/renderer/types/selectionReference.ts`): a zod-validated anchor into the document's own structural coordinates — xlsx worksheet + A1 range, docx body-level paragraph ordinal (+ optional char range), pdf page (+ optional char range), pptx one-based slide + optional OOXML shape id / paragraph / table cell. Each reference carries an `excerpt` snapshot and a `fileStamp` (size + mtime); consumers must reject stale references via `isSelectionReferenceStale` instead of silently re-anchoring. Anchors never use DOM or pixel coordinates.
- **FilePreview pass-through contract**: an optional `onSelectionReference` callback on `FilePreview` and `FilePreviewPluginProps`. A plugin that owns a view→structure inverse mapping reports the current reference (`null` on clear); the host forwards it verbatim; the embedding surface decides presentation. Plugins without a mapping ignore the prop. Documented in the FilePreview README.
- **`office-transform` bundled skill** (`resources/skills/office-transform/`, distributed via the existing `installBuiltinSkills()` mechanism): derives NEW files from anchored regions without ever modifying the original. `office_extract.py` (openpyxl / python-docx / pypdf / python-pptx via `uv run --with`) extracts a range/paragraph/page/shape to csv/md/txt/xlsx/docx/pdf. `office_patch_copy.py` (stdlib only) produces an edited copy of an xlsx/docx by copying the ZIP package and re-serializing only the touched XML part, keeping every other part byte-identical. pptx edits are routed through python-pptx (lxml in-place, round-trip safe) saved to a new path; free-form generation is directed to ad-hoc library code under the skill's invariants.

The pptx anchor shape was validated against `@aiden0z/pptx-renderer`: its text index (`TextIndexEntry`) exposes `slideIndex`/`nodeId`/`paragraphIndex`/`rowIndex`/`cellIndex`, and its `nodeId` and python-pptx's `shape_id` both resolve the same `p:cNvPr/@id`, so future UI producers and the skill consumer share one coordinate system.

Fixes #

### Why we need it and why it was done in this way

This is the shared foundation for selection-driven Office workflows (select a range in a preview → hand a precise, stale-checkable reference to the model → get a derived file back). The skill is useful on its own today — users can describe regions in words — while the schema and FilePreview contract let per-format selection UI land later without reshaping anything.

The following tradeoffs were made:

- Derive-new-file instead of in-place editing: byte-copying the package and rewriting only the touched part confines fidelity risk to that part; in-place round-trip editing was rejected as unsafe for xlsx.
- The FilePreview contract is pure plumbing (no UI, no state) so it cannot conflict with in-flight preview work (#16712's Shell changes were deliberately not touched).
- Anchors enter the schema union only with a validated producer/consumer shape (pptx joined after verifying the renderer's model), rather than speculatively.
- `office_patch_copy.py` is stdlib-only so the highest-risk operation has zero dependency surface; extraction uses per-format readers provided at invocation time via `uv run --with`.

The following alternatives were considered:

- Editing via library round-trip for all formats — rejected: openpyxl drops parts it cannot parse. python-pptx/python-docx preserve unknown XML, so pptx edits do use the library (saved to a new path).
- DOM/pixel-based selection anchors — rejected: they drift with the rendering implementation; structural coordinates are stable across renderer changes.
- Embedding an editing-oriented engine (Univer etc.) — rejected for the same reasons as in #16712's review: far too heavy for read + derive.

Links to places where the discussion took place: None

### Breaking changes

None. The FilePreview prop is optional and ignored by all existing plugins; the schema is new; the skill is additive.

### Special notes for your reviewer

- Suggested review order: `selectionReference.ts` (the protocol) → FilePreview `types.ts`/`FilePreview.tsx`/README (the contract) → `resources/skills/office-transform/` (the consumer).
- The skill scripts were exercised end-to-end on generated sample files: xlsx extract (csv/md/xlsx), docx paragraph extract with charRange, pptx slide/shape/paragraph/table-cell extract (incl. CJK text), xlsx patch-copy (numbers/strings/booleans/created cells) and docx paragraph replacement — with a zip-level assertion that all untouched parts stayed byte-identical, and a python-pptx edit round-trip keeping untouched tables intact.
- Full-suite status: lint, format, and docs:check-links pass. `pnpm test` has 4 pre-existing environment failures in this container (root user defeats the unlink-denial fixture in `orphanSweep.test.ts`; ICU locale metadata differences fail `UsageHeatmap`/`UsageSettings`/`time` tests) — verified identical on a clean tree with these changes stashed. All new and touched test files pass (9 schema tests, 8 FilePreview tests).
- `pnpm install` in the dev container needs `libxtst-dev`/`libevdev-dev` system headers for `selection-hook` (unrelated to this PR, noting for anyone reproducing).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Add the office-transform built-in agent skill: agents can extract worksheet ranges, document paragraphs, PDF pages, and slide shapes into new files, and derive edited copies of xlsx/docx/pptx documents — the original file is never modified.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhYFcipo1ZfExDtuVAa5WV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhYFcipo1ZfExDtuVAa5WV)_