### PR TITLE
fix(workspace-selector): avoid duplicate workspace refresh

### DIFF
--- a/src/renderer/components/resourceCatalog/selectors/WorkspaceSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/WorkspaceSelector.tsx
@@ -139,13 +139,12 @@ export function WorkspaceSelector({
 
     try {
       const workspace = await createWorkspace({ body: { path: folderPath } })
-      await refetch()
       await onChange(workspace.id)
     } catch (error) {
       logger.error('Failed to create workspace from folder', error as Error, { folderPath })
       toast.error(t('agent.session.workspace_selector.create_failed'))
     }
-  }, [createWorkspace, handleOpenChange, onChange, refetch, t])
+  }, [createWorkspace, handleOpenChange, onChange, t])
 
   const handleRequestDeleteWorkspace = useCallback(
     (workspace: AgentWorkspaceEntity) => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/WorkspaceSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/WorkspaceSelector.test.tsx
@@ -353,6 +353,8 @@ describe('WorkspaceSelector', () => {
     selectFolderMock.mockResolvedValue('/Users/jd/new-project')
     const { onChange } = renderSelector()
     openPopover()
+    await waitFor(() => expect(refetchWorkspacesMock).toHaveBeenCalledOnce())
+    refetchWorkspacesMock.mockClear()
 
     fireEvent.click(screen.getByRole('button', { name: 'Add new work directory' }))
 
@@ -361,7 +363,7 @@ describe('WorkspaceSelector', () => {
         body: { path: '/Users/jd/new-project' }
       })
     )
-    expect(refetchWorkspacesMock).toHaveBeenCalled()
+    expect(refetchWorkspacesMock).not.toHaveBeenCalled()
     expect(onChange).toHaveBeenCalledWith('workspace-created')
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Creating a workspace waited for the mutation's configured workspace-list refresh, then explicitly refetched the same list before selecting the new workspace.

After this PR:

Workspace creation relies on the mutation's existing refresh and selects the created workspace without a duplicate request.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18467

### Why we need it and why it was done in this way

`useMutation.trigger()` already waits for configured refresh paths. Removing only the redundant `refetch()` preserves list convergence while avoiding a second sequential request and the associated selection delay.

The following tradeoffs were made:

The selector continues to refresh when opened; this change only removes the duplicate refresh from workspace creation.

The following alternatives were considered:

Removing the mutation refresh was rejected because that refresh is the shared cache-convergence mechanism for workspace creation.

Links to places where the discussion took place: #18467

### Breaking changes

None.

### Special notes for your reviewer

The regression test clears the valid open-time refresh before asserting that workspace creation does not issue another explicit refresh.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Workspace creation no longer waits for a redundant workspace-list refresh before selecting the new workspace.
```
