### PR TITLE
fix(knowledge-content): keep code fences when saving a conversation to a knowledge base

### DIFF
--- a/src/renderer/services/__tests__/knowledgeContent.test.ts
+++ b/src/renderer/services/__tests__/knowledgeContent.test.ts
@@ -1,0 +1,42 @@
+import { processMessagesContent } from '@renderer/services/knowledgeContent'
+import type { ExportableMessage } from '@renderer/types/messageExport'
+import { CONTENT_TYPES } from '@renderer/utils/knowledge'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@renderer/hooks/useTopic', () => ({
+  getTopicMessages: vi.fn()
+}))
+
+const message = (role: 'user' | 'assistant', text: string): ExportableMessage =>
+  ({
+    id: `message-${role}`,
+    role,
+    topicId: 'topic-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    status: 'success',
+    parts: [{ type: 'text', text }]
+  }) as ExportableMessage
+
+describe('processMessagesContent', () => {
+  it('does not put a horizontal rule between the title and the first message', () => {
+    const result = processMessagesContent('采购管理', [message('user', 'hi')], [CONTENT_TYPES.TEXT])
+
+    expect(result.text.startsWith('# 采购管理\n\n##')).toBe(true)
+  })
+
+  it('separates consecutive messages with a horizontal rule', () => {
+    const result = processMessagesContent(
+      '采购管理',
+      [message('user', 'hi'), message('assistant', 'hello')],
+      [CONTENT_TYPES.TEXT]
+    )
+
+    expect(result.text.split('\n\n---\n\n')).toHaveLength(2)
+  })
+
+  it('omits the title when the user did not select text content', () => {
+    const result = processMessagesContent('采购管理', [message('user', 'hi')], [CONTENT_TYPES.CODE])
+
+    expect(result.text).not.toContain('采购管理')
+  })
+})

