### PR TITLE
fix(chat-composer): preserve width across topic switches

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -673,13 +673,12 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
     scrollElement.addEventListener('scroll', handleAnchorUpdate, { passive: true })
     window.addEventListener('resize', handleAnchorUpdate)
 
+    // The layout owner survives topic switches, so preserve its width-derived gutter.
     return () => {
       resizeObserver.disconnect()
       if (frame !== null) cancelAnimationFrame(frame)
       scrollElement.removeEventListener('scroll', handleAnchorUpdate)
       window.removeEventListener('resize', handleAnchorUpdate)
-      // On unmount the composer must not keep yielding rail space.
-      setRailGutterPx(0)
     }
   }, [data.isInitialLoading, data.listKey, setRailGutterPx, shouldTrackAnchorPosition, topic.id])
 

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -38,7 +38,7 @@ const messageListSearchMock = vi.hoisted(() => ({
 const chatLayoutModeMock = vi.hoisted(() => ({
   railGutterPx: 0,
   setForceWideLayout: () => {},
-  setRailGutterPx: () => {}
+  setRailGutterPx: vi.fn()
 }))
 
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
@@ -301,6 +301,7 @@ describe('MessageList', () => {
     messageGroupMountCounts.clear()
     messageListSearchMock.props = null
     chatLayoutModeMock.railGutterPx = 0
+    chatLayoutModeMock.setRailGutterPx.mockReset()
   })
 
   it('exposes a stable message-list boundary', () => {
@@ -352,6 +353,23 @@ describe('MessageList', () => {
       paddingLeft: '48px',
       paddingRight: '48px'
     })
+  })
+
+  it('preserves the measured rail gutter when the message list unmounts', () => {
+    Object.defineProperty(messageVirtualListMocks.scrollElement!, 'clientWidth', { value: 820 })
+    const view = render(
+      <MessageListProvider
+        value={createValue([createMessage('assistant-1', 'assistant')], { messageNavigation: 'anchor' })}>
+        <MessageList />
+      </MessageListProvider>
+    )
+
+    expect(chatLayoutModeMock.setRailGutterPx).toHaveBeenCalledWith(24)
+
+    chatLayoutModeMock.setRailGutterPx.mockClear()
+    view.unmount()
+
+    expect(chatLayoutModeMock.setRailGutterPx).not.toHaveBeenCalled()
   })
 
   it('keeps historical groups sealed while only the live tail changes', () => {

--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -1,5 +1,6 @@
 import { usePreference } from '@data/hooks/usePreference'
 import CitationsPanel from '@renderer/components/chat/citations/CitationsPanel'
+import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import { ResourcePaneCountButton, type ResourcePaneCountButtonProps } from '@renderer/components/chat/panes/Shell'
 import ConversationCenterState from '@renderer/components/chat/shell/ConversationCenterState'
 import ConversationShell from '@renderer/components/chat/shell/ConversationShell'
@@ -161,7 +162,7 @@ const Chat: FC<Props> = (props) => {
       onLocateMessageHandledProp?.()
     }
   }, [locateMessageIdProp, onLocateMessageHandledProp])
-  const center =
+  const centerContent =
     centerSurface?.content ??
     (activeTopic ? (
       <ChatContent
@@ -182,6 +183,8 @@ const Chat: FC<Props> = (props) => {
       // the empty center rather than spinning forever. Same split as AgentChat.
       <ConversationCenterState state={props.topicPending ? 'loading' : 'empty'} />
     ))
+  // ChatContent is keyed by topic; keep width-derived layout state outside that remount boundary.
+  const center = <ChatLayoutModeProvider>{centerContent}</ChatLayoutModeProvider>
 
   return (
     <ConversationShell

--- a/src/renderer/pages/home/ChatContent.tsx
+++ b/src/renderer/pages/home/ChatContent.tsx
@@ -1,6 +1,5 @@
 import { MessageEditingProvider } from '@renderer/components/chat/editing/MessageEditingContext'
 import type { TopicMessageFlowLiveState } from '@renderer/components/chat/flow'
-import { ChatLayoutModeProvider } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import {
   RefreshProvider,
   TranslationOverlayProvider,
@@ -268,9 +267,7 @@ const ChatContentInner: FC<InnerProps> = ({
           <TranslationOverlaySetterProvider value={runtime.setTranslationOverlay}>
             <TranslationOverlayProvider value={runtime.translationOverlay}>
               <MessageEditingProvider>
-                <ChatLayoutModeProvider>
-                  <ConversationStageCenter placement={placement} main={main} composer={composer} />
-                </ChatLayoutModeProvider>
+                <ConversationStageCenter placement={placement} main={main} composer={composer} />
               </MessageEditingProvider>
             </TranslationOverlayProvider>
           </TranslationOverlaySetterProvider>

--- a/src/renderer/pages/home/__tests__/Chat.test.tsx
+++ b/src/renderer/pages/home/__tests__/Chat.test.tsx
@@ -1,5 +1,7 @@
+import type * as ChatLayoutModeContextModule from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import type { Topic } from '@renderer/types/topic'
 import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -126,12 +128,29 @@ vi.mock('react-hotkeys-hook', () => ({
   useHotkeys: vi.fn()
 }))
 
-vi.mock('../ChatContent', () => ({
-  default: (props: any) => {
+vi.mock('../ChatContent', async () => {
+  const { useChatLayoutMode } = await vi.importActual<typeof ChatLayoutModeContextModule>(
+    '@renderer/components/chat/layout/ChatLayoutModeContext'
+  )
+
+  function MockChatContent(props: any) {
     chatContentProps.current = props
-    return <div data-testid="chat-content" />
+    const { railGutterPx, setRailGutterPx } = useChatLayoutMode()
+
+    return (
+      <div data-testid="chat-content">
+        <output aria-label="rail gutter">{railGutterPx}</output>
+        <button type="button" onClick={() => setRailGutterPx(24)}>
+          reserve rail gutter
+        </button>
+      </div>
+    )
   }
-}))
+
+  return {
+    default: MockChatContent
+  }
+})
 
 vi.mock('../components/ChatNavbar', () => ({
   default: ({
@@ -214,6 +233,18 @@ describe('Chat', () => {
     })
 
     expect(providerHookArgs.at(-1)).toEqual([undefined, { enabled: true }])
+  })
+
+  it('preserves the rail gutter while switching topics', async () => {
+    const user = userEvent.setup()
+    const view = render(<Chat activeTopic={topic} />)
+
+    await user.click(screen.getByRole('button', { name: 'reserve rail gutter' }))
+    expect(screen.getByRole('status', { name: 'rail gutter' })).toHaveTextContent('24')
+
+    view.rerender(<Chat activeTopic={{ ...topic, id: 'topic-2' }} />)
+
+    expect(screen.getByRole('status', { name: 'rail gutter' })).toHaveTextContent('24')
   })
 
   it('renders the navbar while the active topic is still resolving', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Switching between conversations remounted the topic-owned chat layout provider. The composer first rendered with a zero anchor-rail gutter, then narrowed after the new message list measured its viewport.

After this PR:

The chat shell owns the layout provider outside the topic-keyed remount boundary, and transient message-list cleanup preserves the width-derived gutter. The composer now keeps a stable width while switching conversations.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The anchor-rail gutter depends on the chat viewport width and navigation preference, not on the active topic. Keeping that state in a topic-owned subtree reset valid layout state during every conversation switch.

The following tradeoffs were made:

- The last measured gutter is retained while the replacement message list is loading; the new list refreshes it when its scroller mounts.

The following alternatives were considered:

- Replacing `useEffect` with `useLayoutEffect` would only hide the reset when the message scroller is immediately available; it would not cover history-loading transitions.
- Animating the padding change would mask the reset instead of removing the incorrect intermediate state.

Links to places where the discussion took place: None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- Added a regression test that preserves the rail gutter across a topic-keyed `ChatContent` remount.
- Passed: Biome, Oxlint, ESLint, and `pnpm typecheck:web`.
- Not run: Vitest and manual Electron verification, per the repository's user-owned verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the chat composer changing width when switching conversations.
```
