### PR TITLE
fix(claude-code): parse [1m]/[128k] suffix as context window fallback

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/contextWindowSuffix.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/contextWindowSuffix.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { isAnthropicOfficialHost, with1mSuffix } from '../contextWindowSuffix'
+import {
+  isAnthropicOfficialHost,
+  parseContextWindowSuffix,
+  resolveAgentContextWindow,
+  with1mSuffix
+} from '../contextWindowSuffix'
 
 describe('with1mSuffix', () => {
   it('appends [1m] when a non-Anthropic model declares >= 1M context', () => {
@@ -42,5 +47,64 @@ describe('isAnthropicOfficialHost', () => {
 
   it('is false for an unparseable base URL', () => {
     expect(isAnthropicOfficialHost('not a url')).toBe(false)
+  })
+})
+
+describe('parseContextWindowSuffix', () => {
+  it.each([
+    ['deepseek-v4-pro[1m]', 1_000_000],
+    ['deepseek-v4-pro[1M]', 1_000_000],
+    ['some-model[128k]', 128_000],
+    ['some-model[200k]', 200_000],
+    ['some-model[1.5m]', 1_500_000]
+  ])('parses %s into the declared token count', (id, expected) => {
+    expect(parseContextWindowSuffix(id)).toBe(expected)
+  })
+
+  it('returns undefined for an id without a trailing bracket annotation', () => {
+    expect(parseContextWindowSuffix('deepseek-v4-pro')).toBeUndefined()
+    expect(parseContextWindowSuffix('gpt-oss-20b')).toBeUndefined()
+  })
+
+  it('ignores a non-trailing bracket so a mid-id marker is not misread', () => {
+    // The annotation must be the trailing token; `[1m]-v2` does not declare a 1M window.
+    expect(parseContextWindowSuffix('model[1m]-v2')).toBeUndefined()
+  })
+
+  it('returns undefined for empty / missing input', () => {
+    expect(parseContextWindowSuffix('')).toBeUndefined()
+    expect(parseContextWindowSuffix(undefined)).toBeUndefined()
+  })
+})
+
+describe('resolveAgentContextWindow', () => {
+  // Priority: row value > registry preset > id suffix. Each lower tier only runs when every higher
+  // tier is undefined, mirroring the `??` chain in agentSessionWarmup.
+
+  it('prefers the row-owned context window over preset and suffix', () => {
+    // A preset-backed row already merged the precise value; neither fallback may override it.
+    expect(resolveAgentContextWindow(1_048_600, 1_000_000, 'deepseek-v4-pro[1m]')).toBe(1_048_600)
+  })
+
+  it('falls back to the registry preset when the row has no value (plain id that missed the match)', () => {
+    // A custom row with a plain id that just failed preset matching — the suffix is absent, so the
+    // preset window (declared in the catalog) is the right value, not 100K.
+    expect(resolveAgentContextWindow(undefined, 1_048_600, 'deepseek-v4-pro')).toBe(1_048_600)
+  })
+
+  it('falls back to the id suffix when neither row nor preset has a value (suffixed custom row)', () => {
+    // The #18397 case: the [1m] suffix defeated normalizeModelId so the preset never matched
+    // (presetContextWindow is undefined); the suffix the user typed is the sole source.
+    expect(resolveAgentContextWindow(undefined, undefined, 'deepseek-v4-pro[1m]')).toBe(1_000_000)
+  })
+
+  it('prefers the registry preset over the id suffix when both are available but the row is empty', () => {
+    // The catalog value is precise (1_048_600); the suffix is an approximation (1_000_000). Preset wins.
+    expect(resolveAgentContextWindow(undefined, 1_048_600, 'deepseek-v4-pro[1m]')).toBe(1_048_600)
+  })
+
+  it('returns undefined when no source provides a value', () => {
+    expect(resolveAgentContextWindow(undefined, undefined, 'deepseek-v4-pro')).toBeUndefined()
+    expect(resolveAgentContextWindow(undefined, undefined, undefined)).toBeUndefined()
   })
 })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -13,6 +13,8 @@ import { KB_MANAGE_TOOL_NAME } from '@shared/ai/builtinTools'
 import { CHANNEL_SECURITY_PROMPT } from '@shared/ai/claudecode/constants'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { resolveAgentContextWindow } from '../contextWindowSuffix'
+
 const mocks = vi.hoisted(() => ({
   getAgent: vi.fn(),
   getBuiltinAgentPluginDirectory: vi.fn(),
@@ -598,6 +600,38 @@ describe('buildClaudeCodeSessionSettings', () => {
     // The explicit override wins for the env var; the budget still tracks the real window.
     expect(settings.env).toMatchObject({ CLAUDE_CODE_MAX_CONTEXT_TOKENS: '131072' })
     expect((settings.settings as { autoCompactWindow?: number }).autoCompactWindow).toBeGreaterThan(131_072)
+  })
+
+  // Regression for #18397: a custom row whose id carries `[1m]` has contextWindow=undefined and the
+  // preset never matched (the suffix defeats normalizeModelId, so presetContextWindow is undefined too).
+  // agentSessionWarmup resolves the window via resolveAgentContextWindow, whose last tier parses the
+  // suffix to 1_000_000. This test pins that the resolved value, once it reaches here, actually
+  // unblocks the auto-compact math — instead of the pre-fix state where both the env var and
+  // autoCompactWindow are absent and the SDK falls back to its 100K default.
+  it('treats a [1m] suffix-derived context window as a real 1M budget', async () => {
+    mocks.getAgent.mockReturnValue({
+      id: 'agent-1',
+      type: 'claude-code',
+      model: 'provider::deepseek-v4-pro[1m]',
+      mcps: [],
+      allowedTools: [],
+      configuration: {}
+    })
+    // Mirrors agentSessionWarmup.ts: row undefined + preset undefined (suffix defeated the match) →
+    // the suffix is the sole source.
+    const contextWindow = resolveAgentContextWindow(undefined, undefined, 'deepseek-v4-pro[1m]')
+
+    const settings = await buildClaudeCodeSessionSettings(
+      { id: 'session-1', agentId: 'agent-1', workspace: { type: 'user', path: '/w' } } as never,
+      {} as never,
+      { contextWindow }
+    )
+
+    expect(contextWindow).toBe(1_000_000)
+    expect(settings.env).toMatchObject({ CLAUDE_CODE_MAX_CONTEXT_TOKENS: '1000000' })
+    const autoCompactWindow = (settings.settings as { autoCompactWindow?: number }).autoCompactWindow
+    expect(autoCompactWindow).toBeGreaterThan(100_000)
+    expect(autoCompactWindow).toBeLessThanOrEqual(1_000_000)
   })
 
   it('builds configured MCP bridges from the request snapshot instead of re-reading edited rows', async () => {

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -44,7 +44,7 @@ import {
   mergeAgentLoopbackProxyBypass
 } from './agentProxyEnvironment'
 import type { WarmQueryRequest } from './ClaudeCodeWarmQueryManager'
-import { isAnthropicOfficialHost, with1mSuffix } from './contextWindowSuffix'
+import { isAnthropicOfficialHost, resolveAgentContextWindow, with1mSuffix } from './contextWindowSuffix'
 import { createClaudeCodeQueryOptions } from './queryOptions'
 import {
   buildClaudeCodeSessionSettings,
@@ -467,7 +467,11 @@ export async function buildClaudeCodeQueryRequestForAgentSession(
   // Freeze the model metadata that configures this subprocess. Re-reading it after async route,
   // settings, and skill materialization can otherwise make the baseline describe a different
   // compaction window from the one actually passed to Claude Code.
-  const contextWindow = model.contextWindow
+  const contextWindow = resolveAgentContextWindow(
+    model.contextWindow,
+    providerRegistryService.lookupModel(providerId, modelId).presetModel?.contextWindow,
+    modelId
+  )
   const maxOutputTokens = model.maxOutputTokens
   const fastModeTransport = fastMode && isSupportFastMode(provider, model) ? provider.fastMode.transport : undefined
   const thinkingOptions = resolveClaudeCodeThinkingOptions(model, reasoningEffort)

--- a/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
+++ b/src/main/ai/runtime/claudeCode/contextWindowSuffix.ts
@@ -47,3 +47,38 @@ export function with1mSuffix(
   if (!contextWindow || contextWindow < ONE_MILLION) return modelId
   return `${modelId}[1m]`
 }
+
+/**
+ * Parse a trailing context-window annotation a user baked into a model id — `[1m]`, `[128k]`,
+ * `[200k]`, `[1.5m]` — into a token count. Returns `undefined` when the id has no such suffix, so a
+ * caller can use it as a `??` fallback for a custom row whose `contextWindow` never resolved (the row
+ * failed to match a preset because the suffix defeated `normalizeModelId`, so the registry value was
+ * never merged in). Case-insensitive (`[1M]` matches Code Mate's spelling). Trailing-anchored so a
+ * mid-id bracket is not misread.
+ */
+export function parseContextWindowSuffix(modelId: string | undefined): number | undefined {
+  if (!modelId) return undefined
+  const match = modelId.match(/\[(\d+(?:\.\d+)?)([km])\]$/i)
+  if (!match) return undefined
+  const value = Number(match[1])
+  return match[2].toLowerCase() === 'm' ? value * ONE_MILLION : value * 1000
+}
+
+/**
+ * Resolve the context window to pass to the Claude Code SDK for an Agent session.
+ *
+ * A custom row never merges the registry's `contextWindow` on read, so a row that failed to match a
+ * preset arrives with `rowContextWindow === undefined`. Fall back, in order:
+ *   1. the registry preset's window — covers a plain id that just missed the preset match;
+ *   2. a `[1m]`/`[128k]` annotation in the id — covers a suffixed id the preset can never match
+ *      (normalizeModelId won't strip the bracket).
+ * Preset-backed rows already carry a precise merged value, so step 1 short-circuits before any
+ * fallback runs.
+ */
+export function resolveAgentContextWindow(
+  rowContextWindow: number | undefined,
+  presetContextWindow: number | undefined,
+  modelId: string | undefined
+): number | undefined {
+  return rowContextWindow ?? presetContextWindow ?? parseContextWindowSuffix(modelId)
+}


### PR DESCRIPTION
## Summary

Fixes #18397 — a third-party model (e.g. `deepseek-v4-pro[1m]`) silently fell back to the Claude Code SDK's 100K auto-compact budget instead of its declared ~1M window.

## Root cause

A **custom** model row never merges the registry's `contextWindow` on read (`enrichRowsFromRegistry` only enriches image-gen/reasoning/ownedBy for custom rows — by design, to keep them row-owned). So when a row fails to match a preset, `model.contextWindow` arrives `undefined` at `buildClaudeCodeQueryRequestForAgentSession` (`agentSessionWarmup.ts`). `buildClaudeCodeSessionSettings` then sets neither `CLAUDE_CODE_MAX_CONTEXT_TOKENS` nor `autoCompactWindow` → the SDK falls back to its 100K default.

A row misses the preset match in two ways:
- a plain id on a provider/override the preset doesn't cover;
- an id with a `[1m]` suffix, which `normalizeModelId` won't strip, so `findModel` can never match `deepseek-v4-pro`.

The pipeline itself isn't broken — `settingsBuilder` already converts a non-empty `contextWindow` into the SDK env var + `autoCompactWindow` whenever the value is ≥ 100K. The only missing piece was a non-empty `contextWindow`.

## Fix

A three-tier fallback at the single Agent consumption point (`resolveAgentContextWindow`):

```ts
const contextWindow = resolveAgentContextWindow(
  model.contextWindow,                                                      // 1. row value
  providerRegistryService.lookupModel(providerId, modelId)
    .presetModel?.contextWindow,                                            // 2. registry preset
  modelId                                                                   // 3. [1m]/[128k] suffix
)
```

1. **Row value** — preset-backed rows already merged the precise value; short-circuits here.
2. **Registry preset** — covers a plain id that just missed the preset match (the catalog declares the window, the custom row just didn't inherit it).
3. **`[1m]`/`[128k]`/`[200k]` id suffix** — covers a suffixed id the preset can *never* match (the bracket defeats `normalizeModelId`). `parseContextWindowSuffix`: `[1m]`→1_000_000, `[128k]`→128_000, `[1.5m]`→1_500_000.

Each lower tier only runs when every higher tier is `undefined`, so the most precise available source always wins.

- No schema, no migration, no UI.
- No change to `normalizeModelId` / `enrichRowsFromRegistry` / Code Mate / chat / painting.

## Verification

- `resolveAgentContextWindow` unit tests pin the full priority matrix: row > preset > suffix, plus the `#18397` end case (both row and preset undefined → suffix) and the preset-wins-over-suffix precision case.
- `parseContextWindowSuffix` unit tests: suffix variants, case-insensitivity (`[1M]`), no-suffix → undefined, non-trailing bracket ignored.
- Contract test in `settingsBuilder.test.ts`: the resolved `[1m]` value (1_000_000) fed through `buildClaudeCodeSessionSettings` yields `env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = '1000000'` and `autoCompactWindow` within (100K, 1M] — the 100K fallback symptom cannot occur.
- `pnpm typecheck`, `pnpm i18n:check`, ESLint, Biome format all pass; 128 tests green.

## Scope (intentionally narrow)

- Only the in-process Agent SDK path (`agentSessionWarmup` → `settingsBuilder`).
- Code Mate (`src/renderer/pages/code/`) already has its own `[1M]` checkbox for the external-CLI config-injection path and is untouched.

Closes #18397.
