### PR TITLE
feat(agents): add floating task progress capsule

### DIFF
--- a/src/renderer/components/composer/ComposerFloatingCapsule.tsx
+++ b/src/renderer/components/composer/ComposerFloatingCapsule.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@renderer/utils/style'
+import type { ComponentPropsWithRef } from 'react'
+
+export default function ComposerFloatingCapsule({ children, className, ref, ...props }: ComponentPropsWithRef<'div'>) {
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'pointer-events-auto flex h-9 cursor-default items-center gap-2 rounded-full border border-border-subtle bg-background/95 px-3 text-muted-foreground text-sm shadow-sm outline-none backdrop-blur-sm transition-[border-color,box-shadow] hover:border-border focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-inset',
+        className
+      )}
+      {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/components/composer/ComposerFloatingCapsule.tsx
+++ b/src/renderer/components/composer/ComposerFloatingCapsule.tsx
@@ -6,7 +6,7 @@ export default function ComposerFloatingCapsule({ children, className, ref, ...p
     <div
       ref={ref}
       className={cn(
-        'pointer-events-auto flex h-9 cursor-default items-center gap-2 rounded-full border border-border-subtle bg-background/95 px-3 text-muted-foreground text-sm shadow-sm outline-none backdrop-blur-sm transition-[border-color,box-shadow] hover:border-border focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-inset',
+        'pointer-events-auto flex h-9 cursor-default items-center gap-2 rounded-full border border-border-subtle bg-popover px-3 text-popover-foreground text-sm shadow-sm outline-none transition-[border-color,box-shadow] hover:border-border focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-inset',
         className
       )}
       {...props}>

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -358,7 +358,7 @@
         "stop_run_task": "Stop task",
         "stop_run_task_failed": "Failed to stop task",
         "task_count": "{{completed}} / {{total}} complete",
-        "tasks": "Tasks",
+        "task_progress_compact": "Step {{current}}/{{total}}",
         "tool_uses_one": "{{count}} tool call",
         "tool_uses_other": "{{count}} tool calls",
         "tools_active": "Active",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -358,7 +358,7 @@
         "stop_run_task": "停止任务",
         "stop_run_task_failed": "停止任务失败",
         "task_count": "{{completed}} / {{total}} 已完成",
-        "tasks": "任务",
+        "task_progress_compact": "步骤 {{current}}/{{total}}",
         "tool_uses_one": "{{count}} 次工具调用",
         "tool_uses_other": "{{count}} 次工具调用",
         "tools_active": "活跃",

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -45,7 +45,7 @@ import { useTranslation } from 'react-i18next'
 import AgentChatMain from './AgentChatMain'
 import AgentComposerSlot from './AgentComposerSlot'
 import { AgentChatNavbar } from './components/AgentChatNavbar'
-import { type AgentFileNavigationRequest, AgentRightPane } from './components/AgentRightPane'
+import { type AgentFileNavigationRequest, AgentRightPane, AgentTaskProgressCapsule } from './components/AgentRightPane'
 import { ApiGatewayRequiredDialog } from './components/ApiGatewayRequiredDialog'
 import { locateAgentMessageInList } from './messages/agentMessageListAdapter'
 import type { CreateAgentSessionDefaults } from './types'
@@ -560,22 +560,25 @@ const AgentChatSessionCenter = ({
   composerLaunchOptions
 }: AgentChatSessionCenterProps) => {
   const composer = (
-    <AgentComposerSlot
-      agentId={agentId}
-      activeAgent={activeAgent}
-      activeModel={activeModel}
-      workspaceWarning={workspaceWarning}
-      isMultiSelectMode={isMultiSelectMode}
-      session={session}
-      sessionId={runtime.sessionId}
-      sendMessage={runtime.sendMessage}
-      stop={runtime.stop}
-      isStreaming={runtime.isPending}
-      sendDisabled={composerPending}
-      onCreateEmptySession={onCreateEmptySession}
-      composerContext={runtime.composerContext}
-      composerLaunchOptions={composerLaunchOptions}
-    />
+    <div className="flex w-full flex-col">
+      {!isMultiSelectMode && <AgentTaskProgressCapsule />}
+      <AgentComposerSlot
+        agentId={agentId}
+        activeAgent={activeAgent}
+        activeModel={activeModel}
+        workspaceWarning={workspaceWarning}
+        isMultiSelectMode={isMultiSelectMode}
+        session={session}
+        sessionId={runtime.sessionId}
+        sendMessage={runtime.sendMessage}
+        stop={runtime.stop}
+        isStreaming={runtime.isPending}
+        sendDisabled={composerPending}
+        onCreateEmptySession={onCreateEmptySession}
+        composerContext={runtime.composerContext}
+        composerLaunchOptions={composerLaunchOptions}
+      />
+    </div>
   )
   const main = (
     <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -261,6 +261,7 @@ vi.mock('../components/AgentRightPane', () => {
       Viewport: () => <div data-testid="agent-right-pane-viewport" />,
       Shortcuts: () => <button type="button">Shortcuts</button>
     },
+    AgentTaskProgressCapsule: () => null,
     useAgentRightPaneActions: () => ({
       canOpenAgentToolFlow: true,
       canOpenArtifactFile: true,

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -1,4 +1,12 @@
-import { Badge, Button, ConfirmDialog, HoverCard, HoverCardContent, HoverCardTrigger, Tooltip } from '@cherrystudio/ui'
+import {
+  Button,
+  CircularProgress,
+  ConfirmDialog,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  Tooltip
+} from '@cherrystudio/ui'
 import { loggerService } from '@logger'
 import { AgentContextUsageSummary } from '@renderer/components/chat/agent/AgentContextUsageSummary'
 import MessageList from '@renderer/components/chat/messages/MessageList'
@@ -32,6 +40,7 @@ import {
 } from '@renderer/components/chat/panes/useArtifactFileTreeModel'
 import { EmptyState } from '@renderer/components/chat/primitives'
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
+import ComposerFloatingCapsule from '@renderer/components/composer/ComposerFloatingCapsule'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { usePreference } from '@renderer/data/hooks/usePreference'
 import { useAgentSessionCompaction } from '@renderer/hooks/agent/useAgentSessionCompaction'
@@ -1018,10 +1027,97 @@ function useAgentRightPaneStatus(active = true): AgentRightPaneStatus {
   return status
 }
 
+export function AgentTaskProgressCapsule() {
+  const { t } = useTranslation()
+  const runtime = useAgentRightPaneRuntime()
+  const status = useAgentRightPaneStatus()
+
+  if (status.totalTaskCount === 0 || status.completedTaskCount === status.totalTaskCount) return null
+
+  const hasActiveAssistantRun = runtime.messages.some(
+    (message) => message.role === 'assistant' && message.metadata?.status === 'pending'
+  )
+  const explicitActiveTaskIndex = status.tasks.findIndex((task) => task.status === 'in_progress')
+  const inferredActiveTaskIndex =
+    hasActiveAssistantRun && explicitActiveTaskIndex < 0
+      ? status.tasks.findIndex((task) => task.status === 'pending')
+      : -1
+  const currentTaskIndex =
+    explicitActiveTaskIndex >= 0
+      ? explicitActiveTaskIndex
+      : inferredActiveTaskIndex >= 0
+        ? inferredActiveTaskIndex
+        : status.tasks.findIndex((task) => task.status !== 'completed')
+  const inferredActiveTaskId = inferredActiveTaskIndex >= 0 ? status.tasks[inferredActiveTaskIndex]?.id : undefined
+  const currentTaskNumber = currentTaskIndex >= 0 ? currentTaskIndex + 1 : status.completedTaskCount + 1
+  const progressPercentage = (status.completedTaskCount / status.totalTaskCount) * 100
+  const progressLabel = t('agent.right_pane.status.task_count', {
+    completed: status.completedTaskCount,
+    total: status.totalTaskCount
+  })
+  const compactProgressLabel = t('agent.right_pane.status.task_progress_compact', {
+    current: currentTaskNumber,
+    total: status.totalTaskCount
+  })
+
+  return (
+    <div className="pointer-events-none flex w-full justify-center px-4 pb-2" data-testid="agent-task-progress-capsule">
+      <HoverCard openDelay={120} closeDelay={100}>
+        <HoverCardTrigger asChild>
+          <ComposerFloatingCapsule tabIndex={0} className="gap-1.5 px-2.5">
+            <span
+              role="progressbar"
+              aria-label={progressLabel}
+              aria-valuemin={0}
+              aria-valuemax={status.totalTaskCount}
+              aria-valuenow={status.completedTaskCount}
+              className="flex shrink-0 items-center justify-center">
+              <CircularProgress
+                value={progressPercentage}
+                size={17}
+                strokeWidth={2}
+                className="stroke-border"
+                progressClassName="stroke-info transition-[stroke-dashoffset] duration-300 motion-reduce:transition-none"
+              />
+            </span>
+            <span aria-live="polite" className="tabular-nums">
+              {compactProgressLabel}
+            </span>
+          </ComposerFloatingCapsule>
+        </HoverCardTrigger>
+        <HoverCardContent
+          align="center"
+          side="top"
+          sideOffset={8}
+          className="w-64 max-w-[calc(100vw-2rem)] overflow-hidden p-2.5 shadow-lg">
+          <Scrollbar className="max-h-64" data-testid="agent-task-progress-details">
+            <ul className="space-y-1 pr-1">
+              {status.tasks.map((task) => {
+                const displayStatus = task.id === inferredActiveTaskId ? 'in_progress' : task.status
+                return (
+                  <li key={task.id} className="flex min-w-0 items-start gap-2 rounded-md px-1.5 py-1">
+                    <TaskStatusIcon status={displayStatus} />
+                    <span
+                      className={cn(
+                        'wrap-break-word min-w-0 flex-1 whitespace-normal text-xs leading-5',
+                        displayStatus === 'completed' ? 'text-muted-foreground' : 'text-foreground'
+                      )}>
+                      {displayStatus === 'in_progress' && task.activeText ? task.activeText : task.title}
+                    </span>
+                  </li>
+                )
+              })}
+            </ul>
+          </Scrollbar>
+        </HoverCardContent>
+      </HoverCard>
+    </div>
+  )
+}
+
 function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPanelScope>) {
   const meta = useAgentRightPaneMeta()
   const actions = useAgentRightPaneActions()
-  const { t } = useTranslation()
   const status = useAgentRightPaneStatus(active)
   const { usage, percentage, maxTokens } = useAgentSessionContextUsage(meta.sessionId, meta.model)
   const compaction = useAgentSessionCompaction(meta.sessionId)
@@ -1030,38 +1126,6 @@ function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPa
 
   return (
     <div className="h-full space-y-4 overflow-auto p-3 text-sm">
-      {status.tasks.length > 0 && (
-        <section className="space-y-2">
-          <div className="flex items-center justify-between gap-2">
-            <h3 className="font-medium text-foreground text-sm">{t('agent.right_pane.status.tasks')}</h3>
-            <Badge variant="outline" className="text-[11px]">
-              {t('agent.right_pane.status.task_count', {
-                completed: status.completedTaskCount,
-                total: status.totalTaskCount
-              })}
-            </Badge>
-          </div>
-          <div className="space-y-1.5">
-            {status.tasks.map((task) => (
-              <div
-                key={task.id}
-                className="flex items-start gap-2 rounded-md border border-border-subtle bg-background-subtle px-2.5 py-2">
-                <TaskStatusIcon status={task.status} />
-                <div className="min-w-0 flex-1">
-                  <div
-                    className={cn(
-                      'wrap-break-word text-foreground text-xs leading-5',
-                      task.status === 'completed' && 'text-muted-foreground line-through'
-                    )}>
-                    {task.status === 'in_progress' && task.activeText ? task.activeText : task.title}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
       {artifacts.length > 0 && <AgentRightPaneArtifactsSection artifacts={artifacts} compact={false} />}
 
       <AgentContextUsageSummary
@@ -1071,7 +1135,7 @@ function AgentStatusRightPanel({ active }: RightPanelComponentProps<AgentRightPa
         isCompacting={isCompacting}
         className="rounded-md border border-border-subtle px-3 py-2"
       />
-      <AgentRightPaneHighlights status={status} includeTasks={false} includeArtifacts={false} />
+      <AgentRightPaneHighlights status={status} includeArtifacts={false} />
     </div>
   )
 }
@@ -1214,12 +1278,10 @@ function AgentRightPaneArtifactsSection({ artifacts, compact }: { artifacts: Age
 function AgentRightPaneHighlights({
   status,
   compact = false,
-  includeTasks = true,
   includeArtifacts = true
 }: {
   status: AgentRightPaneStatus
   compact?: boolean
-  includeTasks?: boolean
   includeArtifacts?: boolean
 }) {
   const actions = useAgentRightPaneActions()
@@ -1228,36 +1290,13 @@ function AgentRightPaneHighlights({
   const shellRunTasks = status.runTasks.filter(isShellRunTask)
   const workflowRunTasks = status.runTasks.filter(isLocalWorkflowRunTask)
   const agentRunTasks = status.runTasks.filter((task) => !isShellRunTask(task) && !isLocalWorkflowRunTask(task))
-  const tasks = includeTasks ? status.tasks : []
   const artifacts = includeArtifacts && actions.canOpenArtifactFile ? status.artifacts : []
-  const hasHighlights = tasks.length > 0 || status.runTasks.length > 0 || artifacts.length > 0
+  const hasHighlights = status.runTasks.length > 0 || artifacts.length > 0
 
   if (!hasHighlights) return null
 
   return (
     <div className={cn('space-y-2.5', compact ? 'text-xs' : 'text-sm')}>
-      {tasks.length > 0 && (
-        <AgentRightPaneHighlightSection
-          title={t('agent.right_pane.status.tasks')}
-          icon={<Activity size={14} className="text-muted-foreground" />}
-          compact={compact}>
-          <ul className="space-y-1">
-            {tasks.map((task) => (
-              <li key={task.id} className="flex min-w-0 items-start gap-2">
-                <TaskStatusIcon status={task.status} />
-                <span
-                  className={cn(
-                    'wrap-break-word min-w-0 flex-1 text-xs leading-5',
-                    task.status === 'completed' ? 'text-muted-foreground line-through' : 'text-muted-foreground'
-                  )}>
-                  {task.status === 'in_progress' && task.activeText ? task.activeText : task.title}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </AgentRightPaneHighlightSection>
-      )}
-
       {artifacts.length > 0 && <AgentRightPaneArtifactsSection artifacts={artifacts} compact={compact} />}
 
       {workflowRunTasks.length > 0 && (

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -1134,7 +1134,7 @@ describe('AgentRightPane', () => {
     expect(screen.getByTestId('shell-tab-title')).toHaveTextContent('Inspect task state')
   })
 
-  it('shows a dsh todo_write snapshot in the status shortcut preview', () => {
+  it('shows a dsh todo_write snapshot in the floating task capsule', () => {
     const todoPart = {
       type: 'dynamic-tool',
       toolCallId: 'dsh-todos-1',
@@ -1156,14 +1156,13 @@ describe('AgentRightPane', () => {
 
     render(
       <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: [todoPart] }}>
-        <AgentRightPane.Shortcuts />
-        <AgentRightPane.Viewport />
+        <AgentTaskProgressCapsule />
       </TestAgentRightPane>
     )
 
-    const preview = screen.getByTestId('status-shortcut-preview')
-    expect(within(preview).getByText('Connect the task list')).toHaveClass('line-through')
-    expect(within(preview).getByText('Verify the right pane')).toBeInTheDocument()
+    const details = screen.getByTestId('agent-task-progress-details')
+    expect(within(details).getByText('Connect the task list')).toHaveClass('text-muted-foreground')
+    expect(within(details).getByText('Verify the right pane')).toBeInTheDocument()
   })
 
   it('renders local Workflow progress separately without offering a root FlowTab fallback', () => {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -1,3 +1,8 @@
+import {
+  HoverCard as RealHoverCard,
+  HoverCardContent as RealHoverCardContent,
+  HoverCardTrigger as RealHoverCardTrigger
+} from '@cherrystudio/ui/components'
 import type * as ArtifactPanePath from '@renderer/components/chat/panes/artifactPanePath'
 import { useRightPanelState } from '@renderer/components/chat/panes/Shell'
 import type * as ChatPrimitives from '@renderer/components/chat/primitives'
@@ -5,6 +10,7 @@ import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/mess
 import type { PhysicalFileMetadata } from '@shared/types/file'
 import { TreeDir, TreeDirRoot, TreeFile } from '@shared/utils/file'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type {
   ButtonHTMLAttributes,
   ComponentProps,
@@ -33,7 +39,8 @@ const {
   useCommandHandlerMock,
   useDirectoryTreeMock,
   ipcRequestMock,
-  toastErrorMock
+  toastErrorMock,
+  uiMockState
 } = vi.hoisted(() => ({
   buildAgentToolFlowProjectionMock: vi.fn(),
   getToolResultMock: vi.fn(),
@@ -63,7 +70,8 @@ const {
   useCommandHandlerMock: vi.fn(),
   useDirectoryTreeMock: vi.fn(),
   ipcRequestMock: vi.fn(),
-  toastErrorMock: vi.fn()
+  toastErrorMock: vi.fn(),
+  uiMockState: { useRealHoverCard: false }
 }))
 
 vi.mock('../agentRightPaneProjection', async (importActual) => {
@@ -118,19 +126,25 @@ vi.mock('@cherrystudio/ui', () => ({
         </button>
       </div>
     ) : null,
-  HoverCard: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  HoverCardContent: ({ children, className }: PropsWithChildren<{ className?: string }>) => (
-    <div className={className} data-testid="status-shortcut-preview">
-      {children}
-    </div>
-  ),
-  HoverCardTrigger: ({ children }: PropsWithChildren) =>
-    isValidElement(children) ? (
-      // eslint-disable-next-line @eslint-react/no-clone-element -- mock reproduces Radix asChild slot behavior
-      cloneElement(children as ReactElement<Record<string, unknown>>, { 'data-hover-card-trigger': 'true' })
+  HoverCard: (props: ComponentProps<typeof RealHoverCard>) =>
+    uiMockState.useRealHoverCard ? <RealHoverCard {...props} /> : <div>{props.children}</div>,
+  HoverCardContent: (props: ComponentProps<typeof RealHoverCardContent>) =>
+    uiMockState.useRealHoverCard ? (
+      <RealHoverCardContent {...props} />
     ) : (
-      <>{children}</>
+      <div className={props.className} data-testid="status-shortcut-preview">
+        {props.children}
+      </div>
     ),
+  HoverCardTrigger: (props: ComponentProps<typeof RealHoverCardTrigger>) => {
+    if (uiMockState.useRealHoverCard) return <RealHoverCardTrigger {...props} />
+    return isValidElement(props.children) ? (
+      // eslint-disable-next-line @eslint-react/no-clone-element -- mock reproduces Radix asChild slot behavior
+      cloneElement(props.children as ReactElement<Record<string, unknown>>, { 'data-hover-card-trigger': 'true' })
+    ) : (
+      <>{props.children}</>
+    )
+  },
   HorizontalScrollContainer: ({ children }: PropsWithChildren) => <div>{children}</div>,
   Tabs: ({ children }: PropsWithChildren) => <div>{children}</div>,
   TabsContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
@@ -397,13 +411,13 @@ import { AgentRightPane, AgentTaskProgressCapsule, useAgentRightPaneActions } fr
 
 type TestAgentRightPaneProps = ComponentProps<typeof AgentRightPane.Scope>
 
-function createTaskPart(sequence: number, subject: string): CherryMessagePart {
+function createTaskPart(sequence: number, subject: string, activeForm?: string): CherryMessagePart {
   return {
     type: 'dynamic-tool',
     toolCallId: `task-create-${sequence}`,
     toolName: 'TaskCreate',
     state: 'input-available',
-    input: { subject }
+    input: { subject, activeForm }
   } as unknown as CherryMessagePart
 }
 
@@ -530,6 +544,7 @@ describe('AgentRightPane', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    uiMockState.useRealHoverCard = false
     ipcRequestMock.mockResolvedValue({
       kind: 'file',
       type: 'text',
@@ -556,7 +571,9 @@ describe('AgentRightPane', () => {
     getToolResultMock.mockReturnValue('Loaded flow result')
   })
 
-  it('renders the current task plan above the composer and hides it after completion', () => {
+  it('opens the current task plan from hover and keyboard focus, then hides it after completion', async () => {
+    uiMockState.useRealHoverCard = true
+    const user = userEvent.setup()
     const parts = [
       createTaskPart(1, 'Collect context'),
       createTaskPart(2, 'Build a capsule with a long wrapping task title'),
@@ -575,19 +592,22 @@ describe('AgentRightPane', () => {
 
     const capsule = screen.getByTestId('agent-task-progress-capsule')
     const progress = within(capsule).getByRole('progressbar')
-    const details = screen.getByTestId('agent-task-progress-details')
+    const progressLabel = within(capsule).getByText('Step 2/2')
 
-    expect(capsule).toHaveClass('justify-center')
     expect(progress).toHaveAttribute('aria-valuenow', '1')
     expect(progress).toHaveAttribute('aria-valuemax', '2')
-    expect(within(capsule).getByText('Step 2/2')).toBeInTheDocument()
-    expect(capsule.querySelector('[tabindex="0"]')).toHaveClass('gap-1.5', 'px-2.5')
-    expect(details.parentElement).toHaveClass('w-64')
     expect(screen.getByTestId('circular-progress')).toHaveAttribute('data-value', '50')
-    expect(
-      within(details).getByText('Building capsule').closest('li')?.querySelector('.animate-spin')
-    ).toBeInTheDocument()
-    expect(within(details).getByText('Building capsule')).toHaveClass('whitespace-normal', 'wrap-break-word')
+    expect(screen.queryByTestId('agent-task-progress-details')).toBeNull()
+
+    await user.hover(progressLabel)
+    expect(within(await screen.findByTestId('agent-task-progress-details')).getByText('Building capsule')).toBeVisible()
+
+    await user.unhover(progressLabel)
+    await waitFor(() => expect(screen.queryByTestId('agent-task-progress-details')).toBeNull())
+
+    await user.tab()
+    expect(document.activeElement).toHaveTextContent('Step 2/2')
+    expect(within(await screen.findByTestId('agent-task-progress-details')).getByText('Building capsule')).toBeVisible()
 
     const completedParts = [...parts, updateTaskPart(3, '2', 'completed')]
     const completedMessages = createTaskMessages(completedParts, 'success')
@@ -608,7 +628,7 @@ describe('AgentRightPane', () => {
   })
 
   it('infers the first pending task as active only while the assistant turn is running', () => {
-    const parts = [createTaskPart(1, 'Collect context'), createTaskPart(2, 'Build capsule')]
+    const parts = [createTaskPart(1, 'Collect context', 'Collecting context'), createTaskPart(2, 'Build capsule')]
     const messages = createTaskMessages(parts, 'pending')
 
     const view = render(
@@ -620,10 +640,7 @@ describe('AgentRightPane', () => {
     const capsule = screen.getByTestId('agent-task-progress-capsule')
     expect(within(capsule).getByText('Step 1/2')).toBeInTheDocument()
     expect(
-      within(screen.getByTestId('agent-task-progress-details'))
-        .getByText('Collect context')
-        .closest('li')
-        ?.querySelector('.animate-spin')
+      within(screen.getByTestId('agent-task-progress-details')).getByText('Collecting context')
     ).toBeInTheDocument()
 
     const settledMessages = createTaskMessages(parts, 'success')
@@ -633,7 +650,8 @@ describe('AgentRightPane', () => {
       </TestAgentRightPane>
     )
 
-    expect(screen.getByTestId('agent-task-progress-details').querySelector('.animate-spin')).toBeNull()
+    expect(within(screen.getByTestId('agent-task-progress-details')).getByText('Collect context')).toBeInTheDocument()
+    expect(screen.queryByText('Collecting context')).toBeNull()
   })
 
   it('uses a title header and keeps stable shortcuts available while the pane is open', () => {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -84,6 +84,9 @@ vi.mock('@cherrystudio/ui', () => ({
       {children}
     </button>
   ),
+  CircularProgress: ({ value }: { value: number }) => (
+    <span data-testid="circular-progress" data-value={String(value)} />
+  ),
   ConfirmDialog: ({
     cancelText,
     confirmLoading,
@@ -116,7 +119,11 @@ vi.mock('@cherrystudio/ui', () => ({
       </div>
     ) : null,
   HoverCard: ({ children }: PropsWithChildren) => <div>{children}</div>,
-  HoverCardContent: ({ children }: PropsWithChildren) => <div data-testid="status-shortcut-preview">{children}</div>,
+  HoverCardContent: ({ children, className }: PropsWithChildren<{ className?: string }>) => (
+    <div className={className} data-testid="status-shortcut-preview">
+      {children}
+    </div>
+  ),
   HoverCardTrigger: ({ children }: PropsWithChildren) =>
     isValidElement(children) ? (
       // eslint-disable-next-line @eslint-react/no-clone-element -- mock reproduces Radix asChild slot behavior
@@ -320,7 +327,7 @@ vi.mock('@renderer/components/command', () => ({
 }))
 
 vi.mock('@renderer/components/Scrollbar', () => ({
-  default: ({ children }: PropsWithChildren) => <div>{children}</div>
+  default: ({ children, ...props }: ComponentProps<'div'>) => <div {...props}>{children}</div>
 }))
 
 vi.mock('@renderer/data/hooks/usePreference', () => ({
@@ -380,14 +387,44 @@ vi.mock('motion/react', () => ({
 
 // A stable `t` identity mirrors production react-i18next; a fresh closure per render
 // would invalidate the provider's scope memo and break render-isolation assertions.
-const stableT = (key: string) => key
+const stableT = (key: string, values?: Record<string, unknown>) =>
+  key === 'agent.right_pane.status.task_progress_compact' ? `Step ${values?.current}/${values?.total}` : key
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: stableT })
 }))
 
-import { AgentRightPane, useAgentRightPaneActions } from '../AgentRightPane'
+import { AgentRightPane, AgentTaskProgressCapsule, useAgentRightPaneActions } from '../AgentRightPane'
 
 type TestAgentRightPaneProps = ComponentProps<typeof AgentRightPane.Scope>
+
+function createTaskPart(sequence: number, subject: string): CherryMessagePart {
+  return {
+    type: 'dynamic-tool',
+    toolCallId: `task-create-${sequence}`,
+    toolName: 'TaskCreate',
+    state: 'input-available',
+    input: { subject }
+  } as unknown as CherryMessagePart
+}
+
+function updateTaskPart(
+  sequence: number,
+  taskId: string,
+  status: 'completed' | 'in_progress',
+  activeForm?: string
+): CherryMessagePart {
+  return {
+    type: 'dynamic-tool',
+    toolCallId: `task-update-${sequence}`,
+    toolName: 'TaskUpdate',
+    state: 'input-available',
+    input: { taskId, status, activeForm }
+  } as unknown as CherryMessagePart
+}
+
+function createTaskMessages(parts: CherryMessagePart[], status: 'pending' | 'success'): CherryUIMessage[] {
+  return [{ id: 'm1', role: 'assistant', parts, metadata: { status } }] as CherryUIMessage[]
+}
 
 function TestAgentRightPane({
   children,
@@ -517,6 +554,86 @@ describe('AgentRightPane', () => {
       nodeById: fileTreeModelState.nodeById
     }))
     getToolResultMock.mockReturnValue('Loaded flow result')
+  })
+
+  it('renders the current task plan above the composer and hides it after completion', () => {
+    const parts = [
+      createTaskPart(1, 'Collect context'),
+      createTaskPart(2, 'Build a capsule with a long wrapping task title'),
+      updateTaskPart(1, '1', 'completed'),
+      updateTaskPart(2, '2', 'in_progress', 'Building capsule')
+    ]
+    const messages = createTaskMessages(parts, 'pending')
+
+    const view = render(
+      <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: parts }}>
+        <AgentTaskProgressCapsule />
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    const capsule = screen.getByTestId('agent-task-progress-capsule')
+    const progress = within(capsule).getByRole('progressbar')
+    const details = screen.getByTestId('agent-task-progress-details')
+
+    expect(capsule).toHaveClass('justify-center')
+    expect(progress).toHaveAttribute('aria-valuenow', '1')
+    expect(progress).toHaveAttribute('aria-valuemax', '2')
+    expect(within(capsule).getByText('Step 2/2')).toBeInTheDocument()
+    expect(capsule.querySelector('[tabindex="0"]')).toHaveClass('gap-1.5', 'px-2.5')
+    expect(details.parentElement).toHaveClass('w-64')
+    expect(screen.getByTestId('circular-progress')).toHaveAttribute('data-value', '50')
+    expect(
+      within(details).getByText('Building capsule').closest('li')?.querySelector('.animate-spin')
+    ).toBeInTheDocument()
+    expect(within(details).getByText('Building capsule')).toHaveClass('whitespace-normal', 'wrap-break-word')
+
+    const completedParts = [...parts, updateTaskPart(3, '2', 'completed')]
+    const completedMessages = createTaskMessages(completedParts, 'success')
+
+    view.rerender(
+      <TestAgentRightPane sessionId="session-a" messages={completedMessages} partsByMessageId={{ m1: completedParts }}>
+        <AgentTaskProgressCapsule />
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    expect(screen.queryByTestId('agent-task-progress-capsule')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
+
+    expect(within(screen.getByTestId('right-pane')).queryByText('Collect context')).toBeNull()
+  })
+
+  it('infers the first pending task as active only while the assistant turn is running', () => {
+    const parts = [createTaskPart(1, 'Collect context'), createTaskPart(2, 'Build capsule')]
+    const messages = createTaskMessages(parts, 'pending')
+
+    const view = render(
+      <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: parts }}>
+        <AgentTaskProgressCapsule />
+      </TestAgentRightPane>
+    )
+
+    const capsule = screen.getByTestId('agent-task-progress-capsule')
+    expect(within(capsule).getByText('Step 1/2')).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('agent-task-progress-details'))
+        .getByText('Collect context')
+        .closest('li')
+        ?.querySelector('.animate-spin')
+    ).toBeInTheDocument()
+
+    const settledMessages = createTaskMessages(parts, 'success')
+    view.rerender(
+      <TestAgentRightPane sessionId="session-a" messages={settledMessages} partsByMessageId={{ m1: parts }}>
+        <AgentTaskProgressCapsule />
+      </TestAgentRightPane>
+    )
+
+    expect(screen.getByTestId('agent-task-progress-details').querySelector('.animate-spin')).toBeNull()
   })
 
   it('uses a title header and keeps stable shortcuts available while the pane is open', () => {
@@ -1098,15 +1215,8 @@ describe('AgentRightPane', () => {
     expect(screen.queryByTestId('workflow-dag-panel')).toBeNull()
   })
 
-  it('keeps declared artifacts directly under the task plan instead of below the run sections', () => {
+  it('keeps declared artifacts ahead of run sections', () => {
     const parts = [
-      {
-        type: 'dynamic-tool',
-        toolCallId: 'task-1',
-        toolName: 'TaskCreate',
-        state: 'input-available',
-        input: { subject: 'Build the deck' }
-      },
       {
         type: 'dynamic-tool',
         toolCallId: 'artifacts-1',
@@ -1140,7 +1250,6 @@ describe('AgentRightPane', () => {
     fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
 
     const sectionOrder = [
-      screen.getByText('agent.right_pane.status.tasks'),
       screen.getByText('agent.right_pane.info.artifacts'),
       screen.getByTestId('context-usage'),
       screen.getByText('agent.right_pane.info.shell_tasks')
@@ -1154,13 +1263,6 @@ describe('AgentRightPane', () => {
 
   it('hides the artifacts section when the workspace cannot open files', () => {
     const parts = [
-      {
-        type: 'dynamic-tool',
-        toolCallId: 'task-1',
-        toolName: 'TaskCreate',
-        state: 'input-available',
-        input: { subject: 'Build the deck' }
-      },
       {
         type: 'dynamic-tool',
         toolCallId: 'artifacts-1',
@@ -1179,7 +1281,6 @@ describe('AgentRightPane', () => {
     )
     fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
 
-    expect(screen.getByText('agent.right_pane.status.tasks')).toBeInTheDocument()
     expect(screen.queryByText('agent.right_pane.info.artifacts')).toBeNull()
   })
 

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
@@ -316,6 +316,131 @@ describe('agent right pane projections', () => {
     expect(status.totalTaskCount).toBe(1)
   })
 
+  it('keeps a session-wide TaskList scoped when loaded history starts at the current plan', () => {
+    const parts = [
+      toolPart(
+        'create-current',
+        'TaskCreate',
+        undefined,
+        'output-available',
+        { subject: 'Start the current task' },
+        'Task #11 created successfully: Start the current task'
+      ),
+      toolPart(
+        'list-all',
+        'TaskList',
+        undefined,
+        'output-available',
+        {},
+        {
+          tasks: [
+            { id: '1', subject: 'Finish the unloaded old task', status: 'completed', blockedBy: [] },
+            { id: '11', subject: 'Start the current task', status: 'pending', blockedBy: [] }
+          ]
+        }
+      )
+    ]
+    const messages = [message('m2', parts)]
+
+    const status = buildAgentRightPaneStatus(messages, { m2: parts })
+
+    expect(status.tasks).toEqual([
+      expect.objectContaining({ id: '11', title: 'Start the current task', status: 'pending' })
+    ])
+  })
+
+  it('starts a new task plan when a later turn creates tasks after the previous plan completed', () => {
+    const completedParts = [
+      toolPart('create-old', 'TaskCreate', undefined, 'input-available', { subject: 'Finish the old task' }),
+      toolPart('complete-old-1', 'TaskUpdate', undefined, 'output-available', {
+        taskId: '1',
+        status: 'completed'
+      })
+    ]
+    const newParts = [
+      toolPart(
+        'create-new',
+        'TaskCreate',
+        undefined,
+        'output-available',
+        { subject: 'Start the new task' },
+        'Task #11 created successfully: Start the new task'
+      ),
+      toolPart('complete-new', 'TaskUpdate', undefined, 'output-available', {
+        taskId: '11',
+        status: 'completed'
+      }),
+      toolPart(
+        'list-all',
+        'TaskList',
+        undefined,
+        'output-available',
+        {},
+        {
+          tasks: [
+            { id: '1', subject: 'Finish the old task', status: 'completed', blockedBy: [] },
+            { id: '11', subject: 'Start the new task', status: 'completed', blockedBy: [] }
+          ]
+        }
+      )
+    ]
+    const messages = [message('m1', completedParts), message('m2', newParts)]
+
+    const status = buildAgentRightPaneStatus(messages, { m1: completedParts, m2: newParts })
+
+    expect(status.tasks).toHaveLength(1)
+    expect(status.tasks[0]).toMatchObject({ id: '11', title: 'Start the new task', status: 'completed' })
+    expect(status.completedTaskCount).toBe(1)
+    expect(status.totalTaskCount).toBe(1)
+  })
+
+  it('starts a new task plan after the previous plan completes earlier in the same assistant message', () => {
+    const oldParts = [
+      toolPart(
+        'create-old',
+        'TaskCreate',
+        undefined,
+        'output-available',
+        { subject: 'Finish the old task' },
+        'Task #1 created successfully: Finish the old task'
+      )
+    ]
+    const transitionParts = [
+      toolPart('complete-old', 'TaskUpdate', undefined, 'output-available', {
+        taskId: '1',
+        status: 'completed'
+      }),
+      toolPart(
+        'create-new',
+        'TaskCreate',
+        undefined,
+        'output-available',
+        { subject: 'Start the new task' },
+        'Task #11 created successfully: Start the new task'
+      ),
+      toolPart(
+        'list-all',
+        'TaskList',
+        undefined,
+        'output-available',
+        {},
+        {
+          tasks: [
+            { id: '1', subject: 'Finish the old task', status: 'completed', blockedBy: [] },
+            { id: '11', subject: 'Start the new task', status: 'pending', blockedBy: [] }
+          ]
+        }
+      )
+    ]
+    const messages = [message('m1', oldParts), message('m2', transitionParts)]
+
+    const status = buildAgentRightPaneStatus(messages, { m1: oldParts, m2: transitionParts })
+
+    expect(status.tasks).toEqual([
+      expect.objectContaining({ id: '11', title: 'Start the new task', status: 'pending' })
+    ])
+  })
+
   // SDK task events describe spawned processes, not the agent's own plan, so they populate
   // `runTasks` and stay out of the plan's done/total ratio.
   it('applies persisted Claude SDK task events to run tasks, not the plan', () => {

--- a/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
@@ -353,24 +353,43 @@ export function buildAgentToolFlowProjection(
   }
 }
 
-/** Applies one task-ledger tool part; returns whether the part was a ledger write. */
+interface TaskPlanProjectionState {
+  tasks: Map<string, AgentStatusTask>
+  /** Undefined until a TaskCreate is observed, preserving TaskList-only history. */
+  currentPlanTaskIds?: Set<string>
+}
+
 function applyTaskToolPart(
-  taskMap: Map<string, AgentStatusTask>,
+  state: TaskPlanProjectionState,
   part: CherryMessagePart,
-  fallbackId: string
+  fallbackId: string,
+  toolName: string | undefined
 ): boolean {
-  const toolName = getToolNameFromPart(part)
+  const taskMap = state.tasks
   const input = getToolPartInput(part)
   const output = getToolPartOutput(part)
 
   if (toolName === AgentToolsType.TaskCreate) {
+    const currentPlanCompleted =
+      taskMap.size > 0 && Array.from(taskMap.values()).every((task) => task.status === 'completed')
+    if (currentPlanCompleted) {
+      taskMap.clear()
+      state.currentPlanTaskIds = new Set()
+    } else if (taskMap.size === 0 && !state.currentPlanTaskIds) {
+      state.currentPlanTaskIds = new Set()
+    }
+
     const inputRecord = isTaskRecord(input) ? input : {}
     const outputRecord = isTaskRecord(output) ? output : {}
     const outputTask = isTaskRecord(outputRecord.task) ? outputRecord.task : undefined
-    const id = (outputTask ? getTaskId(outputTask) : undefined) ?? getNextTaskOrdinalId(taskMap) ?? fallbackId
+    const outputTextId =
+      typeof output === 'string' ? output.match(/^Task #(\S+) created successfully:/)?.[1] : undefined
+    const id =
+      (outputTask ? getTaskId(outputTask) : undefined) ?? outputTextId ?? getNextTaskOrdinalId(taskMap) ?? fallbackId
     const title = (outputTask ? getTaskTitle(outputTask) : undefined) ?? getTaskTitle(inputRecord, id) ?? id
     const activeText = getTaskActiveText(inputRecord)
     taskMap.set(id, { id, title, activeText, status: 'pending' })
+    state.currentPlanTaskIds?.add(id)
     return true
   }
 
@@ -395,6 +414,7 @@ function applyTaskToolPart(
       const id = getTaskId(task)
       const title = getTaskTitle(task, id)
       if (!id || !title) continue
+      if (state.currentPlanTaskIds && !state.currentPlanTaskIds.has(id)) continue
       taskMap.set(id, {
         id,
         title,
@@ -503,7 +523,8 @@ export function buildAgentRightPaneStatus(
   /** Omitted means "trust the events" — production always passes it. */
   liveness?: AgentRunLiveness
 ): AgentRightPaneStatus {
-  const taskMap = new Map<string, AgentStatusTask>()
+  const taskPlanState: TaskPlanProjectionState = { tasks: new Map() }
+  const taskMap = taskPlanState.tasks
   let todoSnapshotTasks: AgentStatusTask[] | undefined
   const runTaskMap = new Map<string, AgentRunTask>()
   const runTaskOriginMessageIds = new Map<string, string>()
@@ -517,14 +538,14 @@ export function buildAgentRightPaneStatus(
       }
 
       if (!isToolUIPart(part)) return
+      const toolName = getToolNameFromPart(part)
       const fallbackId = getToolCallId(part) ?? `${message.id}-${partIndex}`
       // The plan has two writers — the incremental task ledger and full-list todo snapshots —
       // and the most recent writer owns it: a later ledger write invalidates an earlier snapshot.
-      if (applyTaskToolPart(taskMap, part, fallbackId)) todoSnapshotTasks = undefined
+      if (applyTaskToolPart(taskPlanState, part, fallbackId, toolName)) todoSnapshotTasks = undefined
       const todoSnapshot = getTodoSnapshot(part)
       if (todoSnapshot !== undefined) todoSnapshotTasks = todoSnapshot
 
-      const toolName = getToolNameFromPart(part)
       if (isReportArtifactsTool(toolName)) {
         const parsed = reportArtifactsInputSchema.safeParse(getToolPartInput(part))
         if (parsed.success) {

--- a/src/renderer/pages/agents/components/AgentRightPane/index.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/index.ts
@@ -1,2 +1,7 @@
 export type { AgentFileNavigationRequest, AgentToolFlowOpenInput } from './AgentRightPane'
-export { AgentRightPane, useAgentRightPaneActions, useOptionalAgentFileNavigation } from './AgentRightPane'
+export {
+  AgentRightPane,
+  AgentTaskProgressCapsule,
+  useAgentRightPaneActions,
+  useOptionalAgentFileNavigation
+} from './AgentRightPane'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Agent task progress was shown in the status sidebar, away from the composer, and session-wide task snapshots could mix completed tasks from earlier plans into the current plan.

After this PR:

Agent task progress appears in a centered floating capsule above the composer. The capsule shows live circular progress, expands task details on hover, animates the active task, wraps long labels, and disappears when the current plan completes. Task projection now owns plan generations so paginated history and session-wide `TaskList` snapshots keep only the current plan.

https://github.com/user-attachments/assets/d5999c38-b197-499d-9b7d-00eeb34f4c76

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Task progress is most useful next to the composer, where users monitor and control an active agent run. The visual capsule is implemented as a reusable composer primitive, while task lifecycle rules stay in the existing status projection rather than being duplicated in the UI.

The projection treats ordered task-tool events as the source of plan membership. `TaskList` remains a compatibility source when no `TaskCreate` event is available, but once a plan is observed, session-wide snapshots may only update tasks created in that plan. Plan rollover is evaluated at each `TaskCreate`, independent of message boundaries.

The following tradeoffs were made:

- The first pending task is displayed as active while an assistant turn is running when the SDK has not emitted an explicit `in_progress` update.
- Plan generations are inferred from task-tool chronology because the SDK does not expose a plan-generation identifier.
- The capsule reuses existing task status icons and a small shared composer surface instead of introducing a feature-specific visual implementation.

The following alternatives were considered:

- Keeping the task list in the status sidebar was rejected because it separates active progress from the composer interaction.
- Filtering historical tasks inside the capsule was rejected because it would duplicate domain rules in a UI consumer.
- Treating every `TaskList` response as the current plan was rejected because the SDK snapshot spans earlier completed plans in the session.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The capsule intentionally hides when all tasks in the current plan are complete.
- Regression coverage includes paginated history that starts at the current plan and plan rollover within one assistant message.
- Validation: `pnpm exec vitest run --project renderer src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx` (56 tests) and `pnpm run typecheck:web`.
- External documentation is not required because the interaction is self-contained and localized in the product UI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent task progress now appears in a floating capsule above the composer with live progress and hover details.
```
