### PR TITLE
perf(home-composer): skip unchanged streaming renders

### DIFF
--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -12,6 +12,7 @@ import type { ComposerChatTarget } from '@shared/ai/transport'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { memo } from 'react'
 
 import type { AddNewTopicPayload } from './types'
 
@@ -39,7 +40,7 @@ type ChatComposerSlotProps =
   | (ChatComposerSlotBaseProps & { placement: 'home'; sendDisabled?: never })
   | (ChatComposerSlotBaseProps & { placement: 'docked'; sendDisabled?: boolean })
 
-export default function ChatComposerSlot({
+function ChatComposerSlot({
   placement,
   topic,
   contextUsage,
@@ -94,3 +95,5 @@ export default function ChatComposerSlot({
 
   return <ConversationComposerSlot composerContext={composerContext} fallback={fallback} />
 }
+
+export default memo(ChatComposerSlot)

--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -210,6 +210,15 @@ describe('useChatRuntimeState', () => {
     expect(sent).toBe(false)
   })
 
+  it('keeps sendMessage stable across runtime rerenders', () => {
+    const view = render(<RuntimeHost topicId="topic-1" />)
+    const sendMessage = latestRuntime?.sendMessage
+
+    view.rerender(<RuntimeHost topicId="topic-1" />)
+
+    expect(latestRuntime?.sendMessage).toBe(sendMessage)
+  })
+
   it('keeps branch-live state across an <Activity> hide/show and clears it when the topic changes', async () => {
     const view = render(<ActivityHarness mode="visible" topicId="topic-1" />)
 

--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -16,7 +16,9 @@ const mocks = vi.hoisted(() => ({
   overlayExecutions: [] as ActiveExecution[],
   liveMessageIds: [] as string[],
   liveAssistants: [] as CherryUIMessage[],
-  overlayOnFinish: null as ((executionId: string, event: ExecutionFinishEvent) => void) | null
+  overlayOnFinish: null as ((executionId: string, event: ExecutionFinishEvent) => void) | null,
+  turnSend: vi.fn(),
+  runtimeState: null as ReturnType<typeof useChatRuntimeState> | null
 }))
 
 vi.mock('@logger', () => ({
@@ -80,7 +82,7 @@ vi.mock('@renderer/hooks/useChatWithHistory', () => ({
 vi.mock('@renderer/hooks/useConversationTurnController', () => ({
   useConversationTurnController: (config: unknown) => {
     mocks.turnControllerConfig = config
-    return { send: vi.fn(), phase: 'idle' }
+    return { send: mocks.turnSend, phase: 'idle' }
   }
 }))
 
@@ -156,7 +158,7 @@ function RuntimeHost({
   messages?: CherryUIMessage[]
 }) {
   const topic = useMemo(() => makeTopic(topicId), [topicId])
-  useChatRuntimeState({
+  mocks.runtimeState = useChatRuntimeState({
     topic,
     isHistoryLoading: false,
     initialMessages: messages,
@@ -190,6 +192,20 @@ describe('useChatRuntimeState', () => {
     mocks.liveMessageIds = []
     mocks.liveAssistants = []
     mocks.overlayOnFinish = null
+    mocks.runtimeState = null
+  })
+
+  it('keeps sendMessage stable across runtime rerenders', async () => {
+    const view = render(<RuntimeHost topicId="topic-1" />)
+    const sendMessage = mocks.runtimeState?.sendMessage
+
+    view.rerender(<RuntimeHost topicId="topic-1" />)
+
+    expect(mocks.runtimeState?.sendMessage).toBe(sendMessage)
+    await act(async () => {
+      await mocks.runtimeState?.sendMessage('hello')
+    })
+    expect(mocks.turnSend).toHaveBeenCalledWith({ text: 'hello', options: undefined })
   })
 
   it('keeps branch-live state across an <Activity> hide/show and clears it when the topic changes', async () => {

--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -1,3 +1,4 @@
+import type { UseConversationTurnControllerOptions } from '@renderer/hooks/useConversationTurnController'
 import type { ExecutionFinishEvent } from '@renderer/hooks/useExecutionOverlay'
 import type { Topic } from '@renderer/types/topic'
 import type { ActiveExecution } from '@shared/ai/transport'
@@ -17,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   liveMessageIds: [] as string[],
   liveAssistants: [] as CherryUIMessage[],
   overlayOnFinish: null as ((executionId: string, event: ExecutionFinishEvent) => void) | null,
-  turnSend: vi.fn(),
+  invalidateCache: vi.fn(),
   runtimeState: null as ReturnType<typeof useChatRuntimeState> | null
 }))
 
@@ -31,7 +32,7 @@ vi.mock('@logger', () => ({
 }))
 
 vi.mock('@data/hooks/useDataApi', () => ({
-  useInvalidateCache: () => vi.fn()
+  useInvalidateCache: () => mocks.invalidateCache
 }))
 
 // The live-state builder is the guard's observable output surface: the test
@@ -79,12 +80,19 @@ vi.mock('@renderer/hooks/useChatWithHistory', () => ({
   })
 }))
 
-vi.mock('@renderer/hooks/useConversationTurnController', () => ({
-  useConversationTurnController: (config: unknown) => {
-    mocks.turnControllerConfig = config
-    return { send: mocks.turnSend, phase: 'idle' }
+vi.mock('@renderer/hooks/useConversationTurnController', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/useConversationTurnController')>()
+
+  return {
+    ...actual,
+    useConversationTurnController<TInput, TConversation>(
+      config: UseConversationTurnControllerOptions<TInput, TConversation>
+    ) {
+      mocks.turnControllerConfig = config
+      return actual.useConversationTurnController(config)
+    }
   }
-}))
+})
 
 vi.mock('@renderer/hooks/useExecutionOverlay', () => ({
   useExecutionOverlay: (
@@ -202,10 +210,6 @@ describe('useChatRuntimeState', () => {
     view.rerender(<RuntimeHost topicId="topic-1" />)
 
     expect(mocks.runtimeState?.sendMessage).toBe(sendMessage)
-    await act(async () => {
-      await mocks.runtimeState?.sendMessage('hello')
-    })
-    expect(mocks.turnSend).toHaveBeenCalledWith({ text: 'hello', options: undefined })
   })
 
   it('keeps branch-live state across an <Activity> hide/show and clears it when the topic changes', async () => {

--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -1,3 +1,4 @@
+import type * as ConversationTurnControllerModule from '@renderer/hooks/useConversationTurnController'
 import type { UseConversationTurnControllerOptions } from '@renderer/hooks/useConversationTurnController'
 import type { ExecutionFinishEvent } from '@renderer/hooks/useExecutionOverlay'
 import type { Topic } from '@renderer/types/topic'
@@ -81,7 +82,7 @@ vi.mock('@renderer/hooks/useChatWithHistory', () => ({
 }))
 
 vi.mock('@renderer/hooks/useConversationTurnController', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@renderer/hooks/useConversationTurnController')>()
+  const actual = await importOriginal<typeof ConversationTurnControllerModule>()
 
   return {
     ...actual,

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -306,13 +306,8 @@ export function useChatRuntimeState({
     }),
     [cache.rollbackBranch, refresh, seedReservedMessages]
   )
-  const turnController = useConversationTurnController<
-    ChatTurnInput,
-    { topicId: string; parentAnchorId: string | null }
-  >({
-    scopeKey: topic.id,
-    historyAdapter,
-    ensureConversation: async ({ options }) => {
+  const ensureConversation = useCallback(
+    async ({ options }: ChatTurnInput) => {
       if (isHistoryLoading) return null
 
       return {
@@ -320,7 +315,10 @@ export function useChatRuntimeState({
         parentAnchorId: options?.chatTarget ? options.chatTarget.parentAnchorId : (activeNodeId ?? null)
       }
     },
-    buildStreamRequest: ({ text, options }, conversation) => {
+    [activeNodeId, isHistoryLoading, topic.id]
+  )
+  const buildStreamRequest = useCallback(
+    ({ text, options }: ChatTurnInput, conversation: { topicId: string; parentAnchorId: string | null }) => {
       const requestOptions = {
         topicId: conversation.topicId,
         mentionedModelIds: options?.mentionedModels,
@@ -331,13 +329,27 @@ export function useChatRuntimeState({
 
       return {
         ...requestOptions,
-        trigger: 'submit-message',
+        trigger: 'submit-message' as const,
         parentAnchorId: conversation.parentAnchorId ?? undefined,
         userMessageParts: options?.userMessageParts ?? [{ type: 'text' as const, text }],
         ...(options?.chatTarget ? { targetMode: options.chatTarget.mode } : {})
       }
     },
-    refreshMetadata: ({ topicId }) => invalidateCache(['/topics', `/topics/${topicId}`])
+    []
+  )
+  const refreshMetadata = useCallback(
+    ({ topicId }: { topicId: string }) => invalidateCache(['/topics', `/topics/${topicId}`]),
+    [invalidateCache]
+  )
+  const { phase: turnPhase, send } = useConversationTurnController<
+    ChatTurnInput,
+    { topicId: string; parentAnchorId: string | null }
+  >({
+    scopeKey: topic.id,
+    historyAdapter,
+    ensureConversation,
+    buildStreamRequest,
+    refreshMetadata
   })
 
   const activeStreamingMessageIds = useMemo(() => new Set(liveMessageIds), [liveMessageIds])
@@ -464,21 +476,21 @@ export function useChatRuntimeState({
       isHistoryLoading ||
       isTopicStreamPending ||
       isTopicAwaitingApproval ||
-      turnController.phase === 'persisting' ||
-      turnController.phase === 'opening',
+      turnPhase === 'persisting' ||
+      turnPhase === 'opening',
     assistant
   })
 
   const sendMessage = useCallback(
     async (text: string, options?: ChatTurnInput['options']) => {
       try {
-        return await turnController.send({ text, options })
+        return await send({ text, options })
       } catch (err) {
         logger.warn('failed to open conversation turn', err as Error)
         throw err
       }
     },
-    [turnController]
+    [send]
   )
 
   return {

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -301,13 +301,8 @@ export function useChatRuntimeState({
     }),
     [cache.rollbackBranch, refresh, seedReservedMessages]
   )
-  const { phase: turnPhase, send } = useConversationTurnController<
-    ChatTurnInput,
-    { topicId: string; parentAnchorId: string | null }
-  >({
-    scopeKey: topic.id,
-    historyAdapter,
-    ensureConversation: async ({ options }) => {
+  const ensureConversation = useCallback(
+    async ({ options }: ChatTurnInput) => {
       if (isHistoryLoading) return null
 
       return {
@@ -315,7 +310,10 @@ export function useChatRuntimeState({
         parentAnchorId: options?.chatTarget ? options.chatTarget.parentAnchorId : (activeNodeId ?? null)
       }
     },
-    buildStreamRequest: ({ text, options }, conversation) => {
+    [activeNodeId, isHistoryLoading, topic.id]
+  )
+  const buildStreamRequest = useCallback(
+    ({ text, options }: ChatTurnInput, conversation: { topicId: string; parentAnchorId: string | null }) => {
       const requestOptions = {
         topicId: conversation.topicId,
         mentionedModelIds: options?.mentionedModels,
@@ -325,13 +323,27 @@ export function useChatRuntimeState({
 
       return {
         ...requestOptions,
-        trigger: 'submit-message',
+        trigger: 'submit-message' as const,
         parentAnchorId: conversation.parentAnchorId ?? undefined,
         userMessageParts: options?.userMessageParts ?? [{ type: 'text' as const, text }],
         ...(options?.chatTarget ? { targetMode: options.chatTarget.mode } : {})
       }
     },
-    refreshMetadata: ({ topicId }) => invalidateCache(['/topics', `/topics/${topicId}`])
+    []
+  )
+  const refreshMetadata = useCallback(
+    ({ topicId }: { topicId: string }) => invalidateCache(['/topics', `/topics/${topicId}`]),
+    [invalidateCache]
+  )
+  const { phase: turnPhase, send } = useConversationTurnController<
+    ChatTurnInput,
+    { topicId: string; parentAnchorId: string | null }
+  >({
+    scopeKey: topic.id,
+    historyAdapter,
+    ensureConversation,
+    buildStreamRequest,
+    refreshMetadata
   })
 
   const activeStreamingMessageIds = useMemo(() => new Set(liveMessageIds), [liveMessageIds])

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -301,7 +301,7 @@ export function useChatRuntimeState({
     }),
     [cache.rollbackBranch, refresh, seedReservedMessages]
   )
-  const turnController = useConversationTurnController<
+  const { phase: turnPhase, send } = useConversationTurnController<
     ChatTurnInput,
     { topicId: string; parentAnchorId: string | null }
   >({
@@ -458,21 +458,21 @@ export function useChatRuntimeState({
       isHistoryLoading ||
       isTopicStreamPending ||
       isTopicAwaitingApproval ||
-      turnController.phase === 'persisting' ||
-      turnController.phase === 'opening',
+      turnPhase === 'persisting' ||
+      turnPhase === 'opening',
     assistant
   })
 
   const sendMessage = useCallback(
     async (text: string, options?: ChatTurnInput['options']) => {
       try {
-        await turnController.send({ text, options })
+        await send({ text, options })
       } catch (err) {
         logger.warn('failed to open conversation turn', err as Error)
         throw err
       }
     },
-    [turnController]
+    [send]
   )
 
   return {


### PR DESCRIPTION
### What this PR does

Before this PR:

Streaming execution-overlay snapshots rerendered the unchanged Home composer subtree because `ChatComposerSlot` was not memoized and `sendMessage` depended on the full turn-controller object.

After this PR:

The Home composer uses the same memo boundary as the Agent composer, and `sendMessage` depends only on the stable controller `send` callback.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18465

### Why we need it and why it was done in this way

The following tradeoffs were made:

The change is intentionally limited to the existing Home composer boundary and runtime callback identity. It does not add custom prop comparison or change chat behavior.

The following alternatives were considered:

Memoizing larger Home layout subtrees was avoided because the Agent path already demonstrates the narrower established pattern.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18465

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

`pnpm build:check` completed lint, typecheck, i18n, formatting, documentation links, and 11,364 tests before five unrelated load-sensitive main-process tests timed out. All five failed tests passed when rerun in isolation; the changed Home runtime test passes 7/7.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
