### PR TITLE
fix(translate): disable reasoning for language detection

### DIFF
--- a/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useDetectLang.test.ts
@@ -46,7 +46,14 @@ vi.mock('franc-min', () => ({
 // drive the response per case via mockImplementation/mockResolvedValueOnce.
 const { generateTextMock } = vi.hoisted(() => ({
   generateTextMock:
-    vi.fn<(args: { uniqueModelId: string; system?: string; prompt: string }) => Promise<{ text: string }>>()
+    vi.fn<
+      (args: {
+        uniqueModelId: string
+        reasoningEffort?: string
+        system?: string
+        prompt: string
+      }) => Promise<{ text: string }>
+    >()
 }))
 vi.mock('@renderer/ipc', () => ({
   ipcApi: { request: (_route: string, input: any) => generateTextMock(input) }
@@ -90,6 +97,16 @@ describe('detectLanguageByLLM', () => {
     generateTextMock.mockResolvedValueOnce({ text: '  en-us  ' })
 
     await expect(detectLanguageByLLM('Hello', [lang('en-us'), lang('zh-cn')], TEST_MODEL)).resolves.toBe('en-us')
+  })
+
+  it('disables reasoning for LLM language detection', async () => {
+    await detectLanguageByLLM('Hello', [lang('en-us'), lang('zh-cn')], TEST_MODEL)
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reasoningEffort: 'none'
+      })
+    )
   })
 
   it('throws when no model is supplied', async () => {

--- a/src/renderer/hooks/translate/useDetectLang.ts
+++ b/src/renderer/hooks/translate/useDetectLang.ts
@@ -61,6 +61,7 @@ export const detectLanguageByLLM = async (
 
   const { text: result } = await ipcApi.request('ai.text.generate', {
     uniqueModelId: model.id,
+    reasoningEffort: 'none',
     system: systemPrompt,
     prompt: 'follow system prompt'
   })

--- a/src/shared/ipc/schemas/ai.ts
+++ b/src/shared/ipc/schemas/ai.ts
@@ -157,6 +157,7 @@ export const aiRequestSchemas = {
   'ai.text.generate': defineRoute({
     input: z.strictObject({
       ...aiBaseRequestShape,
+      reasoningEffort: ReasoningEffortOptionSchema.optional(),
       system: z.string().optional(),
       prompt: z.string().optional(),
       messages: z.array(z.custom<ModelMessage>()).optional()


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- LLM-based language detection used by selection translation omitted an explicit reasoning selection after the AI runtime moved to the main process.
- Reasoning-capable quick models could therefore use the provider default thinking mode before translation started, adding latency and potentially producing no plain-text language code.

After this PR:

- The `ai.text.generate` IPC route accepts the existing canonical `reasoningEffort` request field.
- LLM language detection explicitly requests `reasoningEffort: 'none'`.
- A focused regression test protects the renderer-to-main request contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Selection translation performs language detection before translation for short selections. Preserving the v1 no-reasoning behavior on that preliminary request removes avoidable model thinking without changing the selected quick model, translation model, or language-detection policy.

The following tradeoffs were made:

- The change exposes `reasoningEffort` only on one-shot text generation instead of widening unrelated embedding or image IPC payloads.
- Models whose provider profile cannot disable reasoning keep the existing degrade-to-omit behavior.

The following alternatives were considered:

- Forcing `reasoningEffort: 'none'` for every `ai.text.generate` call in the main handler was rejected because unrelated callers should preserve their current defaults.
- Forcing offline `franc` detection was rejected because it would change the configured detection behavior and accuracy tradeoff.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- `pnpm lint` (passes; reports 37 pre-existing ESLint warnings outside the changed files)
- `pnpm format`
- `pnpm test:lint`
- `pnpm typecheck:web`
- `pnpm typecheck:node`

Not run under the local verification policy: Vitest suites, `pnpm build:check`, and manual UI verification. CI remains the full verification owner.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Selection translation now disables model reasoning during LLM language detection when supported, reducing latency and avoiding empty detection output.
```
