### PR TITLE
feat(minimax): add voice cloning

### DIFF
--- a/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
+++ b/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
@@ -186,7 +186,8 @@ describe('createMinimaxProvider', () => {
       )
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ base_resp: { status_code: 1004, status_msg: 'invalid voice ID' } }), {
-          status: 200
+          status: 200,
+          headers: { 'x-request-id': 'request-123' }
         })
       )
     const provider = createMinimaxProvider({ apiKey: 'sk-test', fetch })
@@ -198,6 +199,9 @@ describe('createMinimaxProvider', () => {
         voiceId: 'CustomVoice001',
         model: 'speech-01-hd'
       })
-    ).rejects.toMatchObject({ message: 'invalid voice ID' })
+    ).rejects.toMatchObject({
+      message: 'invalid voice ID',
+      responseHeaders: { 'x-request-id': 'request-123' }
+    })
   })
 })

--- a/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
+++ b/src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts
@@ -128,4 +128,76 @@ describe('createMinimaxProvider', () => {
     )
     expect(result.images).toEqual([image])
   })
+
+  it.each([
+    ['https://api.minimax.io/v1', 'https://api.minimax.io/v1/files/upload'],
+    ['https://api.minimaxi.com/v1', 'https://api.minimaxi.com/v1/files/upload']
+  ])('uploads clone audio and creates a voice through %s', async (baseURL, uploadUrl) => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ file: { file_id: 123456 }, base_resp: { status_code: 0 } }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ voice_id: 'CustomVoice001', base_resp: { status_code: 0 } }), { status: 200 })
+      )
+    const provider = createMinimaxProvider({ apiKey: 'sk-test', baseURL, fetch })
+
+    const result = await provider.cloneVoice({
+      audio: new Blob(['voice sample'], { type: 'audio/mpeg' }),
+      fileName: 'sample.mp3',
+      voiceId: 'CustomVoice001',
+      model: 'speech-2.8-hd'
+    })
+
+    expect(fetch).toHaveBeenNthCalledWith(1, uploadUrl, expect.objectContaining({ method: 'POST' }))
+    const form = fetch.mock.calls[0][1]?.body as FormData
+    expect(form.get('purpose')).toBe('voice_clone')
+    expect((form.get('file') as File).name).toBe('sample.mp3')
+    expect(fetch).toHaveBeenNthCalledWith(2, `${baseURL}/voice_clone`, expect.objectContaining({ method: 'POST' }))
+    expect(JSON.parse(fetch.mock.calls[1][1]?.body as string)).toEqual({
+      file_id: 123456,
+      voice_id: 'CustomVoice001',
+      model: 'speech-2.8-hd'
+    })
+    expect(result).toEqual({ voiceId: 'CustomVoice001' })
+  })
+
+  it('rejects unsupported clone audio before upload', async () => {
+    const fetch = vi.fn()
+    const provider = createMinimaxProvider({ apiKey: 'sk-test', fetch })
+
+    await expect(
+      provider.cloneVoice({
+        audio: new Blob(['voice sample']),
+        fileName: 'sample.ogg',
+        voiceId: 'CustomVoice001',
+        model: 'speech-2.8-hd'
+      })
+    ).rejects.toThrow('Unsupported MiniMax voice clone audio format: ogg')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces clone API errors', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ file: { file_id: 123456 }, base_resp: { status_code: 0 } }), { status: 200 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ base_resp: { status_code: 1004, status_msg: 'invalid voice ID' } }), {
+          status: 200
+        })
+      )
+    const provider = createMinimaxProvider({ apiKey: 'sk-test', fetch })
+
+    await expect(
+      provider.cloneVoice({
+        audio: new Blob(['voice sample']),
+        fileName: 'sample.wav',
+        voiceId: 'CustomVoice001',
+        model: 'speech-01-hd'
+      })
+    ).rejects.toMatchObject({ message: 'invalid voice ID' })
+  })
 })

