### PR TITLE
fix(ai): disable reasoning on one-shot LLM utility calls

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -1143,7 +1143,9 @@ export class AiService extends BaseService {
     } else if (isEmbeddingModel(model) && !hasChatPrimaryEndpoint) {
       probe = this.embedMany({ ...probeRequest, values: ['test'] })
     } else {
-      probe = this.generateText({ ...probeRequest, system: 'test', prompt: 'hi' })
+      // Latency is the probe's measured output — thinking tokens would pollute it
+      // for reasoning-capable models whose provider default enables reasoning.
+      probe = this.generateText({ ...probeRequest, system: 'test', prompt: 'hi', reasoningEffort: 'none' })
     }
 
     try {

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1510,6 +1510,31 @@ describe('AiService tool approval', () => {
     )
   })
 
+  it('disables reasoning on the text-generation probe', async () => {
+    const service = createService()
+    const generateSpy = vi.spyOn(service, 'generateText').mockResolvedValue({ text: 'ok' })
+    mockModelGetByKey.mockReturnValue({
+      id: 'test-provider::test-model',
+      providerId: 'test-provider',
+      apiModelId: 'test-model',
+      name: 'Test Model',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    await service.checkModel({ uniqueModelId: 'test-provider::test-model' })
+
+    expect(generateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: 'test',
+        prompt: 'hi',
+        reasoningEffort: 'none'
+      })
+    )
+  })
+
   it('checks embedding models with the normal embedding path', async () => {
     const service = createService()
     const embedSpy = vi.spyOn(service, 'embedMany').mockResolvedValue({ embeddings: [[1]] })

--- a/src/renderer/utils/__tests__/aiGeneration.test.ts
+++ b/src/renderer/utils/__tests__/aiGeneration.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchGenerate, fetchMessagesSummary, fetchNoteSummary } from '../aiGeneration'
+
+// Stand-in Model — only `.id` reaches the request; nothing else is inspected.
+const TEST_MODEL = { id: 'quick-model', provider: 'test-provider' }
+
+// All three helpers go through ipcApi.request('ai.text.generate', …). Tests drive
+// the response and assert the request contract (reasoning must stay disabled).
+const { generateTextMock } = vi.hoisted(() => ({
+  generateTextMock:
+    vi.fn<
+      (args: {
+        uniqueModelId: string
+        reasoningEffort?: string
+        system?: string
+        prompt?: string
+      }) => Promise<{ text: string }>
+    >()
+}))
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: (_route: string, input: any) => generateTextMock(input) }
+}))
+
+const { readQuickModelMock, readDefaultModelMock } = vi.hoisted(() => ({
+  readQuickModelMock: vi.fn(),
+  readDefaultModelMock: vi.fn()
+}))
+vi.mock('@renderer/utils/model', () => ({
+  readQuickModel: () => readQuickModelMock(),
+  readDefaultModel: () => readDefaultModelMock()
+}))
+
+vi.mock('@renderer/i18n/resolver', () => ({
+  default: { t: (key: string) => key }
+}))
+
+describe('aiGeneration reasoning opt-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    generateTextMock.mockResolvedValue({ text: 'A title' })
+    readQuickModelMock.mockResolvedValue(TEST_MODEL)
+    readDefaultModelMock.mockResolvedValue(TEST_MODEL)
+  })
+
+  it('fetchMessagesSummary disables reasoning on the naming request', async () => {
+    await fetchMessagesSummary({ messages: [{ role: 'user', parts: [] } as never] })
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ uniqueModelId: TEST_MODEL.id, reasoningEffort: 'none' })
+    )
+  })
+
+  it('fetchNoteSummary disables reasoning on the naming request', async () => {
+    expect(await fetchNoteSummary({ content: 'note body' })).toBe('A title')
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ uniqueModelId: TEST_MODEL.id, reasoningEffort: 'none' })
+    )
+  })
+
+  it('fetchGenerate disables reasoning on the generation request', async () => {
+    await fetchGenerate({ prompt: 'system prompt', content: 'user content' })
+
+    expect(generateTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ uniqueModelId: TEST_MODEL.id, reasoningEffort: 'none' })
+    )
+  })
+})

