### PR TITLE
fix(stream-manager): pass assistantId through the retry context resolution

### DIFF
--- a/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
+++ b/src/main/ai/streamManager/context/PersistentChatContextProvider.ts
@@ -559,6 +559,7 @@ export class PersistentChatContextProvider implements ChatContextProvider {
         parent.id,
         req.topicId,
         [model],
+        assistantId,
         contextSettingsOverride,
         toCompactionSink(subscriber)
       )


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

`typecheck:node` fails on `main` with `TS2345` at `src/main/ai/streamManager/context/PersistentChatContextProvider.ts:562`, so the `basic-checks` job is red on `main` and on every open PR (PR CI typechecks the merge with `main`). The `resolveCompactedHistory` call in `prepareAssistantRetry` is missing the `assistantId` argument, so at runtime the retry path would also run with a shifted argument list: the context-settings override lands in the `assistantId` slot, the compaction sink lands in the override slot, and no sink is passed at all.

After this PR:

The retry-path call passes `assistantId` like the other three call sites, `typecheck:node` passes, and retried turns resolve context with the assistant override and compaction fold reporting intact.

Fixes: N/A (CI break on `main`, no tracking issue)

### Why we need it and why it was done in this way

This is a semantic merge race between two PRs that each passed CI individually: #18304 added a new `resolveCompactedHistory` call site in `prepareAssistantRetry` using the then-current 5-parameter signature, while #18192 concurrently inserted an `assistantId` parameter into the method and updated only the call sites its branch knew about. Git auto-merged both cleanly, leaving the new call site one argument short.

The following tradeoffs were made: none — the fix restores the one missing argument so the call matches the method's signature and the other three call sites.

The following alternatives were considered: reverting #18304 or #18192 — disproportionate for a one-argument fix, and both features are otherwise sound.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Verified locally with the repo's node typecheck (`tsgo --noEmit -p tsconfig.node.json --composite false`) — it fails on current `main` and passes with this change. Renderer/web code is untouched; the full CI gate is left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
