### PR TITLE
fix(skills): only block skills on provable dependency gaps, and split SkillService

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -33,6 +33,7 @@ function makeCtx(overrides: Partial<ToolGuardContext> = {}): ToolGuardContext {
     permissionMode: 'default',
     builtinRole: undefined,
     mountedServers: WITHOUT_HOST_TOOLS,
+    pluginDirectories: new Map(),
     cwd: '/ws',
     agentDataPath: '/data',
     interaction: INTERACTIVE,

--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -10,7 +10,16 @@ import {
 import { evaluateToolGuards, type ToolGuardContext, validateToolGuardRules } from '@main/ai/toolApproval/toolGuards'
 import { SESSION_SEND_TOOL_NAME } from '@shared/ai/agentSessionDelivery'
 import { KB_MANAGE_TOOL_NAME } from '@shared/ai/builtinTools'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  checkSkillRuntimeDependencies: vi.fn<() => Promise<{ deny?: string; warning?: string }>>()
+}))
+
+vi.mock('../skillDependencies', () => ({
+  SKILL_TOOL_NAME: 'Skill',
+  checkSkillRuntimeDependencies: mocks.checkSkillRuntimeDependencies
+}))
 
 import { approvalRequiredRuntimeNames, CLAUDE_TOOL_GUARD_RULES, HEADLESS_INTERACTIVE_TOOL_DENIAL } from '../guardRules'
 
@@ -45,6 +54,11 @@ function makeCtx(overrides: Partial<ToolGuardContext> = {}): ToolGuardContext {
 const evaluate = (ctx: ToolGuardContext) => evaluateToolGuards(CLAUDE_TOOL_GUARD_RULES, ctx)
 
 describe('CLAUDE_TOOL_GUARD_RULES', () => {
+  beforeEach(() => {
+    mocks.checkSkillRuntimeDependencies.mockReset()
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({})
+  })
+
   it('is structurally valid', () => {
     expect(validateToolGuardRules(CLAUDE_TOOL_GUARD_RULES)).toEqual([])
   })
@@ -138,6 +152,34 @@ describe('CLAUDE_TOOL_GUARD_RULES', () => {
         })
       )
       expect(decision?.ruleId).toBe('global-install')
+    })
+  })
+
+  describe('skill-absent-dependency', () => {
+    it('denies a provably absent dependency in every mode, bypass included', async () => {
+      mocks.checkSkillRuntimeDependencies.mockResolvedValue({ deny: 'its forked subagent is not installed.' })
+
+      for (const mode of ['default', 'bypassPermissions'] as const) {
+        const decision = await evaluate(
+          makeCtx({ toolName: 'Skill', permissionMode: mode, input: { skill: 'parallel-web-search' } })
+        )
+        expect(decision).toEqual({
+          effect: 'deny',
+          reason: 'its forked subagent is not installed.',
+          ruleId: 'skill-absent-dependency'
+        })
+      }
+    })
+
+    it('leaves an advisory-only result to the hook plane', async () => {
+      mocks.checkSkillRuntimeDependencies.mockResolvedValue({ warning: 'may be missing runtime dependencies.' })
+
+      await expect(evaluate(makeCtx({ toolName: 'Skill', input: { skill: 'shadcn' } }))).resolves.toBeUndefined()
+    })
+
+    it('does not run the check when the call names no skill', async () => {
+      await expect(evaluate(makeCtx({ toolName: 'Skill', input: {} }))).resolves.toBeUndefined()
+      expect(mocks.checkSkillRuntimeDependencies).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
   listSkills: vi.fn(),
   listLocalSkillFolderNames: vi.fn(),
   getSkillPluginDirectory: vi.fn(),
+  checkSkillRuntimeDependencies: vi.fn(),
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createMcpBridgeServer: vi.fn(),
@@ -121,6 +122,12 @@ vi.mock('@main/ai/skills/SkillService', () => ({
     listLocalFolderNames: mocks.listLocalSkillFolderNames,
     getSkillPluginDirectory: mocks.getSkillPluginDirectory
   }
+}))
+
+vi.mock('../skillDependencies', () => ({
+  SKILL_TOOL_NAME: 'Skill',
+  buildPluginDirectoryIndex: vi.fn(async () => new Map()),
+  checkSkillRuntimeDependencies: mocks.checkSkillRuntimeDependencies
 }))
 
 vi.mock('@main/ai/agents/builtin/BuiltinAgentProvisioner', () => ({
@@ -331,6 +338,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.listSkills.mockResolvedValue([])
     mocks.listLocalSkillFolderNames.mockResolvedValue([])
     mocks.getSkillPluginDirectory.mockReturnValue('/app/feature.agents.claude.root')
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({})
     mocks.getBuiltinAgentPluginDirectory.mockReturnValue(undefined)
     mocks.loadBuiltinAgentDefinition.mockReturnValue(undefined)
   })
@@ -391,6 +399,56 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.settings).toMatchObject({ autoCompactEnabled: true, autoMemoryEnabled: false, fastMode: true })
     expect(settings).not.toHaveProperty('fastMode')
     expect(settings.forwardSubagentText).toBe(true)
+  })
+
+  async function runSkillDependencyHook(hookName: 'toolGuardHook' | 'skillDependencyAdvisoryHook') {
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+
+    const hook = settings.hooks?.PreToolUse?.[0]?.hooks.find((candidate) => candidate.name === hookName)
+    return hook?.(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'parallel-web-search', args: 'latest React release' }
+      } as never,
+      'tool-use-1',
+      {} as never
+    )
+  }
+
+  it('denies a skill before forked execution when a declared dependency is provably absent', async () => {
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({
+      deny: 'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
+    })
+
+    expect(await runSkillDependencyHook('toolGuardHook')).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason:
+          'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
+      }
+    })
+  })
+
+  it('lets an unresolved dependency through as context instead of a permission decision', async () => {
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({
+      warning: 'Skill "parallel-web-search" may be missing runtime dependencies.'
+    })
+
+    expect(await runSkillDependencyHook('skillDependencyAdvisoryHook')).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: 'Skill "parallel-web-search" may be missing runtime dependencies.'
+      }
+    })
   })
 
   it('appends root AGENTS.md context and wires lazy nested-instruction loading', async () => {
@@ -2468,8 +2526,9 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.steerHolder).toBeDefined()
 
     const preToolUse = settings.hooks?.PreToolUse?.[0]?.hooks
-    // toolGuardHook (the declarative guard table) + agentsMdHook + rtkRewriteHook + steerHook
-    expect(preToolUse).toHaveLength(4)
+    // toolGuardHook (the declarative guard table) + skillDependencyAdvisoryHook + agentsMdHook +
+    // rtkRewriteHook + steerHook
+    expect(preToolUse).toHaveLength(5)
 
     const steerHook = preToolUse?.find((hook) => hook.name === 'steerHook') as unknown as (input: {
       hook_event_name: string

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   listSkills: vi.fn(),
   listLocalSkillFolderNames: vi.fn(),
   getSkillPluginDirectory: vi.fn(),
-  validateSkillRuntimeDependencies: vi.fn(),
+  checkSkillRuntimeDependencies: vi.fn(),
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createMcpBridgeServer: vi.fn(),
@@ -104,9 +104,13 @@ vi.mock('@main/ai/skills/SkillService', () => ({
   skillService: {
     list: mocks.listSkills,
     listLocalFolderNames: mocks.listLocalSkillFolderNames,
-    getSkillPluginDirectory: mocks.getSkillPluginDirectory,
-    validateRuntimeDependencies: mocks.validateSkillRuntimeDependencies
+    getSkillPluginDirectory: mocks.getSkillPluginDirectory
   }
+}))
+
+vi.mock('../skillDependencies', () => ({
+  buildPluginDirectoryIndex: vi.fn(async () => new Map()),
+  checkSkillRuntimeDependencies: mocks.checkSkillRuntimeDependencies
 }))
 
 vi.mock('@main/ai/agents/builtin/BuiltinAgentProvisioner', () => ({
@@ -308,7 +312,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.listSkills.mockResolvedValue([])
     mocks.listLocalSkillFolderNames.mockResolvedValue([])
     mocks.getSkillPluginDirectory.mockReturnValue('/app/feature.agents.claude.root')
-    mocks.validateSkillRuntimeDependencies.mockResolvedValue(undefined)
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({})
     mocks.getBuiltinAgentPluginDirectory.mockReturnValue(undefined)
     mocks.loadBuiltinAgentDefinition.mockReturnValue(undefined)
   })
@@ -371,10 +375,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.forwardSubagentText).toBe(true)
   })
 
-  it('denies a skill before forked execution when its declared runtime dependencies are missing', async () => {
-    mocks.validateSkillRuntimeDependencies.mockResolvedValue(
-      'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
-    )
+  async function runSkillDependencyHook() {
     const settings = await buildClaudeCodeSessionSettings(
       {
         id: 'session-1',
@@ -387,7 +388,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     const hook = settings.hooks?.PreToolUse?.[0]?.hooks.find(
       (candidate) => candidate.name === 'skillRuntimeDependencyHook'
     )
-    const output = await hook?.(
+    return hook?.(
       {
         hook_event_name: 'PreToolUse',
         tool_name: 'Skill',
@@ -396,13 +397,32 @@ describe('buildClaudeCodeSessionSettings', () => {
       'tool-use-1',
       {} as never
     )
+  }
 
-    expect(output).toEqual({
+  it('denies a skill before forked execution when a declared dependency is provably absent', async () => {
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({
+      deny: 'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
+    })
+
+    expect(await runSkillDependencyHook()).toEqual({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
         permissionDecisionReason:
-          'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
+          'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
+      }
+    })
+  })
+
+  it('lets an unresolved dependency through as context instead of a permission decision', async () => {
+    mocks.checkSkillRuntimeDependencies.mockResolvedValue({
+      warning: 'Skill "parallel-web-search" may be missing runtime dependencies.'
+    })
+
+    expect(await runSkillDependencyHook()).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        additionalContext: 'Skill "parallel-web-search" may be missing runtime dependencies.'
       }
     })
   })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   listSkills: vi.fn(),
   listLocalSkillFolderNames: vi.fn(),
   getSkillPluginDirectory: vi.fn(),
+  validateSkillRuntimeDependencies: vi.fn(),
   modelGetByKey: vi.fn(),
   findBySessionId: vi.fn(),
   createMcpBridgeServer: vi.fn(),
@@ -103,7 +104,8 @@ vi.mock('@main/ai/skills/SkillService', () => ({
   skillService: {
     list: mocks.listSkills,
     listLocalFolderNames: mocks.listLocalSkillFolderNames,
-    getSkillPluginDirectory: mocks.getSkillPluginDirectory
+    getSkillPluginDirectory: mocks.getSkillPluginDirectory,
+    validateRuntimeDependencies: mocks.validateSkillRuntimeDependencies
   }
 }))
 
@@ -306,6 +308,7 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.listSkills.mockResolvedValue([])
     mocks.listLocalSkillFolderNames.mockResolvedValue([])
     mocks.getSkillPluginDirectory.mockReturnValue('/app/feature.agents.claude.root')
+    mocks.validateSkillRuntimeDependencies.mockResolvedValue(undefined)
     mocks.getBuiltinAgentPluginDirectory.mockReturnValue(undefined)
     mocks.loadBuiltinAgentDefinition.mockReturnValue(undefined)
   })
@@ -366,6 +369,42 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.settings).toMatchObject({ autoCompactEnabled: true, autoMemoryEnabled: false, fastMode: true })
     expect(settings).not.toHaveProperty('fastMode')
     expect(settings.forwardSubagentText).toBe(true)
+  })
+
+  it('denies a skill before forked execution when its declared runtime dependencies are missing', async () => {
+    mocks.validateSkillRuntimeDependencies.mockResolvedValue(
+      'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
+    )
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+
+    const hook = settings.hooks?.PreToolUse?.[0]?.hooks.find(
+      (candidate) => candidate.name === 'skillRuntimeDependencyHook'
+    )
+    const output = await hook?.(
+      {
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Skill',
+        tool_input: { skill: 'parallel-web-search', args: 'latest React release' }
+      } as never,
+      'tool-use-1',
+      {} as never
+    )
+
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason:
+          'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
+      }
+    })
   })
 
   it('appends root AGENTS.md context and wires lazy nested-instruction loading', async () => {
@@ -2210,12 +2249,6 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(settings.steerHolder).toBeDefined()
 
     const preToolUse = settings.hooks?.PreToolUse?.[0]?.hooks
-    // interactiveToolPermissionHook + headlessConfigMutationHook + headlessSkillInstallHook +
-    // disabledToolHook + assistantDestructiveOperationHook + assistantFeedbackSubmissionHook +
-    // supportBashPermissionHook + approvalRequiredToolHook + workspacePathHook + agentsMdHook +
-    // dependencyIsolationHook + rtkRewriteHook + steerHook
-    expect(preToolUse).toHaveLength(13)
-
     const steerHook = preToolUse?.find((hook) => hook.name === 'steerHook') as unknown as (input: {
       hook_event_name: string
     }) => Promise<{ continue?: boolean; hookSpecificOutput?: { additionalContext?: string } }>

--- a/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
@@ -7,13 +7,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   findExecutableInEnv: vi.fn<(name: string) => Promise<string | null>>(),
   getByFolderName: vi.fn(() => null as unknown),
+  listAll: vi.fn<() => Array<{ folderName: string; name: string }>>(),
   getInstalledSkillDirectory: vi.fn(() => ''),
   skillPluginDirectory: { value: '/nonexistent-claude-root' }
 }))
 
 vi.mock('@main/utils/commandResolver', () => ({ findExecutableInEnv: mocks.findExecutableInEnv }))
 vi.mock('@data/services/AgentGlobalSkillService', () => ({
-  agentGlobalSkillService: { getByFolderName: mocks.getByFolderName }
+  agentGlobalSkillService: { getByFolderName: mocks.getByFolderName, listAll: mocks.listAll }
 }))
 vi.mock('@main/ai/skills/SkillService', () => ({
   skillService: {
@@ -58,9 +59,22 @@ describe('checkSkillRuntimeDependencies', () => {
     return directory
   }
 
+  /** A library skill whose directory name and SKILL.md `name` disagree, as a bundle's often do. */
+  async function writeLibrarySkill(folderName: string, declaredName: string, frontmatter: string) {
+    const directory = path.join(await createTempDir('skill-deps-library-'), folderName)
+    await fs.promises.mkdir(directory, { recursive: true })
+    await fs.promises.writeFile(
+      path.join(directory, 'SKILL.md'),
+      `---\nname: ${declaredName}\ndescription: test skill\n${frontmatter}---\n\nBody\n`
+    )
+    mocks.getInstalledSkillDirectory.mockReturnValue(directory)
+    return directory
+  }
+
   beforeEach(() => {
     mocks.findExecutableInEnv.mockResolvedValue('/usr/bin/anything')
     mocks.getByFolderName.mockReturnValue(null)
+    mocks.listAll.mockReturnValue([])
     mocks.skillPluginDirectory.value = '/nonexistent-claude-root'
   })
 
@@ -187,6 +201,38 @@ describe('checkSkillRuntimeDependencies', () => {
     ])
 
     expect(mocks.findExecutableInEnv).toHaveBeenCalledExactlyOnceWith('jq')
+  })
+
+  // The installer names the folder after the bundle directory, so a name-addressed call would
+  // otherwise skip the check for every bundle whose directory does not match its `name`.
+  it('checks a library skill addressed by its SKILL.md name rather than its folder', async () => {
+    await writeLibrarySkill('vendor-bundle-dir', 'parallel-web-search', 'context: fork\nagent: parallel:missing\n')
+    mocks.listAll.mockReturnValue([{ folderName: 'vendor-bundle-dir', name: 'parallel-web-search' }])
+    const plugin = await writePlugin('parallel', ['some-other-agent'])
+
+    const result = await checkSkillRuntimeDependencies(
+      'parallel-web-search',
+      await createTempDir('skill-deps-workspace-'),
+      await buildPluginDirectoryIndex([plugin])
+    )
+
+    expect(result.deny).toContain('its forked subagent "parallel:missing" is not installed')
+  })
+
+  it('refuses to guess when the name matches more than one library skill', async () => {
+    mocks.listAll.mockReturnValue([
+      { folderName: 'first-copy', name: 'parallel-web-search' },
+      { folderName: 'second-copy', name: 'parallel-web-search' }
+    ])
+
+    const result = await checkSkillRuntimeDependencies(
+      'parallel-web-search',
+      await createTempDir('skill-deps-workspace-'),
+      new Map()
+    )
+
+    expect(result).toEqual({})
+    expect(mocks.getInstalledSkillDirectory).not.toHaveBeenCalled()
   })
 
   it('stays silent for a skill it cannot locate', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
@@ -69,7 +69,9 @@ describe('checkSkillRuntimeDependencies', () => {
     await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true, force: true })))
   })
 
