### PR TITLE
fix(provider-registry): cap MiniMax-M3 output tokens

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -12256,7 +12256,7 @@
       "family": "minimax",
       "id": "minimax-m3",
       "inputModalities": ["text", "image", "video"],
-      "maxOutputTokens": 1000000,
+      "maxOutputTokens": 524288,
       "metadata": {},
       "name": "MiniMax-M3",
       "openWeights": true,
@@ -21175,5 +21175,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "c6c4dc125631d7e1"
+  "version": "189e0283f273f4fc"
 }

--- a/packages/provider-registry/src/creators/minimax.ts
+++ b/packages/provider-registry/src/creators/minimax.ts
@@ -8,6 +8,7 @@ export default defineCreator({
   reasoningFamilies: [{ pattern: 'minimax-m\\d' }],
   models: [
     { id: 'minimax-m2-1' },
+    { id: 'minimax-m3', maxOutputTokens: 524288 },
     {
       id: 'image-01',
       name: 'image-01',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The provider registry declared `maxOutputTokens: 1000000` for MiniMax-M3. The Pi runtime forwarded that value as the request output limit, but MiniMax rejects values above 524,288.

After this PR:

MiniMax-M3 is capped at 524,288 output tokens in the creator source and generated model catalog, so Pi requests remain within the provider limit.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The provider-enforced output limit belongs in the model registry, which is the shared source of truth consumed by runtimes. Updating the model metadata prevents the invalid request without adding runtime-specific compensation.

The following tradeoffs were made:

The fix intentionally changes only MiniMax-M3's output-token limit and the generated catalog version. No other capabilities or runtime behavior are changed.

The following alternatives were considered:

Clamping the value inside the Pi runtime was rejected because it would move model-specific knowledge into a generic runtime and could affect unrelated models.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation:

- `pnpm exec vitest run packages/provider-registry/src/__tests__/catalog-invariants.test.ts packages/provider-registry/src/__tests__/catalog-source-sync.test.ts` (35 tests passed)
- `pnpm exec biome check packages/provider-registry/src/creators/minimax.ts packages/provider-registry/data/models.json`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix MiniMax-M3 requests failing because the app requested more than the provider's supported output-token limit.
```
