### PR TITLE
fix(quick-assistant): reuse shared virtualized message list

### DIFF
--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -2,7 +2,6 @@ import { useChat } from '@ai-sdk/react'
 import { Separator } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
-import { toMessageListItem } from '@renderer/components/chat/messages/utils/messageListItem'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useExecutionOverlay } from '@renderer/hooks/useExecutionOverlay'
 import { useDefaultModel } from '@renderer/hooks/useModel'
@@ -33,7 +32,7 @@ import InputBar from './components/InputBar'
 // rendering chain (ChatMarkdown, CodeMirror, katex, mermaid). The default
 // 'home' route never renders them, so they stay out of the first paint and
 // only load when a feature is actually invoked.
-const ChatWindow = React.lazy(() => import('../chat/ChatWindow'))
+const QuickAssistantMessageList = React.lazy(() => import('./QuickAssistantMessageList'))
 const TranslateWindow = React.lazy(() => import('../translate/TranslateWindow'))
 
 // Size-stable fallback: the shell (input bar / footer) renders synchronously
@@ -55,9 +54,8 @@ type MiniRoute = 'home' | 'chat' | 'translate' | 'summary' | 'explanation'
  */
 const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] => {
   return messages.map((msg) => {
-    if (!msg.parts) return msg
     let changed = false
-    const newParts = msg.parts.map((part) => {
+    const newParts = msg.parts?.map((part) => {
       if (part.type !== 'reasoning' || part.state !== 'streaming') return part
       const cherry = readCherryMeta(part)
       const startedAt = cherry?.startedAt
@@ -71,7 +69,14 @@ const finalizeLiveMessages = (messages: CherryUIMessage[]): CherryUIMessage[] =>
       changed = true
       return withCherryMeta({ ...part, state: 'done' }, patch)
     })
-    return changed ? { ...msg, parts: newParts } : msg
+    const statusChanged = msg.metadata?.status !== 'success'
+    if (!changed && !statusChanged) return msg
+
+    return {
+      ...msg,
+      ...(newParts ? { parts: newParts } : {}),
+      metadata: { ...msg.metadata, status: 'success' }
+    }
   })
 }
 
@@ -176,13 +181,29 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
     [completedAssistants, liveAssistants]
   )
 
-  const partsByMessageId = useMemo<Record<string, CherryMessagePart[]>>(() => {
+  const historyPartsByMessageId = useMemo<Record<string, CherryMessagePart[]>>(() => {
     const next: Record<string, CherryMessagePart[]> = {}
-    for (const message of [...chatMessages, ...allAssistants]) {
+    for (const message of [...chatMessages, ...completedAssistants]) {
       next[message.id] = (message.parts ?? []) as CherryMessagePart[]
     }
     return next
-  }, [allAssistants, chatMessages])
+  }, [chatMessages, completedAssistants])
+
+  const partsByMessageId = useMemo<Record<string, CherryMessagePart[]>>(() => {
+    const next = { ...historyPartsByMessageId }
+    for (const message of liveAssistants) {
+      next[message.id] = (message.parts ?? []) as CherryMessagePart[]
+    }
+    return next
+  }, [historyPartsByMessageId, liveAssistants])
+
+  const streamingLayers = useMemo(
+    () => ({
+      historyPartsByMessageId,
+      liveMessageIds: liveAssistants.map((message) => message.id)
+    }),
+    [historyPartsByMessageId, liveAssistants]
+  )
 
   // Interleave user messages (from state.messages) with assistant turns
   // (accumulated completed + live). The assumption: users and assistants
@@ -200,28 +221,12 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
       }
       const a = allAssistants[i]
       if (a) {
-        out.push({
-          ...a,
-          metadata: {
-            ...a.metadata,
-            status: a.id === latestAssistantId && isPending ? 'pending' : 'success'
-          }
-        })
+        const status = a.id === latestAssistantId && isPending ? 'pending' : 'success'
+        out.push(a.metadata?.status === status ? a : { ...a, metadata: { ...a.metadata, status } })
       }
     }
     return out
   }, [chatMessages, allAssistants, liveAssistants, isPending])
