### PR TITLE
chore: release v2.0.4

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -156,94 +156,146 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.3 - New Features, Fixes, and Performance
+    Cherry Studio 2.0.4 - New Features, Fixes, and Performance
 
     ✨ New Features
-    - [Composer] Add smooth mouse-wheel and trackpad switching to the reasoning effort control
-    - [Chat] Show the current assistant conversation's context-window usage next to the chat composer
-    - [Web Search] Add Firecrawl as a URL fetch provider (works without an API key on the free keyless quota)
-    - [Knowledge Base] Write a new note straight into a knowledge base
-    - [Chat] Editing a past user message now offers a Save option that keeps the existing reply instead of regenerating
-    - [Workspace] Add Windows Terminal as an external app that opens a terminal in the target directory
-    - [Agent] Agent workspaces now honor scoped AGENTS.md instructions alongside CLAUDE.md
-    - [Code Tools] Add the Pi coding agent to Code Tools
+    - [Composer] Tool permission requests in Agent sessions can now be approved with Enter or denied with Esc
+    - [Context] Restored a "recent messages kept" context limit available globally in Settings → Model and per assistant, plus a new Context Management section exposing master switch, message limit, tool-output truncation threshold, auto-compress, and compression model
+    - [Web Search] Add Querit fetchUrls capability. Querit.ai offers 1,000 free API requests for new users
+    - [MCP Hub] MCP clients connecting to the local API gateway can now open a session to receive live tool-list updates and progress from long-running tools
+    - [MCP Hub] Restored the MCP-over-HTTP endpoints on the local API gateway so external tools can once again use Cherry Studio as a local MCP hub. Action required: clients written against the 1.9.x endpoints should stop unwrapping the `{ success, data }` envelope and stop relying on `Mcp-Session-Id` — the proxy is now stateless
+    - [Agent] Agent conversations can now mention accessible workspace folders with @
+    - [Agent] Add workspace deletion from the shared selector with an impact preview for sessions, agent channels, and scheduled tasks while preserving files on disk
+    - [Models] Add configurable model pricing tiers based on input token count, with separate input, output, cache-read, and cache-write rates for each tier
+    - [Shortcuts] Added configurable keyboard shortcuts for switching to the next or previous tab
+    - [QQ Bot] QQ channel bots can now receive all group messages (not just @mentions) when the per-channel "mention-only" toggle is off and the QQ Open Platform permission is enabled
+    - [Notes] Added a "Back to top" button for long notes, plus a new "Line Break Mode" setting that renders single line breaks as new lines (Obsidian-style) without modifying the source files
+    - [Local Model] Add DirectML (Windows) and CoreML (macOS) hardware acceleration for local models
+    - [Files] Enforce document input limits on file processing
+    - [Privacy] Agent sessions now run the bundled Claude Agent SDK with non-essential traffic disabled, so the bundled CLI no longer sends telemetry, error reports or background config fetches to Anthropic
 
     🐛 Bug Fixes
