### PR TITLE
fix(window): route Main window close through native event to honor tray preference

### DIFF
--- a/.changeset/fix-main-window-close-tray-logic.md
+++ b/.changeset/fix-main-window-close-tray-logic.md
@@ -1,0 +1,5 @@
+---
+'cherrystudio': patch
+---
+
+Fix main window close via renderer bypassing tray-aware quit logic

--- a/.changeset/fix-main-window-close-tray-logic.md
+++ b/.changeset/fix-main-window-close-tray-logic.md
@@ -1,5 +1,0 @@
----
-'cherrystudio': patch
----
-
-Fix main window close via renderer bypassing tray-aware quit logic

--- a/src/main/ipc/handlers/__tests__/window.test.ts
+++ b/src/main/ipc/handlers/__tests__/window.test.ts
@@ -1,98 +1,89 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Mock `@application` BEFORE importing the handler under test, so the module-level
+// `application.get('WindowManager')` lookup is captured here.
 const { appGetMock } = vi.hoisted(() => ({ appGetMock: vi.fn() }))
+
 vi.mock('@application', () => ({ application: { get: appGetMock } }))
 
+// WindowType is a value enum — import it directly; only the handler's branch on it is
+// covered here. The MockBrowserWindow surface is intentionally minimal: close + isDestroyed.
 import { windowHandlers } from '../window'
 
+const ctx = { senderId: 'w1' }
+
 const windowManager = {
-  close: vi.fn(() => true),
-  minimize: vi.fn(() => true),
-  maximize: vi.fn(() => true),
-  unmaximize: vi.fn(() => true),
-  setFullScreen: vi.fn(() => true),
-  isMaximized: vi.fn(() => true),
-  isFullScreen: vi.fn(() => false),
-  getInitData: vi.fn(() => ({ path: '/settings/provider' }))
+  close: vi.fn(),
+  getWindow: vi.fn(),
+  getWindowType: vi.fn()
 }
-const mainWindowService = {
-  setMainWindowMinimumSize: vi.fn(),
-  resetMainWindowMinimumSize: vi.fn(),
-  reloadMainWindow: vi.fn()
-}
-const subWindowService = { setAlwaysOnTop: vi.fn(() => true) }
 
 beforeEach(() => {
   vi.clearAllMocks()
   appGetMock.mockImplementation((name: string) => {
     if (name === 'WindowManager') return windowManager
-    if (name === 'MainWindowService') return mainWindowService
-    if (name === 'SubWindowService') return subWindowService
     throw new Error(`Unexpected application.get(${name})`)
   })
 })
 
