### PR TITLE
ci(prepare): skip prek git-hook install when CI is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "bench:aicore": "vitest bench --run --project aiCore",
     "bench:shared": "vitest bench --run --project shared",
     "docs:check-links": "tsx scripts/check-doc-links.ts",
-    "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && prek install",
+    "prepare": "git config blame.ignoreRevsFile .git-blame-ignore-revs && node -e \"process.env.CI||require('child_process').execSync('prek install',{stdio:'inherit'})\"",
     "claude": "dotenv -e .env -- claude",
     "db:migrations:generate": "drizzle-kit generate --config ./migrations/sqlite-drizzle.config.ts",
     "db:migrations:check": "drizzle-kit check --config ./migrations/sqlite-drizzle.config.ts",


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

- Every `pnpm install` ran the root `prepare` script, which calls `prek install` to write local git hooks. In CI that step is pointless (lint/format/tests run as explicit jobs) and it downloads the `prek` binary from GitHub Releases, so a flaky network fails the whole install: `prepare: Error fetching release: socket hang up` → `ELIFECYCLE Command failed with exit code 1`.

After this PR:

- `prepare` skips `prek install` when `CI` is set (GitHub Actions always sets it); local installs still install the three hooks exactly as before. `git config blame.ignoreRevsFile` still runs everywhere.

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The guard lives in `package.json` rather than `ci.yml` because no workflow references `prek` directly — the failure comes from the `prepare` lifecycle script that every `pnpm install` step triggers, so fixing it once covers all jobs and workflows.

The following alternatives were considered:

- `pnpm install --ignore-scripts` in CI — rejected, it would also skip native module builds.
- `prek install || true` — rejected, it still pays the release download on every CI install and `true` is not a builtin in `cmd.exe` on Windows; the `node -e` guard is cross-platform.
- Dropping the `prek` dependency entirely — rejected, local pre-commit hooks are still wanted.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Verified both branches locally: `CI=1 pnpm run prepare` does nothing beyond the git config, and `env -u CI pnpm run prepare` still installs `pre-commit`, `post-checkout` and `post-merge` hooks.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
