### PR TITLE
fix(chat-attachments): stop blocking images sent to "non-vision" models

### DIFF
--- a/docs/references/ai/chat-attachments.md
+++ b/docs/references/ai/chat-attachments.md
@@ -21,7 +21,7 @@ Decided per file part in `prepareChatMessages`
 |---|---|---|
 | image | model is vision | native image part (inline) |
 | image | non-vision, OCR finds text | OCR text, inline (capped) |
-| image | non-vision, no OCR text (or OCR unconfigured/failed) | user-facing error; no provider request |
+| image | non-vision, no OCR text (or OCR unconfigured/failed) | native image part (inline base64) |
 | pdf | provider+model native PDF | native PDF part (inline) |
 | pdf | otherwise | extracted text, inline (capped) |
 | office (`docx/xlsx/pptx/odf`) | — | extracted text, inline (capped) |
@@ -41,9 +41,11 @@ Decided per file part in `prepareChatMessages`
 - Binary / unsupported types are **not** auto-decoded — they'd inline as mojibake
   — so they get a short note instead.
 - A non-vision image only degrades to OCR text when OCR actually finds text.
-  Otherwise (empty OCR result, unconfigured or failed OCR) attachment routing
-  raises a localized error before opening the provider request. The user can
-  select a vision-capable model or remove the image and try again.
+  Otherwise (empty OCR result, unconfigured or failed OCR) the native image is
+  forwarded anyway — the vision verdict describes the model while the request
+  goes to an endpoint, so the provider decides. A model behind a gateway that
+  accepts images, or whose vision capability is merely under-declared, still
+  sees the picture.
 - Any per-file failure (missing entry, parse error, failed materialization)
   degrades to a `[could not read this file].` note rather than dropping the
   file or failing the request.
@@ -127,5 +129,4 @@ pass through inline, non-native PDFs go through extraction.
 - Content visibility never depends on a tool call.
 - `fileEntryId` never reaches the model (filename in, filename out).
 - Native modalities keep provider-native handling.
-- Known non-vision models never receive native image parts.
 - Per-turn context is bounded by the cap.

--- a/src/main/ai/messages/__tests__/attachmentRouting.test.ts
+++ b/src/main/ai/messages/__tests__/attachmentRouting.test.ts
@@ -98,28 +98,35 @@ describe('prepareChatMessages — routing', () => {
     expect(textOf(out.parts)[0]).toBe('Attached file "a.png":\nocr body')
   })
 
