### PR TITLE
fix(external-apps): use official Windows Terminal icon

### DIFF
--- a/src/renderer/components/icons/SvgIcon.tsx
+++ b/src/renderer/components/icons/SvgIcon.tsx
@@ -472,19 +472,184 @@ export const CursorIcon = (props: SVGProps<SVGSVGElement>) => {
   )
 }
 
-// https://learn.microsoft.com/en-us/windows/terminal
+// Windows Terminal icon by Microsoft, licensed under CC BY-ND 4.0.
+// Source: https://github.com/microsoft/terminal/blob/main/res/terminal/Terminal.svg
+// License: https://github.com/microsoft/terminal/blob/main/res/LICENSE
+// Embedded as JSX with per-render SVG IDs; the artwork geometry and colors are unchanged.
 export const WindowsTerminalIcon = (props: SVGProps<SVGSVGElement>) => {
+  const uid = useId()
+  const maskId = `windows-terminal-mask0-${uid}`
+  const filter0Id = `windows-terminal-filter0-dd-${uid}`
+  const filter1Id = `windows-terminal-filter1-dd-${uid}`
+  const filter2Id = `windows-terminal-filter2-dd-${uid}`
+  const gradient0Id = `windows-terminal-paint0-linear-${uid}`
+  const gradient1Id = `windows-terminal-paint1-linear-${uid}`
+  const gradient2Id = `windows-terminal-paint2-linear-${uid}`
+  const gradient3Id = `windows-terminal-paint3-linear-${uid}`
+  const gradient4Id = `windows-terminal-paint4-linear-${uid}`
+  const gradient5Id = `windows-terminal-paint5-linear-${uid}`
+
   return (
-    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-      <rect x="2.75" y="3.25" width="18.5" height="17.5" rx="3.5" stroke="currentColor" strokeWidth="1.8" />
-      <path
-        d="M7 8.5 10.5 12 7 15.5"
-        stroke="currentColor"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path d="M12 15.5h5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M0 13H16V6H2C0.9 6 0 6.9 0 8V13Z" fill="#CCCCCC" />
+      <path d="M32 6H16V13H32V6Z" fill="#999999" />
+      <path d="M48 13H32V6H46C47.1 6 48 6.9 48 8V13Z" fill="#666666" />
+      <path d="M46 42H2C0.9 42 0 41.1 0 40V12H48V40C48 41.1 47.1 42 46 42Z" fill={`url(#${gradient0Id})`} />
+      <g filter={`url(#${filter0Id})`}>
+        <path
+          d="M15.2 24.3L6.39999 33.1C5.89999 33.6 5.89999 34.3 6.39999 34.7L8.19999 36.5C8.69999 37 9.4 37 9.8 36.5L18.6 27.7C19.1 27.2 19.1 26.5 18.6 26.1L16.8 24.3C16.4 23.9 15.6 23.9 15.2 24.3Z"
+          fill={`url(#${gradient1Id})`}
+        />
+        <mask id={maskId} style={{ maskType: 'alpha' }} maskUnits="userSpaceOnUse" x="6" y="24" width="13" height="13">
+          <path
+            d="M15.2 24.3L6.39999 33.1C5.89999 33.6 5.89999 34.3 6.39999 34.7L8.19999 36.5C8.69999 37 9.4 37 9.8 36.5L18.6 27.7C19.1 27.2 19.1 26.5 18.6 26.1L16.8 24.3C16.4 23.9 15.6 23.9 15.2 24.3Z"
+            fill={`url(#${gradient2Id})`}
+          />
+        </mask>
+        <g mask={`url(#${maskId})`}>
+          <g filter={`url(#${filter1Id})`}>
+            <path
+              d="M9.8 17.3L18.6 26.1C19.1 26.6 19.1 27.3 18.6 27.7L16.8 29.5C16.3 30 15.6 30 15.2 29.5L6.39999 20.7C5.89999 20.2 5.89999 19.5 6.39999 19.1L8.19999 17.3C8.59999 16.9 9.4 16.9 9.8 17.3Z"
+              fill={`url(#${gradient3Id})`}
+            />
+          </g>
+        </g>
+        <path
+          d="M9.8 17.3L18.6 26.1C19.1 26.6 19.1 27.3 18.6 27.7L16.8 29.5C16.3 30 15.6 30 15.2 29.5L6.39999 20.7C5.89999 20.2 5.89999 19.5 6.39999 19.1L8.19999 17.3C8.59999 16.9 9.4 16.9 9.8 17.3Z"
+          fill={`url(#${gradient4Id})`}
+        />
+      </g>
+      <g filter={`url(#${filter2Id})`}>
+        <path
+          d="M40 32H24C23.4 32 23 32.4 23 33V36C23 36.6 23.4 37 24 37H40C40.6 37 41 36.6 41 36V33C41 32.4 40.6 32 40 32Z"
+          fill={`url(#${gradient5Id})`}
+        />
+      </g>
+      <defs>
+        <filter
+          id={filter0Id}
+          x="3.02499"
+          y="15"
+          width="18.95"
+          height="25.875"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="0.5" />
+          <feGaussianBlur stdDeviation="0.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="1" />
+          <feGaussianBlur stdDeviation="1.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+          <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow" />
+          <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape" />
+        </filter>
+        <filter
+          id={filter1Id}
+          x="3.02499"
+          y="15"
+          width="18.95"
+          height="18.875"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="0.5" />
+          <feGaussianBlur stdDeviation="0.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="1" />
+          <feGaussianBlur stdDeviation="1.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+          <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow" />
+          <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape" />
+        </filter>
+        <filter
+          id={filter2Id}
+          x="20"
+          y="30"
+          width="24"
+          height="11"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="0.5" />
+          <feGaussianBlur stdDeviation="0.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" />
+          <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+          <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+          <feOffset dy="1" />
+          <feGaussianBlur stdDeviation="1.5" />
+          <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+          <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow" />
+          <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape" />
+        </filter>
+        <linearGradient
+          id={gradient0Id}
+          x1="36.4462"
+          y1="47.8257"
+          x2="11.8217"
+          y2="5.1748"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#333333" />
+          <stop offset="1" stopColor="#4D4D4D" />
+        </linearGradient>
+        <linearGradient
+          id={gradient1Id}
+          x1="14.5276"
+          y1="33.9959"
+          x2="10.4841"
+          y2="26.9924"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#999999" />
+          <stop offset="1" stopColor="#B3B3B3" />
+        </linearGradient>
+        <linearGradient
+          id={gradient2Id}
+          x1="14.5276"
+          y1="33.9959"
+          x2="10.4841"
+          y2="26.9924"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#999999" />
+          <stop offset="1" stopColor="#B3B3B3" />
+        </linearGradient>
+        <linearGradient
+          id={gradient3Id}
+          x1="16.2747"
+          y1="30.0336"
+          x2="8.73699"
+          y2="16.9781"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#CCCCCC" />
+          <stop offset="1" stopColor="#E6E6E6" />
+        </linearGradient>
+        <linearGradient
+          id={gradient4Id}
+          x1="16.2747"
+          y1="30.0336"
+          x2="8.73699"
+          y2="16.9781"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#CCCCCC" />
+          <stop offset="1" stopColor="#E6E6E6" />
+        </linearGradient>
+        <linearGradient
+          id={gradient5Id}
+          x1="35.1496"
+          y1="39.9553"
+          x2="28.8504"
+          y2="29.0447"
+          gradientUnits="userSpaceOnUse">
+          <stop stopColor="#CCCCCC" />
+          <stop offset="1" stopColor="#E6E6E6" />
+        </linearGradient>
+      </defs>
     </svg>
   )
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

The Windows Terminal entry in the agent workspace's open-in menu used a generic monochrome terminal glyph instead of the application's official icon.

After this PR:

The entry renders Microsoft's official stable Windows Terminal artwork, matching the branded icons used by the other external applications.

Screenshot:

<img width="420" height="381" alt="Windows Terminal official icon in the agent workspace open-in menu" src="https://github.com/user-attachments/assets/2cfd0378-de0e-41f1-93ba-87f09ab95e6f" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The official SVG is embedded in the existing icon component to preserve the current external-app icon ownership and avoid adding a runtime asset lookup.
- React `useId()` namespaces the SVG mask, filters, and gradients so multiple rendered instances cannot collide.
- The artwork geometry and colors remain unchanged; source and CC BY-ND 4.0 attribution are retained next to the component.

The following alternatives were considered:

- Extracting the icon from the installed Store application at runtime was rejected because Windows Terminal is detected through an App Execution Alias and the other external-app icons already use embedded SVGs.
- Keeping the generic terminal glyph was rejected because it did not represent the actual Windows Terminal brand shown alongside VS Code, Cursor, and Zed.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Official artwork source: https://github.com/microsoft/terminal/blob/main/res/terminal/Terminal.svg

Asset license: https://github.com/microsoft/terminal/blob/main/res/LICENSE

Validation:

- `pnpm exec biome check src/renderer/components/icons/SvgIcon.tsx`
- `pnpm exec eslint src/renderer/components/icons/SvgIcon.tsx --max-warnings=0`
- `pnpm typecheck:web`
- `pnpm exec vitest run --project renderer src/renderer/components/chat/panes/__tests__/OpenExternalAppButton.test.tsx` (9 tests passed)
- Rendered the React component at its actual 16x16 menu size

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Windows: show the official Windows Terminal icon in the agent workspace open-in menu.
```