--- a/src/main/ai/provider/custom/minimax/minimaxProvider.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxProvider.ts
@@ -4,6 +4,7 @@ import type { FetchFunction } from '@ai-sdk/provider-utils'
 import { loadApiKey, withoutTrailingSlash } from '@ai-sdk/provider-utils'
 
 import { MinimaxImageModel } from './minimaxImageModel'
+import { type MinimaxVoiceCloneOptions, type MinimaxVoiceCloneResult, MinimaxVoiceCloning } from './minimaxVoiceCloning'
 
 export const MINIMAX_PROVIDER_NAME = 'minimax' as const
 
@@ -22,11 +23,12 @@ export interface MinimaxProvider extends ProviderV3 {
   embeddingModel(modelId: string): EmbeddingModelV3
   textEmbeddingModel(modelId: string): EmbeddingModelV3
   imageModel(modelId: string): ImageModelV3
+  cloneVoice(options: MinimaxVoiceCloneOptions): Promise<MinimaxVoiceCloneResult>
 }
 
 export function createMinimaxProvider(settings: MinimaxProviderSettings = {}): MinimaxProvider {
   const { baseURL = 'https://api.minimax.io/v1', fetch: customFetch } = settings
-  const url = ({ path }: { path: string; modelId: string }) => `${withoutTrailingSlash(baseURL)}${path}`
+  const url = ({ path }: { path: string; modelId?: string }) => `${withoutTrailingSlash(baseURL)}${path}`
   const headers = () => ({
     Authorization: `Bearer ${loadApiKey({
       apiKey: settings.apiKey,
@@ -66,6 +68,8 @@ export function createMinimaxProvider(settings: MinimaxProviderSettings = {}): M
       headers,
       fetch: customFetch
     })
+  const voiceCloning = new MinimaxVoiceCloning({ url, headers, fetch: customFetch })
+  provider.cloneVoice = (options: MinimaxVoiceCloneOptions) => voiceCloning.clone(options)
 
   return provider as MinimaxProvider
 }

--- a/src/main/ai/provider/custom/minimax/minimaxVoiceCloning.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxVoiceCloning.ts
@@ -40,11 +40,20 @@ interface MinimaxVoiceCloneResponse extends MinimaxResponse {
   voice_id?: string
 }
 
+function responseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {}
+  response.headers.forEach((value, key) => {
+    headers[key] = value
+  })
+  return headers
+}
+
 async function parseResponse<T extends MinimaxResponse>(
   response: Response,
   url: string,
   requestBodyValues: Record<string, unknown>
 ): Promise<T> {
+  const headers = responseHeaders(response)
   const responseBody = await response.text()
 
   let parsed: T
@@ -57,6 +66,7 @@ async function parseResponse<T extends MinimaxResponse>(
       url,
       requestBodyValues,
       statusCode: response.status,
+      responseHeaders: headers,
       responseBody
     })
   }
@@ -68,6 +78,7 @@ async function parseResponse<T extends MinimaxResponse>(
       url,
       requestBodyValues,
       statusCode: response.status,
+      responseHeaders: headers,
       responseBody
     })
   }

--- a/src/main/ai/provider/custom/minimax/minimaxVoiceCloning.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxVoiceCloning.ts
@@ -1,0 +1,124 @@
+import { APICallError } from '@ai-sdk/provider'
+import { combineHeaders, type FetchFunction, removeUndefinedEntries } from '@ai-sdk/provider-utils'
+
+const AUDIO_FORMATS = ['mp3', 'm4a', 'wav'] as const
+const MODELS = ['speech-2.8-hd', 'speech-2.6-hd', 'speech-02-hd', 'speech-01-hd'] as const
+
+export type MinimaxVoiceCloneModel = (typeof MODELS)[number]
+
+export interface MinimaxVoiceCloneOptions {
+  audio: Blob
+  fileName: string
+  voiceId: string
+  model: MinimaxVoiceCloneModel
+}
+
+export interface MinimaxVoiceCloneResult {
+  voiceId: string
+}
+
+export interface MinimaxVoiceCloningConfig {
+  url: (options: { path: string }) => string
+  headers: () => Record<string, string | undefined>
+  fetch?: FetchFunction
+}
+
+interface MinimaxResponse {
+  base_resp?: {
+    status_code?: number
+    status_msg?: string
+  }
+}
+
+interface MinimaxUploadResponse extends MinimaxResponse {
+  file?: {
+    file_id?: number
+  }
+}
+
+interface MinimaxVoiceCloneResponse extends MinimaxResponse {
+  voice_id?: string
+}
+
+async function parseResponse<T extends MinimaxResponse>(
+  response: Response,
+  url: string,
+  requestBodyValues: Record<string, unknown>
+): Promise<T> {
+  const responseBody = await response.text()
+
+  let parsed: T
+  try {
+    parsed = JSON.parse(responseBody) as T
+  } catch (cause) {
+    throw new APICallError({
+      message: responseBody || response.statusText,
+      cause,
+      url,
+      requestBodyValues,
+      statusCode: response.status,
+      responseBody
+    })
+  }
+
+  const statusCode = parsed.base_resp?.status_code
+  if (!response.ok || statusCode !== 0) {
+    throw new APICallError({
+      message: parsed.base_resp?.status_msg || response.statusText,
+      url,
+      requestBodyValues,
+      statusCode: response.status,
+      responseBody
+    })
+  }
+
+  return parsed
+}
+
+export class MinimaxVoiceCloning {
+  constructor(private readonly config: MinimaxVoiceCloningConfig) {}
+
+  async clone(options: MinimaxVoiceCloneOptions): Promise<MinimaxVoiceCloneResult> {
+    const extension = options.fileName.split('.').pop()?.toLowerCase()
+    if (!AUDIO_FORMATS.includes(extension as (typeof AUDIO_FORMATS)[number])) {
+      throw new Error(`Unsupported MiniMax voice clone audio format: ${extension || 'unknown'}`)
+    }
+    if (!MODELS.includes(options.model)) {
+      throw new Error(`Unsupported MiniMax voice clone model: ${options.model}`)
+    }
+
+    const fetchFn = this.config.fetch ?? globalThis.fetch
+    const headers = removeUndefinedEntries(combineHeaders(this.config.headers()))
+    const uploadUrl = this.config.url({ path: '/files/upload' })
+    const form = new FormData()
+    form.append('purpose', 'voice_clone')
+    form.append('file', options.audio, options.fileName)
+
+    const uploadResponse = await fetchFn(uploadUrl, { method: 'POST', headers, body: form })
+    const upload = await parseResponse<MinimaxUploadResponse>(uploadResponse, uploadUrl, {
+      purpose: 'voice_clone',
+      fileName: options.fileName
+    })
+    if (typeof upload.file?.file_id !== 'number') {
+      throw new Error('MiniMax voice clone upload did not return a file ID')
+    }
+
+    const cloneUrl = this.config.url({ path: '/voice_clone' })
+    const body = {
+      file_id: upload.file.file_id,
+      voice_id: options.voiceId,
+      model: options.model
+    }
+    const cloneResponse = await fetchFn(cloneUrl, {
+      method: 'POST',
+      headers: removeUndefinedEntries(combineHeaders(headers, { 'Content-Type': 'application/json' })),
+      body: JSON.stringify(body)
+    })
+    const cloned = await parseResponse<MinimaxVoiceCloneResponse>(cloneResponse, cloneUrl, body)
+    if (!cloned.voice_id) {
+      throw new Error('MiniMax voice clone response did not include a voice ID')
+    }
+
+    return { voiceId: cloned.voice_id }
+  }
+}


### PR DESCRIPTION
Reason: MiniMax speech support does not expose the upload and clone operations needed to create reusable custom voices.

This change:

- adds validated audio upload and voice-clone requests for both supported MiniMax API regions;
- exposes voice cloning through the existing MiniMax provider;
- handles API failures and validates the returned voice identifier;
- covers successful uploads, supported regional endpoints, invalid audio, and API errors.

Checks:

- `vitest run --project main src/main/ai/provider/custom/__tests__/minimaxProvider.test.ts` (8 tests passed)
- `biome format` on the three changed TypeScript files
- `eslint` on the three changed TypeScript files
