### PR TITLE
docs(cherry-electron-dev): expand performance diagnostics

### DIFF
--- a/.agents/skills/cherry-electron-dev/references/performance-debugging.md
+++ b/.agents/skills/cherry-electron-dev/references/performance-debugging.md
@@ -9,7 +9,8 @@ DevTools investigations.
 - Quick renderer metrics
 - Interaction trace
 - Memory and allocation
-- Process and main-process checks
+- Development-runtime overhead
+- Node and main-process checks
 - Startup analysis
 - Interpretation and reporting
 
@@ -50,7 +51,7 @@ Choose the smallest profile:
 | Cause of a visible stall? | 5-30 second trace |
 | Memory growth after repetition? | Repeated checkpoints |
 | Allocation source? | Allocation sampling |
-| Main/helper resource use? | Process sampling |
+| Main/helper resource use? | Process sampling, then Node inspector |
 | Slow startup? | Restart-aware startup analysis |
 
 Collect a quiet idle baseline. Keep action, duration, window size, route, data,
@@ -127,6 +128,18 @@ same action a fixed number of times, return to the same idle state, and record
 again across multiple cycles. One larger heap value is not proof; V8 may defer
 GC. Do not force GC unless a post-GC comparison is explicitly needed.
 
+Triangulate renderer memory instead of relying on one number:
+
+- OS RSS or process footprint includes V8, native allocations, graphics, and
+  diagnostic buffers.
+- `JSHeapUsedSize` covers only the live V8 heap.
+- `Nodes`, `Documents`, `Frames`, and `JSEventListeners` expose retained UI
+  structures but not native or performance-entry storage.
+
+Large OS growth with a stable JS heap and stable DOM gauges is not, by itself,
+an application heap leak. Check development-runtime instrumentation before
+changing product code.
+
 For bounded allocation attribution:
 
 ```js
@@ -141,19 +154,191 @@ await fs.writeFile("<PROFILE_PATH>.json", JSON.stringify(profile))
 Use a full heap snapshot only when sampling and gauges are insufficient. Warn
 first: it can pause the renderer, be large, and contain private data.
 
-## Process and main-process checks
+## Development-runtime overhead
 
-Sample the tracked process group several times before, during, and after:
+Development measurements are useful for relative comparisons, but their
+absolute memory and CPU are not a production baseline. HMR, source maps,
+DevTools, Strict Mode, and framework instrumentation can add or retain work.
+Keep visible-DevTools state identical across samples and identify the retaining
+system before attributing growth to Cherry Studio.
+
+React 19 development builds emit component Performance Tracks through User
+Timing. When a changing prop contains a growing HTML or text string, React can
+serialize both previous and current prop values into
+`PerformanceMeasure.detail.devtools.properties` on every render. Those entries
+remain in the renderer's performance timeline until cleared and can make the
+process footprint grow by gigabytes while the JS heap and DOM stay bounded.
+
+Suspect this path when a CPU profile contains `logComponentRender`,
+`addValueToProperties`, or `performance.measure`. Inspect entry counts and
+string lengths without returning or serializing the retained values:
+
+```js
+var timingSummary = await page.evaluate(() => {
+  var measures = performance.getEntriesByType("measure")
+  var reactMeasures = 0
+  var largestProperty = null
+
+  for (var entry of measures) {
+    var devtools = entry.detail?.devtools
+    if (devtools?.track !== "Components ⚛") continue
+    reactMeasures++
+
+    for (var property of devtools.properties ?? []) {
+      if (!Array.isArray(property)) continue
+      for (var value of property) {
+        if (
+          typeof value === "string" &&
+          value.length > (largestProperty?.length ?? 0)
+        ) {
+          largestProperty = { component: entry.name, length: value.length }
+        }
+      }
+    }
+  }
+
+  return { totalMeasures: measures.length, reactMeasures, largestProperty }
+})
+```
+
+Do not call `JSON.stringify()` on all performance entries or return their
+`detail` objects over CDP; that creates another large copy and contaminates the
+measurement.
+
+To distinguish retained diagnostic entries from an application leak:
+
+1. Stop or finish the bounded scenario and capture OS, heap, DOM, and timing
+   counts.
+2. Save any required trace before cleanup; clearing removes evidence from the
+   current User Timing buffer.
+3. Run `performance.clearMeasures()` and `performance.clearMarks()` in the
+   page.
+4. Only for this explicit post-cleanup comparison, run
+   `HeapProfiler.collectGarbage` and resample the same gauges.
+5. If measures immediately accumulate again, rendering is still active; wait
+   for the same idle state and repeat once.
+
+A sharp process-footprint drop after cleanup, with bounded heap and DOM, is
+evidence of development instrumentation retention rather than an equivalent
+production leak. It is not a product fix: never add content truncation,
+memoization, or stream throttling solely to hide this signal. If production
+impact matters, verify it independently against the current production bundle
+or packaged build and report separately whether that validation was run.
+
+## Node and main-process checks
+
+Identify the busy process before profiling. Sample the tracked process group
+several times before, during, and after:
 
 ```bash
 ps -axo pid=,ppid=,pgid=,%cpu=,rss=,command= | \
   awk '$3 == <TRACKED_PGID>'
 ```
 
-Separate Electron main, renderer/helper, Vite, and runner costs. If renderer
-metrics are quiet while main is busy, verify and attach to the recorded Node
-inspector target, normally port `9229`. Use a bounded CPU profile and correlate
-it with application logs. Do not confuse it with renderer CDP `9222`.
+Separate Electron main, renderer/helper, GPU, Vite, runner, and spawned child
+process costs. A Claude Code or MCP child is not part of the Electron main V8
+isolate even when it shares the process group; profile the PID that actually
+owns the CPU or memory.
+
+### Prefer the built-in main-process diagnostics
+
+For startup, lifecycle, database, DataApi, or IPC latency, first read
+[Performance Diagnostics](../../../../docs/guides/diagnostics.md). Restart the
+tracked instance with `CS_DIAGNOSTICS=1` prepended to its existing launch
+command only when the restart is justified by the question. The opt-in path
+provides:
+
+- a `boot-whenReady.cpuprofile` with 1000 microsecond V8 samples;
+- lifecycle service spans and event-loop lag;
+- slow better-sqlite3 queries, DataApi requests, and IPC handlers;
+- window construction and ready-to-show timings.
+
+Keep the sampling interval at 1000 microseconds. Sort CPU profiles by self time;
+wall time assigned to async service initialization can include sibling work and
+is not reliable attribution.
+
+Interpret the combined signals:
+
+| Observation | Likely class | Next evidence |
+| --- | --- | --- |
+| High CPU and profiler self time | Synchronous JavaScript or native call site | Inspect the hottest stack and bound the same input |
+| High event-loop lag | Main thread blocked | Correlate the lag window with CPU, DB, IPC, and logs |
+| Long wall time, low CPU, low lag | Async I/O, network, timer, or subprocess wait | Trace start/end timestamps and the external dependency |
+| `fires=0` during a long startup phase | Microtask chain never yielded | Trust CPU self time, not timer-based lag |
+| Slow better-sqlite3 query plus lag | Synchronous database work | Inspect SQL, row count, query plan, and transaction scope |
+
+### Profile steady-state Node work
+
+For runtime work outside startup, verify that the recorded Node inspector port,
+normally `9229`, belongs to the exact Electron main PID. Inspect
+`http://127.0.0.1:<INSPECTOR_PORT>/json/list`, attach to that target, and collect
+only a bounded reproduction with `Profiler.enable`,
+`Profiler.setSamplingInterval({ interval: 1000 })`, `Profiler.start`, and
+`Profiler.stop`. Save the returned profile under
+`.context/cherry-electron-dev/` and detach the inspector connection afterward.
+Do not confuse the main-process inspector with renderer CDP, normally `9222`.
+
+Do not leave the CPU profiler running while waiting for user input or an
+unbounded stream. Sampling has overhead, and an oversized profile is harder to
+attribute. Compare the same duration and input, and use source-mapped stacks
+from the tracked debug instance.
+
+If the exact main PID has high CPU but the V8 profile does not account for it,
+capture a short native sample of that PID on macOS:
+
+```bash
+sample <ELECTRON_MAIN_PID> 10 -file \
+  .context/cherry-electron-dev/main-native-sample.txt
+```
+
+This gap points toward Electron, a native addon, another main-process thread,
+or the wrong PID—not automatically toward JavaScript. Keep native samples under
+`.context`; stacks and paths may be private.
+
+### Diagnose Node memory growth
+
+At matched idle checkpoints, record both OS RSS/footprint and main-isolate
+memory from `process.memoryUsage()` through inspector `Runtime.evaluate`. Return
+only numeric fields and aggregate resource types; do not return application
+objects or message contents over the inspector channel.
+
+```js
+(() => {
+  var memory = process.memoryUsage()
+  var resources = process.getActiveResourcesInfo?.() ?? []
+  var resourcesByType = {}
+  for (var type of resources) {
+    resourcesByType[type] = (resourcesByType[type] ?? 0) + 1
+  }
+  return { ...memory, resourcesByType }
+})()
+```
+
+Use repeated, fixed-size cycles and return to the same idle state before each
+sample:
+
+- rising `heapUsed` after comparable post-GC checkpoints suggests retained JS
+  objects;
+- rising `external` or `arrayBuffers` suggests Buffer, typed-array, or native
+  backing-store retention;
+- rising handle/resource counts suggest timers, sockets, pipes, or requests
+  that were not released;
+- rising OS footprint with bounded isolate fields points toward Electron/native
+  allocations, SQLite/native addons, allocator fragmentation, or another
+  process—not proof of a JavaScript leak.
+
+Capture the raw checkpoint first. When a post-GC discriminator is necessary,
+call `HeapProfiler.collectGarbage` through the same main-process inspector and
+resample after a fixed quiet delay. Compare post-GC checkpoints with each
+other; do not compare a forced-GC result with an arbitrary pre-GC peak. A heap
+drop without an RSS drop can be allocator retention rather than live objects.
+
+Use `HeapProfiler.startSampling` for bounded allocation attribution. Reserve a
+full heap snapshot for cases sampling cannot resolve: it pauses the main
+process, can be very large, and may contain tokens, prompts, paths, or other
+private data. Never expose the main inspector beyond loopback, and do not add
+permanent diagnostic logging or instrumentation until existing evidence shows
+which boundary lacks observability.
 
 ## Startup analysis
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:
The Electron development skill did not distinguish React development instrumentation memory from production behavior, and its main-process guidance stopped at coarse process sampling.

After this PR:
The skill documents how to attribute React User Timing retention, triangulate renderer memory, profile the exact Electron main process, and use Cherry Studio's built-in startup diagnostics safely.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The guidance favors bounded sampling and numeric aggregates so profiling does not duplicate large private payloads.
- Production verification remains required before treating development-only memory retention as a product defect.

The following alternatives were considered:
- Treating Activity Monitor memory as sufficient evidence was rejected because it cannot distinguish V8, Blink, native, and diagnostic retention.
- Adding permanent application instrumentation was rejected because the existing opt-in diagnostics already cover the main-process path.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

Documentation-only change under `.agents/skills/cherry-electron-dev`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