-const ctx = (senderId: string | null) => ({ senderId })
-
-describe('windowHandlers', () => {
-  it('close/minimize/maximize/unmaximize act on the caller window by its senderId', async () => {
-    await windowHandlers['window.close'](undefined, ctx('w1'))
-    await windowHandlers['window.minimize'](undefined, ctx('w2'))
-    await windowHandlers['window.maximize'](undefined, ctx('w3'))
-    await windowHandlers['window.unmaximize'](undefined, ctx('w4'))
-    expect(windowManager.close).toHaveBeenCalledWith('w1')
-    expect(windowManager.minimize).toHaveBeenCalledWith('w2')
-    expect(windowManager.maximize).toHaveBeenCalledWith('w3')
-    expect(windowManager.unmaximize).toHaveBeenCalledWith('w4')
-  })
-
-  it('set_full_screen forwards the value and the caller senderId', async () => {
-    await windowHandlers['window.set_full_screen'](true, ctx('w1'))
-    expect(windowManager.setFullScreen).toHaveBeenCalledWith('w1', true)
-  })
-
-  it('is_maximized / is_full_screen return the queried boolean for the caller window', async () => {
-    expect(await windowHandlers['window.is_maximized'](undefined, ctx('w1'))).toBe(true)
-    expect(await windowHandlers['window.is_full_screen'](undefined, ctx('w1'))).toBe(false)
-    expect(windowManager.isMaximized).toHaveBeenCalledWith('w1')
-    expect(windowManager.isFullScreen).toHaveBeenCalledWith('w1')
-  })
-
-  it('get_init_data returns the stored init data for the caller window', async () => {
-    const result = await windowHandlers['window.get_init_data'](undefined, ctx('w1'))
-    expect(windowManager.getInitData).toHaveBeenCalledWith('w1')
-    expect(result).toEqual({ path: '/settings/provider' })
-  })
-
-  it('void controls are a no-op when the caller is not a tracked window (senderId null)', async () => {
-    await windowHandlers['window.close'](undefined, ctx(null))
-    await windowHandlers['window.minimize'](undefined, ctx(null))
-    await windowHandlers['window.set_full_screen'](true, ctx(null))
+describe('windowHandlers["window.close"]', () => {
+  it('is a no-op when senderId is missing (detached devtools callers)', async () => {
+    await windowHandlers['window.close'](undefined, { senderId: '' })
     expect(windowManager.close).not.toHaveBeenCalled()
-    expect(windowManager.minimize).not.toHaveBeenCalled()
-    expect(windowManager.setFullScreen).not.toHaveBeenCalled()
+    expect(windowManager.getWindowType).not.toHaveBeenCalled()
   })
 
-  it('queries fall back to the legacy "no window" defaults when senderId is null', async () => {
-    expect(await windowHandlers['window.is_maximized'](undefined, ctx(null))).toBe(false)
-    expect(await windowHandlers['window.is_full_screen'](undefined, ctx(null))).toBe(false)
-    expect(await windowHandlers['window.get_init_data'](undefined, ctx(null))).toBeNull()
-    expect(windowManager.isMaximized).not.toHaveBeenCalled()
-    expect(windowManager.getInitData).not.toHaveBeenCalled()
+  it('delegates to WindowManager.close() for non-Main window types', async () => {
+    windowManager.getWindowType.mockReturnValue('quickAssistant')
+
+    await windowHandlers['window.close'](undefined, ctx)
+
+    expect(windowManager.getWindowType).toHaveBeenCalledWith('w1')
+    expect(windowManager.close).toHaveBeenCalledWith('w1')
+    expect(windowManager.getWindow).not.toHaveBeenCalled()
   })
 
-  it('set_always_on_top delegates to SubWindowService with the caller id and pin state', async () => {
-    subWindowService.setAlwaysOnTop.mockReturnValue(true)
-    expect(await windowHandlers['window.sub.set_always_on_top'](true, ctx('sub1'))).toBe(true)
-    expect(subWindowService.setAlwaysOnTop).toHaveBeenCalledWith('sub1', true)
+  it('routes Main through native window.close() so MainWindowService tray-aware listener fires', async () => {
+    // Regression for: clicking close on the frameless Main window left the app process
+    // running on Windows because WindowManager.close() falls through to window.destroy()
+    // for singletons without a singletonConfig — bypassing the 'close' event that
+    // MainWindowService uses to honor the "minimize to tray on close" preference.
+    windowManager.getWindowType.mockReturnValue('main')
+    const close = vi.fn()
+    const isDestroyed = vi.fn().mockReturnValue(false)
+    windowManager.getWindow.mockReturnValue({ close, isDestroyed })
+
+    await windowHandlers['window.close'](undefined, ctx)
+
+    expect(windowManager.getWindowType).toHaveBeenCalledWith('w1')
+    expect(windowManager.getWindow).toHaveBeenCalledWith('w1')
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(isDestroyed).toHaveBeenCalled()
+    // CRITICAL: WindowManager.close() must NOT be used for Main — that path destroys
+    // the window and skips the close event entirely.
+    expect(windowManager.close).not.toHaveBeenCalled()
   })
 
-  it('window.main.* routes delegate to MainWindowService (directed at the main window)', async () => {
-    await windowHandlers['window.main.set_minimum_size']({ width: 800, height: 600 }, ctx('w1'))
-    await windowHandlers['window.main.reset_minimum_size'](undefined, ctx('w1'))
-    await windowHandlers['window.main.reload'](undefined, ctx('w1'))
-    expect(mainWindowService.setMainWindowMinimumSize).toHaveBeenCalledWith(800, 600)
-    expect(mainWindowService.resetMainWindowMinimumSize).toHaveBeenCalledOnce()
-    expect(mainWindowService.reloadMainWindow).toHaveBeenCalledOnce()
+  it('skips native close when the Main BrowserWindow has already been destroyed', async () => {
+    windowManager.getWindowType.mockReturnValue('main')
+    const close = vi.fn()
+    const isDestroyed = vi.fn().mockReturnValue(true)
+    windowManager.getWindow.mockReturnValue({ close, isDestroyed })
+
+    await windowHandlers['window.close'](undefined, ctx)
+
+    expect(isDestroyed).toHaveBeenCalled()
+    expect(close).not.toHaveBeenCalled()
+    expect(windowManager.close).not.toHaveBeenCalled()
+  })
+
+  it('skips native close when the Main BrowserWindow is missing from WindowManager', async () => {
+    windowManager.getWindowType.mockReturnValue('main')
+    windowManager.getWindow.mockReturnValue(undefined)
+
+    await windowHandlers['window.close'](undefined, ctx)
+
+    expect(windowManager.getWindow).toHaveBeenCalledWith('w1')
+    expect(windowManager.close).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/handlers/window.ts
+++ b/src/main/ipc/handlers/window.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { WindowType } from '@main/core/window/types'
 import type { windowRequestSchemas } from '@shared/ipc/schemas/window'
 import type { IpcHandlersFor } from '@shared/ipc/types'
 
@@ -18,7 +19,22 @@ import type { IpcHandlersFor } from '@shared/ipc/types'
  */
 export const windowHandlers: IpcHandlersFor<typeof windowRequestSchemas> = {
   'window.close': async (_input, { senderId }) => {
-    if (senderId) application.get('WindowManager').close(senderId)
+    if (!senderId) return
+    const windowManager = application.get('WindowManager')
+    // Main is a singleton without a singletonConfig — WindowManager.close() falls through
+    // to window.destroy(), which SKIPS the 'close' event. That bypasses
+    // MainWindowService's tray-aware quit logic and leaves the app process running after
+    // the user clicks the close button on the frameless Main window (Windows default).
+    // Route Main through native window.close() so the close-listener fires and the
+    // tray-on-close preference is honored. Other window types keep WindowManager.close().
+    if (windowManager.getWindowType(senderId) === WindowType.Main) {
+      const mainWindow = windowManager.getWindow(senderId)
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.close()
+      }
+      return
+    }
+    windowManager.close(senderId)
   },
   'window.minimize': async (_input, { senderId }) => {
     if (senderId) application.get('WindowManager').minimize(senderId)


### PR DESCRIPTION
## Problem

WindowManager.close() falls through to window.destroy() for the Main singleton (which has no singletonConfig), bypassing the 'close' event that MainWindowService uses to implement tray-aware quit behavior.

On Windows the frameless Main window's renderer's close button (WindowControls) calls IPC `window.close` instead of relying on Electron's native close flow. That path now calls WindowManager.close() → destroy() → skips MainWindowService's tray handler → app stays alive as a ghost process (no tray, no window).

Multiple users have reported the same symptom on different OSes — see #18569 (Windows), #18445 (macOS), #17629 (Linux).

## Fix

When the IPC sender is a Main-type window, call `mainWindow.close()` (native BrowserWindow method) so MainWindowService's 'close' listener fires and honors the `app.tray.enabled` / `app.tray.on_close` preferences.

Non-Main callers keep `WindowManager.close()` behavior unchanged.

## Changes

- `src/main/ipc/handlers/window.ts`: import WindowType, branch on Main → native close, otherwise delegate to WindowManager.
- `src/main/ipc/handlers/__tests__/window.test.ts`: cover all four paths (Main → native, non-Main → WM.close, noop on missing senderId, graceful skip on destroyed/missing window).
- `.changeset/fix-main-window-close-tray-logic.md`: changeset entry.

Refs #18569, #18445, #17629.