--- a/src/renderer/services/knowledgeContent.ts
+++ b/src/renderer/services/knowledgeContent.ts
@@ -64,11 +64,7 @@ export function processMessagesContent(
   const textParts: string[] = []
   const files: FileMetadata[] = []
 
-  // 添加标题（如果选择了文本类型）
   const selectedTypeSet = new Set(selectedTypes)
-  if (selectedTypeSet.has(CONTENT_TYPES.TEXT)) {
-    textParts.push(`# ${title}`)
-  }
 
   // 处理每个消息
   for (const message of messages) {
@@ -84,8 +80,12 @@ export function processMessagesContent(
     files.push(...messageResult.files)
   }
 
+  // 标题不参与 `---` 分隔，否则标题和首条消息之间会多出一条分割线
+  const body = textParts.join('\n\n---\n\n')
+  const heading = selectedTypeSet.has(CONTENT_TYPES.TEXT) ? `# ${title}` : ''
+
   return {
-    text: textParts.join('\n\n---\n\n'),
+    text: [heading, body].filter(Boolean).join('\n\n'),
     files
   }
 }

--- a/src/renderer/utils/__tests__/knowledge.test.ts
+++ b/src/renderer/utils/__tests__/knowledge.test.ts
@@ -1,3 +1,5 @@
+import type { ExportableMessage } from '@renderer/types/messageExport'
+import { getMainTextContent } from '@renderer/utils/message/find'
 import { describe, expect, it, vi } from 'vitest'
 
 import { CONTENT_TYPES, processMessageContent } from '../knowledge'
@@ -6,64 +8,79 @@ vi.mock('@renderer/hooks/useTopic', () => ({
   getTopicMessages: vi.fn()
 }))
 
-describe('Topic Knowledge Functions', () => {
-  describe('CONTENT_TYPES', () => {
-    it('should have all expected content types', () => {
-      expect(CONTENT_TYPES.TEXT).toBe('text')
-      expect(CONTENT_TYPES.CODE).toBe('code')
-      expect(CONTENT_TYPES.THINKING).toBe('thinking')
-      expect(CONTENT_TYPES.TOOL_USE).toBe('tools')
-      expect(CONTENT_TYPES.CITATION).toBe('citations')
-      expect(CONTENT_TYPES.TRANSLATION).toBe('translations')
-      expect(CONTENT_TYPES.ERROR).toBe('errors')
-      expect(CONTENT_TYPES.FILE).toBe('files')
-      expect(CONTENT_TYPES.IMAGES).toBe('images')
-    })
-  })
+const message = (parts: unknown[]): ExportableMessage =>
+  ({
+    id: 'message-1',
+    role: 'assistant',
+    topicId: 'topic-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    status: 'success',
+    parts
+  }) as ExportableMessage
 
-  describe('Topic Knowledge Functions Integration', () => {
-    it('should be importable without circular dependencies', async () => {
-      // This test verifies that the knowledge functions can be imported
-      // without causing circular dependency issues
-      const knowledgeModule = await import('../knowledge')
-      const knowledgeContentModule = await import('@renderer/services/knowledgeContent')
-
-      expect(knowledgeContentModule).toHaveProperty('analyzeTopicContent')
-      expect(knowledgeContentModule).toHaveProperty('processTopicContent')
-      expect(knowledgeModule).toHaveProperty('CONTENT_TYPES')
-      expect(typeof knowledgeContentModule.analyzeTopicContent).toBe('function')
-      expect(typeof knowledgeContentModule.processTopicContent).toBe('function')
-    })
-  })
-
-  describe('processMessageContent', () => {
-    it('converts file part URLs to absolute filesystem paths for file metadata', () => {
-      const result = processMessageContent(
+describe('processMessageContent', () => {
+  it('converts file part URLs to absolute filesystem paths for file metadata', () => {
+    const result = processMessageContent(
+      message([
         {
-          id: 'message-1',
-          role: 'user',
-          topicId: 'topic-1',
-          createdAt: '2026-01-01T00:00:00.000Z',
-          status: 'success',
-          parts: [
-            {
-              type: 'file',
-              url: 'file:///tmp/report%20final.pdf',
-              filename: 'report final.pdf',
-              mediaType: 'application/pdf'
-            }
-          ]
-        },
-        [CONTENT_TYPES.FILE]
-      )
+          type: 'file',
+          url: 'file:///tmp/report%20final.pdf',
+          filename: 'report final.pdf',
+          mediaType: 'application/pdf'
+        }
+      ]),
+      [CONTENT_TYPES.FILE]
+    )
 
-      expect(result.files).toEqual([
-        expect.objectContaining({
-          name: 'report final.pdf',
-          path: '/tmp/report final.pdf',
-          type: 'application/pdf'
-        })
-      ])
-    })
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        name: 'report final.pdf',
+        path: '/tmp/report final.pdf',
+        type: 'application/pdf'
+      })
+    ])
+  })
+
+  it('keeps the fence and language tag on code parts', () => {
+    const result = processMessageContent(
+      message([{ type: 'data-code', data: { language: 'typescript', content: 'const a = 1' } }]),
+      [CONTENT_TYPES.CODE]
+    )
+
+    expect(result.text).toBe('```typescript\nconst a = 1\n```')
+  })
+
+  // The knowledge-base entry used to re-implement part serialization and lost code
+  // fences, so "save to knowledge base" and "save as note -> knowledge base" produced
+  // different Markdown for the same conversation.
+  it('serializes text-like parts exactly like the shared export path', () => {
+    const parts = [
+      { type: 'text', text: '## 思路\n\n1. 闭包\n\n> 注意 this' },
+      { type: 'data-code', data: { language: 'typescript', content: 'const a = 1' } },
+      { type: 'data-translation', data: { targetLanguage: 'en', content: 'Use a closure.' } },
+      { type: 'data-error', data: { name: 'ApiError', code: '429', message: 'Too many requests' } }
+    ]
+
+    const result = processMessageContent(message(parts), [
+      CONTENT_TYPES.TEXT,
+      CONTENT_TYPES.CODE,
+      CONTENT_TYPES.TRANSLATION,
+      CONTENT_TYPES.ERROR
+    ])
+
+    expect(result.text).toBe(getMainTextContent(message(parts)))
+  })
+
+  it('drops the part types the user did not select', () => {
+    const result = processMessageContent(
+      message([
+        { type: 'text', text: 'answer' },
+        { type: 'data-code', data: { language: 'ts', content: 'const a = 1' } },
+        { type: 'data-error', data: { name: 'ApiError', message: 'boom' } }
+      ]),
+      [CONTENT_TYPES.TEXT]
+    )
+
+    expect(result.text).toBe('answer')
   })
 })

--- a/src/renderer/utils/knowledge.ts
+++ b/src/renderer/utils/knowledge.ts
@@ -1,7 +1,8 @@
 import type { FileMetadata } from '@renderer/types/file'
 import type { ExportableMessage } from '@renderer/types/messageExport'
