### PR TITLE
fix(knowledge): coalesce concurrent reindex requests

### DIFF
--- a/src/main/features/knowledge/__tests__/KnowledgeService.integration.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.integration.test.ts
@@ -134,7 +134,7 @@ describe('KnowledgeService integration', () => {
     ])
   })
 
-  it('restores a failed base into a new base and enqueues indexing for restored roots', async () => {
+  it('restores a failed base and coalesces reindex while its restored root is still indexing', async () => {
     const service = new KnowledgeService()
 
     const { base: restoredBase, skippedMissingSourceCount } = await service.restoreBase({
@@ -197,9 +197,14 @@ describe('KnowledgeService integration', () => {
       .where(eq(knowledgeItemTable.id, SOURCE_CHILD_ITEM_ID))
     expect(sourceChildRows).toHaveLength(1)
 
-    await expect(service.reindexItems(restoredBase.id, [restoredItems[0].id])).rejects.toMatchObject({
-      message: 'Cannot reindex knowledge item until the entire subtree is completed or failed'
-    })
+    listMock.mockResolvedValue([
+      {
+        type: 'knowledge.index-documents',
+        input: { baseId: restoredBase.id, itemId: restoredItems[0].id }
+      }
+    ] as never)
+
+    await expect(service.reindexItems(restoredBase.id, [restoredItems[0].id])).resolves.toBeUndefined()
     expect(enqueueMock).toHaveBeenCalledTimes(1)
 
     const ungroupedRestoredItems = await dbh.db

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -1134,6 +1134,37 @@ describe('KnowledgeService', () => {
       expect(enqueueMock).not.toHaveBeenCalledWith('knowledge.reindex-subtree', expect.anything(), expect.anything())
     })
 
+    it('does not commit the model when a concurrent delete changes subtree status during source admission', async () => {
+      const service = new KnowledgeService()
+      const sourceProbe = createDeferred<'readable'>()
+      let status: KnowledgeItemOf<'file'>['status'] = 'completed'
+      const rootItem = () => createFileItem('file-1', 'kb-1', '/docs/source.pdf', status)
+      knowledgeItemGetRootItemsByBaseIdMock.mockReturnValue([rootItem()])
+      knowledgeItemGetSubtreeItemsMock.mockImplementation(
+        (_baseId: string, _rootIds: string[], options: { includeRoots?: boolean } = {}) =>
+          options.includeRoots ? [rootItem()] : []
+      )
+      probeKnowledgeFileMock.mockReturnValue(sourceProbe.promise)
+      knowledgeItemSetSubtreeStatusTxMock.mockImplementation(() => {
+        status = 'deleting'
+        return ['file-1']
+      })
+
+      const enabling = service
+        .enableEmbeddingModel('kb-1', { embeddingModelId: 'provider::embed', dimensions: 3 })
+        .then(
+          () => null,
+          (error: unknown) => error
+        )
+      await vi.waitFor(() => expect(probeKnowledgeFileMock).toHaveBeenCalledOnce())
+      await service.deleteItems('kb-1', ['file-1'])
+      sourceProbe.resolve('readable')
+
+      expect(await enabling).toMatchObject({ code: ErrorCode.VALIDATION_ERROR })
+      expect(knowledgeBaseUpdateMock).not.toHaveBeenCalled()
+      expect(enqueueMock).not.toHaveBeenCalledWith('knowledge.reindex-subtree', expect.anything(), expect.anything())
+    })
+
     it('rejects a backfill when a root item source no longer exists, without committing the model', async () => {
       const service = new KnowledgeService()
       const root = createFileItem('file-1', 'kb-1', '/docs/gone.pdf', 'completed')
@@ -1794,6 +1825,49 @@ describe('KnowledgeService', () => {
 
     expect(enqueueMock).not.toHaveBeenCalled()
     expect(knowledgeItemSetSubtreeStatusMock).not.toHaveBeenCalled()
+  })
+
+  it('coalesces a two-item reindex request into the active indexing work for both items', async () => {
+    const service = new KnowledgeService()
+    const processingItems = [
+      createNoteItem('note-1', 'kb-1', null, 'processing'),
+      createNoteItem('note-2', 'kb-1', null, 'processing')
+    ]
+    knowledgeItemGetSubtreeItemsMock.mockImplementation(
+      (_baseId: string, rootIds: string[], options: { includeRoots?: boolean } = {}) =>
+        options.includeRoots ? processingItems.filter((item) => rootIds.includes(item.id)) : []
+    )
+    listMock.mockResolvedValue([
+      { type: 'knowledge.index-documents', input: { baseId: 'kb-1', itemId: 'note-1' } },
+      { type: 'knowledge.index-documents', input: { baseId: 'kb-1', itemId: 'note-2' } }
+    ] as never)
+
+    await expect(service.reindexItems('kb-1', ['note-1', 'note-2'])).resolves.toBeUndefined()
+
+    expect(enqueueMock).not.toHaveBeenCalledWith('knowledge.reindex-subtree', expect.anything(), expect.anything())
+  })
+
+  it('does not hide a stranded processing item when its sibling still has active indexing work', async () => {
+    const service = new KnowledgeService()
+    const root = createDirectoryItem('dir-1', null, 'processing')
+    const activeChild = createNoteItem('note-1', 'kb-1', 'dir-1', 'processing')
+    const strandedChild = createNoteItem('note-2', 'kb-1', 'dir-1', 'processing')
+    knowledgeItemGetSubtreeItemsMock.mockImplementation(
+      (_baseId: string, rootIds: string[], options: { includeRoots?: boolean } = {}) => {
+        if (!options.includeRoots) return []
+        if (rootIds.includes('dir-1')) return [root, activeChild, strandedChild]
+        return [activeChild]
+      }
+    )
+    listMock.mockResolvedValue([
+      { type: 'knowledge.index-documents', input: { baseId: 'kb-1', itemId: 'note-1' } }
+    ] as never)
+
+    await expect(service.reindexItems('kb-1', ['dir-1'])).rejects.toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR
+    })
+
+    expect(enqueueMock).not.toHaveBeenCalled()
   })
 
   it('rejects reindex of a directory whose source folder no longer exists, without deleting its vectors', async () => {

--- a/src/main/features/knowledge/ingestion/KnowledgeIngestionService.ts
+++ b/src/main/features/knowledge/ingestion/KnowledgeIngestionService.ts
@@ -7,6 +7,7 @@ import { loggerService } from '@logger'
 import type { KeyedMutex } from '@main/core/concurrency/KeyedMutex'
 import { getFileExt } from '@main/utils/legacyFile'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
+import { ACTIVE_JOB_STATUSES } from '@shared/data/api/schemas/jobs'
 import type { UpdateKnowledgeBaseDto } from '@shared/data/api/schemas/knowledges'
 import { FileProcessorIdSchema } from '@shared/data/presets/fileProcessing'
 import {
@@ -37,6 +38,7 @@ import {
 } from '../pathStorage'
 import { planKnowledgeItemSource } from '../pipeline/sources/sourcePlanning'
 import { cancelActiveKnowledgeJobs, cancelJobOrThrow } from '../tasks/utils/cancel'
+import { narrowKnowledgeJobInput } from '../tasks/utils/jobInput'
 import {
   type KnowledgeBaseId,
   knowledgeDeleteSubtreeIdempotencyKey,
@@ -59,6 +61,12 @@ const logger = loggerService.withContext('Knowledge:IngestionService')
 const FILE_PROCESSING_CHECK_DELAY_MS = 5_000
 const KNOWLEDGE_SUPPORTED_FILE_EXT_SET = new Set<string>(knowledgeSupportedFileExts)
 const REINDEX_ALLOWED_STATUSES = new Set<KnowledgeItemStatus>(['completed', 'failed'])
+const REINDEX_ACTIVE_JOB_TYPES = [
+  'knowledge.prepare-root',
+  'knowledge.index-documents',
+  'knowledge.check-file-processing-result',
+  'knowledge.reindex-subtree'
+] as const
 const DELETE_RECOVERY_ROOT_CHUNK_SIZE = 500
 
 /**
@@ -226,20 +234,19 @@ export class KnowledgeIngestionService implements KnowledgeItemScheduler {
       return
     }
 
-    await this.assertSubtreesCanReindex(baseId, rootItemIds)
+    await this.assertSubtreeSourcesCanReindex(baseId, rootItemIds)
 
-    knowledgeBaseService.getById(baseId)
-    const knowledgeBaseId = toKnowledgeBaseId(baseId)
-    const knowledgeRootItemIds = toKnowledgeItemIds(rootItemIds)
-    const jobManager = application.get('JobManager')
-    jobManager.enqueue(
-      'knowledge.reindex-subtree',
-      { baseId, rootItemIds },
-      {
-        idempotencyKey: knowledgeReindexSubtreeIdempotencyKey(knowledgeBaseId, knowledgeRootItemIds),
-        queue: knowledgeQueueName(knowledgeBaseId)
+    await this.knowledgeLockManager.runExclusive(baseId, async () => {
+      // Coalesce only when durable work covers the subtree. A processing item with no active job
+      // still reaches the status guard so an actually stranded item is not silently hidden.
+      const rootsWithoutActiveWork = await this.getRootsWithoutActiveWork(baseId, rootItemIds)
+      if (rootsWithoutActiveWork.length === 0) {
+        return
       }
-    )
+
+      this.assertSubtreeStatusesCanReindex(baseId, rootsWithoutActiveWork)
+      this.enqueueReindexItems(baseId, rootsWithoutActiveWork)
+    })
   }
 
   /**
@@ -260,16 +267,22 @@ export class KnowledgeIngestionService implements KnowledgeItemScheduler {
 
     if (rootItemIds.length > 0) {
       assertBaseCanRunRuntimeOperation(baseId, 'enableEmbeddingModel')
-      await this.assertSubtreesCanReindex(baseId, rootItemIds)
+      await this.assertSubtreeSourcesCanReindex(baseId, rootItemIds)
     }
 
-    const updatedBase = knowledgeBaseService.update(baseId, patch, { allowEmbeddingModelBackfill: true })
+    return await this.knowledgeLockManager.runExclusive(baseId, () => {
+      if (rootItemIds.length > 0) {
+        this.assertSubtreeStatusesCanReindex(baseId, rootItemIds)
+      }
 
-    if (rootItemIds.length > 0) {
-      await this.reindexItems(baseId, rootItemIds)
-    }
+      const updatedBase = knowledgeBaseService.update(baseId, patch, { allowEmbeddingModelBackfill: true })
 
-    return updatedBase
+      if (rootItemIds.length > 0) {
+        this.enqueueReindexItems(baseId, rootItemIds)
+      }
+
+      return updatedBase
+    })
   }
 
   async scheduleItem(
@@ -469,7 +482,70 @@ export class KnowledgeIngestionService implements KnowledgeItemScheduler {
     }
   }
 
-  private async assertSubtreesCanReindex(baseId: string, rootItemIds: string[]): Promise<void> {
+  private enqueueReindexItems(baseId: string, rootItemIds: string[]): void {
+    knowledgeBaseService.getById(baseId)
+    const knowledgeBaseId = toKnowledgeBaseId(baseId)
+    const knowledgeRootItemIds = toKnowledgeItemIds(rootItemIds)
+    application.get('JobManager').enqueue(
+      'knowledge.reindex-subtree',
+      { baseId, rootItemIds },
+      {
+        idempotencyKey: knowledgeReindexSubtreeIdempotencyKey(knowledgeBaseId, knowledgeRootItemIds),
+        queue: knowledgeQueueName(knowledgeBaseId)
+      }
+    )
+  }
+
+  private async getRootsWithoutActiveWork(baseId: string, rootItemIds: string[]): Promise<string[]> {
+    const activeJobs = await application.get('JobManager').list({
+      queue: knowledgeQueueName(toKnowledgeBaseId(baseId)),
+      status: [...ACTIVE_JOB_STATUSES],
+      type: [...REINDEX_ACTIVE_JOB_TYPES]
+    })
+    const activeRootItemIds = new Set<string>()
+
+    for (const job of activeJobs) {
+      const narrowed = narrowKnowledgeJobInput(job)
+      if (!narrowed || narrowed.input.baseId !== baseId) {
+        continue
+      }
+      if ('itemId' in narrowed.input) {
+        activeRootItemIds.add(narrowed.input.itemId)
+      } else if (narrowed.type === 'knowledge.reindex-subtree') {
+        narrowed.input.rootItemIds.forEach((itemId) => activeRootItemIds.add(itemId))
+      }
+    }
+
+    if (activeRootItemIds.size === 0) {
+      return rootItemIds
+    }
+
+    const activeItemIds = new Set(
+      knowledgeItemService
+        .getSubtreeItems(baseId, [...activeRootItemIds], { includeRoots: true })
+        .map((item) => item.id)
+    )
+    return rootItemIds.filter((rootItemId) => {
+      const subtreeItems = knowledgeItemService.getSubtreeItems(baseId, [rootItemId], { includeRoots: true })
+      const subtreeItemById = new Map(subtreeItems.map((item) => [item.id, item]))
+      const coveredItemIds = new Set<string>()
+
+      for (const item of subtreeItems) {
+        if (!activeItemIds.has(item.id)) continue
+        coveredItemIds.add(item.id)
+        let parentId = item.groupId
+        while (parentId && subtreeItemById.has(parentId)) {
+          coveredItemIds.add(parentId)
+          parentId = subtreeItemById.get(parentId)?.groupId ?? null
+        }
+      }
+
+      if (coveredItemIds.size === 0) return true
+      return subtreeItems.some((item) => !REINDEX_ALLOWED_STATUSES.has(item.status) && !coveredItemIds.has(item.id))
+    })
+  }
+
+  private async assertSubtreeSourcesCanReindex(baseId: string, rootItemIds: string[]): Promise<void> {
     // rootItemIds comes from getOutermostSelectedItemIds, which guarantees the roots are mutually
     // non-descendant (disjoint subtrees), so one batched query's union equals the per-root sum.
     const subtreeItems = knowledgeItemService.getSubtreeItems(baseId, rootItemIds, { includeRoots: true })
@@ -496,14 +572,6 @@ export class KnowledgeIngestionService implements KnowledgeItemScheduler {
       }
     })
 
-    const blockingStatusCounts = new Map<KnowledgeItemStatus, number>()
-    for (const item of subtreeItems) {
-      if (REINDEX_ALLOWED_STATUSES.has(item.status)) {
-        continue
-      }
-      blockingStatusCounts.set(item.status, (blockingStatusCounts.get(item.status) ?? 0) + 1)
-    }
-
     if (missingSourceItemIds.length > 0) {
       throw DataApiErrorFactory.validation(
         {
@@ -521,10 +589,17 @@ export class KnowledgeIngestionService implements KnowledgeItemScheduler {
         'Could not verify the knowledge item source (it may be temporarily unavailable); please try again'
       )
     }
+  }
 
-    if (blockingStatusCounts.size === 0) {
-      return
+  private assertSubtreeStatusesCanReindex(baseId: string, rootItemIds: string[]): void {
+    const blockingStatusCounts = new Map<KnowledgeItemStatus, number>()
+    const subtreeItems = knowledgeItemService.getSubtreeItems(baseId, rootItemIds, { includeRoots: true })
+    for (const item of subtreeItems) {
+      if (REINDEX_ALLOWED_STATUSES.has(item.status)) continue
+      blockingStatusCounts.set(item.status, (blockingStatusCounts.get(item.status) ?? 0) + 1)
     }
+
+    if (blockingStatusCounts.size === 0) return
 
     const statusSummary = [...blockingStatusCounts.entries()]
       .sort(([left], [right]) => left.localeCompare(right))

--- a/src/main/features/knowledge/items.ts
+++ b/src/main/features/knowledge/items.ts
@@ -74,9 +74,9 @@ export async function classifyKnowledgeItemSource(
 
 /**
  * Whether a knowledge item can rebuild from a still-readable source. Gates reindex both at admission
- * (`KnowledgeIngestionService.assertSubtreesCanReindex`) and inside the reindex job's mutation lock right
- * before the delete — a vanished or unverifiable source must never wipe vectors with nothing to
- * rebuild from. Admission additionally distinguishes the two via {@link classifyKnowledgeItemSource}.
+ * (`KnowledgeIngestionService.assertSubtreeSourcesCanReindex`) and inside the reindex job's mutation
+ * lock right before the delete — a vanished or unverifiable source must never wipe vectors with
+ * nothing to rebuild from. Admission additionally distinguishes the two via {@link classifyKnowledgeItemSource}.
  */
 export async function canKnowledgeItemRebuildSource(baseId: string, item: KnowledgeItem): Promise<boolean> {
   return (await classifyKnowledgeItemSource(baseId, item)) === 'rebuildable'

--- a/src/main/features/knowledge/tasks/reindexSubtreeJobHandler.ts
+++ b/src/main/features/knowledge/tasks/reindexSubtreeJobHandler.ts
@@ -66,7 +66,7 @@ export function createReindexSubtreeJobHandler(
         const rootItems = subtreeResult.items
 
         const selectedRoots = rootItems.filter((item) => rootItemIds.includes(item.id))
-        // Admission (assertSubtreesCanReindex) already rejected roots whose source is gone, but the
+        // Admission already rejected roots whose source is gone, but the
         // source can vanish between admission and acquiring this lock. Re-check right before the delete:
         // a root that can no longer rebuild keeps its existing vectors (stays completed/searchable)
         // instead of being wiped with nothing to re-read from.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

- A bulk reindex request could hit the subtree status guard after active ingestion jobs had already moved two or more selected documents to `processing`. The request failed instead of joining the durable work already queued for those documents.
- `enableEmbeddingModel` could pass admission, commit the model, and then fail a second admission check when concurrent work changed an item status in between.

After this PR:

- Reindex admission serializes per knowledge base and coalesces roots whose blocking statuses are covered by active prepare/index/check/reindex jobs. A blocking item without active work still reaches the unchanged safety guard.
- Embedding-model backfill performs its fresh status check, model update, and reindex enqueue in one per-base critical section.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18508

### Why we need it and why it was done in this way

The reproduced race had two concrete server-side causes in `src/main/features/knowledge/ingestion/KnowledgeIngestionService.ts` on the pre-fix `upstream/main`:

1. `reindexItems` called `assertSubtreesCanReindex` at line 229 before the idempotent `knowledge.reindex-subtree` enqueue at lines 235-242. The guard therefore treated statuses backed by durable active jobs exactly like abandoned `processing` statuses and rejected the second concurrent request.
2. `enableEmbeddingModel` checked admission at line 263, updated the base at line 266, then called `reindexItems` at line 269, which repeated admission. A deterministic source-probe/concurrent-delete test proved that the model write could commit before the second check rejected the request.

The renderer bulk path in `DataSourcePanel.tsx:233-242` supplies every selected item, while the single-row action is status-gated in `KnowledgeItemRow.tsx:121,163-174`; the server therefore needs to safely handle duplicate bulk submissions rather than depend on the row-only UI gate.

The fix separates slow source validation from status validation. It keeps source probing outside the lock, then under the existing per-base mutex it reads active durable jobs, coalesces only explained subtrees, re-runs the unchanged status guard for every uncovered root, and enqueues the remaining work. This preserves the protection that prevents vectors from being deleted for a genuinely running, deleting, or stranded subtree.

The following tradeoffs were made:

- Only `prepare-root`, `index-documents`, `check-file-processing-result`, and `reindex-subtree` jobs count as reindex-compatible active work. Delete jobs remain blocking.
- Slow filesystem source checks remain outside the mutex; status-dependent mutation and enqueue decisions are made from fresh state inside it.
- Existing `completed`/`failed` admission semantics remain unchanged for roots not covered by active work.

The following alternatives were considered:

- Relaxing `REINDEX_ALLOWED_STATUSES` or removing the subtree guard was rejected because a reindex deletes vectors before rebuilding them.
- Treating every `processing` status as active was rejected because it would hide truly stranded items. A regression test keeps a processing sibling without an active job blocking.
- Changing Windows directory `fsync` handling was rejected: `src/main/utils/file/fs.ts:207-219` performs it after the atomic rename and catches failures as a durability warning, so the reported `EPERM` does not explain the SQLite status/admission race.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18508, https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvsavtfDL7eR

### Breaking changes

None.

### Special notes for your reviewer

Reproduction and regression evidence:

- Before the fix, a two-document test with active `knowledge.index-documents` jobs failed with `Cannot reindex knowledge item until the entire subtree is completed or failed`.
- Before the fix, the controlled `enableEmbeddingModel` race committed the model before the repeated admission check failed.
- After the fix, the seven focused knowledge suites pass 213 tests, including a real SQLite restore/reindex integration case, active two-item coalescing, TOCTOU prevention, and the stranded-sibling safety case.
- Failure/cancellation convergence was audited rather than changed: prepare/index/check handlers use `markKnowledgeItemFailedOnSettled`, reindex has equivalent settled cleanup, and boot recovery calls `failInterruptedItems`. Their focused cleanup tests pass.

Verification:

- `pnpm test:lint`
- `pnpm exec vitest run --project main <7 focused knowledge test files>` (213 passed)
- `pnpm typecheck:node`
- `pnpm typecheck:web`
- `pnpm exec oxlint --deny-warnings <5 changed files>`
- `pnpm build:check` (passed at `b91c71c24e`; the subsequent unrelated v2.0.5 release commit was rebased and the focused gates above were rerun at `757f04c0e8`)

#### 原始反馈（verbatim）

- 来源表：产研 dev 表「V2 问题反馈」，base `NM62bC0Epaqy0JsKjZYcQCn7nVd` / table `tblbuPFvvugxC8My`
- record_id：`recvsavtfDL7eR`
- 飞书链接：https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvsavtfDL7eR
- 提交人：许思寅（代录）；GitHub 原始作者 zangiefwins
- GitHub：CherryHQ/cherry-studio#18508 https://github.com/CherryHQ/cherry-studio/issues/18508 （状态 OPEN）
- 优先级 P1 / 类型 BUG / 状态 未修复 / 处理人为空
- 用户原话摘要：Windows 11 + Cherry Studio v2.0.3（Electron 41.8.0 / Node 24.16.0）。在同一知识库一次选择两个及以上文档并发嵌入时，部分文档长期停在「处理中」，部分索引失败且无法检索；单文档嵌入正常。日志显示重建保护在子树尚未全部 completed/failed 时被并发触发：`Cannot reindex knowledge item until the entire subtree is completed or failed`。
- 复现步骤（用户给的）：打开知识库 → 添加两个及以上 .md/.pdf 文档 → 同时触发嵌入/索引 → 观察部分文档卡在处理中并弹出错误 → 对比单文档嵌入正常。
- 用户备注里的重要限定：伴随出现的 Windows 目录 fsync EPERM 只表示持久性未确认，**不能当作已确认根因**，不要顺着它硬改。

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Concurrent knowledge-base reindex requests now join active ingestion work instead of failing while documents are still processing.
```
