### PR TITLE
fix(rename): stop IME composition Enter from committing a pinyin title

### DIFF
--- a/src/renderer/components/EditNameDialog.tsx
+++ b/src/renderer/components/EditNameDialog.tsx
@@ -79,6 +79,10 @@ const EditNameDialog = ({
   }
 
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    // IME candidate confirmation still emits keydown; submitting there would save the raw pinyin
+    // buffer instead of the composed text. `keyCode === 229` is the legacy fallback.
+    // oxlint-disable-next-line no-deprecated
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return
     if (event.key !== 'Enter') return
 
     event.preventDefault()

--- a/src/renderer/components/__tests__/EditNameDialog.test.tsx
+++ b/src/renderer/components/__tests__/EditNameDialog.test.tsx
@@ -98,4 +98,22 @@ describe('EditNameDialog', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('Gamma'))
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
+
+  it('does not submit the raw pinyin buffer when Enter confirms an IME candidate', async () => {
+    renderDialog()
+    const input = within(screen.getByRole('dialog')).getByLabelText('Name')
+
+    // Confirming a CJK candidate types Enter while the input still holds the raw pinyin.
+    fireEvent.change(input, { target: { value: "dui'bi" } })
+    expect(fireEvent.keyDown(input, { key: 'Enter', isComposing: true })).toBe(true)
+    // Legacy fallback: browsers that don't expose isComposing report keyCode 229.
+    expect(fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })).toBe(true)
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    // Composition ends, the composed text lands in the input, and Enter submits it.
+    fireEvent.change(input, { target: { value: '对比' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('对比'))
+  })
 })

