### PR TITLE
fix(api-gateway): mount ApiGatewayRequiredDialog at AppShell level (Fixes #18556)

### DIFF
--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -9,6 +9,7 @@ import { isSettingsPath } from '@shared/data/types/settingsPath'
 import { MIN_WINDOW_HEIGHT, SECOND_MIN_WINDOW_WIDTH } from '@shared/utils/window'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { ApiGatewayRequiredDialog } from '@renderer/pages/agents/components/ApiGatewayRequiredDialog'
 import Sidebar from '../app/Sidebar'
 import { createRecentRouteEntryFromTab, recordGlobalSearchRecentEntry } from '../GlobalSearch/globalSearchGroups'
 import GlobalSearchPopup from '../GlobalSearch/GlobalSearchPopup'
@@ -228,6 +229,7 @@ export const AppShell = () => {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       {tabBar}
       {contentArea}
+      <ApiGatewayRequiredDialog />
     </div>
   )
 

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -46,7 +46,6 @@ import AgentChatMain from './AgentChatMain'
 import AgentComposerSlot from './AgentComposerSlot'
 import { AgentChatNavbar } from './components/AgentChatNavbar'
 import { type AgentFileNavigationRequest, AgentRightPane } from './components/AgentRightPane'
-import { ApiGatewayRequiredDialog } from './components/ApiGatewayRequiredDialog'
 import { locateAgentMessageInList } from './messages/agentMessageListAdapter'
 import type { CreateAgentSessionDefaults } from './types'
 import { type AgentChatRuntimeState, useAgentChatRuntimeState } from './useAgentChatRuntimeState'
@@ -604,7 +603,6 @@ const AgentChatSessionCenter = ({
         deleteMessage={runtime.deleteMessage}
         respondToolApproval={runtime.respondToolApproval}
       />
-      <ApiGatewayRequiredDialog sessionId={runtime.sessionId} />
     </div>
   )
 

--- a/src/renderer/pages/agents/components/ApiGatewayRequiredDialog.tsx
+++ b/src/renderer/pages/agents/components/ApiGatewayRequiredDialog.tsx
@@ -1,31 +1,30 @@
 import { ConfirmDialog } from '@cherrystudio/ui'
 import { useApiGateway } from '@renderer/hooks/useApiGateway'
 import { useIpcOn } from '@renderer/ipc'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
-interface Props {
-  sessionId: string
-}
 
 /**
  * Main refuses to bridge an agent through a disabled API gateway (it never starts it implicitly),
  * so it asks here instead. Enabling persists the preference, which is also what makes the gateway
  * come back on the next launch.
  *
+ * Mounted at AppShell level (not inside AgentChat): the trigger fires from a Claude Code runtime
+ * driver regardless of which tab is active, and the prompt must reach the user even when their
+ * agent tab is in the background. Multiple sessions can race for the same prompt — only the first
+ * one matters; later arrivals find `open` already true and re-enter the same dialog.
+ *
  * Enabling is ALL this does. Resending the failed message would be a request the user never
  * approved, rebuilt from text alone — dropping attachments, knowledge scope and the reasoning /
  * fast-mode selection frozen with the original turn.
  */
-export function ApiGatewayRequiredDialog({ sessionId }: Props) {
+export function ApiGatewayRequiredDialog() {
   const [open, setOpen] = useState(false)
 
-  useIpcOn('api_gateway.required', (payload) => {
-    if (payload.sessionId === sessionId) setOpen(true)
+  useIpcOn('api_gateway.required', () => {
+    setOpen(true)
   })
 
-  // Every agent chat renders this, but the prompt is rare — keep the gateway preference and
-  // shared-cache subscriptions out of the common path until it actually fires.
   if (!open) return null
   return <GatewayPrompt onOpenChange={setOpen} />
 }
@@ -34,13 +33,17 @@ function GatewayPrompt({ onOpenChange }: { onOpenChange: (open: boolean) => void
   const { t } = useTranslation()
   const { startApiGateway } = useApiGateway()
   const [enabling, setEnabling] = useState(false)
-  const failed = useRef(false)
+  const [failed, setFailed] = useState(false)
 
   const handleConfirm = async () => {
     setEnabling(true)
     try {
       // `startApiGateway` toasts its own failure and returns false (e.g. the port is taken).
-      failed.current = !(await startApiGateway())
+      const ok = await startApiGateway()
+      setFailed(!ok)
+      if (ok) {
+        onOpenChange(false)
+      }
     } finally {
       setEnabling(false)
     }
@@ -49,8 +52,8 @@ function GatewayPrompt({ onOpenChange }: { onOpenChange: (open: boolean) => void
   // `ConfirmDialog` closes unconditionally once `onConfirm` settles. The event that raised this
   // prompt is transient, so letting a failed start close it would strand the user with no way back.
   const handleOpenChange = (next: boolean) => {
-    if (!next && failed.current) {
-      failed.current = false
+    if (!next && failed) {
+      setFailed(false)
       return
     }
     onOpenChange(next)


### PR DESCRIPTION
Addresses the A1 blocker in issue #18556.

**Problem**: `ApiGatewayRequiredDialog` was mounted inside `AgentChat`, but the `api_gateway.required` IPC event fires from ClaudeCodeRuntimeDriver regardless of which tab is active. When an agent session is dormant or in a background tab, its per-tab dialog subscriber may be unmounted — the prompt would silently drop and the agent runs blocked with no UI indication.

**Fix**: Move the dialog to AppShell level, where it lives for the app lifetime and catches every `api_gateway.required` broadcast unconditionally (no sessionId filter). The dialog uses local React state to track open/failed and re-opens on failed gateway start (preserving the UX from the original).

**Changes**:
- `AppShell.tsx`: import + mount `<ApiGatewayRequiredDialog />`
- `AgentChat.tsx`: remove local `<ApiGatewayRequiredDialog>` and its import
- `ApiGatewayRequiredDialog.tsx`: drop sessionId param + filtered listener, replace with unfiltered `setOpen(true)` on every broadcast; simplify failed-retry via local state instead of `useRef`

Closes #18556