### PR TITLE
chore: release v2.0.5

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -157,146 +157,82 @@ artifactBuildCompleted: scripts/artifact-build-completed.js
 releaseInfo:
   releaseNotes: |
     <!--LANG:en-->
-    Cherry Studio 2.0.4 - New Features, Fixes, and Performance
+    Cherry Studio 2.0.5 - New Features, Fixes, and Performance
 
     ✨ New Features
-    - [Composer] Tool permission requests in Agent sessions can now be approved with Enter or denied with Esc
-    - [Context] Restored a "recent messages kept" context limit available globally in Settings → Model and per assistant, plus a new Context Management section exposing master switch, message limit, tool-output truncation threshold, auto-compress, and compression model
-    - [Web Search] Add Querit fetchUrls capability. Querit.ai offers 1,000 free API requests for new users
-    - [MCP Hub] MCP clients connecting to the local API gateway can now open a session to receive live tool-list updates and progress from long-running tools
-    - [MCP Hub] Restored the MCP-over-HTTP endpoints on the local API gateway so external tools can once again use Cherry Studio as a local MCP hub. Action required: clients written against the 1.9.x endpoints should stop unwrapping the `{ success, data }` envelope and stop relying on `Mcp-Session-Id` — the proxy is now stateless
-    - [Agent] Agent conversations can now mention accessible workspace folders with @
-    - [Agent] Add workspace deletion from the shared selector with an impact preview for sessions, agent channels, and scheduled tasks while preserving files on disk
-    - [Models] Add configurable model pricing tiers based on input token count, with separate input, output, cache-read, and cache-write rates for each tier
-    - [Shortcuts] Added configurable keyboard shortcuts for switching to the next or previous tab
-    - [QQ Bot] QQ channel bots can now receive all group messages (not just @mentions) when the per-channel "mention-only" toggle is off and the QQ Open Platform permission is enabled
-    - [Notes] Added a "Back to top" button for long notes, plus a new "Line Break Mode" setting that renders single line breaks as new lines (Obsidian-style) without modifying the source files
-    - [Local Model] Add DirectML (Windows) and CoreML (macOS) hardware acceleration for local models
-    - [Files] Enforce document input limits on file processing
-    - [Privacy] Agent sessions now run the bundled Claude Agent SDK with non-essential traffic disabled, so the bundled CLI no longer sends telemetry, error reports or background config fetches to Anthropic
+    - [Agent] Add pi (@earendil-works/pi-coding-agent) as a selectable agent runtime alongside Claude Code, letting agents use supported configured providers with managed skills, Soul mode (opt-in), MCP servers, tool approval, permission modes, mid-turn steering, manual /compact, resume, and compaction. Plan mode and plan/small-model tiers remain Claude-only
+    - [Skills] Skills can now be installed from a GitHub link to their SKILL.md file — pick "GitHub" in the online skill search, or hand an agent the link directly. The search source is now chosen from a dropdown instead of tabs, and skill detail timestamps follow the app language instead of the system locale
+    - [Support] Add the preinstalled Cherry Support Agent for Cherry Studio guidance, troubleshooting, FAQs, and feedback. Its initial model follows Cherry Assistant, and About > Feedback now opens Cherry Support
+    - [Updates] Added a notification setting to show a system notification when an app update is available (off by default)
 
     🐛 Bug Fixes