--- a/src/renderer/utils/aiGeneration.ts
+++ b/src/renderer/utils/aiGeneration.ts
@@ -1,6 +1,8 @@
 /**
  * Renderer helpers that call the AI (`ai.text.generate`) to produce short text:
  * generic text generation plus topic/note auto-naming. Stateless request/response.
+ * Every request passes `reasoningEffort: 'none'`: short throwaway output never
+ * benefits from provider-default thinking, which only adds latency and tokens.
  */
 import { preferenceService } from '@data/PreferenceService'
 import { loggerService } from '@logger'
@@ -54,6 +56,7 @@ export async function fetchMessagesSummary({
   try {
     const { text } = await ipcApi.request('ai.text.generate', {
       uniqueModelId: model.id,
+      reasoningEffort: 'none',
       system: prompt,
       prompt: conversation
     })
@@ -84,6 +87,7 @@ export async function fetchNoteSummary({ content }: { content: string; assistant
   try {
     const { text } = await ipcApi.request('ai.text.generate', {
       uniqueModelId: model.id,
+      reasoningEffort: 'none',
       system: prompt,
       prompt: purifiedContent
     })
@@ -113,6 +117,7 @@ export async function fetchGenerate({
     }
     const { text } = await ipcApi.request('ai.text.generate', {
       uniqueModelId: resolvedModel.id,
+      reasoningEffort: 'none',
       system: prompt,
       prompt: content
     })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Renderer one-shot `ai.text.generate` helpers in `src/renderer/utils/aiGeneration.ts` (topic/session auto-naming, note auto-naming, error classification/diagnosis, prompt polish, export title generation) omitted `reasoningEffort`, so reasoning-capable quick/default models fell back to the provider default thinking mode on throwaway short-output requests.
- `AiService.checkModel`'s text-generation probe sent `system: 'test', prompt: 'hi'` without a reasoning selection, so the same provider-default thinking applied to health checks — polluting the latency the probe exists to measure.

After this PR:

- All three `aiGeneration.ts` helpers pass `reasoningEffort: 'none'`, matching the main-process `TopicNamingService` twin and #18574's language-detection fix.
- `checkModel`'s text probe passes `reasoningEffort: 'none'` (rerank/embedding probes are unaffected).
- Focused regression tests assert the request contract on both sides.

Fixes # N/A

### Why we need it and why it was done in this way

Assistant-less one-shot callers that omit `reasoningEffort` keep the reasoning parameter un-emitted (see the precedence note in `buildAgentParams`), so the provider default decides — and for hybrid models (gemini-2.5-flash, GLM, Qwen3, gpt-5 family) that default enables thinking. These requests produce a ~10-word title, a language code, or a one-line classification: thinking adds seconds of latency and token cost with no quality benefit.

The following tradeoffs were made:

- `diagnoseErrorByAI` (structured JSON error diagnosis) also gets `'none'`; its prompt is few-shot constrained, the output is a short classification, and the error dialog is latency-sensitive.
- Models whose provider profile cannot disable reasoning keep the existing degrade-to-omit behavior — identical to #18574.

The following alternatives were considered:

- Adding a per-caller opt-out parameter to `fetchGenerate` for quality-sensitive future callers was rejected (YAGNI): every current caller is a short-output utility request.
- Forcing `reasoningEffort: 'none'` inside the main-process `ai.text.generate` handler for all callers was rejected: unrelated callers keep their current defaults.

Links to places where the discussion took place: follow-up to #18574

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- `pnpm lint` (typecheck:web + typecheck:node included)
- `pnpm vitest run --project renderer` — 873 files / 8908 tests pass
- `pnpm vitest run --project main` — 774 files / 11867 tests pass
- `pnpm format`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809516/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
One-shot AI utility requests (topic/note auto-naming, error classification, prompt polish, export titles, and the model health-check probe) now disable model reasoning when supported, reducing latency and token usage.
```
