### PR TITLE
fix(skill-creator): frontmatter name must match folder name per Agent Skills spec

### DIFF
--- a/resources/skills/skill-creator/SKILL.md
+++ b/resources/skills/skill-creator/SKILL.md
@@ -23,8 +23,9 @@ steps mentioned later in this file (they apply to Claude Code / Claude.ai, not h
    time and the changes are picked up on the next sync.
 
 Use a lowercase, hyphenated `<skill-folder-name>` (e.g. `my-cool-skill`). The `name:`
-field inside your `SKILL.md` frontmatter is the display name and may differ from the
-folder name (e.g. `name: My Cool Skill` with folder `my-cool-skill`).
+field inside your `SKILL.md` frontmatter must match the folder name and use only
+lowercase letters, numbers, and hyphens (e.g. `name: my-cool-skill` with folder
+`my-cool-skill`), per the Agent Skills spec — it is not a free-form display name.
 
 Eval / test workspaces (`<skill-name>-workspace/`, `iteration-*/`, etc.) from the
 evaluation loop described below must be created **outside** that skills directory —


### PR DESCRIPTION
## Summary
The Cherry Studio workflow preamble in `resources/skills/skill-creator/SKILL.md` previously told agents:

> The `name:` field inside your `SKILL.md` frontmatter is the display name and may differ from the folder name (e.g. `name: My Cool Skill` with folder `my-cool-skill`).

This contradicts the [Agent Skills open standard](https://agentskills.io/specification), which requires the `name` field to **match the parent directory name** and allow **only lowercase letters, numbers, and hyphens**. `My Cool Skill` contains uppercase letters and spaces — an invalid `name` that fails spec validation.

## Change
Rewrote the two-line guidance so agents produce spec-compliant skills: the `name` field must match the folder name and use only lowercase letters, numbers, and hyphens (e.g. `name: my-cool-skill` with folder `my-cool-skill`).

## Impact
Agents following the old guidance would author skills that fail `skills-ref validate` and cannot be registered/parsed correctly. The valid convention (`my-cool-skill`) was already used elsewhere in the same file — the preamble now aligns with it.

## Test plan
- `SKILL.md` YAML frontmatter still parses correctly
- No other sections touched