--- a/src/renderer/components/chat/resourceList/base/ResourceList.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceList.tsx
@@ -529,6 +529,10 @@ function RenameField<T extends ResourceListItemBase>({
         event.stopPropagation()
       }}
       onKeyDown={(event) => {
+        // IME candidate confirmation still emits keydown; committing there would save the raw pinyin
+        // buffer instead of the composed text. `keyCode === 229` is the legacy fallback.
+        // oxlint-disable-next-line no-deprecated
+        if (event.nativeEvent.isComposing || event.keyCode === 229) return
         if (event.key === 'Enter') {
           event.preventDefault()
           event.stopPropagation()

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -871,6 +871,55 @@ describe('ResourceList', () => {
     })
   })
 
+  it('keeps inline rename open while an IME is composing so the pinyin buffer is never committed', () => {
+    const onRenameItem = vi.fn()
+    const Provider = ResourceList.Provider<TestItem>
+
+    function Row({ item }: { item: TestItem }) {
+      const { actions } = useResourceList<TestItem>()
+      return (
+        <ResourceList.Item item={item}>
+          <ResourceList.RenameField item={item} aria-label={`Rename ${item.name}`} />
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation()
+              actions.startRename(item.id)
+            }}>
+            Rename {item.name}
+          </button>
+        </ResourceList.Item>
+      )
+    }
+
+    render(
+      <Provider items={ITEMS} onRenameItem={onRenameItem}>
+        <ResourceList.Frame>
+          <ResourceList.VirtualItems<TestItem> renderItem={(item) => <Row item={item} />} />
+        </ResourceList.Frame>
+      </Provider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Alpha' }))
+    const input = screen.getByLabelText('Rename Alpha')
+
+    // Confirming a CJK candidate types Enter while the input still holds the raw pinyin.
+    fireEvent.change(input, { target: { value: "dui'bi" } })
+    expect(fireEvent.keyDown(input, { key: 'Enter', isComposing: true })).toBe(true)
+    expect(onRenameItem).not.toHaveBeenCalled()
+    // Legacy fallback: browsers that don't expose isComposing report keyCode 229.
+    expect(fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 })).toBe(true)
+    expect(onRenameItem).not.toHaveBeenCalled()
+    // Escape only dismisses the candidate window mid-composition; the rename stays open.
+    fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+    expect(screen.getByLabelText('Rename Alpha')).toBeInTheDocument()
+
+    // Composition ends, the composed text lands in the input, and Enter commits it.
+    fireEvent.change(input, { target: { value: '对比' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onRenameItem).toHaveBeenCalledWith('alpha', '对比')
+  })
+
   it('uses product row semantics without flattening foreground hierarchy', () => {
     const Provider = ResourceList.Provider<TestItem>
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR: renaming a workspace agent session (or a topic, or a history record) with a CJK input method saved the **raw pinyin buffer** as the title. Pressing Enter to confirm an IME candidate emits a `keydown`, and both rename handlers treated that as "user submitted": they called `preventDefault()` and committed the current input value — which at that moment still held the un-composed pinyin. The `preventDefault()` also swallowed the IME's own commit, so the Chinese text never landed. Users ended up with titles like `superpowershi'yong` / `dui'bi`. The apostrophe there is the pinyin syllable separator, which only ever exists inside the composition buffer — that is what pins the diagnosis.

After this PR: both handlers ignore keydown while the IME is composing, so Enter reaches the input as a plain candidate confirmation. Once composition ends, Enter commits the composed text as usual.

Two rename entry points were affected, and both are fixed:

| Entry point | File | Reaches |
|---|---|---|
| Context menu → Rename (dialog) | `components/EditNameDialog.tsx` | agent sessions (`Sessions.tsx`), topics (`Topics.tsx`), history records (`HistoryRecordList.tsx`) |
| Inline rename on the row | `components/chat/resourceList/base/ResourceList.tsx` (`RenameField`) | agent session list (`SessionItem.tsx`), home topic list (`Topics.tsx`) |

Fixes # N/A (reported through internal v2 preview feedback, not a GitHub issue)

**原始反馈**：用户「许思寅」(v2 抓虫大赛 · Windows / Cherry Studio v2.0.3)：「在工作区的智能体下修改对话名称，输入的中文名称被保存/显示为拼音式文本而不是中文。」｜ 源记录(dev 表 recvs5fGVYAu2g)：https://mcnnox2fhjfq.feishu.cn/record/Q5Esr6RJkeUN34cGhShczcKenwg

### Why we need it and why it was done in this way

The guard is copied verbatim from the two places in this repo that already solve the same problem — `packages/ui/.../entity-selector.tsx` and `components/GlobalSearch/GlobalSearchPanel.tsx`:

```ts
if (event.nativeEvent.isComposing || event.keyCode === 229) return
```

`keyCode === 229` is the legacy fallback for engines that don't expose `isComposing` on the native event.

The following tradeoffs were made:

- In `RenameField` the guard sits at the top of the handler, so it also covers the `Escape` branch. That is intentional: mid-composition, Escape dismisses the IME candidate window, and cancelling the whole rename there would be just as surprising as committing pinyin. The `Space` branch is the same story (space picks a candidate).
- `onBlur` was deliberately left alone. Chromium fires `compositionend` — committing the composed text into the input — before `blur`, so the blur path already reads the correct value; a composition guard there would break commit-on-blur instead of fixing anything.
- Returning early does not let Enter bubble up and open the row: `ResourceList.Item`'s own `onKeyDown` starts with `if (event.defaultPrevented || event.target !== event.currentTarget) return`, and events originating in the input never satisfy `target === currentTarget`.

The following alternatives were considered:

- Committing on `keyup` instead — changes the interaction model for every user to fix a CJK-only bug.
- Dropping `preventDefault()` — Enter would then bubble and trigger the row's open action.
- Special-casing Windows or a particular IME — this is standard composition-event semantics on every platform, not a Windows quirk.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

**Same defect class elsewhere, deliberately left out of this PR.** Three more rename inputs commit on an unguarded Enter, but they belong to unrelated features and were not part of the report, so I flagged rather than expanded scope. Happy to do them here or in a follow-up, whichever you prefer:

- `src/renderer/pages/files/InlineRename.tsx:40` — file rename
- `src/renderer/components/resourceCatalog/catalog/ResourceGrid.tsx:469` — group rename
- `src/renderer/pages/notes/HeaderNavbar.tsx:193` — note title (only blurs on Enter, so the damage is milder)

**The original report bundled two more symptoms** — a leftover "sticky note / pinned item" marker after renaming, and previously-added app entries disappearing from the left rail. I looked for a shared cause and found none: `ResourceListProvider.commitRename` unconditionally clears the rename state (`setRenamingId(null)` + `dispatch({ type: 'cancelRename' })`), so no failure path leaves rename/pin residue behind. Those two are tracked separately and are **not** addressed here.

**Verification**: `pnpm typecheck:web`, `pnpm test:lint` (exit 0), oxlint on all four changed files (0 warnings, 0 errors), and `vitest run src/renderer/components/chat/resourceList src/renderer/components/__tests__/EditNameDialog.test.tsx packages/ui/.../entity-selector` — 9 files, 155 tests, all passing. Both new tests are genuinely red→green: reverting either fix alone makes its test fail on `expected false to be true`, i.e. `preventDefault()` was wrongly called on the composing Enter.

No visual change — this is a keyboard-event guard only; no layout, style, or copy is touched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed agent session, topic, and history record rename saving the raw pinyin instead of the Chinese title when confirming an IME candidate with Enter.
```
