### PR TITLE
fix(chat-markdown): preserve soft line breaks in chat messages

### DIFF
--- a/src/renderer/assets/styles/markdown.css
+++ b/src/renderer/assets/styles/markdown.css
@@ -72,7 +72,12 @@
   margin: 0.8em 0;
   line-height: inherit;
   text-wrap: pretty;
-  white-space: normal;
+  /* Model/AI output uses \n as a line break; without this, in-paragraph
+   * newlines collapse into a single space (e.g. "count 1..5, one per line"
+   * renders as one line). pre-line keeps \n, collapses incidental runs of
+   * spaces, and trims trailing spaces — gentle for AI-generated prose.
+   * Code blocks keep their own `pre`/`break-spaces` rules above. */
+  white-space: pre-line;
 }
 
 .markdown p:last-child {
@@ -93,14 +98,11 @@
 }
 
 /*
- * Prompt editor preview (PromptEditorField): restore visible line breaks.
+ * Prompt editor preview (PromptEditorField): keep full WYSIWYG spacing.
  *
- * The global `.markdown p { white-space: normal }` above collapses a single
- * soft newline to a space (correct for chat/model replies, where `\n` is a
- * CommonMark soft break). But users author system prompts as structured
- * plain text — one field per line — and expect WYSIWYG rendering. This scoped
- * override re-enables pre-wrap ONLY for the prompt preview container, leaving
- * chat messages, file previews, and model replies on `normal`. See #18377.
+ * The global rule above already preserves newlines via pre-line. But prompts
+ * are user-authored plain text, so keep pre-wrap here to also preserve runs
+ * of spaces and trailing spaces that pre-line would collapse. See #18377.
  */
 .prompt-preview .markdown p {
   white-space: pre-wrap;


### PR DESCRIPTION
### What this PR does

Before this PR: single newlines inside a rendered markdown paragraph collapsed into spaces. E.g. asking a model "count 1..10, one per line" rendered `1 2 3 ... 10` on a single line, in chat messages, the prompt editor preview, and the translate panel alike.

After this PR: `.markdown p` uses `white-space: pre-line` globally, so in-paragraph `\n` renders as a real line break everywhere markdown is displayed. This matches AI output conventions — models use `\n` as a line break.

### Why we need it and why it was done in this way

The root cause was traced to remark-parse 11 no longer emitting `softBreak` nodes: in-paragraph newlines stay inside `text` node values, so remark-rehype outputs a Literal newline and the browser collapses it under `white-space: normal`. The same regression was previously fixed scoped for the prompt preview in #18390 (`.prompt-preview .markdown p { white-space: pre-wrap }`).

The following tradeoffs were made:

The fix is a single global CSS rule rather than a remark plugin, because a remark plugin cannot reach every affected surface: **the translate panel renders markdown via markdown-it** (`shikiMarkdownIt` → `TranslateOutputPane.tsx:49`) **outside the streamdown/remark pipeline**, so a remark plugin would be a no-op there. Only CSS spans both rendering chains. Scope of the change is intentionally broad — it affects 7 rendering surfaces, all by design:

1. Chat messages (streamdown via `ChatMarkdownRuntime`)
2. Prompt editor preview (streamdown via `PromptEditorField`)
3. Translate panel (markdown-it via `TranslateOutputPane`)
4. MCP description panel (`McpDescription`)
5. Error detail modal (`ErrorDetailModal`)
6. In-chat MCP tool results (`MessageMcpTool`)
7. In-chat meta tool results (`MessageMetaTool`)

For surfaces 1–3 newlines were the reported broken behavior; for 4–7 preserving `\n` is equally correct (structured tool/stack output). Fenced code blocks are unaffected (they keep their own `pre`/`break-spaces` rules), as are plain-text fallbacks (inline `white-space: pre-wrap`).

Known side effect, accepted: `pre-line` collapses runs of consecutive spaces to one and trims trailing spaces (vs `pre-wrap` which preserves them). AI prose rarely relies on run-of-spaces alignment; anything that does should use a code block (which keeps `pre`). The prompt editor preview specifically keeps its existing `pre-wrap` override so user-authored prompts stay fully WYSIWYG.

The following alternatives were considered:

- **Remark plugin** (`remarkSoftBreaks`, splitting `\n` into `break` nodes): rejected — the translate panel's markdown-it path never sees remark plugins, so it would require a second, parallel markdown-it plugin; one CSS rule covers both chains.
- **Scoped CSS** (`.message-content-container .markdown p`): rejected — it has the same translate-panel blind spot (that surface is not inside the chat container class).
- **Patching streamdown's parser with `breaks: true`**: rejected — global behavior change in a minified third-party patch, and still invisible to the markdown-it chain.

A draft remark-plugin implementation was built and verified, then discarded in favor of the CSS approach after the translate-panel analysis; the tradeoff is discussed in the review thread.

Fixes # (no issue filed)

### Breaking changes

None.

### Special notes for your reviewer

Locally verified: `ChatMarkdown` / `MainTextBlock` / `PromptEditorField` / `TranslatePage` test suites pass (78 tests); oxlint clean. Not covered by automated JS tests: rendered-browser behavior of `pre-line`, which needs a manual check (screenshot an assistant message with per-line breaks and a translate output).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed chat messages, prompt previews, and translations rendering single line breaks as spaces — in-paragraph newlines now display as actual line breaks, matching AI output conventions.
```