-    - [Web Search] Fix Zhipu web search failing with a missing API key error even after the Zhipu API key was configured in model provider settings
-    - [Rename] Fix Agent session, topic, and history record rename saving the raw pinyin instead of the Chinese title when confirming an IME candidate with Enter
-    - [Chat] Conversation recency now follows actual chat activity, so renaming, moving, reordering, or other metadata changes no longer make an older conversation appear recent
-    - [Workspace] Show the official Windows Terminal icon in the agent workspace open-in menu on Windows
-    - [Chat] Fix multi-model Retry, Retry All, and @ model replies so they target the correct live execution, stale retry state cannot reappear, and repeated replies from the same model remain visible in multi-model message groups
-    - [Knowledge Base] Prevent knowledge-base imports and migrations from producing overlong filenames when resolving name collisions
-    - [Errors] Chat and provider connection-check errors now show the service provider's own error message instead of bare HTTP status text, and an HTTP 403 is no longer reported as an invalid API key
-    - [OAuth] Fix Codex and Grok CLI OAuth sign-in so pending browser authorization can be canceled and immediately retried without stale callbacks or cancellation requests disrupting the new flow
-    - [Navigation] Fix navigation to /app/* routes (e.g. opening the feedback assistant) and to routes carrying query strings being blocked by the main-window route allowlist
-    - [CherryIN] CherryIN chat now blocks native audio attachments for Qwen models that do not support audio, preventing failed upstream requests
-    - [DeepSeek] Fix DeepSeek auto thinking mode sending an invalid thinking.type "auto" parameter that caused chat start to fail with an AI SDK type validation error
-    - [Prompt] Fix assistant/agent prompt preview collapsing multi-line system prompts into a single line
-    - [UI] Fix the close button of tall dialogs (e.g. the provider editor after expanding "more settings") becoming unclickable where it overlaps the window title bar
-    - [Web Search] Fix the built-in @cherry/fetch tool and web search page fetching failing with "HTTP error: 301" on URLs that redirect
-    - [Models] Fix model selector tag filters appearing cut off: the filter row now shows an edge fade when more tags are hidden, making horizontal overflow visible
-    - [Models] Fix long model names overlapping the capability icons in the model management drawer
-    - [Doubao] Fix Doubao model connection checks failing with "Invalid JSON response" when Ark omits output text annotations
-    - [OCR] Fix System OCR on Windows still failing for JPEG, GIF and WebP images: images are now transcoded to PNG before recognition
-    - [OCR] Fix System OCR on Windows failing on every JPEG image (WIC error 0x88982F07): the native engine now receives image bytes instead of a file path, which also fixes BMP/TIFF/GIF/WebP/HEIF inputs
-    - [Agent] Fix agent sessions on models whose catalog output cap equals their context window (such as DeepSeek V4 Pro) compacting repeatedly from 100K tokens on, and stop the context-usage readout from reporting the compaction budget as the model's context window
-    - [macOS] Hide the macOS Dock icon when minimizing to tray on close (and on launch-to-tray), restoring v1 behavior
-    - [Agent] Fix an issue where multiple tool permission requests in one reply could stall the conversation and require switching conversations to continue
-    - [Painting] Fix painting size controls and the parameter popover covering nearby content
-    - [Agent] Work agent sessions interrupted by an abnormal exit no longer resume the interrupted Claude Code execution. On restart their history is preserved and settled, and the next reply starts from a fresh runtime connection
-    - [Agent] Fix agent session streams rendering fragmented or duplicated reasoning blocks after reconnecting to a long-running turn (stream replay buffer overflow)
-    - [MCP] MCP server logs can now be selected and copied — added a "Copy logs" button to the MCP server logs tab
-    - [Agent] Scheduled tasks for the same agent can now run up to three jobs concurrently instead of always running sequentially
-    - [Agent] Prevent internal Claude Agent system reminders from appearing in conversations and newly persisted assistant messages
-    - [Painting] Fix long prompts pasted into Painting still appearing blank after the initial long-text paste fix
-    - [Agent] Fix the agent edit dialog trapping users after a failed save; a repeat explicit close now discards the unsaved change and exits
-    - [Bailian] Fix Bailian models failing with "Normal mode does not support web_extractor" when thinking is disabled: web search now works in non-thinking mode without the web extractor tool
-    - [Windows] Fix command discovery for bundled Git and user-installed tools located in Windows paths containing non-ASCII characters
-    - [Knowledge Base] Fix knowledge base lists not loading entries beyond the first 100 records
-    - [Assistant] Fix assistant edits that could fail and trap users in the edit dialog when legacy settings were present
-    - [Mini App] Reopening a mini app from the sidebar now switches to its existing tab instead of replacing the current tab
-    - [Topic Naming] Fix auto-generated conversation and agent-session titles: the naming request no longer carries the assistant's tool configuration, so auto-naming no longer fails when the assistant has web search enabled and the naming model cannot combine disabled thinking with a web tool
-    - [Code Viewer] Fix long unbreakable lines (base64, URLs, minified JSON) in chat code blocks and the trace call-chain detail view being clipped / not wrapping when auto-wrap is enabled. They now wrap correctly; disabling wrap still scrolls horizontally
-    - [Sidebar] Preserved collapsed assistant folders in the classic conversation sidebar when switching between Chat and Work
-    - [Backup] Fix automatic backups running again shortly after every app restart instead of respecting the configured interval
-    - [Shortcuts] Fix window-local zoom shortcuts being captured by Cherry Studio while it is unfocused
-    - [Agent] Fix Agent workspace file mentions so files in deeper nested folders can be found with @ search. Action required: when OCR cannot extract text from an image attached to a text-only model, Cherry Studio now stops before sending the request and asks you to choose a vision-capable model or remove the image
-    - [Migration] Fix "No tool output found for tool call" when continuing a conversation migrated from v1 that used MCP tools
-    - [Image Viewer] Fix rotation and flip not being baked into the saved image
-    - [Thinking Block] Fix the "Auto-collapse thinking content" setting having no effect when disabled — turning it off now keeps thinking blocks expanded
-    - [MCP] Fix npx/uv stdio MCP servers not resolving on Windows when launched via the system PATH
-    - [MCP] Propagate the stream abort signal into in-flight MCP tool calls, so aborting a reply reliably cancels running MCP tools
-    - [Models] Fix model sizes being lost when multiple models share the same family key
-    - [Settings] Disabling the system tray now also disables the quick assistant's tray-click launch option
+    - [Models] Fix a model re-listed under a provider prefix (e.g. nvidia/gpt-oss-20b) being displayed with the wrong name and size when the catalog has a differently-sized sibling
+    - [Models] Fix OpenVINO Model Server models not appearing in the model manager or "Get models" after a successful download
+    - [Models] Fix model availability checks for chat models also advertised with embedding endpoints, preventing false unavailable status and API Gateway rejection
+    - [Models] Fix image generation failing with "Missing modelDescriptor" for the DashScope models qwen-image-3.0 and qwen-image-3.0-pro
+    - [Models] Fix tiered model pricing so partially specified currencies are preserved and usage can still be priced when providers report an input-token breakdown without an aggregate input-token count
+    - [Models] Fix CherryIN model synchronization retaining four removed DeepSeek aliases, allowing stale entries to be cleaned instead of being treated as available models
+    - [Chat] Fix streamed replies becoming stuck when a chat tab is detached into a new window immediately after sending
+    - [Chat] Fix the chat composer changing width when switching conversations
+    - [Chat] Fix chat attachments with a malformed stored mediaType (e.g. a bare .png label instead of image/png) failing on every model with "file part media type .png" — the mediaType is now normalized before the provider request
+    - [Chat] Fix FileManager base64 image persistence for standard data URLs with media type parameters
+    - [Pins] Pin changes now stay synchronized across open windows, including pinned topic and agent-session ordering and pins removed by cascading deletes
+    - [Topics] Fix topic drag moves across assistants so ownership and ordering update atomically without leaving a partial move after an error
+    - [Topics] Topic naming now uses the Quick Assistant model and no longer has a separate model setting. Action required: review the Quick Assistant model selection if a different topic naming model was previously configured
+    - [Topics] Fix very long conversations (over ~1000 messages) failing to delete with "too many levels of trigger recursion" — deleting the topic or its assistant, and clearing the conversation, now work at any length
+    - [Sidebar] Collapsing and reopening the conversation navigation sidebar now preserves its list state
+    - [Search] Global search now keeps long message previews responsive by rendering only the visible messages
+    - [Artifacts] Fix Markdown artifact previews on Windows when generated file paths omit the slash after the drive letter
+    - [Agent] Newly created agents now appear at the top of the agent list by default
+    - [API Gateway] The API Gateway no longer starts on its own. It now starts only when enabled in Settings → API Gateway, so turning it off finally sticks across restarts. Agents whose model has to be bridged through the gateway ask before starting it, and resend the message once you accept
+    - [Migration] Fix V1-to-V2 migration failures caused by legacy model IDs containing route-reserved characters
+    - [Migration] Fix v1 files whose extension ended in a space or dot (e.g. ".exe ") becoming unreadable after migrating to v2 — opening, hashing or deleting them failed with a missing-file error
+    - [Migration] Fix agent migration skipping filesystem targets when workspaces overlap. Action required: after upgrading, review Agents reported with skipped filesystem targets and restore any missing identity, memory, or workspace files from the preserved v1 data
+    - [i18n] Fix translated UI strings that were wrong or out of date: the max tool-call rounds hint no longer omits or hard-codes the default round limit, the translation input placeholder no longer shows text meant for an older version of that field, and the OpenClaw migration and runtime removal messages now match what the app actually does. Affects German, Greek, Spanish, French, Japanese, Portuguese, Romanian, Russian, Vietnamese and both Chinese locales
+    - [i18n] Fix machine translations being written without validation, preventing damaged locale strings
+    - [Vertex AI] Fix Vertex AI Service Account requests when the official API host is configured explicitly
 
     ⚡ Performance
-    - [Chat] Fix renderer crashes ("app suddenly closes") during long fast streaming replies, caused by quadratic memory growth in stream handling and rendering. Very large streamed replies now render with bounded memory, and oversized single markdown blocks no longer fail to render
+    - [Memory] Reduced memory growth during long-running sessions by bounding retained tabs and Mini App WebViews and sharing assistant topic views
+    - [Memory] Fix renderer memory growth caused by inactive conversation history pages remaining in the SWR cache
 
     <!--LANG:zh-CN-->
-    Cherry Studio 2.0.4 - 新功能、修复与性能优化
+    Cherry Studio 2.0.5 - 新功能、修复与性能优化
 
     ✨ 新功能
-    - [输入框] Agent 会话中的工具权限请求现在可以用 Enter 同意、Esc 拒绝
-    - [上下文] 恢复"保留最近 N 条消息"的上下文限制，可在设置 → 模型中全局配置或按助手覆盖；并在设置 → 模型中新增"上下文管理"区域，暴露主开关、消息数量、工具输出截断阈值、自动压缩与压缩模型等参数
-    - [联网搜索] 新增 Querit fetchUrls 能力，Querit.ai 对新用户提供 1,000 次免费 API 请求
-    - [MCP 中心] 连接到本地 API 网关的 MCP 客户端现在可以打开会话，接收工具列表的实时更新和长耗时工具的进度回调
-    - [MCP 中心] 恢复本地 API 网关上的 MCP-over-HTTP 端点，外部工具可以再次将 Cherry Studio 作为本地 MCP 中心。需要采取行动：基于 1.9.x 端点的客户端应停止解包 `{ success, data }` 信封并不再依赖 `Mcp-Session-Id`，代理现在为无状态
-    - [Agent] Agent 对话现在可以用 @ 提及可访问的工作区文件夹
-    - [Agent] 新增从共享选择器中删除工作区的能力，并提供对会话、Agent 渠道和定时任务的影响预览，磁盘上的文件会被保留
-    - [模型] 新增基于输入 token 数量的可配置模型价格分层，每层支持独立的输入、输出、缓存读、缓存写费率
-    - [快捷键] 新增可在设置中自定义的标签页切换快捷键（下一个 / 上一个标签页）
-    - [QQ 机器人] QQ 频道机器人在关闭按频道"仅 @ 提及"开关且开通 QQ 开放平台权限后，现在可以接收所有群消息（而不仅是 @ 消息）
-    - [笔记] 为长笔记新增"回到顶部"按钮，并新增"换行模式"设置，可以将单换行渲染为换行（类 Obsidian 风格）而不修改源文件
-    - [本地模型] 新增 DirectML（Windows）和 CoreML（macOS）本地模型硬件加速
-    - [文件] 对文件处理强制执行文档输入限制
-    - [隐私] Agent 会话现在以禁用非必要流量方式运行捆绑的 Claude Agent SDK，捆绑 CLI 不再向 Anthropic 发送遥测、错误报告或后台配置拉取
+    - [Agent] 新增 pi（@earendil-works/pi-coding-agent）作为可选的 Agent 运行时，与 Claude Code 并列，让 Agent 可以使用已配置的受支持服务商，支持托管技能、Soul 模式（可选）、MCP 服务器、工具审批、权限模式、回合中干预、手动 /compact、恢复与压缩。计划模式以及 plan/small 模型层级仍仅限 Claude（Pi SDK 不支持）
+    - [技能] 现在可以通过 GitHub 链接安装技能的 SKILL.md 文件 —— 在在线技能搜索中选择"GitHub"，或直接把链接给到 Agent。搜索来源改为下拉选择而非标签页，技能详情的时间戳跟随应用语言而非系统区域设置
+    - [支持] 新增预装的 Cherry Support 助手，提供 Cherry Studio 使用指引、故障排查、常见问题与反馈。其初始模型跟随 Cherry Assistant，"关于 > 反馈"现在会打开 Cherry Support
+    - [更新] 新增通知设置，在应用有可用更新时显示系统通知（默认关闭）
 
     🐛 问题修复
-    - [联网搜索] 修复在模型服务商设置中配置了 Zhipu API Key 后，Zhipu 联网搜索仍报缺少 API Key 错误的问题
-    - [重命名] 修复 Agent 会话、话题和历史记录重命名时，按 Enter 确认输入法候选词会把原始拼音当作中文标题保存的问题
-    - [对话] 对话的最近活跃时间现在跟随实际的聊天行为，重命名、移动、排序等元数据变更不再让旧对话出现在最近列表中
-    - [工作区] 在 Windows 上 Agent 工作区的"打开方式"菜单显示官方 Windows Terminal 图标
-    - [对话] 修复多模型重试、全部重试和 @模型 回复指向错误的执行现场、陈旧重试状态会复现，以及同一模型的重复回复在多模型消息组中丢失的问题
-    - [知识库] 修复知识库导入和迁移在处理文件名冲突时生成超长文件名的问题
-    - [错误显示] 对话和服务商连接检查错误现在会显示服务商自己的错误信息，而不是裸的 HTTP 状态文本；HTTP 403 不再被报为无效 API Key
-    - [OAuth] 修复 Codex 和 Grok CLI 的 OAuth 登录：现在可以取消挂起的浏览器授权并立即重试，不会被陈旧回调或取消请求打断新流程
-    - [导航] 修复主窗口路由白名单拦截 /app/* 路由（如打开反馈助手）和带查询字符串的路由的问题，深链和应用内导航到这些路由现在可正常工作
-    - [CherryIN] CherryIN 对话现在会为不支持音频的 Qwen 模型屏蔽原生音频附件，避免上游请求失败
-    - [DeepSeek] 修复 DeepSeek auto thinking 模式发送了无效的 thinking.type "auto" 参数导致对话启动失败的问题（AI SDK 类型校验错误）
-    - [提示词] 修复助手/Agent 提示词预览把多行系统提示词折叠成一行的问题
-    - [界面] 修复高对话框（如展开"更多设置"后的服务商编辑器）的关闭按钮在与窗口标题栏重叠区域无法点击的问题
-    - [联网搜索] 修复内置 @cherry/fetch 工具和联网搜索页面抓取在 URL 重定向时报 "HTTP error: 301" 失败的问题
-    - [模型] 修复模型选择器标签筛选被截断的问题：当有更多标签被隐藏时，筛选行现在会出现边缘渐变以提示横向溢出
-    - [模型] 修复模型管理抽屉中长模型名与能力图标重叠的问题
-    - [豆包] 修复当 Ark 省略输出文本注释时，豆包模型连接检查报 "Invalid JSON response" 失败的问题
-    - [OCR] 修复 Windows 上系统 OCR 仍对 JPEG、GIF、WebP 图像失败的问题：原生引擎只能解码 PNG，现在会在识别前将图像转码为 PNG
-    - [OCR] 修复 Windows 上系统 OCR 对所有 JPEG 图像失败的问题（WIC 错误 0x88982F07）：原生引擎现在接收图像字节而非文件路径，同时修复了 BMP/TIFF/GIF/WebP/HEIF 输入
-    - [Agent] 修复模型的目录输出上限等于其上下文窗口（如 DeepSeek V4 Pro）时，Agent 会话从 100K 开始反复压缩的问题，并停止让上下文用量读数把压缩预算报告为模型上下文窗口
-    - [macOS] 在关闭到托盘和启动到托盘时隐藏 macOS Dock 图标，恢复 v1 行为
-    - [Agent] 修复单条回复中出现多个工具权限请求时可能导致对话卡住、必须切换会话才能继续的问题
-    - [绘画] 修复绘画尺寸控制和参数浮层遮挡附近内容的问题
-    - [Agent] 被异常退出打断的 Work Agent 会话不再恢复被中断的 Claude Code 执行。重启后历史保留且已稳定，下一条回复从新的运行时连接开始
-    - [Agent] 修复 Agent 会话在重连到一个长时间运行的回合后（流式回放缓冲区溢出）渲染出碎片化或重复推理块的问题
-    - [MCP] MCP 服务器日志现在可以选中并复制 —— 在 MCP 服务器日志页签新增了"复制日志"按钮
-    - [Agent] 同一 Agent 的定时任务现在最多可以并行运行三个作业，而不再总是串行执行
-    - [Agent] 阻止内部 Claude Agent 系统提醒出现在对话和新持久化的助手消息中
-    - [绘画] 修复长提示词粘贴到绘画后仍然显示空白的问题（在初次长文本粘贴修复之后）
-    - [Agent] 修复 Agent 编辑对话框在保存失败后困住用户的问题；再次显式关闭现在会丢弃未保存的更改并退出
-    - [百炼] 修复百炼模型在关闭思考时报 "Normal mode does not support web_extractor" 失败的问题：非思考模式下联网搜索现在会跳过 web_extractor 工具正常工作
-    - [Windows] 修复包含非 ASCII 字符的 Windows 路径下捆绑 Git 和用户已安装工具的命令发现问题
-    - [知识库] 修复知识库列表无法加载第 100 条之后记录的问题
-    - [助手] 修复存在遗留设置时助手编辑可能失败并把用户困在编辑对话框中的问题
-    - [小程序] 从侧边栏重新打开小程序现在会切换到它已有的标签页，而不是替换当前标签页
-    - [话题命名] 修复自动生成的对话和 Agent 会话标题：命名请求不再携带助手的工具配置（MCP 工具、联网搜索、知识库），因此当助手启用了联网搜索且命名模型无法将禁用思考与 web 工具组合时，自动命名不再失败
-    - [代码查看器] 修复对话代码块和追踪调用链详情中无法换行的长行（base64、URL、压缩 JSON）在开启自动换行时被裁剪的问题：现在可以正确换行；关闭换行时仍可横向滚动
-    - [侧边栏] 在经典对话侧边栏中，切换 Chat 和 Work 时保留助手分组的折叠状态
-    - [备份] 修复自动备份在每次应用重启后不久就再次运行、而不遵守配置间隔的问题
-    - [快捷键] 修复窗口级缩放快捷键在 Cherry Studio 未获焦点时仍被其捕获的问题
-    - [Agent] 修复 Agent 工作区文件提及，让更深层嵌套文件夹中的文件也能通过 @ 搜索找到。需要采取行动：当 OCR 无法从附加到纯文本模型的图像中提取文本时，Cherry Studio 现在会在发送请求前停止，并要求你选择支持视觉的模型或移除该图像
-    - [迁移] 修复从 v1 迁移且使用了 MCP 工具的对话在继续时报 "No tool output found for tool call" 的问题
-    - [图片查看器] 修复旋转和翻转未写入保存图像的问题
-    - [思考块] 修复"自动折叠思考内容"设置在禁用时无效的问题 —— 关闭后思考块会保持展开
-    - [MCP] 修复 Windows 上通过系统 PATH 启动 npx/uv stdio MCP 服务器时无法解析的问题
-    - [MCP] 将流式中止信号传递到正在执行中的 MCP 工具调用，中止回复时可以可靠地取消运行中的 MCP 工具
-    - [模型] 修复多个模型共享同一家族键时型号大小丢失的问题
-    - [设置] 关闭系统托盘现在也会同时关闭快捷助手的托盘点击启动选项
+    - [模型] 修复在服务商前缀下重新列出的模型（如 nvidia/gpt-oss-20b）在目录中存在不同尺寸的同族模型时显示错误名称和尺寸的问题
+    - [模型] 修复 OpenVINO Model Server 模型在下载成功后不出现在模型管理器或"获取模型"中的问题
+    - [模型] 修复同时被声明为嵌入端点的聊天模型可用性检查误判为不可用并被 API 网关拒绝的问题
+    - [模型] 修复 DashScope 的 qwen-image-3.0 和 qwen-image-3.0-pro 模型图像生成报 "Missing modelDescriptor" 失败的问题
+    - [模型] 修复分层模型定价在部分货币未指定时丢失、且服务商返回输入 token 明细而无汇总输入 token 数时无法计价的问题
+    - [模型] 修复 CherryIN 模型同步仍保留四个已移除的 DeepSeek 别名的问题，现在可以检测并清理陈旧条目，而不会被当作可用模型
+    - [对话] 修复在发送后立即将对话标签页分离到新窗口时流式回复卡住的问题
+    - [对话] 修复切换对话时输入框宽度变化的问题
+    - [对话] 修复存储的 mediaType 格式错误（如仅有 .png 标签而非 image/png）导致所有模型都报 "file part media type .png" 失败的问题 —— mediaType 现在会在请求前被规范化
+    - [对话] 修复带媒体类型参数的标准 data URL 的 base64 图片在 FileManager 中持久化失败的问题
+    - [置顶] 置顶变更现在在所有打开的窗口间保持同步，包括置顶话题与 Agent 会话的顺序，以及被级联删除移除的置顶
+    - [话题] 修复跨助手拖动话题的移动，所有权与顺序会原子更新，错误后不会留下部分移动
+    - [话题] 话题命名现在使用快捷助手模型，不再有单独的模型设置。需要采取行动：如果之前配置了不同的话题命名模型，请检查快捷助手的模型选择
+    - [话题] 修复超长对话（超过约 1000 条消息）删除时报 "too many levels of trigger recursion" 失败的问题 —— 删除话题或其助手、清空对话现在可在任意长度下正常工作
+    - [侧边栏] 折叠并重新展开对话导航侧边栏现在会保留其列表状态
+    - [搜索] 全局搜索现在只渲染可见消息，让长消息预览保持流畅
+    - [Artifact] 修复 Windows 上生成的文件路径缺少盘符后斜杠时 Markdown artifact 预览失败的问题
+    - [Agent] 新创建的 Agent 现在默认出现在 Agent 列表顶部
+    - [API 网关] API 网关不再自行启动。现在只有在"设置 → API 网关"中启用时才会启动，关闭后重启也能保持关闭。模型需要通过网关桥接的 Agent 会在启动前询问，接受后重新发送消息
+    - [迁移] 修复包含路由保留字符的遗留模型 ID 导致 V1 到 V2 迁移失败的问题
+    - [迁移] 修复扩展名以空格或点结尾的 v1 文件（如 ".exe "）迁移到 v2 后无法读取的问题 —— 打开、哈希或删除会报缺失文件错误
+    - [迁移] 修复工作区重叠时 Agent 迁移跳过文件系统目标的问题。需要采取行动：升级后，请检查被报告跳过文件系统目标的 Agent，并从保留的 v1 数据中恢复任何缺失的身份、记忆或工作区文件
+    - [国际化] 修复翻译错误或过时的界面字符串：最大工具调用轮次提示不再遗漏或硬编码默认轮次上限，翻译输入占位符不再显示旧版本字段文本，OpenClaw 迁移与运行时移除消息现在与实际行为一致。影响德语、希腊语、西班牙语、法语、日语、葡萄牙语、罗马尼亚语、俄语、越南语及两种中文
+    - [国际化] 修复机器翻译未经验证即写入的问题，防止损坏的语言字符串
+    - [Vertex AI] 修复显式配置官方 API 主机时 Vertex AI 服务账号请求失败的问题
 
     ⚡ 性能优化
-    - [对话] 修复在长时间快速流式回复期间因流处理和渲染中的二次内存增长导致的渲染进程崩溃（"应用突然关闭"）。超大流式回复现在以有界内存渲染，超大的单个 Markdown 块也不再渲染失败
+    - [内存] 通过限制保留的标签页和 Mini App WebView、共享助手话题视图，减少长时间运行会话的内存增长
+    - [内存] 修复非活动对话历史页面残留在 SWR 缓存中导致的渲染进程内存增长
     <!--LANG:END-->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CherryStudio",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "private": true,
   "description": "A powerful AI assistant for producer.",
   "desktopName": "CherryStudio.desktop",

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "package": {
     "name": "CherryStudio",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "A powerful AI assistant for producer.",
     "homepage": "https://github.com/CherryHQ/cherry-studio"
   },

--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Erstellt oder überschreibt Dateien",
           "label": "Schreiben"
+        },
+        "bash": {
+          "description": "Shell-Befehle ausführen",
+          "label": "Shell-Befehle ausführen"
+        },
+        "edit": {
+          "description": "Dateien bearbeiten",
+          "label": "Dateien bearbeiten"
+        },
+        "find": {
+          "description": "Dateien suchen",
+          "label": "Dateien suchen"
+        },
+        "grep": {
+          "description": "Dateiinhalt durchsuchen",
+          "label": "Dateiinhalt durchsuchen"
+        },
+        "ls": {
+          "description": "Verzeichnisinhalt auflisten",
+          "label": "Verzeichnisinhalt auflisten"
+        },
+        "read": {
+          "description": "Dateien lesen",
+          "label": "Dateien lesen"
+        },
+        "write": {
+          "description": "Dateien schreiben",
+          "label": "Dateien schreiben"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "API-Server erfolgreich gestoppt"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Aktivieren",
+      "description": "Das Modell dieses Agenten muss über das lokale API-Gateway von Cherry Studio gebrückt werden. Das Aktivieren startet das Gateway auch automatisch bei zukünftigen Starts; Sie können es in den Einstellungen wieder deaktivieren.",
+      "title": "API-Gateway aktivieren?"
     },
     "status": {
       "running": "Läuft",
@@ -2502,7 +2530,7 @@
     "openai-response": "OpenAI-Response"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Dieses Modell muss über das lokale API-Gateway von Cherry Studio gebrückt werden, das derzeit deaktiviert ist. Aktivieren Sie es, um diesen Agenten auszuführen.",
     "availableProviders": "Verfügbare Anbieter",
     "availableTools": "Verfügbare Tools",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Suchen Sie in Online-Registern nach installierbaren Skills.",
       "empty_title": "Nach Fähigkeiten suchen",
+      "github_empty_description": "Fügen Sie einen Link zu einer SKILL.md-Datei einer Fähigkeit ein, z. B. github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Von GitHub installieren",
+      "github_url_invalid": "Fügen Sie einen GitHub-Link ein, der mit SKILL.md endet",
+      "github_url_label": "GitHub-SKILL.md-URL",
+      "github_url_placeholder": "GitHub-Link, endend mit /SKILL.md",
       "no_results_description": "Versuchen Sie ein anderes Stichwort oder importieren Sie eine lokale ZIP-Datei oder ein Verzeichnis.",
       "no_results_title": "Keine Fähigkeiten gefunden",
       "search_failed_description": "Suche fehlgeschlagen. Bitte versuchen Sie es später erneut.",
+      "search_label": "Fähigkeiten suchen",
       "search_placeholder": "Suchkompetenzen...",
+      "source_label": "Fähigkeitsquelle",
       "title": "Online-Skill-Suche"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Neuer Tag-Name..."
     },
     "tag_sync_failed": "Synchronisierung der Tags fehlgeschlagen",
-    "time_ago": {
-      "days": "vor {{count}} Tag(en)",
-      "hours": "{{count}} Stunde(n) her",
-      "just_now": "Gerade eben",
-      "minutes": "vor {{count}} Minute(n)",
-      "months": "vor {{count}} Monat/Monaten"
-    },
     "title": "Bibliothek",
     "toolbar": {
       "add_group_placeholder": "Gruppenname...",
@@ -7665,7 +7693,8 @@
       "assistant": "Assistenten-Nachrichten",
       "backup": "Sicherung",
       "knowledge_embed": "Wissensdatenbank",
-      "title": "Benachrichtigungen"
+      "title": "Benachrichtigungen",
+      "update": "App-Update"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Δημιουργεί ή αντικαθιστά αρχεία",
           "label": "Γράψε"
+        },
+        "bash": {
+          "description": "Εκτέλεση εντολών shell",
+          "label": "Εκτέλεση εντολών shell"
+        },
+        "edit": {
+          "description": "Επεξεργασία αρχείων",
+          "label": "Επεξεργασία αρχείων"
+        },
+        "find": {
+          "description": "Εύρεση αρχείων",
+          "label": "Εύρεση αρχείων"
+        },
+        "grep": {
+          "description": "Αναζήτηση περιεχομένου αρχείων",
+          "label": "Αναζήτηση περιεχομένου αρχείων"
+        },
+        "ls": {
+          "description": "Λίστα περιεχομένου καταλόγου",
+          "label": "Λίστα περιεχομένου καταλόγου"
+        },
+        "read": {
+          "description": "Ανάγνωση αρχείων",
+          "label": "Ανάγνωση αρχείων"
+        },
+        "write": {
+          "description": "Εγγραφή αρχείων",
+          "label": "Εγγραφή αρχείων"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Ο διακομιστής API σταμάτησε επιτυχώς"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Ενεργοποίηση",
+      "description": "Το μοντέλο αυτού του πράκτορα πρέπει να γεφυρωθεί μέσω του τοπικού Διακομιστή API του Cherry Studio. Η ενεργοποίησή του ξεκινά επίσης αυτόματα τον διακομιστή σε μελλοντικές εκκινήσεις· μπορείτε να τον απενεργοποιήσετε ξανά στις Ρυθμίσεις.",
+      "title": "Ενεργοποίηση του Διακομιστή API;"
     },
     "status": {
       "running": "Εκτελείται",
@@ -2502,7 +2530,7 @@
     "openai-response": "Απάντηση OpenAI"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Αυτό το μοντέλο πρέπει να γεφυρωθεί μέσω του τοπικού Διακομιστή API του Cherry Studio, ο οποίος είναι προς το παρόν απενεργοποιημένος. Ενεργοποιήστε τον για να εκτελέσετε αυτόν τον πράκτορα.",
     "availableProviders": "Διαθέσιμοι πάροχοι",
     "availableTools": "Διαθέσιμα εργαλεία",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Αναζητήστε σε διαδικτυακά μητρώα για να βρείτε εγκαταστάσιμες δεξιότητες.",
       "empty_title": "Αναζήτηση δεξιοτήτων",
+      "github_empty_description": "Επικολλήστε έναν σύνδεσμο προς ένα αρχείο SKILL.md μιας ικανότητας, π.χ. github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Εγκατάσταση από GitHub",
+      "github_url_invalid": "Επικολλήστε έναν σύνδεσμο GitHub που τελειώνει με SKILL.md",
+      "github_url_label": "URL SKILL.md GitHub",
+      "github_url_placeholder": "Σύνδεσμος GitHub που λήγει σε /SKILL.md",
       "no_results_description": "Δοκιμάστε μια άλλη λέξη-κλειδί ή εισαγάγετε ένα τοπικό αρχείο ZIP ή φάκελο.",
       "no_results_title": "Δεν βρέθηκαν δεξιότητες",
       "search_failed_description": "Η αναζήτηση απέτυχε. Παρακαλώ δοκιμάστε ξανά αργότερα.",
+      "search_label": "Αναζήτηση ικανοτήτων",
       "search_placeholder": "Αναζήτηση δεξιοτήτων...",
+      "source_label": "Πηγή ικανότητας",
       "title": "Αναζήτηση δεξιοτήτων online"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Νέο όνομα ετικέτας..."
     },
     "tag_sync_failed": "Αποτυχία συγχρονισμού ετικετών",
-    "time_ago": {
-      "days": "{{count}} ημέρα/ες πριν",
-      "hours": "{{count}} ώρα/ώρες πριν",
-      "just_now": "Μόλις τώρα",
-      "minutes": "{{count}} λεπτό(ά) πριν",
-      "months": "{{count}} μήνα/μήνες πριν"
-    },
     "title": "Βιβλιοθήκη",
     "toolbar": {
       "add_group_placeholder": "Όνομα ομάδας...",
@@ -7665,7 +7693,8 @@
       "assistant": "Μήνυμα βοηθού",
       "backup": "Δημιουργία αντιγράφου ασφαλείας",
       "knowledge_embed": "Βάση γνώσης",
-      "title": "Ειδοποιήσεις"
+      "title": "Ειδοποιήσεις",
+      "update": "Ενημέρωση Εφαρμογής"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Crea o sobrescribe archivos",
           "label": "Escribir"
+        },
+        "bash": {
+          "description": "Ejecutar comandos de shell",
+          "label": "Ejecutar comandos de shell"
+        },
+        "edit": {
+          "description": "Editar archivos",
+          "label": "Editar archivos"
+        },
+        "find": {
+          "description": "Buscar archivos",
+          "label": "Buscar archivos"
+        },
+        "grep": {
+          "description": "Buscar contenido en archivos",
+          "label": "Buscar contenido en archivos"
+        },
+        "ls": {
+          "description": "Listar contenido del directorio",
+          "label": "Listar contenido del directorio"
+        },
+        "read": {
+          "description": "Leer archivos",
+          "label": "Leer archivos"
+        },
+        "write": {
+          "description": "Escribir archivos",
+          "label": "Escribir archivos"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Servidor API detenido exitosamente"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Habilitar",
+      "description": "El modelo de este agente debe ser puenteado a través de la API Gateway local de Cherry Studio. Habilitarlo también inicia la puerta de enlace automáticamente en futuros lanzamientos; puede desactivarla nuevamente en Configuración.",
+      "title": "¿Habilitar la API Gateway?"
     },
     "status": {
       "running": "Ejecutándose",
@@ -2502,7 +2530,7 @@
     "openai-response": "Respuesta de OpenAI"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Este modelo debe ser puenteado a través de la API Gateway local de Cherry Studio, que actualmente está deshabilitada. Habilítela para ejecutar este agente.",
     "availableProviders": "Proveedores disponibles",
     "availableTools": "Herramientas disponibles",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Busca en los registros en línea para encontrar habilidades instalables.",
       "empty_title": "Buscar habilidades",
+      "github_empty_description": "Pega un enlace al archivo SKILL.md de una habilidad, por ejemplo github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Instalar desde GitHub",
+      "github_url_invalid": "Pega un enlace de GitHub que termine con SKILL.md",
+      "github_url_label": "URL del SKILL.md en GitHub",
+      "github_url_placeholder": "Enlace de GitHub que termina en /SKILL.md",
       "no_results_description": "Prueba otra palabra clave o importa un archivo ZIP local o una carpeta.",
       "no_results_title": "No se encontraron habilidades",
       "search_failed_description": "La búsqueda falló. Por favor, inténtelo de nuevo más tarde.",
+      "search_label": "Buscar habilidades",
       "search_placeholder": "Buscar habilidades...",
+      "source_label": "Origen de la habilidad",
       "title": "Búsqueda de habilidades en línea"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Nuevo nombre de etiqueta..."
     },
     "tag_sync_failed": "Error al sincronizar etiquetas",
-    "time_ago": {
-      "days": "hace {{count}} día(s)",
-      "hours": "{{count}} hora(s) atrás",
-      "just_now": "Ahora mismo",
-      "minutes": "hace {{count}} minuto(s)",
-      "months": "hace {{count}} mes(es)"
-    },
     "title": "Biblioteca",
     "toolbar": {
       "add_group_placeholder": "Nombre del grupo...",
@@ -7665,7 +7693,8 @@
       "assistant": "Mensaje del asistente",
       "backup": "Copia de seguridad",
       "knowledge_embed": "Base de conocimiento",
-      "title": "Notificaciones"
+      "title": "Notificaciones",
+      "update": "Actualización de la aplicación"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Crée ou écrase des fichiers",
           "label": "Écrire"
+        },
+        "bash": {
+          "description": "Exécuter des commandes shell",
+          "label": "Exécuter des commandes shell"
+        },
+        "edit": {
+          "description": "Modifier des fichiers",
+          "label": "Modifier des fichiers"
+        },
+        "find": {
+          "description": "Trouver des fichiers",
+          "label": "Trouver des fichiers"
+        },
+        "grep": {
+          "description": "Rechercher dans le contenu des fichiers",
+          "label": "Rechercher dans le contenu des fichiers"
+        },
+        "ls": {
+          "description": "Lister le contenu du répertoire",
+          "label": "Lister le contenu du répertoire"
+        },
+        "read": {
+          "description": "Lire des fichiers",
+          "label": "Lire des fichiers"
+        },
+        "write": {
+          "description": "Écrire des fichiers",
+          "label": "Écrire des fichiers"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Serveur API arrêté avec succès"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Activer",
+      "description": "Le modèle de cet agent doit être relayé par le Serveur API local de Cherry Studio. L'activation démarre aussi automatiquement le serveur aux lancements futurs ; vous pourrez le désactiver à nouveau dans les Paramètres.",
+      "title": "Activer le Serveur API ?"
     },
     "status": {
       "running": "En cours d'exécution",
@@ -2502,7 +2530,7 @@
     "openai-response": "Réponse OpenAI"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Ce modèle doit être relayé par le Serveur API local de Cherry Studio, qui est actuellement désactivé. Activez-le pour exécuter cet agent.",
     "availableProviders": "Fournisseurs disponibles",
     "availableTools": "Outils disponibles",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Recherchez dans les registres en ligne pour trouver des compétences installables.",
       "empty_title": "Rechercher des compétences",
+      "github_empty_description": "Collez un lien vers le fichier SKILL.md d'une compétence, par exemple github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Installer depuis GitHub",
+      "github_url_invalid": "Collez un lien GitHub qui se termine par SKILL.md",
+      "github_url_label": "URL SKILL.md GitHub",
+      "github_url_placeholder": "Lien GitHub se terminant par /SKILL.md",
       "no_results_description": "Essayez un autre mot-clé ou importez un fichier ZIP local ou un répertoire.",
       "no_results_title": "Aucune compétence trouvée",
       "search_failed_description": "La recherche a échoué. Veuillez réessayer plus tard.",
+      "search_label": "Rechercher des compétences",
       "search_placeholder": "Compétences de recherche...",
+      "source_label": "Source de la compétence",
       "title": "Recherche de compétences en ligne"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Nouveau nom d'étiquette..."
     },
     "tag_sync_failed": "Échec de la synchronisation des étiquettes",
-    "time_ago": {
-      "days": "{{count}} jour(s)",
-      "hours": "{{count}} heure(s)",
-      "just_now": "À l'instant",
-      "minutes": "{{count}} minute(s)",
-      "months": "{{count}} mois"
-    },
     "title": "Bibliothèque",
     "toolbar": {
       "add_group_placeholder": "Nom du groupe...",
@@ -7665,7 +7693,8 @@
       "assistant": "Message de l'assistant",
       "backup": "Sauvegarder",
       "knowledge_embed": "Base de connaissances",
-      "title": "Notifications"
+      "title": "Notifications",
+      "update": "Mise à jour de l'application"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "ファイルを作成または上書きします",
           "label": "書け"
+        },
+        "bash": {
+          "description": "シェルコマンドを実行",
+          "label": "シェルコマンドを実行"
+        },
+        "edit": {
+          "description": "ファイルを編集",
+          "label": "ファイルを編集"
+        },
+        "find": {
+          "description": "ファイルを検索",
+          "label": "ファイルを検索"
+        },
+        "grep": {
+          "description": "ファイル内容を検索",
+          "label": "ファイル内容を検索"
+        },
+        "ls": {
+          "description": "ディレクトリ内容を一覧表示",
+          "label": "ディレクトリ内容を一覧表示"
+        },
+        "read": {
+          "description": "ファイルを読み込む",
+          "label": "ファイルを読み込む"
+        },
+        "write": {
+          "description": "ファイルを書き込む",
+          "label": "ファイルを書き込む"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "API サーバーが正常に停止されました"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "有効化",
+      "description": "このエージェントのモデルは、Cherry StudioのローカルAPIサーバーを通してブリッジする必要があります。有効にすると、以後の起動時にゲートウェイが自動的に開始されます。設定で再度オフにすることもできます。",
+      "title": "APIサーバーを有効にしますか？"
     },
     "status": {
       "running": "実行中",
@@ -2502,7 +2530,7 @@
     "openai-response": "OpenAI-Response"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "このモデルはCherry StudioのローカルAPIサーバーを通してブリッジする必要がありますが、現在は無効です。このエージェントを実行するには有効化してください。",
     "availableProviders": "利用可能なプロバイダー",
     "availableTools": "利用可能なツール",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "オンラインのレジストリを検索して、インストール可能なスキルを見つけてください。",
       "empty_title": "スキルを検索",
+      "github_empty_description": "SKILL.mdファイルへのリンクを貼り付けてください。例: github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "GitHubからインストール",
+      "github_url_invalid": "SKILL.mdで終わるGitHubリンクを貼り付けてください",
+      "github_url_label": "GitHub SKILL.md URL",
+      "github_url_placeholder": "/SKILL.mdで終わるGitHubリンク",
       "no_results_description": "別のキーワードを試すか、ローカルのZIPファイルまたはフォルダーをインポートしてください。",
       "no_results_title": "スキルが見つかりません",
       "search_failed_description": "検索に失敗しました。後でもう一度お試しください。",
+      "search_label": "スキルを検索",
       "search_placeholder": "検索スキル...",
+      "source_label": "スキルソース",
       "title": "オンラインスキル検索"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "新しいタグ名..."
     },
     "tag_sync_failed": "タグの同期に失敗しました",
-    "time_ago": {
-      "days": "{{count}}日前",
-      "hours": "{{count}}時間前",
-      "just_now": "たった今",
-      "minutes": "{{count}}分前",
-      "months": "{{count}} か月前"
-    },
     "title": "図書館",
     "toolbar": {
       "add_group_placeholder": "グループ名...",
@@ -7665,7 +7693,8 @@
       "assistant": "アシスタントメッセージ",
       "backup": "バックアップメッセージ",
       "knowledge_embed": "ナレッジベースメッセージ",
-      "title": "通知"
+      "title": "通知",
+      "update": "アプリ更新"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Cria ou sobrescreve ficheiros",
           "label": "Escreva"
+        },
+        "bash": {
+          "description": "Executar comandos do terminal",
+          "label": "Executar comandos do terminal"
+        },
+        "edit": {
+          "description": "Editar ficheiros",
+          "label": "Editar ficheiros"
+        },
+        "find": {
+          "description": "Procurar ficheiros",
+          "label": "Procurar ficheiros"
+        },
+        "grep": {
+          "description": "Pesquisar conteúdos de ficheiros",
+          "label": "Pesquisar conteúdos de ficheiros"
+        },
+        "ls": {
+          "description": "Listar conteúdos do diretório",
+          "label": "Listar conteúdos do diretório"
+        },
+        "read": {
+          "description": "Ler ficheiros",
+          "label": "Ler ficheiros"
+        },
+        "write": {
+          "description": "Escrever ficheiros",
+          "label": "Escrever ficheiros"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Servidor API parado com sucesso"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Ativar",
+      "description": "O modelo deste agente deve ser ligado através da API Gateway local do Cherry Studio. Ativá-la também inicia a gateway automaticamente em inícios futuros; pode desativá-la novamente em Configurações.",
+      "title": "Ativar a API Gateway?"
     },
     "status": {
       "running": "A executar",
@@ -2502,7 +2530,7 @@
     "openai-response": "Resposta OpenAI"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Este modelo deve ser ligado através da API Gateway local do Cherry Studio, que atualmente está desativada. Ative-a para executar este agente.",
     "availableProviders": "Fornecedores disponíveis",
     "availableTools": "Ferramentas disponíveis",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Pesquise em registos online para encontrar competências instaláveis.",
       "empty_title": "Pesquisar competências",
+      "github_empty_description": "Cole a ligação para um ficheiro SKILL.md de uma skill, por exemplo github.com/proprietário/repositório/blob/main/skills/minha-skill/SKILL.md",
+      "github_empty_title": "Instalar do GitHub",
+      "github_url_invalid": "Cole uma ligação do GitHub que termine com SKILL.md",
+      "github_url_label": "URL GitHub SKILL.md",
+      "github_url_placeholder": "Ligação GitHub que termina em /SKILL.md",
       "no_results_description": "Experimente outra palavra-chave ou importe um ficheiro ZIP local ou uma pasta.",
       "no_results_title": "Nenhuma competência encontrada",
       "search_failed_description": "A pesquisa falhou. Por favor, tente novamente mais tarde.",
+      "search_label": "Pesquisar skills",
       "search_placeholder": "Procurar competências...",
+      "source_label": "Origem da skill",
       "title": "Pesquisa de competências online"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Novo nome da tag..."
     },
     "tag_sync_failed": "Falha ao sincronizar etiquetas",
-    "time_ago": {
-      "days": "{{count}} dia(s) atrás",
-      "hours": "{{count}} hora(s) atrás",
-      "just_now": "Agora mesmo",
-      "minutes": "{{count}} minuto(s) atrás",
-      "months": "{{count}} mês(es) atrás"
-    },
     "title": "Biblioteca",
     "toolbar": {
       "add_group_placeholder": "Nome do grupo...",
@@ -7665,7 +7693,8 @@
       "assistant": "Mensagem do assistente",
       "backup": "Backup",
       "knowledge_embed": "Base de conhecimento",
-      "title": "Notificações"
+      "title": "Notificações",
+      "update": "Atualização da Aplicação"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Creează sau suprascrie fișiere",
           "label": "Scrie"
+        },
+        "bash": {
+          "description": "Rulează comenzi shell",
+          "label": "Rulează comenzi shell"
+        },
+        "edit": {
+          "description": "Editează fișiere",
+          "label": "Editează fișiere"
+        },
+        "find": {
+          "description": "Găsește fișiere",
+          "label": "Găsește fișiere"
+        },
+        "grep": {
+          "description": "Caută în conținutul fișierelor",
+          "label": "Caută în conținutul fișierelor"
+        },
+        "ls": {
+          "description": "Listează conținutul directorului",
+          "label": "Listează conținutul directorului"
+        },
+        "read": {
+          "description": "Citește fișiere",
+          "label": "Citește fișiere"
+        },
+        "write": {
+          "description": "Scrie fișiere",
+          "label": "Scrie fișiere"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Serverul API s-a oprit cu succes"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Activează",
+      "description": "Modelul acestui agent trebuie să fie conectat prin serverul API local Cherry Studio. Activarea va porni, de asemenea, automat serverul la următoarele lansări; îl puteți dezactiva din nou în Setări.",
+      "title": "Activezi serverul API?"
     },
     "status": {
       "running": "Rulează",
@@ -2502,7 +2530,7 @@
     "openai-response": "OpenAI-Response"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Acest model trebuie să fie conectat prin serverul API local Cherry Studio, care este în prezent dezactivat. Activează-l pentru a rula acest agent.",
     "availableProviders": "Furnizori disponibili",
     "availableTools": "Instrumente disponibile",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Caută în registrele online abilități care pot fi instalate.",
       "empty_title": "Caută abilități",
+      "github_empty_description": "Lipește un link către fișierul SKILL.md al unei abilități, de exemplu github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Instalează de pe GitHub",
+      "github_url_invalid": "Lipește un link GitHub care se termină cu SKILL.md",
+      "github_url_label": "URL SKILL.md GitHub",
+      "github_url_placeholder": "Link GitHub care se termină cu /SKILL.md",
       "no_results_description": "Încearcă un alt cuvânt cheie sau importă un fișier ZIP sau director local.",
       "no_results_title": "Nu au fost găsite abilități",
       "search_failed_description": "Căutarea a eșuat. Încearcă din nou mai târziu.",
+      "search_label": "Caută abilități",
       "search_placeholder": "Căutare abilități...",
+      "source_label": "Sursa abilității",
       "title": "Căutare abilități online"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Nume nou pentru etichetă..."
     },
     "tag_sync_failed": "Nu s-au putut sincroniza etichetele",
-    "time_ago": {
-      "days": "acum {{count}} zi(zile)",
-      "hours": "{{count}} oră/oră în urmă",
-      "just_now": "Chiar acum",
-      "minutes": "acum {{count}} minut(e",
-      "months": "acum {{count}} lună/luni"
-    },
     "title": "Bibliotecă",
     "toolbar": {
       "add_group_placeholder": "Numele grupului...",
@@ -7665,7 +7693,8 @@
       "assistant": "Mesaj asistent",
       "backup": "Mesaj backup",
       "knowledge_embed": "Mesaj bază de cunoștințe",
-      "title": "Notificări"
+      "title": "Notificări",
+      "update": "Actualizare aplicație"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Создает или перезаписывает файлы",
           "label": "Напишите"
+        },
+        "bash": {
+          "description": "Выполнять команды shell",
+          "label": "Выполнять команды shell"
+        },
+        "edit": {
+          "description": "Редактировать файлы",
+          "label": "Редактировать файлы"
+        },
+        "find": {
+          "description": "Искать файлы",
+          "label": "Искать файлы"
+        },
+        "grep": {
+          "description": "Искать содержимое файлов",
+          "label": "Искать содержимое файлов"
+        },
+        "ls": {
+          "description": "Просматривать содержимое каталога",
+          "label": "Просматривать содержимое каталога"
+        },
+        "read": {
+          "description": "Читать файлы",
+          "label": "Читать файлы"
+        },
+        "write": {
+          "description": "Записывать файлы",
+          "label": "Записывать файлы"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "API сервер успешно остановлен"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Включить",
+      "description": "Модель этого агента должна быть подключена через локальный API Gateway Cherry Studio. Включение также запускает шлюз автоматически при последующих запусках; его можно снова отключить в Настройках.",
+      "title": "Включить API Gateway?"
     },
     "status": {
       "running": "Работает",
@@ -2502,7 +2530,7 @@
     "openai-response": "OpenAI-Response"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Эта модель должна быть подключена через локальный API Gateway Cherry Studio, который сейчас отключён. Включите его для запуска этого агента.",
     "availableProviders": "Доступные провайдеры",
     "availableTools": "Доступные инструменты",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Поищите в онлайн-реестрах навыки, которые можно установить.",
       "empty_title": "Поиск навыков",
+      "github_empty_description": "Вставьте ссылку на файл SKILL.md навыка, например github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Установить из GitHub",
+      "github_url_invalid": "Вставьте ссылку GitHub, оканчивающуюся на SKILL.md",
+      "github_url_label": "Ссылка GitHub на SKILL.md",
+      "github_url_placeholder": "Ссылка GitHub, оканчивающаяся на /SKILL.md",
       "no_results_description": "Попробуйте другое ключевое слово или импортируйте локальный ZIP-архив или папку.",
       "no_results_title": "Навыки не найдены",
       "search_failed_description": "Поиск не удался. Пожалуйста, попробуйте позже.",
+      "search_label": "Искать навыки",
       "search_placeholder": "Навыки поиска...",
+      "source_label": "Источник навыка",
       "title": "Поиск навыков онлайн"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Новое имя тега..."
     },
     "tag_sync_failed": "Не удалось синхронизировать теги",
-    "time_ago": {
-      "days": "{{count}} день(дня/дней) назад",
-      "hours": "{{count}} час(а/ов) назад",
-      "just_now": "Только что",
-      "minutes": "{{count}} минут(у/ы) назад",
-      "months": "{{count}} месяц(ев) назад"
-    },
     "title": "Библиотека",
     "toolbar": {
       "add_group_placeholder": "Название группы...",
@@ -7665,7 +7693,8 @@
       "assistant": "Сообщение ассистента",
       "backup": "Резервное сообщение",
       "knowledge_embed": "Сообщение базы знаний",
-      "title": "Уведомления"
+      "title": "Уведомления",
+      "update": "Обновление приложения"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -1088,6 +1088,34 @@
         "Write": {
           "description": "Tạo hoặc ghi đè lên các tệp",
           "label": "Viết"
+        },
+        "bash": {
+          "description": "Chạy lệnh shell",
+          "label": "Chạy lệnh shell"
+        },
+        "edit": {
+          "description": "Sửa tập tin",
+          "label": "Sửa tập tin"
+        },
+        "find": {
+          "description": "Tìm tập tin",
+          "label": "Tìm tập tin"
+        },
+        "grep": {
+          "description": "Tìm kiếm nội dung tập tin",
+          "label": "Tìm kiếm nội dung tập tin"
+        },
+        "ls": {
+          "description": "Liệt kê nội dung thư mục",
+          "label": "Liệt kê nội dung thư mục"
+        },
+        "read": {
+          "description": "Đọc tập tin",
+          "label": "Đọc tập tin"
+        },
+        "write": {
+          "description": "Ghi tập tin",
+          "label": "Ghi tập tin"
         }
       }
     },
@@ -1155,9 +1183,9 @@
       "stopSuccess": "Máy chủ API đã dừng thành công"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "Bật",
+      "description": "Mô hình của Agent này phải được cầu nối qua Máy chủ API cục bộ của Cherry Studio. Bật tính năng này cũng sẽ tự động khởi động máy chủ trong các lần chạy sau; bạn có thể tắt lại trong Cài đặt.",
+      "title": "Bật Máy chủ API?"
     },
     "status": {
       "running": "Chạy",
@@ -2502,7 +2530,7 @@
     "openai-response": "Phản hồi của OpenAI"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "Mô hình này phải được cầu nối qua Máy chủ API cục bộ của Cherry Studio, nhưng máy chủ hiện đang bị tắt. Bật nó lên để chạy Agent này.",
     "availableProviders": "Nhà cung cấp có sẵn",
     "availableTools": "Công cụ có sẵn",
     "backup": {
@@ -3872,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "Tìm kiếm trong các sổ đăng ký trực tuyến để tìm các kỹ năng có thể cài đặt.",
       "empty_title": "Tìm kiếm kỹ năng",
+      "github_empty_description": "Dán liên kết đến tập tin SKILL.md của một kỹ năng, ví dụ github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "Cài đặt từ GitHub",
+      "github_url_invalid": "Hãy dán liên kết GitHub có kết thúc bằng SKILL.md",
+      "github_url_label": "URL SKILL.md trên GitHub",
+      "github_url_placeholder": "Liên kết GitHub, kết thúc bằng /SKILL.md",
       "no_results_description": "Thử một từ khóa khác hoặc nhập tệp ZIP hoặc thư mục cục bộ.",
       "no_results_title": "Không tìm thấy kỹ năng nào",
       "search_failed_description": "Tìm kiếm thất bại. Vui lòng thử lại sau.",
+      "search_label": "Tìm kiếm kỹ năng",
       "search_placeholder": "Kỹ năng tìm kiếm...",
+      "source_label": "Nguồn kỹ năng",
       "title": "Tìm kiếm kỹ năng trực tuyến"
     },
     "sort": {
@@ -3902,13 +3937,6 @@
       "placeholder": "Tên thẻ mới..."
     },
     "tag_sync_failed": "Không đồng bộ được thẻ",
-    "time_ago": {
-      "days": "{{count}} ngày trước",
-      "hours": "{{count}} giờ trước",
-      "just_now": "Vừa xong",
-      "minutes": "{{count}} phút trước",
-      "months": "{{count}} tháng trước"
-    },
     "title": "Thư viện",
     "toolbar": {
       "add_group_placeholder": "Tên nhóm...",
@@ -7665,7 +7693,8 @@
       "assistant": "Tin nhắn Trợ lý",
       "backup": "Tin nhắn sao lưu",
       "knowledge_embed": "Thông báo từ KnowledgeBase",
-      "title": "Thông báo"
+      "title": "Thông báo",
+      "update": "Cập nhật Ứng dụng"
     },
     "openai": {
       "service_tier": {

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -1183,9 +1183,9 @@
       "stopSuccess": "API 閘道停止成功"
     },
     "required": {
-      "confirm": "[to be translated]:Enable",
-      "description": "[to be translated]:This agent's model must be bridged through Cherry Studio's local API Gateway. Enabling it also starts the gateway automatically on future launches; you can turn it off again in Settings.",
-      "title": "[to be translated]:Enable the API Gateway?"
+      "confirm": "啟用",
+      "description": "此智能體使用的模型必須透過 Cherry Studio 的本機 API Gateway 橋接。啟用後閘道會在之後啟動時自動執行；您隨時可以在設定中再次關閉。",
+      "title": "啟用 API Gateway？"
     },
     "status": {
       "running": "執行中",
@@ -2530,7 +2530,7 @@
     "openai-response": "OpenAI-Response"
   },
   "error": {
-    "api_gateway_required": "[to be translated]:This model must be bridged through Cherry Studio's local API Gateway, which is currently disabled. Enable it to run this agent.",
+    "api_gateway_required": "此模型必須透過 Cherry Studio 的本機 API Gateway 橋接，但閘道目前為停用狀態。請啟用它才能執行此智能體。",
     "availableProviders": "可用供應商",
     "availableTools": "可用工具",
     "backup": {
@@ -3900,10 +3900,17 @@
     "skill_marketplace": {
       "empty_description": "搜尋線上技能來源，尋找可安裝的技能。",
       "empty_title": "搜尋技能",
+      "github_empty_description": "請貼上技能的 SKILL.md 檔案連結，例如 github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
+      "github_empty_title": "從 GitHub 安裝",
+      "github_url_invalid": "請貼上以 SKILL.md 結尾的 GitHub 連結",
+      "github_url_label": "GitHub SKILL.md 連結",
+      "github_url_placeholder": "GitHub 連結，以 /SKILL.md 結尾",
       "no_results_description": "請嘗試其他關鍵字，或從本機匯入 ZIP 檔或資料夾。",
       "no_results_title": "未找到技能",
       "search_failed_description": "搜尋失敗，請稍後再試。",
+      "search_label": "搜尋技能",
       "search_placeholder": "搜尋技能...",
+      "source_label": "技能來源",
       "title": "線上搜尋技能"
     },
     "sort": {
@@ -3930,13 +3937,6 @@
       "placeholder": "新標籤名稱..."
     },
     "tag_sync_failed": "同步標籤失敗",
-    "time_ago": {
-      "days": "{{count}} 天前",
-      "hours": "{{count}} 小時前",
-      "just_now": "剛才",
-      "minutes": "{{count}} 分鐘前",
-      "months": "{{count}} 個月前"
-    },
     "title": "資源庫",
     "toolbar": {
       "add_group_placeholder": "群組名稱...",
@@ -7693,7 +7693,8 @@
       "assistant": "助理訊息",
       "backup": "備份訊息",
       "knowledge_embed": "知識庫訊息",
-      "title": "通知"
+      "title": "通知",
+      "update": "應用程式更新"
     },
     "openai": {
       "service_tier": {


### PR DESCRIPTION
### What this PR does

Prepares the **v2.0.5** patch release.

Before this PR: `main` is at `2.0.4` with unreleased commits since `v2.0.4`.
After this PR: version bumped to `2.0.5`, bilingual release notes added to `electron-builder.yml`, and `resources/builtin-agents/cherry-assistant/product-manifest.json` regenerated with the new package version.

### Why we need it and why it was done in this way

Routine patch release. Collects user-facing fixes and features since v2.0.4. Internal refactors (e.g. `refactor(icons)`, `perf(main-runtime)`, `perf(renderer)`, `perf(mcp-settings)`) and CI-only changes are excluded from the release notes per the prepare-release skill rules.

The following tradeoffs were made:

- Bumped patch (2.0.4 → 2.0.5) per the release argument.
- Release notes were generated from the ```` ```release-note ```` blocks of each commit; commits with `NONE` or excluded categories (Daily Auto I18N, CI, internal refactor) were skipped.

The following alternatives were considered:

- `minor` bump — rejected; no user-visible behavior change requiring a minor bump beyond the accumulated fixes.

### Breaking changes

None.

### Special notes for your reviewer

Release notes (English) for review:

---

Cherry Studio 2.0.5 - New Features, Fixes, and Performance

✨ New Features
- [Agent] Add pi (@earendil-works/pi-coding-agent) as a selectable agent runtime alongside Claude Code, letting agents use supported configured providers with managed skills, Soul mode (opt-in), MCP servers, tool approval, permission modes, mid-turn steering, manual /compact, resume, and compaction. Plan mode and plan/small-model tiers remain Claude-only
- [Skills] Skills can now be installed from a GitHub link to their SKILL.md file — pick "GitHub" in the online skill search, or hand an agent the link directly. The search source is now chosen from a dropdown instead of tabs, and skill detail timestamps follow the app language instead of the system locale
- [Support] Add the preinstalled Cherry Support Agent for Cherry Studio guidance, troubleshooting, FAQs, and feedback. Its initial model follows Cherry Assistant, and About > Feedback now opens Cherry Support
- [Updates] Added a notification setting to show a system notification when an app update is available (off by default)

🐛 Bug Fixes
- [Models] Fix a model re-listed under a provider prefix (e.g. nvidia/gpt-oss-20b) being displayed with the wrong name and size when the catalog has a differently-sized sibling
- [Models] Fix OpenVINO Model Server models not appearing in the model manager or "Get models" after a successful download
- [Models] Fix model availability checks for chat models also advertised with embedding endpoints, preventing false unavailable status and API Gateway rejection
- [Models] Fix image generation failing with "Missing modelDescriptor" for the DashScope models qwen-image-3.0 and qwen-image-3.0-pro
- [Models] Fix tiered model pricing so partially specified currencies are preserved and usage can still be priced when providers report an input-token breakdown without an aggregate input-token count
- [Models] Fix CherryIN model synchronization retaining four removed DeepSeek aliases, allowing stale entries to be cleaned instead of being treated as available models
- [Chat] Fix streamed replies becoming stuck when a chat tab is detached into a new window immediately after sending
- [Chat] Fix the chat composer changing width when switching conversations
- [Chat] Fix chat attachments with a malformed stored mediaType (e.g. a bare .png label instead of image/png) failing on every model with "file part media type .png" — the mediaType is now normalized before the provider request
- [Chat] Fix FileManager base64 image persistence for standard data URLs with media type parameters
- [Pins] Pin changes now stay synchronized across open windows, including pinned topic and agent-session ordering and pins removed by cascading deletes
- [Topics] Fix topic drag moves across assistants so ownership and ordering update atomically without leaving a partial move after an error
- [Topics] Topic naming now uses the Quick Assistant model and no longer has a separate model setting. Action required: review the Quick Assistant model selection if a different topic naming model was previously configured
- [Topics] Fix very long conversations (over ~1000 messages) failing to delete with "too many levels of trigger recursion" — deleting the topic or its assistant, and clearing the conversation, now work at any length
- [Sidebar] Collapsing and reopening the conversation navigation sidebar now preserves its list state
- [Search] Global search now keeps long message previews responsive by rendering only the visible messages
- [Artifacts] Fix Markdown artifact previews on Windows when generated file paths omit the slash after the drive letter
- [Agent] Newly created agents now appear at the top of the agent list by default
- [API Gateway] The API Gateway no longer starts on its own. It now starts only when enabled in Settings → API Gateway, so turning it off finally sticks across restarts. Agents whose model has to be bridged through the gateway ask before starting it, and resend the message once you accept
- [Migration] Fix V1-to-V2 migration failures caused by legacy model IDs containing route-reserved characters
- [Migration] Fix v1 files whose extension ended in a space or dot (e.g. ".exe ") becoming unreadable after migrating to v2 — opening, hashing or deleting them failed with a missing-file error
- [Migration] Fix agent migration skipping filesystem targets when workspaces overlap. Action required: after upgrading, review Agents reported with skipped filesystem targets and restore any missing identity, memory, or workspace files from the preserved v1 data
- [i18n] Fix translated UI strings that were wrong or out of date: the max tool-call rounds hint no longer omits or hard-codes the default round limit, the translation input placeholder no longer shows text meant for an older version of that field, and the OpenClaw migration and runtime removal messages now match what the app actually does. Affects German, Greek, Spanish, French, Japanese, Portuguese, Romanian, Russian, Vietnamese and both Chinese locales
- [i18n] Fix machine translations being written without validation, preventing damaged locale strings
- [Vertex AI] Fix Vertex AI Service Account requests when the official API host is configured explicitly

⚡ Performance
- [Memory] Reduced memory growth during long-running sessions by bounding retained tabs and Mini App WebViews and sharing assistant topic views
- [Memory] Fix renderer memory growth caused by inactive conversation history pages remaining in the SWR cache

---

Included commits (v2.0.4..release/v2.0.5):

- fix(provider-registry): resolve prefixed size-colliding model ids to their own override (#18487)
- perf(main-runtime): reduce cold idle memory with lazy loading (#18472)
- fix(pins): synchronize pin changes across windows (#18499)
- fix(topic-move): make cross-assistant moves atomic (#18501)
- fix(tab-retention): bound background memory usage (#18504)
- fix(message-service): delete conversations past SQLite's cascade depth limit (#18479)
- perf(mcp-settings): isolate log tab updates (#18473)
- fix(data-api): bound inactive conversation history cache (#18505)
- ci(update-mergeable-prs): merge main into approved PRs that are behind (#18524)
- feat(cherry-support): add built-in support agent (#18498)
- fix(workspace-selector): avoid duplicate refresh (#18475)
- fix(topic-branch): avoid duplicate tree refetch (#18470)
- fix(global-search): virtualize message previews (#18402)
- feat(notification): add app update notification preference (#18332)
- fix(model-list): query OVMS for its servable status on /v1/config (#18482)
- fix: prefer chat endpoints for mixed model health checks (#18447)
- fix(file): accept parameterized base64 data URLs (#17406)
- perf(renderer): consolidate first-paint lazy loading (#18405)
- fix(agent-list): place newly created agents first (#18427)
- fix(dashscope): register qwen-image-3.0 image models (#18527)
- fix(model-pricing): preserve currency and derive tier input totals (#18453)
- feat(skill-install): install a skill from a GitHub SKILL.md URL (#18438)
- fix(provider-model-migration): skip invalid legacy model IDs (#18381)
- fix(i18n-translate): validate machine translations before writing them (#18510)
- fix(chat-composer): preserve width across topic switches (#18529)
- fix(agent-migration): continue past overlapping workspaces (#18372)
- fix(file-migration): copy trailing-space/dot ext uploads to their v2 name (#18514)
- fix(topic-naming): use quick assistant model (#18517)
- fix(chat-attachments): sanitize bad mediaType before provider dispatch (#18481)
- fix(conversation-sidebar): preserve collapsed pane state (#18507)
- fix(artifact-pane): repair malformed Windows artifact paths (#18516)
- fix(provider-registry): remove stale CherryIN DeepSeek aliases (#18526)
- fix(api-gateway): stop the gateway from starting itself (#18523)
- fix(cache): prevent detached window stream stalls (#18531)
- refactor(icons): load icons per key instead of whole catalogs (#18441)
- fix(vertex-ai): preserve default service routing (#18174)
- feat(agent-runtime): add pi as a second agent-session runtime driver (#16630)

### Checklist

- [x] Branch: This PR targets the correct branch — `main` for active development
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: N/A — no code changes, release-only
- [x] Refactor: N/A — release-only
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: N/A — no user-guide update required for a release bump
- [x] Self-review: Release notes reviewed against commit `release-note` blocks

### Review checklist

- [ ] Review generated release notes in `electron-builder.yml`
- [ ] Verify version bump in `package.json`
- [ ] Verify generated product manifest uses the release version
- [ ] CI passes
- [ ] Merge to trigger release build

### Release note

```release-note
NONE
```