### PR TITLE
ci(update-mergeable-prs): merge main into approved PRs that are behind

### DIFF
--- a/.github/workflows/update-mergeable-prs.yml
+++ b/.github/workflows/update-mergeable-prs.yml
@@ -1,0 +1,34 @@
+name: Merge main into mergeable PRs
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 * * * *' # catches PRs approved while already behind main
+  workflow_dispatch:
+
+concurrency:
+  group: update-mergeable-prs
+  cancel-in-progress: false
+
+permissions: {} # uses a PAT so the merge commit triggers CI
+
+jobs:
+  update-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge main into approved PRs whose only blocker is being behind
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN_GITHUB_WRITE }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh pr list --base main --state open --limit 100 \
+            --json number,isDraft,mergeStateStatus,reviewDecision \
+            --jq '.[] | select(.isDraft == false and .mergeStateStatus == "BEHIND" and .reviewDecision == "APPROVED") | .number' \
+          | while read -r pr; do
+              if gh api --method PUT "repos/$GH_REPO/pulls/$pr/update-branch" --silent; then
+                echo "updated #$pr"
+              else
+                echo "could not update #$pr"
+              fi
+            done

--- a/.github/workflows/update-mergeable-prs.yml
+++ b/.github/workflows/update-mergeable-prs.yml
@@ -15,6 +15,7 @@ permissions: {} # uses a PAT so the merge commit triggers CI
 
 jobs:
   update-branch:
+    if: github.repository == 'CherryHQ/cherry-studio'
     runs-on: ubuntu-latest
     steps:
       - name: Merge main into approved PRs whose only blocker is being behind


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR: an approved PR whose only remaining blocker is being behind `main` sat idle until someone manually clicked "Update branch".

After this PR: a new workflow (`.github/workflows/update-mergeable-prs.yml`) runs on every push to `main` (plus hourly and on manual dispatch), lists open PRs against `main`, and calls `PUT /pulls/{n}/update-branch` for each one that is non-draft, `APPROVED`, and `mergeStateStatus == "BEHIND"` — so `main` gets merged in and CI re-runs without human intervention.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: the filter is deliberately narrow (non-draft + approved + `BEHIND`) so drafts, conflicted, and unreviewed PRs are never touched; it uses `secrets.TOKEN_GITHUB_WRITE` because a merge commit pushed with `GITHUB_TOKEN` would not trigger CI, leaving the PR with stale checks; there is no per-PR opt-in label and no rate cap, so a push to `main` that unblocks many PRs at once will start that many CI runs.

The following alternatives were considered: relying on GitHub's native auto-merge / "always suggest updating branches" repo settings (does not reliably re-run required checks after the update), and a polling-only cron (push-to-`main` is the actual event that makes a PR fall behind, so the hourly run only exists to catch PRs approved while already behind).

Links to places where the discussion took place: None

### Breaking changes

None — CI-only change, no user-facing behavior is affected.

### Special notes for your reviewer

- The workflow does **not** merge the PRs themselves; it only merges `main` into them. Adding `gh pr merge --auto` would be a one-line follow-up if that is wanted.
- Requires the existing `TOKEN_GITHUB_WRITE` secret (already used by `auto-update-catalog.yml`).
- Verified locally: the YAML parses, and the `--jq` filter selects only the eligible PR out of a 5-case sample covering draft, conflicted (`DIRTY`), unapproved, and up-to-date (`CLEAN`) PRs.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