-    - [Sidebar] Add a Manage Sidebar action that opens Launchpad so hidden sidebar entries can be restored, and fix context-menu dismissal from blank sidebar space on Windows
-    - [Agent] Fix raw internal citation markers appearing in IM channel replies
-    - [Agent] Prevent agent conversations from being automatically renamed after their initial turn
-    - [Agent] Fix the configured Agent system prompt being overridden by workspace or persona instructions
-    - [Agent] Agent attachments now remain available in session history and are provided as managed file paths
-    - [Coding Partner] Respect the configured default terminal when launching Coding Partner tools on Linux
-    - [Composer] Keep the chat composer compact while a conversation right panel is maximized
-    - [Linux] Fix Linux startup failures on older distributions by shipping a GLIBC 2.28-compatible better-sqlite3
-    - [Providers] Fix "reasoning_content in thinking mode must be passed back to the API" errors on multi-turn conversations with thinking models (DeepSeek, GLM, Kimi, MiniMax) over OpenAI-compatible providers
-    - [Mini App] Fix ChatGPT MiniApps remaining blocked by the loading overlay after the page becomes ready
-    - [Agent] Fix Agent sessions that could fail with tool_use ID uniqueness errors until the conversation was cleared
-    - [MCP] Fix stdio MCP servers (globally installed npm packages, standalone binaries) failing to load tools in Agent sessions on Windows
-    - [Notes] Update note rows in the sidebar to use an icon consistent with the rest of the interface
-    - [MCP] Fix MCP stdio servers leaving orphaned child processes behind after a failed liveness ping or reconnect
-    - [App] Quitting no longer force-kills the app when one background service is slow to stop; each service gets its own shutdown window
-    - [MCP] Fix MCP tool routing when distinct servers or tools normalize to the same identifier, including non-ASCII names
-    - [Knowledge Base] Fix Knowledge Base assistants failing on Anthropic models with "Schema is too complex for compilation"
-    - [Backup] Fix automatic backups failing on Windows when Chromium holds a LevelDB lock file
-    - [UI] Improve assistant and agent conversation lists with consistent row colors, focus feedback, action spacing, and status indicators
-    - [Agent] Fix IM channel bots (QQ/WeChat/Feishu/Telegram/etc.) being denied MCP tool access with "Approval requested outside a live interactive turn"
-    - [Composer] Unsent chat and agent-session drafts now stay with their conversation, including attachments, knowledge bases, and mentioned models
-    - [Providers] OpenCode Go/Zen conversations now preserve session affinity, improving provider-side prompt-cache reuse
-    - [Models] Ollama models that report native thinking support now expose the appropriate reasoning controls
-    - [Selection Assistant] Fix the Selection Assistant carrying the previous selection and answer into the next action
-    - [Coding Partner] Fix OpenCode auto-compaction configuration and keep CLI config Editor previews synchronized
-    - [Agent] Fix Agent responses showing raw citation markers when large web or knowledge lookup results are deferred
-    - [Coding Partner] Fix Code Mate's OpenAI Codex authentication switching so standalone Codex and Conductor retain a valid mode
+    - [Web Search] Fix Zhipu web search failing with a missing API key error even after the Zhipu API key was configured in model provider settings
+    - [Rename] Fix Agent session, topic, and history record rename saving the raw pinyin instead of the Chinese title when confirming an IME candidate with Enter
+    - [Chat] Conversation recency now follows actual chat activity, so renaming, moving, reordering, or other metadata changes no longer make an older conversation appear recent
+    - [Workspace] Show the official Windows Terminal icon in the agent workspace open-in menu on Windows
+    - [Chat] Fix multi-model Retry, Retry All, and @ model replies so they target the correct live execution, stale retry state cannot reappear, and repeated replies from the same model remain visible in multi-model message groups
+    - [Knowledge Base] Prevent knowledge-base imports and migrations from producing overlong filenames when resolving name collisions
+    - [Errors] Chat and provider connection-check errors now show the service provider's own error message instead of bare HTTP status text, and an HTTP 403 is no longer reported as an invalid API key
+    - [OAuth] Fix Codex and Grok CLI OAuth sign-in so pending browser authorization can be canceled and immediately retried without stale callbacks or cancellation requests disrupting the new flow
+    - [Navigation] Fix navigation to /app/* routes (e.g. opening the feedback assistant) and to routes carrying query strings being blocked by the main-window route allowlist
+    - [CherryIN] CherryIN chat now blocks native audio attachments for Qwen models that do not support audio, preventing failed upstream requests
+    - [DeepSeek] Fix DeepSeek auto thinking mode sending an invalid thinking.type "auto" parameter that caused chat start to fail with an AI SDK type validation error
+    - [Prompt] Fix assistant/agent prompt preview collapsing multi-line system prompts into a single line
+    - [UI] Fix the close button of tall dialogs (e.g. the provider editor after expanding "more settings") becoming unclickable where it overlaps the window title bar
+    - [Web Search] Fix the built-in @cherry/fetch tool and web search page fetching failing with "HTTP error: 301" on URLs that redirect
+    - [Models] Fix model selector tag filters appearing cut off: the filter row now shows an edge fade when more tags are hidden, making horizontal overflow visible
+    - [Models] Fix long model names overlapping the capability icons in the model management drawer
+    - [Doubao] Fix Doubao model connection checks failing with "Invalid JSON response" when Ark omits output text annotations
+    - [OCR] Fix System OCR on Windows still failing for JPEG, GIF and WebP images: images are now transcoded to PNG before recognition
+    - [OCR] Fix System OCR on Windows failing on every JPEG image (WIC error 0x88982F07): the native engine now receives image bytes instead of a file path, which also fixes BMP/TIFF/GIF/WebP/HEIF inputs
+    - [Agent] Fix agent sessions on models whose catalog output cap equals their context window (such as DeepSeek V4 Pro) compacting repeatedly from 100K tokens on, and stop the context-usage readout from reporting the compaction budget as the model's context window
+    - [macOS] Hide the macOS Dock icon when minimizing to tray on close (and on launch-to-tray), restoring v1 behavior
+    - [Agent] Fix an issue where multiple tool permission requests in one reply could stall the conversation and require switching conversations to continue
+    - [Painting] Fix painting size controls and the parameter popover covering nearby content
+    - [Agent] Work agent sessions interrupted by an abnormal exit no longer resume the interrupted Claude Code execution. On restart their history is preserved and settled, and the next reply starts from a fresh runtime connection
+    - [Agent] Fix agent session streams rendering fragmented or duplicated reasoning blocks after reconnecting to a long-running turn (stream replay buffer overflow)
+    - [MCP] MCP server logs can now be selected and copied — added a "Copy logs" button to the MCP server logs tab
+    - [Agent] Scheduled tasks for the same agent can now run up to three jobs concurrently instead of always running sequentially
+    - [Agent] Prevent internal Claude Agent system reminders from appearing in conversations and newly persisted assistant messages
+    - [Painting] Fix long prompts pasted into Painting still appearing blank after the initial long-text paste fix
+    - [Agent] Fix the agent edit dialog trapping users after a failed save; a repeat explicit close now discards the unsaved change and exits
+    - [Bailian] Fix Bailian models failing with "Normal mode does not support web_extractor" when thinking is disabled: web search now works in non-thinking mode without the web extractor tool
+    - [Windows] Fix command discovery for bundled Git and user-installed tools located in Windows paths containing non-ASCII characters
+    - [Knowledge Base] Fix knowledge base lists not loading entries beyond the first 100 records
+    - [Assistant] Fix assistant edits that could fail and trap users in the edit dialog when legacy settings were present
+    - [Mini App] Reopening a mini app from the sidebar now switches to its existing tab instead of replacing the current tab
+    - [Topic Naming] Fix auto-generated conversation and agent-session titles: the naming request no longer carries the assistant's tool configuration, so auto-naming no longer fails when the assistant has web search enabled and the naming model cannot combine disabled thinking with a web tool
+    - [Code Viewer] Fix long unbreakable lines (base64, URLs, minified JSON) in chat code blocks and the trace call-chain detail view being clipped / not wrapping when auto-wrap is enabled. They now wrap correctly; disabling wrap still scrolls horizontally
+    - [Sidebar] Preserved collapsed assistant folders in the classic conversation sidebar when switching between Chat and Work
+    - [Backup] Fix automatic backups running again shortly after every app restart instead of respecting the configured interval
+    - [Shortcuts] Fix window-local zoom shortcuts being captured by Cherry Studio while it is unfocused
+    - [Agent] Fix Agent workspace file mentions so files in deeper nested folders can be found with @ search. Action required: when OCR cannot extract text from an image attached to a text-only model, Cherry Studio now stops before sending the request and asks you to choose a vision-capable model or remove the image
+    - [Migration] Fix "No tool output found for tool call" when continuing a conversation migrated from v1 that used MCP tools
+    - [Image Viewer] Fix rotation and flip not being baked into the saved image
+    - [Thinking Block] Fix the "Auto-collapse thinking content" setting having no effect when disabled — turning it off now keeps thinking blocks expanded
+    - [MCP] Fix npx/uv stdio MCP servers not resolving on Windows when launched via the system PATH
+    - [MCP] Propagate the stream abort signal into in-flight MCP tool calls, so aborting a reply reliably cancels running MCP tools
+    - [Models] Fix model sizes being lost when multiple models share the same family key
+    - [Settings] Disabling the system tray now also disables the quick assistant's tray-click launch option
 
     ⚡ Performance
-    - [Chat] Smoother tab switching in chat and agent pages: switching tabs no longer re-issues IPC calls or forces full re-renders, and the agent right-panel expansion state is no longer reset
-    - [Startup] Reduce main-process startup memory by lazy-loading heavy dependencies (jsdom, sharp, officeparser, tesseract.js, Claude agent SDK); each now loads on first use
+    - [Chat] Fix renderer crashes ("app suddenly closes") during long fast streaming replies, caused by quadratic memory growth in stream handling and rendering. Very large streamed replies now render with bounded memory, and oversized single markdown blocks no longer fail to render
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.3 - 新功能、修复与性能优化
+    Cherry Studio 2.0.4 - 新功能、修复与性能优化
 
     ✨ 新功能
-    - [输入框] 深度思考强度的滑块支持鼠标滚轮和触控板顺滑切换
-    - [对话] 在输入框旁显示当前助手对话的上下文窗口占用
-    - [联网搜索] 新增 Firecrawl 作为 URL 抓取 provider（在免费额度下可无需 API Key 使用）
-    - [知识库] 支持直接向知识库中新建笔记
-    - [对话] 编辑历史用户消息时新增"保存"选项，可保留原有回复而无需重新生成
-    - [工作区] 新增 Windows Terminal 作为外部应用，可在目标目录打开终端
-    - [Agent] Agent 工作区现在会读取作用域内的 AGENTS.md 指令，与 CLAUDE.md 并存
-    - [代码工具] 代码工具新增 Pi 编码 Agent
+    - [输入框] Agent 会话中的工具权限请求现在可以用 Enter 同意、Esc 拒绝
+    - [上下文] 恢复"保留最近 N 条消息"的上下文限制，可在设置 → 模型中全局配置或按助手覆盖；并在设置 → 模型中新增"上下文管理"区域，暴露主开关、消息数量、工具输出截断阈值、自动压缩与压缩模型等参数
+    - [联网搜索] 新增 Querit fetchUrls 能力，Querit.ai 对新用户提供 1,000 次免费 API 请求
+    - [MCP 中心] 连接到本地 API 网关的 MCP 客户端现在可以打开会话，接收工具列表的实时更新和长耗时工具的进度回调
+    - [MCP 中心] 恢复本地 API 网关上的 MCP-over-HTTP 端点，外部工具可以再次将 Cherry Studio 作为本地 MCP 中心。需要采取行动：基于 1.9.x 端点的客户端应停止解包 `{ success, data }` 信封并不再依赖 `Mcp-Session-Id`，代理现在为无状态
+    - [Agent] Agent 对话现在可以用 @ 提及可访问的工作区文件夹
+    - [Agent] 新增从共享选择器中删除工作区的能力，并提供对会话、Agent 渠道和定时任务的影响预览，磁盘上的文件会被保留
+    - [模型] 新增基于输入 token 数量的可配置模型价格分层，每层支持独立的输入、输出、缓存读、缓存写费率
+    - [快捷键] 新增可在设置中自定义的标签页切换快捷键（下一个 / 上一个标签页）
+    - [QQ 机器人] QQ 频道机器人在关闭按频道"仅 @ 提及"开关且开通 QQ 开放平台权限后，现在可以接收所有群消息（而不仅是 @ 消息）
+    - [笔记] 为长笔记新增"回到顶部"按钮，并新增"换行模式"设置，可以将单换行渲染为换行（类 Obsidian 风格）而不修改源文件
+    - [本地模型] 新增 DirectML（Windows）和 CoreML（macOS）本地模型硬件加速
+    - [文件] 对文件处理强制执行文档输入限制
+    - [隐私] Agent 会话现在以禁用非必要流量方式运行捆绑的 Claude Agent SDK，捆绑 CLI 不再向 Anthropic 发送遥测、错误报告或后台配置拉取
 
     🐛 问题修复
-    - [侧边栏] 新增"管理侧边栏"入口可打开启动台恢复隐藏项，并修复 Windows 上空白处右键菜单无法关闭的问题
-    - [Agent] 修复 IM 渠道回复中出现原始内部引用标记的问题
-    - [Agent] 修复 Agent 对话在首轮之后被自动重命名的问题
-    - [Agent] 修复 Agent 配置的系统提示词被工作区或 persona 指令覆盖的问题
-    - [Agent] Agent 附件现在可在会话历史中保留，并以受管文件路径方式提供给 Agent
-    - [代码工具] 修复 Linux 上启动代码工具时未使用系统默认终端的问题
-    - [输入框] 修复对话右侧面板最大化时输入框被撑开的问题
-    - [Linux] 修复较旧的 Linux 发行版上因 better-sqlite3 不兼容而无法启动的问题，打包 GLIBC 2.28 兼容版本
-    - [模型服务商] 修复 DeepSeek、GLM、Kimi、MiniMax 等思考模型多轮对话时"reasoning_content must be passed back"的报错
-    - [小程序] 修复 ChatGPT 小程序在页面就绪后仍被加载遮罩挡住的问题
-    - [Agent] 修复 Agent 会话因 tool_use ID 重复而失败，必须清空对话才能恢复的问题
-    - [MCP] 修复 Windows 上 stdio 类型 MCP 服务器（全局 npm 包、独立二进制）在 Agent 会话中无法加载工具的问题
-    - [笔记] 笔记侧边栏的图标样式与界面其他部分保持一致
-    - [MCP] 修复 stdio MCP 服务器在 ping 失败或重连后残留子进程的问题
-    - [应用] 退出应用时不再因单个后台服务停止缓慢而强制结束，每个服务拥有独立的关闭窗口
-    - [MCP] 修复不同 MCP 服务器或工具在归一化后标识符相同（含非 ASCII 名称）导致的工具路由错误
-    - [知识库] 修复知识库助手在 Anthropic 模型上报"Schema is too complex for compilation"的问题
-    - [备份] 修复 Windows 上自动备份因 Chromium 占用 LevelDB 锁文件而失败的问题
-    - [UI] 改进助手与 Agent 对话列表的行配色、聚焦反馈、操作间距和状态指示
-    - [Agent] 修复 IM 渠道机器人（QQ/微信/飞书/Telegram 等）被拒绝访问 MCP 工具的问题
-    - [输入框] 未发送的对话和 Agent 会话草稿现在会跟随对应会话保留，包含附件、知识库和 @模型 选择
-    - [模型服务商] OpenCode Go/Zen 对话现在会保持会话亲和性，提升服务商侧 prompt 缓存复用
-    - [模型] Ollama 上报原生思考能力的模型现在会显示对应的推理控制项
-    - [划词助手] 修复划词助手将上一次选中内容与回答带入下一次操作的问题
-    - [代码工具] 修复 OpenCode 自动压缩配置无效的问题，并保持 CLI 配置编辑器预览同步
-    - [Agent] 修复大体积网页或知识库查找结果被延迟时，Agent 回复出现原始引用标记的问题
-    - [代码工具] 修复 Code Mate 切换 OpenAI Codex 认证模式后无效的问题，独立 Codex 和 Conductor 现可保留有效认证
+    - [联网搜索] 修复在模型服务商设置中配置了 Zhipu API Key 后，Zhipu 联网搜索仍报缺少 API Key 错误的问题
+    - [重命名] 修复 Agent 会话、话题和历史记录重命名时，按 Enter 确认输入法候选词会把原始拼音当作中文标题保存的问题
+    - [对话] 对话的最近活跃时间现在跟随实际的聊天行为，重命名、移动、排序等元数据变更不再让旧对话出现在最近列表中
+    - [工作区] 在 Windows 上 Agent 工作区的"打开方式"菜单显示官方 Windows Terminal 图标
+    - [对话] 修复多模型重试、全部重试和 @模型 回复指向错误的执行现场、陈旧重试状态会复现，以及同一模型的重复回复在多模型消息组中丢失的问题
+    - [知识库] 修复知识库导入和迁移在处理文件名冲突时生成超长文件名的问题
+    - [错误显示] 对话和服务商连接检查错误现在会显示服务商自己的错误信息，而不是裸的 HTTP 状态文本；HTTP 403 不再被报为无效 API Key
+    - [OAuth] 修复 Codex 和 Grok CLI 的 OAuth 登录：现在可以取消挂起的浏览器授权并立即重试，不会被陈旧回调或取消请求打断新流程
+    - [导航] 修复主窗口路由白名单拦截 /app/* 路由（如打开反馈助手）和带查询字符串的路由的问题，深链和应用内导航到这些路由现在可正常工作
+    - [CherryIN] CherryIN 对话现在会为不支持音频的 Qwen 模型屏蔽原生音频附件，避免上游请求失败
+    - [DeepSeek] 修复 DeepSeek auto thinking 模式发送了无效的 thinking.type "auto" 参数导致对话启动失败的问题（AI SDK 类型校验错误）
+    - [提示词] 修复助手/Agent 提示词预览把多行系统提示词折叠成一行的问题
+    - [界面] 修复高对话框（如展开"更多设置"后的服务商编辑器）的关闭按钮在与窗口标题栏重叠区域无法点击的问题
+    - [联网搜索] 修复内置 @cherry/fetch 工具和联网搜索页面抓取在 URL 重定向时报 "HTTP error: 301" 失败的问题
+    - [模型] 修复模型选择器标签筛选被截断的问题：当有更多标签被隐藏时，筛选行现在会出现边缘渐变以提示横向溢出
+    - [模型] 修复模型管理抽屉中长模型名与能力图标重叠的问题
+    - [豆包] 修复当 Ark 省略输出文本注释时，豆包模型连接检查报 "Invalid JSON response" 失败的问题
+    - [OCR] 修复 Windows 上系统 OCR 仍对 JPEG、GIF、WebP 图像失败的问题：原生引擎只能解码 PNG，现在会在识别前将图像转码为 PNG
+    - [OCR] 修复 Windows 上系统 OCR 对所有 JPEG 图像失败的问题（WIC 错误 0x88982F07）：原生引擎现在接收图像字节而非文件路径，同时修复了 BMP/TIFF/GIF/WebP/HEIF 输入
+    - [Agent] 修复模型的目录输出上限等于其上下文窗口（如 DeepSeek V4 Pro）时，Agent 会话从 100K 开始反复压缩的问题，并停止让上下文用量读数把压缩预算报告为模型上下文窗口
+    - [macOS] 在关闭到托盘和启动到托盘时隐藏 macOS Dock 图标，恢复 v1 行为
+    - [Agent] 修复单条回复中出现多个工具权限请求时可能导致对话卡住、必须切换会话才能继续的问题
+    - [绘画] 修复绘画尺寸控制和参数浮层遮挡附近内容的问题
+    - [Agent] 被异常退出打断的 Work Agent 会话不再恢复被中断的 Claude Code 执行。重启后历史保留且已稳定，下一条回复从新的运行时连接开始
+    - [Agent] 修复 Agent 会话在重连到一个长时间运行的回合后（流式回放缓冲区溢出）渲染出碎片化或重复推理块的问题
+    - [MCP] MCP 服务器日志现在可以选中并复制 —— 在 MCP 服务器日志页签新增了"复制日志"按钮
+    - [Agent] 同一 Agent 的定时任务现在最多可以并行运行三个作业，而不再总是串行执行
+    - [Agent] 阻止内部 Claude Agent 系统提醒出现在对话和新持久化的助手消息中
+    - [绘画] 修复长提示词粘贴到绘画后仍然显示空白的问题（在初次长文本粘贴修复之后）
+    - [Agent] 修复 Agent 编辑对话框在保存失败后困住用户的问题；再次显式关闭现在会丢弃未保存的更改并退出
+    - [百炼] 修复百炼模型在关闭思考时报 "Normal mode does not support web_extractor" 失败的问题：非思考模式下联网搜索现在会跳过 web_extractor 工具正常工作
+    - [Windows] 修复包含非 ASCII 字符的 Windows 路径下捆绑 Git 和用户已安装工具的命令发现问题
+    - [知识库] 修复知识库列表无法加载第 100 条之后记录的问题
+    - [助手] 修复存在遗留设置时助手编辑可能失败并把用户困在编辑对话框中的问题
+    - [小程序] 从侧边栏重新打开小程序现在会切换到它已有的标签页，而不是替换当前标签页
+    - [话题命名] 修复自动生成的对话和 Agent 会话标题：命名请求不再携带助手的工具配置（MCP 工具、联网搜索、知识库），因此当助手启用了联网搜索且命名模型无法将禁用思考与 web 工具组合时，自动命名不再失败
+    - [代码查看器] 修复对话代码块和追踪调用链详情中无法换行的长行（base64、URL、压缩 JSON）在开启自动换行时被裁剪的问题：现在可以正确换行；关闭换行时仍可横向滚动
+    - [侧边栏] 在经典对话侧边栏中，切换 Chat 和 Work 时保留助手分组的折叠状态
+    - [备份] 修复自动备份在每次应用重启后不久就再次运行、而不遵守配置间隔的问题
+    - [快捷键] 修复窗口级缩放快捷键在 Cherry Studio 未获焦点时仍被其捕获的问题
+    - [Agent] 修复 Agent 工作区文件提及，让更深层嵌套文件夹中的文件也能通过 @ 搜索找到。需要采取行动：当 OCR 无法从附加到纯文本模型的图像中提取文本时，Cherry Studio 现在会在发送请求前停止，并要求你选择支持视觉的模型或移除该图像
+    - [迁移] 修复从 v1 迁移且使用了 MCP 工具的对话在继续时报 "No tool output found for tool call" 的问题
+    - [图片查看器] 修复旋转和翻转未写入保存图像的问题
+    - [思考块] 修复"自动折叠思考内容"设置在禁用时无效的问题 —— 关闭后思考块会保持展开
+    - [MCP] 修复 Windows 上通过系统 PATH 启动 npx/uv stdio MCP 服务器时无法解析的问题
+    - [MCP] 将流式中止信号传递到正在执行中的 MCP 工具调用，中止回复时可以可靠地取消运行中的 MCP 工具
+    - [模型] 修复多个模型共享同一家族键时型号大小丢失的问题
+    - [设置] 关闭系统托盘现在也会同时关闭快捷助手的托盘点击启动选项
 
     ⚡ 性能优化
-    - [对话] 对话和 Agent 页面切换标签更顺滑：不再重复发起 IPC 调用或整体重渲染，Agent 右侧面板的展开状态也不再被重置
-    - [启动] 降低主进程启动内存占用：jsdom、sharp、officeparser、tesseract.js、Claude agent SDK 等重组件改为首次使用时加载
+    - [对话] 修复在长时间快速流式回复期间因流处理和渲染中的二次内存增长导致的渲染进程崩溃（"应用突然关闭"）。超大流式回复现在以有界内存渲染，超大的单个 Markdown 块也不再渲染失败
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "package": {
     "name": "CherryStudio",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "A powerful AI assistant for producer.",
     "homepage": "https://github.com/CherryHQ/cherry-studio"
   },


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:
The latest released version of Cherry Studio on `main` is `v2.0.3`. Since then, ~90 commits have landed with bug fixes, new features, and performance work that have not been cut into a release.

After this PR:
- Bumps `package.json` and the generated `resources/builtin-agents/cherry-assistant/product-manifest.json` from `2.0.3` → `2.0.4`.
- Replaces the `releaseInfo.releaseNotes` block in `electron-builder.yml` with bilingual (English + Simplified Chinese) notes covering all user-facing changes since `v2.0.3`.
- Regenerates the built-in knowledge product manifest via `pnpm build:builtin-knowledge`.

Merging this PR triggers `release.yml`, which builds on macOS, Windows, and Linux and creates a draft GitHub Release.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- A patch bump (`2.0.3` → `2.0.4`) was chosen per the `prepare-release` argument because the changes since `v2.0.3` are bug fixes and small features with no breaking API changes.
- Release notes were filtered to user-visible changes only; developer-only work (CI/build, internal refactors, test infrastructure, dev-mode trace viewer improvements) was excluded even when the commit contained a non-`NONE` release-note block.
- Two entries carry an `Action required:` marker (MCP-over-HTTP envelope change on the local API gateway, and the OCR text-only model guard) and were preserved verbatim from the contributor-supplied release notes.
- GPG signing of the release commit was not possible in CI (no signing key), so the commit is DCO-signed only; the GitHub merge commit will be signed by GitHub's web-flow GPG key, matching prior releases.

The following alternatives were considered:

- A minor bump (`2.1.0`) — rejected; no breaking changes and no major new capability warrants a minor bump.
- Manual release-note authoring without the `prepare-release` skill — rejected; the skill is the canonical automation.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None for end users. Two items carry `action required` markers for advanced users of the local API gateway / MCP hub:

- **MCP-over-HTTP on the local API gateway**: clients written against the 1.9.x endpoints should stop unwrapping the `{ success, data }` envelope and stop relying on `Mcp-Session-Id` — the proxy is now stateless.
- **OCR + text-only models**: when OCR cannot extract text from an image attached to a text-only model, Cherry Studio now stops before sending the request and asks you to choose a vision-capable model or remove the image.

### Special notes for your reviewer

<!-- optional -->

Generated by the `prepare-release` skill (patch bump). Please review the release notes in `electron-builder.yml` for accuracy and tone before merging. The PR body's English summary below mirrors the `<!--LANG:en-->` block.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (only version files + release notes)
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

---

## Summary

Cherry Studio **v2.0.4** (patch release). Bumps version files to `2.0.4` and ships bilingual release notes covering ~90 commits since `v2.0.3`.

### Release notes (English)

Cherry Studio 2.0.4 - New Features, Fixes, and Performance

✨ New Features
- [Composer] Tool permission requests in Agent sessions can now be approved with Enter or denied with Esc
- [Context] Restored a "recent messages kept" context limit available globally in Settings → Model and per assistant, plus a new Context Management section exposing master switch, message limit, tool-output truncation threshold, auto-compress, and compression model
- [Web Search] Add Querit fetchUrls capability. Querit.ai offers 1,000 free API requests for new users
- [MCP Hub] MCP clients connecting to the local API gateway can now open a session to receive live tool-list updates and progress from long-running tools
- [MCP Hub] Restored the MCP-over-HTTP endpoints on the local API gateway so external tools can once again use Cherry Studio as a local MCP hub. Action required: clients written against the 1.9.x endpoints should stop unwrapping the `{ success, data }` envelope and stop relying on `Mcp-Session-Id` — the proxy is now stateless
- [Agent] Agent conversations can now mention accessible workspace folders with @
- [Agent] Add workspace deletion from the shared selector with an impact preview for sessions, agent channels, and scheduled tasks while preserving files on disk
- [Models] Add configurable model pricing tiers based on input token count, with separate input, output, cache-read, and cache-write rates for each tier
- [Shortcuts] Added configurable keyboard shortcuts for switching to the next or previous tab
- [QQ Bot] QQ channel bots can now receive all group messages (not just @mentions) when the per-channel "mention-only" toggle is off and the QQ Open Platform permission is enabled
- [Notes] Added a "Back to top" button for long notes, plus a new "Line Break Mode" setting that renders single line breaks as new lines (Obsidian-style) without modifying the source files
- [Local Model] Add DirectML (Windows) and CoreML (macOS) hardware acceleration for local models
- [Files] Enforce document input limits on file processing
- [Privacy] Agent sessions now run the bundled Claude Agent SDK with non-essential traffic disabled, so the bundled CLI no longer sends telemetry, error reports or background config fetches to Anthropic

🐛 Bug Fixes
- [Web Search] Fix Zhipu web search failing with a missing API key error even after the Zhipu API key was configured in model provider settings
- [Rename] Fix Agent session, topic, and history record rename saving the raw pinyin instead of the Chinese title when confirming an IME candidate with Enter
- [Chat] Conversation recency now follows actual chat activity, so renaming, moving, reordering, or other metadata changes no longer make an older conversation appear recent
- [Workspace] Show the official Windows Terminal icon in the agent workspace open-in menu on Windows
- [Chat] Fix multi-model Retry, Retry All, and @ model replies so they target the correct live execution, stale retry state cannot reappear, and repeated replies from the same model remain visible in multi-model message groups
- [Knowledge Base] Prevent knowledge-base imports and migrations from producing overlong filenames when resolving name collisions
- [Errors] Chat and provider connection-check errors now show the service provider's own error message instead of bare HTTP status text, and an HTTP 403 is no longer reported as an invalid API key
- [OAuth] Fix Codex and Grok CLI OAuth sign-in so pending browser authorization can be canceled and immediately retried without stale callbacks or cancellation requests disrupting the new flow
- [Navigation] Fix navigation to /app/* routes (e.g. opening the feedback assistant) and to routes carrying query strings being blocked by the main-window route allowlist
- [CherryIN] CherryIN chat now blocks native audio attachments for Qwen models that do not support audio, preventing failed upstream requests
- [DeepSeek] Fix DeepSeek auto thinking mode sending an invalid thinking.type "auto" parameter that caused chat start to fail with an AI SDK type validation error
- [Prompt] Fix assistant/agent prompt preview collapsing multi-line system prompts into a single line
- [UI] Fix the close button of tall dialogs (e.g. the provider editor after expanding "more settings") becoming unclickable where it overlaps the window title bar
- [Web Search] Fix the built-in @cherry/fetch tool and web search page fetching failing with "HTTP error: 301" on URLs that redirect
- [Models] Fix model selector tag filters appearing cut off: the filter row now shows an edge fade when more tags are hidden, making horizontal overflow visible
- [Models] Fix long model names overlapping the capability icons in the model management drawer
- [Doubao] Fix Doubao model connection checks failing with "Invalid JSON response" when Ark omits output text annotations
- [OCR] Fix System OCR on Windows still failing for JPEG, GIF and WebP images: images are now transcoded to PNG before recognition
- [OCR] Fix System OCR on Windows failing on every JPEG image (WIC error 0x88982F07): the native engine now receives image bytes instead of a file path, which also fixes BMP/TIFF/GIF/WebP/HEIF inputs
- [Agent] Fix agent sessions on models whose catalog output cap equals their context window (such as DeepSeek V4 Pro) compacting repeatedly from 100K tokens on, and stop the context-usage readout from reporting the compaction budget as the model's context window
- [macOS] Hide the macOS Dock icon when minimizing to tray on close (and on launch-to-tray), restoring v1 behavior
- [Agent] Fix an issue where multiple tool permission requests in one reply could stall the conversation and require switching conversations to continue
- [Painting] Fix painting size controls and the parameter popover covering nearby content
- [Agent] Work agent sessions interrupted by an abnormal exit no longer resume the interrupted Claude Code execution. On restart their history is preserved and settled, and the next reply starts from a fresh runtime connection
- [Agent] Fix agent session streams rendering fragmented or duplicated reasoning blocks after reconnecting to a long-running turn (stream replay buffer overflow)
- [MCP] MCP server logs can now be selected and copied — added a "Copy logs" button to the MCP server logs tab
- [Agent] Scheduled tasks for the same agent can now run up to three jobs concurrently instead of always running sequentially
- [Agent] Prevent internal Claude Agent system reminders from appearing in conversations and newly persisted assistant messages
- [Painting] Fix long prompts pasted into Painting still appearing blank after the initial long-text paste fix
- [Agent] Fix the agent edit dialog trapping users after a failed save; a repeat explicit close now discards the unsaved change and exits
- [Bailian] Fix Bailian models failing with "Normal mode does not support web_extractor" when thinking is disabled: web search now works in non-thinking mode without the web extractor tool
- [Windows] Fix command discovery for bundled Git and user-installed tools located in Windows paths containing non-ASCII characters
- [Knowledge Base] Fix knowledge base lists not loading entries beyond the first 100 records
- [Assistant] Fix assistant edits that could fail and trap users in the edit dialog when legacy settings were present
- [Mini App] Reopening a mini app from the sidebar now switches to its existing tab instead of replacing the current tab
- [Topic Naming] Fix auto-generated conversation and agent-session titles: the naming request no longer carries the assistant's tool configuration, so auto-naming no longer fails when the assistant has web search enabled and the naming model cannot combine disabled thinking with a web tool
- [Code Viewer] Fix long unbreakable lines (base64, URLs, minified JSON) in chat code blocks and the trace call-chain detail view being clipped / not wrapping when auto-wrap is enabled. They now wrap correctly; disabling wrap still scrolls horizontally
- [Sidebar] Preserved collapsed assistant folders in the classic conversation sidebar when switching between Chat and Work
- [Backup] Fix automatic backups running again shortly after every app restart instead of respecting the configured interval
- [Shortcuts] Fix window-local zoom shortcuts being captured by Cherry Studio while it is unfocused
- [Agent] Fix Agent workspace file mentions so files in deeper nested folders can be found with @ search. Action required: when OCR cannot extract text from an image attached to a text-only model, Cherry Studio now stops before sending the request and asks you to choose a vision-capable model or remove the image
- [Migration] Fix "No tool output found for tool call" when continuing a conversation migrated from v1 that used MCP tools
- [Image Viewer] Fix rotation and flip not being baked into the saved image
- [Thinking Block] Fix the "Auto-collapse thinking content" setting having no effect when disabled — turning it off now keeps thinking blocks expanded
- [MCP] Fix npx/uv stdio MCP servers not resolving on Windows when launched via the system PATH
- [MCP] Propagate the stream abort signal into in-flight MCP tool calls, so aborting a reply reliably cancels running MCP tools
- [Models] Fix model sizes being lost when multiple models share the same family key
- [Settings] Disabling the system tray now also disables the quick assistant's tray-click launch option

⚡ Performance
- [Chat] Fix renderer crashes ("app suddenly closes") during long fast streaming replies, caused by quadratic memory growth in stream handling and rendering. Very large streamed replies now render with bounded memory, and oversized single markdown blocks no longer fail to render

### Included commits (since v2.0.3)

- 54816a677 fix(prepare-release): restrict translation check to JSON files in i18n directories
- b83ba4c580 docs: Update Vietnamese and Traditional Chinese translations for various UI elements and error messages
- b641ebbe0e test(main-i18n): drop catalog-content assertions from t() tests (#18506)
- 8a2311c917 ci(prepare): skip prek git-hook install when CI is set (#18503)
- 8c8000caa7 🤖 Daily Auto I18N Sync: Aug 13, 2026 (#18502)
- 99dcfd1f04 fix(web-search): read the Zhipu search key from its model provider (#18480)
- 5ff3bfd87a feat(permission-composer): add enter/esc shortcuts for tool approval (#18359)
- d31644b849 fix(context-settings): pass assistant id to retry compaction (#18495)
- 9a1981c467 fix(stream-manager): pass assistantId through the retry context resolution (#18492)
- 7b14c71802 feat(context-settings): read attachments in full, gate fs_read, and restore a last-N context limit (#18192)
- 56821db891 fix(rename): stop IME composition Enter from committing a pinyin title (#18456)
- 726446b54c feat(conversation-activity): track recent activity separately (#18308)
- 4511670ef1 fix(external-apps): use official Windows Terminal icon (#18455)
- dd3dd52d5d fix(chat-stream): harden multi-model retry and stream convergence (#18304)
- 7d7bed2729 perf(ai-transport): stop quadratic memory growth that crashes the renderer on long fast streams (#18450)
- fcd264fc5e fix(provider-registry): resolve same-family model sizes via size-preserving key (#18391)
- a7bf3b0b55 Feat/add querit webcontent provider (#18451)
- ce287925dd fix(knowledge): keep deduplicated filenames within limit (#18358)
- 50092331df feat(file-processing): enforce document input limits (#18364)
- 034b942451 fix(error-display): surface the provider's real error instead of status text (#18431)
- d1c389511a fix(api-gateway): send stable prompt_cache_key for internal Agent Responses requests (#18343)
- bd590393ec refactor(qq-channel): unify group-message dedup with rollback & mention strip (#18383)
- a5c2fbbe5e fix(oauth): allow canceling pending browser sign-ins (#18367)
- 6675236234 fix(main-window-navigation): allow /app routes and query strings in route allowlist (#18266)
- 736842b57a fix(mcp): use findExecutableInEnv for npx/uv resolution on Windows (#18436)
- 0fc1fadc1e fix(cherryin): align audio capabilities with model support (#18386)
- f167e91581 test(renderer): remove low-value implementation assertions (#18424)
- 2169ac2c32 feat(claude-code): disable Claude Agent SDK non-essential traffic (#18433)
- 74e02873b8 feat(model-pricing): support tiered rates by input token count (#18248)
- fe58d63a81 fix(stream-manager): stop leaking per-stream destroyed listeners on WebContents (#18278)
- 29455a6aae fix(observability): record final provider body in http trace (#18348)
- c85902092f fix(provider-registry): map deepseek auto thinking to enabled (#18274)
- d0248ee988 fix(prompt-editor): preserve newlines in prompt preview (#18377) (#18390)
- cb067aa81f feat(local-model): add DirectML and CoreML acceleration (#18350)
- 338e3c3e1f fix(ui): keep DialogContent clickable over titlebar drag region (#18406)
- 0e996a12e8 fix(remote-fetch): follow redirects in built-in fetch and web search (#18380)
- b7ac744693 fix(model-selector): add edge fade to overflowing tag filter row (#18414)
- cc5c599ecc fix(skill-creator): frontmatter name must match folder name per Agent Skills spec (#18417)
- cd82f996fb ci(claude): consolidate GitHub workflows (#18426)
- faefb0795f ci(claude-review): improve PR review automation (#18423)
- 32d26c593a fix(provider-settings): restore model name truncation in manage drawer (#18416)
- 2fbd18ea9d chore(renderer-utils): remove unused renderer utilities (#18418)
- 588a7ae076 fix(knowledge): reject relative paths that escape the material root on the host (#18401)
- b2bbe55a49 feat(api-gateway): unified token estimator + real tool-result images (#17195)
- 584f154cc6 fix(doubao): normalize missing Responses annotations (#18392)
- ab75125f94 fix(system-ocr): transcode non-PNG images to PNG on Windows (#18361)
- 48b9c70375 feat(agent-composer): support folder mentions (#18342)
- d5117df2a0 fix(claude-code-runtime): budget auto-compaction against the real request (#18338)
- e3575c7068 fix(window-manager): hide Dock icon on close-to-tray (#18186) (#18366)
- 1f99a7d3c0 fix(tool-approval): advance multiple permission requests (#18312)
- d1ffaa82ce fix(image-viewer): bake rotation/flip into saved image (#18322)
- 52d817dca7 feat(qq-channel): handle GROUP_MESSAGE_CREATE event with per-channel mention-only toggle (#18152)
- 65df56847a fix(painting): keep size controls clear of nearby content (#18360)
- d5b7c44ba6 fix(agent-session): discard crashed sessions' resume tokens at boot reconcile (#18289)
- bfdf63dd6a fix(ai-stream): keep overflowed replay parseable after ring eviction (#18295)
- 764274b0a6 feat(api-gateway): add opt-in MCP sessions with server-to-client push and progress (#18094)
- 5f6e39f079 feat(api-gateway): restore MCP-over-HTTP endpoints (/v1/mcps) (#18080)
- a54c659906 fix(mcp-settings): allow copying MCP logs (#18249)
- cf7d2f3e3d fix(agent-jobs): allow bounded scheduled task concurrency (#18355)
- a10fe9b8ba fix(agent-session): filter system reminder echoes (#18250)
- ff78a10341 fix(composer): use active editor for long text paste (#18301)
- 5ac7d9a58b fix(agent-editor): let an explicit close discard a failed agent save (#18331)
- a8d9fb4210 fix(dashscope): skip web_extractor when thinking is disabled (#18349)
- 5e5830b580 fix(windows-env): preserve Unicode command paths (#18201)
- 324f26f728 feat(shortcuts): add tab navigation shortcuts (#16629)
- 516a8c24fa refactor(knowledge): type material paths as PosixRelativeFilePath (#18230)
- c3e03396fb refactor(file-utils): split path spec from filename convention, add RelativeFilePath brands (#18229)
- 6e428f8b95 fix(system-ocr): send image bytes on Windows so JPEG decodes (#18335)
- 63471a4d96 fix(knowledge): add cursor pagination to knowledge base lists (#18300)
- 1c352d2315 perf(trace-viewer): virtualize large span trees (#18296)
- 7bb65e75d9 fix(assistant-editor): recover from legacy save failures (#18257)
- 1cab3af8e6 fix(mini-app): reuse existing sidebar tab (#18233)
- b68fafcaf7 fix(topic-naming): keep auto-rename requests free of assistant tool config (#18320)
- 6fab717dcd fix(thinking-block): honor auto-collapse setting when disabled (#18073)
- 205f042800 fix(code-viewer): wrap long unbroken lines in wrapped mode instead of clipping (#18290)
- e883e0db27 docs(claude-md): cap inline comments, ban behavior-pinning tests, drop linear-history rule (#18302)
- 9e71fa216f fix(resource-list): persist assistant group collapse (#18252)
- 6f9ab1befc fix(backup): preserve auto-backup intervals across restarts (#18226)
- f9dd175d5f fix(shortcut-service): keep window shortcuts local (#18282)
- eb54e79537 fix(agent): find deeply nested workspace file mentions (#18139)
- ea3cbe5ba1 refactor(knowledge-readers): route only PDFs through document processors (#18161)
- 9621232429 fix(chat-attachments): block unreadable images for text-only models (#18297)
- 0119f3c265 fix(ai-messages): normalize legacy v1 MCP tool names before model replay (#18224)
- 191c372deb fix(mcp-runtime): propagate stream abort signal into in-flight MCP tool calls (#18294)
- 9b448194fa feat(agent-workspace): add delete impact preview (#18164)
- 147cab5417 feat(notes): add back-to-top button and line-break mode (#17788)
- 066cdbd711 fix(settings): sync tray-dependent preferences (#17445)
- c5a5c9d952 ci(prepare-release): sync and translate i18n before cutting a release (#18214)
- ed0843b5e5 perf(ai-trace): serve the trace viewer incrementally and bound its retention (#18203)
- 4f843a6ce1 test(ai): add chat turn integration trajectories (#17550)

## Review checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] Verify generated product manifest uses the release version
- [ ] CI passes
- [ ] Merge to trigger release build
