### PR TITLE
fix(provider-settings): show CherryAI in the provider list

### DIFF
--- a/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
+++ b/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
@@ -140,16 +140,30 @@ describe('useModelSelectorData', () => {
     expect(result.current.selectableModelsById.has('google::gemini-pro')).toBe(false)
   })
 
-  it.each(['cherryai', LOCAL_EMBEDDING_PROVIDER_ID])('hides the provider settings action for %s', (providerId) => {
+  it('exposes the provider settings action for CherryAI groups', () => {
     wireDeps({
-      providers: [makeProvider(providerId)],
-      models: [makeModel('qwen', providerId)]
+      providers: [makeProvider('cherryai')],
+      models: [makeModel('qwen', 'cherryai')]
     })
 
     const { result } = renderHook(() => useModelSelectorData({ searchText: '' }))
 
     expect(result.current.listItems.find((item) => item.type === 'group')).toMatchObject({
-      key: `provider-${providerId}`,
+      key: 'provider-cherryai',
+      canNavigateToSettings: true
+    })
+  })
+
+  it('hides the provider settings action for the local-embedding provider', () => {
+    wireDeps({
+      providers: [makeProvider(LOCAL_EMBEDDING_PROVIDER_ID)],
+      models: [makeModel('qwen', LOCAL_EMBEDDING_PROVIDER_ID)]
+    })
+
+    const { result } = renderHook(() => useModelSelectorData({ searchText: '' }))
+
+    expect(result.current.listItems.find((item) => item.type === 'group')).toMatchObject({
+      key: `provider-${LOCAL_EMBEDDING_PROVIDER_ID}`,
       canNavigateToSettings: false
     })
   })

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelList.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelList.tsx
@@ -1,4 +1,5 @@
 import { ButtonGroup } from '@cherrystudio/ui'
+import { isManagedCherryAiProviderId } from '@shared/data/presets/cherryai'
 import React, { memo } from 'react'
 
 import { modelListClasses } from '../primitives/ProviderSettingsPrimitives'
@@ -23,26 +24,31 @@ function ModelListContent({
 }) {
   const { isHealthChecking } = useModelListHealthRun()
   const disabled = isHealthChecking
+  // The managed CherryAI provider is protected default data, so its model list
+  // is read-only — no pull/add/download toolbar actions.
+  const isManagedReadOnly = isManagedCherryAiProviderId(providerId)
 
   return (
     <>
       <ProviderModelList
         providerId={providerId}
         disabled={disabled}
-        actions={({ disabled: toolbarDisabled }) => (
-          <ButtonGroup className={modelListClasses.toolbarButtonGroup}>
-            <ProviderModelPullReconcile
-              providerId={providerId}
-              disabled={toolbarDisabled}
-              guideVersion={modelPullGuideVersion}
-            />
-            {providerId === 'ovms' ? (
-              <ProviderModelDownload providerId={providerId} disabled={toolbarDisabled} />
-            ) : (
-              <ProviderModelAdd providerId={providerId} disabled={toolbarDisabled} />
-            )}
-          </ButtonGroup>
-        )}
+        actions={({ disabled: toolbarDisabled }) =>
+          isManagedReadOnly ? null : (
+            <ButtonGroup className={modelListClasses.toolbarButtonGroup}>
+              <ProviderModelPullReconcile
+                providerId={providerId}
+                disabled={toolbarDisabled}
+                guideVersion={modelPullGuideVersion}
+              />
+              {providerId === 'ovms' ? (
+                <ProviderModelDownload providerId={providerId} disabled={toolbarDisabled} />
+              ) : (
+                <ProviderModelAdd providerId={providerId} disabled={toolbarDisabled} />
+              )}
+            </ButtonGroup>
+          )
+        }
       />
       <ProviderModelHealthCheck disabled={disabled} hasVisibleModels={false} renderTrigger={false} />
     </>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListItem.tsx
@@ -2,6 +2,7 @@ import { Avatar, AvatarFallback, Button, RowFlex, Tooltip } from '@cherrystudio/
 import { useIcon } from '@cherrystudio/ui/icons'
 import { toast } from '@renderer/services/toast'
 import { getModelLogoRef } from '@renderer/utils/model'
+import { isManagedCherryAiProviderId } from '@shared/data/presets/cherryai'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { Bolt, Minus } from 'lucide-react'
@@ -34,6 +35,9 @@ const ModelListItem: React.FC<ModelListItemProps> = ({
 }) => {
   const { t } = useTranslation()
   const Icon = useIcon(getModelLogoRef(model))
+  // Managed CherryAI default data is read-only: hide the per-model edit/delete
+  // actions (the backend rejects mutations on the managed default model).
+  const isManagedCherryAiModel = isManagedCherryAiProviderId(model.providerId)
   const deleteTooltip = isDefaultModel
     ? t('settings.models.manage.default_model_cannot_remove')
     : t('settings.models.manage.remove_model')
@@ -84,31 +88,33 @@ const ModelListItem: React.FC<ModelListItemProps> = ({
             </div>
             <FreeTrialModelTag modelId={model.id} providerId={model.providerId} />
           </div>
-          <div className={modelListClasses.rowInlineActions}>
-            <Tooltip content={t('common.settings')} placement="top">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className={modelListClasses.rowActionButton}
-                aria-label={t('common.settings')}
-                onClick={handleEdit}>
-                <Bolt className="size-4" />
-              </Button>
-            </Tooltip>
-            <Tooltip content={deleteTooltip} placement="top">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className={`${modelListClasses.rowActionButton} ${modelListClasses.rowDangerActionButton}`}
-                aria-label={t('settings.models.manage.remove_model')}
-                disabled={disabled || isDefaultModel}
-                onClick={handleDelete}>
-                <Minus className="size-4" />
-              </Button>
-            </Tooltip>
-          </div>
+          {!isManagedCherryAiModel && (
+            <div className={modelListClasses.rowInlineActions}>
+              <Tooltip content={t('common.settings')} placement="top">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className={modelListClasses.rowActionButton}
+                  aria-label={t('common.settings')}
+                  onClick={handleEdit}>
+                  <Bolt className="size-4" />
+                </Button>
+              </Tooltip>
+              <Tooltip content={deleteTooltip} placement="top">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className={`${modelListClasses.rowActionButton} ${modelListClasses.rowDangerActionButton}`}
+                  aria-label={t('settings.models.manage.remove_model')}
+                  disabled={disabled || isDefaultModel}
+                  onClick={handleDelete}>
+                  <Minus className="size-4" />
+                </Button>
+              </Tooltip>
+            </div>
+          )}
         </div>
       </RowFlex>
     </div>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListItem.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelListItem.test.tsx
@@ -257,4 +257,26 @@ describe('ModelListItem', () => {
       expect(toast.error).toHaveBeenCalledWith('settings.models.manage.model_in_use_by_knowledge_base')
     })
   })
+
+  it('hides the edit and delete actions for managed CherryAI models', () => {
+    render(
+      <ModelListItem
+        model={
+          {
+            id: 'cherryai::qwen',
+            providerId: 'cherryai',
+            name: 'Qwen',
+            isEnabled: true,
+            capabilities: []
+          } as any
+        }
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Qwen')).toBeInTheDocument()
+    expect(screen.queryByLabelText('common.settings')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('settings.models.manage.remove_model')).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSetting.tsx
@@ -7,6 +7,7 @@ import { useCallback, useState } from 'react'
 
 import ProviderHeader from './components/ProviderHeader'
 import AuthenticationSection from './ConnectionSettings/AuthenticationSection'
+import { useProviderMeta } from './hooks/providerSetting/useProviderMeta'
 import { useProviderOnboardingAutoEnable } from './hooks/providerSetting/useProviderOnboardingAutoEnable'
 import { ModelList, ModelListHealthProvider, useModelListHealth } from './ModelList'
 import { providerDetailColumnClasses, ProviderSettingsContainer } from './primitives/ProviderSettingsPrimitives'
@@ -18,12 +19,15 @@ interface ProviderSettingProps {
 
 function ProviderSettingSections({ providerId, isLoginBased }: { providerId: string; isLoginBased: boolean }) {
   const health = useModelListHealth()
+  const { isManagedReadOnly } = useProviderMeta(providerId)
   const [modelPullGuideVersion, setModelPullGuideVersion] = useState(0)
   const requestModelPullGuide = useCallback(() => {
     setModelPullGuideVersion((version) => version + 1)
   }, [])
 
-  const authenticationSection = (
+  // The managed CherryAI provider is protected default data: its credential and
+  // host editors are read-only, so the whole authentication section is omitted.
+  const authenticationSection = isManagedReadOnly ? null : (
     <AuthenticationSection
       providerId={providerId}
       onOpenModelHealthCheck={health.openHealthCheck}

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderList.test.tsx
@@ -216,7 +216,7 @@ describe('ProviderList', () => {
     expect(onSelectProvider).toHaveBeenCalledWith('anthropic')
   })
 
-  it('hides CherryAI from the provider list', () => {
+  it('shows CherryAI in the provider list', () => {
     useProvidersMock.mockReturnValue({
       providers: [
         ...providers,
@@ -233,8 +233,8 @@ describe('ProviderList', () => {
     render(<ProviderList selectedProviderId="openai" onSelectProvider={vi.fn()} />)
 
     expect(screen.getByText('OpenAI')).toBeInTheDocument()
-    expect(screen.queryByText('CherryAI')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('provider-list-item-cherryai')).not.toBeInTheDocument()
+    expect(screen.getByText('CherryAI')).toBeInTheDocument()
+    expect(screen.getByTestId('provider-list-item-cherryai')).toBeInTheDocument()
   })
 
   it('offers only safe canonical preset sources to the custom provider editor', () => {

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSetting.test.tsx
@@ -5,6 +5,7 @@ import ProviderSetting from '../ProviderSetting'
 
 const useProviderMock = vi.fn()
 const useProviderOnboardingAutoEnableMock = vi.fn()
+const useProviderMetaMock = vi.fn()
 const openHealthCheckMock = vi.fn()
 const authenticationSectionPropsSpy = vi.fn()
 
@@ -20,6 +21,10 @@ vi.mock('@renderer/hooks/useProvider', () => ({
 
 vi.mock('../hooks/providerSetting/useProviderOnboardingAutoEnable', () => ({
   useProviderOnboardingAutoEnable: (...args: any[]) => useProviderOnboardingAutoEnableMock(...args)
+}))
+
+vi.mock('../hooks/providerSetting/useProviderMeta', () => ({
+  useProviderMeta: (...args: any[]) => useProviderMetaMock(...args)
 }))
 
 vi.mock('../components/ProviderHeader', () => ({
@@ -46,6 +51,9 @@ describe('ProviderSetting', () => {
     vi.clearAllMocks()
     useProviderMock.mockReturnValue({
       provider: { id: 'openai', isEnabled: true, name: 'openai' }
+    })
+    useProviderMetaMock.mockReturnValue({
+      isManagedReadOnly: false
     })
   })
 
@@ -76,5 +84,20 @@ describe('ProviderSetting', () => {
     const { container } = render(<ProviderSetting providerId="missing" />)
 
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('omits the authentication section for the managed CherryAI provider', () => {
+    useProviderMock.mockReturnValue({
+      provider: { id: 'cherryai', isEnabled: true, name: 'CherryAI' }
+    })
+    useProviderMetaMock.mockReturnValue({
+      isManagedReadOnly: true
+    })
+
+    render(<ProviderSetting providerId="cherryai" />)
+
+    expect(screen.getByText('provider-header-cherryai')).toBeInTheDocument()
+    expect(screen.queryByText('authentication-section-cherryai')).not.toBeInTheDocument()
+    expect(screen.getByText('model-list-cherryai')).toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
@@ -82,7 +82,7 @@ describe('ProviderSettingsPage', () => {
     })
   })
 
-  it('does not select CherryAI when it is remembered or requested by URL', async () => {
+  it('selects CherryAI when it is remembered or requested by URL', async () => {
     MockUseCacheUtils.setPersistCacheValue('settings.provider.last_selected_provider_id', 'cherryai')
     searchMock = { id: 'cherryai' }
     useProvidersMock.mockReturnValue({
@@ -92,10 +92,9 @@ describe('ProviderSettingsPage', () => {
     render(<ProviderSettingsPage />)
 
     await waitFor(() => {
-      expect(screen.getByText('provider-setting-openai')).toBeInTheDocument()
+      expect(screen.getByText('provider-setting-cherryai')).toBeInTheDocument()
     })
-    expect(screen.getByTestId('selected-provider-id')).toHaveTextContent('openai')
-    expect(screen.queryByText('provider-setting-cherryai')).not.toBeInTheDocument()
+    expect(screen.getByTestId('selected-provider-id')).toHaveTextContent('cherryai')
   })
 
   it('passes a stable provider selector to deep-link import across rerenders', () => {

--- a/src/renderer/pages/settings/ProviderSettings/components/ProviderHeader.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/ProviderHeader.tsx
@@ -80,7 +80,7 @@ export default function ProviderHeader({ providerId }: ProviderHeaderProps) {
         </div>
         <Switch
           checked={provider.isEnabled}
-          disabled={isTogglingEnabled}
+          disabled={isTogglingEnabled || meta.isManagedReadOnly}
           onCheckedChange={(enabled) => void handleToggleEnabled(enabled)}
         />
       </div>

--- a/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderHeader.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/components/__tests__/ProviderHeader.test.tsx
@@ -15,8 +15,12 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@cherrystudio/ui', () => {
   return {
-    Switch: ({ checked, onCheckedChange }: any) => (
-      <button type="button" data-checked={checked ? 'true' : 'false'} onClick={() => onCheckedChange(!checked)}>
+    Switch: ({ checked, onCheckedChange, disabled }: any) => (
+      <button
+        type="button"
+        data-checked={checked ? 'true' : 'false'}
+        data-disabled={disabled ? 'true' : 'false'}
+        onClick={() => onCheckedChange(!checked)}>
         switch
       </button>
     ),
@@ -144,5 +148,18 @@ describe('ProviderHeader', () => {
     fireEvent.click(screen.getByRole('button', { name: 'settings.provider.api.options.label' }))
 
     expect(screen.getByText('api-options-drawer')).toBeInTheDocument()
+  })
+
+  it('disables the enable toggle for the managed CherryAI provider', () => {
+    useProviderMetaMock.mockReturnValue({
+      fancyProviderName: 'CherryAI',
+      docsWebsite: undefined,
+      showApiOptionsButton: false,
+      isManagedReadOnly: true
+    })
+
+    render(<ProviderHeader providerId="cherryai" />)
+
+    expect(screen.getByRole('button', { name: 'switch' })).toHaveAttribute('data-disabled', 'true')
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/__tests__/useProviderMeta.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/__tests__/useProviderMeta.test.ts
@@ -206,4 +206,44 @@ describe('useProviderMeta', () => {
 
     expect(result.current.showApiOptionsButton).toBe(false)
   })
+
+  it('marks the managed CherryAI provider read-only and hides its api/host editors', () => {
+    useProviderMock.mockReturnValue({
+      provider: {
+        id: 'cherryai',
+        name: 'CherryAI',
+        authType: 'api-key',
+        apiKeys: [],
+        apiFeatures: {},
+        settings: {},
+        isEnabled: true
+      }
+    })
+
+    const { result } = renderHook(() => useProviderMeta('cherryai'))
+
+    expect(result.current.isManagedReadOnly).toBe(true)
+    expect(result.current.isApiKeyFieldVisible).toBe(false)
+    expect(result.current.isConnectionFieldVisible).toBe(false)
+  })
+
+  it('keeps a normal provider editable', () => {
+    useProviderMock.mockReturnValue({
+      provider: {
+        id: 'openai',
+        name: 'OpenAI',
+        authType: 'api-key',
+        apiKeys: [],
+        apiFeatures: {},
+        settings: {},
+        isEnabled: true
+      }
+    })
+
+    const { result } = renderHook(() => useProviderMeta('openai'))
+
+    expect(result.current.isManagedReadOnly).toBe(false)
+    expect(result.current.isApiKeyFieldVisible).toBe(true)
+    expect(result.current.isConnectionFieldVisible).toBe(true)
+  })
 })

--- a/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderMeta.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderMeta.ts
@@ -1,6 +1,7 @@
 import { useProvider } from '@renderer/hooks/useProvider'
 import { hasVisibleProviderApiOptions } from '@renderer/pages/settings/ProviderSettings/utils/providerApiOptions'
 import { getFancyProviderName } from '@renderer/pages/settings/ProviderSettings/utils/providerDisplay'
+import { isManagedCherryAiProviderId } from '@shared/data/presets/cherryai'
 import { isAwsBedrockProvider, isAzureOpenAIProvider, isVertexProvider, matchesPreset } from '@shared/utils/provider'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -14,6 +15,9 @@ export function useProviderMeta(providerId: string) {
     const hideApiInput = provider ? isAwsBedrockProvider(provider) : false
     const hideApiKeyInput = provider ? matchesPreset(provider, 'copilot') || isVertexProvider(provider) : false
     const isDmxapi = provider ? matchesPreset(provider, 'dmxapi') : false
+    // The managed CherryAI free-trial provider is protected default data: it
+    // uses a built-in key, so its credential/host editors are read-only.
+    const isManagedReadOnly = provider ? isManagedCherryAiProviderId(provider.id) : false
 
     return {
       provider,
@@ -25,10 +29,11 @@ export function useProviderMeta(providerId: string) {
       isAzureOpenAI: provider ? isAzureOpenAIProvider(provider) : false,
       isCherryIN: provider ? matchesPreset(provider, 'cherryin') : false,
       isDmxapi,
+      isManagedReadOnly,
       isChineseUser: i18n.language.startsWith('zh'),
       showApiOptionsButton: provider ? hasVisibleProviderApiOptions(provider) : false,
-      isApiKeyFieldVisible: !hideApiInput && !hideApiKeyInput,
-      isConnectionFieldVisible: !hideApiInput && !isDmxapi
+      isApiKeyFieldVisible: !hideApiInput && !hideApiKeyInput && !isManagedReadOnly,
+      isConnectionFieldVisible: !hideApiInput && !isDmxapi && !isManagedReadOnly
     }
   }, [i18n.language, provider])
 }

--- a/src/renderer/pages/settings/ProviderSettings/utils/__tests__/providerDisplay.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/__tests__/providerDisplay.test.ts
@@ -2,12 +2,11 @@ import { LOCAL_EMBEDDING_PROVIDER_ID } from '@shared/data/presets/localEmbedding
 import type { Provider } from '@shared/data/types/provider'
 import { describe, expect, it, vi } from 'vitest'
 
-// isProviderSettingsListVisibleProvider only reads the provider id; stub the i18n +
-// CherryAI helpers the module imports so the test stays focused on visibility.
+// isProviderSettingsListVisibleProvider only reads the provider id; stub the
+// i18n + provider helpers the module imports so the test stays focused.
 vi.mock('@renderer/i18n', () => ({ default: { t: (k: string) => k } }))
 vi.mock('@renderer/i18n/label', () => ({ getProviderLabelKey: (id: string) => id }))
 vi.mock('@shared/utils/provider', () => ({
-  isCherryAIProvider: (p: Provider) => p.id === 'cherryai',
   isLoginBasedProvider: (p: Provider) =>
     p.authMethods !== undefined && p.authMethods.length > 0 && !p.authMethods.includes('api-key')
 }))
@@ -33,8 +32,8 @@ describe('isProviderSettingsListVisibleProvider', () => {
     expect(isProviderSettingsListVisibleProvider(provider(LOCAL_EMBEDDING_PROVIDER_ID))).toBe(false)
   })
 
-  it('hides the CherryAI provider', () => {
-    expect(isProviderSettingsListVisibleProvider(provider('cherryai'))).toBe(false)
+  it('keeps the CherryAI provider visible', () => {
+    expect(isProviderSettingsListVisibleProvider(provider('cherryai'))).toBe(true)
   })
 
   it('keeps a normal provider visible', () => {

--- a/src/renderer/utils/providerSettings.ts
+++ b/src/renderer/utils/providerSettings.ts
@@ -1,9 +1,8 @@
 import { LOCAL_EMBEDDING_PROVIDER_ID } from '@shared/data/presets/localEmbedding'
 import type { Provider } from '@shared/data/types/provider'
-import { isCherryAIProvider } from '@shared/utils/provider'
 
 export function isProviderSettingsListVisibleProvider(provider: Provider): boolean {
   // The local embedding provider is download-managed, so exposing generic
   // edit/disable/delete controls would bypass its weight lifecycle checks.
-  return !isCherryAIProvider(provider) && provider.id !== LOCAL_EMBEDDING_PROVIDER_ID
+  return provider.id !== LOCAL_EMBEDDING_PROVIDER_ID
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the managed CherryAI free-trial provider was hidden from the
Settings → Model Services provider list, so users could not find "CherryAI"
even though its free-trial model is the app default — searching the list only
surfaced "CherryIN", a separate provider.

After this PR: CherryAI appears in the provider list as read-only protected
data. Its credential and host editors are omitted, the enable toggle is
disabled, and the model list hides its toolbar and per-model edit/delete
actions (consistent with the "protected default data" policy in #15990). As a
side effect, a CherryAI group in the model selector now links to its settings
page instead of suppressing the link.

Fixes #18525

### Why we need it and why it was done in this way

The following tradeoffs were made: CherryAI stays protected default data — its
free-trial credential is managed and the backend rejects mutations on it — so
the detail page is read-only rather than exposing edit controls that would
error.

The following alternatives were considered: making the managed provider fully
editable was rejected because it would reverse the free-trial design in #15990;
aliasing the CherryAI search to CherryIN was rejected because they are distinct
providers.

Links to places where the discussion took place: #15990 (CherryAI default provider design), #18525 (this bug)

### Breaking changes

None. The CherryAI provider remains non-editable on the backend
(`ProviderService` still rejects update/delete/API-key mutations); this PR only
surfaces it in the UI as a read-only entry.

### Special notes for your reviewer

- The CherryAI provider row already suppresses management actions via
  `canManageProvider`, so the list stays non-deletable/non-editable.
- `isProviderSettingsListVisibleProvider` also drives the model selector's
  "go to settings" action; CherryAI now navigates there consistently.
- Local-embedding remains hidden from the list (download-managed).

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. No user-guide change is required for surfacing an existing provider in the settings list.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
CherryAI now appears in Settings → Model Services as a read-only provider entry, so the default free-trial provider is findable in the provider list (its paid API-key setup is via CherryIN).
```
