### PR TITLE
test(main-i18n): drop catalog-content assertions from t() tests

### DIFF
--- a/src/main/i18n/__tests__/index.test.ts
+++ b/src/main/i18n/__tests__/index.test.ts
@@ -68,30 +68,6 @@ describe('main i18n', () => {
       expect(t('dialog.save_file', undefined, 'zh-CN')).toBe('保存文件')
       expect(t('dialog.save_file')).toBe('Save File')
     })
-
-    it('localizes the PDF page-limit error in Chinese and falls back to English', () => {
-      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
-      expect(t('file_processing.errors.pdf_page_limit_exceeded', { maxPages: 200 })).toBe(
-        '该 PDF 超过当前文档解析服务的 200 页上限，请手动拆分 PDF 后重新添加。'
-      )
-
-      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'ja-JP')
-      expect(t('file_processing.errors.pdf_page_limit_exceeded', { maxPages: 1000 })).toBe(
-        'This PDF exceeds the 1000-page limit for the current document parsing service. Split the PDF manually, then add it again.'
-      )
-    })
-
-    it('localizes the document size-limit error in Chinese and falls back to English', () => {
-      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
-      expect(t('file_processing.errors.document_size_limit_exceeded', { maxSize: '200 MB' })).toBe(
-        '当前文档解析服务要求文件小于 200 MB，请压缩或拆分后重新添加。'
-      )
-
-      MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'ja-JP')
-      expect(t('file_processing.errors.document_size_limit_exceeded', { maxSize: '1 GB' })).toBe(
-        'The current document parsing service requires files smaller than 1 GB. Compress or split this file, then add it again.'
-      )
-    })
   })
 
   describe('getI18n', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

`src/main/i18n/__tests__/index.test.ts` had two cases that asserted the exact catalog text of `file_processing.errors.pdf_page_limit_exceeded` / `document_size_limit_exceeded`, including an assertion that `ja-JP` had no translation and therefore fell back to English. The Daily Auto I18N Sync (#18502) translated both keys into `ja-JP`, so `main-test (3/3)` went red on `main` ([run 31666771066](https://github.com/CherryHQ/cherry-studio/actions/runs/31666771066/job/94342987120)).

After this PR:

Both cases are deleted and the main test job is green again. The remaining tests in the file still cover the actual `t()` contract — language selection, `{{var}}` interpolation, unmatched placeholders, the explicit `language` override, and the missing-key passthrough.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: deleting rather than updating the expectations gives up nothing real — the two cases only restated the catalog JSON, so their only failure mode was "a translation changed", which the sync bot does on a schedule. Updating them to the new Japanese strings would just re-arm the same trap.

The following alternatives were considered: (1) re-pinning the expectations to the current `ja-JP` strings — rejected, breaks again on the next re-translation; (2) keeping a dedicated en-US fallback test — rejected for now, every machine catalog is fully synced, so the fallback branch cannot be triggered by a real key without depending on `translate/*.json` content that the bot owns.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Test-only change; no production code touched. `pnpm vitest run src/main/i18n/__tests__/index.test.ts` → 12 passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
