### PR TITLE
fix(i18n): allow full API paths in base URL placeholder (#18490)

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -7924,9 +7924,9 @@
       "balance": "Balance",
       "base_url": {
         "invalid": "Enter a valid HTTP or HTTPS URL",
-        "label": "Base URL",
-        "placeholder": "Base URL: https://example.com",
-        "required": "Please enter the Base URL"
+        "label": "API URL",
+        "placeholder": "e.g. https://example.com or https://api.example.com/v1/chat/completions",
+        "required": "Please enter the API URL"
       },
       "basic_auth": {
         "label": "HTTP authentication",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -7924,9 +7924,9 @@
       "balance": "余额",
       "base_url": {
         "invalid": "请输入有效的 HTTP 或 HTTPS 地址",
-        "label": "Base URL",
-        "placeholder": "Base URL：https://example.com",
-        "required": "请输入 Base URL"
+        "label": "API 地址",
+        "placeholder": "例如 https://example.com 或 https://api.example.com/v1/chat/completions",
+        "required": "请输入 API 地址"
       },
       "basic_auth": {
         "label": "HTTP 认证",


### PR DESCRIPTION
## Summary

Closes #18490. Replaces #18539 (which was closed — it bundled several unrelated fixes from my local history into one PR).

## What changed

Only the i18n copy for the provider config `base_url` field, in both `en-us.json` and `zh-cn.json`:

- `label`: "Base URL" → "API URL" / "API 地址"
- `placeholder`: now shows a full-path example (`https://example.com` or `https://api.example.com/v1/chat/completions`)
- `required`: "Please enter the Base URL" → "Please enter the API URL"

That's it. No code change. The underlying `formatApiHost` / `hasApiVersion` already accept full paths (verified in the review thread on #18539), so widening the copy is the only thing needed to stop users from thinking they must enter a bare host.

## Why a new PR

The original #18539 had 7 commits because my local branch had accumulated several other fixes (copilot reasoning_effort normalization, doubao-seedream routing, etc.). That set of changes is already pending in #18368, #18540, and other dedicated PRs. This clean branch cherry-picks only the single i18n commit onto a fresh base from `CherryHQ/cherry-studio:main`.

## Verification

- No node_modules locally (1.8 GB RAM sandbox), so I could not run `pnpm i18n:check` / `pnpm build:check`. CI is the canonical validator.
- Diff sanity: 2 files, 6 lines changed, no key additions or removals — both locale files stay structurally identical.

## Checklist

- [x] Conventional commit scope (`i18n`)
- [x] Signed off (`-S` already present on the cherry-picked commit)
- [x] No secrets, no new env vars
- [x] Single commit, single concern
