### PR TITLE
ci(claude-review): improve PR review automation

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,12 @@
 name: Claude Code Review
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review"
+        required: true
+        type: string
   pull_request:
     types: [opened, ready_for_review, reopened]
     # Optional: Only run on specific file changes
@@ -14,7 +20,7 @@ on:
 
 jobs:
   claude-review:
-    # Automatically review same-repository PRs, or manually review when a trusted user comments @claude review.
+    # Automatically review same-repository PRs, or manually review through Actions or @claude review.
     # https://github.com/anthropics/claude-code-action/issues/542
     if: |
       (
@@ -26,6 +32,8 @@ jobs:
         (github.event.issue.pull_request != null) &&
         contains(github.event.comment.body, '@claude review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) || (
+        github.event_name == 'workflow_dispatch'
       )
     runs-on: ubuntu-latest
     permissions:
@@ -34,10 +42,36 @@ jobs:
       id-token: write
 
     steps:
+      - name: Resolve manually requested PR
+        if: github.event_name == 'workflow_dispatch'
+        id: manual-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$REQUESTED_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::PR number must be a positive integer"
+            exit 1
+          fi
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$REQUESTED_PR_NUMBER")"
+          if [[ "$(jq -r '.state' <<< "$pr_json")" != "open" ]]; then
+            echo "::error::PR #$REQUESTED_PR_NUMBER is not open"
+            exit 1
+          fi
+
+          {
+            echo "number=$(jq -r '.number' <<< "$pr_json")"
+            echo "head_sha=$(jq -r '.head.sha' <<< "$pr_json")"
+            echo "base_ref=$(jq -r '.base.ref' <<< "$pr_json")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+          ref: ${{ github.event.pull_request.head.sha || steps.manual-pr.outputs.head_sha || format('refs/pull/{0}/head', github.event.issue.number) }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
@@ -51,9 +85,9 @@ jobs:
             You are performing a read-only, evidence-based review of the pull request below. Do not modify files, create commits, or change repository state.
 
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-            EVENT HEAD SHA: ${{ github.event.pull_request.head.sha || 'MANUAL_TRIGGER' }}
-            BASE BRANCH: ${{ github.event.pull_request.base.ref || 'resolve with gh pr view' }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || steps.manual-pr.outputs.number }}
+            EVENT HEAD SHA: ${{ github.event.pull_request.head.sha || steps.manual-pr.outputs.head_sha || 'MANUAL_TRIGGER' }}
+            BASE BRANCH: ${{ github.event.pull_request.base.ref || steps.manual-pr.outputs.base_ref || 'resolve with gh pr view' }}
 
             ## Plan and execute the review
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,55 +2,88 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
-    # Only trigger code review for PRs from the main repository due to upstream OIDC issues
+    # Automatically review same-repository PRs, or manually review when a trusted user comments @claude review.
     # https://github.com/anthropics/claude-code-action/issues/542
     if: |
-      (github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event.pull_request.draft == false)
+      (
+        (github.event_name == 'pull_request') &&
+        (github.event.pull_request.head.repo.full_name == github.repository) &&
+        (github.event.pull_request.draft == false)
+      ) || (
+        (github.event_name == 'issue_comment') &&
+        (github.event.issue.pull_request != null) &&
+        contains(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
-      issues: read
       id-token: write
-      actions: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ vars.ANTHROPIC_BASE_URL }}
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            You are performing a read-only, evidence-based review of the pull request below. Do not modify files, create commits, or change repository state.
 
-            PR number: ${{ github.event.number }}
-            Repo: ${{ github.repository }}
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+            EVENT HEAD SHA: ${{ github.event.pull_request.head.sha || 'MANUAL_TRIGGER' }}
+            BASE BRANCH: ${{ github.event.pull_request.base.ref || 'resolve with gh pr view' }}
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            ## Plan and execute the review
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Before reviewing the implementation in depth, create a concise internal review plan based on the PR intent, diff, repository guidance, size, risk, and affected subsystems. The plan must identify:
+            - the behavior or invariants the PR is expected to preserve or change;
+            - the affected subsystems, integration paths, and highest-risk boundaries;
+            - the concrete review angles and evidence needed to complete each one;
+            - whether to review directly or use multiple agents, with work divided by subsystem or risk rather than file count;
+            - how candidate findings will be verified, deduplicated, and published.
+
+            Do not publish the plan. Execute the review systematically against it, completing every planned angle. If new evidence materially changes the scope or risk, update the plan before continuing rather than expanding the review ad hoc.
+
+            Review a small, focused PR directly and perform an adversarial second pass. For a large, cross-cutting, or high-risk PR, launch the minimum useful number of independent read-only reviewer subagents in parallel according to the plan. Assign only angles relevant to the actual changes.
+
+            Each reviewer must follow the repository guidance, inspect sufficient context, cite exact evidence, and return candidate findings only. Reviewers must not modify files or post comments. After reviewers finish, if any candidates exist, launch one fresh read-only verifier subagent with no reviewer conversation history. Give it the combined candidate findings and require it to actively try to disprove each one by checking callers, invariants, platform constraints, intentional design, and current code. The verifier must return CONFIRM or REJECT with concrete evidence for every candidate. Skip the verifier only when all reviewers report no findings.
+
+            The main agent must confirm that the review plan is complete, synthesize the result, resolve disagreements, deduplicate overlaps and existing PR feedback visible in context, and independently re-read every surviving finding before publishing. Only the main agent may post GitHub comments.
+
+            ## Finding threshold and output
+
+            - Report only high-confidence issues caused or made reachable by this PR: runtime correctness, data loss, security, broken contracts, unsafe migration, concrete performance regressions, or clear project-boundary violations with a realistic maintenance cost.
+            - Every finding must identify an exact file and changed line, explain the violated behavior or project rule, give a realistic failure scenario and impact, and suggest the smallest reasonable fix or author decision.
+            - Use Blocker for runtime, data, security, contract, migration, or high-risk infrastructure failures; Warning for a concrete maintainability or ownership problem with a clear fix; Notice only when a specific design intent must be confirmed.
+            - Reject pure style preferences, formatter concerns, speculative future needs, optional refactors, pre-existing unrelated problems, duplicate comments, and missing guards when actual callers guarantee the precondition.
+            - Do not claim approval or merge readiness. CI, signatures, conflicts, and other process gates are separate from the code findings unless their evidence directly proves a defect in this PR.
+            - Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` for line-specific findings. Use `gh pr comment` only for a cross-cutting actionable finding or, when no findings survive verification, one concise top-level comment saying so.
+            - Do not post praise, change summaries, speculative suggestions, or review analysis. Only post the final GitHub comments; do not submit review text as ordinary messages.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          claude_args: |
+            --model ${{ vars.ANTHROPIC_MODEL }}
+            --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR: Claude PR review used OAuth, ran only when a PR opened, and used a generic prompt.

After this PR: Claude review uses the configured base URL, API key, and model; automatically reviews non-draft same-repository PRs when opened, marked ready, or reopened without rerunning for each push; accepts trusted `@claude review` requests; and follows a plan-first, adaptive reviewer/verifier flow that publishes only confirmed findings.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: automatic reviews do not rerun on every push to limit token usage, while repository collaborators can request a fresh review explicitly.

The following alternatives were considered: keeping `synchronize` was rejected because of repeated token cost, and OAuth was replaced to support the configured Anthropic-compatible gateway.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The required `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL`, and `ANTHROPIC_API_KEY` configuration is present, but the workflow is currently `disabled_manually` and must be re-enabled after merge; validation passed with `pnpm lint` (0 errors, 38 existing warnings), typecheck, i18n, format, YAML parsing, Prettier, and `git diff --check`, while tests and build checks were not run for this workflow-only change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