-  it('rejects before native materialization when OCR finds no text', async () => {
+  // A local vision verdict describes the model, not the endpoint it is called
+  // through: rejecting here locked users of image-capable gateways/proxies out
+  // of sending any image at all (a photo OCRs to nothing, so every turn failed).
+  it.each([
+    ['OCR finds no text', () => ocrMock.mockResolvedValueOnce('   ')],
+    [
+      'OCR is unconfigured or fails',
+      () => ocrMock.mockRejectedValueOnce(new Error('Default file processor for image_to_text is not configured'))
+    ]
+  ])('forwards the native image to a non-vision model when %s', async (_case, arrangeOcr) => {
     getByIdMock.mockResolvedValueOnce({ ext: 'png' })
-    ocrMock.mockResolvedValueOnce('   ')
+    arrangeOcr()
+    const materialized = { type: 'file', url: 'data:image/png;base64,AA', mediaType: 'image/png' }
+    resolveMock.mockResolvedValueOnce(materialized)
 
-    await expect(run([fileWithEntry('e1', 'a.png', 'image/png')], NONE)).rejects.toMatchObject({
-      name: 'NonVisionImageOcrError',
-      i18nKey: 'image_unreadable_for_non_vision_model'
-    })
+    const [out] = await run([fileWithEntry('e1', 'a.png', 'image/png')], NONE)
 
-    expect(resolveMock).not.toHaveBeenCalled()
+    expect(out.parts).toEqual([materialized])
   })
 
-  it('rejects before native materialization when OCR is unconfigured or fails', async () => {
+  it('degrades to a note when the native image fallback also fails', async () => {
     getByIdMock.mockResolvedValueOnce({ ext: 'png' })
-    ocrMock.mockRejectedValueOnce(new Error('Default file processor for image_to_text is not configured'))
+    ocrMock.mockResolvedValueOnce('')
+    resolveMock.mockResolvedValueOnce(null)
 
-    await expect(run([fileWithEntry('e1', 'a.png', 'image/png')], NONE)).rejects.toMatchObject({
-      name: 'NonVisionImageOcrError',
-      i18nKey: 'image_unreadable_for_non_vision_model'
-    })
+    const [out] = await run([fileWithEntry('e1', 'a.png', 'image/png')], NONE)
 
-    expect(resolveMock).not.toHaveBeenCalled()
+    expect(out.parts.filter((p) => p.type === 'file')).toHaveLength(0)
+    expect(textOf(out.parts)[0]).toBe('Attached file "a.png": [could not read this file].')
   })
 
   it('inlines extracted text for office docs', async () => {

--- a/src/main/ai/messages/attachmentRouting.ts
+++ b/src/main/ai/messages/attachmentRouting.ts
@@ -8,8 +8,8 @@
  *     `extractDocumentText`, image via OCR, audio/video/binary → a note),
  *     inlined and capped. Over the cap, the head is inlined + a `read_file`
  *     pointer. A non-vision image whose OCR yields no text (or whose OCR is
- *     unconfigured/failed) stops before the provider call with a user-facing
- *     error.
+ *     unconfigured/failed) is forwarded as the native image instead, letting
+ *     the provider decide what it can do with it.
  *
  * Content is always inlined, so visibility never depends on the model choosing
  * to call `read_file` — weak and non-tool models see it too. Every failure
@@ -41,18 +41,6 @@ import { extractDocumentText, noExtractableTextNote } from './attachmentTextExtr
 import { materializeNativeFilePart } from './fileProcessor'
 
 const logger = loggerService.withContext('ai:attachmentRouting')
-
-const NON_VISION_IMAGE_OCR_ERROR_MESSAGE =
-  "The selected model doesn't support images, and Cherry Studio couldn't extract readable text from the attachment. Choose a vision-capable model or remove the image and try again."
-
-class NonVisionImageOcrError extends Error {
-  readonly i18nKey = 'image_unreadable_for_non_vision_model'
-
-  constructor() {
-    super(NON_VISION_IMAGE_OCR_ERROR_MESSAGE)
-    this.name = 'NonVisionImageOcrError'
-  }
-}
 
 /** Generate a unique model-facing handle, suffixing ` (2)`, ` (3)`, … until the
  *  *final* alias is free — so a generated suffix can't collide with a real name. */
@@ -106,7 +94,8 @@ function isNative(ext: string, fileType: FileType, ns: NativeFileSupport): boole
 
 /**
  * OCR a non-vision image. Returns trimmed text, or `null` when OCR found no
- * text or is unavailable (unconfigured / failed). Abort rethrows.
+ * text or is unavailable (unconfigured / failed) — the caller falls back to
+ * forwarding the native image instead. Abort rethrows.
  */
 async function ocrNonVisionImage(entryId: string, signal?: AbortSignal): Promise<string | null> {
   try {
@@ -114,7 +103,7 @@ async function ocrNonVisionImage(entryId: string, signal?: AbortSignal): Promise
     return text || null
   } catch (error) {
     if (signal?.aborted || isAbortError(error)) throw error
-    logger.warn('OCR unavailable or failed for a non-vision model', { error })
+    logger.warn('OCR unavailable or failed; forwarding the native image instead', { error })
     return null
   }
 }
@@ -227,12 +216,18 @@ async function prepareChatMessage<T extends UIMessage>(
         continue
       }
 
-      // Non-vision image → OCR text when it finds any. If OCR cannot produce
-      // text, stop before opening a provider request: sending the native image
-      // to a known non-vision model would only produce a deterministic API error.
+      // Non-vision image → OCR text when it finds any; otherwise forward the native
+      // image: the verdict describes the model, but the request goes to an endpoint
+      // (a gateway in front of it may accept images), so let the provider decide.
       if (fileType === FILE_TYPE.IMAGE) {
         const ocrText = await ocrNonVisionImage(fileEntryId, ctx.signal)
-        if (ocrText === null) throw new NonVisionImageOcrError()
+        if (ocrText === null) {
+          if (!(await inlineNative(part))) {
+            logger.warn('Native image fallback failed; degrading to note', { messageId: message.id, displayName })
+            kept.push(noteOf(handle) as UIMessage['parts'][number])
+          }
+          continue
+        }
         defer(kept, pending, handle, ocrText)
         continue
       }
@@ -242,7 +237,6 @@ async function prepareChatMessage<T extends UIMessage>(
       defer(kept, pending, handle, body)
     } catch (error) {
       if (ctx.signal?.aborted || isAbortError(error)) throw error
-      if (error instanceof NonVisionImageOcrError) throw error
       logger.error('Failed to prepare attached file', error as Error, { messageId: message.id, displayName })
       kept.push(noteOf(handle) as UIMessage['parts'][number])
     }
@@ -253,8 +247,8 @@ async function prepareChatMessage<T extends UIMessage>(
 
 /**
  * Prepare chat messages for the model: native files stay inline, non-native
- * files become capped extracted text. A non-vision image with no OCR text
- * rejects before the provider call. Single pass, applied to every model.
+ * files become capped extracted text (a non-vision image with no OCR text
+ * falls back to the native image). Single pass, applied to every model.
  */
 export async function prepareChatMessages<T extends UIMessage = UIMessage>(
   messages: T[],

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -2601,7 +2601,6 @@
       "503": "Service unavailable. Please try again later",
       "504": "Gateway timeout. Please try again later"
     },
-    "image_unreadable_for_non_vision_model": "The selected model doesn't support images, and Cherry Studio couldn't extract readable text from the attachment. Choose a vision-capable model or remove the image and try again.",
     "lastError": "Last Error",
     "maxEmbeddingsPerCall": "Max Embeddings Per Call",
     "message": "Error Message",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -2601,7 +2601,6 @@
       "503": "服务不可用，请稍后再试",
       "504": "网关超时，请稍后再试"
     },
-    "image_unreadable_for_non_vision_model": "当前模型不支持图片，且 Cherry Studio 未能从附件中识别出有效文字。请选择支持图片的模型，或移除图片后重试。",
     "lastError": "最后错误",
     "maxEmbeddingsPerCall": "每次调用的最大嵌入",
     "message": "错误信息",

--- a/v2-refactor-temp/docs/breaking-changes/2026-07-30-chat-image-ocr-native-fallback.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-07-30-chat-image-ocr-native-fallback.md
@@ -21,3 +21,5 @@ Nothing. Images with recognizable text keep the existing OCR-to-text behavior; c
 ## Notes for release manager
 
 Only the empty-OCR / OCR-unavailable path changed; OCR-with-text, explicit OCR features (translation workflow), and the `read_file` tool are unchanged.
+
+#18297 replaced this fallback with a localized error that failed the turn before the request (shipped in v2.0.5 with an "action required" release note); the behavior described above is what v2 ships. Users on a gateway or proxy that accepts images could not send any image while the block was in place, and because attachment routing replays the whole conversation, one such image failed every later turn of it too. Describe the net behavior once — do not carry the v2.0.5 "action required" wording into the release note.


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Attaching an image to a model Cherry Studio classifies as non-vision failed the whole turn with a red error block ("The selected model doesn't support images…") whenever OCR produced no text — which is the normal outcome for a photo, and also what happens when OCR is unavailable. Because `prepareChatMessages` re-runs over the entire conversation on every turn, one such image in the history failed every subsequent turn of that conversation as well.

After this PR:

That pre-flight block is removed. A non-vision image is still OCR'd first and inlined as text when OCR finds any; when it does not, the image is forwarded to the provider as a native image part again (and only degrades to a `[could not read this file].` note if that materialization itself fails). This restores the routing behavior of #17637, which #18297 had replaced with the hard block.

Fixes # N/A (reported via internal user feedback — Cherry Studio 内测群 6, v2.0.5 regression, P1)

### Why we need it and why it was done in this way

A user routes DeepSeek through a PAL/MiMo gateway that resolves images upstream, so the endpoint accepts images even though the model id reads as text-only. This worked until v2.0.5 and has been hard-blocked client-side since.

That is the structural problem with the block: `isVisionModel()` describes a **model**, but the request is sent to an **endpoint**. For first-party providers the two coincide; for gateways, reverse proxies, aggregators and OpenAI-compatible self-hosted endpoints they do not, and nothing in local metadata can tell the two apart — a gateway can put any model id in front of any backend. #17637 concluded from this that the provider must decide; #18297 assumed the local verdict was authoritative enough to reject on, and this regression is the consequence.

The cost asymmetry also favors forwarding. Blocking a request that would have worked removes the feature entirely for those users (and poisons the whole conversation, per the re-run above). Forwarding a request that will not work costs one provider error the user can act on — the same error class they would see for any other unsupported input.

The following tradeoffs were made:

- A genuinely text-only model now receives a native image part again when OCR finds nothing, and may answer with a provider-side 4xx instead of Cherry Studio's localized message. That is #18297's stated concern, accepted here as the smaller harm; if we want to spare those users the raw API error, the right place is mapping the provider's image-related error after the fact (an alternative #18297 itself considered), not a pre-flight veto based on metadata that cannot describe a third-party endpoint.
- OCR-first is unchanged, so text-heavy screenshots and scans still become inline text on non-vision models, still content-version cached, no extra per-turn cost.
- `error.image_unreadable_for_non_vision_model` lost its only producer and is removed from `locales/en-us.json` + `locales/zh-cn.json`. Error blocks already stored in v2.0.5 history fall back to the serialized English message (`ErrorBlock` guards with `i18n.exists`), rather than showing a raw key. `translate/*` is left to the sync job, per the renderer catalog check.

The following alternatives were considered:

- **Three-state OCR result** (`text` / `empty` / `unavailable`), forwarding only when OCR is unavailable and keeping the block when OCR ran and read nothing. Rejected: it does not fix the report. `image_to_text` has a self-healing platform default (`system` on macOS/Windows, `tesseract` on Linux — `resolveDefaultImageToTextProcessor`), so OCR is normally available and a photo simply OCRs to an empty string. The reported user lands in the `empty` branch, which this variant would keep blocking.
- **Narrowing the block by capability provenance** (only block when `inputModalities` explicitly declares a modality set without `image`). Rejected: a gateway-hosted model id that matches the global catalog inherits that catalog's declared modalities, so the misclassified case stays misclassified.
- **Narrowing the block to first-party providers** (`isFirstPartyFileProvider`). Rejected: after that narrowing the block only fires for openai/anthropic/google/azure/bedrock/vertex, whose text-only SKUs are a thin tail — a gate with almost no remaining domain is worse than no gate.

Links to places where the discussion took place:

- Original user report (internal feedback base, record `recvseU23qzoc2`): https://mcnnox2fhjfq.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvseU23qzoc2
- Source: Cherry Studio 官方内测群 6 · 杰, filed by 许思寅. P1 / BUG / v2.0.5. User's words: "此前通过 PAL/MiMo 为 DeepSeek 配置视觉模型，使非视觉模型可以处理图片；升级到 V2.0.5 后发送照片会弹出红色错误提示，升级前可用。"
- Prior art: #17637 (introduced the native fallback), #18297 (replaced it with the block being removed here).

### Breaking changes

Behavior change (notice-level): images attached to models without declared vision support are sent to the provider as native images again when OCR finds no text, instead of failing the turn locally. This reverses the user-facing effect of #18297 (which shipped an "action required" release note in v2.0.5) and restores #17637.

Rather than adding a fragment that would have to be reconciled with two earlier ones at release prep, this is recorded on the existing entry it restores — `v2-refactor-temp/docs/breaking-changes/2026-07-30-chat-image-ocr-native-fallback.md` — which now states that the described behavior is what v2 ships and that the v2.0.5 "action required" wording should not reach the release note.

### Special notes for your reviewer

- `stripUnsupportedMedia` (`messageCapabilities.ts`) still gates only audio/video, so the fallback image part survives history replay — the #17637 delivery path was never removed, only its producer.
- `resolveRequiredNativeFileSupport` (`AiService.ts`) records an image requirement only when the primary model already supports images, so a fallback image part does not perturb fallback-model selection.
- Abort semantics unchanged: `ocrNonVisionImage` rethrows on abort and converts only other failures into the native fallback.
- Tests: the two block-pinning cases in `attachmentRouting.test.ts` are replaced by empty-OCR and failed-OCR forwarding cases plus a double-failure note case.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a v2.0.5 regression where attaching an image to a model without declared vision support failed the turn with an error whenever no text could be read from the image. The image is sent to the provider again, so models behind gateways or proxies that do accept images work as they did before.
```
