### PR TITLE
fix(cache): prevent detached window stream stalls

### DIFF
--- a/src/renderer/data/CacheService.ts
+++ b/src/renderer/data/CacheService.ts
@@ -112,6 +112,7 @@ export class CacheService {
   // Shared cache ready state for initialization sync
   private sharedCacheReady = false
   private sharedCacheReadyCallbacks: Array<() => void> = []
+  private sharedKeysUpdatedDuringInitialSync = new Set<string>()
 
   constructor() {
     this.initialize()
@@ -968,6 +969,8 @@ export class CacheService {
       let syncedCount = 0
 
       for (const [key, entry] of Object.entries(allShared)) {
+        if (this.sharedKeysUpdatedDuringInitialSync.has(key)) continue
+
         // Skip expired entries
         if (entry.expireAt && Date.now() > entry.expireAt) {
           continue
@@ -993,6 +996,7 @@ export class CacheService {
     } catch (error) {
       logger.error('Failed to sync shared cache from Main:', error as Error)
     } finally {
+      this.sharedKeysUpdatedDuringInitialSync.clear()
       this.markSharedCacheReady()
     }
   }
@@ -1144,6 +1148,8 @@ export class CacheService {
     // Listen for cache sync messages from other windows
     window.api.cache.onSync((message: CacheSyncMessage) => {
       if (message.type === 'shared') {
+        if (!this.sharedCacheReady) this.sharedKeysUpdatedDuringInitialSync.add(message.key)
+
         if (message.value === undefined) {
           // Deletion tombstone: physically remove and always notify so
           // observers see the value disappear (unlike main's

--- a/src/renderer/data/__tests__/CacheService.shared.test.ts
+++ b/src/renderer/data/__tests__/CacheService.shared.test.ts
@@ -10,7 +10,7 @@
  *    NOT notify subscribers; value changes and deletion tombstones do notify.
  *    Equality is judged against the raw physical entry, never TTL-aware.
  */
-import type { CacheSyncMessage } from '@shared/data/cache/cacheTypes'
+import type { CacheEntry, CacheSyncMessage } from '@shared/data/cache/cacheTypes'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Undo the global mock from renderer.setup.ts — we want the REAL CacheService
@@ -24,6 +24,7 @@ const BASE = 1_000_000
 
 // JobManager's live progress key — the standing consumer of TTL'd entries.
 const KEY = 'jobs.progress.job-1' as const
+const STREAM_KEY = 'topic.stream.statuses.topic-1' as const
 
 let now: number
 
@@ -107,6 +108,32 @@ describe('getSharedSnapshot (pure physical read)', () => {
 })
 
 describe('inbound sync gating (fix A3)', () => {
+  it('keeps a live stream status update that arrives while the initial snapshot is in flight', async () => {
+    let resolveInitialSync!: (entries: Record<string, CacheEntry>) => void
+    getAllShared.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveInitialSync = resolve
+        })
+    )
+    const { service, inbound } = await createService()
+
+    const streamingStatus = {
+      status: 'streaming',
+      activeExecutions: [{ executionId: 'provider::model', attemptId: 1, anchorMessageId: 'assistant-1' }],
+      awaitingApprovalAnchors: []
+    }
+    inbound({ type: 'shared', key: STREAM_KEY, value: streamingStatus })
+    resolveInitialSync({
+      [STREAM_KEY]: {
+        value: { status: 'pending', activeExecutions: [], awaitingApprovalAnchors: [] }
+      }
+    })
+    await vi.waitFor(() => expect(service.isSharedCacheReady()).toBe(true))
+
+    expect(service.getSharedSnapshot(STREAM_KEY)).toEqual(streamingStatus)
+  })
+
   it('deletion tombstone physically deletes and always notifies', async () => {
     const { service, inbound } = await createService()
     inbound({ type: 'shared', key: KEY, value: { progress: 100 } })

--- a/src/renderer/data/__tests__/CacheService.shared.test.ts
+++ b/src/renderer/data/__tests__/CacheService.shared.test.ts
@@ -24,7 +24,6 @@ const BASE = 1_000_000
 
 // JobManager's live progress key — the standing consumer of TTL'd entries.
 const KEY = 'jobs.progress.job-1' as const
-const STREAM_KEY = 'topic.stream.statuses.topic-1' as const
 
 let now: number
 
@@ -108,7 +107,7 @@ describe('getSharedSnapshot (pure physical read)', () => {
 })
 
 describe('inbound sync gating (fix A3)', () => {
-  it('keeps a live stream status update that arrives while the initial snapshot is in flight', async () => {
+  it('keeps a live update that arrives while the initial snapshot is in flight', async () => {
     let resolveInitialSync!: (entries: Record<string, CacheEntry>) => void
     getAllShared.mockImplementationOnce(
       () =>
@@ -118,20 +117,11 @@ describe('inbound sync gating (fix A3)', () => {
     )
     const { service, inbound } = await createService()
 
-    const streamingStatus = {
-      status: 'streaming',
-      activeExecutions: [{ executionId: 'provider::model', attemptId: 1, anchorMessageId: 'assistant-1' }],
-      awaitingApprovalAnchors: []
-    }
-    inbound({ type: 'shared', key: STREAM_KEY, value: streamingStatus })
-    resolveInitialSync({
-      [STREAM_KEY]: {
-        value: { status: 'pending', activeExecutions: [], awaitingApprovalAnchors: [] }
-      }
-    })
+    inbound({ type: 'shared', key: KEY, value: { progress: 50 } })
+    resolveInitialSync({ [KEY]: { value: { progress: 0 } } })
     await vi.waitFor(() => expect(service.isSharedCacheReady()).toBe(true))
 
-    expect(service.getSharedSnapshot(STREAM_KEY)).toEqual(streamingStatus)
+    expect(service.getSharedSnapshot(KEY)).toEqual({ progress: 50 })
   })
 
   it('deletion tombstone physically deletes and always notifies', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Detaching a chat tab into a new window immediately after sending could leave the new window on a stale `pending` stream snapshot. A newer live `streaming` update received during renderer startup could be overwritten when the older initial SharedCache snapshot finished loading, leaving the detached window without active executions and permanently showing the thinking state.

After this PR:

Renderer SharedCache initialization records keys updated by live sync events while the initial snapshot is in flight. The snapshot merge skips those keys, so a detached window retains the newest stream status and attaches to the active execution. A focused regression test covers the stale `pending` snapshot racing a live `streaming` update.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

SharedCache already subscribes to live updates before requesting its startup snapshot, but it had no merge guard for updates received during that request. Tracking only the affected keys closes the bootstrap race at its source without adding stream-specific IPC, retries, or window handoff state.

The following tradeoffs were made:

- The renderer retains a small per-key set only until initial SharedCache synchronization completes.
- The fix applies consistently to all SharedCache keys, not only stream status keys.

The following alternatives were considered:

- Retrying stream attachment from the detached window was rejected because it would mask the stale SharedCache state rather than prevent it.
- Adding a two-phase tab/window handoff was rejected as unnecessary for this cache bootstrap race.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- `pnpm install` completed with the workspace already up to date.
- `pnpm format` passed with no fixes required.
- `pnpm lint` passed, including typecheck and i18n validation; it reported 39 pre-existing warnings outside the changed files.
- Tests, `pnpm build:check`, and manual Electron verification were not run under the workspace's user-owned verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string `action required`.
2. If no release note is required, just write `NONE`.
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or non-user-facing work, write `NONE`.
-->

```release-note
Fixed streamed replies becoming stuck when a chat tab is detached into a new window immediately after sending.
```