-
-  const messageItems = useMemo(
-    () =>
-      displayMessages.map((message) =>
-        toMessageListItem(message, {
-          assistantId: currentAssistant?.id,
-          topicId: temporaryTopicId ?? ''
-        })
-      ),
-    [currentAssistant?.id, displayMessages, temporaryTopicId]
-  )
 
   const latestAssistantUIMsg = useMemo(() => allAssistants[allAssistants.length - 1], [allAssistants])
 
@@ -242,7 +247,7 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
   }, [stopChat, setMessages, clearExecutionMessages])
 
   const isLoading = isPreparing || isStreaming
-  const isOutputted = messageItems.some((message) => message.role === 'assistant')
+  const isOutputted = displayMessages.some((message) => message.role === 'assistant')
 
   useEffect(() => {
     if (route === 'home') {
@@ -446,12 +451,14 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
             </div>
           )}
           <Suspense fallback={<LazyBranchFallback />}>
-            <ChatWindow
+            <QuickAssistantMessageList
               route={route}
+              topicId={temporaryTopicId ?? 'pending-temp'}
               assistant={currentAssistant ?? null}
               isOutputted={isOutputted}
-              messages={messageItems}
+              messages={displayMessages}
               partsByMessageId={partsByMessageId}
+              streamingLayers={streamingLayers}
             />
           </Suspense>
           {flowError && (

--- a/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
+++ b/src/renderer/windows/quickAssistant/home/HomeWindow.tsx
@@ -455,6 +455,7 @@ const HomeWindow: FC<{ draggable?: boolean }> = ({ draggable = true }) => {
               route={route}
               topicId={temporaryTopicId ?? 'pending-temp'}
               assistant={currentAssistant ?? null}
+              model={currentModel}
               isOutputted={isOutputted}
               messages={displayMessages}
               partsByMessageId={partsByMessageId}

--- a/src/renderer/windows/quickAssistant/home/QuickAssistantMessageList.tsx
+++ b/src/renderer/windows/quickAssistant/home/QuickAssistantMessageList.tsx
@@ -14,6 +14,7 @@ import { toMessageListItem } from '@renderer/components/chat/messages/utils/mess
 import type { Assistant } from '@renderer/types/assistant'
 import type { Topic } from '@renderer/types/topic'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import { Loader2 } from 'lucide-react'
 import { useMemo, useRef } from 'react'
 
@@ -23,6 +24,7 @@ interface QuickAssistantMessageListProps {
   route: 'chat' | 'summary' | 'explanation'
   topicId: string
   assistant: Assistant | null
+  model?: Model
   isOutputted: boolean
   messages: CherryUIMessage[]
   partsByMessageId: Record<string, CherryMessagePart[]>
@@ -33,6 +35,7 @@ function useQuickAssistantMessageListProviderValue({
   route,
   topicId,
   assistant,
+  model,
   messages,
   partsByMessageId,
   streamingLayers
@@ -41,22 +44,54 @@ function useQuickAssistantMessageListProviderValue({
   const platformActions = useMessagePlatformActions()
   const visibleMessages = useMemo(() => (route === 'chat' ? messages : messages.slice(1)), [messages, route])
   const messageItemCacheRef = useRef(
-    new WeakMap<CherryUIMessage, { assistantId?: string; item: MessageListItem; topicId: string }>()
+    new WeakMap<CherryUIMessage, { assistantId?: string; item: MessageListItem; modelId?: string; topicId: string }>()
   )
+  const createdAtCacheRef = useRef({ topicId, byMessageId: new Map<string, string>() })
+  if (createdAtCacheRef.current.topicId !== topicId) {
+    createdAtCacheRef.current = { topicId, byMessageId: new Map() }
+  }
+  const fallbackModel = useMemo(() => {
+    if (!model) return undefined
+    const { modelId } = parseUniqueModelId(model.id)
+    return {
+      id: model.apiModelId ?? modelId,
+      name: model.name,
+      provider: model.providerId,
+      group: model.group
+    }
+  }, [model])
 
   const messageItems = useMemo(
     () =>
       visibleMessages.map((message) => {
         const cached = messageItemCacheRef.current.get(message)
-        if (cached && cached.assistantId === assistant?.id && cached.topicId === topicId) {
+        if (
+          cached &&
+          cached.assistantId === assistant?.id &&
+          cached.modelId === model?.id &&
+          cached.topicId === topicId
+        ) {
           return cached.item
         }
 
-        const item = toMessageListItem(message, { assistantId: assistant?.id, topicId })
-        messageItemCacheRef.current.set(message, { assistantId: assistant?.id, item, topicId })
+        const baseItem = toMessageListItem(message, { assistantId: assistant?.id, topicId })
+        let createdAt = baseItem.createdAt || createdAtCacheRef.current.byMessageId.get(message.id)
+        if (!createdAt) {
+          createdAt = new Date().toISOString()
+          createdAtCacheRef.current.byMessageId.set(message.id, createdAt)
+        }
+        const item = {
+          ...baseItem,
+          createdAt,
+          ...(message.role === 'assistant' && {
+            modelId: baseItem.modelId ?? model?.id,
+            model: baseItem.model ?? fallbackModel
+          })
+        }
+        messageItemCacheRef.current.set(message, { assistantId: assistant?.id, item, modelId: model?.id, topicId })
         return item
       }),
-    [assistant?.id, topicId, visibleMessages]
+    [assistant?.id, fallbackModel, model?.id, topicId, visibleMessages]
   )
 
   const topic = useMemo<Topic>(

--- a/src/renderer/windows/quickAssistant/home/QuickAssistantMessageList.tsx
+++ b/src/renderer/windows/quickAssistant/home/QuickAssistantMessageList.tsx
@@ -1,0 +1,115 @@
+import { useMessageListRenderConfig } from '@renderer/components/chat/messages/hooks/useMessageListRenderConfig'
+import { useMessagePlatformActions } from '@renderer/components/chat/messages/hooks/useMessagePlatformActions'
+import MessageList from '@renderer/components/chat/messages/MessageList'
+import { MessageListProvider } from '@renderer/components/chat/messages/MessageListProvider'
+import {
+  DEFAULT_MESSAGE_LIST_CONFIG,
+  type MessageListItem,
+  type MessageListMeta,
+  type MessageListProviderValue,
+  type MessageListState,
+  type MessageStreamingLayers
+} from '@renderer/components/chat/messages/types'
+import { toMessageListItem } from '@renderer/components/chat/messages/utils/messageListItem'
+import type { Assistant } from '@renderer/types/assistant'
+import type { Topic } from '@renderer/types/topic'
+import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { Loader2 } from 'lucide-react'
+import { useMemo, useRef } from 'react'
+
+const EMPTY_TOPIC_MESSAGES: Topic['messages'] = []
+
+interface QuickAssistantMessageListProps {
+  route: 'chat' | 'summary' | 'explanation'
+  topicId: string
+  assistant: Assistant | null
+  isOutputted: boolean
+  messages: CherryUIMessage[]
+  partsByMessageId: Record<string, CherryMessagePart[]>
+  streamingLayers: MessageStreamingLayers
+}
+
+function useQuickAssistantMessageListProviderValue({
+  route,
+  topicId,
+  assistant,
+  messages,
+  partsByMessageId,
+  streamingLayers
+}: Omit<QuickAssistantMessageListProps, 'isOutputted'>): MessageListProviderValue {
+  const { renderConfig } = useMessageListRenderConfig()
+  const platformActions = useMessagePlatformActions()
+  const visibleMessages = useMemo(() => (route === 'chat' ? messages : messages.slice(1)), [messages, route])
+  const messageItemCacheRef = useRef(
+    new WeakMap<CherryUIMessage, { assistantId?: string; item: MessageListItem; topicId: string }>()
+  )
+
+  const messageItems = useMemo(
+    () =>
+      visibleMessages.map((message) => {
+        const cached = messageItemCacheRef.current.get(message)
+        if (cached && cached.assistantId === assistant?.id && cached.topicId === topicId) {
+          return cached.item
+        }
+
+        const item = toMessageListItem(message, { assistantId: assistant?.id, topicId })
+        messageItemCacheRef.current.set(message, { assistantId: assistant?.id, item, topicId })
+        return item
+      }),
+    [assistant?.id, topicId, visibleMessages]
+  )
+
+  const topic = useMemo<Topic>(
+    () => ({
+      id: topicId,
+      assistantId: assistant?.id,
+      name: '',
+      createdAt: '',
+      updatedAt: '',
+      messages: EMPTY_TOPIC_MESSAGES
+    }),
+    [assistant?.id, topicId]
+  )
+
+  const state = useMemo<MessageListState>(
+    () => ({
+      topic,
+      messages: messageItems,
+      partsByMessageId,
+      streamingLayers,
+      messageNavigation: 'none',
+      listKey: topicId,
+      renderConfig,
+      ...DEFAULT_MESSAGE_LIST_CONFIG
+    }),
+    [messageItems, partsByMessageId, renderConfig, streamingLayers, topic, topicId]
+  )
+  const meta = useMemo<MessageListMeta>(
+    () => ({
+      selectionLayer: false,
+      assistantProfile: assistant ? { name: assistant.name, avatar: assistant.emoji } : undefined
+    }),
+    [assistant]
+  )
+
+  return useMemo(() => ({ state, actions: platformActions, meta }), [meta, platformActions, state])
+}
+
+const QuickAssistantMessageList = (props: QuickAssistantMessageListProps) => {
+  const value = useQuickAssistantMessageListProviderValue(props)
+
+  return (
+    <div className="bubble relative mb-auto flex min-h-0 w-full flex-1 [-webkit-app-region:no-drag]">
+      <MessageListProvider value={value}>
+        <MessageList />
+      </MessageListProvider>
+      {!props.isOutputted && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-5 flex justify-center">
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default QuickAssistantMessageList

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.lazy.test.ts
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.lazy.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, it, vi } from 'vitest'
 // concurrency can blow past the global testTimeout — pin a generous bound.
 const PROBE_TIMEOUT = 45_000
 
-const chatWindowEvaluated = vi.hoisted(() => vi.fn())
+const messageListEvaluated = vi.hoisted(() => vi.fn())
 const translateWindowEvaluated = vi.hoisted(() => vi.fn())
 
-vi.mock('../../chat/ChatWindow', () => {
-  chatWindowEvaluated()
+vi.mock('../QuickAssistantMessageList', () => {
+  messageListEvaluated()
   return { default: () => null }
 })
 
@@ -27,7 +27,7 @@ describe('HomeWindow lazy boundaries', () => {
     'importing HomeWindow does not evaluate the chat/translate branches',
     async () => {
       await import('../HomeWindow')
-      expect(chatWindowEvaluated).not.toHaveBeenCalled()
+      expect(messageListEvaluated).not.toHaveBeenCalled()
       expect(translateWindowEvaluated).not.toHaveBeenCalled()
     },
     PROBE_TIMEOUT
@@ -36,8 +36,8 @@ describe('HomeWindow lazy boundaries', () => {
   it(
     'positive control: the branch modules load on demand',
     async () => {
-      await import('../../chat/ChatWindow')
-      expect(chatWindowEvaluated).toHaveBeenCalledTimes(1)
+      await import('../QuickAssistantMessageList')
+      expect(messageListEvaluated).toHaveBeenCalledTimes(1)
     },
     PROBE_TIMEOUT
   )

--- a/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/HomeWindow.test.tsx
@@ -105,19 +105,35 @@ vi.mock('../components/InputBar', () => ({
   default: ({
     text,
     placeholder,
-    handleChange
+    handleChange,
+    handleKeyDown
   }: {
     text: string
     placeholder: string
     handleChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  }) => <input data-testid="quick-input" value={text} placeholder={placeholder} onChange={handleChange} />
+    handleKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void
+  }) => (
+    <input
+      data-testid="quick-input"
+      value={text}
+      placeholder={placeholder}
+      onChange={handleChange}
+      onKeyDown={handleKeyDown}
+    />
+  )
 }))
 
 vi.mock('../components/FeatureMenus', () => ({
   default: vi.fn(
-    ({ ref }: { ref?: React.RefObject<{ useFeature: () => void; resetSelectedIndex: () => void } | null> }) => {
+    ({
+      ref,
+      setRoute
+    }: {
+      ref?: React.RefObject<{ useFeature: () => void; resetSelectedIndex: () => void } | null>
+      setRoute: (route: 'chat') => void
+    }) => {
       if (ref) {
-        ref.current = { useFeature: vi.fn(), resetSelectedIndex: vi.fn() }
+        ref.current = { useFeature: () => setRoute('chat'), resetSelectedIndex: vi.fn() }
       }
       return <div data-testid="feature-menus" />
     }
@@ -133,8 +149,8 @@ vi.mock('../components/ClipboardPreview', () => ({
     clipboardText ? <div data-testid="clipboard-preview">{clipboardText}</div> : null
 }))
 
-vi.mock('../../chat/ChatWindow', () => ({
-  default: () => <div data-testid="chat-window" />
+vi.mock('../QuickAssistantMessageList', () => ({
+  default: () => <div data-testid="quick-assistant-message-list" />
 }))
 
 vi.mock('../../translate/TranslateWindow', () => ({
@@ -144,6 +160,9 @@ vi.mock('../../translate/TranslateWindow', () => ({
 describe('HomeWindow', () => {
   beforeEach(() => {
     state.quickAssistantId = ''
+    state.messages = []
+    state.activeExecutions = []
+    state.liveAssistants = []
     state.sendMessage.mockClear()
     state.stopChat.mockClear()
     state.setMessages.mockClear()
@@ -165,5 +184,20 @@ describe('HomeWindow', () => {
 
     expect(screen.getByTestId('quick-input')).toHaveValue('hello')
     expect(screen.queryByTestId('clipboard-preview')).not.toBeInTheDocument()
+  })
+
+  it('clears the shared message-list source when the temporary conversation resets', async () => {
+    render(<HomeWindow draggable={false} />)
+    const input = screen.getByTestId('quick-input')
+
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { code: 'Enter', key: 'Enter' })
+    expect(await screen.findByTestId('quick-assistant-message-list')).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByTestId('quick-input'), { code: 'Escape', key: 'Escape' })
+
+    expect(state.resetTemporaryTopic).toHaveBeenCalledTimes(1)
+    expect(state.setMessages).toHaveBeenLastCalledWith([])
+    expect(state.clearExecutionMessages).toHaveBeenCalled()
   })
 })

--- a/src/renderer/windows/quickAssistant/home/__tests__/QuickAssistantMessageList.metadata.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/QuickAssistantMessageList.metadata.test.tsx
@@ -1,0 +1,141 @@
+import '@testing-library/jest-dom/vitest'
+
+import { defaultMessageRenderConfig, type MessageListItem } from '@renderer/components/chat/messages/types'
+import type { CherryUIMessage } from '@shared/data/types/message'
+import type { Model } from '@shared/data/types/model'
+import { render, screen } from '@testing-library/react'
+import dayjs from 'dayjs'
+import type { HTMLAttributes, ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import QuickAssistantMessageList from '../QuickAssistantMessageList'
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessageListRenderConfig', () => ({
+  useMessageListRenderConfig: () => ({ renderConfig: defaultMessageRenderConfig })
+}))
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessagePlatformActions', () => ({
+  useMessagePlatformActions: () => ({})
+}))
+
+vi.mock('@renderer/components/chat/messages/MultiSelectActionPopup', () => ({ default: () => null }))
+vi.mock('@renderer/components/SelectionContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('@renderer/components/chat/messages/layout/NarrowLayout', () => ({
+  default: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>
+}))
+vi.mock('@renderer/components/chat/messages/frame/MessageContent', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/frame/MessageMenuBar', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/frame/MessageOutline', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageAnchorLine', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageGroupMenuBar', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageListSearch', () => ({ MessageListSearch: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageNavigation', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/SelectionBox', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/SiblingNavigator', () => ({ default: () => null }))
+vi.mock('@renderer/components/HorizontalScrollContainer', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('@renderer/hooks/useTheme', () => ({ useTheme: () => ({ theme: 'light' }) }))
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({ setTimeoutTimer: (_key: string, callback: () => void) => callback() })
+}))
+vi.mock('@renderer/utils/image', () => ({
+  captureScrollable: vi.fn(),
+  captureScrollableAsDataUrl: vi.fn()
+}))
+vi.mock('@cherrystudio/ui/icons', async (importOriginal) => {
+  const Icon = Object.assign(() => <span data-testid="model-icon" />, {
+    Avatar: () => <span data-testid="model-avatar" />
+  })
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    useIcon: () => Icon
+  }
+})
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+vi.mock('@renderer/components/chat/messages/list/MessageVirtualList', () => ({
+  MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX: 12,
+  MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX: 6,
+  MessageVirtualList: ({
+    items,
+    renderItem
+  }: {
+    items: [string, MessageListItem[]][]
+    renderItem: (item: [string, MessageListItem[]], index: number) => ReactNode
+  }) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={item[0]}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  )
+}))
+
+const model: Model = {
+  id: 'cherryai::qwen',
+  providerId: 'cherryai',
+  apiModelId: 'qwen',
+  name: 'Qwen',
+  capabilities: [],
+  supportsStreaming: true,
+  isEnabled: true,
+  isHidden: false
+}
+
+const createModelOnlyMessage = (): CherryUIMessage =>
+  ({
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'Hello' }]
+  }) as CherryUIMessage
+
+describe('QuickAssistantMessageList display metadata', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('shows stable model identity and time for a production-shaped model-only response', () => {
+    const initialTime = new Date('2026-08-12T08:00:00.000Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(initialTime)
+    const message = createModelOnlyMessage()
+
+    const view = render(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-1"
+        assistant={null}
+        model={model}
+        isOutputted
+        messages={[message]}
+        partsByMessageId={{ [message.id]: message.parts ?? [] }}
+        streamingLayers={{ historyPartsByMessageId: {}, liveMessageIds: [message.id] }}
+      />
+    )
+
+    const timestamp = dayjs(initialTime).format('MM/DD HH:mm')
+    expect(screen.getAllByText('Qwen')).not.toHaveLength(0)
+    expect(screen.getByText(timestamp)).toBeInTheDocument()
+    expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument()
+
+    vi.setSystemTime(new Date('2026-08-12T08:01:00.000Z'))
+    view.rerender(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-1"
+        assistant={null}
+        model={model}
+        isOutputted
+        messages={[{ ...message }]}
+        partsByMessageId={{ [message.id]: message.parts ?? [] }}
+        streamingLayers={{ historyPartsByMessageId: {}, liveMessageIds: [message.id] }}
+      />
+    )
+
+    expect(screen.getByText(timestamp)).toBeInTheDocument()
+    expect(screen.queryByText(dayjs().format('MM/DD HH:mm'))).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/windows/quickAssistant/home/__tests__/QuickAssistantMessageList.test.tsx
+++ b/src/renderer/windows/quickAssistant/home/__tests__/QuickAssistantMessageList.test.tsx
@@ -1,0 +1,214 @@
+import '@testing-library/jest-dom/vitest'
+
+import { defaultMessageRenderConfig, type MessageListItem } from '@renderer/components/chat/messages/types'
+import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { render, screen } from '@testing-library/react'
+import type { HTMLAttributes, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import QuickAssistantMessageList from '../QuickAssistantMessageList'
+
+const listProbe = vi.hoisted(() => ({
+  itemKeys: [] as string[],
+  renderLimit: 4,
+  topicId: '',
+  groupRenderCounts: new Map<string, number>()
+}))
+
+const renderConfig = defaultMessageRenderConfig
+const platformActions = {}
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessageListRenderConfig', () => ({
+  useMessageListRenderConfig: () => ({ renderConfig })
+}))
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessagePlatformActions', () => ({
+  useMessagePlatformActions: () => platformActions
+}))
+
+vi.mock('@renderer/components/chat/messages/MultiSelectActionPopup', () => ({ default: () => null }))
+vi.mock('@renderer/components/SelectionContextMenu', () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+vi.mock('@renderer/components/chat/messages/layout/NarrowLayout', () => ({
+  default: ({ children, ...props }: HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>
+}))
+vi.mock('@renderer/components/chat/messages/frame/MessageOutline', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageAnchorLine', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageListSearch', () => ({ MessageListSearch: () => null }))
+vi.mock('@renderer/components/chat/messages/list/MessageNavigation', () => ({ default: () => null }))
+vi.mock('@renderer/components/chat/messages/list/SelectionBox', () => ({ default: () => null }))
+vi.mock('@renderer/hooks/useTimer', () => ({
+  useTimer: () => ({ setTimeoutTimer: (_key: string, callback: () => void) => callback() })
+}))
+vi.mock('@renderer/utils/image', () => ({
+  captureScrollable: vi.fn(),
+  captureScrollableAsDataUrl: vi.fn()
+}))
+
+vi.mock('@renderer/components/chat/messages/list/MessageGroup', () => ({
+  default: ({ messages }: { messages: MessageListItem[] }) => {
+    const groupId = messages.map((message) => message.id).join(',')
+    listProbe.groupRenderCounts.set(groupId, (listProbe.groupRenderCounts.get(groupId) ?? 0) + 1)
+    return <div data-testid="message-group">{groupId}</div>
+  }
+}))
+
+vi.mock('@renderer/components/chat/messages/list/MessageVirtualList', () => ({
+  MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX: 12,
+  MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX: 6,
+  MessageVirtualList: ({
+    items,
+    getItemKey,
+    renderItem,
+    topicId
+  }: {
+    items: [string, MessageListItem[]][]
+    getItemKey: (item: [string, MessageListItem[]], index: number) => string
+    renderItem: (item: [string, MessageListItem[]], index: number) => ReactNode
+    topicId?: string
+  }) => {
+    listProbe.itemKeys = items.map(getItemKey)
+    listProbe.topicId = topicId ?? ''
+    const firstRenderedIndex = Math.max(0, items.length - listProbe.renderLimit)
+
+    return (
+      <div data-testid="virtual-list">
+        {items.slice(firstRenderedIndex).map((item, index) => (
+          <div key={getItemKey(item, firstRenderedIndex + index)}>{renderItem(item, firstRenderedIndex + index)}</div>
+        ))}
+      </div>
+    )
+  }
+}))
+
+const createMessage = (
+  id: string,
+  role: CherryUIMessage['role'],
+  parentId?: string,
+  status: 'pending' | 'success' = 'success'
+): CherryUIMessage =>
+  ({
+    id,
+    role,
+    metadata: { createdAt: '2026-08-12T00:00:00.000Z', parentId, status },
+    parts: [{ type: 'text', text: id }]
+  }) as CherryUIMessage
+
+const getParts = (messages: CherryUIMessage[]): Record<string, CherryMessagePart[]> =>
+  Object.fromEntries(messages.map((message) => [message.id, message.parts ?? []])) as Record<
+    string,
+    CherryMessagePart[]
+  >
+
+describe('QuickAssistantMessageList', () => {
+  beforeEach(() => {
+    listProbe.itemKeys = []
+    listProbe.renderLimit = 4
+    listProbe.topicId = ''
+    listProbe.groupRenderCounts.clear()
+  })
+
+  it('keeps 100 chronological turns on the shared bounded virtual list with the latest turn last', () => {
+    const messages = Array.from({ length: 100 }, (_, index) => {
+      const userId = `user-${index}`
+      return [createMessage(userId, 'user'), createMessage(`assistant-${index}`, 'assistant', userId)]
+    }).flat()
+    const partsByMessageId = getParts(messages)
+
+    render(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-1"
+        assistant={null}
+        isOutputted
+        messages={messages}
+        partsByMessageId={partsByMessageId}
+        streamingLayers={{ historyPartsByMessageId: partsByMessageId, liveMessageIds: [] }}
+      />
+    )
+
+    expect(listProbe.itemKeys).toHaveLength(200)
+    expect(listProbe.itemKeys[0]).toBe('useruser-0')
+    expect(listProbe.itemKeys.at(-1)).toBe('assistantuser-99')
+    expect(screen.getAllByTestId('message-group')).toHaveLength(4)
+    expect(screen.getByText('assistant-99')).toBeInTheDocument()
+  })
+
+  it('keeps historical rows isolated while the live assistant updates', () => {
+    listProbe.renderLimit = Number.POSITIVE_INFINITY
+    const historyUser = createMessage('user-history', 'user')
+    const historyAssistant = createMessage('assistant-history', 'assistant', historyUser.id)
+    const liveAssistant = createMessage('assistant-live', 'assistant', 'user-live', 'pending')
+    const historyMessages = [historyUser, historyAssistant]
+    const historyPartsByMessageId = getParts(historyMessages)
+    const buildParts = (text: string) => ({
+      ...historyPartsByMessageId,
+      'assistant-live': [{ type: 'text', text }] as CherryMessagePart[]
+    })
+
+    const view = render(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-1"
+        assistant={null}
+        isOutputted
+        messages={[...historyMessages, liveAssistant]}
+        partsByMessageId={buildParts('a')}
+        streamingLayers={{ historyPartsByMessageId, liveMessageIds: [liveAssistant.id] }}
+      />
+    )
+
+    view.rerender(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-1"
+        assistant={null}
+        isOutputted
+        messages={[...historyMessages, { ...liveAssistant }]}
+        partsByMessageId={buildParts('ab')}
+        streamingLayers={{ historyPartsByMessageId, liveMessageIds: [liveAssistant.id] }}
+      />
+    )
+
+    expect(listProbe.groupRenderCounts.get(historyUser.id)).toBe(1)
+    expect(listProbe.groupRenderCounts.get(historyAssistant.id)).toBe(1)
+    expect(listProbe.groupRenderCounts.get(liveAssistant.id)).toBe(2)
+  })
+
+  it('filters the source row for summary views and drops all rows when the temporary topic resets', () => {
+    listProbe.renderLimit = Number.POSITIVE_INFINITY
+    const user = createMessage('user-1', 'user')
+    const assistant = createMessage('assistant-1', 'assistant', user.id)
+    const messages = [user, assistant]
+    const partsByMessageId = getParts(messages)
+    const view = render(
+      <QuickAssistantMessageList
+        route="summary"
+        topicId="topic-1"
+        assistant={null}
+        isOutputted
+        messages={messages}
+        partsByMessageId={partsByMessageId}
+        streamingLayers={{ historyPartsByMessageId: partsByMessageId, liveMessageIds: [] }}
+      />
+    )
+
+    expect(listProbe.itemKeys).toEqual([`assistant${user.id}`])
+
+    view.rerender(
+      <QuickAssistantMessageList
+        route="chat"
+        topicId="topic-2"
+        assistant={null}
+        isOutputted={false}
+        messages={[]}
+        partsByMessageId={{}}
+        streamingLayers={{ historyPartsByMessageId: {}, liveMessageIds: [] }}
+      />
+    )
+
+    expect(listProbe.itemKeys).toEqual([])
+    expect(listProbe.topicId).toBe('topic-2')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR:

Quick Assistant rendered every message through its own non-virtualized reverse-column list.

After this PR:

Quick Assistant supplies a thin `MessageListProviderValue` adapter to the shared virtualized `MessageList`. The adapter preserves chronological ordering, summary/explanation source filtering, bottom-following behavior, streaming isolation, and temporary-conversation resets.

Fixes #17438

### Why we need it and why it was done in this way

Long Quick Assistant conversations mounted the full message history and duplicated list behavior already owned by the shared message renderer.

The following tradeoffs were made:

- Keep the adapter local to Quick Assistant and project only the state/actions/meta required by `MessageListProvider`.
- Reuse the shared streaming-layer contract so live updates do not invalidate historical rows.
- Keep feature routes lazy-loaded so the shared rendering chain does not affect the Quick Assistant home view's initial load.

The following alternatives were considered:

- Adding virtualization to the legacy Quick Assistant list was rejected because it would create a second virtualizer and duplicate shared behavior.
- Expanding shared adapter contracts was unnecessary for this use case.

Links to places where the discussion took place: #17438

### Breaking changes

None.

### Special notes for your reviewer

- Focused renderer tests: 3 files, 8 tests passed.
- `pnpm format` passed.
- Full `pnpm build:check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Quick Assistant now virtualizes long conversations through the shared message list for smoother rendering.
```