-  it('denies a forked skill whose subagent plugin is not loaded', async () => {
+  // The index only holds the plugins settingsBuilder passes; the enabled setting sources let the SDK
+  // load others, so an unindexed plugin is not evidence that its subagent is missing.
+  it('warns instead of denying when the subagent plugin is not in the index', async () => {
     const workdir = await writeWorkspaceSkill(
       'parallel-web-search',
       'context: fork\nagent: parallel:parallel-subagent\n'
@@ -77,9 +79,8 @@ describe('checkSkillRuntimeDependencies', () => {
 
     const result = await checkSkillRuntimeDependencies('parallel-web-search', workdir, new Map())
 
-    expect(result.deny).toBe(
-      'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
-    )
+    expect(result.deny).toBeUndefined()
+    expect(result.warning).toContain('"parallel:parallel-subagent"')
   })
 
   it('denies a forked skill whose plugin is loaded but defines no such subagent', async () => {
@@ -163,12 +164,29 @@ describe('checkSkillRuntimeDependencies', () => {
       'parallel-web-search',
       'context: fork\nagent: parallel:parallel-subagent\nallowed-tools: Bash(parallel-cli:*)\n'
     )
+    const plugin = await writePlugin('parallel', ['some-other-agent'])
     mocks.findExecutableInEnv.mockResolvedValue(null)
 
-    const result = await checkSkillRuntimeDependencies('parallel-web-search', workdir, new Map())
+    const result = await checkSkillRuntimeDependencies(
+      'parallel-web-search',
+      workdir,
+      await buildPluginDirectoryIndex([plugin])
+    )
 
     expect(result.deny).toContain('its forked subagent "parallel:parallel-subagent" is not installed')
     expect(result.deny).toContain('the executable "parallel-cli"')
+  })
+
+  // The guard rule and the advisory hook both ask about the same tool call.
+  it('probes PATH once when both PreToolUse planes ask about the same call', async () => {
+    const workdir = await writeWorkspaceSkill('local-skill', 'allowed-tools: Bash(jq:*)\n')
+
+    await Promise.all([
+      checkSkillRuntimeDependencies('local-skill', workdir, new Map()),
+      checkSkillRuntimeDependencies('local-skill', workdir, new Map())
+    ])
+
+    expect(mocks.findExecutableInEnv).toHaveBeenCalledExactlyOnceWith('jq')
   })
 
   it('stays silent for a skill it cannot locate', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/skillDependencies.test.ts
@@ -1,0 +1,236 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findExecutableInEnv: vi.fn<(name: string) => Promise<string | null>>(),
+  getByFolderName: vi.fn(() => null as unknown),
+  getInstalledSkillDirectory: vi.fn(() => ''),
+  skillPluginDirectory: { value: '/nonexistent-claude-root' }
+}))
+
+vi.mock('@main/utils/commandResolver', () => ({ findExecutableInEnv: mocks.findExecutableInEnv }))
+vi.mock('@data/services/AgentGlobalSkillService', () => ({
+  agentGlobalSkillService: { getByFolderName: mocks.getByFolderName }
+}))
+vi.mock('@main/ai/skills/SkillService', () => ({
+  skillService: {
+    getInstalledSkillDirectory: mocks.getInstalledSkillDirectory,
+    getSkillPluginDirectory: () => mocks.skillPluginDirectory.value
+  }
+}))
+
+import { buildPluginDirectoryIndex, checkSkillRuntimeDependencies } from '../skillDependencies'
+
+describe('checkSkillRuntimeDependencies', () => {
+  const tempDirs: string[] = []
+
+  async function createTempDir(prefix: string) {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  /** Write a real SKILL.md so the frontmatter parser, not a stub, decides what was declared. */
+  async function writeWorkspaceSkill(name: string, frontmatter: string) {
+    const workdir = await createTempDir('skill-deps-workspace-')
+    const directory = path.join(workdir, '.claude', 'skills', name)
+    await fs.promises.mkdir(directory, { recursive: true })
+    await fs.promises.writeFile(
+      path.join(directory, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: test skill\n${frontmatter}---\n\nBody\n`
+    )
+    return workdir
+  }
+
+  async function writePlugin(name: string, agentNames: string[]) {
+    const directory = await createTempDir(`plugin-${name}-`)
+    await fs.promises.mkdir(path.join(directory, '.claude-plugin'), { recursive: true })
+    await fs.promises.writeFile(path.join(directory, '.claude-plugin', 'plugin.json'), JSON.stringify({ name }))
+    if (agentNames.length > 0) {
+      await fs.promises.mkdir(path.join(directory, 'agents'), { recursive: true })
+      for (const agentName of agentNames) {
+        await fs.promises.writeFile(path.join(directory, 'agents', `${agentName}.md`), '# Agent')
+      }
+    }
+    return directory
+  }
+
+  beforeEach(() => {
+    mocks.findExecutableInEnv.mockResolvedValue('/usr/bin/anything')
+    mocks.getByFolderName.mockReturnValue(null)
+    mocks.skillPluginDirectory.value = '/nonexistent-claude-root'
+  })
+
+  afterEach(async () => {
+    vi.clearAllMocks()
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true, force: true })))
+  })
+
+  it('denies a forked skill whose subagent plugin is not loaded', async () => {
+    const workdir = await writeWorkspaceSkill(
+      'parallel-web-search',
+      'context: fork\nagent: parallel:parallel-subagent\n'
+    )
+
+    const result = await checkSkillRuntimeDependencies('parallel-web-search', workdir, new Map())
+
+    expect(result.deny).toBe(
+      'Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.'
+    )
+  })
+
+  it('denies a forked skill whose plugin is loaded but defines no such subagent', async () => {
+    const workdir = await writeWorkspaceSkill(
+      'parallel-web-search',
+      'context: fork\nagent: parallel:parallel-subagent\n'
+    )
+    const plugin = await writePlugin('parallel', ['some-other-agent'])
+
+    const result = await checkSkillRuntimeDependencies(
+      'parallel-web-search',
+      workdir,
+      await buildPluginDirectoryIndex([plugin])
+    )
+
+    expect(result.deny).toContain('its forked subagent "parallel:parallel-subagent" is not installed')
+  })
+
+  it('allows a forked skill once its plugin subagent exists', async () => {
+    const workdir = await writeWorkspaceSkill(
+      'parallel-web-search',
+      'context: fork\nagent: parallel:parallel-subagent\n'
+    )
+    const plugin = await writePlugin('parallel', ['parallel-subagent'])
+
+    const result = await checkSkillRuntimeDependencies(
+      'parallel-web-search',
+      workdir,
+      await buildPluginDirectoryIndex([plugin])
+    )
+
+    expect(result).toEqual({})
+  })
+
+  it('warns instead of denying when a bare subagent name does not resolve', async () => {
+    const workdir = await writeWorkspaceSkill('reviewer-skill', 'context: fork\nagent: my-custom-reviewer\n')
+
+    const result = await checkSkillRuntimeDependencies('reviewer-skill', workdir, new Map())
+
+    expect(result.deny).toBeUndefined()
+    expect(result.warning).toContain('"my-custom-reviewer"')
+  })
+
+  it('treats SDK builtin subagents as available', async () => {
+    const workdir = await writeWorkspaceSkill('explore-skill', 'context: fork\nagent: general-purpose\n')
+
+    expect(await checkSkillRuntimeDependencies('explore-skill', workdir, new Map())).toEqual({})
+  })
+
+  it('ignores a declared agent when the skill does not fork', async () => {
+    const workdir = await writeWorkspaceSkill('inline-skill', 'agent: parallel:parallel-subagent\n')
+
+    expect(await checkSkillRuntimeDependencies('inline-skill', workdir, new Map())).toEqual({})
+  })
+
+  // allowed-tools entries are often interchangeable alternatives: shadcn declares three CLIs for the
+  // same operation, so an npm-only machine must still be able to run it.
+  it('never denies over allowed-tools executables and names the ones that did not resolve', async () => {
+    const workdir = await writeWorkspaceSkill(
+      'shadcn',
+      'allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)\n'
+    )
+    mocks.findExecutableInEnv.mockImplementation(async (name) => (name === 'npx' ? '/usr/bin/npx' : null))
+
+    const result = await checkSkillRuntimeDependencies('shadcn', workdir, new Map())
+
+    expect(result.deny).toBeUndefined()
+    expect(result.warning).toContain('the executables "pnpm", "bunx"')
+    expect(result.warning).not.toContain('"npx"')
+  })
+
+  it('skips shell builtins and stays silent when every declared executable resolves', async () => {
+    const workdir = await writeWorkspaceSkill('local-skill', 'allowed-tools: Bash(cd:*), Bash(echo:*), Bash(jq:*)\n')
+
+    expect(await checkSkillRuntimeDependencies('local-skill', workdir, new Map())).toEqual({})
+    expect(mocks.findExecutableInEnv).toHaveBeenCalledExactlyOnceWith('jq')
+  })
+
+  it('reports both gaps when a denied skill also declares an unresolved executable', async () => {
+    const workdir = await writeWorkspaceSkill(
+      'parallel-web-search',
+      'context: fork\nagent: parallel:parallel-subagent\nallowed-tools: Bash(parallel-cli:*)\n'
+    )
+    mocks.findExecutableInEnv.mockResolvedValue(null)
+
+    const result = await checkSkillRuntimeDependencies('parallel-web-search', workdir, new Map())
+
+    expect(result.deny).toContain('its forked subagent "parallel:parallel-subagent" is not installed')
+    expect(result.deny).toContain('the executable "parallel-cli"')
+  })
+
+  it('stays silent for a skill it cannot locate', async () => {
+    const workdir = await createTempDir('skill-deps-empty-')
+
+    expect(await checkSkillRuntimeDependencies('not-installed', workdir, new Map())).toEqual({})
+  })
+
+  it('resolves a plugin-qualified skill through its plugin directory', async () => {
+    const plugin = await writePlugin('parallel', [])
+    const skillDirectory = path.join(plugin, 'skills', 'web-search')
+    await fs.promises.mkdir(skillDirectory, { recursive: true })
+    await fs.promises.writeFile(
+      path.join(skillDirectory, 'SKILL.md'),
+      '---\nname: web-search\ndescription: test\ncontext: fork\nagent: parallel:missing-agent\n---\n\nBody\n'
+    )
+    const workdir = await createTempDir('skill-deps-workspace-')
+
+    const result = await checkSkillRuntimeDependencies(
+      'parallel:web-search',
+      workdir,
+      await buildPluginDirectoryIndex([plugin])
+    )
+
+    expect(result.deny).toContain('its forked subagent "parallel:missing-agent" is not installed')
+  })
+
+  it('resolves a bare subagent from the workspace and the Cherry plugin root', async () => {
+    const workdir = await writeWorkspaceSkill('reviewer-skill', 'context: fork\nagent: my-custom-reviewer\n')
+    await fs.promises.mkdir(path.join(workdir, '.claude', 'agents'), { recursive: true })
+    await fs.promises.writeFile(path.join(workdir, '.claude', 'agents', 'my-custom-reviewer.md'), '# Agent')
+
+    expect(await checkSkillRuntimeDependencies('reviewer-skill', workdir, new Map())).toEqual({})
+
+    await fs.promises.rm(path.join(workdir, '.claude', 'agents'), { recursive: true })
+    const claudeRoot = await createTempDir('claude-root-')
+    await fs.promises.mkdir(path.join(claudeRoot, 'agents'), { recursive: true })
+    await fs.promises.writeFile(path.join(claudeRoot, 'agents', 'my-custom-reviewer.md'), '# Agent')
+    mocks.skillPluginDirectory.value = claudeRoot
+
+    expect(await checkSkillRuntimeDependencies('reviewer-skill', workdir, new Map())).toEqual({})
+  })
+})
+
+describe('buildPluginDirectoryIndex', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true, force: true })))
+  })
+
+  it('skips unreadable and malformed manifests instead of failing the session', async () => {
+    const good = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'plugin-good-'))
+    const broken = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'plugin-broken-'))
+    tempDirs.push(good, broken)
+    await fs.promises.mkdir(path.join(good, '.claude-plugin'), { recursive: true })
+    await fs.promises.mkdir(path.join(broken, '.claude-plugin'), { recursive: true })
+    await fs.promises.writeFile(path.join(good, '.claude-plugin', 'plugin.json'), '{"name":"good"}')
+    await fs.promises.writeFile(path.join(broken, '.claude-plugin', 'plugin.json'), '{ not json')
+
+    const index = await buildPluginDirectoryIndex([good, broken, '/nonexistent-plugin'])
+
+    expect(index).toEqual(new Map([['good', good]]))
+  })
+})

--- a/src/main/ai/runtime/claudeCode/guardRules.ts
+++ b/src/main/ai/runtime/claudeCode/guardRules.ts
@@ -25,6 +25,7 @@ import { CONFIG_TOOL_NAME } from '@shared/ai/builtinTools'
 import { claudeToolRequiresUserInteraction } from '@shared/ai/claudecode/toolRegistry'
 
 import { isPathWithinAllowedRoots } from './pathContainment'
+import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
 
 export const ASK_USER_QUESTION_TOOL_NAME = 'AskUserQuestion'
 export const HEADLESS_INTERACTIVE_TOOL_DENIAL =
@@ -83,6 +84,13 @@ const pathOutsideAllowedRoots = async (ctx: ToolGuardContext): Promise<GuardHit 
   return { evidence: requestedPath }
 }
 
+const skillWithAbsentDependency = async (ctx: ToolGuardContext): Promise<GuardHit | null> => {
+  const skillName = ctx.input?.skill
+  if (typeof skillName !== 'string' || !skillName) return null
+  const { deny } = await checkSkillRuntimeDependencies(skillName, ctx.cwd, ctx.pluginDirectories)
+  return deny ? { evidence: deny } : null
+}
+
 const matchesRequiredApproval = (ctx: ToolGuardContext, bypassApproval: 'lift' | 'enforce'): GuardHit | null => {
   const policy = findBuiltinToolPolicy(ctx.toolName, ctx.mountedServers)
   return policy?.approval === 'required' && policy.bypassApproval === bypassApproval ? {} : null
@@ -105,6 +113,16 @@ const CROSS_CUTTING_TOOL_GUARD_RULES: readonly ToolGuardRule[] = [
     effect: 'deny',
     reason: (hit) =>
       `Blocked to avoid cross-agent dependency pollution: ${hit.evidence}. Install project dependencies in the current workspace (e.g. \`bun install <pkg>\`, or \`uv run --with <pkg> python\` for Python). For one-off tools use \`bun x <tool>\` / \`uvx <tool>\`; for persistent CLIs use \`cli_search\` then \`cli_install\`.`
+  },
+  {
+    // The SDK forks a skill whether or not its declared subagent exists, degrading into unrelated
+    // output instead of an error. Only a provably absent dependency blocks; everything else is
+    // advisory context (see skillDependencies). Not an approval — bypassPermissions does not lift it.
+    id: 'skill-absent-dependency',
+    bypassBehavior: 'enforce',
+    match: { tool: SKILL_TOOL_NAME, when: skillWithAbsentDependency },
+    effect: 'deny',
+    reason: (hit) => hit.evidence ?? 'The skill declares a runtime dependency that is not installed.'
   },
   {
     id: 'headless-config-mutation',

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -21,6 +21,7 @@ import { rtkRewrite } from '@main/utils/rtk'
 import type { AgentRuntimeUserInput } from '../types'
 import type { AgentsMdLoader } from './AgentsMdLoader'
 import { CLAUDE_TOOL_GUARD_RULES } from './guardRules'
+import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
 import type { ClaudeCodeSettings } from './types'
 
 const logger = loggerService.withContext('ClaudeCodeHooks')
@@ -57,6 +58,8 @@ export interface ClaudeCodeHookContext {
   builtinRole: string | undefined
   /** Cherry-owned MCP servers mounted for this session. */
   mountedServers: ReadonlySet<string>
+  /** Loaded plugin directories by manifest name; indexed once per session. */
+  pluginDirectories: ReadonlyMap<string, string>
   agentsMdLoader: AgentsMdLoader
 }
 
@@ -81,6 +84,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       permissionMode: snapshot?.getPermissionMode(),
       builtinRole: ctx.builtinRole,
       mountedServers: ctx.mountedServers,
+      pluginDirectories: ctx.pluginDirectories,
       cwd,
       agentDataPath,
       interaction: application.get('AgentSessionRuntimeService').getInteractionState(sessionId),
@@ -97,6 +101,22 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
         permissionDecisionReason: decision.reason
       }
     }
+  }
+
+  // Advisory half of the skill dependency check (the blocking half is a guard rule): an unresolved
+  // dependency that cannot be *proven* absent is surfaced to the model so it reports the failure
+  // instead of substituting unrelated output.
+  const skillDependencyAdvisoryHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || input.hook_event_name !== 'PreToolUse') return {}
+    const event = input as Record<string, unknown>
+    if (String(event.tool_name ?? '') !== SKILL_TOOL_NAME) return {}
+    const skillName = (event.tool_input as Record<string, unknown> | undefined)?.skill
+    if (typeof skillName !== 'string' || !skillName) return {}
+
+    const { warning } = await checkSkillRuntimeDependencies(skillName, cwd, ctx.pluginDirectories)
+    if (!warning) return {}
+    logger.debug('Skill declares unresolved runtime dependencies', { sessionId, skillName, warning })
+    return { hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: warning } }
   }
 
   const rtkRewriteHook: HookCallback = async (input): Promise<HookJSONOutput> => {
@@ -173,7 +193,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
   }
 
   return {
-    PreToolUse: [{ hooks: [toolGuardHook, agentsMdHook, rtkRewriteHook, steerHook] }],
+    PreToolUse: [{ hooks: [toolGuardHook, skillDependencyAdvisoryHook, agentsMdHook, rtkRewriteHook, steerHook] }],
     PostToolUse: [{ hooks: [postToolTimingHook] }],
     PostToolUseFailure: [{ hooks: [postToolTimingHook] }]
   }

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -73,6 +73,7 @@ import {
 } from './guardRules'
 import { buildClaudeCodeHooks, surfaceExitPlanModeInput } from './hooks'
 import { buildMcpServers, buildMcpToolMetadata, warmAgentMcpToolCaches } from './mcpCatalog'
+import { buildPluginDirectoryIndex } from './skillDependencies'
 import { decisionToPermissionResult } from './ToolApprovalRegistry'
 import type { ClaudeCodeSettings, McpToolDisplayMetadata } from './types'
 
@@ -199,7 +200,8 @@ export async function buildClaudeCodeSessionSettings(
     agent,
     mountedServers,
     agentDataPath,
-    agentsMdLoader
+    agentsMdLoader,
+    await buildPluginDirectoryIndex(plugins?.map((plugin) => plugin.path) ?? [])
   )
 
   // 5. System prompt. The citation guidance is gated on the same resolved scope that decides whether
@@ -409,7 +411,8 @@ async function buildToolPermissions(
   agent: AgentEntity,
   mountedServers: ReadonlySet<string>,
   agentDataPath: string,
-  agentsMdLoader: AgentsMdLoader
+  agentsMdLoader: AgentsMdLoader,
+  pluginDirectories: ReadonlyMap<string, string>
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
@@ -547,6 +550,7 @@ async function buildToolPermissions(
     agentDataPath,
     builtinRole,
     mountedServers,
+    pluginDirectories,
     agentsMdLoader
   })
 

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -104,6 +104,7 @@ import {
   isLarkFormSubmissionCommand,
   isPermanentDeletionToolName
 } from './assistantCommandSafety'
+import { buildPluginDirectoryIndex, checkSkillRuntimeDependencies } from './skillDependencies'
 import { decisionToPermissionResult } from './ToolApprovalRegistry'
 import type { ClaudeCodeSettings, McpToolDisplayMetadata, SteerHolder, ToolApprovalEmitterHolder } from './types'
 
@@ -490,7 +491,7 @@ export async function buildClaudeCodeSessionSettings(
     assistantMcpEnabled,
     agentDataPath,
     agentsMdLoader,
-    plugins?.map((plugin) => plugin.path) ?? []
+    await buildPluginDirectoryIndex(plugins?.map((plugin) => plugin.path) ?? [])
   )
 
   // 5. System prompt. The citation guidance is gated on the same resolved scope that decides whether
@@ -899,7 +900,7 @@ async function buildToolPermissions(
   assistantMcpEnabled: boolean,
   agentDataPath: string,
   agentsMdLoader: AgentsMdLoader,
-  pluginDirectories: readonly string[]
+  pluginDirectories: ReadonlyMap<string, string>
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
@@ -1154,16 +1155,18 @@ async function buildToolPermissions(
     const skillName = toolInput?.skill
     if (typeof skillName !== 'string' || !skillName) return {}
 
-    const reason = await skillService.validateRuntimeDependencies(skillName, cwd, pluginDirectories)
-    if (!reason) return {}
-    logger.info('Blocked skill with missing runtime dependencies', { sessionId: session.id, skillName, reason })
-    return {
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: reason
+    const { deny, warning } = await checkSkillRuntimeDependencies(skillName, cwd, pluginDirectories)
+    if (deny) {
+      logger.info('Blocked skill with an absent runtime dependency', { sessionId: session.id, skillName, deny })
+      return {
+        hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'deny', permissionDecisionReason: deny }
       }
     }
+    if (warning) {
+      logger.debug('Skill declares unresolved runtime dependencies', { sessionId: session.id, skillName, warning })
+      return { hookSpecificOutput: { hookEventName: 'PreToolUse', additionalContext: warning } }
+    }
+    return {}
   }
 
   // disabledTools enforcement runs as a PreToolUse hook, not in `canUseTool`: the SDK skips

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -489,7 +489,8 @@ export async function buildClaudeCodeSessionSettings(
     agent,
     assistantMcpEnabled,
     agentDataPath,
-    agentsMdLoader
+    agentsMdLoader,
+    plugins?.map((plugin) => plugin.path) ?? []
   )
 
   // 5. System prompt. The citation guidance is gated on the same resolved scope that decides whether
@@ -897,7 +898,8 @@ async function buildToolPermissions(
   agent: AgentEntity,
   assistantMcpEnabled: boolean,
   agentDataPath: string,
-  agentsMdLoader: AgentsMdLoader
+  agentsMdLoader: AgentsMdLoader,
+  pluginDirectories: readonly string[]
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
@@ -1144,6 +1146,26 @@ async function buildToolPermissions(
     }
   }
 
+  const skillRuntimeDependencyHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+    if (!input || input.hook_event_name !== 'PreToolUse') return {}
+    const toolName = String((input as Record<string, unknown>).tool_name ?? '')
+    if (toolName !== 'Skill') return {}
+    const toolInput = (input as Record<string, unknown>).tool_input as Record<string, unknown> | undefined
+    const skillName = toolInput?.skill
+    if (typeof skillName !== 'string' || !skillName) return {}
+
+    const reason = await skillService.validateRuntimeDependencies(skillName, cwd, pluginDirectories)
+    if (!reason) return {}
+    logger.info('Blocked skill with missing runtime dependencies', { sessionId: session.id, skillName, reason })
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason
+      }
+    }
+  }
+
   // disabledTools enforcement runs as a PreToolUse hook, not in `canUseTool`: the SDK skips
   // `canUseTool` for auto-approved paths (bypassPermissions / acceptEdits / default safe-tools), but
   // PreToolUse hooks fire on every tool call regardless of permission mode. The snapshot's disabled
@@ -1384,6 +1406,7 @@ async function buildToolPermissions(
             interactiveToolPermissionHook,
             headlessConfigMutationHook,
             headlessSkillInstallHook,
+            skillRuntimeDependencyHook,
             disabledToolHook,
             assistantDestructiveOperationHook,
             assistantFeedbackSubmissionHook,

--- a/src/main/ai/runtime/claudeCode/skillDependencies.ts
+++ b/src/main/ai/runtime/claudeCode/skillDependencies.ts
@@ -122,8 +122,13 @@ async function resolveSkillDirectory(
     return pluginDirectory ? path.join(pluginDirectory, 'skills', skillName.slice(separator + 1)) : null
   }
 
-  const installed = agentGlobalSkillService.getByFolderName(skillName)
-  if (installed) return skillService.getInstalledSkillDirectory(installed)
+  const byFolder = agentGlobalSkillService.getByFolderName(skillName)
+  if (byFolder) return skillService.getInstalledSkillDirectory(byFolder)
+
+  // The SDK addresses a skill by its SKILL.md `name` or its directory name, but the installer derives
+  // folderName from the bundle directory. Only a unique name match is safe to check a call against.
+  const byName = agentGlobalSkillService.listAll().filter((skill) => skill.name === skillName)
+  if (byName.length === 1) return skillService.getInstalledSkillDirectory(byName[0])
 
   const localDirectory = path.join(cwd, '.claude', 'skills', skillName)
   return (await findSkillMdPath(localDirectory)) ? localDirectory : null

--- a/src/main/ai/runtime/claudeCode/skillDependencies.ts
+++ b/src/main/ai/runtime/claudeCode/skillDependencies.ts
@@ -1,0 +1,159 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { agentGlobalSkillService } from '@data/services/AgentGlobalSkillService'
+import { skillService } from '@main/ai/skills/SkillService'
+import { findExecutableInEnv } from '@main/utils/commandResolver'
+import { findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
+
+/**
+ * Runtime dependency checks for the SDK's `Skill` tool. A skill declares its fork subagent and its
+ * Bash surface in frontmatter, and the SDK forks regardless of whether either resolves — a missing
+ * subagent degrades into unrelated output instead of an error.
+ *
+ * Only a plugin-qualified subagent can be *proven* absent (its plugin and agent file are both
+ * enumerable), so that is the only case that blocks. Everything else — an unresolvable bare agent
+ * name, a declared executable that is not on PATH — is reported as advisory context, because
+ * `allowed-tools` is a permission allowlist whose entries are frequently interchangeable
+ * alternatives, and PATH lookup cannot see commands the Bash tool reaches through Git Bash.
+ */
+
+export const SKILL_TOOL_NAME = 'Skill'
+
+const NAME_PATTERN = /^[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?$/
+const BASH_EXECUTABLE_PATTERN = /^Bash\(\s*([a-zA-Z0-9_][a-zA-Z0-9_-]{0,127})(?=[:\s)])/u
+const SDK_BUILTIN_SUBAGENTS = new Set(['claude', 'Explore', 'general-purpose', 'Plan', 'statusline-setup'])
+const SHELL_BUILTINS = new Set(
+  'cd command echo eval exec export false printf pwd read set source test true type unset'.split(' ')
+)
+
+export interface SkillDependencyCheck {
+  /** Set only when a declared dependency is provably absent. */
+  deny?: string
+  /** Advisory note for the model; never blocks the call. */
+  warning?: string
+}
+
+/** Index plugin directories by manifest name. Built once per session, not per tool call. */
+export async function buildPluginDirectoryIndex(directories: readonly string[]): Promise<Map<string, string>> {
+  const index = new Map<string, string>()
+  for (const directory of directories) {
+    try {
+      const manifest = JSON.parse(
+        await fs.promises.readFile(path.join(directory, '.claude-plugin', 'plugin.json'), 'utf-8')
+      ) as { name?: unknown }
+      if (typeof manifest.name === 'string' && !index.has(manifest.name)) index.set(manifest.name, directory)
+    } catch {
+      // The SDK owns reporting malformed plugin manifests.
+    }
+  }
+  return index
+}
+
+export async function checkSkillRuntimeDependencies(
+  skillName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<SkillDependencyCheck> {
+  const skillDirectory = await resolveSkillDirectory(skillName, cwd, pluginDirectories)
+  if (!skillDirectory) return {}
+
+  let metadata: Awaited<ReturnType<typeof parseSkillMetadata>>
+  try {
+    metadata = await parseSkillMetadata(skillDirectory, skillName, 'skills', { calculateSize: false })
+  } catch {
+    return {}
+  }
+
+  const notes: string[] = []
+  const executables = await findUnresolvedExecutables(metadata.allowed_tools ?? [])
+  if (executables.length > 0) {
+    const list = executables.map((name) => `"${name}"`).join(', ')
+    notes.push(
+      `It declares the ${executables.length === 1 ? 'executable' : 'executables'} ${list}, which did not resolve on this machine; if such a command fails, report that failure instead of substituting other content.`
+    )
+  }
+
+  const agentName = metadata.context === 'fork' ? metadata.agent : undefined
+  const agentStatus = agentName ? await resolveAgentStatus(agentName, cwd, pluginDirectories) : 'available'
+  if (agentStatus === 'absent') {
+    const head = `Skill "${skillName}" cannot run: its forked subagent "${agentName}" is not installed.`
+    return { deny: [head, ...notes].join(' ') }
+  }
+  if (agentStatus === 'unresolved') {
+    notes.unshift(`Its forked subagent "${agentName}" did not resolve in this session.`)
+  }
+
+  if (notes.length === 0) return {}
+  return { warning: [`Skill "${skillName}" may be missing runtime dependencies.`, ...notes].join(' ') }
+}
+
+async function resolveSkillDirectory(
+  skillName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<string | null> {
+  if (!NAME_PATTERN.test(skillName)) return null
+
+  const separator = skillName.indexOf(':')
+  if (separator >= 0) {
+    const pluginDirectory = pluginDirectories.get(skillName.slice(0, separator))
+    return pluginDirectory ? path.join(pluginDirectory, 'skills', skillName.slice(separator + 1)) : null
+  }
+
+  const installed = agentGlobalSkillService.getByFolderName(skillName)
+  if (installed) return skillService.getInstalledSkillDirectory(installed)
+
+  const localDirectory = path.join(cwd, '.claude', 'skills', skillName)
+  return (await findSkillMdPath(localDirectory)) ? localDirectory : null
+}
+
+/**
+ * `absent` is reserved for a plugin-qualified name whose plugin is loaded but has no such agent, or
+ * whose plugin is not loaded at all. A bare name that misses is `unresolved`: the SDK's builtin
+ * roster is a moving target, so a miss is not proof.
+ */
+async function resolveAgentStatus(
+  agentName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<'available' | 'unresolved' | 'absent'> {
+  if (!NAME_PATTERN.test(agentName)) return 'available'
+  if (SDK_BUILTIN_SUBAGENTS.has(agentName)) return 'available'
+
+  const separator = agentName.indexOf(':')
+  if (separator >= 0) {
+    const pluginDirectory = pluginDirectories.get(agentName.slice(0, separator))
+    if (!pluginDirectory) return 'absent'
+    const definition = path.join(pluginDirectory, 'agents', `${agentName.slice(separator + 1)}.md`)
+    return (await isFile(definition)) ? 'available' : 'absent'
+  }
+
+  const roots = [path.join(cwd, '.claude'), skillService.getSkillPluginDirectory(), ...pluginDirectories.values()]
+  for (const root of roots) {
+    if (await isFile(path.join(root, 'agents', `${agentName}.md`))) return 'available'
+  }
+  return 'unresolved'
+}
+
+async function findUnresolvedExecutables(allowedTools: readonly string[]): Promise<string[]> {
+  const declared = Array.from(
+    new Set(
+      allowedTools
+        .map((tool) => tool.match(BASH_EXECUTABLE_PATTERN)?.[1])
+        .filter((name): name is string => typeof name === 'string' && !SHELL_BUILTINS.has(name))
+    )
+  )
+  const resolved = await Promise.all(
+    declared.map(async (name) => ((await findExecutableInEnv(name)) ? undefined : name))
+  )
+  return resolved.filter((name): name is string => name !== undefined)
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}

--- a/src/main/ai/runtime/claudeCode/skillDependencies.ts
+++ b/src/main/ai/runtime/claudeCode/skillDependencies.ts
@@ -50,7 +50,28 @@ export async function buildPluginDirectoryIndex(directories: readonly string[]):
   return index
 }
 
-export async function checkSkillRuntimeDependencies(
+const inFlightChecks = new Map<string, Promise<SkillDependencyCheck>>()
+
+/**
+ * Both PreToolUse planes ask about the same tool call — the guard rule for `deny`, the advisory hook
+ * for `warning` — so share the in-flight run instead of re-parsing SKILL.md and re-probing PATH
+ * twice. The entry is dropped as soon as it settles; nothing is cached across tool calls.
+ */
+export function checkSkillRuntimeDependencies(
+  skillName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<SkillDependencyCheck> {
+  const key = `${cwd}\0${skillName}`
+  const shared = inFlightChecks.get(key)
+  if (shared) return shared
+
+  const check = runDependencyCheck(skillName, cwd, pluginDirectories).finally(() => inFlightChecks.delete(key))
+  inFlightChecks.set(key, check)
+  return check
+}
+
+async function runDependencyCheck(
   skillName: string,
   cwd: string,
   pluginDirectories: ReadonlyMap<string, string>
@@ -109,9 +130,10 @@ async function resolveSkillDirectory(
 }
 
 /**
- * `absent` is reserved for a plugin-qualified name whose plugin is loaded but has no such agent, or
- * whose plugin is not loaded at all. A bare name that misses is `unresolved`: the SDK's builtin
- * roster is a moving target, so a miss is not proof.
+ * `absent` is reserved for a plugin-qualified name whose plugin is indexed and has no such agent
+ * file — the one case the index can settle. A bare name that misses is `unresolved` (the SDK's
+ * builtin roster is a moving target), and so is an unindexed plugin: the index only holds what
+ * settingsBuilder passes as `plugins`, while the enabled setting sources let the SDK load more.
  */
 async function resolveAgentStatus(
   agentName: string,
@@ -124,7 +146,7 @@ async function resolveAgentStatus(
   const separator = agentName.indexOf(':')
   if (separator >= 0) {
     const pluginDirectory = pluginDirectories.get(agentName.slice(0, separator))
-    if (!pluginDirectory) return 'absent'
+    if (!pluginDirectory) return 'unresolved'
     const definition = path.join(pluginDirectory, 'agents', `${agentName.slice(separator + 1)}.md`)
     return (await isFile(definition)) ? 'available' : 'absent'
   }

--- a/src/main/ai/runtime/claudeCode/skillDependencies.ts
+++ b/src/main/ai/runtime/claudeCode/skillDependencies.ts
@@ -1,0 +1,157 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { agentGlobalSkillService } from '@data/services/AgentGlobalSkillService'
+import { skillService } from '@main/ai/skills/SkillService'
+import { findExecutableInEnv } from '@main/utils/commandResolver'
+import { findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
+
+/**
+ * Runtime dependency checks for the SDK's `Skill` tool. A skill declares its fork subagent and its
+ * Bash surface in frontmatter, and the SDK forks regardless of whether either resolves — a missing
+ * subagent degrades into unrelated output instead of an error.
+ *
+ * Only a plugin-qualified subagent can be *proven* absent (its plugin and agent file are both
+ * enumerable), so that is the only case that blocks. Everything else — an unresolvable bare agent
+ * name, a declared executable that is not on PATH — is reported as advisory context, because
+ * `allowed-tools` is a permission allowlist whose entries are frequently interchangeable
+ * alternatives, and PATH lookup cannot see commands the Bash tool reaches through Git Bash.
+ */
+
+const NAME_PATTERN = /^[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?$/
+const BASH_EXECUTABLE_PATTERN = /^Bash\(\s*([a-zA-Z0-9_][a-zA-Z0-9_-]{0,127})(?=[:\s)])/u
+const SDK_BUILTIN_SUBAGENTS = new Set(['claude', 'Explore', 'general-purpose', 'Plan', 'statusline-setup'])
+const SHELL_BUILTINS = new Set(
+  'cd command echo eval exec export false printf pwd read set source test true type unset'.split(' ')
+)
+
+export interface SkillDependencyCheck {
+  /** Set only when a declared dependency is provably absent. */
+  deny?: string
+  /** Advisory note for the model; never blocks the call. */
+  warning?: string
+}
+
+/** Index plugin directories by manifest name. Built once per session, not per tool call. */
+export async function buildPluginDirectoryIndex(directories: readonly string[]): Promise<Map<string, string>> {
+  const index = new Map<string, string>()
+  for (const directory of directories) {
+    try {
+      const manifest = JSON.parse(
+        await fs.promises.readFile(path.join(directory, '.claude-plugin', 'plugin.json'), 'utf-8')
+      ) as { name?: unknown }
+      if (typeof manifest.name === 'string' && !index.has(manifest.name)) index.set(manifest.name, directory)
+    } catch {
+      // The SDK owns reporting malformed plugin manifests.
+    }
+  }
+  return index
+}
+
+export async function checkSkillRuntimeDependencies(
+  skillName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<SkillDependencyCheck> {
+  const skillDirectory = await resolveSkillDirectory(skillName, cwd, pluginDirectories)
+  if (!skillDirectory) return {}
+
+  let metadata: Awaited<ReturnType<typeof parseSkillMetadata>>
+  try {
+    metadata = await parseSkillMetadata(skillDirectory, skillName, 'skills', { calculateSize: false })
+  } catch {
+    return {}
+  }
+
+  const notes: string[] = []
+  const executables = await findUnresolvedExecutables(metadata.allowed_tools ?? [])
+  if (executables.length > 0) {
+    const list = executables.map((name) => `"${name}"`).join(', ')
+    notes.push(
+      `It declares the ${executables.length === 1 ? 'executable' : 'executables'} ${list}, which did not resolve on this machine; if such a command fails, report that failure instead of substituting other content.`
+    )
+  }
+
+  const agentName = metadata.context === 'fork' ? metadata.agent : undefined
+  const agentStatus = agentName ? await resolveAgentStatus(agentName, cwd, pluginDirectories) : 'available'
+  if (agentStatus === 'absent') {
+    const head = `Skill "${skillName}" cannot run: its forked subagent "${agentName}" is not installed.`
+    return { deny: [head, ...notes].join(' ') }
+  }
+  if (agentStatus === 'unresolved') {
+    notes.unshift(`Its forked subagent "${agentName}" did not resolve in this session.`)
+  }
+
+  if (notes.length === 0) return {}
+  return { warning: [`Skill "${skillName}" may be missing runtime dependencies.`, ...notes].join(' ') }
+}
+
+async function resolveSkillDirectory(
+  skillName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<string | null> {
+  if (!NAME_PATTERN.test(skillName)) return null
+
+  const separator = skillName.indexOf(':')
+  if (separator >= 0) {
+    const pluginDirectory = pluginDirectories.get(skillName.slice(0, separator))
+    return pluginDirectory ? path.join(pluginDirectory, 'skills', skillName.slice(separator + 1)) : null
+  }
+
+  const installed = agentGlobalSkillService.getByFolderName(skillName)
+  if (installed) return skillService.getInstalledSkillDirectory(installed)
+
+  const localDirectory = path.join(cwd, '.claude', 'skills', skillName)
+  return (await findSkillMdPath(localDirectory)) ? localDirectory : null
+}
+
+/**
+ * `absent` is reserved for a plugin-qualified name whose plugin is loaded but has no such agent, or
+ * whose plugin is not loaded at all. A bare name that misses is `unresolved`: the SDK's builtin
+ * roster is a moving target, so a miss is not proof.
+ */
+async function resolveAgentStatus(
+  agentName: string,
+  cwd: string,
+  pluginDirectories: ReadonlyMap<string, string>
+): Promise<'available' | 'unresolved' | 'absent'> {
+  if (!NAME_PATTERN.test(agentName)) return 'available'
+  if (SDK_BUILTIN_SUBAGENTS.has(agentName)) return 'available'
+
+  const separator = agentName.indexOf(':')
+  if (separator >= 0) {
+    const pluginDirectory = pluginDirectories.get(agentName.slice(0, separator))
+    if (!pluginDirectory) return 'absent'
+    const definition = path.join(pluginDirectory, 'agents', `${agentName.slice(separator + 1)}.md`)
+    return (await isFile(definition)) ? 'available' : 'absent'
+  }
+
+  const roots = [path.join(cwd, '.claude'), skillService.getSkillPluginDirectory(), ...pluginDirectories.values()]
+  for (const root of roots) {
+    if (await isFile(path.join(root, 'agents', `${agentName}.md`))) return 'available'
+  }
+  return 'unresolved'
+}
+
+async function findUnresolvedExecutables(allowedTools: readonly string[]): Promise<string[]> {
+  const declared = Array.from(
+    new Set(
+      allowedTools
+        .map((tool) => tool.match(BASH_EXECUTABLE_PATTERN)?.[1])
+        .filter((name): name is string => typeof name === 'string' && !SHELL_BUILTINS.has(name))
+    )
+  )
+  const resolved = await Promise.all(
+    declared.map(async (name) => ((await findExecutableInEnv(name)) ? undefined : name))
+  )
+  return resolved.filter((name): name is string => name !== undefined)
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.promises.stat(filePath)).isFile()
+  } catch {
+    return false
+  }
+}

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -46,12 +46,6 @@ const MAX_FOLDER_NAME_LENGTH = 80
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
 const SKILLS_PLUGIN_MANIFEST = `${JSON.stringify({ name: 'cherry-studio-skills' }, null, 2)}\n`
 const BUILTIN_VERSION_FILE = '.version'
-const RUNTIME_SKILL_NAME_PATTERN = /^[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?$/
-const BASH_EXECUTABLE_PATTERN = /^Bash\(\s*([a-zA-Z0-9_][a-zA-Z0-9_-]{0,127})(?=[:\s)])/u
-const SDK_BUILTIN_SUBAGENTS = new Set(['claude', 'Explore', 'general-purpose', 'Plan', 'statusline-setup'])
-const SHELL_BUILTINS = new Set(
-  'cd command echo eval exec export false printf pwd read set source test true type unset'.split(' ')
-)
 
 function isOutsidePath(relativePath: string): boolean {
   return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
@@ -283,120 +277,6 @@ export class SkillService {
       if (await findSkillMdPath(skill.path)) names.push(skill.name)
     }
     return names
-  }
-
-  /** Return a user-facing error when a skill declares unavailable runtime dependencies. */
-  async validateRuntimeDependencies(
-    skillName: string,
-    cwd: string,
-    pluginDirectories: readonly string[]
-  ): Promise<string | undefined> {
-    const skillDirectory = await this.resolveRuntimeSkillDirectory(skillName, cwd, pluginDirectories)
-    if (!skillDirectory) return undefined
-
-    let metadata: Awaited<ReturnType<typeof parseSkillMetadata>>
-    try {
-      metadata = await parseSkillMetadata(skillDirectory, skillName, 'skills', { calculateSize: false })
-    } catch {
-      return undefined
-    }
-
-    const missing: string[] = []
-    if (
-      metadata.context === 'fork' &&
-      metadata.agent &&
-      !(await this.isRuntimeAgentAvailable(metadata.agent, cwd, pluginDirectories))
-    ) {
-      missing.push(`missing subagent "${metadata.agent}"`)
-    }
-
-    const executables = Array.from(
-      new Set(
-        (metadata.allowed_tools ?? [])
-          .map((tool) => tool.match(BASH_EXECUTABLE_PATTERN)?.[1])
-          .filter((name): name is string => typeof name === 'string' && !SHELL_BUILTINS.has(name))
-      )
-    )
-    const missingExecutables = (
-      await Promise.all(executables.map(async (name) => ((await findExecutableInEnv(name)) ? undefined : name)))
-    ).filter((name): name is string => name !== undefined)
-    if (missingExecutables.length > 0) {
-      missing.push(
-        `missing executable${missingExecutables.length === 1 ? '' : 's'} ${missingExecutables
-          .map((name) => `"${name}"`)
-          .join(', ')}`
-      )
-    }
-
-    return missing.length > 0 ? `Skill "${skillName}" cannot run: ${missing.join('; ')}.` : undefined
-  }
-
-  private async resolveRuntimeSkillDirectory(
-    skillName: string,
-    cwd: string,
-    pluginDirectories: readonly string[]
-  ): Promise<string | null> {
-    if (!RUNTIME_SKILL_NAME_PATTERN.test(skillName)) return null
-
-    const separator = skillName.indexOf(':')
-    if (separator >= 0) {
-      const pluginDirectory = await this.findPluginDirectory(skillName.slice(0, separator), pluginDirectories)
-      return pluginDirectory ? path.join(pluginDirectory, 'skills', skillName.slice(separator + 1)) : null
-    }
-
-    const installed = agentGlobalSkillService.getByFolderName(skillName)
-    if (installed) return this.getInstalledSkillDirectory(installed)
-
-    const localDirectory = path.join(cwd, '.claude', 'skills', skillName)
-    return (await findSkillMdPath(localDirectory)) ? localDirectory : null
-  }
-
-  private async isRuntimeAgentAvailable(
-    agentName: string,
-    cwd: string,
-    pluginDirectories: readonly string[]
-  ): Promise<boolean> {
-    if (!RUNTIME_SKILL_NAME_PATTERN.test(agentName)) return false
-    if (SDK_BUILTIN_SUBAGENTS.has(agentName)) return true
-
-    const separator = agentName.indexOf(':')
-    if (separator >= 0) {
-      const pluginDirectory = await this.findPluginDirectory(agentName.slice(0, separator), pluginDirectories)
-      return Boolean(
-        pluginDirectory &&
-          (await this.isReadableFile(path.join(pluginDirectory, 'agents', `${agentName.slice(separator + 1)}.md`)))
-      )
-    }
-
-    const roots = [path.join(cwd, '.claude'), this.getSkillPluginDirectory(), ...pluginDirectories]
-    for (const root of roots) {
-      if (await this.isReadableFile(path.join(root, 'agents', `${agentName}.md`))) return true
-    }
-    return false
-  }
-
-  private async findPluginDirectory(name: string, pluginDirectories: readonly string[]): Promise<string | null> {
-    for (const directory of pluginDirectories) {
-      try {
-        const manifest = JSON.parse(
-          await fs.promises.readFile(path.join(directory, '.claude-plugin', 'plugin.json'), 'utf-8')
-        ) as { name?: unknown }
-        if (manifest.name === name) return directory
-      } catch {
-        // The SDK owns reporting malformed plugin manifests.
-      }
-    }
-    return null
-  }
-
-  private async isReadableFile(filePath: string): Promise<boolean> {
-    try {
-      const stats = await fs.promises.stat(filePath)
-      await fs.promises.access(filePath, fs.constants.R_OK)
-      return stats.isFile()
-    } catch {
-      return false
-    }
   }
 
   private async listLocalSkillDirectories(workdir: string): Promise<Array<{ name: string; path: string }>> {

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -46,6 +46,12 @@ const MAX_FOLDER_NAME_LENGTH = 80
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
 const SKILLS_PLUGIN_MANIFEST = `${JSON.stringify({ name: 'cherry-studio-skills' }, null, 2)}\n`
 const BUILTIN_VERSION_FILE = '.version'
+const RUNTIME_SKILL_NAME_PATTERN = /^[a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?$/
+const BASH_EXECUTABLE_PATTERN = /^Bash\(\s*([a-zA-Z0-9_][a-zA-Z0-9_-]{0,127})(?=[:\s)])/u
+const SDK_BUILTIN_SUBAGENTS = new Set(['claude', 'Explore', 'general-purpose', 'Plan', 'statusline-setup'])
+const SHELL_BUILTINS = new Set(
+  'cd command echo eval exec export false printf pwd read set source test true type unset'.split(' ')
+)
 
 function isOutsidePath(relativePath: string): boolean {
   return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
@@ -277,6 +283,120 @@ export class SkillService {
       if (await findSkillMdPath(skill.path)) names.push(skill.name)
     }
     return names
+  }
+
+  /** Return a user-facing error when a skill declares unavailable runtime dependencies. */
+  async validateRuntimeDependencies(
+    skillName: string,
+    cwd: string,
+    pluginDirectories: readonly string[]
+  ): Promise<string | undefined> {
+    const skillDirectory = await this.resolveRuntimeSkillDirectory(skillName, cwd, pluginDirectories)
+    if (!skillDirectory) return undefined
+
+    let metadata: Awaited<ReturnType<typeof parseSkillMetadata>>
+    try {
+      metadata = await parseSkillMetadata(skillDirectory, skillName, 'skills', { calculateSize: false })
+    } catch {
+      return undefined
+    }
+
+    const missing: string[] = []
+    if (
+      metadata.context === 'fork' &&
+      metadata.agent &&
+      !(await this.isRuntimeAgentAvailable(metadata.agent, cwd, pluginDirectories))
+    ) {
+      missing.push(`missing subagent "${metadata.agent}"`)
+    }
+
+    const executables = Array.from(
+      new Set(
+        (metadata.allowed_tools ?? [])
+          .map((tool) => tool.match(BASH_EXECUTABLE_PATTERN)?.[1])
+          .filter((name): name is string => typeof name === 'string' && !SHELL_BUILTINS.has(name))
+      )
+    )
+    const missingExecutables = (
+      await Promise.all(executables.map(async (name) => ((await findExecutableInEnv(name)) ? undefined : name)))
+    ).filter((name): name is string => name !== undefined)
+    if (missingExecutables.length > 0) {
+      missing.push(
+        `missing executable${missingExecutables.length === 1 ? '' : 's'} ${missingExecutables
+          .map((name) => `"${name}"`)
+          .join(', ')}`
+      )
+    }
+
+    return missing.length > 0 ? `Skill "${skillName}" cannot run: ${missing.join('; ')}.` : undefined
+  }
+
+  private async resolveRuntimeSkillDirectory(
+    skillName: string,
+    cwd: string,
+    pluginDirectories: readonly string[]
+  ): Promise<string | null> {
+    if (!RUNTIME_SKILL_NAME_PATTERN.test(skillName)) return null
+
+    const separator = skillName.indexOf(':')
+    if (separator >= 0) {
+      const pluginDirectory = await this.findPluginDirectory(skillName.slice(0, separator), pluginDirectories)
+      return pluginDirectory ? path.join(pluginDirectory, 'skills', skillName.slice(separator + 1)) : null
+    }
+
+    const installed = agentGlobalSkillService.getByFolderName(skillName)
+    if (installed) return this.getInstalledSkillDirectory(installed)
+
+    const localDirectory = path.join(cwd, '.claude', 'skills', skillName)
+    return (await findSkillMdPath(localDirectory)) ? localDirectory : null
+  }
+
+  private async isRuntimeAgentAvailable(
+    agentName: string,
+    cwd: string,
+    pluginDirectories: readonly string[]
+  ): Promise<boolean> {
+    if (!RUNTIME_SKILL_NAME_PATTERN.test(agentName)) return false
+    if (SDK_BUILTIN_SUBAGENTS.has(agentName)) return true
+
+    const separator = agentName.indexOf(':')
+    if (separator >= 0) {
+      const pluginDirectory = await this.findPluginDirectory(agentName.slice(0, separator), pluginDirectories)
+      return Boolean(
+        pluginDirectory &&
+          (await this.isReadableFile(path.join(pluginDirectory, 'agents', `${agentName.slice(separator + 1)}.md`)))
+      )
+    }
+
+    const roots = [path.join(cwd, '.claude'), this.getSkillPluginDirectory(), ...pluginDirectories]
+    for (const root of roots) {
+      if (await this.isReadableFile(path.join(root, 'agents', `${agentName}.md`))) return true
+    }
+    return false
+  }
+
+  private async findPluginDirectory(name: string, pluginDirectories: readonly string[]): Promise<string | null> {
+    for (const directory of pluginDirectories) {
+      try {
+        const manifest = JSON.parse(
+          await fs.promises.readFile(path.join(directory, '.claude-plugin', 'plugin.json'), 'utf-8')
+        ) as { name?: unknown }
+        if (manifest.name === name) return directory
+      } catch {
+        // The SDK owns reporting malformed plugin manifests.
+      }
+    }
+    return null
+  }
+
+  private async isReadableFile(filePath: string): Promise<boolean> {
+    try {
+      const stats = await fs.promises.stat(filePath)
+      await fs.promises.access(filePath, fs.constants.R_OK)
+      return stats.isFile()
+    } catch {
+      return false
+    }
   }
 
   private async listLocalSkillDirectories(workdir: string): Promise<Array<{ name: string; path: string }>> {

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -7,14 +7,9 @@ import { application } from '@application'
 import { agentGlobalSkillService } from '@data/services/AgentGlobalSkillService'
 import { loggerService } from '@logger'
 import { isWin } from '@main/core/platform'
-import { getProxyEnvironment } from '@main/services/proxy/proxyEnv'
-import { findExecutableInEnv } from '@main/utils/commandResolver'
-import { deleteDirectoryRecursive } from '@main/utils/fileOperations'
 import { directoryExists } from '@main/utils/legacyFile'
 import { findAllSkillDirectories, findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
-import { executeCommand } from '@main/utils/processRunner'
 import { getShellEnv } from '@main/utils/shellEnv'
-import { assertZipEntriesWithin } from '@main/utils/zipSafety'
 import type { InstalledSkill, ListSkillsQuery } from '@shared/data/api/schemas/skills'
 import type {
   SkillFileNode,
@@ -26,70 +21,18 @@ import type {
   SystemSkillCandidate,
   SystemSkillPlacement
 } from '@shared/types/skill'
-import { ClawhubSkillDetailSchema } from '@shared/types/skill'
-import { encodeGithubPath, parseGithubSkillUrl } from '@shared/utils/skillMarketplace'
 import { Mutex } from 'async-mutex'
-import { net } from 'electron'
-import StreamZip from 'node-stream-zip'
 
+import { extractZip, resolveSkillDirectory, validateZipFile } from './skillArchive'
 import { SkillInstaller } from './SkillInstaller'
+import { buildFileTree, createTempDir, normalizeFolderKey, safeRemoveDirectory, sanitizeFolderName } from './skillPaths'
+import { fetchRemoteSkill } from './skillRemoteSource'
 import { buildSystemSkillSources } from './systemSkillSources'
 
 const logger = loggerService.withContext('SkillService')
 
-// API base URLs for the 3 search sources
-const CLAUDE_PLUGINS_API = 'https://api.claude-plugins.dev'
-
-// ZIP extraction limits
-const MAX_EXTRACTED_SIZE = 100 * 1024 * 1024 // 100MB
-const MAX_FILES_COUNT = 2000
-const MAX_FOLDER_NAME_LENGTH = 80
-// A direct-URL install points git at a repository nobody vetted; no single step may hang forever.
-const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
-const MAX_GIT_TREE_OUTPUT_BYTES = 16 * 1024 * 1024
 const SKILLS_PLUGIN_MANIFEST = `${JSON.stringify({ name: 'cherry-studio-skills' }, null, 2)}\n`
 const BUILTIN_VERSION_FILE = '.version'
-
-type GithubRef = {
-  name: string
-  oid: string
-  namespace: 'heads' | 'tags'
-}
-
-type GithubSkillTarget = { kind: 'root' } | { kind: 'directory'; path: string }
-
-type GithubRefResolution =
-  | { kind: 'resolved'; ref: GithubRef; target: GithubSkillTarget }
-  | { kind: 'ambiguous'; name: string }
-  | { kind: 'no-match' }
-
-function resolveGithubRef(refs: readonly GithubRef[], refAndPath: readonly string[]): GithubRefResolution {
-  const refsByName = new Map<string, GithubRef[]>()
-  for (const ref of refs) {
-    refsByName.set(ref.name, [...(refsByName.get(ref.name) ?? []), ref])
-  }
-
-  for (let length = refAndPath.length; length >= 1; length--) {
-    const name = refAndPath.slice(0, length).join('/')
-    const matches = refsByName.get(name)
-    if (!matches?.length) continue
-    if (matches.length > 1) return { kind: 'ambiguous', name }
-
-    return {
-      kind: 'resolved',
-      ref: matches[0],
-      target:
-        length === refAndPath.length
-          ? { kind: 'root' }
-          : { kind: 'directory', path: refAndPath.slice(length).join('/') }
-    }
-  }
-  return { kind: 'no-match' }
-}
-
-function isOutsidePath(relativePath: string): boolean {
-  return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
-}
 
 /**
  * Skill management service.
@@ -174,7 +117,7 @@ export class SkillService {
 
     const skillRoot = this.getMirrorPath(skill.folderName)
     try {
-      return await this.buildFileTree(skillRoot, skillRoot)
+      return await buildFileTree(skillRoot, skillRoot)
     } catch {
       return []
     }
@@ -189,7 +132,7 @@ export class SkillService {
   }
 
   async getByFolderName(name: string): Promise<InstalledSkill | null> {
-    const folderName = this.sanitizeFolderName(name)
+    const folderName = sanitizeFolderName(name)
     return agentGlobalSkillService.getByFolderName(folderName)
   }
 
@@ -198,7 +141,7 @@ export class SkillService {
    * the global Skills storage root.
    */
   getSkillDirectory(name: string): string {
-    return this.getSkillStoragePath(this.sanitizeFolderName(name))
+    return this.getSkillStoragePath(sanitizeFolderName(name))
   }
 
   /** Resolve the app-owned directory for an installed skill. */
@@ -233,21 +176,15 @@ export class SkillService {
    * or "github:{https URL of the skill's SKILL.md}".
    */
   async install(options: SkillInstallOptions): Promise<InstalledSkill> {
-    const { installSource } = options
-    const [source, ...rest] = installSource.split(':')
-    const identifier = rest.join(':')
+    const [source, ...rest] = options.installSource.split(':')
+    const fetched = await fetchRemoteSkill(source, rest.join(':'))
 
-    switch (source) {
-      case 'claude-plugins':
-        return this.installFromClaudePlugins(identifier)
-      case 'skills.sh':
-        return this.installFromSkillsSh(identifier)
-      case 'clawhub':
-        return this.installFromClawhub(identifier)
-      case 'github':
-        return this.installFromGithub(identifier)
-      default:
-        throw new Error(`Unknown install source: ${source}`)
+    try {
+      const installed = await this.installSkillDir(fetched.skillDir, 'marketplace', fetched.sourceUrl)
+      fetched.onInstalled?.()
+      return installed
+    } finally {
+      await safeRemoveDirectory(fetched.tempDir)
     }
   }
 
@@ -255,17 +192,17 @@ export class SkillService {
     const { zipFilePath } = options
     logger.info('Installing skill from ZIP', { zipFilePath })
 
-    await this.validateZipFile(zipFilePath)
+    await validateZipFile(zipFilePath)
     const canonicalZipPath = await fs.promises.realpath(zipFilePath)
     const sourceUrl = pathToFileURL(canonicalZipPath).href
-    const tempDir = await this.createTempDir('zip-install')
+    const tempDir = await createTempDir('zip-install')
 
     try {
-      await this.extractZip(canonicalZipPath, tempDir)
-      const skillDir = await this.locateSkillDir(tempDir)
+      await extractZip(canonicalZipPath, tempDir)
+      const skillDir = await resolveSkillDirectory(tempDir, null, null)
       return await this.installSkillDir(skillDir, 'zip', sourceUrl)
     } finally {
-      await this.safeRemoveDirectory(tempDir)
+      await safeRemoveDirectory(tempDir)
     }
   }
 
@@ -355,7 +292,7 @@ export class SkillService {
         }
       })
     )
-    const installedByFolder = new Map(installed.map((skill) => [this.normalizeFolderKey(skill.folderName), skill]))
+    const installedByFolder = new Map(installed.map((skill) => [normalizeFolderKey(skill.folderName), skill]))
     const managedRoot = await fs.promises
       .realpath(application.getPath('feature.agents.skills'))
       .catch(() => path.resolve(application.getPath('feature.agents.skills')))
@@ -386,9 +323,9 @@ export class SkillService {
           const metadata = await parseSkillMetadata(canonicalPath, skillDirectory.sourcePath, 'skills', {
             calculateSize: false
           })
-          const folderName = this.sanitizeFolderName(metadata.filename)
+          const folderName = sanitizeFolderName(metadata.filename)
           const registered = installedByPath.get(canonicalPath)
-          const folderConflict = installedByFolder.get(this.normalizeFolderKey(folderName))
+          const folderConflict = installedByFolder.get(normalizeFolderKey(folderName))
           const status = registered ? 'registered' : folderConflict ? 'conflict' : 'available'
 
           candidates.set(canonicalPath, {
@@ -488,365 +425,6 @@ export class SkillService {
   // Source-specific install flows
   // ===========================================================================
 
-  private async installFromClaudePlugins(identifier: string): Promise<InstalledSkill> {
-    const parts = identifier.split('/')
-    const [owner, repo, ...directoryParts] = parts
-    const directoryPath = directoryParts.join('/')
-    const skillName = directoryParts[directoryParts.length - 1] ?? ''
-
-    const invalidRepositoryPart = (part: string) =>
-      !part || part === '.' || part === '..' || !/^[a-zA-Z0-9_.-]+$/.test(part)
-    const invalidDirectoryPart = (part: string) =>
-      !part || part !== part.trim() || part === '.' || part === '..' || part.includes('\\') || part.includes('\0')
-
-    if (
-      invalidRepositoryPart(owner) ||
-      invalidRepositoryPart(repo) ||
-      !directoryPath ||
-      !skillName ||
-      directoryParts.some(invalidDirectoryPart)
-    ) {
-      throw new Error(`Invalid claude-plugins identifier: ${identifier}`)
-    }
-
-    const repoUrl = `https://github.com/${owner}/${repo}`
-    const sourceUrl = `${repoUrl}/tree/main/${directoryPath}`
-    const tempDir = await this.createTempDir('claude-plugins')
-
-    try {
-      await this.cloneRepository(repoUrl, tempDir)
-      const skillDir = await this.resolveSkillDirectory(tempDir, skillName, directoryPath)
-      const installed = await this.installSkillDir(skillDir, 'marketplace', sourceUrl)
-
-      this.reportInstall(owner, repo, skillName).catch((err) => {
-        logger.warn('Failed to report install', { error: err instanceof Error ? err.message : String(err) })
-      })
-
-      return installed
-    } finally {
-      await this.safeRemoveDirectory(tempDir)
-    }
-  }
-
-  /**
-   * Install the one skill a GitHub SKILL.md URL points at. No registry is involved: the URL carries
-   * the repo and the path, and the shared parser is the same one the UI validates with.
-   *
-   * A GitHub URL has no delimiter between the ref and the path, so the boundary is resolved against
-   * the repo's own refs. What gets fetched is the commit observed during that lookup, not the ref
-   * name again: a branch that moves in between would otherwise hand over different content than the
-   * one whose tree was inspected.
-   */
-  private async installFromGithub(identifier: string): Promise<InstalledSkill> {
-    const location = parseGithubSkillUrl(identifier)
-    if (!location) {
-      throw new Error(`Invalid GitHub skill URL: ${identifier}`)
-    }
-
-    const { owner, repo, refNamespace, refAndPath, descriptorFileName } = location
-    const repoUrl = `https://github.com/${owner}/${repo}`
-    const { ref, namespace, oid, target } = await this.resolveGithubCommit(repoUrl, refAndPath, refNamespace)
-    logger.info('Installing from GitHub', { owner, repo, ref, namespace, oid, target })
-
-    // Keep the resolved ref and namespace, not the commit, as the stored origin so equivalent URL
-    // forms update the same skill while a same-named branch and tag remain distinct.
-    const sourcePath = target.kind === 'root' ? ref : `${ref}/${target.path}`
-    const sourceUrl = namespace
-      ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${namespace}/${encodeGithubPath(`${sourcePath}/${descriptorFileName}`)}`
-      : `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
-    const tempDir = await this.createTempDir('github')
-
-    try {
-      const { contentDir, skillDir } = await this.materializeGithubTarget(
-        repoUrl,
-        oid,
-        target,
-        descriptorFileName,
-        tempDir
-      )
-      await this.validateRepositorySkillDirectory(contentDir, skillDir, path.join(skillDir, descriptorFileName))
-      await this.assertSkillDirectoryWithinLimits(skillDir)
-      return await this.installSkillDir(skillDir, 'marketplace', sourceUrl)
-    } finally {
-      await this.safeRemoveDirectory(tempDir)
-    }
-  }
-
-  /**
-   * Ask the remote where the ref ends and which commit it points at. A branch name may contain `/`,
-   * so `blob/feature/foo/skills/demo/SKILL.md` is only unambiguous once the repo's refs are known.
-   * A commit permalink needs no ref and is the one identity that cannot drift.
-   */
-  private async resolveGithubCommit(
-    repoUrl: string,
-    refAndPath: string[],
-    refNamespace: 'heads' | 'tags' | null
-  ): Promise<{ ref: string; namespace: 'heads' | 'tags' | null; oid: string; target: GithubSkillTarget }> {
-    const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
-    const output = await this.runGit(gitCommand, ['ls-remote', '--heads', '--tags', '--', repoUrl])
-    const refs = output.split('\n').flatMap((line) => {
-      const [oid, fullName] = line.split('\t').map((part) => part.trim())
-      // `^{}` marks a tag's dereferenced commit; the tag itself is already listed.
-      const match = fullName?.match(/^refs\/(heads|tags)\/(.+?)(?:\^\{\})?$/)
-      if (!oid || !match || fullName.endsWith('^{}')) return []
-      return [{ oid, namespace: match[1] as 'heads' | 'tags', name: match[2] }]
-    })
-
-    const matchingRefs = refNamespace ? refs.filter((ref) => ref.namespace === refNamespace) : refs
-    const resolution = resolveGithubRef(matchingRefs, refAndPath)
-    switch (resolution.kind) {
-      case 'resolved':
-        return {
-          ref: resolution.ref.name,
-          namespace: resolution.ref.namespace,
-          oid: resolution.ref.oid,
-          target: resolution.target
-        }
-      case 'ambiguous':
-        throw new Error(`${repoUrl} has both a branch and a tag named "${resolution.name}"; the URL cannot say which.`)
-      case 'no-match': {
-        const [head, ...rest] = refAndPath
-        // A permalink names its commit outright, so no ref has to match for it to be exact.
-        if (refNamespace === null && /^[0-9a-f]{40}$/i.test(head)) {
-          const target: GithubSkillTarget =
-            rest.length === 0 ? { kind: 'root' } : { kind: 'directory', path: rest.join('/') }
-          return { ref: head, namespace: null, oid: head.toLowerCase(), target }
-        }
-        throw new Error(`No branch or tag in ${repoUrl} matches "${refAndPath.join('/')}"`)
-      }
-    }
-  }
-
-  /**
-   * Fetch one commit into a bare repository and check out only installable content into a separate
-   * work tree. Keeping the two roots separate prevents a repository-root skill from copying `.git`.
-   */
-  private async materializeGithubTarget(
-    repoUrl: string,
-    oid: string,
-    target: GithubSkillTarget,
-    descriptorFileName: 'SKILL.md' | 'skill.md',
-    tempDir: string
-  ): Promise<{ contentDir: string; skillDir: string }> {
-    const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
-    const gitDir = path.join(tempDir, 'repo.git')
-    const contentDir = path.join(tempDir, 'content')
-    const git = (args: string[], options?: { maxOutputBytes?: number }) =>
-      this.runGit(gitCommand, [`--git-dir=${gitDir}`, ...args], options)
-
-    await fs.promises.mkdir(contentDir, { recursive: true })
-    await this.runGit(gitCommand, ['init', '--bare', '--quiet', gitDir])
-    await git(['fetch', '--quiet', '--depth', '1', '--filter=blob:none', '--no-tags', '--', repoUrl, oid])
-    const pathspec = target.kind === 'root' ? '.' : `:(top,literal)${target.path}`
-    const sizedTree = await git(
-      ['ls-tree', '-lr', '-z', '--full-tree', 'FETCH_HEAD', ...(target.kind === 'root' ? [] : ['--', pathspec])],
-      { maxOutputBytes: MAX_GIT_TREE_OUTPUT_BYTES }
-    )
-    this.assertGithubTargetTree(sizedTree, target, descriptorFileName)
-
-    await this.runGit(gitCommand, [
-      `--git-dir=${gitDir}`,
-      `--work-tree=${contentDir}`,
-      'checkout',
-      '--quiet',
-      'FETCH_HEAD',
-      '--',
-      pathspec
-    ])
-
-    return {
-      contentDir,
-      skillDir: target.kind === 'root' ? contentDir : path.join(contentDir, target.path)
-    }
-  }
-
-  /** Validate the selected Git tree before checkout writes any untrusted content. */
-  private assertGithubTargetTree(
-    sizedTree: string,
-    target: GithubSkillTarget,
-    descriptorFileName: 'SKILL.md' | 'skill.md'
-  ): void {
-    const foldKey = (value: string) => value.normalize('NFC').toLowerCase()
-    const targetParts = target.kind === 'root' ? [] : target.path.split('/')
-
-    const sizedEntries = sizedTree.split('\0').flatMap((record) => {
-      if (!record) return []
-      const tab = record.indexOf('\t')
-      if (tab === -1) return []
-      const [, type, , rawSize] = record.slice(0, tab).trim().split(/\s+/)
-      if (type !== 'blob' || !/^\d+$/.test(rawSize)) return []
-      const entryPath = record.slice(tab + 1)
-      const relativePath = target.kind === 'root' ? entryPath : entryPath.split('/').slice(targetParts.length).join('/')
-      return [{ path: relativePath, size: Number(rawSize) }]
-    })
-
-    const seenPaths = new Map<string, string>()
-    for (const entry of sizedEntries) {
-      const parts = entry.path.split('/')
-      for (let length = 1; length <= parts.length; length++) {
-        const prefix = parts.slice(0, length).join('/')
-        const key = parts.slice(0, length).map(foldKey).join('/')
-        const previous = seenPaths.get(key)
-        if (previous && previous !== prefix) {
-          throw new Error(
-            `The commit contains paths that collide once case and Unicode are normalized (${previous}, ${prefix}).`
-          )
-        }
-        seenPaths.set(key, prefix)
-      }
-    }
-
-    if (!sizedEntries.some((entry) => entry.path === descriptorFileName)) {
-      const location = target.kind === 'root' ? descriptorFileName : `${target.path}/${descriptorFileName}`
-      throw new Error(`No ${descriptorFileName} found at the selected GitHub location: ${location}`)
-    }
-    if (sizedEntries.length > MAX_FILES_COUNT) {
-      throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
-    }
-    const totalSize = sizedEntries.reduce((sum, entry) => sum + entry.size, 0)
-    if (totalSize > MAX_EXTRACTED_SIZE) {
-      throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
-    }
-  }
-
-  /** Apply the same ceilings an untrusted ZIP gets — a repository is no more trusted than an archive. */
-  private async assertSkillDirectoryWithinLimits(skillDir: string): Promise<void> {
-    let totalSize = 0
-    let fileCount = 0
-
-    const walk = async (directory: string): Promise<void> => {
-      for (const entry of await fs.promises.readdir(directory, { withFileTypes: true })) {
-        const entryPath = path.join(directory, entry.name)
-        if (entry.isDirectory()) {
-          await walk(entryPath)
-          continue
-        }
-        if (!entry.isFile()) continue
-
-        fileCount += 1
-        totalSize += (await fs.promises.stat(entryPath)).size
-        if (totalSize > MAX_EXTRACTED_SIZE) {
-          throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
-        }
-        if (fileCount > MAX_FILES_COUNT) {
-          throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
-        }
-      }
-    }
-
-    await walk(skillDir)
-  }
-
-  /**
-   * The single entry point for every git subprocess an install spawns: bounded, non-interactive, and
-   * routed through Cherry's proxy — which lives in the main process env, not in the captured login shell.
-   */
-  private async runGit(gitCommand: string, args: string[], options?: { maxOutputBytes?: number }): Promise<string> {
-    const env = await getShellEnv()
-    return executeCommand(gitCommand, args, {
-      capture: true,
-      maxOutputBytes: options?.maxOutputBytes,
-      timeout: GIT_COMMAND_TIMEOUT_MS,
-      env: {
-        ...env,
-        ...getProxyEnvironment(process.env),
-        GIT_TERMINAL_PROMPT: '0',
-        GIT_LFS_SKIP_SMUDGE: '1',
-        GIT_ASKPASS: '',
-        GCM_INTERACTIVE: 'never'
-      }
-    })
-  }
-
-  private async installFromSkillsSh(identifier: string): Promise<InstalledSkill> {
-    const parts = identifier.split('/')
-    if (parts.length !== 3 || parts.some((part) => !part)) {
-      throw new Error(`Invalid skills.sh identifier: ${identifier}`)
-    }
-    logger.info('Installing from skills.sh', { identifier })
-
-    const owner = parts[0]
-    const repo = parts[1]
-    const skillName = parts[2]
-    const repoUrl = `https://github.com/${owner}/${repo}`
-    const tempDir = await this.createTempDir('skills-sh')
-
-    try {
-      await this.cloneRepository(repoUrl, tempDir)
-      const skillDir = await this.resolveSkillDirectory(tempDir, skillName, null)
-      return await this.installSkillDir(skillDir, 'marketplace', repoUrl)
-    } finally {
-      await this.safeRemoveDirectory(tempDir)
-    }
-  }
-
-  private async installFromClawhub(identifier: string): Promise<InstalledSkill> {
-    const [ownerHandle, slug, ...extraParts] = identifier.split('/')
-    const invalidPart = (part: string | undefined) => !part || !/^[a-zA-Z0-9_.-]+$/.test(part)
-    if (extraParts.length > 0 || invalidPart(ownerHandle) || invalidPart(slug)) {
-      throw new Error(`Invalid clawhub identifier: ${identifier}`)
-    }
-
-    const detailUrl = new URL(`https://clawhub.ai/api/v1/skills/${encodeURIComponent(slug)}`)
-    detailUrl.searchParams.set('ownerHandle', ownerHandle)
-    const detailResp = await net.fetch(detailUrl.toString(), {
-      headers: { 'User-Agent': 'CherryStudio' }
-    })
-
-    if (!detailResp.ok) {
-      throw new Error(`clawhub detail failed: HTTP ${detailResp.status}`)
-    }
-
-    const detailResult = ClawhubSkillDetailSchema.safeParse(await detailResp.json())
-    if (!detailResult.success) {
-      throw new Error('clawhub detail returned invalid metadata')
-    }
-    if (
-      detailResult.data.skill.slug !== slug ||
-      detailResult.data.owner?.handle.toLowerCase() !== ownerHandle.toLowerCase()
-    ) {
-      throw new Error(`clawhub detail did not match the requested skill: ${identifier}`)
-    }
-
-    const sourceUrl = `https://clawhub.ai/${ownerHandle}/skills/${slug}`
-
-    const downloadUrl = new URL('https://clawhub.ai/api/v1/download')
-    downloadUrl.searchParams.set('slug', slug)
-    downloadUrl.searchParams.set('ownerHandle', ownerHandle)
-    const downloadResp = await net.fetch(downloadUrl.toString(), {
-      headers: { 'User-Agent': 'CherryStudio' }
-    })
-
-    if (!downloadResp.ok) {
-      throw new Error(`clawhub download failed: HTTP ${downloadResp.status}`)
-    }
-
-    const tempDir = await this.createTempDir('clawhub')
-    const zipPath = path.join(tempDir, 'skill.zip')
-
-    try {
-      const buffer = Buffer.from(await downloadResp.arrayBuffer())
-      await fs.promises.writeFile(zipPath, buffer)
-      const extractDir = path.join(tempDir, this.sanitizeFolderName(slug))
-      await fs.promises.mkdir(extractDir, { recursive: true })
-      await this.extractZip(zipPath, extractDir)
-      // ClawHub serves one published skill bundle whose descriptor is at the archive root. Nested
-      // SKILL.md files are supporting content, not alternative install candidates.
-      const skillMdPath = await findSkillMdPath(extractDir)
-      if (!skillMdPath) {
-        throw new Error(`No SKILL.md found at the clawhub archive root: ${identifier}`)
-      }
-      const skillDir = await this.validateRepositorySkillDirectory(extractDir, extractDir, skillMdPath)
-      const metadata = await parseSkillMetadata(skillDir, slug, 'skills', { calculateSize: false })
-      if ((metadata.slug ?? metadata.name).toLowerCase() !== slug.toLowerCase()) {
-        throw new Error(`clawhub archive did not match the requested skill: ${identifier}`)
-      }
-      return await this.installSkillDir(skillDir, 'marketplace', sourceUrl)
-    } finally {
-      await this.safeRemoveDirectory(tempDir)
-    }
-  }
-
   // ===========================================================================
   // Core install logic
   // ===========================================================================
@@ -872,7 +450,7 @@ export class SkillService {
 
     const skillsRoot = path.resolve(application.getPath('feature.agents.skills'))
     const isInPlace = path.resolve(path.dirname(skillDir)) === skillsRoot
-    const folderName = isInPlace ? path.basename(skillDir) : this.sanitizeFolderName(metadata.filename)
+    const folderName = isInPlace ? path.basename(skillDir) : sanitizeFolderName(metadata.filename)
 
     const existing = this.findCatalogSkillCaseInsensitive(folderName)
     if (existing) {
@@ -975,180 +553,6 @@ export class SkillService {
 
     logger.info('Skill installed', { id: inserted.id, name: metadata.name, folderName: destFolderName, source })
     return inserted
-  }
-
-  // ===========================================================================
-  // Git operations
-  // ===========================================================================
-
-  /**
-   * One shallow clone of whatever the remote calls its default branch — which is what a bare
-   * `git clone` already checks out, so resolving the branch first only adds a second way to hang.
-   */
-  private async cloneRepository(repoUrl: string, destDir: string): Promise<void> {
-    const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
-    await this.runGit(gitCommand, ['clone', '--depth', '1', '--', repoUrl, destDir])
-  }
-
-  // ===========================================================================
-  // ZIP operations
-  // ===========================================================================
-
-  private async validateZipFile(zipFilePath: string): Promise<void> {
-    const stats = await fs.promises.stat(zipFilePath)
-    if (!stats.isFile()) {
-      throw new Error(`Not a file: ${zipFilePath}`)
-    }
-    if (!zipFilePath.toLowerCase().endsWith('.zip')) {
-      throw new Error(`Not a ZIP file: ${zipFilePath}`)
-    }
-  }
-
-  private async extractZip(zipFilePath: string, destDir: string): Promise<void> {
-    const zip = new StreamZip.async({ file: zipFilePath })
-
-    try {
-      const entries = await zip.entries()
-      assertZipEntriesWithin(Object.keys(entries), destDir)
-      let totalSize = 0
-      let fileCount = 0
-
-      for (const entry of Object.values(entries)) {
-        totalSize += entry.size
-        fileCount++
-
-        if (totalSize > MAX_EXTRACTED_SIZE) {
-          throw new Error(`ZIP too large: ${totalSize} bytes exceeds ${MAX_EXTRACTED_SIZE}`)
-        }
-        if (fileCount > MAX_FILES_COUNT) {
-          throw new Error(`ZIP has too many files: ${fileCount} exceeds ${MAX_FILES_COUNT}`)
-        }
-      }
-
-      await zip.extract(null, destDir)
-    } finally {
-      await zip.close()
-    }
-  }
-
-  // ===========================================================================
-  // Directory resolution
-  // ===========================================================================
-
-  private async locateSkillDir(extractedDir: string): Promise<string> {
-    return this.resolveSkillDirectory(extractedDir, null, null)
-  }
-
-  /**
-   * A symlinked component silently redirects the requested path elsewhere in the repository, so an
-   * explicitly selected directory would install a skill other than the one shown to the user. The
-   * realpath containment check alone cannot see this: the target stays inside the repository.
-   */
-  private async assertNoSymlinkComponents(repoDir: string, relativePath: string): Promise<void> {
-    let current = repoDir
-    for (const part of relativePath.split(path.sep).filter(Boolean)) {
-      current = path.join(current, part)
-      const stats = await fs.promises.lstat(current).catch(() => null)
-      if (stats?.isSymbolicLink()) {
-        throw new Error(`Skill directory path passes through a symlink: ${relativePath}`)
-      }
-    }
-  }
-
-  private async resolveSkillDirectory(
-    repoDir: string,
-    skillName: string | null,
-    directoryPath: string | null
-  ): Promise<string> {
-    if (directoryPath) {
-      const resolved = path.resolve(repoDir, directoryPath)
-      // Reject a directoryPath that escapes the clone root — a crafted identifier could otherwise
-      // point install at an arbitrary local directory (path traversal).
-      const relative = path.relative(repoDir, resolved)
-      if (isOutsidePath(relative)) {
-        throw new Error(`Skill directory path escapes the repository: ${directoryPath}`)
-      }
-      await this.assertNoSymlinkComponents(repoDir, relative)
-      const skillMdPath = await findSkillMdPath(resolved)
-      if (skillMdPath) return this.validateRepositorySkillDirectory(repoDir, resolved, skillMdPath)
-
-      // Fail closed: an explicit directoryPath with no SKILL.md must NOT fall back to guessing a
-      // different candidate in the repo — the user confirmed skill A and must not get skill B.
-      throw new Error(`No SKILL.md found at the specified skill directory: ${directoryPath}`)
-    }
-
-    const candidates = await findAllSkillDirectories(repoDir, repoDir, 8)
-
-    if (skillName) {
-      const matches: typeof candidates = []
-      for (const candidate of candidates) {
-        try {
-          const metadata = await parseSkillMetadata(
-            candidate.folderPath,
-            candidate.sourcePath || path.basename(candidate.folderPath),
-            'skills',
-            { calculateSize: false }
-          )
-          if (metadata.name === skillName) matches.push(candidate)
-        } catch (error) {
-          logger.warn('Failed to parse repository skill candidate', {
-            folderPath: candidate.folderPath,
-            error: error instanceof Error ? error.message : String(error)
-          })
-        }
-      }
-
-      if (matches.length === 1) {
-        return this.validateRepositorySkillDirectory(repoDir, matches[0].folderPath)
-      }
-      if (matches.length > 1) {
-        throw new Error(`Multiple SKILL.md files declare the specified skill: ${skillName}`)
-      }
-      throw new Error(`No SKILL.md found for the specified skill: ${skillName}`)
-    }
-
-    if (candidates.length === 1) {
-      return this.validateRepositorySkillDirectory(repoDir, candidates[0].folderPath)
-    }
-
-    if (candidates.length > 0) {
-      logger.warn('resolveSkillDirectory: fallback to first candidate', {
-        directoryPath,
-        skillName,
-        candidateCount: candidates.length,
-        selected: candidates[0].folderPath
-      })
-      return this.validateRepositorySkillDirectory(repoDir, candidates[0].folderPath)
-    }
-
-    const rootSkill = await findSkillMdPath(repoDir)
-    if (rootSkill) return this.validateRepositorySkillDirectory(repoDir, repoDir, rootSkill)
-
-    throw new Error(`No skill directory found in ${repoDir}`)
-  }
-
-  private async validateRepositorySkillDirectory(
-    repoDir: string,
-    skillDir: string,
-    knownSkillMdPath?: string
-  ): Promise<string> {
-    const [repoRealPath, skillRealPath] = await Promise.all([
-      fs.promises.realpath(repoDir),
-      fs.promises.realpath(skillDir)
-    ])
-    const relativeSkillPath = path.relative(repoRealPath, skillRealPath)
-    if (isOutsidePath(relativeSkillPath)) {
-      throw new Error(`Skill directory resolves outside the repository: ${skillDir}`)
-    }
-
-    const skillMdPath = knownSkillMdPath ?? (await findSkillMdPath(skillRealPath))
-    if (!skillMdPath) throw new Error(`No SKILL.md found in ${skillDir}`)
-    const skillMdRealPath = await fs.promises.realpath(skillMdPath)
-    const relativeDescriptorPath = path.relative(repoRealPath, skillMdRealPath)
-    if (isOutsidePath(relativeDescriptorPath)) {
-      throw new Error(`Skill descriptor resolves outside the repository: ${skillMdPath}`)
-    }
-    return skillRealPath
   }
 
   // ===========================================================================
@@ -1346,7 +750,7 @@ export class SkillService {
     const dbSkills = agentGlobalSkillService.listAll()
     const dbGroups = new Map<string, InstalledSkill[]>()
     for (const skill of dbSkills) {
-      const key = this.normalizeFolderKey(skill.folderName)
+      const key = normalizeFolderKey(skill.folderName)
       const group = dbGroups.get(key)
       if (group) group.push(skill)
       else dbGroups.set(key, [skill])
@@ -1389,7 +793,7 @@ export class SkillService {
         continue
       }
       if (!entry.isDirectory()) continue
-      const folderKey = this.normalizeFolderKey(entry.name)
+      const folderKey = normalizeFolderKey(entry.name)
       const group = directoryGroups.get(folderKey)
       if (group) group.push(entry)
       else directoryGroups.set(folderKey, [entry])
@@ -1421,7 +825,7 @@ export class SkillService {
     }
 
     for (const [folderName, contentHash] of onDisk) {
-      const folderKey = this.normalizeFolderKey(folderName)
+      const folderKey = normalizeFolderKey(folderName)
       if (conflictingDbKeys.has(folderKey)) continue
 
       const existing = dbByFolder.get(folderKey)
@@ -1476,7 +880,7 @@ export class SkillService {
       if (skill.source === 'builtin') continue
       // Prune ONLY when the whole folder is gone from disk. A present folder whose descriptor is
       // momentarily missing/unreadable (atomic save, EACCES) keeps its row — see presentFolders.
-      if (presentFolders.has(this.normalizeFolderKey(skill.folderName))) continue
+      if (presentFolders.has(normalizeFolderKey(skill.folderName))) continue
       // Agent file tools write outside mutationLock. Recheck the canonical path immediately before
       // deleting so a folder recreated after the initial readdir snapshot keeps its row and all
       // agent_skill enablement.
@@ -1504,10 +908,10 @@ export class SkillService {
    */
   private async reconcileMirror(): Promise<void> {
     const all = agentGlobalSkillService.listAll()
-    const known = new Set(all.map((s) => this.normalizeFolderKey(s.folderName)))
+    const known = new Set(all.map((s) => normalizeFolderKey(s.folderName)))
     const groups = new Map<string, InstalledSkill[]>()
     for (const skill of all) {
-      const key = this.normalizeFolderKey(skill.folderName)
+      const key = normalizeFolderKey(skill.folderName)
       const group = groups.get(key)
       if (group) group.push(skill)
       else groups.set(key, [skill])
@@ -1538,7 +942,7 @@ export class SkillService {
     for (const entry of entries) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
       const folderName = entry.name
-      if (known.has(this.normalizeFolderKey(folderName))) continue
+      if (known.has(normalizeFolderKey(folderName))) continue
 
       // This is an app-owned one-way projection. Unknown entries are either stale POSIX symlinks,
       // stale Windows directory copies, or out-of-band writes; none belong in the SDK discovery root.
@@ -1594,10 +998,6 @@ export class SkillService {
     }
   }
 
-  private normalizeFolderKey(folderName: string): string {
-    return folderName.toLowerCase()
-  }
-
   private computeBuiltinDirectoryHash(skillDir: string): Promise<string> {
     return this.installer.computeDirectoryHash(skillDir, {
       ignoredRelativePaths: [BUILTIN_VERSION_FILE]
@@ -1605,10 +1005,8 @@ export class SkillService {
   }
 
   private findCatalogSkillCaseInsensitive(folderName: string): InstalledSkill | null {
-    const key = this.normalizeFolderKey(folderName)
-    const matches = agentGlobalSkillService
-      .listAll()
-      .filter((skill) => this.normalizeFolderKey(skill.folderName) === key)
+    const key = normalizeFolderKey(folderName)
+    const matches = agentGlobalSkillService.listAll().filter((skill) => normalizeFolderKey(skill.folderName) === key)
     if (matches.length > 1) {
       throw new Error(
         `Multiple catalog skills conflict by case for "${folderName}": ${matches.map((skill) => skill.folderName).join(', ')}`
@@ -1626,73 +1024,14 @@ export class SkillService {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw error
     }
-    const key = this.normalizeFolderKey(folderName)
-    const matches = entries.filter(
-      (entry) => !entry.name.startsWith('.') && this.normalizeFolderKey(entry.name) === key
-    )
+    const key = normalizeFolderKey(folderName)
+    const matches = entries.filter((entry) => !entry.name.startsWith('.') && normalizeFolderKey(entry.name) === key)
     if (matches.length > 1) {
       throw new Error(
         `Multiple library directories conflict by case for "${folderName}": ${matches.map((entry) => entry.name).join(', ')}`
       )
     }
     return matches[0]?.name ?? null
-  }
-
-  private sanitizeFolderName(folderName: string): string {
-    let sanitized = folderName.replace(/[/\\]/g, '_')
-    sanitized = sanitized.replace(new RegExp(String.fromCharCode(0), 'g'), '')
-    sanitized = sanitized.replace(/[^a-zA-Z0-9_-]/g, '_')
-
-    if (sanitized.length > MAX_FOLDER_NAME_LENGTH) {
-      sanitized = sanitized.slice(0, MAX_FOLDER_NAME_LENGTH)
-    }
-
-    return sanitized
-  }
-
-  private async createTempDir(prefix: string): Promise<string> {
-    const root = application.getPath('feature.agents.skills.install.temp')
-    await fs.promises.mkdir(root, { recursive: true })
-    // mkdtemp, not a timestamp: two installs starting in the same millisecond would otherwise share
-    // one workspace and delete each other's checkout on cleanup.
-    return fs.promises.mkdtemp(path.join(root, `${prefix}-`))
-  }
-
-  private async safeRemoveDirectory(dirPath: string): Promise<void> {
-    try {
-      await deleteDirectoryRecursive(dirPath)
-    } catch (error) {
-      logger.warn('Failed to clean up temp directory', {
-        dirPath,
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
-  }
-
-  private async buildFileTree(dir: string, root: string): Promise<SkillFileNode[]> {
-    const entries = await fs.promises.readdir(dir, { withFileTypes: true })
-    const nodes: SkillFileNode[] = []
-
-    const sorted = entries
-      .filter((e) => !e.name.startsWith('.') && e.name !== 'node_modules')
-      .sort((a, b) => {
-        if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
-        return a.name.localeCompare(b.name)
-      })
-
-    for (const entry of sorted) {
-      const fullPath = path.join(dir, entry.name)
-      const relativePath = path.relative(root, fullPath)
-
-      if (entry.isDirectory()) {
-        const children = await this.buildFileTree(fullPath, root)
-        nodes.push({ name: entry.name, path: relativePath, type: 'directory', children })
-      } else {
-        nodes.push({ name: entry.name, path: relativePath, type: 'file' })
-      }
-    }
-
-    return nodes
   }
 
   /**
@@ -1784,11 +1123,6 @@ export class SkillService {
       logger.info('Built-in skill synced to DB', { folderName: destFolderName, firstInstall: !existing, filesUpdated })
       return filesUpdated
     })
-  }
-
-  private async reportInstall(owner: string, repo: string, skillName: string): Promise<void> {
-    const url = `${CLAUDE_PLUGINS_API}/api/skills/${owner}/${repo}/${skillName}/install`
-    await net.fetch(url, { method: 'POST' })
   }
 }
 

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -38,6 +38,28 @@ vi.mock('@main/utils/processRunner', () => ({
   executeCommand: executeCommandMock
 }))
 
+// Spy wrappers over the real implementations: install tests stub a single step (temp dir, ZIP
+// extraction, directory resolution) while the rest of the path still runs for real.
+vi.mock('../skillPaths', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof skillPaths
+  return {
+    ...actual,
+    createTempDir: vi.fn(actual.createTempDir),
+    safeRemoveDirectory: vi.fn(actual.safeRemoveDirectory)
+  }
+})
+vi.mock('../skillArchive', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof skillArchive
+  return {
+    ...actual,
+    extractZip: vi.fn(actual.extractZip),
+    resolveSkillDirectory: vi.fn(actual.resolveSkillDirectory)
+  }
+})
+
+// Namespaced so the local `createTempDir` test helper cannot shadow the module export.
+import * as skillArchive from '../skillArchive'
+import * as skillPaths from '../skillPaths'
 import { SkillService } from '../SkillService'
 
 const AGENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -57,7 +79,19 @@ describe('SkillService', () => {
 
   afterEach(async () => {
     vi.unstubAllEnvs()
+    // A marketplace install fires `reportInstall` telemetry through `net.fetch`; without this, that
+    // call lands in the next test's request assertions.
+    vi.mocked(net.fetch).mockReset()
     await Promise.all(tempDirs.splice(0).map((dir) => fs.promises.rm(dir, { recursive: true, force: true })))
+  })
+
+  // These are spies over the real implementations; drop any per-test stub and call history so one
+  // install test cannot hand its stub to the next.
+  beforeEach(() => {
+    vi.mocked(skillPaths.createTempDir).mockReset()
+    vi.mocked(skillPaths.safeRemoveDirectory).mockReset()
+    vi.mocked(skillArchive.extractZip).mockReset()
+    vi.mocked(skillArchive.resolveSkillDirectory).mockReset()
   })
 
   async function seedAgent() {
@@ -598,16 +632,9 @@ describe('SkillService', () => {
       )
     })
 
-    it('delegates to installFromClaudePlugins for claude-plugins source', async () => {
-      const skillService = new SkillService()
-      const spy = vi.spyOn(skillService as never, 'installFromClaudePlugins').mockResolvedValue({} as never)
-      await skillService.install({ installSource: 'claude-plugins:owner/repo/skill' })
-      expect(spy).toHaveBeenCalledWith('owner/repo/skill')
-    })
-
     it('rejects ambiguous claude-plugins identifiers without a directory path', async () => {
       const skillService = new SkillService()
-      const createTempDirSpy = vi.spyOn(skillService as never, 'createTempDir')
+      const createTempDirSpy = vi.mocked(skillPaths.createTempDir)
 
       await expect(skillService.install({ installSource: 'claude-plugins:owner/repo/' })).rejects.toThrow(
         'Invalid claude-plugins identifier: owner/repo/'
@@ -617,7 +644,7 @@ describe('SkillService', () => {
 
     it('rejects claude-plugins identifiers with path traversal before cloning', async () => {
       const skillService = new SkillService()
-      const createTempDirSpy = vi.spyOn(skillService as never, 'createTempDir')
+      const createTempDirSpy = vi.mocked(skillPaths.createTempDir)
 
       await expect(
         skillService.install({ installSource: 'claude-plugins:owner/repo/skills/../outside' })
@@ -636,8 +663,8 @@ describe('SkillService', () => {
     }) {
       const skillService = new SkillService()
       const workDir = await createTempDir('github-install-')
-      vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(workDir as never)
-      vi.spyOn(skillService as never, 'safeRemoveDirectory').mockResolvedValue(undefined as never)
+      vi.mocked(skillPaths.createTempDir).mockResolvedValue(workDir as never)
+      vi.mocked(skillPaths.safeRemoveDirectory).mockResolvedValue(undefined as never)
       const tree = (options.tree ?? ['skills/demo/SKILL.md']).map((entry) =>
         typeof entry === 'string' ? { path: entry, size: 8 } : entry
       )
@@ -976,7 +1003,7 @@ describe('SkillService', () => {
 
     it('rejects a github URL that does not point at a SKILL.md file before cloning', async () => {
       const skillService = new SkillService()
-      const createTempDirSpy = vi.spyOn(skillService as never, 'createTempDir')
+      const createTempDirSpy = vi.mocked(skillPaths.createTempDir)
 
       for (const url of [
         'https://github.com/owner/repo',
@@ -997,8 +1024,7 @@ describe('SkillService', () => {
     async function setupClonedInstall() {
       const skillService = new SkillService()
       const workDir = await createTempDir('clone-install-')
-      vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(workDir as never)
-      vi.spyOn(skillService as never, 'reportInstall').mockResolvedValue(undefined as never)
+      vi.mocked(skillPaths.createTempDir).mockResolvedValue(workDir)
       const gitCalls: Array<{ args: string[]; options?: { env?: Record<string, string>; timeout?: number } }> = []
 
       executeCommandMock.mockImplementation(async (_command: string, args: string[], options?: object) => {
@@ -1051,20 +1077,6 @@ describe('SkillService', () => {
 
       await expect(installFromClone(skillService)).rejects.toThrow('Command timed out')
       expect(gitCalls).toHaveLength(1)
-    })
-
-    it('delegates to installFromSkillsSh for skills.sh source', async () => {
-      const skillService = new SkillService()
-      const spy = vi.spyOn(skillService as never, 'installFromSkillsSh').mockResolvedValue({} as never)
-      await skillService.install({ installSource: 'skills.sh:owner/repo/skill' })
-      expect(spy).toHaveBeenCalledWith('owner/repo/skill')
-    })
-
-    it('delegates to installFromClawhub for clawhub source', async () => {
-      const skillService = new SkillService()
-      const spy = vi.spyOn(skillService as never, 'installFromClawhub').mockResolvedValue({} as never)
-      await skillService.install({ installSource: 'clawhub:owner/my-skill' })
-      expect(spy).toHaveBeenCalledWith('owner/my-skill')
     })
 
     it('rejects a clawhub source without its publisher identity', async () => {
@@ -1138,8 +1150,8 @@ describe('SkillService', () => {
           )
         )
         .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3]), { status: 200 }))
-      const createTempDirSpy = vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(tempDir as never)
-      const extractZipSpy = vi.spyOn(skillService as never, 'extractZip').mockImplementation(async () => {
+      const createTempDirSpy = vi.mocked(skillPaths.createTempDir).mockResolvedValue(tempDir as never)
+      const extractZipSpy = vi.mocked(skillArchive.extractZip).mockImplementation(async () => {
         await fs.promises.writeFile(path.join(extractDir, 'SKILL.md'), '---\nname: code\n---\n')
         await fs.promises.mkdir(path.join(extractDir, 'nested'), { recursive: true })
         await fs.promises.writeFile(path.join(extractDir, 'nested', 'SKILL.md'), '---\nname: nested\n---\n')
@@ -1194,9 +1206,9 @@ describe('SkillService', () => {
       await fs.promises.mkdir(extractDir, { recursive: true })
       const canonicalZipPath = await fs.promises.realpath(realZipPath)
 
-      vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(extractDir as never)
-      const extractZipSpy = vi.spyOn(skillService as never, 'extractZip').mockResolvedValue(undefined as never)
-      vi.spyOn(skillService as never, 'locateSkillDir').mockResolvedValue(locatedSkillDir as never)
+      vi.mocked(skillPaths.createTempDir).mockResolvedValue(extractDir as never)
+      const extractZipSpy = vi.mocked(skillArchive.extractZip).mockResolvedValue(undefined as never)
+      vi.mocked(skillArchive.resolveSkillDirectory).mockResolvedValue(locatedSkillDir as never)
       const installSkillDirSpy = vi.spyOn(skillService as never, 'installSkillDir').mockResolvedValue({} as never)
 
       await skillService.installFromZip({ zipFilePath: linkedZipPath })
@@ -1206,7 +1218,6 @@ describe('SkillService', () => {
     })
 
     it('accepts ZIP archives containing 2,000 entries', async () => {
-      const skillService = new SkillService()
       const root = await createTempDir('skill-zip-limit-')
       const zipPath = path.join(root, 'limit.zip')
       const extractDir = path.join(root, 'extract')
@@ -1215,11 +1226,10 @@ describe('SkillService', () => {
       zip.writeZip(zipPath)
       await fs.promises.mkdir(extractDir)
 
-      await expect(skillService['extractZip'](zipPath, extractDir)).resolves.toBeUndefined()
+      await expect(skillArchive.extractZip(zipPath, extractDir)).resolves.toBeUndefined()
     })
 
     it('rejects ZIP archives containing more than 2,000 entries', async () => {
-      const skillService = new SkillService()
       const root = await createTempDir('skill-zip-limit-')
       const zipPath = path.join(root, 'over-limit.zip')
       const extractDir = path.join(root, 'extract')
@@ -1227,7 +1237,7 @@ describe('SkillService', () => {
       for (let index = 0; index < 2_001; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
       zip.writeZip(zipPath)
 
-      await expect(skillService['extractZip'](zipPath, extractDir)).rejects.toThrow(
+      await expect(skillArchive.extractZip(zipPath, extractDir)).rejects.toThrow(
         'ZIP has too many files: 2001 exceeds 2000'
       )
     })
@@ -1245,33 +1255,30 @@ describe('SkillService', () => {
     ])('rejects a selected skill directory that is a symlink pointing %s', async (_case, createTarget) => {
       // Containment alone cannot catch the in-repo case: the target stays inside the clone, so the
       // user would silently install a different skill than the URL named.
-      const skillService = new SkillService()
       const repoDir = await createTempDir('skill-repo-')
       const targetDir = await createTarget(repoDir)
       await fs.promises.writeFile(path.join(targetDir, 'SKILL.md'), '# target')
       await fs.promises.symlink(targetDir, path.join(repoDir, 'linked'), 'dir')
       vi.mocked(findSkillMdPath).mockResolvedValue(path.join(targetDir, 'SKILL.md'))
 
-      await expect(skillService['resolveSkillDirectory'](repoDir, null, 'linked')).rejects.toThrow(
+      await expect(skillArchive.resolveSkillDirectory(repoDir, null, 'linked')).rejects.toThrow(
         'passes through a symlink'
       )
     })
 
     it('accepts an in-repository directory whose name starts with two dots', async () => {
-      const skillService = new SkillService()
       const repoDir = await createTempDir('skill-repo-')
       const skillDir = path.join(repoDir, '..archive')
       await fs.promises.mkdir(skillDir, { recursive: true })
       await fs.promises.writeFile(path.join(skillDir, 'SKILL.md'), '# archive')
       vi.mocked(findSkillMdPath).mockResolvedValue(path.join(skillDir, 'SKILL.md'))
 
-      await expect(skillService['resolveSkillDirectory'](repoDir, null, '..archive')).resolves.toBe(
+      await expect(skillArchive.resolveSkillDirectory(repoDir, null, '..archive')).resolves.toBe(
         await fs.promises.realpath(skillDir)
       )
     })
 
     it('fails closed when an explicit skills.sh target is not present', async () => {
-      const skillService = new SkillService()
       const repoDir = await createTempDir('skill-repo-')
       const otherSkill = path.join(repoDir, 'other-skill')
       await fs.promises.mkdir(otherSkill, { recursive: true })
@@ -1279,13 +1286,12 @@ describe('SkillService', () => {
       vi.mocked(findAllSkillDirectories).mockResolvedValue([{ folderPath: otherSkill, sourcePath: 'other-skill' }])
       vi.mocked(parseSkillMetadata).mockResolvedValue({ name: 'other-skill' } as never)
 
-      await expect(skillService['resolveSkillDirectory'](repoDir, 'requested-skill', null)).rejects.toThrow(
+      await expect(skillArchive.resolveSkillDirectory(repoDir, 'requested-skill', null)).rejects.toThrow(
         'No SKILL.md found for the specified skill: requested-skill'
       )
     })
 
     it('selects the unique skills.sh candidate whose metadata name matches the reviewed skill id', async () => {
-      const skillService = new SkillService()
       const repoDir = await createTempDir('skill-repo-')
       const first = path.join(repoDir, 'first', 'shared-name')
       const second = path.join(repoDir, 'second', 'shared-name')
@@ -1303,13 +1309,12 @@ describe('SkillService', () => {
       })
       vi.mocked(findSkillMdPath).mockImplementation(async (directory) => path.join(directory, 'SKILL.md'))
 
-      await expect(skillService['resolveSkillDirectory'](repoDir, 'reviewed-skill', null)).resolves.toBe(
+      await expect(skillArchive.resolveSkillDirectory(repoDir, 'reviewed-skill', null)).resolves.toBe(
         await fs.promises.realpath(second)
       )
     })
 
     it('rejects skills.sh candidates only when multiple descriptors claim the reviewed skill id', async () => {
-      const skillService = new SkillService()
       const repoDir = await createTempDir('skill-repo-')
       const first = path.join(repoDir, 'first', 'shared-name')
       const second = path.join(repoDir, 'second', 'shared-name')
@@ -1319,7 +1324,7 @@ describe('SkillService', () => {
       ])
       vi.mocked(parseSkillMetadata).mockResolvedValue({ name: 'reviewed-skill' } as never)
 
-      await expect(skillService['resolveSkillDirectory'](repoDir, 'reviewed-skill', null)).rejects.toThrow(
+      await expect(skillArchive.resolveSkillDirectory(repoDir, 'reviewed-skill', null)).rejects.toThrow(
         'Multiple SKILL.md files declare the specified skill: reviewed-skill'
       )
     })
@@ -2042,11 +2047,7 @@ describe('SkillService', () => {
   })
 
   describe('extractZip (zip-slip guard)', () => {
-    const callExtractZip = (service: SkillService, zipPath: string, destDir: string) =>
-      (service as unknown as { extractZip: (z: string, d: string) => Promise<void> }).extractZip(zipPath, destDir)
-
     it('rejects entries that escape the destination dir before extracting', async () => {
-      const skillService = new SkillService()
       const zipDir = await createTempDir('skill-zipslip-')
       const destDir = await createTempDir('skill-dest-')
       const zip = new AdmZip()
@@ -2057,7 +2058,7 @@ describe('SkillService', () => {
 
       // node-stream-zip rejects malicious names itself ('Malicious entry') and the
       // explicit guard is defense-in-depth — either layer rejecting satisfies the contract.
-      await expect(callExtractZip(skillService, zipPath, destDir)).rejects.toThrow(/zip-slip|Malicious entry/)
+      await expect(skillArchive.extractZip(zipPath, destDir)).rejects.toThrow(/zip-slip|Malicious entry/)
 
       // Nothing was written — not the safe entry, and no marker escaped beside destDir.
       expect(fs.existsSync(path.join(destDir, 'SKILL.md'))).toBe(false)
@@ -2065,7 +2066,6 @@ describe('SkillService', () => {
     })
 
     it('extracts a well-formed skill zip', async () => {
-      const skillService = new SkillService()
       const zipDir = await createTempDir('skill-zip-ok-')
       const destDir = await createTempDir('skill-dest-')
       const zip = new AdmZip()
@@ -2074,7 +2074,7 @@ describe('SkillService', () => {
       const zipPath = path.join(zipDir, 'skill.zip')
       zip.writeZip(zipPath)
 
-      await callExtractZip(skillService, zipPath, destDir)
+      await skillArchive.extractZip(zipPath, destDir)
       await expect(fs.promises.readFile(path.join(destDir, 'SKILL.md'), 'utf-8')).resolves.toContain('name: x')
     })
   })

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -26,11 +26,6 @@ vi.mock('@main/utils/shellEnv', () => ({
   getShellEnv: vi.fn().mockResolvedValue({})
 }))
 
-const findExecutableInEnvMock = vi.hoisted(() => vi.fn().mockResolvedValue(null))
-vi.mock('@main/utils/commandResolver', () => ({
-  findExecutableInEnv: findExecutableInEnvMock
-}))
-
 const executeCommandMock = vi.hoisted(() => vi.fn())
 vi.mock('@main/utils/processRunner', () => ({
   executeCommand: executeCommandMock
@@ -331,58 +326,6 @@ describe('SkillService', () => {
 
       expect(result).toEqual(['valid-skill'])
       expect(parseSkillMetadata).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('validateRuntimeDependencies', () => {
-    beforeEach(() => {
-      findExecutableInEnvMock.mockResolvedValue(null)
-      vi.mocked(findSkillMdPath).mockImplementation(async (directory) => {
-        const descriptor = path.join(directory, 'SKILL.md')
-        try {
-          await fs.promises.access(descriptor)
-          return descriptor
-        } catch {
-          return null
-        }
-      })
-      vi.mocked(parseSkillMetadata).mockResolvedValue({
-        context: 'fork',
-        agent: 'parallel:parallel-subagent',
-        allowed_tools: ['Bash(parallel-cli:*)']
-      } as never)
-    })
-
-    it('reports every missing dependency declared by a forked skill', async () => {
-      const skillService = new SkillService()
-      const workdir = await createTempDir('skill-runtime-deps-')
-      const skillDirectory = path.join(workdir, '.claude', 'skills', 'parallel-web-search')
-      await fs.promises.mkdir(skillDirectory, { recursive: true })
-      await fs.promises.writeFile(path.join(skillDirectory, 'SKILL.md'), '# Search')
-
-      const result = await skillService.validateRuntimeDependencies('parallel-web-search', workdir, [])
-
-      expect(result).toBe(
-        'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
-      )
-    })
-
-    it('allows the skill when its plugin agent and executable are available', async () => {
-      const skillService = new SkillService()
-      const workdir = await createTempDir('skill-runtime-deps-')
-      const skillDirectory = path.join(workdir, '.claude', 'skills', 'parallel-web-search')
-      const pluginDirectory = await createTempDir('parallel-plugin-')
-      await fs.promises.mkdir(skillDirectory, { recursive: true })
-      await fs.promises.mkdir(path.join(pluginDirectory, '.claude-plugin'))
-      await fs.promises.mkdir(path.join(pluginDirectory, 'agents'))
-      await fs.promises.writeFile(path.join(skillDirectory, 'SKILL.md'), '# Search')
-      await fs.promises.writeFile(path.join(pluginDirectory, '.claude-plugin', 'plugin.json'), '{"name":"parallel"}')
-      await fs.promises.writeFile(path.join(pluginDirectory, 'agents', 'parallel-subagent.md'), '# Agent')
-      findExecutableInEnvMock.mockResolvedValue('/usr/local/bin/parallel-cli')
-
-      const result = await skillService.validateRuntimeDependencies('parallel-web-search', workdir, [pluginDirectory])
-
-      expect(result).toBeUndefined()
     })
   })
 

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -26,6 +26,11 @@ vi.mock('@main/utils/shellEnv', () => ({
   getShellEnv: vi.fn().mockResolvedValue({})
 }))
 
+const findExecutableInEnvMock = vi.hoisted(() => vi.fn().mockResolvedValue(null))
+vi.mock('@main/utils/commandResolver', () => ({
+  findExecutableInEnv: findExecutableInEnvMock
+}))
+
 const executeCommandMock = vi.hoisted(() => vi.fn())
 vi.mock('@main/utils/processRunner', () => ({
   executeCommand: executeCommandMock
@@ -326,6 +331,58 @@ describe('SkillService', () => {
 
       expect(result).toEqual(['valid-skill'])
       expect(parseSkillMetadata).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('validateRuntimeDependencies', () => {
+    beforeEach(() => {
+      findExecutableInEnvMock.mockResolvedValue(null)
+      vi.mocked(findSkillMdPath).mockImplementation(async (directory) => {
+        const descriptor = path.join(directory, 'SKILL.md')
+        try {
+          await fs.promises.access(descriptor)
+          return descriptor
+        } catch {
+          return null
+        }
+      })
+      vi.mocked(parseSkillMetadata).mockResolvedValue({
+        context: 'fork',
+        agent: 'parallel:parallel-subagent',
+        allowed_tools: ['Bash(parallel-cli:*)']
+      } as never)
+    })
+
+    it('reports every missing dependency declared by a forked skill', async () => {
+      const skillService = new SkillService()
+      const workdir = await createTempDir('skill-runtime-deps-')
+      const skillDirectory = path.join(workdir, '.claude', 'skills', 'parallel-web-search')
+      await fs.promises.mkdir(skillDirectory, { recursive: true })
+      await fs.promises.writeFile(path.join(skillDirectory, 'SKILL.md'), '# Search')
+
+      const result = await skillService.validateRuntimeDependencies('parallel-web-search', workdir, [])
+
+      expect(result).toBe(
+        'Skill "parallel-web-search" cannot run: missing subagent "parallel:parallel-subagent"; missing executable "parallel-cli".'
+      )
+    })
+
+    it('allows the skill when its plugin agent and executable are available', async () => {
+      const skillService = new SkillService()
+      const workdir = await createTempDir('skill-runtime-deps-')
+      const skillDirectory = path.join(workdir, '.claude', 'skills', 'parallel-web-search')
+      const pluginDirectory = await createTempDir('parallel-plugin-')
+      await fs.promises.mkdir(skillDirectory, { recursive: true })
+      await fs.promises.mkdir(path.join(pluginDirectory, '.claude-plugin'))
+      await fs.promises.mkdir(path.join(pluginDirectory, 'agents'))
+      await fs.promises.writeFile(path.join(skillDirectory, 'SKILL.md'), '# Search')
+      await fs.promises.writeFile(path.join(pluginDirectory, '.claude-plugin', 'plugin.json'), '{"name":"parallel"}')
+      await fs.promises.writeFile(path.join(pluginDirectory, 'agents', 'parallel-subagent.md'), '# Agent')
+      findExecutableInEnvMock.mockResolvedValue('/usr/local/bin/parallel-cli')
+
+      const result = await skillService.validateRuntimeDependencies('parallel-web-search', workdir, [pluginDirectory])
+
+      expect(result).toBeUndefined()
     })
   })
 
@@ -1619,9 +1676,17 @@ describe('SkillService', () => {
       await expect(fs.promises.access(path.join(mirrorRoot, 'foo'))).rejects.toThrow()
     })
 
-    it('quarantines modified builtin content instead of updating its trusted hash or mirror', async () => {
+    it('copies complete builtin content and quarantines later modifications', async () => {
       vi.mocked(findSkillMdPath).mockImplementation(async (directory) => path.join(directory, 'SKILL.md'))
       const builtinDir = await writeLibrarySkill('skill-creator', '# trusted')
+      await Promise.all([
+        fs.promises.mkdir(path.join(builtinDir, 'agents')),
+        fs.promises.mkdir(path.join(builtinDir, 'scripts'))
+      ])
+      await Promise.all([
+        fs.promises.writeFile(path.join(builtinDir, 'agents', 'reviewer.md'), '# Reviewer'),
+        fs.promises.writeFile(path.join(builtinDir, 'scripts', 'run.sh'), '#!/bin/sh')
+      ])
       const trustedHash = await skillService['computeBuiltinDirectoryHash'](builtinDir)
       await dbh.db.insert(agentGlobalSkillTable).values({
         id: SKILL_ID_BUILTIN,
@@ -1633,6 +1698,12 @@ describe('SkillService', () => {
       })
       await skillService.linkMirror('skill-creator')
       expect((await fs.promises.lstat(path.join(mirrorRoot, 'skill-creator'))).isSymbolicLink()).toBe(false)
+      await expect(
+        fs.promises.readFile(path.join(mirrorRoot, 'skill-creator', 'agents', 'reviewer.md'), 'utf-8')
+      ).resolves.toBe('# Reviewer')
+      await expect(
+        fs.promises.readFile(path.join(mirrorRoot, 'skill-creator', 'scripts', 'run.sh'), 'utf-8')
+      ).resolves.toBe('#!/bin/sh')
       await fs.promises.writeFile(path.join(builtinDir, 'SKILL.md'), '# modified by agent')
 
       await skillService.reconcileSkills()

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -1959,9 +1959,17 @@ describe('SkillService', () => {
       await expect(fs.promises.access(path.join(mirrorRoot, 'foo'))).rejects.toThrow()
     })
 
-    it('quarantines modified builtin content instead of updating its trusted hash or mirror', async () => {
+    it('copies complete builtin content and quarantines later modifications', async () => {
       vi.mocked(findSkillMdPath).mockImplementation(async (directory) => path.join(directory, 'SKILL.md'))
       const builtinDir = await writeLibrarySkill('skill-creator', '# trusted')
+      await Promise.all([
+        fs.promises.mkdir(path.join(builtinDir, 'agents')),
+        fs.promises.mkdir(path.join(builtinDir, 'scripts'))
+      ])
+      await Promise.all([
+        fs.promises.writeFile(path.join(builtinDir, 'agents', 'reviewer.md'), '# Reviewer'),
+        fs.promises.writeFile(path.join(builtinDir, 'scripts', 'run.sh'), '#!/bin/sh')
+      ])
       const trustedHash = await skillService['computeBuiltinDirectoryHash'](builtinDir)
       await dbh.db.insert(agentGlobalSkillTable).values({
         id: SKILL_ID_BUILTIN,
@@ -1973,6 +1981,12 @@ describe('SkillService', () => {
       })
       await skillService.linkMirror('skill-creator')
       expect((await fs.promises.lstat(path.join(mirrorRoot, 'skill-creator'))).isSymbolicLink()).toBe(false)
+      await expect(
+        fs.promises.readFile(path.join(mirrorRoot, 'skill-creator', 'agents', 'reviewer.md'), 'utf-8')
+      ).resolves.toBe('# Reviewer')
+      await expect(
+        fs.promises.readFile(path.join(mirrorRoot, 'skill-creator', 'scripts', 'run.sh'), 'utf-8')
+      ).resolves.toBe('#!/bin/sh')
       await fs.promises.writeFile(path.join(builtinDir, 'SKILL.md'), '# modified by agent')
 
       await skillService.reconcileSkills()

--- a/src/main/ai/skills/skillArchive.ts
+++ b/src/main/ai/skills/skillArchive.ts
@@ -1,0 +1,197 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { loggerService } from '@logger'
+import { isOutsidePath } from '@main/utils/file'
+import { findAllSkillDirectories, findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
+import { assertZipEntriesWithin } from '@main/utils/zipSafety'
+import StreamZip from 'node-stream-zip'
+
+/**
+ * Handling for an untrusted skill tree on disk, however it arrived — an extracted ZIP or a shallow
+ * clone. Owns the extraction ceilings and every containment check that decides which directory in
+ * that tree is the skill being installed.
+ */
+
+const logger = loggerService.withContext('SkillArchive')
+
+/** The install-wide ceilings — a Git tree is checked against these before checkout, too. */
+export const MAX_EXTRACTED_SIZE = 100 * 1024 * 1024 // 100MB
+export const MAX_FILES_COUNT = 2000
+
+export async function validateZipFile(zipFilePath: string): Promise<void> {
+  const stats = await fs.promises.stat(zipFilePath)
+  if (!stats.isFile()) {
+    throw new Error(`Not a file: ${zipFilePath}`)
+  }
+  if (!zipFilePath.toLowerCase().endsWith('.zip')) {
+    throw new Error(`Not a ZIP file: ${zipFilePath}`)
+  }
+}
+
+export async function extractZip(zipFilePath: string, destDir: string): Promise<void> {
+  const zip = new StreamZip.async({ file: zipFilePath })
+
+  try {
+    const entries = await zip.entries()
+    assertZipEntriesWithin(Object.keys(entries), destDir)
+    let totalSize = 0
+    let fileCount = 0
+
+    for (const entry of Object.values(entries)) {
+      totalSize += entry.size
+      fileCount++
+
+      if (totalSize > MAX_EXTRACTED_SIZE) {
+        throw new Error(`ZIP too large: ${totalSize} bytes exceeds ${MAX_EXTRACTED_SIZE}`)
+      }
+      if (fileCount > MAX_FILES_COUNT) {
+        throw new Error(`ZIP has too many files: ${fileCount} exceeds ${MAX_FILES_COUNT}`)
+      }
+    }
+
+    await zip.extract(null, destDir)
+  } finally {
+    await zip.close()
+  }
+}
+
+/** Apply the same ceilings an untrusted ZIP gets — a repository is no more trusted than an archive. */
+export async function assertSkillDirectoryWithinLimits(skillDir: string): Promise<void> {
+  let totalSize = 0
+  let fileCount = 0
+
+  const walk = async (directory: string): Promise<void> => {
+    for (const entry of await fs.promises.readdir(directory, { withFileTypes: true })) {
+      const entryPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await walk(entryPath)
+        continue
+      }
+      if (!entry.isFile()) continue
+
+      fileCount += 1
+      totalSize += (await fs.promises.stat(entryPath)).size
+      if (totalSize > MAX_EXTRACTED_SIZE) {
+        throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
+      }
+      if (fileCount > MAX_FILES_COUNT) {
+        throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
+      }
+    }
+  }
+
+  await walk(skillDir)
+}
+
+/**
+ * A symlinked component silently redirects the requested path elsewhere in the repository, so an
+ * explicitly selected directory would install a skill other than the one shown to the user. The
+ * realpath containment check alone cannot see this: the target stays inside the repository.
+ */
+async function assertNoSymlinkComponents(repoDir: string, relativePath: string): Promise<void> {
+  let current = repoDir
+  for (const part of relativePath.split(path.sep).filter(Boolean)) {
+    current = path.join(current, part)
+    const stats = await fs.promises.lstat(current).catch(() => null)
+    if (stats?.isSymbolicLink()) {
+      throw new Error(`Skill directory path passes through a symlink: ${relativePath}`)
+    }
+  }
+}
+
+export async function resolveSkillDirectory(
+  repoDir: string,
+  skillName: string | null,
+  directoryPath: string | null
+): Promise<string> {
+  if (directoryPath) {
+    const resolved = path.resolve(repoDir, directoryPath)
+    // Reject a directoryPath that escapes the clone root — a crafted identifier could otherwise
+    // point install at an arbitrary local directory (path traversal).
+    const relative = path.relative(repoDir, resolved)
+    if (isOutsidePath(relative)) {
+      throw new Error(`Skill directory path escapes the repository: ${directoryPath}`)
+    }
+    await assertNoSymlinkComponents(repoDir, relative)
+    const skillMdPath = await findSkillMdPath(resolved)
+    if (skillMdPath) return validateRepositorySkillDirectory(repoDir, resolved, skillMdPath)
+
+    // Fail closed: an explicit directoryPath with no SKILL.md must NOT fall back to guessing a
+    // different candidate in the repo — the user confirmed skill A and must not get skill B.
+    throw new Error(`No SKILL.md found at the specified skill directory: ${directoryPath}`)
+  }
+
+  const candidates = await findAllSkillDirectories(repoDir, repoDir, 8)
+
+  if (skillName) {
+    const matches: typeof candidates = []
+    for (const candidate of candidates) {
+      try {
+        const metadata = await parseSkillMetadata(
+          candidate.folderPath,
+          candidate.sourcePath || path.basename(candidate.folderPath),
+          'skills',
+          { calculateSize: false }
+        )
+        if (metadata.name === skillName) matches.push(candidate)
+      } catch (error) {
+        logger.warn('Failed to parse repository skill candidate', {
+          folderPath: candidate.folderPath,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
+    if (matches.length === 1) {
+      return validateRepositorySkillDirectory(repoDir, matches[0].folderPath)
+    }
+    if (matches.length > 1) {
+      throw new Error(`Multiple SKILL.md files declare the specified skill: ${skillName}`)
+    }
+    throw new Error(`No SKILL.md found for the specified skill: ${skillName}`)
+  }
+
+  if (candidates.length === 1) {
+    return validateRepositorySkillDirectory(repoDir, candidates[0].folderPath)
+  }
+
+  if (candidates.length > 0) {
+    logger.warn('resolveSkillDirectory: fallback to first candidate', {
+      directoryPath,
+      skillName,
+      candidateCount: candidates.length,
+      selected: candidates[0].folderPath
+    })
+    return validateRepositorySkillDirectory(repoDir, candidates[0].folderPath)
+  }
+
+  const rootSkill = await findSkillMdPath(repoDir)
+  if (rootSkill) return validateRepositorySkillDirectory(repoDir, repoDir, rootSkill)
+
+  throw new Error(`No skill directory found in ${repoDir}`)
+}
+
+export async function validateRepositorySkillDirectory(
+  repoDir: string,
+  skillDir: string,
+  knownSkillMdPath?: string
+): Promise<string> {
+  const [repoRealPath, skillRealPath] = await Promise.all([
+    fs.promises.realpath(repoDir),
+    fs.promises.realpath(skillDir)
+  ])
+  const relativeSkillPath = path.relative(repoRealPath, skillRealPath)
+  if (isOutsidePath(relativeSkillPath)) {
+    throw new Error(`Skill directory resolves outside the repository: ${skillDir}`)
+  }
+
+  const skillMdPath = knownSkillMdPath ?? (await findSkillMdPath(skillRealPath))
+  if (!skillMdPath) throw new Error(`No SKILL.md found in ${skillDir}`)
+  const skillMdRealPath = await fs.promises.realpath(skillMdPath)
+  const relativeDescriptorPath = path.relative(repoRealPath, skillMdRealPath)
+  if (isOutsidePath(relativeDescriptorPath)) {
+    throw new Error(`Skill descriptor resolves outside the repository: ${skillMdPath}`)
+  }
+  return skillRealPath
+}

--- a/src/main/ai/skills/skillPaths.ts
+++ b/src/main/ai/skills/skillPaths.ts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { deleteDirectoryRecursive } from '@main/utils/fileOperations'
+import type { SkillFileNode } from '@shared/types/skill'
+
+const logger = loggerService.withContext('SkillPaths')
+
+const MAX_FOLDER_NAME_LENGTH = 80
+
+export function sanitizeFolderName(folderName: string): string {
+  let sanitized = folderName.replace(/[/\\]/g, '_')
+  sanitized = sanitized.replace(new RegExp(String.fromCharCode(0), 'g'), '')
+  sanitized = sanitized.replace(/[^a-zA-Z0-9_-]/g, '_')
+
+  if (sanitized.length > MAX_FOLDER_NAME_LENGTH) {
+    sanitized = sanitized.slice(0, MAX_FOLDER_NAME_LENGTH)
+  }
+
+  return sanitized
+}
+
+/** Case-folding key for folder names, so a case-only difference never reads as two skills. */
+export function normalizeFolderKey(folderName: string): string {
+  return folderName.toLowerCase()
+}
+
+export async function createTempDir(prefix: string): Promise<string> {
+  const root = application.getPath('feature.agents.skills.install.temp')
+  await fs.promises.mkdir(root, { recursive: true })
+  // mkdtemp, not a timestamp: two installs starting in the same millisecond would otherwise share
+  // one workspace and delete each other's checkout on cleanup.
+  return fs.promises.mkdtemp(path.join(root, `${prefix}-`))
+}
+
+export async function safeRemoveDirectory(dirPath: string): Promise<void> {
+  try {
+    await deleteDirectoryRecursive(dirPath)
+  } catch (error) {
+    logger.warn('Failed to clean up temp directory', {
+      dirPath,
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+}
+
+export async function buildFileTree(dir: string, root: string): Promise<SkillFileNode[]> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true })
+  const nodes: SkillFileNode[] = []
+
+  const sorted = entries
+    .filter((e) => !e.name.startsWith('.') && e.name !== 'node_modules')
+    .sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+
+  for (const entry of sorted) {
+    const fullPath = path.join(dir, entry.name)
+    const relativePath = path.relative(root, fullPath)
+
+    if (entry.isDirectory()) {
+      const children = await buildFileTree(fullPath, root)
+      nodes.push({ name: entry.name, path: relativePath, type: 'directory', children })
+    } else {
+      nodes.push({ name: entry.name, path: relativePath, type: 'file' })
+    }
+  }
+
+  return nodes
+}

--- a/src/main/ai/skills/skillRemoteSource.ts
+++ b/src/main/ai/skills/skillRemoteSource.ts
@@ -1,0 +1,444 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+import { loggerService } from '@logger'
+import { getProxyEnvironment } from '@main/services/proxy/proxyEnv'
+import { findExecutableInEnv } from '@main/utils/commandResolver'
+import { findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
+import { executeCommand } from '@main/utils/processRunner'
+import { getShellEnv } from '@main/utils/shellEnv'
+import { ClawhubSkillDetailSchema } from '@shared/types/skill'
+import { encodeGithubPath, parseGithubSkillUrl } from '@shared/utils/skillMarketplace'
+import { net } from 'electron'
+
+import {
+  assertSkillDirectoryWithinLimits,
+  extractZip,
+  MAX_EXTRACTED_SIZE,
+  MAX_FILES_COUNT,
+  resolveSkillDirectory,
+  validateRepositorySkillDirectory
+} from './skillArchive'
+import { createTempDir, safeRemoveDirectory, sanitizeFolderName } from './skillPaths'
+
+/**
+ * Acquisition of a marketplace skill into a caller-owned temp directory. Nothing here touches the
+ * catalog or the library mutation lock: the caller commits the fetched directory and disposes of the
+ * temp workspace.
+ */
+
+const logger = loggerService.withContext('SkillRemoteSource')
+
+// API base URLs for the 3 search sources
+const CLAUDE_PLUGINS_API = 'https://api.claude-plugins.dev'
+// A direct-URL install points git at a repository nobody vetted; no single step may hang forever.
+const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
+const MAX_GIT_TREE_OUTPUT_BYTES = 16 * 1024 * 1024
+
+type GithubRef = {
+  name: string
+  oid: string
+  namespace: 'heads' | 'tags'
+}
+
+type GithubSkillTarget = { kind: 'root' } | { kind: 'directory'; path: string }
+
+type GithubRefResolution =
+  | { kind: 'resolved'; ref: GithubRef; target: GithubSkillTarget }
+  | { kind: 'ambiguous'; name: string }
+  | { kind: 'no-match' }
+
+function resolveGithubRef(refs: readonly GithubRef[], refAndPath: readonly string[]): GithubRefResolution {
+  const refsByName = new Map<string, GithubRef[]>()
+  for (const ref of refs) {
+    refsByName.set(ref.name, [...(refsByName.get(ref.name) ?? []), ref])
+  }
+
+  for (let length = refAndPath.length; length >= 1; length--) {
+    const name = refAndPath.slice(0, length).join('/')
+    const matches = refsByName.get(name)
+    if (!matches?.length) continue
+    if (matches.length > 1) return { kind: 'ambiguous', name }
+
+    return {
+      kind: 'resolved',
+      ref: matches[0],
+      target:
+        length === refAndPath.length
+          ? { kind: 'root' }
+          : { kind: 'directory', path: refAndPath.slice(length).join('/') }
+    }
+  }
+  return { kind: 'no-match' }
+}
+
+export interface FetchedSkill {
+  /** Temp workspace holding the checkout; the caller removes it once the install has committed. */
+  tempDir: string
+  skillDir: string
+  sourceUrl: string
+  /** Fire-and-forget notification to run once the install has committed. */
+  onInstalled?: () => void
+}
+
+/** `openTempDir` is lazy so a malformed identifier is rejected before anything is written to disk. */
+type Fetcher = (identifier: string, openTempDir: () => Promise<string>) => Promise<Omit<FetchedSkill, 'tempDir'>>
+
+const FETCHERS: Record<string, Fetcher> = {
+  'claude-plugins': fetchFromClaudePlugins,
+  'skills.sh': fetchFromSkillsSh,
+  clawhub: fetchFromClawhub,
+  github: fetchFromGithub
+}
+
+/**
+ * Fetch from a marketplace installSource handle.
+ * Format: "claude-plugins:{owner}/{repo}/{directoryPath}",
+ * "skills.sh:{owner}/{repo}/{skillId}", "clawhub:{owner}/{slug}",
+ * or "github:{https URL of the skill's SKILL.md}".
+ */
+export async function fetchRemoteSkill(source: string, identifier: string): Promise<FetchedSkill> {
+  const fetcher = FETCHERS[source]
+  if (!fetcher) {
+    throw new Error(`Unknown install source: ${source}`)
+  }
+
+  // The prefix comes from the matched key, never from raw user input.
+  let tempDir = ''
+  const openTempDir = async () => (tempDir = await createTempDir(source.replace(/[^a-zA-Z0-9-]/g, '-')))
+
+  try {
+    const fetched = await fetcher(identifier, openTempDir)
+    return { tempDir, ...fetched }
+  } catch (error) {
+    if (tempDir) await safeRemoveDirectory(tempDir)
+    throw error
+  }
+}
+
+async function fetchFromClaudePlugins(
+  identifier: string,
+  openTempDir: () => Promise<string>
+): Promise<Omit<FetchedSkill, 'tempDir'>> {
+  const parts = identifier.split('/')
+  const [owner, repo, ...directoryParts] = parts
+  const directoryPath = directoryParts.join('/')
+  const skillName = directoryParts[directoryParts.length - 1] ?? ''
+
+  const invalidRepositoryPart = (part: string) =>
+    !part || part === '.' || part === '..' || !/^[a-zA-Z0-9_.-]+$/.test(part)
+  const invalidDirectoryPart = (part: string) =>
+    !part || part !== part.trim() || part === '.' || part === '..' || part.includes('\\') || part.includes('\0')
+
+  if (
+    invalidRepositoryPart(owner) ||
+    invalidRepositoryPart(repo) ||
+    !directoryPath ||
+    !skillName ||
+    directoryParts.some(invalidDirectoryPart)
+  ) {
+    throw new Error(`Invalid claude-plugins identifier: ${identifier}`)
+  }
+
+  const repoUrl = `https://github.com/${owner}/${repo}`
+  const tempDir = await openTempDir()
+  await cloneRepository(repoUrl, tempDir)
+
+  return {
+    skillDir: await resolveSkillDirectory(tempDir, skillName, directoryPath),
+    sourceUrl: `${repoUrl}/tree/main/${directoryPath}`,
+    onInstalled: () => {
+      reportInstall(owner, repo, skillName).catch((err) => {
+        logger.warn('Failed to report install', { error: err instanceof Error ? err.message : String(err) })
+      })
+    }
+  }
+}
+
+/**
+ * Fetch the one skill a GitHub SKILL.md URL points at. No registry is involved: the URL carries
+ * the repo and the path, and the shared parser is the same one the UI validates with.
+ *
+ * A GitHub URL has no delimiter between the ref and the path, so the boundary is resolved against
+ * the repo's own refs. What gets fetched is the commit observed during that lookup, not the ref
+ * name again: a branch that moves in between would otherwise hand over different content than the
+ * one whose tree was inspected.
+ */
+async function fetchFromGithub(
+  identifier: string,
+  openTempDir: () => Promise<string>
+): Promise<Omit<FetchedSkill, 'tempDir'>> {
+  const location = parseGithubSkillUrl(identifier)
+  if (!location) {
+    throw new Error(`Invalid GitHub skill URL: ${identifier}`)
+  }
+
+  const { owner, repo, refNamespace, refAndPath, descriptorFileName } = location
+  const repoUrl = `https://github.com/${owner}/${repo}`
+  const { ref, namespace, oid, target } = await resolveGithubCommit(repoUrl, refAndPath, refNamespace)
+  logger.info('Installing from GitHub', { owner, repo, ref, namespace, oid, target })
+
+  const sourcePath = target.kind === 'root' ? ref : `${ref}/${target.path}`
+  const sourceUrl = namespace
+    ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${namespace}/${encodeGithubPath(`${sourcePath}/${descriptorFileName}`)}`
+    : `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
+
+  const tempDir = await openTempDir()
+  const { contentDir, skillDir } = await materializeGithubTarget(repoUrl, oid, target, descriptorFileName, tempDir)
+  await validateRepositorySkillDirectory(contentDir, skillDir, path.join(skillDir, descriptorFileName))
+  await assertSkillDirectoryWithinLimits(skillDir)
+
+  return { skillDir, sourceUrl }
+}
+
+async function fetchFromSkillsSh(
+  identifier: string,
+  openTempDir: () => Promise<string>
+): Promise<Omit<FetchedSkill, 'tempDir'>> {
+  const parts = identifier.split('/')
+  if (parts.length !== 3 || parts.some((part) => !part)) {
+    throw new Error(`Invalid skills.sh identifier: ${identifier}`)
+  }
+  logger.info('Installing from skills.sh', { identifier })
+
+  const [owner, repo, skillName] = parts
+  const repoUrl = `https://github.com/${owner}/${repo}`
+  const tempDir = await openTempDir()
+  await cloneRepository(repoUrl, tempDir)
+
+  return { skillDir: await resolveSkillDirectory(tempDir, skillName, null), sourceUrl: repoUrl }
+}
+
+async function fetchFromClawhub(
+  identifier: string,
+  openTempDir: () => Promise<string>
+): Promise<Omit<FetchedSkill, 'tempDir'>> {
+  const [ownerHandle, slug, ...extraParts] = identifier.split('/')
+  const invalidPart = (part: string | undefined) => !part || !/^[a-zA-Z0-9_.-]+$/.test(part)
+  if (extraParts.length > 0 || invalidPart(ownerHandle) || invalidPart(slug)) {
+    throw new Error(`Invalid clawhub identifier: ${identifier}`)
+  }
+
+  const detailUrl = new URL(`https://clawhub.ai/api/v1/skills/${encodeURIComponent(slug)}`)
+  detailUrl.searchParams.set('ownerHandle', ownerHandle)
+  const detailResp = await net.fetch(detailUrl.toString(), {
+    headers: { 'User-Agent': 'CherryStudio' }
+  })
+
+  if (!detailResp.ok) {
+    throw new Error(`clawhub detail failed: HTTP ${detailResp.status}`)
+  }
+
+  const detailResult = ClawhubSkillDetailSchema.safeParse(await detailResp.json())
+  if (!detailResult.success) {
+    throw new Error('clawhub detail returned invalid metadata')
+  }
+  if (
+    detailResult.data.skill.slug !== slug ||
+    detailResult.data.owner?.handle.toLowerCase() !== ownerHandle.toLowerCase()
+  ) {
+    throw new Error(`clawhub detail did not match the requested skill: ${identifier}`)
+  }
+
+  const downloadUrl = new URL('https://clawhub.ai/api/v1/download')
+  downloadUrl.searchParams.set('slug', slug)
+  downloadUrl.searchParams.set('ownerHandle', ownerHandle)
+  const downloadResp = await net.fetch(downloadUrl.toString(), {
+    headers: { 'User-Agent': 'CherryStudio' }
+  })
+
+  if (!downloadResp.ok) {
+    throw new Error(`clawhub download failed: HTTP ${downloadResp.status}`)
+  }
+
+  const tempDir = await openTempDir()
+  const zipPath = path.join(tempDir, 'skill.zip')
+  const buffer = Buffer.from(await downloadResp.arrayBuffer())
+  await fs.promises.writeFile(zipPath, buffer)
+  const extractDir = path.join(tempDir, sanitizeFolderName(slug))
+  await fs.promises.mkdir(extractDir, { recursive: true })
+  await extractZip(zipPath, extractDir)
+  // ClawHub serves one published skill bundle whose descriptor is at the archive root. Nested
+  // SKILL.md files are supporting content, not alternative install candidates.
+  const skillMdPath = await findSkillMdPath(extractDir)
+  if (!skillMdPath) {
+    throw new Error(`No SKILL.md found at the clawhub archive root: ${identifier}`)
+  }
+  const skillDir = await validateRepositorySkillDirectory(extractDir, extractDir, skillMdPath)
+  const metadata = await parseSkillMetadata(skillDir, slug, 'skills', { calculateSize: false })
+  if ((metadata.slug ?? metadata.name).toLowerCase() !== slug.toLowerCase()) {
+    throw new Error(`clawhub archive did not match the requested skill: ${identifier}`)
+  }
+
+  return { skillDir, sourceUrl: `https://clawhub.ai/${ownerHandle}/skills/${slug}` }
+}
+
+/**
+ * Ask the remote where the ref ends and which commit it points at. A branch name may contain `/`,
+ * so `blob/feature/foo/skills/demo/SKILL.md` is only unambiguous once the repo's refs are known.
+ * A commit permalink needs no ref and is the one identity that cannot drift.
+ */
+async function resolveGithubCommit(
+  repoUrl: string,
+  refAndPath: string[],
+  refNamespace: 'heads' | 'tags' | null
+): Promise<{ ref: string; namespace: 'heads' | 'tags' | null; oid: string; target: GithubSkillTarget }> {
+  const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
+  const output = await runGit(gitCommand, ['ls-remote', '--heads', '--tags', '--', repoUrl])
+  const refs = output.split('\n').flatMap((line) => {
+    const [oid, fullName] = line.split('\t').map((part) => part.trim())
+    // `^{}` marks a tag's dereferenced commit; the tag itself is already listed.
+    const match = fullName?.match(/^refs\/(heads|tags)\/(.+?)(?:\^\{\})?$/)
+    if (!oid || !match || fullName.endsWith('^{}')) return []
+    return [{ oid, namespace: match[1] as 'heads' | 'tags', name: match[2] }]
+  })
+
+  const matchingRefs = refNamespace ? refs.filter((ref) => ref.namespace === refNamespace) : refs
+  const resolution = resolveGithubRef(matchingRefs, refAndPath)
+  switch (resolution.kind) {
+    case 'resolved':
+      return {
+        ref: resolution.ref.name,
+        namespace: resolution.ref.namespace,
+        oid: resolution.ref.oid,
+        target: resolution.target
+      }
+    case 'ambiguous':
+      throw new Error(`${repoUrl} has both a branch and a tag named "${resolution.name}"; the URL cannot say which.`)
+    case 'no-match': {
+      const [head, ...rest] = refAndPath
+      if (refNamespace === null && /^[0-9a-f]{40}$/i.test(head)) {
+        const target: GithubSkillTarget =
+          rest.length === 0 ? { kind: 'root' } : { kind: 'directory', path: rest.join('/') }
+        return { ref: head, namespace: null, oid: head.toLowerCase(), target }
+      }
+      throw new Error(`No branch or tag in ${repoUrl} matches "${refAndPath.join('/')}"`)
+    }
+  }
+}
+
+/**
+ * Fetch one commit into a bare repository and check out only installable content into a separate
+ * work tree. Keeping the two roots separate prevents a repository-root skill from copying `.git`.
+ */
+async function materializeGithubTarget(
+  repoUrl: string,
+  oid: string,
+  target: GithubSkillTarget,
+  descriptorFileName: 'SKILL.md' | 'skill.md',
+  tempDir: string
+): Promise<{ contentDir: string; skillDir: string }> {
+  const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
+  const gitDir = path.join(tempDir, 'repo.git')
+  const contentDir = path.join(tempDir, 'content')
+  const git = (args: string[], options?: { maxOutputBytes?: number }) =>
+    runGit(gitCommand, [`--git-dir=${gitDir}`, ...args], options)
+
+  await fs.promises.mkdir(contentDir, { recursive: true })
+  await runGit(gitCommand, ['init', '--bare', '--quiet', gitDir])
+  await git(['fetch', '--quiet', '--depth', '1', '--filter=blob:none', '--no-tags', '--', repoUrl, oid])
+  const pathspec = target.kind === 'root' ? '.' : `:(top,literal)${target.path}`
+  const sizedTree = await git(
+    ['ls-tree', '-lr', '-z', '--full-tree', 'FETCH_HEAD', ...(target.kind === 'root' ? [] : ['--', pathspec])],
+    { maxOutputBytes: MAX_GIT_TREE_OUTPUT_BYTES }
+  )
+  assertGithubTargetTree(sizedTree, target, descriptorFileName)
+
+  await runGit(gitCommand, [
+    `--git-dir=${gitDir}`,
+    `--work-tree=${contentDir}`,
+    'checkout',
+    '--quiet',
+    'FETCH_HEAD',
+    '--',
+    pathspec
+  ])
+
+  return {
+    contentDir,
+    skillDir: target.kind === 'root' ? contentDir : path.join(contentDir, target.path)
+  }
+}
+
+function assertGithubTargetTree(
+  sizedTree: string,
+  target: GithubSkillTarget,
+  descriptorFileName: 'SKILL.md' | 'skill.md'
+): void {
+  const foldKey = (value: string) => value.normalize('NFC').toLowerCase()
+  const targetParts = target.kind === 'root' ? [] : target.path.split('/')
+
+  const sizedEntries = sizedTree.split('\0').flatMap((record) => {
+    if (!record) return []
+    const tab = record.indexOf('\t')
+    if (tab === -1) return []
+    const [, type, , rawSize] = record.slice(0, tab).trim().split(/\s+/)
+    if (type !== 'blob' || !/^\d+$/.test(rawSize)) return []
+    const entryPath = record.slice(tab + 1)
+    const relativePath = target.kind === 'root' ? entryPath : entryPath.split('/').slice(targetParts.length).join('/')
+    return [{ path: relativePath, size: Number(rawSize) }]
+  })
+
+  const seenPaths = new Map<string, string>()
+  for (const entry of sizedEntries) {
+    const parts = entry.path.split('/')
+    for (let length = 1; length <= parts.length; length++) {
+      const prefix = parts.slice(0, length).join('/')
+      const key = parts.slice(0, length).map(foldKey).join('/')
+      const previous = seenPaths.get(key)
+      if (previous && previous !== prefix) {
+        throw new Error(
+          `The commit contains paths that collide once case and Unicode are normalized (${previous}, ${prefix}).`
+        )
+      }
+      seenPaths.set(key, prefix)
+    }
+  }
+
+  if (!sizedEntries.some((entry) => entry.path === descriptorFileName)) {
+    const location = target.kind === 'root' ? descriptorFileName : `${target.path}/${descriptorFileName}`
+    throw new Error(`No ${descriptorFileName} found at the selected GitHub location: ${location}`)
+  }
+  if (sizedEntries.length > MAX_FILES_COUNT) {
+    throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
+  }
+  const totalSize = sizedEntries.reduce((sum, entry) => sum + entry.size, 0)
+  if (totalSize > MAX_EXTRACTED_SIZE) {
+    throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
+  }
+}
+
+/**
+ * The single entry point for every git subprocess an install spawns: bounded, non-interactive, and
+ * routed through Cherry's proxy — which lives in the main process env, not in the captured login shell.
+ */
+async function runGit(gitCommand: string, args: string[], options?: { maxOutputBytes?: number }): Promise<string> {
+  const env = await getShellEnv()
+  return executeCommand(gitCommand, args, {
+    capture: true,
+    maxOutputBytes: options?.maxOutputBytes,
+    timeout: GIT_COMMAND_TIMEOUT_MS,
+    env: {
+      ...env,
+      ...getProxyEnvironment(process.env),
+      GIT_TERMINAL_PROMPT: '0',
+      GIT_LFS_SKIP_SMUDGE: '1',
+      GIT_ASKPASS: '',
+      GCM_INTERACTIVE: 'never'
+    }
+  })
+}
+
+/**
+ * One shallow clone of whatever the remote calls its default branch — which is what a bare
+ * `git clone` already checks out, so resolving the branch first only adds a second way to hang.
+ */
+async function cloneRepository(repoUrl: string, destDir: string): Promise<void> {
+  const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
+  await runGit(gitCommand, ['clone', '--depth', '1', '--', repoUrl, destDir])
+}
+
+async function reportInstall(owner: string, repo: string, skillName: string): Promise<void> {
+  const url = `${CLAUDE_PLUGINS_API}/api/skills/${owner}/${repo}/${skillName}/install`
+  await net.fetch(url, { method: 'POST' })
+}

--- a/src/main/ai/toolApproval/__tests__/toolGuards.test.ts
+++ b/src/main/ai/toolApproval/__tests__/toolGuards.test.ts
@@ -9,6 +9,7 @@ function makeCtx(overrides: Partial<ToolGuardContext> = {}): ToolGuardContext {
     permissionMode: undefined,
     builtinRole: undefined,
     mountedServers: new Set<string>(),
+    pluginDirectories: new Map(),
     cwd: '/ws',
     agentDataPath: '/data',
     interaction: { currentTurn: 'interactive', userResponse: 'stream' },

--- a/src/main/ai/toolApproval/toolGuards.ts
+++ b/src/main/ai/toolApproval/toolGuards.ts
@@ -32,6 +32,8 @@ export interface ToolGuardContext {
   readonly builtinRole: string | undefined
   /** Cherry-owned MCP servers mounted for this session (not role-derivable). */
   readonly mountedServers: ReadonlySet<string>
+  /** Loaded plugin directories by manifest name, for conditions that resolve plugin-owned files. */
+  readonly pluginDirectories: ReadonlyMap<string, string>
   readonly cwd: string
   readonly agentDataPath: string
   readonly interaction: ToolGuardInteractionState

--- a/src/main/utils/__tests__/markdownParser.test.ts
+++ b/src/main/utils/__tests__/markdownParser.test.ts
@@ -94,10 +94,13 @@ Body`
     expect(metadata.tools).toEqual(['Read', 'Grep'])
   })
 
-  it('reads the skill slug and nested metadata version', async () => {
+  it('reads skill runtime fields and nested metadata version', async () => {
     vi.mocked(fs.promises.readFile).mockResolvedValue(`---
-name: Git
-slug: git
+name: parallel-web-search
+slug: parallel-web-search
+context: fork
+agent: parallel:parallel-subagent
+allowed-tools: Bash(parallel-cli:*)
 metadata:
   version: "1.0.12"
 ---
@@ -106,8 +109,13 @@ Body`)
 
     const metadata = await parseSkillMetadata('/abs/skill', 'skills/git', 'skills')
 
-    expect(metadata.slug).toBe('git')
+    expect(metadata.slug).toBe('parallel-web-search')
     expect(metadata.version).toBe('1.0.12')
+    expect(metadata).toMatchObject({
+      context: 'fork',
+      agent: 'parallel:parallel-subagent',
+      allowed_tools: ['Bash(parallel-cli:*)']
+    })
   })
 
   it('prefers a top-level skill version over metadata.version', async () => {

--- a/src/main/utils/file/__tests__/path.test.ts
+++ b/src/main/utils/file/__tests__/path.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { canWrite, isPathInside, isSameOrInside } from '../path'
+import { canWrite, isOutsidePath, isPathInside, isSameOrInside } from '../path'
 
 describe('isPathInside', () => {
   it('returns true when child is directly inside parent', () => {
@@ -66,6 +66,28 @@ describe('isSameOrInside', () => {
       expect(isSameOrInside('/Users/me/Data/Files', '/users/me/data/files')).toBe(true)
     }
   )
+})
+
+describe('isOutsidePath', () => {
+  it('rejects a relative path that walks out of the base', () => {
+    expect(isOutsidePath('..')).toBe(true)
+    expect(isOutsidePath(path.join('..', 'sibling'))).toBe(true)
+  })
+
+  it('rejects an absolute path, which ignores the base entirely', () => {
+    expect(isOutsidePath(path.resolve('/elsewhere'))).toBe(true)
+  })
+
+  it('accepts the base itself and any descendant of it', () => {
+    expect(isOutsidePath('')).toBe(false)
+    expect(isOutsidePath(path.join('nested', 'skill'))).toBe(false)
+  })
+
+  // The naive `startsWith('..')` check reads this as an escape; it is an ordinary child directory.
+  it('accepts a child whose name merely starts with two dots', () => {
+    expect(isOutsidePath('..archive')).toBe(false)
+    expect(isOutsidePath(path.join('..archive', 'SKILL.md'))).toBe(false)
+  })
 })
 
 describe('canWrite', () => {

--- a/src/main/utils/file/index.ts
+++ b/src/main/utils/file/index.ts
@@ -87,6 +87,6 @@ export {
   write
 } from './fs'
 export { decodeTextBufferIfText, getFileType, isTextByContent, mimeToExt } from './metadata'
-export { canWrite, isNotEmptyDir, isPathInside, isSameOrInside, resolvePath } from './path'
+export { canWrite, isNotEmptyDir, isOutsidePath, isPathInside, isSameOrInside, resolvePath } from './path'
 export { getPathStatus, type PathStatus, type PathStatusKind } from './pathStatus'
 export { open, showInFolder } from './shell'

--- a/src/main/utils/file/path.ts
+++ b/src/main/utils/file/path.ts
@@ -58,6 +58,19 @@ export function isSameOrInside(candidate: string, container: string): boolean {
   )
 }
 
+/**
+ * True iff an already-computed `path.relative()` result escapes its base.
+ *
+ * Distinct from `!isSameOrInside`: it takes the relative path the caller
+ * already has, treats `''` (the base itself) as inside, and matches `..` only
+ * as a whole segment — so a child directory literally named `..archive` is not
+ * mistaken for an escape. It also compares exactly what was passed, without the
+ * platform case folding `isPathInside` applies.
+ */
+export function isOutsidePath(relativePath: string): boolean {
+  return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
+}
+
 /** Check if a path is writable for the current process. */
 export async function canWrite(target: AbsoluteFilePath): Promise<boolean> {
   try {

--- a/src/main/utils/markdownParser.ts
+++ b/src/main/utils/markdownParser.ts
@@ -371,8 +371,10 @@ export async function parseSkillMetadata(
     }
   }
 
-  // Parse tools (skills use 'tools', not 'allowed_tools')
   const tools = toStringArray(data.tools)
+  const allowedTools = toStringArray(data['allowed-tools'] ?? data.allowed_tools)
+  const context = toString(data.context)
+  const agent = toString(data.agent)
 
   // Parse tags
   const tags = toStringArray(data.tags)
@@ -406,7 +408,10 @@ export async function parseSkillMetadata(
     name,
     slug,
     description,
+    allowed_tools: allowedTools,
     tools,
+    context,
+    agent,
     category, // "skills" for flat structure
     type: 'skill',
     tags,

--- a/src/main/utils/markdownParser.ts
+++ b/src/main/utils/markdownParser.ts
@@ -369,8 +369,10 @@ export async function parseSkillMetadata(
     }
   }
 
-  // Parse tools (skills use 'tools', not 'allowed_tools')
   const tools = toStringArray(data.tools)
+  const allowedTools = toStringArray(data['allowed-tools'] ?? data.allowed_tools)
+  const context = toString(data.context)
+  const agent = toString(data.agent)
 
   // Parse tags
   const tags = toStringArray(data.tags)
@@ -404,7 +406,10 @@ export async function parseSkillMetadata(
     name,
     slug,
     description,
+    allowed_tools: allowedTools,
     tools,
+    context,
+    agent,
     category, // "skills" for flat structure
     type: 'skill',
     tags,

--- a/src/main/utils/plugin.ts
+++ b/src/main/utils/plugin.ts
@@ -12,8 +12,10 @@ export const PluginMetadataSchema = z.object({
 
   // Content
   description: z.string().optional(),
-  allowed_tools: z.array(z.string()).optional(), // from frontmatter (for commands)
+  allowed_tools: z.array(z.string()).optional(), // from frontmatter (for commands and skills)
   tools: z.array(z.string()).optional(), // from frontmatter (for agents and skills)
+  context: z.string().optional(), // skill execution context (for example, "fork")
+  agent: z.string().optional(), // subagent selected by a forked skill
 
   // Organization
   category: z.string(), // derived from parent folder name


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

This PR carries two related change sets. The dependency gate is the user-facing fix; the `SkillService` split is the refactor it landed on top of (originally reviewed as CherryHQ#18560, squash-merged into this branch).

**1. Skill runtime dependency gate**

Before this PR:

A skill could declare a forked subagent and a Bash CLI that were unavailable at runtime. Claude Agent SDK still accepted the `Skill` call, so the fork continued without a dependency error and could return unrelated catalog-like content instead of performing the requested work.

After this PR:

Cherry Studio resolves the selected skill's declared runtime dependencies immediately before the SDK runs it, and blocks only what it can prove absent. A plugin-qualified fork subagent whose plugin is indexed but has no such agent definition denies the call with `Skill "parallel-web-search" cannot run: its forked subagent "parallel:parallel-subagent" is not installed.` Anything that merely fails to resolve — an unqualified agent name, a plugin that is not in the session's index, a declared Bash executable that is not on `PATH` — is delivered as `PreToolUse` `additionalContext` so the model reports the real failure instead of substituting unrelated output.

**2. `SkillService` split**

Before this PR:

`SkillService.ts` was ~1800 lines mixing catalog/lifecycle ownership with ZIP extraction, Git fetching, marketplace HTTP, path sanitation, and containment checks.

After this PR:

Those concerns move to three cohesive modules with no behavior change — `skillPaths.ts` (folder-name sanitation, temp dirs, file tree), `skillArchive.ts` (extraction ceilings and every containment check over an untrusted skill tree), `skillRemoteSource.ts` (per-source acquisition into a caller-owned temp dir). `SkillService` keeps the catalog, the mutation lock, and the mirror. `isOutsidePath` moves to `@main/utils/file` next to the other path predicates.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # — no linked GitHub issue.

### Why we need it and why it was done in this way

A real SDK trace confirmed that `parallel:parallel-subagent` was absent from the initialized agent catalog, while the SDK still accepted the `Skill` tool call and emitted forked execution messages. The trace contained no `search_skills` invocation, and that tool's JSON result shape does not match the reported output. The unrelated list therefore came from the silently degraded fork, not the skill marketplace search path.

The mirror path was also ruled out: Cherry Studio's Windows/builtin branch recursively copies the complete skill directory. A regression assertion now covers nested `agents/` and `scripts/` content. The reported Windows symlink `EPERM` can skip a user-local symlink during discovery, but it does not truncate a successfully mirrored managed skill.

The fix stays at Cherry Studio's existing SDK boundary. Skill runtime frontmatter is parsed, declared dependencies are resolved against the exact workspace/plugin set passed to the session, and the existing executable resolver checks the user's environment. A `PreToolUse` denial makes the missing dependencies visible to the model and user before the SDK can silently fork.

The split is here because the dependency gate needs `SkillService`'s path and containment helpers from a second caller, and reaching into a 1800-line class for them would have deepened the coupling instead of naming the boundary.

The following tradeoffs were made:

- Only a plugin-qualified fork subagent whose plugin **is** in the session index blocks. That is the one case the index can settle. An unindexed plugin is not proof: the index holds only what `settingsBuilder` passes as `plugins`, while the enabled setting sources let the SDK load more, and the guard rule enforces under `bypassPermissions` — a false `absent` would leave a working skill unrunnable with no override.
- The SDK's builtin subagent roster is not stable enough for an unqualified name to be treated as proof, and `allowed-tools` is a permission allowlist whose entries are frequently interchangeable alternatives — `shadcn` declares `Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)` for one operation, and an npm-only machine must still be able to run it. Executable resolution also cannot see the coreutils the Bash tool reaches through Git Bash on Windows, which is the platform this was reported on.
- A library skill is resolved by folder name first and then by its `SKILL.md` `name`, because the SDK accepts either but the installer derives the folder name from the bundle directory. The name fallback is taken only when it is unique, so an ambiguous name can never deny a call against a different skill's dependencies.
- Validation is limited to explicit `context`, `agent`, and `allowed-tools` declarations; free-form compatibility prose is not guessed.
- Dependencies are checked at invocation time so installing or removing a CLI takes effect without reinstalling the skill. The guard rule and the advisory hook share one in-flight run per tool call rather than each re-parsing `SKILL.md` and re-probing `PATH`.
- The check lives in `runtime/claudeCode/skillDependencies.ts`, next to its only caller: the SDK plugin layout, builtin subagent roster and `allowed-tools` syntax are Claude Agent SDK semantics, while `SkillService` stays the driver-agnostic skill catalog the `pi` runtime also reads. Plugin manifests are indexed once per session instead of re-read on every `Skill` call.
- The split moves code without changing it. Extraction ceilings stay single-sourced in `skillArchive` so the pre-checkout tree check and the post-checkout directory walk, which run in the same GitHub install, cannot drift apart.

The following alternatives were considered:

- Automatically install missing CLIs or subagents: rejected because it would add unrequested installation and trust semantics.
- Fall back to another search tool: rejected because that is a product decision and could change the skill's intended behavior.
- Deny on any unresolved dependency: rejected because it converts a silent failure into a false denial of working skills, which is a worse regression than the bug.
- Patch or replace the Claude Agent SDK fork behavior: unnecessary once Cherry Studio can reject the invalid call at its existing hook boundary.
- Leave `SkillService` intact and import its private helpers: rejected because it spreads the class's internals across the runtime layer.

Links to places where the discussion took place: [original Feishu feedback](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrSclYy7uSh), CherryHQ#18560

### Breaking changes

None. This changes a silent failed execution into an explicit dependency error. The split is internal and preserves every existing install path.

### Special notes for your reviewer

**Scope changed after the first approvals.** This PR was approved at 13 files / +541. It now carries CherryHQ#18560 (the `SkillService` split) plus follow-up fixes, at 20 files / +1515 / -770. GitHub did not dismiss the earlier approvals, so the split and the follow-ups have not been reviewed here. Suggest a fresh pass over `419314d47f..HEAD`.

Original feedback:

- Source: product/R&D dev table “v2 preview issue feedback”; base `NM62bC0Epaqy0JsKjZYcQCn7nVd`, table `tblbuPFvvugxC8My`, record `recvrSclYy7uSh`.
- Submitter: 许思寅. Original source: compressed-package feedback record `rec27Wd1h25q5M`, item 20.
- Metadata: P2; Windows 10 19045; Cherry Studio v2.0.0; status 未修复; type BUG.
- User summary: “parallel-web-search Skill 引用了未注册的 parallel-subagent 和未安装的 parallel-cli，执行后没有搜索也没有明确错误，而是返回一段无关技能/任务列表。依赖缺失应显式失败或回退到可用搜索工具。”
- Reproduction: install and invoke `parallel-web-search`, pass any query, then observe forked execution return an unrelated skill list without searching.
- Environment: `parallel-cli` was not installed. The feedback also mentions a Skills-directory symlink `EPERM` in Windows logs.
- Source record: https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvrSclYy7uSh

Validation:

- `skillDependencies.test.ts` parses real `SKILL.md` frontmatter rather than a stubbed parser, covering the deny cases, the unindexed-plugin and bare-name warnings, a `shadcn`-shaped regression proving interchangeable CLI declarations never deny, name-addressed resolution, and the ambiguity refusal.
- `guardRules.test.ts` covers the new rule under `bypassPermissions`, matching how every other rule in that table is pinned.
- The `PreToolUse` regression covers both hook outcomes: a permission denial and an `additionalContext`-only pass.
- The name-addressed path was additionally exercised end-to-end against a real ZIP install into a real database, with no parser or service stubs, on a bundle whose directory name and `SKILL.md` `name` disagree.
- `SkillService.test.ts` asserts a builtin mirror copies nested `agents/` and `scripts/` content.
- `pnpm build:check`, `pnpm test`, `pnpm test:lint`, `pnpm typecheck:node`, changed-file oxlint with warnings denied.

No renderer or visual behavior was changed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Report a clear error when a skill's forked subagent is not installed, and warn about unresolved CLI executables, instead of silently continuing with unrelated output.
```
