### PR TITLE
fix(knowledge-lookup): stop an unreadable kb tool result from breaking the conversation

### DIFF
--- a/src/main/ai/tools/__tests__/knowledgeLookup.test.ts
+++ b/src/main/ai/tools/__tests__/knowledgeLookup.test.ts
@@ -16,7 +16,13 @@ vi.mock('@application', () => ({
   }
 }))
 
-import { searchKnowledge } from '../knowledgeLookup'
+import {
+  KNOWLEDGE_UNREADABLE_OUTPUT_NOTE,
+  knowledgeListModelOutput,
+  knowledgeManageModelOutput,
+  knowledgeReadModelOutput,
+  searchKnowledge
+} from '../knowledgeLookup'
 
 const CITE_ID = /^[0-9a-f]{8}-\d+$/
 
@@ -55,5 +61,51 @@ describe('searchKnowledge', () => {
       ['base1', 'README.md'],
       ['base2', 'README.md']
     ])
+  })
+})
+
+// `toModelOutput` re-runs over every stored tool part on each turn, so a part whose output no longer
+// matches a known shape must render a note. Throwing there fails the whole request — the reported
+// symptom was a knowledge-base conversation that could not be continued until the base was removed.
+describe('model output formatters on unreadable stored output', () => {
+  const listInput = { query: null, groupId: null, baseId: null, cursor: null }
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a rendered marker string', '<persisted-output>…</persisted-output>'],
+    ['an MCP result envelope', { content: [{ type: 'text', text: 'kb_list output' }] }],
+    ['an object with neither items nor nodes', {}],
+    ['nodes without the array', { baseId: 'base1', nodes: undefined }],
+    ['items without the array', { total: 3, items: undefined }]
+  ])('kb_list renders the note for %s instead of throwing', (_label, output) => {
+    expect(knowledgeListModelOutput(output as never, listInput)).toEqual({
+      type: 'text',
+      value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE
+    })
+  })
+
+  it('kb_list still renders its known shapes', () => {
+    expect(knowledgeListModelOutput({ items: [{ id: 'b1' }], total: 1 } as never, listInput)).toEqual({
+      type: 'json',
+      value: { items: [{ id: 'b1' }], total: 1 }
+    })
+    expect(
+      knowledgeListModelOutput({ baseId: 'b1', totalItems: 0, truncated: false, nodes: [] } as never, {
+        ...listInput,
+        baseId: 'b1'
+      })
+    ).toEqual({ type: 'text', value: 'Knowledge base "b1" has no items yet.' })
+  })
+
+  it('kb_read and kb_manage render the note for a non-object output', () => {
+    expect(knowledgeReadModelOutput(undefined as never)).toEqual({
+      type: 'text',
+      value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE
+    })
+    expect(knowledgeManageModelOutput('marker' as never)).toEqual({
+      type: 'text',
+      value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE
+    })
   })
 })

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -133,6 +133,20 @@ export const KNOWLEDGE_LOOKUP_ERROR_NOTE =
 export const KNOWLEDGE_LIST_ERROR_NOTE =
   'Listing the knowledge bases failed (a knowledge-service error); tell the user instead of retrying.'
 
