### PR TITLE
fix(agent-session): clear remembered session id on delete-recovery to stop white-screen crash

### DIFF
--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -281,9 +281,14 @@ const AgentPage = () => {
   })
   const reenterAgentRoute = useCallback(() => {
     initialEmptySessionEvaluatedRef.current = false
+    // The bound session is gone. Drop the remembered id too, otherwise the bare re-entry
+    // re-reads it in `resolveAgentEntrySessionId`, 404s, and (when latest also lands on a
+    // mid-delete row) the recovery effect fires again — a navigate loop React aborts as a
+    // maximum-update-depth render error that tears down the whole window.
+    setLastUsedSessionId(null)
     clearActiveSession()
     void navigate({ to: '/app/agents', search: {}, replace: true })
-  }, [clearActiveSession, navigate])
+  }, [clearActiveSession, navigate, setLastUsedSessionId])
   // The URL-bound session no longer exists: its by-id query settled with NOT_FOUND (deleted while
   // this tab was dormant, or a rotted deep link). Recovery is a plain replace-navigation back
   // through the entry interceptor, which resolves the next target — no in-page state surgery.

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -281,10 +281,10 @@ const AgentPage = () => {
   })
   const reenterAgentRoute = useCallback(() => {
     initialEmptySessionEvaluatedRef.current = false
-    // The bound session is gone. Drop the remembered id too, otherwise the bare re-entry
-    // re-reads it in `resolveAgentEntrySessionId`, 404s, and (when latest also lands on a
-    // mid-delete row) the recovery effect fires again — a navigate loop React aborts as a
-    // maximum-update-depth render error that tears down the whole window.
+    // The bound session is gone. Drop the remembered id too: `ui.agent.last_used_session_id`
+    // is never cleared on delete, so without this the bare re-entry re-reads the stale id in
+    // `resolveAgentEntrySessionId`, 404s, and the NOT_FOUND recovery fires again — a navigate
+    // loop React aborts as a maximum-update-depth render error that tears down the window.
     setLastUsedSessionId(null)
     clearActiveSession()
     void navigate({ to: '/app/agents', search: {}, replace: true })

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -2,6 +2,7 @@ import { cacheService } from '@data/CacheService'
 import { WindowFrameProvider } from '@renderer/components/chat/shell/WindowFrameContext'
 import { getAgentDraftCacheKey } from '@renderer/components/composer/variants/agent/agentDraftCache'
 import { useCommandHandler } from '@renderer/hooks/command'
+import { DataApiErrorFactory } from '@shared/data/api/errors'
 import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
 import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
@@ -1361,6 +1362,30 @@ describe('AgentPage', () => {
         replace: true
       })
     )
+  })
+
+  it('clears the remembered session id and converges when the bound route resolves NOT_FOUND', async () => {
+    // Regression for the white-screen crash: the URL binds to a deleted session while
+    // `ui.agent.last_used_session_id` still remembers it. Without clearing the remembered
+    // id, the bare re-entry re-reads it in `resolveAgentEntrySessionId`, 404s again, and
+    // the recovery effect loops until React aborts with a maximum-update-depth error.
+    agentPageMocks.routeSearch = { sessionId: 'session-deleted' }
+    agentPageMocks.lastUsedSessionId = 'session-deleted'
+    // The by-id query settled with NOT_FOUND: the session is gone, and loading finished.
+    activeSessionMocks.session = null
+    activeSessionMocks.sessionSource = 'none'
+    activeSessionMocks.error = DataApiErrorFactory.notFound('Session', 'session-deleted')
+
+    render(<AgentPage />)
+
+    await waitFor(() => expect(agentPageMocks.setLastUsedSessionId).toHaveBeenCalledWith(null))
+    // Recovery re-enters the bare route exactly once and does not loop. (Downstream
+    // first-entry auto-create may navigate again to bind a fresh session — that is a
+    // separate, bounded step, not a repeat of the NOT_FOUND recovery.)
+    const recoveryNavigations = agentPageMocks.navigate.mock.calls.filter(
+      (call) => call[0]?.search && Object.keys(call[0].search).length === 0
+    )
+    expect(recoveryNavigations).toHaveLength(1)
   })
 
   it('creates and activates an empty session after creating an agent from the classic-layout add entry', async () => {

--- a/src/renderer/utils/conversationEntry.ts
+++ b/src/renderer/utils/conversationEntry.ts
@@ -1,6 +1,9 @@
 import { cacheService } from '@data/CacheService'
 import { dataApiService } from '@data/DataApiService'
+import { loggerService } from '@logger'
 import { isDataApiNotFoundError } from '@shared/data/api/errors'
+
+const logger = loggerService.withContext('conversationEntry')
 
 /**
  * Entry-target resolution for the conversation routes (`/app/chat`, `/app/agents`),
@@ -30,8 +33,17 @@ export async function resolveChatEntryTopicId(): Promise<string | null> {
     }
   }
 
-  const { topic } = await dataApiService.get('/topics/latest')
-  return topic?.id ?? null
+  // Mirror the by-id branch: a transient failure here (e.g. a row mid-cascade-delete
+  // surfacing through the join) falls through to a bare entry instead of escaping into
+  // `beforeLoad`, where it would push the route into an error state and compound the
+  // delete/recovery race.
+  try {
+    const { topic } = await dataApiService.get('/topics/latest')
+    return topic?.id ?? null
+  } catch (error) {
+    logger.warn('Falling through after topic latest failed', error as Error)
+    return null
+  }
 }
 
 export async function resolveAgentEntrySessionId(): Promise<string | null> {
@@ -45,6 +57,15 @@ export async function resolveAgentEntrySessionId(): Promise<string | null> {
     }
   }
 
-  const { session } = await dataApiService.get('/agent-sessions/latest')
-  return session?.id ?? null
+  // Mirror the by-id branch: a transient failure here (e.g. a session row
+  // mid-cascade-delete surfacing through the workspace join) falls through to a
+  // bare entry instead of escaping into `beforeLoad`, where it would push the
+  // route into an error state and compound the delete/recovery race.
+  try {
+    const { session } = await dataApiService.get('/agent-sessions/latest')
+    return session?.id ?? null
+  } catch (error) {
+    logger.warn('Falling through after session latest failed', error as Error)
+    return null
+  }
 }

--- a/src/renderer/utils/conversationEntry.ts
+++ b/src/renderer/utils/conversationEntry.ts
@@ -1,9 +1,6 @@
 import { cacheService } from '@data/CacheService'
 import { dataApiService } from '@data/DataApiService'
-import { loggerService } from '@logger'
 import { isDataApiNotFoundError } from '@shared/data/api/errors'
-
-const logger = loggerService.withContext('conversationEntry')
 
 /**
  * Entry-target resolution for the conversation routes (`/app/chat`, `/app/agents`),
@@ -33,17 +30,8 @@ export async function resolveChatEntryTopicId(): Promise<string | null> {
     }
   }
 
-  // Mirror the by-id branch: a transient failure here (e.g. a row mid-cascade-delete
-  // surfacing through the join) falls through to a bare entry instead of escaping into
-  // `beforeLoad`, where it would push the route into an error state and compound the
-  // delete/recovery race.
-  try {
-    const { topic } = await dataApiService.get('/topics/latest')
-    return topic?.id ?? null
-  } catch (error) {
-    logger.warn('Falling through after topic latest failed', error as Error)
-    return null
-  }
+  const { topic } = await dataApiService.get('/topics/latest')
+  return topic?.id ?? null
 }
 
 export async function resolveAgentEntrySessionId(): Promise<string | null> {
@@ -57,15 +45,6 @@ export async function resolveAgentEntrySessionId(): Promise<string | null> {
     }
   }
 
-  // Mirror the by-id branch: a transient failure here (e.g. a session row
-  // mid-cascade-delete surfacing through the workspace join) falls through to a
-  // bare entry instead of escaping into `beforeLoad`, where it would push the
-  // route into an error state and compound the delete/recovery race.
-  try {
-    const { session } = await dataApiService.get('/agent-sessions/latest')
-    return session?.id ?? null
-  } catch (error) {
-    logger.warn('Falling through after session latest failed', error as Error)
-    return null
-  }
+  const { session } = await dataApiService.get('/agent-sessions/latest')
+  return session?.id ?? null
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

Deleting an agent's **last** session triggered an auto-created replacement; deleting that new session **crashed the window to a white screen** (window-level error boundary, `MainApp` re-mounted dozens of times).

After this PR:

Deleting sessions no longer white-screens — the delete-recovery path converges instead of looping. (Console still logs the expected `GET /agent-sessions/{deleted-id}` 404s — these are swallowed by design and harmless; see Special notes.)

### Why we need it and why it was done in this way

**Root cause** — a navigate loop, not an uncaught error:

`ui.agent.last_used_session_id` is never cleared on delete. After `reenterAgentRoute` reset the URL, `resolveAgentEntrySessionId` re-read the remembered (now-deleted) id, 404'd (swallowed), fell through to latest, and the NOT_FOUND recovery effect fired again → a navigate loop React aborted as a *maximum-update-depth* render error → window-level error boundary → white screen.

**Fix** (`AgentPage.tsx`): clear `last_used_session_id` in `reenterAgentRoute` so the bare re-entry skips the stale id and resolves a valid session, converging the loop.

### Changes in this update (review feedback from @zhangjiadi225)

- **Reverted the `/latest` catch-all** (`conversationEntry.ts` is now identical to `main`). The earlier draft wrapped the `/agent-sessions/latest` and `/topics/latest` reads in try/catch. Per review: better-sqlite3 reads see state before-or-after the synchronous delete transaction, so the stated mid-cascade case cannot occur — the catch-all had no proven justification and would convert genuine loading failures (timeout, 5xx, db errors) into empty-library semantics, letting the bare page create a session when sessions merely failed to load. Unexpected errors now propagate as before. The primary fix is what actually stops the loop and is unchanged.
- **Added regression coverage** (`AgentPage.test.tsx`): starts with a stale route bound to a deleted session plus a remembered `last_used_session_id`, resolves the active session as NOT_FOUND, and asserts the remembered id is cleared and recovery navigation converges without repeating. Verified it fails (times out at the `setLastUsedSessionId(null)` assertion) when the fix is removed.

The following alternatives were considered:
- Clear `last_used_session_id` at delete time in `Sessions.tsx`. Rejected: deletion entry points span `Sessions.tsx`, `AgentPage` (agent deletion), and global search; doing it centrally at the recovery boundary (`reenterAgentRoute`) is more robust and covers every path that hits a stale URL.

### Special notes for your reviewer

- Console `error`-level `DataApiService` 404 logs during delete are **expected and pre-existing** — `resolveAgentEntrySessionId` validates the remembered id via a by-id request, and `useSession` queries the active id; both legitimately 404 a deleted id and swallow it. They are noisy but harmless. A follow-up could downgrade validation-path 404s to `warn` in `DataApiService`, but that is a wider cross-cutting change and out of scope here.
- Reproduction (verified by the reporter): 5 agents, drain any agent down to 1 task, delete it (auto-creates a new session), then delete the new one.
- Local verification: typecheck clean; `AgentPage.test.tsx` (65), `conversationEntry.test.ts` (9) pass; oxlint + biome clean. **Full `pnpm lint` / `pnpm build:check` and a manual repro were run by the reporter** — no more white screen.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found it
- [x] Upgrade: N/A — no data migration or stored-state change
- [x] Documentation: Not required — bug fix, no user-facing behavior change beyond fixing the crash
- [x] Self-review: Reviewed via `git diff` before requesting review

### Release note

```release-note
Fixed a crash where deleting an agent's last session (then the auto-created replacement) could white-screen the window.
```