### PR TITLE
fix(knowledge-data-source): skip in-flight items in bulk reindex

### DIFF
--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3157,6 +3157,8 @@
         "delete_confirm_title": "Delete Selected Data Sources?",
         "loaded_only_hint": "Applies to loaded items only ({{total}} total)",
         "reindex": "Reindex",
+        "reindex_none_eligible": "All selected data sources are still processing and cannot be reindexed yet",
+        "reindex_skipped": "Skipped {{count}} data source(s) still processing",
         "selected_count": "{{count}} selected"
       },
       "chunks_count": "{{count}} chunks",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3157,6 +3157,8 @@
         "delete_confirm_title": "确认批量删除",
         "loaded_only_hint": "仅作用于已加载项，共 {{total}} 项",
         "reindex": "重新索引",
+        "reindex_none_eligible": "选中的数据源都在处理中，暂时无法重新索引",
+        "reindex_skipped": "已跳过 {{count}} 个处理中的数据源",
         "selected_count": "已选 {{count}} 项"
       },
       "chunks_count": "{{count}} chunks",

--- a/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
@@ -18,7 +18,7 @@ import type { KnowledgeFilePreviewTarget } from '../../types'
 import DataSourcePanelHeader from './DataSourcePanelHeader'
 import KnowledgeItemList from './KnowledgeItemList'
 import { dataSourceTypeDisplayConfig } from './utils/models'
