### PR TITLE
fix(knowledge-rag): restore 0.01 similarity-threshold precision

### DIFF
--- a/src/renderer/pages/knowledge/panels/ragConfig/RetrievalSection.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/RetrievalSection.tsx
@@ -43,10 +43,10 @@ const RetrievalSection = ({
           onValueChange={onThresholdChange}
           min={0}
           max={1}
-          step={0.1}
-          minLabel="0.0"
-          maxLabel="1.0"
-          formatValue={(value) => value.toFixed(1)}
+          step={0.01}
+          minLabel="0.00"
+          maxLabel="1.00"
+          formatValue={(value) => value.toFixed(2)}
         />
       ) : null}
     </div>

--- a/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/ragConfig/__tests__/RagConfigPanel.test.tsx
@@ -426,15 +426,20 @@ describe('RagConfigPanel', () => {
 
     const thresholdSlider = screen.getByRole('slider', { name: '相似度阈值' })
     expect(thresholdSlider).toHaveValue('0')
+    // The threshold is a 0.01-granularity knob, so 0.65 must stay reachable and
+    // be shown as typed instead of being rounded to a tenth.
+    expect(thresholdSlider).toHaveAttribute('step', '0.01')
 
-    fireEvent.change(thresholdSlider, { target: { value: '0.7' } })
+    fireEvent.change(thresholdSlider, { target: { value: '0.65' } })
+    expect(screen.getByText('0.65')).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: '保存' }))
 
     await waitFor(() => {
       expect(mockSave).toHaveBeenCalledWith(
         expect.objectContaining({
           rerankModelId: 'jina::jina-reranker-v2-base-multilingual',
-          threshold: 0.7
+          threshold: 0.65
         })
       )
     })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the knowledge base's **relevance threshold** slider was pinned to `step={0.1}` and rendered with `toFixed(1)`, so the only reachable values were the eleven tenths `0.0, 0.1, … 1.0`. A user who wanted `0.65` could not set it — the slider walks `0 → 0.1 → 0.2 → … → 0.7`, and any finer value already stored in the base was displayed rounded (`0.65` showed as `0.7`). v1 let this knob move in `0.01` steps, so upgrading users lost precision they had been relying on.

After this PR: the same slider uses `step={0.01}` and shows two decimals, so `0.65` is reachable and displayed as typed. The scale labels follow (`0.00` / `1.00`).

| | Before | After |
|---|---|---|
| Reachable values | `0.0 … 1.0` (11 stops) | `0.00 … 1.00` (101 stops) |
| Readout for `0.65` | `0.7` | `0.65` |

**Before**

![Before — threshold slider steps in tenths, cannot reach 0.65](https://raw.githubusercontent.com/kennyzheng-builds/samba/28aa17013049da1a16d986274334c841ade1673a/before.png)

**After**

![After — threshold slider reaches 0.65](https://raw.githubusercontent.com/kennyzheng-builds/samba/28aa17013049da1a16d986274334c841ade1673a/after.png)

Only the threshold slider changed. The Top K slider above it keeps `step={1}` — it counts documents.

Fixes # N/A (reported through internal v2 preview feedback, not a GitHub issue)

**原始反馈**：用户「许思寅」(V2 抓虫大赛 · Cherry Studio v2.0.0-rc.1)：「知识库 score 精度和 V1 不同，V1 精度 0.01，目前默认值也为 0」｜ 源记录(dev 表 recvrcDEyltw4p)：https://mcnnox2fhjfq.feishu.cn/record/IXDNrjYE9eF6uCcHJvOcKi59nhc

### Why we need it and why it was done in this way

The slider was the only place the precision was lost. Everything below it already accepts arbitrary decimals, so no other layer needed touching — I verified the whole write path:

- `RagConfigPanel.tsx` → `utils/rag.ts` `buildKnowledgeRagConfigPatch` passes `values.threshold` through unchanged; there is no rounding step.
- `KnowledgeThresholdSchema` (`src/shared/data/types/knowledge.ts`) is `z.number().min(0).max(1)` — a range bound, not a precision bound.
- The DB column is `threshold: real()` (`src/main/data/db/schemas/knowledge.ts`), so a fractional value persists as-is. No migration is needed.

The following tradeoffs were made:

- 101 stops make a single arrow-key press move 1/100 of the track. That is the point of the report — the coarse-grained keyboard walk is what removed the values users wanted — and it matches v1's granularity.
- The min/max labels moved to `0.00` / `1.00` so the scale reads at the same precision as the value. Leaving them at `0.0` / `1.0` would imply a granularity the control no longer has.

The following alternatives were considered:

- Adding a numeric input next to the slider: solves precision but adds a control the report did not ask for, and the panel's other knobs are slider-only.
- Keeping `step={0.1}` and only widening the display format: the display was the smaller half of the bug; the value would still be unreachable.

Links to places where the discussion took place: N/A

### Breaking changes

None. Existing bases keep their stored threshold; a value that was previously only *displayed* rounded (e.g. a `0.65` carried over from v1) now shows its real value.

### Special notes for your reviewer

**The reporter's second remark — "目前默认值也为 0" — is confirmed but deliberately left alone.** `DEFAULT_KNOWLEDGE_THRESHOLD = 0.0` in `src/renderer/pages/knowledge/utils/rag.ts:8`, so a base with no stored threshold does open at `0`. Whether that default should change is a product call, not a correctness one, so it is out of scope here. Happy to follow up if you want a different default.

**Verified in the running app**, not just in tests. With a rerank model selected, walking the slider up from `0` with the arrow key gives:

- before: `0 → 0.1 → 0.2 → 0.3 → 0.4 → 0.5 → 0.6 → 0.7` — `0.65` does not exist on the track
- after: `0.65` is reachable and the readout shows `0.65`

The screenshots above are that same drawer, before and after.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
知识库的「相似度阈值」滑块恢复 0.01 精度（此前只能取 0.1 的整数倍），与 v1 一致。
Restored 0.01 precision on the knowledge base relevance-threshold slider, which was previously limited to steps of 0.1.
```
