### PR TITLE
fix(agent-composer): name skills by directory in the injected prompt

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3833,7 +3833,7 @@ describe('AgentComposer', () => {
       kind: 'skill',
       label: 'Review (fast)',
       description: 'Review changed files',
-      promptText: 'Use the Review (fast) skill.',
+      promptText: 'Use the review-fast skill.',
       payload: reviewSkill
     })
   })

--- a/src/renderer/components/composer/variants/__tests__/agentComposerTokens.test.ts
+++ b/src/renderer/components/composer/variants/__tests__/agentComposerTokens.test.ts
@@ -55,6 +55,19 @@ describe('agent composer token mapping', () => {
     })
   })
 
+  it('prompts with the skill directory name when the display name differs', () => {
+    const skill = {
+      name: 'Magic Word',
+      description: 'Prints the magic word',
+      filename: 'magic-word'
+    } satisfies LocalSkill
+
+    expect(agentSkillToComposerToken(skill)).toMatchObject({
+      label: 'Magic Word',
+      promptText: 'Use the magic-word skill.'
+    })
+  })
+
   it('extracts file token ids by kind', () => {
     const ids = getAgentComposerTokenIds(
       [

--- a/src/renderer/components/composer/variants/agentComposerTokens.ts
+++ b/src/renderer/components/composer/variants/agentComposerTokens.ts
@@ -25,7 +25,9 @@ export function agentSkillToComposerToken(skill: LocalSkill): ComposerDraftToken
     kind: 'skill',
     label: skill.name,
     ...(skill.description && { description: skill.description }),
-    promptText: `Use the ${skill.name} skill.`,
+    // The runtime lists and resolves skills by directory name, never by the SKILL.md / library
+    // display name — naming the latter makes the agent report the skill as missing on first call.
+    promptText: `Use the ${skill.filename} skill.`,
     payload: skill
   }
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Picking a skill from the agent composer injected the prompt sentence `Use the ${skill.name} skill.` — the **display name** (`SKILL.md` frontmatter `name` for workspace skills, the library display name for managed ones). The runtime lists and resolves skills by **directory name** (`.claude/skills/<dir>` for workspace skills, `folderName` for managed ones). Whenever the two differ, the agent answers on the first call that no such skill exists, and only uses it after the user insists.

After this PR:

The injected sentence names the directory the runtime actually resolves (`LocalSkill.filename`), so the skill is invoked on the first call.

Fixes # N/A

### Why we need it and why it was done in this way

Reported by an internal preview tester: a skill placed under the agent workspace's `.claude/skills/` shows up in the composer's skill menu and can be picked, but the agent claims it cannot find the skill on the first run and only discovers it after being reminded.

Reproduced against the shipped Agent SDK (0.3.220) with the real CLI, workspace skill directory `magic-word` whose `SKILL.md` declares `name: sorcery`, whitelist `["magic-word"]`:

- `"Use the sorcery skill."` → *"I don't see a 'sorcery' skill available. The only skill currently available is: **magic-word**"* — the reported symptom.
- `"Use the magic-word skill."` → the model calls `Skill(magic-word)` and the skill runs. First call, no reminder.

Ruled out along the way (verified, no change needed):

- The workspace skill whitelist itself is correct — `buildSkillWhitelist` passes `.claude/skills` directory names and the SDK's allowlist matcher accepts both the directory name and the frontmatter name; a session with a matching name works on the first call.
- Warm/prewarm staleness — the warm-query signature covers the full options (including `skills`), so a stale parked process is never consumed.
- Snapshot staleness across a mid-session skill addition — `reconcile` re-scans `.claude/skills` before every fresh turn and rebuilds; verified end-to-end with a resume, the newly added skill is invoked on the next turn.

The following tradeoffs were made:

- The token label and the composer chip keep the display name; only the model-facing sentence changes. Message rendering already replaces this prompt span with `/<filename>/` (`replaceComposerTokenPromptText`), so nothing visible changes for the user.

The following alternatives were considered:

- Making `skill.list_local` report the directory name as the skill's `name` — that would change what users see in the skill menu and lose the human-readable title.
- Widening the runtime whitelist to also carry display names — the whitelist is only a filter over what the SDK discovers, so it cannot make the model aware of a name the SDK never lists.

Links to places where the discussion took place: internal preview feedback record `recvrpOBU6u0tv` (Cherry Studio 官方内测群 5, 2026-08-05)

### Breaking changes

None.

### Special notes for your reviewer

Original feedback (verbatim, internal preview feedback table):

- 来源表：产研 dev 表「V2 预览版问题反馈」，base `NM62bC0Epaqy0JsKjZYcQCn7nVd` / table `tblbuPFvvugxC8My`
- record_id：`recvrpOBU6u0tv`
- 提交人：许思寅（来源：Cherry Studio 官方内测群 5 · Patrick · 2026-08-05）
- 用户原话摘要：「用户把 Skill 放在 Cherry 工作目录中，斜杠命令可以看到并调用，但 Agent 第一次执行时声称找不到该 Skill，必须由用户再次提醒才会发现，说明 Skill 注册展示与 Agent 运行时发现结果不一致。」
- 复现步骤（用户给的）：在 Cherry 工作目录放置 Skill → 输入 / 可以看到并调用 → 第一次让 Agent 使用该 Skill → Agent 回复找不到 → 再次提醒其查找后才能发现。
- 记录状态：状态=沟通中、处理人为空、类型=BUG、P2。备注注明精确版本/平台/目录结构待确认。

- Unrelated observation, deliberately **not** changed here: `findSkillMdPath` accepts `skill.md` as well as `SKILL.md`, while the Agent SDK only ever reads `<dir>/SKILL.md`. On a case-sensitive filesystem that lets Cherry list a workspace skill the runtime can never load. Aligning Cherry to `SKILL.md` only would regress case-insensitive platforms (where `skill.md` works today), so it is left alone.
- `AgentComposer.test.tsx` had an assertion pinning the old behaviour (`Use the Review (fast) skill.` for the `review-fast` directory) — that fixture is exactly the broken shape, so the expectation was corrected rather than kept green.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix agent skills picked from the composer being reported as missing on the first call when the skill's display name differs from its directory name.
```
