### PR TITLE
fix(agents): recreate session when deleting an agent's only non-active session

### DIFF
--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -721,6 +721,13 @@ const Sessions = ({
     },
     [displayMode, isRightPanel, setSessionExpansionAgent, setSessionExpansionTime, setSessionExpansionWorkdir]
   )
+
+  // Silent creation for a stranded agent: when the deleted (non-active) session was that agent's
+  // only one, open a fresh empty session for it without activating it or switching the user's view.
+  const { trigger: createSessionSilently } = useMutation('POST', '/agent-sessions', {
+    refresh: ['/agent-sessions']
+  })
+
   const handleDeleteSession = useCallback(
     async (id: string) => {
       // Capture the deleted session before removal so selection can be scoped to its agent even
@@ -730,7 +737,43 @@ const Sessions = ({
         sessionItemsRef.current.find((session) => session.id === id)
 
       const success = await deleteSession(id)
-      if (!success || activeSessionId !== id) return
+      if (!success) return
+
+      // Deleting a non-active session must not move the active selection. But if the removed session
+      // was its agent's only one, silently open a fresh empty session for that agent so it stays in
+      // the list instead of vanishing.
+      if (activeSessionId !== id) {
+        const deletedAgentHasSessionsLeft = deletedSession
+          ? filteredGroupedSessions.some((session) => session.agentId === deletedSession.agentId && session.id !== id)
+          : true
+        if (!deletedAgentHasSessionsLeft) {
+          const seed = deletedSession
+            ? buildCreateSessionSeed({
+                agentId: deletedSession.agentId,
+                workspace: deletedSession.workspace,
+                workspaceId: deletedSession.workspaceId
+              })
+            : null
+          if (seed?.agentId) {
+            try {
+              await createSessionSilently({
+                body: {
+                  agentId: seed.agentId,
+                  name: '',
+                  workspace: seed.workspace ?? { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+                }
+              })
+            } catch (err) {
+              logger.error('Failed to create session after deleting last session of an agent', {
+                err,
+                sessionId: id
+              })
+              toast.error(formatErrorMessageWithPrefix(err, t('agent.session.create.error.failed')))
+            }
+          }
+        }
+        return
+      }
 
       // Deleting the active session selects a neighbour within the *same agent* (both layouts), so we
       // never jump to an unrelated agent's session. When that agent has no other session left, open a
@@ -773,7 +816,16 @@ const Sessions = ({
         if (!createdSession) setActiveSessionId(null)
       }
     },
-    [activeSessionId, agentIdFilter, deleteSession, filteredGroupedSessions, onCreateSession, setActiveSessionId, t]
+    [
+      activeSessionId,
+      agentIdFilter,
+      createSessionSilently,
+      deleteSession,
+      filteredGroupedSessions,
+      onCreateSession,
+      setActiveSessionId,
+      t
+    ]
   )
 
   const handleRenameSession = useCallback(

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -279,6 +279,7 @@ const tabsContextMocks = vi.hoisted(() => ({
 const windowFrameMocks = vi.hoisted(() => ({ mode: 'embedded' as 'embedded' | 'window' }))
 
 const dataApiMocks = vi.hoisted(() => ({
+  createSessionSilently: vi.fn().mockResolvedValue({ id: 'created-session' }),
   deleteAgent: vi.fn().mockResolvedValue(undefined),
   deleteAgentSessions: vi.fn().mockResolvedValue({ deletedIds: [] as string[] }),
   deleteWorkspace: vi.fn().mockResolvedValue({ deletedIds: [] as string[] }),
@@ -494,19 +495,21 @@ vi.mock('@renderer/data/hooks/useDataApi', () => ({
     dataApiMocks.mutationOptions.set(`${method} ${path}`, options ?? {})
     return {
       trigger:
-        method === 'PATCH' && path === '/agent-workspaces/:id/order'
-          ? dataApiMocks.reorderWorkspace
-          : method === 'PATCH' && path === '/agents/:id/order'
-            ? dataApiMocks.reorderAgent
-            : method === 'PATCH' && path === '/agent-workspaces/:workspaceId'
-              ? dataApiMocks.updateWorkspace
-              : method === 'DELETE' && path === '/agent-workspaces/:workspaceId'
-                ? dataApiMocks.deleteWorkspace
-                : method === 'DELETE' && path === '/agents/:agentId'
-                  ? dataApiMocks.deleteAgent
-                  : method === 'DELETE' && path === '/agents/:agentId/sessions'
-                    ? dataApiMocks.deleteAgentSessions
-                    : dataApiMocks.findOrCreateWorkspace,
+        method === 'POST' && path === '/agent-sessions'
+          ? dataApiMocks.createSessionSilently
+          : method === 'PATCH' && path === '/agent-workspaces/:id/order'
+            ? dataApiMocks.reorderWorkspace
+            : method === 'PATCH' && path === '/agents/:id/order'
+              ? dataApiMocks.reorderAgent
+              : method === 'PATCH' && path === '/agent-workspaces/:workspaceId'
+                ? dataApiMocks.updateWorkspace
+                : method === 'DELETE' && path === '/agent-workspaces/:workspaceId'
+                  ? dataApiMocks.deleteWorkspace
+                  : method === 'DELETE' && path === '/agents/:agentId'
+                    ? dataApiMocks.deleteAgent
+                    : method === 'DELETE' && path === '/agents/:agentId/sessions'
+                      ? dataApiMocks.deleteAgentSessions
+                      : dataApiMocks.findOrCreateWorkspace,
       isLoading: false,
       error: undefined
     }
@@ -846,6 +849,7 @@ describe('Sessions', () => {
     dataApiMocks.refetchAgents.mockResolvedValue(undefined)
     dataApiMocks.reorderAgent.mockResolvedValue(undefined)
     dataApiMocks.updateWorkspace.mockResolvedValue(undefined)
+    dataApiMocks.createSessionSilently.mockResolvedValue({ id: 'created-session' })
     dataApiMocks.mutationOptions.clear()
     sessionDataMocks.deleteSession.mockResolvedValue(true)
     sessionDataMocks.deleteSessions.mockResolvedValue({ deletedIds: [] })
@@ -2398,6 +2402,63 @@ describe('Sessions', () => {
       })
     )
     expect(setActiveSessionId).not.toHaveBeenCalledWith('session-b-first', expect.anything())
+  })
+
+  it('silently recreates a session for an agent after deleting its only non-active session, without switching the view', async () => {
+    // Regression: deleting a session that is NOT the active one used to early-return before the
+    // "agent has no session left → create one" branch. When the deleted session was that agent's
+    // only one, the agent vanished from the list. The fix silently creates a replacement session
+    // for the stranded agent without activating it or moving the current selection.
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent', configuration: { avatar: 'B' } }
+      ],
+      isLoading: false,
+      error: undefined
+    })
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a-only', name: 'A Only session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-b-first', name: 'B First session', agentId: 'agent-b', orderKey: 'b' })
+      ]
+    })
+    const onCreateSession = vi.fn()
+    const setActiveSessionId = vi.fn()
+
+    // Active session belongs to agent-b; the deleted session is agent-a's only one.
+    render(
+      <SessionsForTest
+        activeSessionId="session-b-first"
+        onCreateSession={onCreateSession}
+        setActiveSessionId={setActiveSessionId}
+      />
+    )
+
+    const sessionRow = screen.getByText('A Only session').closest('[role="option"]')
+    const deleteButton = within(sessionRow as HTMLElement).getByLabelText('Delete')
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+
+    await vi.waitFor(() => expect(sessionDataMocks.deleteSession).toHaveBeenCalledWith('session-a-only'))
+    // A replacement session is silently created for the stranded agent-a (not via the activate path).
+    await vi.waitFor(() =>
+      expect(dataApiMocks.createSessionSilently).toHaveBeenCalledWith({
+        body: {
+          agentId: 'agent-a',
+          name: '',
+          workspace: { type: 'user', workspaceId: 'ws-a' }
+        }
+      })
+    )
+    // The current view is undisturbed: the active selection is never moved or cleared.
+    expect(setActiveSessionId).not.toHaveBeenCalled()
+    expect(onCreateSession).not.toHaveBeenCalled()
   })
 
   it('clears the active session and toasts when the post-delete session create fails in the right panel', async () => {


### PR DESCRIPTION
### What this PR does

**Before this PR:**

Deleting a non-active session early-returned before the "agent has no session left → create one" branch (`Sessions.tsx` `handleDeleteSession`). When the deleted session was its agent's only one — while the active session belonged to a different agent — no replacement was created, so the stranded agent **vanished** from the session list.

**After this PR:**

The guard is split. Deleting a non-active session still never moves the active selection, but if the removed session was its agent's only one, a fresh empty session is silently created for that agent so it stays visible — without activating it or switching the user's current view.

### Why we need it and why it was done this way

The original guard `if (!success || activeSessionId !== id) return` was correct in intent (deleting a non-active session shouldn't disturb the current view) but it collapsed two concerns: "don't move the active selection" and "ensure the deleted session's agent still has a session". Splitting them lets us keep the selection untouched while still preventing the agent from disappearing.

The silent creation path (`POST /agent-sessions`, refresh `/agent-sessions`) deliberately does **not** activate the new session — deleting a non-active session is a background tidy-up and must not switch the user away from whatever they're doing, matching the expectation expressed during the fix discussion.

**Tradeoffs:**

- A dedicated `useMutation('POST', '/agent-sessions')` (`createSessionSilently`) was added rather than reusing the existing `onCreateSession` (=`createAndActivateEmptySession`) prop. `onCreateSession` always activates and switches the view, which would interrupt the user — unacceptable for deleting a non-active session. The dedicated mutation is the smallest path that creates without activating.

**Alternatives considered:**

- *Reuse `onCreateSession` (activate the new session):* rejected — would force a view switch when deleting a non-active session.
- *Do nothing and let the agent vanish:* the current bug; rejected.

### Breaking changes

None. Deleting the active session still selects a same-agent neighbour or creates a fresh empty session, unchanged. Only the previously-broken non-active delete path gains a silent recreation.

### Special notes for your reviewer

Regression test added: `silently recreates a session for an agent after deleting its only non-active session, without switching the view`. Verified it fails on the pre-fix code (silent create called 0 times) and passes after. The mock layer gained a `POST /agent-sessions` mutation route that was previously missing.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than I found it
- [x] Upgrade: No upgrade/migration impact (renderer-only, no schema/data changes)
- [x] Documentation: No user-guide update required (bug fix, no new user-facing feature)
- [x] Self-review: Reviewed the diff before requesting review

### Release note

```release-note
Fix: deleting an agent's only remaining session while it is not the active session no longer causes that agent to disappear from the list — a replacement session is silently created for it.
```