### PR TITLE
fix(provider-registry): prevent cross-size model matches

### DIFF
--- a/packages/provider-registry/src/__tests__/registry-loader.test.ts
+++ b/packages/provider-registry/src/__tests__/registry-loader.test.ts
@@ -115,6 +115,18 @@ describe('RegistryLoader override index — prefixed id resolves to its own size
     expect(loader.findOverride('nvidia', 'gpt-oss-20b')?.apiModelId).toBe('openai/gpt-oss-20b')
     expect(loader.findOverride('nvidia', 'openai/gpt-oss-120b')?.modelId).toBe('gpt-oss-120b')
   })
+
+  it('returns null when the requested size has no override', () => {
+    const loader = newLoader(rows)
+
+    expect(loader.findOverride('nvidia', 'nvidia/gpt-oss-9b')).toBeNull()
+  })
+
+  it('keeps the family-key fallback for ids without a parameter size', () => {
+    const loader = newLoader(rows)
+
+    expect(loader.findOverride('nvidia', 'nvidia/gpt-oss')?.modelId).toBe('gpt-oss-120b')
+  })
 })
 
 describe('RegistryLoader.findModel — registry-tag (colon) size/quant ids', () => {
@@ -155,11 +167,29 @@ describe('RegistryLoader.findModel — size-preserving catalog matches', () => {
 
     expect(loader.findModel('qwen3.5-9b')?.id).toBe('qwen3-5-9b')
     expect(loader.findModel('qwen3.5-27b')?.id).toBe('qwen3-5-27b')
+    expect(loader.findModel('nvidia/gpt-oss-20b')?.id).toBe('gpt-oss-20b')
   })
 
-  it('falls back to the family key when no size-specific catalog row exists', () => {
+  it('returns null when no size-specific catalog row exists', () => {
     const loader = modelLoader([model('qwen3-5')])
 
-    expect(loader.findModel('qwen3.5-999b')?.id).toBe('qwen3-5')
+    expect(loader.findModel('qwen3.5-999b')).toBeNull()
+  })
+
+  it('keeps the family-key fallback for ids without a parameter size', () => {
+    const loader = modelLoader([model('qwen3-5-27b')])
+
+    expect(loader.findModel('qwen3.5')?.id).toBe('qwen3-5-27b')
+  })
+})
+
+describe('RegistryLoader.findModel — explicit size misses', () => {
+  it.each([
+    ['qwen3.5-9b', 'qwen3-5-27b'],
+    ['nvidia/gpt-oss-20b', 'gpt-oss-120b']
+  ])('returns null for %s rather than the indexed %s sibling', (modelId, siblingId) => {
+    const loader = modelLoader([model(siblingId)])
+
+    expect(loader.findModel(modelId)).toBeNull()
   })
 })

--- a/packages/provider-registry/src/registry-loader.ts
+++ b/packages/provider-registry/src/registry-loader.ts
@@ -14,7 +14,7 @@ import type { ProviderConfig } from './schemas/provider'
 import { ProviderListSchema } from './schemas/provider'
 import type { ProviderModelOverride } from './schemas/provider-models'
 import { ProviderModelListSchema } from './schemas/provider-models'
-import { colonVariantTagToHyphen, normalizeModelId } from './utils/normalize'
+import { colonVariantTagToHyphen, extractParameterSize, normalizeModelId } from './utils/normalize'
 
 function readAndParse<T>(jsonPath: string, schema: { parse: (data: unknown) => T }): T {
   try {
@@ -223,8 +223,10 @@ export class RegistryLoader {
       return this.modelBySizedNorm!.get(normalizeModelId(modelId, { keepParameterSize: true })) ?? null
     }
     // Prefer the size-preserving key before the family key so distinct catalog sizes keep their metadata.
-    const sizedHit = this.modelBySizedNorm!.get(normalizeModelId(modelId, { keepParameterSize: true }))
+    const sizedModelId = normalizeModelId(modelId, { keepParameterSize: true })
+    const sizedHit = this.modelBySizedNorm!.get(sizedModelId)
     if (sizedHit) return sizedHit
+    if (extractParameterSize(sizedModelId)) return null
     return this.modelByNormId!.get(normalizeModelId(modelId)) ?? null
   }
 
@@ -236,25 +238,22 @@ export class RegistryLoader {
   findOverride(providerId: string, modelId: string): ProviderModelOverride | null {
     this.loadProviderModels()
     const key = `${providerId}::${modelId}`
-    const normKey = `${providerId}::${normalizeModelId(modelId)}`
-    const sizedNormKey = `${providerId}::${normalizeModelId(modelId, { keepParameterSize: true })}`
     // BOTH exact lookups (canonical modelId, then provider apiModelId) must precede BOTH normalized
     // fallbacks. `normalizeModelId` strips size/date suffixes, so several distinct rows collapse to one
     // normalized key (`google.gemma-3-27b-it` and `gemma-3-12b-it` both → `gemma-3-it`). If the normalized
     // canonical fallback ran before the exact apiModelId map, an exact SDK id like `google.gemma-3-27b-it`
     // would resolve through whichever same-family row was indexed first instead of its own row.
-    // The SIZE-PRESERVING fallbacks run before the size-agnostic ones for the same reason: a prefixed id
-    // that misses the exact keys (`nvidia/gpt-oss-20b`) must land on its own size's row, not the first
-    // same-family sibling (`gpt-oss-120b`) to claim the `gpt-oss` family key.
-    return (
-      this.overrideByKey!.get(key) ??
-      this.overrideByApiKey!.get(key) ??
-      this.overrideBySizedNormKey!.get(sizedNormKey) ??
-      this.overrideBySizedNormApiKey!.get(sizedNormKey) ??
-      this.overrideByNormKey!.get(normKey) ??
-      this.overrideByNormApiKey!.get(normKey) ??
-      null
-    )
+    const exact = this.overrideByKey!.get(key) ?? this.overrideByApiKey!.get(key)
+    if (exact) return exact
+
+    const sizedModelId = normalizeModelId(modelId, { keepParameterSize: true })
+    const sizedNormKey = `${providerId}::${sizedModelId}`
+    const sizedHit = this.overrideBySizedNormKey!.get(sizedNormKey) ?? this.overrideBySizedNormApiKey!.get(sizedNormKey)
+    if (sizedHit) return sizedHit
+    if (extractParameterSize(sizedModelId)) return null
+
+    const normKey = `${providerId}::${normalizeModelId(modelId)}`
+    return this.overrideByNormKey!.get(normKey) ?? this.overrideByNormApiKey!.get(normKey) ?? null
   }
 
   /** O(1) get all overrides for a provider. */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

- When a model ID carried an explicit parameter size but its size-preserving catalog lookup missed, `findModel()` fell through to a size-agnostic family key. In isolated regression fixtures, `qwen3.5-9b` returned the `qwen3-5-27b` row and `nvidia/gpt-oss-20b` returned the `gpt-oss-120b` row.
- `findOverride()` had the same residual collision in its normalized fallbacks. A vendor-prefixed 20B alias could inherit the first indexed 120B override.

After this PR:

- Size-preserving model and override matches still resolve normally, including `qwen3.5-9b` to `qwen3-5-9b` and `nvidia/gpt-oss-20b` to `gpt-oss-20b` when those rows exist.
- If an explicit-size lookup misses, `findModel()` and `findOverride()` now return `null` instead of borrowing a sibling model's metadata. In the same isolated fixtures, both wrong-size results above become `null`.
- IDs without a parameter size retain the existing family-key fallback, and colon-tag matching retains its existing strict behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18486

### Why we need it and why it was done in this way

`normalizeModelId()` strips parameter sizes by default. The final family fallback therefore collapses IDs such as `qwen3.5-9b` and `nvidia/gpt-oss-20b` onto keys shared by 27B and 120B siblings. The existing size-preserving index added by #18391 prevents this when an exact-size row exists, but its miss path could still return a wrong sibling. This change closes that path with the same rule already used by the adjacent colon-tag branch: missing metadata is safer than incorrect pricing, limits, or `presetModelId` metadata.

`findOverride()` was audited at the same time. Its exact canonical/API lookups were safe, but both normalized fallbacks were size-agnostic. Two small size-preserving override indexes and the same explicit-size miss guard fix that collision without changing unsized lookup behavior.

Original feedback: submitted by 许思寅 (triage; original upstream author ybybwdwd), P1 bug on Windows 11 / Cherry Studio v2.0.3. A custom vLLM OpenAI-compatible endpoint returned `qwen3.5-9b`, while the UI displayed Qwen3.5 27B. A custom API gateway returned `nvidia/gpt-oss-20b`, while the UI displayed Nvidia: GPT-OSS-120B; the built-in Nvidia provider displayed it correctly. [Source record share link](https://mcnnox2fhjfq.feishu.cn/record/OzYgrwdxqe11NBc1a28cWmT7nhh) · [R&D dev Base record `recvrZrjUohGgO`](https://vq11ftzpe1.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&view=vewlNjnHUw&record=recvrZrjUohGgO)

The following tradeoffs were made:

- Explicit-size aliases without a corresponding row now receive no registry metadata rather than potentially incorrect sibling metadata.
- The override loader keeps two additional normalized maps so canonical and provider API aliases can preserve parameter size in O(1) lookups.

The following alternatives were considered:

- Keeping the family fallback for explicit-size misses was rejected because it recreates the reported identity, pricing, and limit mismatch.
- Editing or regenerating catalog data was rejected because this is a lookup-semantics bug and the catalog JSON files are generated artifacts.
- Provider-specific handling for Qwen or Nvidia was rejected in favor of the existing normalization contract shared by all providers.

Links to places where the discussion took place: [#18486](https://github.com/CherryHQ/cherry-studio/issues/18486), background [#18389](https://github.com/CherryHQ/cherry-studio/issues/18389), and the earlier partial fix [#18391](https://github.com/CherryHQ/cherry-studio/pull/18391).

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None. This removes an invalid fallback that assigned metadata from a different parameter-size model.

### Special notes for your reviewer

<!-- optional -->

- Red/green proof: four targeted assertions failed before the production change with the 9B/20B IDs resolving to 27B/120B siblings; all 17 `registry-loader` tests passed after the change.
- Added coverage for hyphenated parameter sizes, vendor prefix plus parameter size, colon tags, unsized family fallback, and equivalent `findOverride()` behavior.
- Passed: `pnpm test:provider-registry` (18 files, 309 tests), `pnpm typecheck:web`, oxlint on both changed files with `--deny-warnings`, `pnpm format`, `pnpm lint`, and `pnpm test:lint`.
- Full `pnpm test` and `pnpm build:check` reach an unrelated existing failure in `src/main/i18n/__tests__/index.test.ts`: two `ja-JP` assertions expect English fallback text even though the Japanese catalog now contains translations. The provider-registry project remains fully green.
- No renderer, UI, i18n, or generated catalog data changed; no visual evidence is required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix custom OpenAI-compatible providers incorrectly displaying metadata from a same-family model with a different parameter size.
```
