### PR TITLE
perf(export): parallelize multi-message Notion conversion

### DIFF
--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -606,6 +606,19 @@ const convertThinkingToNotionBlocks = async (thinkingContent: string): Promise<a
   }
 }
 
+// Reasoning content comes from the message itself, not from the body markdown,
+// so callers can produce these blocks concurrently with the body conversion.
+const convertThinkingBlocksFor = async (message: ExportableMessage, reasoningEnabled: boolean): Promise<any[]> => {
+  if (!reasoningEnabled) {
+    return []
+  }
+  const thinkingContent = stripCitationMarkers(getThinkingContent(message))
+  if (!thinkingContent) {
+    return []
+  }
+  return convertThinkingToNotionBlocks(thinkingContent)
+}
+
 const executeNotionExport = async (title: string, allBlocks: any[]): Promise<boolean> => {
   if (getExportState()) {
     toast.warning(i18n.t('message.warn.export.exporting'))
@@ -705,28 +718,25 @@ export const exportMessagesToNotion = async (title: string, messages: Exportable
 
     const titleBlocks = await convertMarkdownToNotionBlocks(`# ${title}`)
 
-    // 为每个消息创建blocks
-    const allBlocks: any[] = [...titleBlocks]
-
-    for (const message of messages) {
-      // 将单个消息转换为markdown
-      const messageMarkdown = await messageToMarkdown(message, excludeCitationsInExport)
-      const messageBlocks = await convertMarkdownToNotionBlocks(messageMarkdown)
-
-      if (notionExportReasoning) {
-        const thinkingContent = stripCitationMarkers(getThinkingContent(message))
-        if (thinkingContent) {
-          const thinkingBlocks = await convertThinkingToNotionBlocks(thinkingContent)
-          if (messageBlocks.length > 0) {
-            messageBlocks.splice(1, 0, ...thinkingBlocks)
-          } else {
-            messageBlocks.push(...thinkingBlocks)
-          }
+    // Body and reasoning conversions take independent inputs, so they run
+    // concurrently per message and across messages; map+Promise.all keeps input order.
+    const convertMessage = async (message: ExportableMessage): Promise<any[]> => {
+      const [messageBlocks, thinkingBlocks] = await Promise.all([
+        messageToMarkdown(message, excludeCitationsInExport).then(convertMarkdownToNotionBlocks),
+        convertThinkingBlocksFor(message, notionExportReasoning)
+      ])
+      if (thinkingBlocks.length > 0) {
+        if (messageBlocks.length > 0) {
+          messageBlocks.splice(1, 0, ...thinkingBlocks)
+        } else {
+          messageBlocks.push(...thinkingBlocks)
         }
       }
-
-      allBlocks.push(...messageBlocks)
+      return messageBlocks
     }
+
+    const messageBlocksList = await Promise.all(messages.map(convertMessage))
+    const allBlocks: any[] = [...titleBlocks, ...messageBlocksList.flat()]
 
     return executeNotionExport(title, allBlocks)
   })

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -7,7 +7,7 @@ import type { Message, MessageBlock } from '@renderer/types/newMessage'
 import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import type * as MessageFind from '@renderer/utils/message/find'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // --- Mocks Setup ---
 
@@ -18,7 +18,7 @@ const notionMocks = vi.hoisted(() => ({
     helper: 0
   },
   createPage: vi.fn(),
-  markdownToBlocks: vi.fn((markdown: string) => [{ markdown }]),
+  markdownToBlocks: vi.fn((markdown: string) => [{ markdown }, { markdown: `${markdown}\n` }]),
   appendBlocks: vi.fn()
 }))
 
@@ -147,6 +147,7 @@ import { markdownToPlainText } from '@renderer/utils/markdown'
 
 import {
   exportMarkdownToObsidian,
+  exportMessagesToNotion,
   exportMessageToNotion,
   exportTopicToNotes,
   messagesToMarkdown,
@@ -321,6 +322,89 @@ describe('ExportService', () => {
 
     await expect(exportMessageToNotion('Second', 'Second export')).resolves.toBe(true)
     expect(notionMocks.moduleLoads).toEqual(loaded)
+  })
+
+  describe('exportMessagesToNotion', () => {
+    beforeEach(async () => {
+      await preferenceService.set('data.integration.notion.api_key', 'notion-key')
+      await preferenceService.set('data.integration.notion.database_id', 'database-id')
+      await preferenceService.set('data.integration.notion.page_name_key', 'Name')
+      await preferenceService.set('data.integration.notion.export_reasoning', true)
+      notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
+      notionMocks.appendBlocks.mockResolvedValue(undefined)
+    })
+
+    afterEach(async () => {
+      // Reset notion preferences so they don't leak into sibling suites (set writes to the
+      // file-scoped mock singleton whose values survive vi.clearAllMocks).
+      await preferenceService.set('data.integration.notion.export_reasoning', false)
+      await preferenceService.set('data.integration.notion.api_key', '')
+      await preferenceService.set('data.integration.notion.database_id', '')
+    })
+
+    const messageWith = (body: string, thinking: string) =>
+      createExportView([
+        { type: 'reasoning', text: thinking },
+        { type: 'text', text: body }
+      ])
+
+    it('appends blocks in input order with reasoning spliced after the first body block', async () => {
+      await expect(
+        exportMessagesToNotion('Ordered Topic', [
+          messageWith('body-one', 'thinking-one'),
+          messageWith('body-two', 'thinking-two')
+        ])
+      ).resolves.toBe(true)
+
+      const children = notionMocks.appendBlocks.mock.calls[0][0].children
+      // title(2) + per message [body(2), reasoning spliced at index 1] x 2 => 8
+      expect(children).toHaveLength(8)
+      expect(children[0]).toEqual({ markdown: '# Ordered Topic' })
+      expect(children[1].markdown).toEqual('# Ordered Topic\n')
+      expect(children[2].markdown).toContain('body-one')
+      expect(children[3].type).toBe('toggle') // spliced right after the first body block
+      expect(children[3].toggle.children[0].markdown).toContain('thinking-one')
+      expect(children[4].markdown).toContain('body-one')
+      expect(children[5].markdown).toContain('body-two')
+      expect(children[6].type).toBe('toggle')
+      expect(children[6].toggle.children[0].markdown).toContain('thinking-two')
+      expect(children[7].markdown).toContain('body-two')
+    })
+
+    it('starts every message conversion before any one completes', async () => {
+      const originalImpl = vi.mocked(preferenceService.getMultiple).getMockImplementation()!
+      const releaseGates: Array<() => void> = []
+      const getMultipleSpy = vi.spyOn(preferenceService, 'getMultiple')
+      getMultipleSpy.mockImplementation(async (keys) => {
+        const values = await originalImpl(keys)
+        // messageToMarkdown is the only caller requesting the standardize flag.
+        const isMessageConversion = Object.values(keys).includes('data.export.markdown.standardize_citations')
+        if (!isMessageConversion) {
+          return values
+        }
+        return new Promise<Record<string, any>>((resolve) => releaseGates.push(() => resolve(values)))
+      })
+
+      try {
+        const exportPromise = exportMessagesToNotion('Concurrent Topic', [
+          messageWith('body-one', 'thinking-one'),
+          messageWith('body-two', 'thinking-two'),
+          messageWith('body-three', 'thinking-three')
+        ])
+
+        // All three message conversions must reach their gate while every gate is
+        // still closed; a serial implementation would block message two on one's gate.
+        await vi.waitFor(() => expect(releaseGates).toHaveLength(3))
+        // Reasoning conversion also runs per message without waiting for any body.
+        expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-one')
+        expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-two')
+
+        releaseGates.forEach((release) => release())
+        await expect(exportPromise).resolves.toBe(true)
+      } finally {
+        getMultipleSpy.mockRestore()
+      }
+    })
   })
 
   describe('messageToMarkdown', () => {

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -340,6 +340,7 @@ describe('ExportService', () => {
       await preferenceService.set('data.integration.notion.export_reasoning', false)
       await preferenceService.set('data.integration.notion.api_key', '')
       await preferenceService.set('data.integration.notion.database_id', '')
+      await preferenceService.set('data.integration.notion.page_name_key', '')
     })
 
     const messageWith = (body: string, thinking: string) =>
@@ -395,9 +396,12 @@ describe('ExportService', () => {
         // All three message conversions must reach their gate while every gate is
         // still closed; a serial implementation would block message two on one's gate.
         await vi.waitFor(() => expect(releaseGates).toHaveLength(3))
-        // Reasoning conversion also runs per message without waiting for any body.
-        expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-one')
-        expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-two')
+        // Reasoning conversion also runs per message without waiting for any body;
+        // waitFor covers its async hop through loadNotionDependencies on a cold cache.
+        await vi.waitFor(() => {
+          expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-one')
+          expect(notionMocks.markdownToBlocks).toHaveBeenCalledWith('thinking-two')
+        })
 
         releaseGates.forEach((release) => release())
         await expect(exportPromise).resolves.toBe(true)


### PR DESCRIPTION
### What this PR does

Before this PR:

`exportMessagesToNotion()` converted every message in a serial `for...await` loop, and within each message waited for the body conversion before starting the reasoning conversion. Since `messageToMarkdown()` performs a `preferenceService` IPC round-trip per message, exporting long topics or Agent sessions paid the sum of every message's conversion latency before the Notion request could even begin (#18553).

After this PR:

Message conversions run concurrently via `messages.map()` + `Promise.all` (input order preserved by construction, flattened afterwards), and within each message the body and reasoning conversions run as two independent promises. Output blocks are byte-for-byte identical to the serial version — same title blocks, same per-message order, same reasoning splice position. The Notion API phase (`pages.create` + `appendBlocks`) is intentionally unchanged and stays serialized: concurrent appends to the same block's children land in nondeterministic order and would also approach the 3 req/s rate limit.

Fixes #18553

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Only the local conversion phase is parallelized; the API phase stays serialized because Notion block-children ordering under concurrent appends is nondeterministic and the rate limit forbids it.
- `Promise.all` (fail-fast) is used instead of `allSettled` to keep the existing error semantics: any conversion failure aborts the export exactly as before.
- No concurrency limiter (`p-limit` etc.): each conversion is one IPC round-trip plus synchronous CPU parsing; hundreds of messages are fine unbounded.

The following alternatives were considered:

- Web Worker offload of `markdownToBlocks` — solves renderer CPU jank, not this issue's serialized wait; deferred as a separate effort.
- Parallelizing the append phase — rejected for ordering/rate-limit reasons above.
- `Promise.allSettled` — rejected: would silently export partially-converted topics, a behavior change.

Links to places where the discussion took place: #18553

### Breaking changes

None. Function signature, return values, toasts, mutex timing, and final block layout are unchanged.

### Special notes for your reviewer

- New focused tests in `ExportService.test.ts`: one asserts the full block layout (title → per-message body with reasoning toggle spliced after the first body block), one asserts concurrent starts via deferred gates on the `preferenceService.getMultiple` mock. Both were mutation-verified: reverting to a serial loop makes the concurrency test fail, and changing `splice` to `push` makes the order test fail.
- The single-message path `exportMessageToNotion` keeps its serial body→reasoning shape on purpose (minimal fix scope per the issue).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) is considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Exporting long topics to Notion now prepares messages concurrently, noticeably reducing the wait before the upload starts. Output content and ordering are unchanged.
```
