### PR TITLE
fix(composer): preserve disabled-send feedback in deferred composer fallback

### DIFF
--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -2,6 +2,7 @@ import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import NarrowLayout from '@renderer/components/chat/layout/NarrowLayout'
 import SendMessageButton from '@renderer/components/SendMessageButton'
+import { toast } from '@renderer/services/toast'
 import type { SendMessageShortcut } from '@shared/data/preference/preferenceTypes'
 import { CirclePause } from 'lucide-react'
 import {
@@ -81,6 +82,17 @@ function DeferredComposerSurface(props: ComposerSurfaceProps) {
   const [Runtime, setRuntime] = useState<ComponentType<ComposerSurfaceProps>>()
   const [runtimeReady, setRuntimeReady] = useState(false)
   const [isComposing, setIsComposing] = useState(false)
+  const sendBlockedReasonRef = useRef(props.sendBlockedReason)
+
+  useEffect(() => {
+    sendBlockedReasonRef.current = props.sendBlockedReason
+  }, [props.sendBlockedReason])
+
+  const showBlockedSendReason = useCallback(() => {
+    if (sendBlockedReasonRef.current) {
+      toast.error(sendBlockedReasonRef.current)
+    }
+  }, [])
 
   const requestRuntime = useCallback(() => {
     void loadRuntime()
@@ -213,7 +225,11 @@ function DeferredComposerSurface(props: ComposerSurfaceProps) {
         <CirclePause size={20} />
       </button>
     ) : (
-      <SendMessageButton disabled={props.sendDisabled} sendMessage={() => void props.onSendDraft(getFallbackDraft())} />
+      <SendMessageButton
+        disabled={props.sendDisabled}
+        sendMessage={() => void props.onSendDraft(getFallbackDraft())}
+        onDisabledClick={showBlockedSendReason}
+      />
     )
   const inputbarElement = (
     <div
@@ -276,7 +292,12 @@ function DeferredComposerSurface(props: ComposerSurfaceProps) {
             }
             if (!isSendShortcut(event, sendMessageShortcut)) return
             event.preventDefault()
-            if (!event.repeat && !props.sendDisabled) void props.onSendDraft(getFallbackDraft())
+            if (event.repeat) return
+            if (props.sendDisabled) {
+              showBlockedSendReason()
+            } else {
+              void props.onSendDraft(getFallbackDraft())
+            }
           }}
         />
       </div>

--- a/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
@@ -13,12 +13,25 @@ import type { ComposerDraftToken } from '../tokens'
 const mocks = vi.hoisted(() => ({
   onSendDraft: vi.fn(),
   runtimeLoads: 0,
-  runtimeIntent: undefined as ComposerDeferredIntent | undefined
+  runtimeIntent: undefined as ComposerDeferredIntent | undefined,
+  toastError: vi.fn()
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: mocks.toastError }
 }))
 
 vi.mock('@renderer/components/SendMessageButton', () => ({
-  default: ({ sendMessage }: { sendMessage: () => void }) => (
-    <button type="button" onClick={sendMessage}>
+  default: ({
+    disabled,
+    onDisabledClick,
+    sendMessage
+  }: {
+    disabled?: boolean
+    onDisabledClick?: () => void
+    sendMessage: () => void
+  }) => (
+    <button type="button" onClick={disabled ? onDisabledClick : sendMessage}>
       Send
     </button>
   )
@@ -95,6 +108,7 @@ describe('deferred ComposerSurface', () => {
     vi.stubGlobal('DataTransfer', FakeDataTransfer)
     mocks.runtimeIntent = undefined
     mocks.onSendDraft.mockClear()
+    mocks.toastError.mockClear()
     MockUsePreferenceUtils.resetMocks()
   })
 
@@ -300,5 +314,19 @@ describe('deferred ComposerSurface', () => {
     const { container } = render(<Harness isLoading sendDisabled />)
     const pause = container.querySelector('[data-ui="chat.composer.action.pause"]')
     expect(pause?.getAttribute('aria-label')).toBeTruthy()
+  })
+
+  it('shows blocked-send feedback when the disabled send button is clicked before the runtime loads', () => {
+    render(<Harness sendDisabled sendBlockedReason="test.send_blocked" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+    expect(mocks.toastError).toHaveBeenCalledWith('test.send_blocked')
+  })
+
+  it('shows blocked-send feedback when the send shortcut is pressed while disabled', () => {
+    render(<Harness sendDisabled sendBlockedReason="test.send_blocked" />)
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Message' }), { key: 'Enter' })
+    expect(mocks.toastError).toHaveBeenCalledWith('test.send_blocked')
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: The deferred `ComposerSurface` fallback renders `SendMessageButton` with `disabled` and `sendMessage`, but omits the runtime's `onDisabledClick={showBlockedSendReason}` behavior. Agent and Chat composers pass user-facing reasons through `sendBlockedReason` (missing model/agent, pending-reference, etc.). Before the rich runtime loads, clicking the disabled send button gives no explanation; after it loads, the same action shows the expected toast.

After this PR: The fallback and runtime send controls expose the same disabled-click feedback. Both clicking the disabled send button and pressing the send keyboard shortcut while blocked now show the blocked-send reason toast via `onDisabledClick={showBlockedSendReason}` in the deferred fallback.

Fixes #18554

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Minimal change: added a ref-synced `showBlockedSendReason` callback in the deferred fallback, mirroring the existing runtime pattern (`ComposerSurfaceRuntime.tsx:681-685`).

The following alternatives were considered:
- Extracting a shared hook was considered but rejected as over-engineering for a single-use callback with two lines of logic.

### Breaking changes

None.

### Special notes for your reviewer

The fix covers both interaction paths in the fallback:
1. **Click path**: `SendMessageButton.onDisabledClick={showBlockedSendReason}`
2. **Keyboard shortcut path**: added `showBlockedSendReason()` call when `sendDisabled` is true in the `onKeyDown` handler

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Preserve disabled-send feedback in deferred composer fallback
```
