### PR TITLE
fix(main-window): quit when closing without tray

### DIFF
--- a/docs/references/window-manager/window-manager-api-reference.md
+++ b/docs/references/window-manager/window-manager-api-reference.md
@@ -9,7 +9,7 @@ Two layers: **Consumer** methods are the universal API and should be used by all
 | Method | Layer | Signature | Description |
 |--------|-------|-----------|-------------|
 | `open` | **Consumer** | `(type: WindowType, args?: OpenWindowArgs) => string` | Lifecycle-aware open: singleton reuse, pool recycle, or fresh create per registry `lifecycle`. Returns window ID. |
-| `close` | **Consumer** | `(windowId: string) => boolean` | Lifecycle-aware release: destroys `default` and singleton-without-config windows; hides pooled / singleton-with-retention windows into the warmup state machine (GC destroys per config). |
+| `close` | **Consumer** | `(windowId: string) => boolean` | Lifecycle-aware release: destroys `default` and singleton-without-config windows; hides pooled / singleton-with-retention windows into the warmup state machine (GC destroys per config). Destruction runs through `window.destroy()`, so the native `close` event does **not** fire — see the [`close`-event carve-out](./window-manager-usage.md#window-api-layers-consumer-vs-internal). |
 | `create` | Internal | `(type: WindowType, args?: OpenWindowArgs) => string` | Force fresh creation; throws if a singleton of this type already exists. Use only as a defensive assertion — consumer code should use `open()` + `onWindowCreatedByType` instead. |
 | `destroy` | Internal | `(windowId: string) => boolean` | Force destroy via `window.destroy()`, which skips the `close` event — and therefore skips the pool's `close` interception, bypassing pool recycling. Non-pooled windows: identical to `close()`. Pooled windows: use `suspendPool(type)` for pool-wide shutdown instead of destroying individual pooled windows. |
 

--- a/docs/references/window-manager/window-manager-migration-guide.md
+++ b/docs/references/window-manager/window-manager-migration-guide.md
@@ -103,11 +103,13 @@ See [Injecting behavior: `onWindowCreated` is the canonical hook](./window-manag
 | `this.window = new BrowserWindow(...)` | `wm.open(WindowType.MyWindow)` |
 | `this.window.show()` | `wm.show(windowId)` |
 | `this.window.hide()` | `wm.hide(windowId)` |
-| `this.window.close()` | `wm.close(windowId)` |
+| `this.window.close()` | `wm.close(windowId)` — except when a native `close` listener owns the policy (see note) |
 | `this.window.webContents.send(...)` | `wm.getWindow(windowId)?.webContents.send(...)` or `wm.broadcastToType(...)` |
 | `BrowserWindow.fromWebContents(e.sender)` | `wm.getWindowIdByWebContents(e.sender)` |
 
 Note: there is intentionally no entry for `this.window.destroy()`. `wm.close()` already handles destruction for non-pooled windows and pool-return for pooled windows. `wm.destroy()` is an internal primitive — see [Window API layers](./window-manager-usage.md#window-api-layers-consumer-vs-internal).
+
+Note: `wm.close()` destroys via `window.destroy()` and therefore skips the native `close` event. If your window's close behavior lives in a `close` listener, keep `win.close()` in the owning service and expose it as a method instead — see the [`close`-event carve-out](./window-manager-usage.md#window-api-layers-consumer-vs-internal).
 
 ## Step 5: Handle show behavior
 

--- a/docs/references/window-manager/window-manager-usage.md
+++ b/docs/references/window-manager/window-manager-usage.md
@@ -199,6 +199,8 @@ WindowManager exposes four lifecycle methods, arranged in two layers:
 
 **Why `destroy()` is not a consumer API.** On non-pooled windows (default and singleton) `close()` falls through to the same `destroyWindow()` call — there is no behavioral difference. On pooled windows, `destroy()` bypasses the pool, which is almost never what a consumer actually wants; the correct API for "stop the whole pool" is `suspendPool(type)`, which destroys idle windows and prevents further recycling without touching in-use windows.
 
+**Carve-out: windows whose close policy lives in a `close` listener.** Because both paths end in `window.destroy()`, `wm.close()` never fires the native `close` event. A window that decides its own close behavior there — hide-to-tray, quit the app, prompt on unsaved changes — is silently bypassed by `wm.close()`. Such a window must be closed by the service that owns it, calling `win.close()` on the `BrowserWindow` it already holds and exposing that as a method (e.g. `MainWindowService.requestClose(windowId)`, which the `window.close` IPC route consults before falling back to `wm.close()`). Tracking is unaffected: WM's `'closed'` listener still fires `onWindowDestroyed` and still cleans up, and the singleton bounds-persistence listener runs on `close`.
+
 ### Consumer-loaded windows (`htmlPath: ''`)
 
 A registry entry with `htmlPath: ''` is **consumer-loaded**: WM wires the window (preload, behavior, bounds, lifecycle) but loads no content — the domain service loads it after `open()`. For hidden, one-shot surfaces rendering *generated* content (print / PDF, offscreen render).

--- a/src/main/ipc/handlers/__tests__/window.test.ts
+++ b/src/main/ipc/handlers/__tests__/window.test.ts
@@ -16,6 +16,7 @@ const windowManager = {
   getInitData: vi.fn(() => ({ path: '/settings/provider' }))
 }
 const mainWindowService = {
+  requestClose: vi.fn(() => false),
   setMainWindowMinimumSize: vi.fn(),
   resetMainWindowMinimumSize: vi.fn(),
   reloadMainWindow: vi.fn()
@@ -35,12 +36,26 @@ beforeEach(() => {
 const ctx = (senderId: string | null) => ({ senderId })
 
 describe('windowHandlers', () => {
-  it('close/minimize/maximize/unmaximize act on the caller window by its senderId', async () => {
+  it('lets MainWindowService handle a main-window close request', async () => {
+    mainWindowService.requestClose.mockReturnValue(true)
     await windowHandlers['window.close'](undefined, ctx('w1'))
+
+    expect(mainWindowService.requestClose).toHaveBeenCalledWith('w1')
+    expect(windowManager.close).not.toHaveBeenCalled()
+  })
+
+  it('delegates non-main close requests to WindowManager', async () => {
+    mainWindowService.requestClose.mockReturnValue(false)
+    await windowHandlers['window.close'](undefined, ctx('w2'))
+
+    expect(mainWindowService.requestClose).toHaveBeenCalledWith('w2')
+    expect(windowManager.close).toHaveBeenCalledWith('w2')
+  })
+
+  it('minimize/maximize/unmaximize act on the caller window by its senderId', async () => {
     await windowHandlers['window.minimize'](undefined, ctx('w2'))
     await windowHandlers['window.maximize'](undefined, ctx('w3'))
     await windowHandlers['window.unmaximize'](undefined, ctx('w4'))
-    expect(windowManager.close).toHaveBeenCalledWith('w1')
     expect(windowManager.minimize).toHaveBeenCalledWith('w2')
     expect(windowManager.maximize).toHaveBeenCalledWith('w3')
     expect(windowManager.unmaximize).toHaveBeenCalledWith('w4')
@@ -68,6 +83,7 @@ describe('windowHandlers', () => {
     await windowHandlers['window.close'](undefined, ctx(null))
     await windowHandlers['window.minimize'](undefined, ctx(null))
     await windowHandlers['window.set_full_screen'](true, ctx(null))
+    expect(mainWindowService.requestClose).not.toHaveBeenCalled()
     expect(windowManager.close).not.toHaveBeenCalled()
     expect(windowManager.minimize).not.toHaveBeenCalled()
     expect(windowManager.setFullScreen).not.toHaveBeenCalled()

--- a/src/main/ipc/handlers/window.ts
+++ b/src/main/ipc/handlers/window.ts
@@ -3,14 +3,13 @@ import type { windowRequestSchemas } from '@shared/ipc/schemas/window'
 import type { IpcHandlersFor } from '@shared/ipc/types'
 
 /**
- * Thin adapters for the WindowManager caller-window control routes. Each one acts on
- * the window that issued the call, identified by `ctx.senderId` (the WindowId main
- * derived from `event.sender` — the renderer cannot forge it), then delegates to the
- * matching by-id `WindowManager` method.
+ * Thin adapters for caller-window control routes. Each one acts on the window that
+ * issued the call, identified by `ctx.senderId` (the WindowId main derived from
+ * `event.sender` — the renderer cannot forge it), then delegates to its lifecycle owner.
  *
- * SCOPE GUARD: keep this map to WindowManager caller-window operations only. Opening a
- * named window (settings/search) or driving the main-window singleton (reload, min-size)
- * are different domains — do not add them here just because they touch "a window".
+ * SCOPE GUARD: caller-window controls stay with their lifecycle owner. Explicit
+ * `window.main.*` / `window.sub.*` routes delegate to their domain services; opening
+ * named windows (settings/search) remains outside this map.
  *
  * A null `senderId` means the caller is not a window WindowManager tracks (e.g. detached
  * devtools). That is an accepted no-op, mirroring the legacy handlers' `if (!windowId)
@@ -18,7 +17,11 @@ import type { IpcHandlersFor } from '@shared/ipc/types'
  */
 export const windowHandlers: IpcHandlersFor<typeof windowRequestSchemas> = {
   'window.close': async (_input, { senderId }) => {
-    if (senderId) application.get('WindowManager').close(senderId)
+    if (!senderId) return
+
+    if (!application.get('MainWindowService').requestClose(senderId)) {
+      application.get('WindowManager').close(senderId)
+    }
   },
   'window.minimize': async (_input, { senderId }) => {
     if (senderId) application.get('WindowManager').minimize(senderId)

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -170,6 +170,16 @@ export class MainWindowService extends BaseService {
     this.mainWindow?.reload()
   }
 
+  /** Start the native close flow when `windowId` identifies the current main window. */
+  public requestClose(windowId: string): boolean {
+    const mainWindow = this.mainWindow
+    if (!mainWindow || mainWindow.isDestroyed()) return false
+    if (application.get('WindowManager').getWindowId(mainWindow) !== windowId) return false
+
+    mainWindow.close()
+    return true
+  }
+
   /**
    * Open the main window via WindowManager.
    * Singleton lifecycle: reuses an existing main window if present (show + focus),

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -18,6 +18,7 @@ const { platformState, prefValues, applicationMock, windowManagerMock, loggerMoc
     }
     const windowManagerMock = {
       getWindow: vi.fn(),
+      getWindowId: vi.fn(),
       // Mirrors the real shape: runtime behavior setters live on `wm.behavior`
       // (see BehaviorController in src/main/core/window/behavior.ts).
       behavior: {
@@ -137,6 +138,7 @@ interface MockBrowserWindow extends EventEmitter {
   isMinimized: ReturnType<typeof vi.fn>
   isVisible: ReturnType<typeof vi.fn>
   isFocused: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
   hide: ReturnType<typeof vi.fn>
   show: ReturnType<typeof vi.fn>
   focus: ReturnType<typeof vi.fn>
@@ -158,6 +160,7 @@ function createMockWindow(): MockBrowserWindow {
   win.isMinimized = vi.fn(() => false)
   win.isVisible = vi.fn(() => true)
   win.isFocused = vi.fn(() => true)
+  win.close = vi.fn()
   win.hide = vi.fn()
   win.show = vi.fn()
   win.focus = vi.fn()
@@ -210,6 +213,7 @@ describe('MainWindowService', () => {
     applicationMock.quit.mockReset()
     applicationMock.forceExit.mockReset()
     windowManagerMock.behavior.setMacShowInDockByType.mockReset()
+    windowManagerMock.getWindowId.mockReset()
     windowManagerMock.open.mockClear()
     windowManagerMock.pushInitDataToType.mockClear()
     loggerMock.error.mockReset()
@@ -461,6 +465,24 @@ describe('MainWindowService', () => {
       win.emit('close', event)
 
       expect(windowManagerMock.behavior.setMacShowInDockByType).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('requestClose', () => {
+    it('starts the native close flow only for the current main window', () => {
+      ;(svc as any).mainWindow = win
+      windowManagerMock.getWindowId.mockReturnValue('main-window')
+
+      expect(svc.requestClose('main-window')).toBe(true)
+      expect(win.close).toHaveBeenCalledOnce()
+    })
+
+    it('leaves non-main close requests to their lifecycle owner', () => {
+      ;(svc as any).mainWindow = win
+      windowManagerMock.getWindowId.mockReturnValue('main-window')
+
+      expect(svc.requestClose('sub-window')).toBe(false)
+      expect(win.close).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

With the system tray disabled on Windows or Linux, clicking the frameless main window's close button destroyed the window directly. That bypassed `MainWindowService`'s close policy, while an eager hidden subwindow could keep the Electron process tree alive.

After this PR:

Main-window close requests enter the native `BrowserWindow` close flow through `MainWindowService`, so the existing tray and application-quit policy runs. Non-main windows continue using `WindowManager.close()`, preserving singleton and pool lifecycle behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18445

### Why we need it and why it was done in this way

The following tradeoffs were made:

The IPC handler asks `MainWindowService` to recognize and handle its owned main window before falling back to `WindowManager`. This adds a small service method but keeps raw `BrowserWindow` access and main-window policy in the owning service.

The following alternatives were considered:

- Calling `BrowserWindow.close()` directly from the IPC handler was rejected because consumers must not obtain raw windows through `WindowManager` outside the documented loading exception.
- Changing `WindowManager.close()` semantics was rejected because programmatic close callers rely on lifecycle-aware destruction or pool release.
- Removing the eager subwindow standby was rejected because it would treat the symptom and reduce window warmup behavior.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18445

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validation:

- The focused window IPC and `MainWindowService` test batch completed with 159 passing tests and one unrelated pre-existing `will-navigate` failure.
- `pnpm build:check` completed lint (0 errors, 40 existing warnings), type checks, i18n checks, documentation link checks, formatting checks, and the native-module rebuild. Its full main-process test phase stopped with an unrelated Windows baseline of 11,032 passing, 242 failing, and 41 skipped tests while using Node.js 24.19.0, which is outside the repository's supported `<24.16.0` range.
- Manual Windows verification with the system tray disabled confirmed that clicking the real title-bar close button completed lifecycle shutdown and left no tracked Electron processes running.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where closing the main window with the system tray disabled could leave Cherry Studio processes running in the background.
```
