### PR TITLE
fix(knowledge): reject relative paths that escape the material root on the host

### DIFF
--- a/src/main/features/knowledge/__tests__/pathStorage.win32.test.ts
+++ b/src/main/features/knowledge/__tests__/pathStorage.win32.test.ts
@@ -1,0 +1,57 @@
+// The material-root containment guard under Windows path semantics. It cannot be covered
+// on a POSIX runner: once `assertSafeKnowledgeRelativePath` has read a value as POSIX,
+// nothing can still escape when POSIX also does the joining. The gap only opens when the
+// two readings disagree, so this file swaps `node:path` for `path.win32`.
+import type * as NodePath from 'node:path'
+import nodePath from 'node:path'
+
+import type { PosixRelativeFilePath } from '@shared/utils/file'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof NodePath>('node:path')
+  return { ...actual.win32, default: actual.win32 }
+})
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  const mocked = mockApplicationFactory()
+  mocked.application.getPath = vi.fn((key: string) => `C:\\Users\\me\\Data\\${key}`)
+  return mocked
+})
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }) }
+}))
+
+const brand = (value: string) => value as PosixRelativeFilePath
+
+describe('getKnowledgeBaseFilePath on a Windows host', () => {
+  it.each([
+    ['a climb out of raw/', '..\\outside.pdf'],
+    ['a climb past the base dir', '..\\..\\..\\evil.pdf'],
+    ['a climb reached after descending', 'a\\..\\..\\x.pdf'],
+    ['a value resolving back onto the material root', 'a\\..']
+  ])('rejects %s, which POSIX reads as one ordinary filename', async (_label, value) => {
+    // Read as POSIX these are single legal filenames containing a backslash, so the
+    // storage contract accepts them and only the host-side guard can stop them.
+    const { KnowledgeRelativePathSchema } = await import('@shared/data/types/knowledge')
+    expect(KnowledgeRelativePathSchema.safeParse(value).success).toBe(true)
+
+    const { getKnowledgeBaseFilePath } = await import('../pathStorage')
+    expect(() => getKnowledgeBaseFilePath('b1', brand(value))).toThrow(/escapes the material root/)
+  })
+
+  it.each([
+    ['a plain name', 'report.pdf'],
+    ['a nested path', 'docs/sub/a.pdf'],
+    ['a backslash name that Windows reads as a subdirectory but does not escape', 'a\\b.pdf'],
+    ['an interior climb that stays inside', 'a\\b\\..\\c.pdf']
+  ])('still resolves %s', async (_label, value) => {
+    const { getKnowledgeBaseFilePath } = await import('../pathStorage')
+    const resolved = getKnowledgeBaseFilePath('b1', brand(value))
+    expect(
+      resolved.startsWith(`${nodePath.win32.join('C:\\Users\\me\\Data\\feature.knowledgebase.data', 'b1')}\\raw\\`)
+    ).toBe(true)
+  })
+})

--- a/src/main/features/knowledge/pathStorage.ts
+++ b/src/main/features/knowledge/pathStorage.ts
@@ -69,7 +69,26 @@ export function getKnowledgeVectorStoreFilePathSync(baseId: string): AbsoluteFil
 
 export function getKnowledgeBaseFilePath(baseId: string, relativePath: string): AbsoluteFilePath {
   assertSafeKnowledgeRelativePath(relativePath)
-  return AbsoluteFilePathSchema.parse(path.join(getKnowledgeMaterialDir(baseId), relativePath))
+
+  const materialDir = getKnowledgeMaterialDir(baseId)
+  const resolved = path.join(materialDir, relativePath)
+  assertResolvesBelow(materialDir, resolved, relativePath)
+  return AbsoluteFilePathSchema.parse(resolved)
+}
+
+/**
+ * Host-side half of the boundary guard: `assertSafeKnowledgeRelativePath` reads the value as
+ * POSIX (the storage contract), `path.join` reads it as the host, and the two disagree about
+ * `\` — so a legitimately stored `..\outside.pdf` climbs out of `raw/` on Windows, taking
+ * `deleteKnowledgeItemFiles` with it.
+ */
+function assertResolvesBelow(materialDir: string, resolved: string, relativePath: string): void {
+  const rel = path.relative(materialDir, resolved)
+  // `''` means it landed back on the root — returning that as one item's file would let a
+  // single-item delete take the whole tree.
+  if (rel === '' || rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    throw new Error(`Knowledge relative path escapes the material root on this platform: ${relativePath}`)
+  }
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR:

`getKnowledgeBaseFilePath` validated a stored `relativePath` with `assertSafeKnowledgeRelativePath` — which reads it as POSIX — and then handed it straight to `path.join`, which reads it as the **host**. The two readings disagree about `\`, so a value that is one ordinary, legitimately stored filename on Linux (`..\outside.pdf`) resolves *outside* `raw/` when the same base is opened on Windows. `..\..\..\evil.pdf` reaches the userData `Data/` directory. Because `deleteKnowledgeItemFiles` resolves through the same helper, that is a delete outside the base, not merely a read.

After this PR:

The join result is checked against the material root using the platform actually running, so whatever string is about to be handed to `fs` is the string that gets verified. A path that climbs out — or that lands back **on** the root (`a\..`, where `path.relative` returns `''`) — throws instead of resolving.

Fixes #

### Why we need it and why it was done in this way

This is a regression introduced by #18230. The guard that preceded the `RelativeFilePath` refactor folded `\` to `/` before checking, and that fold happened to catch these values; the refactor replaced it with a POSIX-only reading and dropped the fold. It is fixed here rather than in #18230 because the containment rule is the knowledge layer's business rule, and #18230 was scoped to the type refactor. This was promised to the reviewer of #18230.

The following tradeoffs were made:

- **Check the join result, not the input string.** A second, Windows-flavoured reading could have been added to `KnowledgeRelativePathSchema`, but that only covers the divergences known today. Verifying what `path.join` actually produced stays correct for any future divergence between the two readings.
- **Throw rather than sanitize.** These values reach the helper already branded and already accepted by the storage contract; silently rewriting one would change which file an existing item points at. Callers that must not abort already route through `deleteKnowledgeItemFilesBestEffort`, which logs and swallows.
- **Keep the POSIX reading as the storage contract.** `relativePath` stays POSIX-shaped in the database; this guard is purely about what happens at the `fs` boundary, so nothing stored changes.

The following alternatives were considered:

- Restoring the old `\` → `/` fold. Rejected: it silently reinterprets a path the storage layer considers a single valid filename, so the item would read from a different file rather than report a problem.
- Widening `assertSafeKnowledgeRelativePath` to reject any `\`. Rejected as a separate concern — that is a question about what may be *stored* (see #18272), not about resolving what already is.

Links to places where the discussion took place: review thread on #18230

### Breaking changes

None. No stored value changes shape, and no path that resolved inside the material root before now throws.

### Special notes for your reviewer

The new test file swaps `node:path` for `path.win32` to stand in for a Windows host. This cannot be covered on a POSIX runner: once `assertSafeKnowledgeRelativePath` has read a value as POSIX, nothing can still escape when POSIX also does the joining — the gap only exists where the two readings disagree.

The four reject cases were confirmed to fail without the fix and the four accept cases to pass with and without it, so the test is not vacuous.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
