### PR TITLE
fix(ui): dismiss action popovers after selection

### DIFF
--- a/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -311,7 +311,11 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({
                 <Popover open={captureOpen} onOpenChange={setCaptureOpen}>
                   <Tooltip content={t('html_artifacts.capture.label')}>
                     <PopoverTrigger asChild>
-                      <Button variant="ghost" size="icon-sm" className="[-webkit-app-region:no-drag]">
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        aria-label={t('html_artifacts.capture.label')}
+                        className="[-webkit-app-region:no-drag]">
                         <Camera className="size-3.5" />
                       </Button>
                     </PopoverTrigger>

--- a/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -147,6 +147,8 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({
 
   const handleCapture = useCallback(
     async (to: 'file' | 'clipboard') => {
+      setCaptureOpen(false)
+
       try {
         const title = extractHtmlTitle(html)
         const fileName = getFileNameFromHtmlTitle(title) || 'html-artifact'
@@ -168,8 +170,6 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({
         }
       } catch (error) {
         logger.error('Failed to capture HTML artifact preview', error as Error)
-      } finally {
-        setCaptureOpen(false)
       }
     },
     [html, t]

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
@@ -99,4 +99,15 @@ describe('HtmlArtifactsPopup', () => {
     fireEvent.click(overlay!)
     expect(onClose).not.toHaveBeenCalled()
   })
+
+  it('dismisses the capture menu after selecting a destination', () => {
+    render(<HtmlArtifactsPopup open editable={false} title="HTML Artifacts" html="<h1>Hello</h1>" onClose={vi.fn()} />)
+    const captureTrigger = document.querySelector('.lucide-camera')?.closest('button')
+
+    expect(captureTrigger).toBeInTheDocument()
+    fireEvent.click(captureTrigger!)
+    fireEvent.click(screen.getByRole('button', { name: /html_artifacts\.capture\.to_file/ }))
+
+    expect(screen.queryByRole('button', { name: /html_artifacts\.capture\.to_file/ })).not.toBeInTheDocument()
+  })
 })

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
@@ -102,10 +102,7 @@ describe('HtmlArtifactsPopup', () => {
 
   it('dismisses the capture menu after selecting a destination', () => {
     render(<HtmlArtifactsPopup open editable={false} title="HTML Artifacts" html="<h1>Hello</h1>" onClose={vi.fn()} />)
-    const captureTrigger = document.querySelector('.lucide-camera')?.closest('button')
-
-    expect(captureTrigger).toBeInTheDocument()
-    fireEvent.click(captureTrigger!)
+    fireEvent.click(screen.getByRole('button', { name: 'html_artifacts.capture.label' }))
     fireEvent.click(screen.getByRole('button', { name: /html_artifacts\.capture\.to_file/ }))
 
     expect(screen.queryByRole('button', { name: /html_artifacts\.capture\.to_file/ })).not.toBeInTheDocument()

--- a/src/renderer/components/chat/messages/tools/__tests__/ClickableFilePath.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/ClickableFilePath.test.tsx
@@ -9,6 +9,8 @@ import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListProviderValue } from '../../types'
 import { ClickableFilePath } from '../shared/ClickableFilePath'
 
+// Opt out of the global @cherrystudio/ui mock: its PopoverContent ignores `open`,
+// so menu dismissal is only observable against the real popover.
 vi.mock('@cherrystudio/ui', async (importOriginal) => importOriginal<typeof CherryStudioUi>())
 
 const mockOpenArtifactFile = vi.fn().mockResolvedValue(undefined)
@@ -191,7 +193,7 @@ describe('ClickableFilePath', () => {
   })
 
   it('should align the file manager menu item with the agent navbar style without separators', () => {
-    const { container } = renderWithProvider(<ClickableFilePath path="/tmp/test.ts" />, {
+    renderWithProvider(<ClickableFilePath path="/tmp/test.ts" />, {
       showInFolder: mockShowInFolder,
       openInExternalApp: mockOpenInExternalApp
     })
@@ -201,7 +203,7 @@ describe('ClickableFilePath', () => {
     expect(screen.getByText('Finder')).toBeInTheDocument()
     expect(screen.queryByText('Reveal in Finder')).not.toBeInTheDocument()
     expect(screen.getByText('Visual Studio Code')).toBeInTheDocument()
-    expect(container.querySelector('[role="separator"], hr')).toBeNull()
+    expect(screen.queryByRole('separator')).toBeNull()
   })
 
   it('should dismiss the actions menu after selecting the file manager', async () => {

--- a/src/renderer/components/chat/messages/tools/__tests__/ClickableFilePath.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/ClickableFilePath.test.tsx
@@ -1,3 +1,4 @@
+import type * as CherryStudioUi from '@cherrystudio/ui'
 import { setInlineFilePathHomePath } from '@renderer/utils/filePath'
 import type { ExternalAppInfo } from '@shared/types/externalApp'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -7,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListProviderValue } from '../../types'
 import { ClickableFilePath } from '../shared/ClickableFilePath'
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => importOriginal<typeof CherryStudioUi>())
 
 const mockOpenArtifactFile = vi.fn().mockResolvedValue(undefined)
 const mockOpenPath = vi.fn().mockResolvedValue(undefined)
@@ -199,6 +202,16 @@ describe('ClickableFilePath', () => {
     expect(screen.queryByText('Reveal in Finder')).not.toBeInTheDocument()
     expect(screen.getByText('Visual Studio Code')).toBeInTheDocument()
     expect(container.querySelector('[role="separator"], hr')).toBeNull()
+  })
+
+  it('should dismiss the actions menu after selecting the file manager', async () => {
+    renderWithProvider(<ClickableFilePath path="/tmp/test.ts" />, { showInFolder: mockShowInFolder })
+
+    fireEvent.click(screen.getByRole('button', { name: 'More' }))
+    fireEvent.click(screen.getByRole('button', { name: /Finder/ }))
+
+    await waitFor(() => expect(mockShowInFolder).toHaveBeenCalledWith('/tmp/test.ts'))
+    expect(screen.queryByRole('button', { name: /Finder/ })).not.toBeInTheDocument()
   })
 
   it('should call openArtifactFile on Enter key', async () => {

--- a/src/renderer/components/chat/messages/tools/shared/ClickableFilePath.tsx
+++ b/src/renderer/components/chat/messages/tools/shared/ClickableFilePath.tsx
@@ -7,7 +7,7 @@ import { normalizeInlineFilePath, resolveInlineFilePath } from '@renderer/utils/
 import { isMac, isWin } from '@renderer/utils/platform'
 import type { ExternalAppInfo } from '@shared/types/externalApp'
 import { FolderOpen, MoreHorizontal } from 'lucide-react'
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useOptionalMessageListActions, useOptionalMessageListUi } from '../../MessageListProvider'
@@ -24,6 +24,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({
   interactive = true
 }: ClickableFilePathProps) {
   const { t } = useTranslation()
+  const [actionsMenuOpen, setActionsMenuOpen] = useState(false)
   const displayPath = useMemo(() => normalizeInlineFilePath(path), [path])
   const targetPath = useMemo(() => resolveInlineFilePath(path), [path])
   const iconName = useMemo(() => getFileIconName(displayPath), [displayPath])
@@ -105,7 +106,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({
         </span>
       </Tooltip>
       {hasMoreActions && (
-        <Popover>
+        <Popover open={actionsMenuOpen} onOpenChange={setActionsMenuOpen}>
           <PopoverTrigger asChild>
             <button
               type="button"
@@ -128,6 +129,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({
                   icon={renderFileManagerIcon()}
                   onClick={(e) => {
                     e.stopPropagation()
+                    setActionsMenuOpen(false)
                     Promise.resolve(showInFolder(targetPath)).catch(() => {
                       notifyError?.(t('chat.input.tools.file_not_found', { path: targetPath }))
                     })
@@ -142,6 +144,7 @@ export const ClickableFilePath = memo(function ClickableFilePath({
                     icon={getEditorIcon(app)}
                     onClick={(e) => {
                       e.stopPropagation()
+                      setActionsMenuOpen(false)
                       openInEditor(app)
                     }}
                   />

--- a/src/renderer/components/chat/panes/OpenExternalAppButton.tsx
+++ b/src/renderer/components/chat/panes/OpenExternalAppButton.tsx
@@ -132,10 +132,6 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
   const primaryTooltip = tooltip ?? primaryLabel
   const defaultAppName = t('agent.preview_pane.default_app')
   const hasAlternativeTargets = Boolean(fileTargetPath) || availableEditors.length > 0
-  const runAfterMenuClose = (action: () => void) => {
-    setMenuOpen(false)
-    action()
-  }
   const menu = (
     <PopoverContent className="w-56 p-1" align={menuTrigger ? 'start' : 'end'}>
       <MenuList>
@@ -143,14 +139,20 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
           <MenuItem
             label={defaultAppName}
             icon={<FileText size={16} />}
-            onClick={() => runAfterMenuClose(() => void openFileWithDefaultApp())}
+            onClick={() => {
+              setMenuOpen(false)
+              void openFileWithDefaultApp()
+            }}
           />
         )}
         <MenuItem
           label={fileManagerName}
           icon={renderFileManagerIcon()}
           active={selectedTarget === FILE_MANAGER_TARGET}
-          onClick={() => runAfterMenuClose(() => void openFileManager())}
+          onClick={() => {
+            setMenuOpen(false)
+            void openFileManager()
+          }}
         />
         {availableEditors.map((app) => (
           <MenuItem
@@ -158,7 +160,10 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
             label={app.name}
             icon={getEditorIcon(app)}
             active={selectedTarget === app.id}
-            onClick={() => runAfterMenuClose(() => void openInEditor(app))}
+            onClick={() => {
+              setMenuOpen(false)
+              void openInEditor(app)
+            }}
           />
         ))}
       </MenuList>

--- a/src/renderer/components/chat/panes/OpenExternalAppButton.tsx
+++ b/src/renderer/components/chat/panes/OpenExternalAppButton.tsx
@@ -20,7 +20,7 @@ import { isMac, isWin } from '@renderer/utils/platform'
 import { cn } from '@renderer/utils/style'
 import type { ExternalAppId, ExternalAppInfo } from '@shared/types/externalApp'
 import { ChevronDown, FileText, FolderOpen } from 'lucide-react'
-import { type ReactNode, useCallback, useMemo } from 'react'
+import { type ReactNode, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const FILE_MANAGER_TARGET = 'file_manager' as const
@@ -44,6 +44,7 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
   const openTargetPath = fileTargetPath ?? workdir
   const { data: externalApps } = useExternalApps({ enabled: true })
   const [lastUsedTarget, setLastUsedTarget] = usePersistCache('agent.open_external_app.last_used_target')
+  const [menuOpen, setMenuOpen] = useState(false)
 
   const availableEditors = useMemo(() => {
     if (!externalApps) {
@@ -131,6 +132,10 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
   const primaryTooltip = tooltip ?? primaryLabel
   const defaultAppName = t('agent.preview_pane.default_app')
   const hasAlternativeTargets = Boolean(fileTargetPath) || availableEditors.length > 0
+  const runAfterMenuClose = (action: () => void) => {
+    setMenuOpen(false)
+    action()
+  }
   const menu = (
     <PopoverContent className="w-56 p-1" align={menuTrigger ? 'start' : 'end'}>
       <MenuList>
@@ -138,14 +143,14 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
           <MenuItem
             label={defaultAppName}
             icon={<FileText size={16} />}
-            onClick={() => void openFileWithDefaultApp()}
+            onClick={() => runAfterMenuClose(() => void openFileWithDefaultApp())}
           />
         )}
         <MenuItem
           label={fileManagerName}
           icon={renderFileManagerIcon()}
           active={selectedTarget === FILE_MANAGER_TARGET}
-          onClick={() => void openFileManager()}
+          onClick={() => runAfterMenuClose(() => void openFileManager())}
         />
         {availableEditors.map((app) => (
           <MenuItem
@@ -153,7 +158,7 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
             label={app.name}
             icon={getEditorIcon(app)}
             active={selectedTarget === app.id}
-            onClick={() => void openInEditor(app)}
+            onClick={() => runAfterMenuClose(() => void openInEditor(app))}
           />
         ))}
       </MenuList>
@@ -163,7 +168,7 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
   if (menuTrigger) {
     const trigger = <PopoverTrigger asChild>{menuTrigger}</PopoverTrigger>
     return (
-      <Popover>
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         {tooltip ? <NormalTooltip content={tooltip}>{trigger}</NormalTooltip> : trigger}
         {menu}
       </Popover>
@@ -199,7 +204,7 @@ const OpenExternalAppButton = ({ workdir, filePath, menuTrigger, tooltip, classN
           {primaryIcon}
         </Button>
       </NormalTooltip>
-      <Popover>
+      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <Button
             type="button"

--- a/src/renderer/components/chat/panes/__tests__/OpenExternalAppButton.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/OpenExternalAppButton.test.tsx
@@ -67,8 +67,17 @@ vi.mock('@cherrystudio/ui', async () => {
     ),
     MenuList: ({ children }: PropsWithChildren) => <div>{children}</div>,
     NormalTooltip: ({ children }: PropsWithChildren<{ content: string }>) => <>{children}</>,
-    Popover: ({ children }: PropsWithChildren) => {
-      const [open, setOpen] = ReactActual.useState(false)
+    Popover: ({
+      children,
+      open: controlledOpen,
+      onOpenChange
+    }: PropsWithChildren<{ open?: boolean; onOpenChange?: (open: boolean) => void }>) => {
+      const [uncontrolledOpen, setUncontrolledOpen] = ReactActual.useState(false)
+      const open = controlledOpen ?? uncontrolledOpen
+      const setOpen = (nextOpen: boolean) => {
+        if (controlledOpen === undefined) setUncontrolledOpen(nextOpen)
+        onOpenChange?.(nextOpen)
+      }
       return <PopoverContext value={{ open, setOpen }}>{children}</PopoverContext>
     },
     PopoverContent: ({ children }: PropsWithChildren) => {
@@ -221,7 +230,9 @@ describe('OpenExternalAppButton', () => {
     await user.click(screen.getByRole('button', { name: 'Finder' }))
     await waitFor(() => expect(mocks.openPath).toHaveBeenCalledWith('/tmp/workspace'))
     expect(MockUseCacheUtils.getPersistCacheValue('agent.open_external_app.last_used_target')).toBe('file_manager')
+    expect(screen.queryByRole('button', { name: 'Finder' })).not.toBeInTheDocument()
 
+    await user.click(screen.getByRole('button', { name: 'More' }))
     await user.click(screen.getByRole('button', { name: 'Cursor' }))
     await waitFor(() =>
       expect(MockUseCacheUtils.getPersistCacheValue('agent.open_external_app.last_used_target')).toBe('cursor')


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Selecting an action in several Popover-based menus could leave the menu visible after the action was invoked. The HTML artifact capture menu also remained open until its asynchronous capture work completed.

After this PR:

One-shot action popovers close immediately when a menu item is selected, before external app, file, or capture work begins. This covers the external-app split button, clickable file paths, and HTML artifact capture destinations.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

`MenuItem` is a standard button and Radix Popover does not automatically dismiss arbitrary button children. The affected consumers now control their own open state and close before starting an action, following the existing one-shot menu pattern in the renderer.

The following tradeoffs were made:

- The three affected consumers own a small amount of explicit open state so shared `MenuItem` behavior remains unchanged for persistent and multi-action popovers.

The following alternatives were considered:

- Automatically dismiss every shared `MenuItem`. This was rejected because the component is also used in popovers that should remain open.
- Close only after asynchronous work completes. This was rejected because slow work keeps the menu visible and a late completion could close a menu the user reopened.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Audited analogous renderer Popover and MenuItem action menus; persistent settings, sliders, and multi-select popovers were intentionally left unchanged.
- Added regression coverage for immediate dismissal in all three affected components.
- Validation: 29 focused renderer tests, `pnpm typecheck:web`, Biome, ESLint, and `git diff --check` passed.
- No user-guide update is required because this restores expected transient-menu behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix action popovers remaining open after selecting external apps, file actions, or HTML capture destinations.
```