+/**
+ * A stored tool result that matches none of the shapes below (an output written by an older build, a
+ * trimmed/rendered envelope, a non-object). The `toModelOutput` formatters re-run over EVERY tool
+ * part of the conversation on every turn (`convertToModelMessages`), so one unreadable part must
+ * degrade to this note — throwing breaks every later turn of that conversation, not just the part.
+ */
+export const KNOWLEDGE_UNREADABLE_OUTPUT_NOTE =
+  'This knowledge base tool result could not be read back from the conversation history. Ignore it — call kb_list to re-check the current knowledge bases before acting on it.'
+
+/** Narrow to the object shapes the formatters below discriminate on; anything else is unreadable. */
+function isObjectOutput<T>(output: T): output is T & object {
+  return typeof output === 'object' && output !== null && !Array.isArray(output)
+}
+
 export function isKnowledgeLookupError(output: KnowledgeSearchResultOrError): output is KnowledgeLookupError {
   // kb_search success is always the results array; the error object is the only non-array shape.
   // kb_list has two object success shapes, so it uses explicit property discriminants instead.
@@ -272,6 +286,10 @@ async function readConcept(
 export function knowledgeReadModelOutput(
   output: KnowledgeReadResultOrError
 ): { type: 'text'; value: string } | { type: 'json'; value: KbReadOutput | KbGrepOutput } {
+  if (!isObjectOutput(output)) {
+    logger.warn('kb_read output is not an object; rendering the unreadable-output note', { received: typeof output })
+    return { type: 'text', value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE }
+  }
   if (isConceptLookupError(output)) {
     return { type: 'text', value: output.error }
   }
@@ -517,6 +535,10 @@ export async function manageKnowledge(
 export function knowledgeManageModelOutput(
   output: KnowledgeManageResultOrError
 ): { type: 'text'; value: string } | { type: 'json'; value: KbManageOutput } {
+  if (!isObjectOutput(output)) {
+    logger.warn('kb_manage output is not an object; rendering the unreadable-output note', { received: typeof output })
+    return { type: 'text', value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE }
+  }
   if (isConceptLookupError(output)) {
     return { type: 'text', value: output.error }
   }
@@ -639,15 +661,22 @@ export function knowledgeListModelOutput(
 ): { type: 'text'; value: string } | { type: 'json'; value: KbListOutput | KbTreeOutput } {
   const outlineMode = input?.baseId != null
 
+  if (!isObjectOutput(output)) {
+    logger.warn('kb_list output is not an object; rendering the unreadable-output note', { received: typeof output })
+    return { type: 'text', value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE }
+  }
+
   if ('error' in output) {
     // Outline mode surfaces the specific error (out-of-scope / not-found / service); list mode hides
     // the raw listBasesForDiscovery() infra error behind a fixed note (mirrors kb_search's all-failed path).
     return { type: 'text', value: outlineMode ? output.error : KNOWLEDGE_LIST_ERROR_NOTE }
   }
 
-  if ('items' in output) {
+  // `Array.isArray` rather than the key alone: a stored part can carry `items`/`nodes` without the
+  // array (or neither), and a bare deref of the missing one is what crashed the whole conversation.
+  if ('items' in output && Array.isArray(output.items)) {
     if (output.items.length === 0) {
-      if (output.total > 0 || input.cursor) {
+      if (output.total > 0 || input?.cursor) {
         return {
           type: 'text',
           value:
@@ -666,10 +695,17 @@ export function knowledgeListModelOutput(
   }
 
   // Outline mode success: one base's tree.
-  if (output.nodes.length === 0) {
-    return { type: 'text', value: `Knowledge base "${output.baseId}" has no items yet.` }
+  if ('nodes' in output && Array.isArray(output.nodes)) {
+    if (output.nodes.length === 0) {
+      return { type: 'text', value: `Knowledge base "${output.baseId}" has no items yet.` }
+    }
+    return { type: 'json', value: output }
   }
-  return { type: 'json', value: output }
+
+  logger.warn('kb_list output matches no known shape; rendering the unreadable-output note', {
+    keys: Object.keys(output)
+  })
+  return { type: 'text', value: KNOWLEDGE_UNREADABLE_OUTPUT_NOTE }
 }
 
 function buildOutputItem(


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A conversation with a knowledge base attached could get permanently stuck on `TypeError: Cannot read properties of undefined (reading 'length')`, thrown from `knowledgeListModelOutput` through `createToolModelOutput` / `convertToModelMessages`. Every later turn of that conversation failed the same way; the user could only continue by detaching the knowledge base, and restoring a backup of an affected conversation reproduced it again.

`knowledgeListModelOutput` discriminated its three-way union with two key probes (`'error' in output`, then `'items' in output`) and let the last branch dereference `output.nodes.length` with no guard at all. `toModelOutput` is not only run on the tool result that was just produced — `convertToModelMessages` re-runs it over *every* stored tool part of the conversation on every turn (`src/main/ai/messages/messageRules.ts`). So one stored part whose output no longer matches a live shape (written by an older build, a rendered `$persistedToolOutput` envelope, an MCP-style result envelope, an interrupted empty result) fell through to that branch and threw — and a throw there fails the whole request, not just that one part. `knowledgeReadModelOutput` / `knowledgeManageModelOutput` had the same class of bug one step earlier: `'error' in output` throws `Cannot use 'in' operator` when the stored output is a string or `undefined`.

After this PR:

- `knowledgeListModelOutput` guards the non-object case, discriminates `items` / `nodes` with `Array.isArray` instead of key presence, and falls back to a fixed note (`KNOWLEDGE_UNREADABLE_OUTPUT_NOTE`) plus a `logger.warn` when the output matches no known shape.
- `knowledgeReadModelOutput` and `knowledgeManageModelOutput` get the same non-object guard before their `'error' in output` probe.
- `input.cursor` becomes `input?.cursor`, matching the `input?.baseId` / `input?.query` reads around it.
- `knowledgeSearchModelOutput` needed no change — its `!Array.isArray(output)` discriminant already routes any malformed value to the error note.

Fixes: N/A (reported via internal feedback board, no GitHub issue)

### Why we need it and why it was done in this way

A `toModelOutput` formatter is effectively total over `unknown`: it is replayed across the whole persisted history, so it must survive any shape the history holds instead of trusting the live union type. Degrading an unreadable part to a short note keeps the rest of the conversation usable — the model is told to ignore that result and call `kb_list` again — whereas throwing bricks the conversation for good.

The following tradeoffs were made:

- The fallback note is one shared constant for `kb_list` / `kb_read` / `kb_manage` rather than three tailored ones. It deliberately does not tell the model to repeat the call, so it is also safe for `kb_manage` (a destructive tool).
- The formatters are hardened at the read boundary rather than validating stored outputs against their Zod schemas on load: the parse would cost per-part work on every turn, and the formatters have to be defensive anyway.

The following alternatives were considered:

- Sanitising tool parts at persistence time — does not help the conversations that are already broken on disk, which is exactly the reported case.
- Catching around the `convertToModelMessages` call — would hide the failure for all tools and lose the per-part steer.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Original user report (Cherry Studio official group 57, Windows, v2.0.5, P1): "using a knowledge base, the conversation reports `TypeError: Cannot read properties of undefined (reading 'length')`; the stack goes from `knowledgeListModelOutput` into `createToolModelOutput` / `convertToModelMessages`. Only closing the knowledge base lets the conversation continue. Rolling back to 2.0.4, changing the install directory and rebuilding the knowledge base did not help, and importing a backup of the affected conversation reproduces it."
Source record: https://mcnnox2fhjfq.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvseU23q81nX

The new tests reproduce the reported error verbatim against the old code — reverting `knowledgeLookup.ts` alone makes them fail with `Cannot read properties of undefined (reading 'length')` (and `Cannot use 'in' operator` for the string / `undefined` cases).

Self-verification: `vitest run src/main/ai/tools src/main/ai/mcp src/main/ai/messages` (64 files, 859 tests) pass, `typecheck:node`, `oxlint --deny-warnings`, `eslint` and `biome check` clean on the changed files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix a knowledge base conversation getting permanently stuck on "TypeError: Cannot read properties of undefined (reading 'length')": a stored kb_list/kb_read/kb_manage tool result whose shape can no longer be read is now skipped with a note instead of failing every later turn.
```
