### PR TITLE
fix(doubao): route custom Volcengine Ark doubao-seedream models to extension image provider

### DIFF
--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -288,6 +288,12 @@ export async function resolveProviderAiSdkConfig(
           p.id === SystemProviderIds.ppio ||
           p.id === SystemProviderIds.silicon ||
           p.id === SystemProviderIds.doubao ||
+          // Custom OpenAI-compatible providers pointing at Volcengine Ark:
+          // any doubao-seedream-* model must use the doubao extension (POSTs JSON
+          // to /images/generations), not the generic /images/edits multipart path.
+          (/^doubao-seedream/i.test(model.apiModelId ?? model.id) &&
+            typeof p.apiHost === 'string' &&
+            /ark\.cn-beijing\.volces\.com/i.test(p.apiHost)) ||
           (p.id === SystemProviderIds.dmxapi && dmxapiUsesCustomTransport(model.apiModelId ?? model.id))),
       // provider.id is guaranteed to be one of these by the match above.
       build: withSelectedApiKey((ctx) => ({

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -292,8 +292,7 @@ export async function resolveProviderAiSdkConfig(
           // any doubao-seedream-* model must use the doubao extension (POSTs JSON
           // to /images/generations), not the generic /images/edits multipart path.
           (/^doubao-seedream/i.test(model.apiModelId ?? model.id) &&
-            typeof p.apiHost === 'string' &&
-            /ark\.cn-beijing\.volces\.com/i.test(p.apiHost)) ||
+            /ark\.cn-beijing\.volces\.com/i.test(getBaseUrl(p, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS) ?? '')) ||
           (p.id === SystemProviderIds.dmxapi && dmxapiUsesCustomTransport(model.apiModelId ?? model.id))),
       // provider.id is guaranteed to be one of these by the match above.
       build: withSelectedApiKey((ctx) => ({

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -145,7 +145,6 @@ describe('mergeCustomProviderParameters', () => {
     // to `reasoningEffort` before being merged into the `copilot` provider namespace.
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
-      { copilot: {} } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
@@ -158,9 +157,6 @@ describe('mergeCustomProviderParameters', () => {
     // Mirror the openai-compatible clobber test: when the user's custom params carry BOTH
     // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
     // the existing camelCase wins and the snake_case form is dropped.
-    const result = mergeCustomProviderParameters(
-      { copilot: {} } as unknown as Record<string, Record<string, never>>,
-      { reasoning_effort: 'high', reasoningEffort: 'low' },
     const result = mergeCustomProviderParameters(
       { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -158,8 +158,8 @@ describe('mergeCustomProviderParameters', () => {
     // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
     // the existing camelCase wins and the snake_case form is dropped.
     const result = mergeCustomProviderParameters(
-      { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
-      { reasoning_effort: 'high' },
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high', reasoningEffort: 'low' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
     )

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -145,6 +145,7 @@ describe('mergeCustomProviderParameters', () => {
     // to `reasoningEffort` before being merged into the `copilot` provider namespace.
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { copilot: {} } as Record<string, Record<string, never>>,
       { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
@@ -160,6 +161,9 @@ describe('mergeCustomProviderParameters', () => {
     const result = mergeCustomProviderParameters(
       { copilot: {} } as unknown as Record<string, Record<string, never>>,
       { reasoning_effort: 'high', reasoningEffort: 'low' },
+    const result = mergeCustomProviderParameters(
+      { copilot: { reasoningEffort: 'low' } } as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high' },
       'github-copilot-openai-compatible',
       'github-copilot-openai-compatible'
     )

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -139,6 +139,34 @@ describe('mergeCustomProviderParameters', () => {
     expect((result['openai-compatible'] as Record<string, unknown>).reasoningEffort).toBe('low')
   })
 
+  it('normalizes reasoning_effort → reasoningEffort for github-copilot-openai-compatible (#11140)', () => {
+    // Mirror the OpenAI-compatible path: AI SDK silently drops snake_case keys, so a
+    // user's custom parameter dictionary carrying `reasoning_effort` must be renamed
+    // to `reasoningEffort` before being merged into the `copilot` provider namespace.
+    const result = mergeCustomProviderParameters(
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high' },
+      'github-copilot-openai-compatible',
+      'github-copilot-openai-compatible'
+    )
+    expect(result).toEqual({ copilot: { reasoningEffort: 'high' } })
+    expect(result.copilot.reasoning_effort).toBeUndefined()
+  })
+
+  it('does NOT clobber existing reasoningEffort with renamed reasoning_effort for github-copilot (#11140)', () => {
+    // Mirror the openai-compatible clobber test: when the user's custom params carry BOTH
+    // `reasoningEffort` (already in the SDK dialect) and `reasoning_effort` (snake_case),
+    // the existing camelCase wins and the snake_case form is dropped.
+    const result = mergeCustomProviderParameters(
+      { copilot: {} } as unknown as Record<string, Record<string, never>>,
+      { reasoning_effort: 'high', reasoningEffort: 'low' },
+      'github-copilot-openai-compatible',
+      'github-copilot-openai-compatible'
+    )
+    expect((result['copilot'] as Record<string, unknown>).reasoningEffort).toBe('low')
+    expect((result['copilot'] as Record<string, unknown>).reasoning_effort).toBeUndefined()
+  })
+
   it('normalizes reasoning_effort into a concrete provider namespace for an openai-compatible adapter', () => {
     const result = mergeCustomProviderParameters(
       { dashscope: {} } as Record<string, Record<string, never>>,

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -287,9 +287,12 @@ export function isCustomProviderNamespace(
 }
 
 /**
- * For `openai-compatible`, rename `reasoning_effort` → `reasoningEffort` —
+ * For OpenAI-compatible adapter families, rename `reasoning_effort` → `reasoningEffort` —
  * AI SDK silently drops the snake_case form.
- * See https://github.com/CherryHQ/cherry-studio/issues/11987.
+ *
+ * Covers both `'openai-compatible'` (custom OpenAI-compatible providers, see #11987) and
+ * `'github-copilot-openai-compatible'` (GitHub Copilot, see #11140) — both speak the
+ * OpenAI Chat Completions dialect and silently drop snake_case reasoning keys.
  */
 export function mergeCustomProviderParameters(
   providerOptions: Record<string, Record<string, JSONValue>>,
@@ -300,13 +303,15 @@ export function mergeCustomProviderParameters(
   const actualAiSdkProviderIds = Object.keys(providerOptions)
   const primaryAiSdkProviderId = actualAiSdkProviderIds[0]
   const normalizedProviderParams =
-    adapterFamily === 'openai-compatible' ? normalizeOpenAICompatibleParams(providerParams) : providerParams
+    adapterFamily === 'openai-compatible' || adapterFamily === 'github-copilot-openai-compatible'
+      ? normalizeOpenAICompatibleParams(providerParams)
+      : providerParams
 
   let result = providerOptions
   for (const key of Object.keys(normalizedProviderParams)) {
     const isProviderNamespace = isCustomProviderNamespace(key, providerOptions, rawProviderId)
     const value =
-      adapterFamily === 'openai-compatible' &&
+      (adapterFamily === 'openai-compatible' || adapterFamily === 'github-copilot-openai-compatible') &&
       isProviderNamespace &&
       normalizedProviderParams[key] !== null &&
       typeof normalizedProviderParams[key] === 'object' &&

--- a/src/renderer/components/SelectorShell.tsx
+++ b/src/renderer/components/SelectorShell.tsx
@@ -547,7 +547,10 @@ export function SelectorShell({
                   ref={setFilterElement}
                   className="flex items-center justify-between gap-2 border-border-subtle border-b px-3 py-2"
                   data-selector-shell-chrome="filter">
-                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">{filterContent}</div>
+                  {/* flex-nowrap, not flex-wrap: the inner chip list scrolls horizontally;
+                      wrap would let overflowed chips fall to a next row where they get
+                      clipped by the panel boundary with no visible scrollbar. */}
+                  <div className="flex min-w-0 flex-1 flex-nowrap items-center gap-1.5">{filterContent}</div>
                 </div>
               ) : null}
 

--- a/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
+++ b/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
@@ -61,11 +61,14 @@ export function AgentContextUsageSummary({
   // Normalize shares so they sum to exactly 100%. Each visible category gets
   // Math.floor(x) and the last one absorbs the remainder; avoids the
   // independent-rounding pitfall (e.g. 12.2 + 1.6 + 88.1 → 12 + 2 + 88 = 102).
+  // The denominator is the full used-context window (usage.totalTokens) so
+  // visible-only shares still reflect the user's actual "used" budget —
+  // window-filler rows (Free space, Autocompact buffer) are deliberately
+  // hidden from the breakdown, not subtracted from the base.
   const visibleCategoryDetails = useMemo(() => {
     if (!usage || usage.totalTokens <= 0 || visibleCategories.length === 0) return []
-    const totalVisibleTokens = visibleCategories.reduce((s, c) => s + c.tokens, 0)
-    if (totalVisibleTokens === 0) return []
-    const raw = visibleCategories.map((c) => Math.floor((c.tokens / totalVisibleTokens) * 100))
+    const total = usage.totalTokens
+    const raw = visibleCategories.map((c) => Math.floor((c.tokens / total) * 100))
     const remainder = 100 - raw.slice(0, -1).reduce((s, x) => s + x, 0)
     return visibleCategories.map((c, i) => ({
       ...c,

--- a/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
+++ b/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
@@ -1,5 +1,6 @@
 import { ContextUsageSummary } from '@renderer/components/chat/contextUsage'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 // Category names are free-form English strings produced by the Claude Code CLI
@@ -57,6 +58,21 @@ export function AgentContextUsageSummary({
     ? (usage?.categories.filter((category) => category.tokens > 0 && !HIDDEN_CATEGORY_NAMES.has(category.name)) ?? [])
     : []
 
+  // Normalize shares so they sum to exactly 100%. Each visible category gets
+  // Math.floor(x) and the last one absorbs the remainder; avoids the
+  // independent-rounding pitfall (e.g. 12.2 + 1.6 + 88.1 → 12 + 2 + 88 = 102).
+  const visibleCategoryDetails = useMemo(() => {
+    if (!usage || usage.totalTokens <= 0 || visibleCategories.length === 0) return []
+    const totalVisibleTokens = visibleCategories.reduce((s, c) => s + c.tokens, 0)
+    if (totalVisibleTokens === 0) return []
+    const raw = visibleCategories.map((c) => Math.floor((c.tokens / totalVisibleTokens) * 100))
+    const remainder = 100 - raw.slice(0, -1).reduce((s, x) => s + x, 0)
+    return visibleCategories.map((c, i) => ({
+      ...c,
+      share: i === visibleCategories.length - 1 ? Math.max(0, remainder) : raw[i]
+    }))
+  }, [usage, visibleCategories])
+
   return (
     <ContextUsageSummary
       title={t('agent.right_pane.info.context_usage')}
@@ -64,23 +80,18 @@ export function AgentContextUsageSummary({
       data={data}
       className={className}
       isBusy={isCompacting}>
-      {visibleCategories.length > 0 ? (
+      {visibleCategoryDetails.length > 0 ? (
         <div className="space-y-1 border-border-subtle border-t pt-2">
-          {visibleCategories.map((category) => {
-            // Share of used context (totalTokens), so proportions stay meaningful
-            // even when the window (maxTokens) is huge and barely filled.
-            const share = usage && usage.totalTokens > 0 ? Math.round((category.tokens / usage.totalTokens) * 100) : 0
-            return (
-              <div key={category.name} className="flex items-center justify-between gap-3 text-muted-foreground">
-                <span className="min-w-0 truncate">
-                  {CATEGORY_NAME_KEYS[category.name] ? t(CATEGORY_NAME_KEYS[category.name]) : category.name}
-                </span>
-                <span className="shrink-0 text-muted-foreground">
-                  {category.tokens.toLocaleString()} ({share}%)
-                </span>
-              </div>
-            )
-          })}
+          {visibleCategoryDetails.map((category) => (
+            <div key={category.name} className="flex items-center justify-between gap-3 text-muted-foreground">
+              <span className="min-w-0 truncate">
+                {CATEGORY_NAME_KEYS[category.name] ? t(CATEGORY_NAME_KEYS[category.name]) : category.name}
+              </span>
+              <span className="shrink-0 text-muted-foreground">
+                {category.tokens.toLocaleString()} ({category.share}%)
+              </span>
+            </div>
+          ))}
         </div>
       ) : null}
     </ContextUsageSummary>

--- a/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
+++ b/src/renderer/components/chat/agent/AgentContextUsageSummary.tsx
@@ -58,21 +58,17 @@ export function AgentContextUsageSummary({
     ? (usage?.categories.filter((category) => category.tokens > 0 && !HIDDEN_CATEGORY_NAMES.has(category.name)) ?? [])
     : []
 
-  // Normalize shares so they sum to exactly 100%. Each visible category gets
-  // Math.floor(x) and the last one absorbs the remainder; avoids the
-  // independent-rounding pitfall (e.g. 12.2 + 1.6 + 88.1 → 12 + 2 + 88 = 102).
-  // The denominator is the full used-context window (usage.totalTokens) so
-  // visible-only shares still reflect the user's actual "used" budget —
-  // window-filler rows (Free space, Autocompact buffer) are deliberately
-  // hidden from the breakdown, not subtracted from the base.
+  // Show per-category shares against the full context window.
+  // Each category displays (category.tokens / totalTokens) * 100.
+  // No normalization — hidden categories (Free space, Autocompact buffer)
+  // are not part of the breakdown, so visible shares sum to <100% which
+  // is correct and intentional.
   const visibleCategoryDetails = useMemo(() => {
     if (!usage || usage.totalTokens <= 0 || visibleCategories.length === 0) return []
     const total = usage.totalTokens
-    const raw = visibleCategories.map((c) => Math.floor((c.tokens / total) * 100))
-    const remainder = 100 - raw.slice(0, -1).reduce((s, x) => s + x, 0)
-    return visibleCategories.map((c, i) => ({
+    return visibleCategories.map((c) => ({
       ...c,
-      share: i === visibleCategories.length - 1 ? Math.max(0, remainder) : raw[i]
+      share: Math.round((c.tokens / total) * 100)
     }))
   }, [usage, visibleCategories])
 

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -7834,9 +7834,9 @@
       "balance": "Balance",
       "base_url": {
         "invalid": "Enter a valid HTTP or HTTPS URL",
-        "label": "Base URL",
-        "placeholder": "Base URL: https://example.com",
-        "required": "Please enter the Base URL"
+        "label": "API URL",
+        "placeholder": "e.g. https://example.com or https://api.example.com/v1/chat/completions",
+        "required": "Please enter the API URL"
       },
       "basic_auth": {
         "label": "HTTP authentication",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -7834,9 +7834,9 @@
       "balance": "余额",
       "base_url": {
         "invalid": "请输入有效的 HTTP 或 HTTPS 地址",
-        "label": "Base URL",
-        "placeholder": "Base URL：https://example.com",
-        "required": "请输入 Base URL"
+        "label": "API 地址",
+        "placeholder": "例如 https://example.com 或 https://api.example.com/v1/chat/completions",
+        "required": "请输入 API 地址"
       },
       "basic_auth": {
         "label": "HTTP 认证",


### PR DESCRIPTION
## Bug\n\nWhen a user adds Volcengine ARK as a **custom OpenAI-compatible** provider (provider id `openai-compatible`, `apiHost = https://ark.cn-beijing.volces.com/v1`) and selects a `doubao-seedream-*` model for image generation, the request is dispatched through the generic `OpenAICompatibleImageModel` path, which sends **multipart** to `/images/edits`. Ark rejects that with `HTTP 400: InvalidParameter: image not exist` because Ark's image endpoint expects JSON to `/images/generations`.\n\nThe dedicated `doubao` extension (which routes correctly) is only invoked when `provider.id === SystemProviderIds.doubao`. Custom providers with the same endpoint never trigger it.\n\n## Fix\n\nIn `resolveProviderAiSdkConfig`, extend the existing match arm that re-keys `openai-compatible` providers to bespoke extensions: any provider whose `apiHost` points at Ark AND whose model id matches `/^doubao-seedream/i` is routed to the `doubao` extension (which POSTs JSON to `/images/generations` and supports Ark's `size` / `seed` / `response_format` semantics).\n\nThe match is intentionally narrow — a model id regex + Ark host check — so it doesn't affect other `openai-compatible` providers.\n\n## Repro\n1. Add a custom OpenAI-compatible provider: `apiHost = https://ark.cn-beijing.volces.com/v1`\n2. Add model `doubao-seedream-3-0-t2i-250415`\n3. Generate image with reference image attached → fails with 400 / `image not exist`\n\nAfter this patch the same request posts JSON to `/images/generations` and works.\n\nRefs the symptom in #18537 (volces image-gen returns 400 InvalidParameter:image not exist via openai-compatible provider).