+import { getRenderableTextContent } from '@renderer/utils/message/find'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import type { CodePartData, ErrorPartData, TranslationPartData } from '@shared/data/types/uiParts'
+import type { CodePartData } from '@shared/data/types/uiParts'
 
 /**
  * 内容类型常量定义
@@ -186,6 +187,15 @@ export function processMessageContent(
   }
 }
 
+// Part types whose Markdown is owned by `getRenderableTextContent`; the knowledge
+// path only decides whether the user selected them, never how they serialize.
+const CANONICAL_PART_CONTENT_TYPES: Partial<Record<CherryMessagePart['type'], ContentType>> = {
+  text: CONTENT_TYPES.TEXT,
+  'data-code': CONTENT_TYPES.CODE,
+  'data-translation': CONTENT_TYPES.TRANSLATION,
+  'data-error': CONTENT_TYPES.ERROR
+}
+
 /**
  * 处理所选类型的文本内容
  */
@@ -197,36 +207,15 @@ function processTextlikePart(
 ): string {
   const partId = `${messageId}-part-${index}`
 
+  const canonicalContentType = CANONICAL_PART_CONTENT_TYPES[part.type]
+  if (canonicalContentType) {
+    return selectedTypes.has(canonicalContentType) ? getRenderableTextContent(part) : ''
+  }
+
   switch (part.type) {
-    case 'text': {
-      if (!selectedTypes.has(CONTENT_TYPES.TEXT)) return ''
-      return part.text || ''
-    }
-
-    case 'data-code': {
-      if (!selectedTypes.has(CONTENT_TYPES.CODE)) return ''
-      return getDataPart<CodePartData>(part)?.content || ''
-    }
-
     case 'reasoning': {
       if (!selectedTypes.has(CONTENT_TYPES.THINKING)) return ''
       return `<think>\n${part.text || ''}\n</think>`
-    }
-
-    case 'data-error': {
-      if (!selectedTypes.has(CONTENT_TYPES.ERROR)) return ''
-      const data = getDataPart<ErrorPartData>(part)
-      const error = data
-        ? { name: data.name ?? undefined, message: data.message ?? data.code ?? 'Error occurred', stack: data.stack }
-        : undefined
-      const errorContent = error ? JSON.stringify(error) : 'Error occurred'
-      return `<error>\n${errorContent}\n</error>`
-    }
-
-    case 'data-translation': {
-      if (!selectedTypes.has(CONTENT_TYPES.TRANSLATION)) return ''
-      const data = getDataPart<TranslationPartData>(part)
-      return `<translation target="${data?.targetLanguage ?? ''}">\n${data?.content ?? ''}\n</translation>`
     }
 
     case 'file': {

--- a/src/renderer/utils/message/find.ts
+++ b/src/renderer/utils/message/find.ts
@@ -37,7 +37,12 @@ function formatErrorPart(data: Partial<ErrorPartData> | undefined): string {
   return [data.name, data.code, data.message].filter(Boolean).join('\n')
 }
 
-function getRenderableTextContent(part: CherryMessagePart): string {
+/**
+ * Canonical part → Markdown serialization for the text-like part types
+ * (`text` / `data-code` / `data-translation` / `data-error`). Every export path
+ * must go through this so a code part keeps its fences and language tag.
+ */
+export function getRenderableTextContent(part: CherryMessagePart): string {
   switch (part.type) {
     case 'text':
       return part.text ?? ''


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Saving a conversation to a knowledge base produced different Markdown than saving it as a note first and then importing that note — same conversation, two entries, two results. The most visible symptom is that **fenced code blocks lose their fences and language tag**, so code renders as an ordinary paragraph in the knowledge base.

Both entries sit next to each other in the topic context menu (`保存到笔记` / `保存到知识库`, `useTopicMenuActions.ts:124` and `:135`), which is where the report came from.

**Root cause.** The two entries use two independent part → Markdown serializers:

| Entry | Path |
| --- | --- |
| Save to notes | `exportTopicToNotes` → `topicToMarkdown` → `messageToMarkdown` → `getMainTextContent` → `getRenderableTextContent` (`utils/message/find.ts`) |
| Save to knowledge base | `SaveToKnowledgePopup.showForTopic` → `processTopicContent` → `processMessagesContent` → `processMessageContent` (`utils/knowledge.ts`) |

`processTextlikePart` in `utils/knowledge.ts` re-implemented the serialization and diverged from the canonical one. The note path is also what every other export (Notion / Yuque / SiYuan / Obsidian) uses, so the knowledge-base entry was the only outlier.

**Evidence.** Both serializers were run on the same topic on `upstream/main` (`d5c5110`) — a user message plus an assistant message carrying `text` + `data-code` + `data-translation` + `data-error` parts.

Before this PR:

<table>
<tr><th>Save to notes (correct)</th><th>Save to knowledge base (broken)</th></tr>
<tr><td>

~~~markdown
# 采购管理有哪些

## 🧑‍💻 User

帮我写一个 TS 的防抖函数

---
## 🤖 Assistant

## 思路

1. 用闭包保存 timer
2. 返回新函数

> 注意 this 绑定

```typescript
function debounce(fn: Function, ms: number) {
  let t: any
  return () => {}
}
```

Use a closure to hold the timer.

ApiError
429
Too many requests
~~~

</td><td>

~~~markdown
# 采购管理有哪些

---

## 用户：

帮我写一个 TS 的防抖函数

---

## 助手：

## 思路

1. 用闭包保存 timer
2. 返回新函数

> 注意 this 绑定

function debounce(fn: Function, ms: number) {
  let t: any
  return () => {}
}

<translation target="en">
Use a closure to hold the timer.
</translation>

<error>
{"name":"ApiError","message":"Too many requests"}
</error>
~~~

</td></tr>
</table>

Three concrete defects on the knowledge-base side:

1. **`data-code` loses its fence and language tag** — the code block degrades into a plain paragraph. This is the reported symptom.
2. `data-translation` / `data-error` are wrapped in `<translation>` / `<error>` XML tags instead of plain Markdown; the error path also JSON-stringifies the payload and drops the `code` field.
3. A stray `---` horizontal rule sits between the topic title and the first message, because the title was joined into the same `---`-separated list as the messages.

After this PR: the knowledge-base output matches the note output for every shared part type — code keeps its fence and language, translations and errors are plain text, and the title is followed directly by the first message.

Fixes # N/A

### Why we need it and why it was done in this way

`getRenderableTextContent` in `utils/message/find.ts` is already the canonical part → Markdown serializer for `text` / `data-code` / `data-translation` / `data-error`; it was just module-private. This PR exports it and has the knowledge path call it, so `utils/knowledge.ts` now only decides **whether** a part is included, never **how** it serializes. That removes the second implementation instead of patching it to match.

The following tradeoffs were made:

- **The content-type checkboxes are preserved.** The popup still lets users include or exclude main text / code / thinking / tool calls / translations / errors / files. Only the serialization of the selected parts changed — the shared serializer is applied to the selected subset rather than replacing the selection UI.
- **`reasoning`, tool, file and image parts keep their existing handling** (`<think>`, `<tool>`, `<image>`, `<file>`). The canonical serializer does not cover them — the note path never exports reasoning or tool calls at all — so folding them in would have deleted knowledge-base capability rather than fixing formatting.
- **Role headings are deliberately left alone.** The knowledge path emits localized `## 用户：` / `## 助手：` while exports emit `## 🧑‍💻 User` / `## 🤖 Assistant`. Both are valid Markdown headings and neither corrupts content, so unifying them would be a behavior change beyond this bug.

The following alternatives were considered:

- **Route the popup through `messageToMarkdown` wholesale.** Rejected: it drops tool-call parts entirely, which would silently break the "tool calls" checkbox, and it would force the export-only role headings onto knowledge-base content.
- **Duplicate the fence / plain-text formatting inside `utils/knowledge.ts`.** Rejected: that keeps two serializers in sync by hand, and they would drift again on the next part type.

Links to places where the discussion took place: internal beta feedback (Cherry Studio official beta group 2, 2026-08-12), tracked in the dev feedback table as record `recvsbeXAAnx98`.

### Breaking changes

None. Knowledge-base items saved before this change keep their stored content; only newly saved conversations use the corrected formatting.

### Special notes for your reviewer

- `getRenderableTextContent` is newly exported from `utils/message/find.ts`; its implementation is unchanged.
- The four new test cases were cross-verified: they all **fail** on the unfixed code and pass on the fix (`git stash` the two source files, re-run, `git stash pop`).
- Two pre-existing behavior-pinning cases in `utils/__tests__/knowledge.test.ts` were removed per the repository testing guidelines, since the file was already being edited: one asserted that the `CONTENT_TYPES` constant mirrors itself, the other that the module is importable.
- `src/renderer/pages/settings/DataSettings/__tests__/legacyV1BrowserData.test.ts` and `BasicDataSettings.test.tsx` fail on this branch, but they also fail on a clean `upstream/main` — verified by stashing all changes and re-running. They are unrelated to this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed conversations saved directly to a knowledge base losing their formatting: fenced code blocks now keep their fence and language tag, translations and errors are no longer wrapped in XML tags, and the stray divider between the conversation title and the first message is gone. Saving to a knowledge base now produces the same Markdown as saving to notes.
```
