### PR TITLE
fix(usage-settings): remember the usage page's view selections

### DIFF
--- a/src/renderer/pages/settings/UsageSettings/UsageSettings.tsx
+++ b/src/renderer/pages/settings/UsageSettings/UsageSettings.tsx
@@ -1,14 +1,13 @@
 import { Button, EmptyState, Popover, PopoverContent, PopoverTrigger, SegmentedControl } from '@cherrystudio/ui'
+import { usePersistCache } from '@data/hooks/useCache'
 import { useProviders } from '@renderer/hooks/useProvider'
 import { formatCompactNumber } from '@renderer/utils/number'
 import { cn } from '@renderer/utils/style'
 import type {
   AiUsageRecordGroupIdentity,
   AiUsageRecordListSortBy,
-  AiUsageRecordSortOrder,
   AiUsageRecordStatsBucket
 } from '@shared/data/api/schemas/aiUsageRecords'
-import type { Currency } from '@shared/data/types/model'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -25,7 +24,6 @@ import {
   getWindowRange,
   GROUP_BY_KEYS,
   GROUP_BY_LABEL_KEYS,
-  type GroupByKey,
   METRIC_KEYS,
   METRIC_LABEL_KEYS,
   PERIOD_CHART_TYPES,
@@ -35,16 +33,14 @@ import {
   TOP_COUNT_KEYS,
   TOTAL_CHART_TYPES,
   type UsageChartType,
-  type UsageMetricKey,
-  type UsageRollupKey,
+  type UsageTopCount,
   WINDOW_KEYS,
-  WINDOW_LABEL_KEYS,
-  type WindowKey
+  WINDOW_LABEL_KEYS
 } from './usageAnalytics'
 import { formatCost, parseDateKey } from './usageDisplay'
 import { UsageDistributionChart } from './UsageDistributionChart'
 import { UsageEntriesTable } from './UsageEntriesTable'
-import UsageHeatmap, { type UsageHeatmapMetric } from './UsageHeatmap'
+import UsageHeatmap from './UsageHeatmap'
 import {
   InsightCell,
   MetricCell,
@@ -71,17 +67,19 @@ type UsageApiKeyDisplay = Pick<
 
 function UsageSettings() {
   const { t, i18n } = useTranslation()
-  const [windowKey, setWindowKey] = useState<WindowKey>('30d')
-  const [groupBy, setGroupBy] = useState<GroupByKey>('provider')
-  const [chartMetric, setChartMetric] = useState<UsageMetricKey>('tokens')
-  const [selectedChartType, setSelectedChartType] = useState<UsageChartType>('bar')
-  const [rollup, setRollup] = useState<UsageRollupKey>('daily')
-  const [topCount, setTopCount] = useState<number>(10)
+  const [windowKey, setWindowKey] = usePersistCache('settings.usage.window')
+  const [groupBy, setGroupBy] = usePersistCache('settings.usage.group_by')
+  const [chartMetric, setChartMetric] = usePersistCache('settings.usage.chart_metric')
+  const [selectedChartType, setSelectedChartType] = usePersistCache('settings.usage.chart_type')
+  const [rollup, setRollup] = usePersistCache('settings.usage.rollup')
+  const [topCount, setTopCount] = usePersistCache('settings.usage.top_count')
+  // Drill-down day is session-scoped: restoring a past date would reopen the page on an empty range.
   const [selectedDate, setSelectedDate] = useState<string | undefined>()
-  const [selectedCurrency, setSelectedCurrency] = useState<Currency | undefined>()
-  const [heatmapMetric, setHeatmapMetric] = useState<UsageHeatmapMetric>('tokens')
-  const [entrySortBy, setEntrySortBy] = useState<AiUsageRecordListSortBy>('createdAt')
-  const [entrySortOrder, setEntrySortOrder] = useState<AiUsageRecordSortOrder>('desc')
+  const [persistedCurrency, setSelectedCurrency] = usePersistCache('settings.usage.currency')
+  const [heatmapMetric, setHeatmapMetric] = usePersistCache('settings.usage.heatmap_metric')
+  const [entrySortBy, setEntrySortBy] = usePersistCache('settings.usage.entry_sort_by')
+  const [entrySortOrder, setEntrySortOrder] = usePersistCache('settings.usage.entry_sort_order')
+  const selectedCurrency = persistedCurrency ?? undefined
 
   const windowRange = useMemo(() => getWindowRange(windowKey), [windowKey])
   const previousWindowRange = useMemo(() => getPreviousWindowRange(windowKey), [windowKey])
@@ -617,7 +615,7 @@ function UsageSettings() {
                           <SegmentedControl
                             options={topCountOptions}
                             value={String(topCount)}
-                            onValueChange={(value) => setTopCount(Number(value))}
+                            onValueChange={(value) => setTopCount(Number(value) as UsageTopCount)}
                             size="sm"
                           />
                         </UsageControlRow>

--- a/src/renderer/pages/settings/UsageSettings/__tests__/UsageSettings.test.tsx
+++ b/src/renderer/pages/settings/UsageSettings/__tests__/UsageSettings.test.tsx
@@ -1,0 +1,96 @@
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import UsageSettings from '../UsageSettings'
+
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviders: () => ({ providers: [] })
+}))
+
+vi.mock('../UsageDistributionChart', () => ({
+  UsageDistributionChart: () => null
+}))
+
+vi.mock('../UsageEntriesTable', () => ({
+  UsageEntriesTable: () => null
+}))
+
+vi.mock('../useUsageData', () => {
+  const totals = {
+    costCurrency: null,
+    totalCost: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalTokens: 0,
+    totalNoCacheTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    recordCount: 0,
+    requestCount: 0,
+    estimatedRequestCount: 0,
+    unpricedRequestCount: 0
+  }
+
+  return {
+    useUsageData: () => ({
+      costTotals: [],
+      costCurrency: undefined,
+      timelineBuckets: [],
+      overviewBuckets: [],
+      exploreBuckets: [],
+      exploreTimelineRows: [],
+      overviewTotals: totals,
+      previousOverviewTotals: totals,
+      exploreTotals: totals,
+      exploreOther: totals,
+      timelineLoading: false,
+      overviewLoading: false,
+      exploreStatsLoading: false,
+      exploreTimelineLoading: false,
+      entries: [],
+      entryTotal: 0,
+      entriesLoading: false,
+      entriesRefreshing: false,
+      hasNextEntryPage: false,
+      loadNextEntryPage: vi.fn()
+    })
+  }
+})
+
+const segmentedControlOf = (optionLabel: string) =>
+  screen.getByRole('button', { name: optionLabel }).closest('[data-testid="segmented-control"]')
+
+describe('UsageSettings', () => {
+  beforeEach(() => {
+    MockUseCacheUtils.resetMocks()
+  })
+
+  it('starts on the documented defaults', () => {
+    render(<UsageSettings />)
+
+    expect(segmentedControlOf('最近 30 天')).toHaveAttribute('data-value', '30d')
+    expect(segmentedControlOf('供应商')).toHaveAttribute('data-value', 'provider')
+    expect(segmentedControlOf('Token')).toHaveAttribute('data-value', 'tokens')
+    expect(segmentedControlOf('按天')).toHaveAttribute('data-value', 'daily')
+    expect(segmentedControlOf('柱状图')).toHaveAttribute('data-value', 'bar')
+    expect(segmentedControlOf('10')).toHaveAttribute('data-value', '10')
+  })
+
+  it('restores the view selections after leaving and returning to the page', () => {
+    const first = render(<UsageSettings />)
+
+    fireEvent.click(screen.getByRole('button', { name: '最近 90 天' }))
+    fireEvent.click(screen.getByRole('button', { name: '模型' }))
+    fireEvent.click(screen.getByRole('button', { name: '按周' }))
+    fireEvent.click(screen.getByRole('button', { name: '20' }))
+
+    first.unmount()
+    render(<UsageSettings />)
+
+    expect(segmentedControlOf('最近 90 天')).toHaveAttribute('data-value', '90d')
+    expect(segmentedControlOf('模型')).toHaveAttribute('data-value', 'model')
+    expect(segmentedControlOf('按周')).toHaveAttribute('data-value', 'weekly')
+    expect(segmentedControlOf('20')).toHaveAttribute('data-value', '20')
+  })
+})

--- a/src/renderer/pages/settings/UsageSettings/usageAnalytics.ts
+++ b/src/renderer/pages/settings/UsageSettings/usageAnalytics.ts
@@ -31,6 +31,7 @@ export type GroupByKey = (typeof GROUP_BY_KEYS)[number]
 export type UsageMetricKey = (typeof METRIC_KEYS)[number]
 export type UsageChartType = (typeof CHART_TYPE_KEYS)[number]
 export type UsageRollupKey = (typeof ROLLUP_KEYS)[number]
+export type UsageTopCount = (typeof TOP_COUNT_KEYS)[number]
 
 export const EMPTY_TIMELINE_BUCKETS: AiUsageRecordTimelineBucket[] = []
 export const EMPTY_STATS_METRICS: AiUsageRecordStatsMetrics = {

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -1,5 +1,7 @@
+import type { AiUsageRecordListSortBy, AiUsageRecordSortOrder } from '@shared/data/api/schemas/aiUsageRecords'
 import type { JobProgress, JobSnapshot } from '@shared/data/api/schemas/jobs'
 import type { MiniAppRegion, TransientMiniApp } from '@shared/data/types/miniApp'
+import type { Currency } from '@shared/data/types/model'
 import type { AutoBackupType } from '@shared/types/backup'
 import type { AbsoluteFilePath } from '@shared/types/file'
 
@@ -389,6 +391,20 @@ export type RendererPersistCacheSchema = {
   'ui.agent.session.expansion.workdir': string[] | null
   'settings.provider.last_selected_provider_id': string | null
   'settings.provider.filter_mode': 'all' | 'agent' | 'enabled' | 'disabled'
+  // Usage statistics view selections, persisted so leaving and re-entering the page restores
+  // them. The heatmap drill-down date stays component-local: a stored past date would reopen
+  // the page on an empty range.
+  'settings.usage.window': '30d' | '90d' | '365d'
+  'settings.usage.group_by': 'provider' | 'model' | 'apiKey' | 'source'
+  'settings.usage.chart_metric': 'tokens' | 'requests' | 'cost'
+  'settings.usage.chart_type': 'stack' | 'pie' | 'bar' | 'line'
+  'settings.usage.rollup': 'total' | 'daily' | 'weekly' | 'monthly'
+  'settings.usage.top_count': 5 | 10 | 20
+  'settings.usage.heatmap_metric': 'tokens' | 'cost'
+  'settings.usage.entry_sort_by': AiUsageRecordListSortBy
+  'settings.usage.entry_sort_order': AiUsageRecordSortOrder
+  // Null defers to the cost-total fallback (USD, else the first currency with usage).
+  'settings.usage.currency': Currency | null
   // MCP marketplace "available servers" fetched per provider; re-fetchable, so cached not stored
   'feature.mcp.provider_available_servers': CacheValueTypes.McpAvailableServers
   'agent.open_external_app.last_used_target': CacheValueTypes.AgentOpenExternalAppTarget
@@ -421,6 +437,16 @@ export const DefaultRendererPersistCache: RendererPersistCacheSchema = {
   'ui.agent.session.expansion.workdir': null,
   'settings.provider.last_selected_provider_id': null,
   'settings.provider.filter_mode': 'all',
+  'settings.usage.window': '30d',
+  'settings.usage.group_by': 'provider',
+  'settings.usage.chart_metric': 'tokens',
+  'settings.usage.chart_type': 'bar',
+  'settings.usage.rollup': 'daily',
+  'settings.usage.top_count': 10,
+  'settings.usage.heatmap_metric': 'tokens',
+  'settings.usage.entry_sort_by': 'createdAt',
+  'settings.usage.entry_sort_order': 'desc',
+  'settings.usage.currency': null,
   'feature.mcp.provider_available_servers': {},
   'agent.open_external_app.last_used_target': null,
   'ui.emoji.recently_used': []


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Every filter/view selection on Settings → Usage lived in plain `useState` with a hard-coded default. Leaving the page unmounts `UsageSettings`, so coming back reset the time window, group-by, metric, chart type, rollup, top-N, heatmap metric, currency and the entries table sorting to their defaults.

After this PR:

Those ten selections are stored in the renderer persist cache (`settings.usage.*`), so re-entering the page restores whatever the user last picked. Nothing about the layout, styling or copy changes — only what the controls are set to when the page mounts.

Original feedback: user「许思寅」(V2 抓虫大赛)：「用量统计未记住上一次选择，切换页面后变成默认选择」 ｜ 源记录 (dev 表 `recvqKnStQfrNn`)：https://mcnnox2fhjfq.feishu.cn/record/SY5krbY94e15Trc8bm0cX76Hnnh

N/A — no linked GitHub issue; the report came from the internal V2 bug-bash feedback table linked above.

### Why we need it and why it was done in this way

The page already had a persistence mechanism available in the repo — `usePersistCache` over `RendererPersistCacheSchema` — and a direct precedent in `ProviderList.tsx` (`settings.provider.filter_mode`). This PR follows that pattern rather than introducing anything new: ten fixed keys under `settings.usage.*`, each with a schema default equal to the previous hard-coded default (`30d` / `provider` / `tokens` / `bar` / `daily` / `10` / `tokens` / `createdAt` / `desc`), so existing users see exactly the same page on first entry after upgrading.

The following tradeoffs were made:

- **`selectedDate` (heatmap drill-down) is deliberately NOT persisted.** It is a session-scoped drill-down into one specific day; restoring a date picked days ago would reopen the page filtered to a range that is now off-window or empty. It stays component-local `useState`.
- **`selectedCurrency` IS persisted**, as `Currency | null`. `null` keeps the existing fallback (USD, else the first currency with usage), so a stored currency that no longer has any usage still degrades to the same behavior as today instead of showing an empty view.
- **Ten separate keys instead of one object blob.** Matches the existing schema style and avoids a read-modify-write blob that two windows could clobber; the cost is ten schema lines.
- The `settings.usage.*` value unions are spelled out in `@shared` because the source unions (`WindowKey`, `GroupByKey`, …) are renderer-only types. They are structurally identical, so any future drift in `usageAnalytics.ts` fails to compile at the call sites rather than silently diverging.

The following alternatives were considered:

- Keeping the state in a parent/route component: only survives while the settings route is mounted, so it would not fix the reported case, and would not survive a restart.
- `Preference`: these are transient view choices, not user settings worth syncing/backup — the persist cache tier is what the repo already uses for exactly this kind of "remember my last view" state.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- No visual change: no element, layout, spacing or string was touched; only which option the controls start on.
- Pre-existing oddity noticed, not touched: `UsageSettings/__tests__/UsageSettings.test.ts` actually tests `usageAnalytics.ts`, not the component. The new component test is added as `UsageSettings.test.tsx` alongside it.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: N/A — no user-guide change required; behavior is "the page remembers your last selection".
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Settings → Usage now remembers your last selected time window, grouping, metric, chart type, rollup, top-N, heatmap metric, currency and table sorting when you leave and return to the page.
```
