### PR TITLE
fix(agent-session): keep agent reasoning inside thinking blocks

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -591,6 +591,44 @@ describe('ClaudeCodeStreamAdapter', () => {
     expect(parts[2]).toMatchObject({ type: 'reasoning-end', id: (parts[0] as any).id })
   })
 
+  it('preserves a whole-snapshot thinking block as reasoning when nothing was streamed', () => {
+    const { adapter, parts } = createAdapter()
+
+    adapter.handleMessage({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: { content: [{ type: 'thinking', thinking: 'plan' }] }
+    } as any)
+
+    expect(parts.map((part) => part.type)).toEqual(['reasoning-start', 'reasoning-delta', 'reasoning-end'])
+    expect(parts[1]).toMatchObject({ type: 'reasoning-delta', id: (parts[0] as any).id, delta: 'plan' })
+    expect(parts[2]).toMatchObject({ type: 'reasoning-end', id: (parts[0] as any).id })
+  })
+
+  it('does not duplicate thinking that a whole-snapshot assistant message re-delivers after streaming', () => {
+    const { adapter, parts } = createAdapter()
+
+    adapter.handleMessage(
+      streamEvent({ type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '' } })
+    )
+    adapter.handleMessage(
+      streamEvent({ type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'plan' } })
+    )
+    adapter.handleMessage(streamEvent({ type: 'content_block_stop', index: 0 }))
+    adapter.handleMessage({
+      type: 'assistant',
+      parent_tool_use_id: null,
+      session_id: 'sdk-1',
+      uuid: crypto.randomUUID(),
+      message: { content: [{ type: 'thinking', thinking: 'plan' }] }
+    } as any)
+
+    expect(parts.map((part) => part.type)).toEqual(['reasoning-start', 'reasoning-delta', 'reasoning-end'])
+    expect(parts.filter((part) => part.type === 'reasoning-delta')).toHaveLength(1)
+  })
+
   it('attaches parent tool metadata to streamed text and reasoning parts', () => {
     const { adapter, parts } = createAdapter()
 

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -140,6 +140,7 @@ type StreamContext = {
   textPartId: string | undefined
   accumulatedText: string
   streamedTextLength: number
+  streamedReasoningLength: number
   usage: LanguageModelV3Usage
   hasReceivedStreamEvents: boolean
   hasStreamedJson: boolean
@@ -542,6 +543,7 @@ export class ClaudeCodeStreamAdapter {
       textPartId: undefined,
       accumulatedText: '',
       streamedTextLength: 0,
+      streamedReasoningLength: 0,
       usage: createEmptyUsage(),
       hasReceivedStreamEvents: false,
       hasStreamedJson: false,
@@ -961,6 +963,7 @@ export class ClaudeCodeStreamAdapter {
     const reasoningPartId = ctx.reasoningBlocksByIndex.get(blockIndex) ?? ctx.currentReasoningPartId
     if (reasoningPartId) {
       ctx.sink.enqueue({ type: 'reasoning-delta', id: reasoningPartId, delta: thinking })
+      ctx.streamedReasoningLength += thinking.length
     }
   }
 
@@ -1044,6 +1047,12 @@ export class ClaudeCodeStreamAdapter {
 
     if (text) {
       this.handleAssistantText(text, sdkParentToolUseId, ctx)
+    }
+
+    const thinking = content.map((c: BetaContentBlock) => (c.type === 'thinking' ? c.thinking : '')).join('')
+
+    if (thinking) {
+      this.handleAssistantReasoning(thinking, sdkParentToolUseId, ctx)
     }
   }
 
@@ -1141,6 +1150,35 @@ export class ClaudeCodeStreamAdapter {
     }
   }
 
+  /**
+   * Whole-snapshot mirror of {@link handleAssistantText} for `thinking` blocks.
+   * The streamed path already tagged thinking as reasoning; only the unstreamed
+   * remainder is emitted so a snapshot never drops or duplicates reasoning.
+   */
+  private handleAssistantReasoning(thinking: string, sdkParentToolUseId: SdkParentToolUseId, ctx: StreamContext): void {
+    const reasoningLength = ctx.streamedReasoningLength
+    const deltaReasoning = ctx.hasReceivedStreamEvents
+      ? thinking.length > reasoningLength
+        ? thinking.slice(reasoningLength)
+        : ''
+      : thinking
+    ctx.streamedReasoningLength = ctx.hasReceivedStreamEvents ? thinking.length : reasoningLength + thinking.length
+
+    if (!deltaReasoning) return
+
+    const providerMetadata = this.buildParentProviderMetadata(sdkParentToolUseId)
+    if (!ctx.currentReasoningPartId) {
+      const partId = generateId()
+      ctx.currentReasoningPartId = partId
+      ctx.sink.enqueue({ type: 'reasoning-start', id: partId, providerMetadata })
+      ctx.sink.enqueue({ type: 'reasoning-delta', id: partId, delta: deltaReasoning })
+      ctx.sink.enqueue({ type: 'reasoning-end', id: partId })
+      ctx.currentReasoningPartId = undefined
+    } else {
+      ctx.sink.enqueue({ type: 'reasoning-delta', id: ctx.currentReasoningPartId, delta: deltaReasoning })
+    }
+  }
+
   private handleUserMessage(message: SDKUserMessage, ctx: StreamContext): void {
     if (!message.message?.content) return
 
@@ -1156,6 +1194,9 @@ export class ClaudeCodeStreamAdapter {
       ctx.accumulatedText = ''
       ctx.streamedTextLength = 0
     }
+    // Reasoning length is reset at every message boundary (a turn can run many
+    // assistant messages without opening a text part, e.g. `thinking` + `tool_use`).
+    ctx.streamedReasoningLength = 0
 
     const sdkParentToolUseId = message.parent_tool_use_id
     const content = message.message.content

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -218,6 +218,11 @@ interface RenderGroupedEntryOptions {
   settleActiveTools?: boolean
   settleStreamingReasoning?: boolean
   toolDisplay?: 'content' | 'disclosure'
+  /**
+   * Agent sessions: a `text` part folded into a process group is the model's
+   * narration/reasoning, so render it as a collapsible thinking block.
+   */
+  narrationAsThinking?: boolean
 }
 
 const EMPTY_CITATION_PROJECTIONS: ReadonlyMap<CherryMessagePart, ResolvedCitationMarkers> = new Map()
@@ -557,6 +562,11 @@ function renderPart(
     }
 
     case 'text': {
+      if (options?.narrationAsThinking) {
+        // Folded agent-session narration (text that precedes a tool call) reads
+        // like reasoning — present it as a collapsible thinking block.
+        return <ThinkingBlock key={partId} id={partId} content={part.text || ''} isStreaming={isStreaming} />
+      }
       const cherryMeta = getCherryMeta(part)
       const references = cherryMeta?.references as ContentReference[] | undefined
       let converted = references ? referenceCitationsCache.get(references) : undefined
@@ -864,9 +874,12 @@ function renderGroupedEntry(
   const rendered = renderPart(entry.part, partId, message, isStreaming, isTranslationOverlayActive, options)
   if (!rendered) return null
 
+  const isNarrationText = options?.narrationAsThinking && (entry.part.type as string) === 'text'
   const wrapperClassName =
     entry.part.type === 'text'
-      ? 'text-foreground'
+      ? isNarrationText
+        ? 'message-thought-wrapper'
+        : 'text-foreground'
       : isReasoningMessagePart(entry.part)
         ? 'message-thought-wrapper'
         : undefined
@@ -876,7 +889,7 @@ function renderGroupedEntry(
       key={partId}
       enableAnimation={enableAnimation}
       className={wrapperClassName}
-      messagePartId={entry.part.type === 'text' ? partId : undefined}>
+      messagePartId={entry.part.type === 'text' && !isNarrationText ? partId : undefined}>
       {rendered}
     </AnimatedBlockWrapper>
   )
@@ -893,7 +906,14 @@ type NestedHistoryItem =
   | { kind: 'process'; key: number; entries: PartEntry[] }
   | { kind: 'content'; key: number; entry: GroupedEntry }
 
-function groupNestedHistoryEntries(entries: readonly PartEntry[]): NestedHistoryItem[] {
+/** Agent-session topic ids are `agent-session:<sessionId>` (see `buildAgentSessionTopicId`). */
+const AGENT_SESSION_TOPIC_PREFIX = 'agent-session:'
+
+function isAgentSessionTopicId(topicId: string): boolean {
+  return topicId.startsWith(AGENT_SESSION_TOPIC_PREFIX)
+}
+
+function groupNestedHistoryEntries(entries: readonly PartEntry[], foldNarration = false): NestedHistoryItem[] {
   const result: NestedHistoryItem[] = []
   let contentEntries: PartEntry[] = []
   let processEntries: PartEntry[] = []
@@ -923,9 +943,21 @@ function groupNestedHistoryEntries(entries: readonly PartEntry[]): NestedHistory
       continue
     }
 
-    if ((entry.part.type as string) === 'reasoning' || isToolUIPart(entry.part)) {
-      flushContent()
+    const isProcessPart = (entry.part.type as string) === 'reasoning' || isToolUIPart(entry.part)
+
+    if (isProcessPart) {
+      if (foldNarration && contentEntries.length > 0) {
+        // Agent sessions: fold the pending narration text into the process group
+        // so it renders inside the tool disclosure instead of standalone body text.
+        processEntries.push(...contentEntries)
+        contentEntries = []
+      } else {
+        flushContent()
+      }
       processEntries.push(entry)
+    } else if (foldNarration && processEntries.length > 0) {
+      // Text after a process part stays pending; it folds into the next one.
+      contentEntries.push(entry)
     } else {
       flushProcess()
       contentEntries.push(entry)
@@ -942,9 +974,10 @@ function renderNestedHistory(
   message: MessageListItem,
   isTranslationOverlayActive: boolean,
   options: RenderGroupedEntryOptions,
-  liveProcessMode?: 'last' | 'settled'
+  liveProcessMode?: 'last' | 'settled',
+  foldNarration = false
 ): React.ReactNode {
-  const nestedItems = groupNestedHistoryEntries(entries)
+  const nestedItems = groupNestedHistoryEntries(entries, foldNarration)
   let lastProcessIndex = -1
   if (liveProcessMode === 'last') {
     for (let index = nestedItems.length - 1; index >= 0; index--) {
@@ -964,7 +997,10 @@ function renderNestedHistory(
       return (
         <React.Fragment key={`process-${message.id}-${item.key}`}>
           {groupPartEntries(item.entries).map((entry) =>
-            renderGroupedEntry(entry, message, false, isTranslationOverlayActive, options)
+            renderGroupedEntry(entry, message, false, isTranslationOverlayActive, {
+              ...options,
+              narrationAsThinking: foldNarration
+            })
           )}
         </React.Fragment>
       )
@@ -978,7 +1014,8 @@ function renderNestedHistory(
             renderGroupedEntry(entry, message, false, isTranslationOverlayActive, {
               ...options,
               enableAnimation: false,
-              reasoningDisplay: 'disclosure'
+              reasoningDisplay: 'disclosure',
+              narrationAsThinking: foldNarration
             })
           )}
         </React.Fragment>
@@ -1004,7 +1041,8 @@ function renderNestedHistory(
                 ...options,
                 enableAnimation: false,
                 reasoningDisplay: 'disclosure',
-                toolDisplay: 'content'
+                toolDisplay: 'content',
+                narrationAsThinking: foldNarration
               })
             )}
           </div>
@@ -1136,7 +1174,8 @@ const ActiveMessageProcess = React.memo(
                   settleStreamingReasoning: !isStreamLive,
                   toolDisplay: 'disclosure'
                 },
-                isLastProcess && !hasResultContent ? 'last' : 'settled'
+                isLastProcess && !hasResultContent ? 'last' : 'settled',
+                isAgentSessionTopicId(message.topicId)
               )}
             </React.Fragment>
           )
@@ -1265,7 +1304,9 @@ const MessageProcessLayout = React.memo(function MessageProcessLayout({
                 ...completedRenderOptions,
                 reasoningDisplay: 'disclosure',
                 toolDisplay: 'content'
-              }
+              },
+          undefined,
+          isAgentSessionTopicId(message.topicId)
         )
       : null
   const completedResult = groupPartEntries(completedLayout.resultEntries).map((entry) => {

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -1986,4 +1986,40 @@ describe('MessagePartsRenderer', () => {
       expect(screen.getByTestId('completed-process-trigger')).toHaveAttribute('aria-expanded', 'false')
     })
   })
+
+  describe('agent-session narration folding', () => {
+    it('renders pre-tool narration text as a collapsible thinking block in agent sessions', () => {
+      renderParts(
+        [
+          { type: 'text', text: 'Narration before the tool', state: 'done' },
+          toolPart('bash'),
+          { type: 'text', text: 'Final answer', state: 'done' }
+        ] as unknown as CherryMessagePart[],
+        msg({ topicId: 'agent-session:session-1' })
+      )
+
+      fireEvent.click(screen.getByTestId('completed-process-trigger'))
+      expandCollapsedChildToolGroups()
+
+      expect(screen.getByTestId('mock-thinking-block')).toHaveTextContent('Narration before the tool')
+      // The narration is folded into the process disclosure, not standalone body text.
+      expect(latestMainTextProps(0)).toBeUndefined()
+      expect(screen.getByText('Final answer')).toBeInTheDocument()
+    })
+
+    it('keeps pre-tool text as body text outside agent sessions', () => {
+      renderParts([
+        { type: 'text', text: 'Narration before the tool', state: 'done' },
+        toolPart('bash'),
+        { type: 'text', text: 'Final answer', state: 'done' }
+      ] as unknown as CherryMessagePart[])
+
+      fireEvent.click(screen.getByTestId('completed-process-trigger'))
+      expandCollapsedChildToolGroups()
+
+      expect(screen.queryByTestId('mock-thinking-block')).toBeNull()
+      expect(latestMainTextProps(0)).toBeDefined()
+      expect(screen.getByText('Final answer')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:
- The Claude Code stream adapter's whole-snapshot path (`handleAssistantMessage`) extracted only `text` blocks, so any `thinking` block delivered in a complete assistant message was silently dropped — reasoning was lost.
- When a model returned its reasoning as a plain `text` part (e.g. `kimi-for-coding` without a proper `thinking` block), agent-session messages rendered that pre-tool narration as a large standalone body-text block.

After this PR:
- Whole-snapshot `thinking` blocks are emitted as `reasoning` chunks (diffed against already-streamed reasoning via `streamedReasoningLength`), so reasoning is never dropped or duplicated.
- In agent-session messages, a `text` part that precedes a tool call is folded into the collapsible process disclosure and rendered as a thinking block, so the model's narration no longer reads as standalone body text.

Fixes #18371

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Fixing the renderer to fold pre-tool `text` is a heuristic scoped strictly to agent-session topics (`agent-session:` topic ids). In that context, text before a tool call is the model's narration/reasoning, not the final answer. Non-agent-session messages are unchanged.
- The adapter-side fix mirrors the existing `handleAssistantText` diff logic (`streamedTextLength`) with a parallel `streamedReasoningLength`, so whole-snapshot reasoning is only emitted for the portion not already streamed.

The following alternatives were considered:
- Treating every `text` part as reasoning globally — rejected, would misrender genuine answers in regular chat.
- Classifying `text`-as-reasoning at the data layer — rejected, there is no reliable signal once the model delivers reasoning as text.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18371 (reporter supplied the persisted message parts showing the reasoning landed as `type: text`).

### Breaking changes

None.

### Special notes for your reviewer

- The renderer heuristic only applies to agent-session messages; the final answer text stays a normal body block.
- `streamAdapter` fix is defensive: in normal streaming the streamed path already tags thinking as reasoning, so the whole-snapshot path now only closes the gap where thinking is delivered without stream events.
- Full `pnpm test` on a Windows machine reports ~272 pre-existing failures in migration/path tests (e.g. `ChatMappings.test.ts` "must be an absolute filesystem path") that are unrelated to this change; the touched files' tests pass (`streamAdapter.test.ts` 67/67, `MessagePartsRenderer.test.tsx` 70/70).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed agent sessions rendering the model's reasoning as plain body text when it is delivered as a regular text part; it now appears inside the collapsible thinking block. Also fixed a case where reasoning delivered in a whole-snapshot assistant message could be dropped entirely.
```