-import { getItemTitle } from './utils/selectors'
+import { canReindexKnowledgeItem, getItemTitle } from './utils/selectors'
 
 export interface DataSourcePanelProps {
   embeddingModelId?: string | null
@@ -231,12 +231,26 @@ const DataSourcePanelContent = ({
   )
 
   const handleBulkReindex = useCallback(async () => {
-    const itemIds = items.filter((item) => selectedIds.has(item.id)).map((item) => item.id)
+    const selectedItems = items.filter((item) => selectedIds.has(item.id))
+    // The main process rejects the whole batch when any selected item is still
+    // indexing, which would also drop the failed ones the user wants to retry.
+    // Skip them here instead, mirroring the row menu's own gate.
+    const reindexableItems = selectedItems.filter(canReindexKnowledgeItem)
+    const skippedCount = selectedItems.length - reindexableItems.length
+
+    if (reindexableItems.length === 0) {
+      toast.warning(t('knowledge.data_source.bulk.reindex_none_eligible'))
+      return
+    }
+
     try {
-      await onReindexItems(itemIds)
+      await onReindexItems(reindexableItems.map((item) => item.id))
     } catch (error) {
       toast.error(formatErrorMessageWithPrefix(error, t('knowledge.data_source.reindex_failed')))
       return
+    }
+    if (skippedCount > 0) {
+      toast.warning(t('knowledge.data_source.bulk.reindex_skipped', { count: skippedCount }))
     }
     setSelectedIds(new Set())
   }, [items, onReindexItems, selectedIds, t])

--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemRow.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemRow.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 
 import { KNOWLEDGE_ITEM_ROW_GRID, knowledgeDataSourceCheckboxClassName } from './styles'
 import { type DataSourceStatusViewModel, dataSourceTypeDisplayConfig } from './utils/models'
-import { toKnowledgeItemRowViewModel } from './utils/selectors'
+import { canReindexKnowledgeItem, toKnowledgeItemRowViewModel } from './utils/selectors'
 
 export interface KnowledgeItemRowProps {
   item: KnowledgeItem
@@ -118,7 +118,7 @@ const KnowledgeItemRow = ({
   // `failed` carries a reason code in `error` (e.g. a migrated folder whose vectors could not
   // be migrated); surface it as the badge tooltip.
   const failureReason = item.status === 'failed' ? getKnowledgeItemFailureReason(item, t) : null
-  const canReindex = item.status === 'completed' || item.status === 'failed'
+  const canReindex = canReindexKnowledgeItem(item)
   const canViewChunks = item.status === 'completed'
   // Every row's primary click views its original content in-app: files/URLs delegate
   // preview/fallback/error handling to `previewSource`, directories drill into their children, and

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
@@ -308,6 +308,8 @@ vi.mock('react-i18next', () => ({
             'knowledge.data_source.empty.shortcuts.directory.title': '目录导入',
             'knowledge.data_source.bulk.delete': '删除',
             'knowledge.data_source.bulk.reindex': '重新索引',
+            'knowledge.data_source.bulk.reindex_skipped': `已跳过 ${options?.count} 个处理中的数据源`,
+            'knowledge.data_source.bulk.reindex_none_eligible': '选中的数据源都在处理中，暂时无法重新索引',
             'knowledge.data_source.bulk.delete_confirm_title': '确认批量删除',
             'knowledge.data_source.table.columns.name': '名称',
             'knowledge.data_source.table.columns.type': '类型',
@@ -1066,6 +1068,66 @@ describe('DataSourcePanel', () => {
     await waitFor(() => {
       expect(screen.queryByText('已选 1 项')).not.toBeInTheDocument()
     })
+  })
+
+  // The main process rejects a reindex batch outright when any selected subtree is still
+  // active, so sending in-flight rows would also drop the failed ones the user meant to retry
+  // (issue #18508: concurrent embedding leaves some rows processing, select-all then fails).
+  it('sends only completed/failed rows to bulk reindex and reports the skipped in-flight ones', async () => {
+    const onReindexItems = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <DataSourcePanel
+        updatedAt="2026-04-15T09:00:00+08:00"
+        items={[
+          createFileItem({ id: 'file-1', originName: '季度报告.pdf', status: 'failed' }),
+          createFileItem({ id: 'file-2', originName: '会议记录.pdf', status: 'processing' }),
+          createFileItem({ id: 'file-3', originName: '年度总结.pdf', status: 'completed' })
+        ]}
+        isLoading={false}
+        onAdd={vi.fn()}
+        onDelete={vi.fn()}
+        onReindex={vi.fn()}
+        onReindexItems={onReindexItems}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '全选' }))
+    fireEvent.click(screen.getByRole('button', { name: '重新索引' }))
+
+    await waitFor(() => {
+      expect(onReindexItems).toHaveBeenCalledWith(['file-1', 'file-3'])
+    })
+    expect(toast.warning).toHaveBeenCalledWith('已跳过 1 个处理中的数据源')
+  })
+
+  it('skips the reindex request entirely when every selected row is still in flight', async () => {
+    const onReindexItems = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <DataSourcePanel
+        updatedAt="2026-04-15T09:00:00+08:00"
+        items={[
+          createFileItem({ id: 'file-1', originName: '季度报告.pdf', status: 'processing' }),
+          createFileItem({ id: 'file-2', originName: '会议记录.pdf', status: 'embedding' })
+        ]}
+        isLoading={false}
+        onAdd={vi.fn()}
+        onDelete={vi.fn()}
+        onReindex={vi.fn()}
+        onReindexItems={onReindexItems}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('checkbox', { name: '全选' }))
+    fireEvent.click(screen.getByRole('button', { name: '重新索引' }))
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledWith('选中的数据源都在处理中，暂时无法重新索引')
+    })
+    expect(onReindexItems).not.toHaveBeenCalled()
+    // Selection survives so the user can switch to another bulk action (delete allows in-flight rows).
+    expect(screen.getByText('已选 2 项')).toBeInTheDocument()
   })
 
   it('confirms bulk delete for selected rows and clears selection after one bulk operation', async () => {

--- a/src/renderer/pages/knowledge/panels/dataSource/utils/selectors.ts
+++ b/src/renderer/pages/knowledge/panels/dataSource/utils/selectors.ts
@@ -2,6 +2,15 @@ import type { KnowledgeItem } from '@shared/data/types/knowledge'
 
 import { dataSourceTypeDisplayConfig, type KnowledgeItemRowViewModel } from './models'
 
+/**
+ * Whether reindexing this item would be admitted by the main process. Mirrors
+ * `REINDEX_ALLOWED_STATUSES` in `KnowledgeIngestionService`, which rejects the whole
+ * batch when any selected subtree is still active — so the bulk action must filter
+ * with the same predicate the row menu uses, or one in-flight item blocks the rest.
+ */
+export const canReindexKnowledgeItem = (item: KnowledgeItem): boolean =>
+  item.status === 'completed' || item.status === 'failed'
+
 export const getItemStatus = (item: KnowledgeItem) => {
   switch (item.type) {
     case 'file':


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The data-source panel's bulk **Reindex** button sent every selected id, while the per-row menu only offered Reindex for `completed`/`failed` items. Because `assertSubtreesCanReindex` rejects a reindex batch *outright* when any selected subtree is still active, selecting all rows while some documents were still embedding failed the whole batch — including the `failed` rows the user actually wanted to retry. The user saw `Cannot reindex knowledge item until the entire subtree is completed or failed` and nothing was retried.

After this PR:

Bulk reindex filters the selection with the same predicate the row menu uses (extracted as `canReindexKnowledgeItem`) and reports how many in-flight items were skipped. When nothing is eligible the selection is kept, so the user can switch to bulk delete — which does accept in-flight items.

Fixes #18508

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Filtering client-side rather than relaxing the main-process guard.** The all-or-nothing admission check is deliberate and pinned by `KnowledgeService.test.ts` (`'rejects a whole reindex batch when one root subtree is still active'`), so this PR does not touch that contract. Making the guard best-effort per root is a separate, product-visible decision.
- **Filtering per action instead of blocking selection.** Disabling the checkbox for in-flight rows (or disabling the bulk bar entirely) would have been simpler, but `deleteItems` places no status restriction on items — bulk delete of an in-flight row is legitimate and must keep working.

The following alternatives were considered:

- Auto-retrying failed items — rejected; reindexing re-spends the paid embedding API and must stay user-initiated.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18508

### Breaking changes

None.

### Special notes for your reviewer

**The error quoted as the root cause in #18508 is not the root cause.** `Failed to reindex knowledge source` is emitted only by `useReindexKnowledgeItem`; the add-file path logs `Failed to add knowledge sources`. The reporter must have clicked Reindex manually after documents appeared stuck — so the reindex rejection is a *consequence* of the stall, not its cause. This PR fixes that consequence, which is what makes the failed documents unrecoverable from the UI.

The `EPERM` fsync warnings quoted in the issue are unrelated log noise on Windows and are **not** addressed here.

Two things this PR deliberately does **not** fix, since they need their own changes:

1. **Embedding fan-out has no global limiter** — this is the likely reason the report only reproduces with 2+ documents. The per-base queue `base.{baseId}` runs `defaultConcurrency: 5`, and each `embedMany` independently allows `EMBEDDING_MAX_PARALLEL_CALLS = 5`, so a single base can issue ~25 concurrent embedding requests. `AiService`'s own comment calls unbounded fan-out "the primary embedding rate-limit trigger".
2. **Items stuck at `processing`** — queue seats are counted by SQL over `status='running'`, but the per-job timeout only aborts an `AbortSignal` and `KeyedMutex.runExclusive` does not accept one, so a handler parked on the base lock keeps its seat past the timeout. `docs/references/job-and-scheduler/concurrency-and-locks.md` notes mid-session recovery is not implemented. Not reproduced at runtime — reported here as analysis only.

Verification: the two new bulk-reindex tests were confirmed to fail when the filter is reverted. `pnpm build:check` has two pre-existing failures in `settings/DataSettings/` that also fail on a clean tree.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed bulk "Reindex" in the knowledge base failing entirely when any selected data source was still being processed, which also prevented failed sources from being retried. In-flight sources are now skipped and reported instead.
```
