### PR TITLE
feat(export): convert markdown alerts to notion callouts

### DIFF
--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -30,7 +30,7 @@ import {
 import type { markdownToBlocks } from '@tryfabric/martian'
 import dayjs from 'dayjs'
 import DOMPurify from 'dompurify'
-import type { Blockquote, Paragraph, Text } from 'mdast'
+import type { Blockquote } from 'mdast'
 import type { appendBlocks } from 'notion-helper'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -557,12 +557,14 @@ const isAlertQuoteNode = (quote: Blockquote): boolean => {
   return firstNode?.type === 'text' && ALERT_MARKER_RE.test(firstNode.value)
 }
 
-// One flag per source blockquote in document order (parents before children),
-// consumed in the same order while rewriting martian's quote blocks.
+// One flag per source blockquote in document order, consumed in the same order below.
+// The visitor must not return a value — visit treats numbers as index moves.
 const collectAlertQuoteFlags = (markdown: string): boolean[] => {
   const flags: boolean[] = []
   const tree = unified().use(remarkParse).parse(markdown)
-  visit(tree, 'blockquote', (node) => flags.push(isAlertQuoteNode(node)))
+  visit(tree, 'blockquote', (node) => {
+    flags.push(isAlertQuoteNode(node))
+  })
   return flags
 }
 

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -524,9 +524,75 @@ export const exportMessageAsMarkdown = async (
   }
 }
 
+// GitHub-style alert marker (e.g. "[!NOTE]") leading the first paragraph inside a quote
+const ALERT_MARKER_RE = /^\[!([A-Za-z][\w-]*)\]/
+
+// Fixed alert-type → Notion callout icon/color pairs (issue #16388 spec)
+const ALERT_CALLOUT_MAP: Record<string, { emoji: string; color: string }> = {
+  NOTE: { emoji: '💡', color: 'blue_background' },
+  TIP: { emoji: '✅', color: 'green_background' },
+  IMPORTANT: { emoji: '⭐', color: 'purple_background' },
+  WARNING: { emoji: '⚠️', color: 'yellow_background' },
+  CAUTION: { emoji: '🚫', color: 'red_background' }
+}
+const UNKNOWN_ALERT_CALLOUT = { emoji: '📝', color: 'gray_background' }
+
+const stripLeadingNewline = (segment: any): any =>
+  segment?.text ? { ...segment, text: { ...segment.text, content: segment.text.content.replace(/^\n/, '') } } : segment
+
+// Drop the marker from the paragraph's rich text segments; marker may share a segment
+// with the body or occupy its own (e.g. bolded marker).
+const stripAlertMarker = (segments: any[], markerLength: number): any[] => {
+  const [first, ...rest] = segments
+  const remainder = first.text.content.slice(markerLength).replace(/^\n/, '')
+  if (remainder) {
+    return [{ ...first, text: { ...first.text, content: remainder } }, ...rest]
+  }
+  return rest.length > 0 ? [stripLeadingNewline(rest[0]), ...rest.slice(1)] : []
+}
+
+const quoteToCallout = (block: any): any => {
+  const firstChild = block.quote?.children?.[0]
+  if (firstChild?.type !== 'paragraph') {
+    return block
+  }
+  const segments = firstChild.paragraph.rich_text ?? []
+  const match = ALERT_MARKER_RE.exec(segments[0]?.text?.content ?? '')
+  if (!match) {
+    return block
+  }
+  const style = ALERT_CALLOUT_MAP[match[1].toUpperCase()] ?? UNKNOWN_ALERT_CALLOUT
+  return {
+    object: 'block',
+    type: 'callout',
+    callout: {
+      rich_text: stripAlertMarker(segments, match[0].length),
+      icon: { type: 'emoji', emoji: style.emoji },
+      color: style.color,
+      children: block.quote.children.slice(1)
+    }
+  }
+}
+
+// Rewrite GitHub-style alert quotes ("> [!TYPE]") in martian output into native
+// Notion callout blocks; plain quotes are left untouched.
+export const rewriteAlertQuotesToCallouts = (blocks: any[]): any[] => {
+  const rewriteBlock = (block: any): any => {
+    if (!block?.type) {
+      return block
+    }
+    const payload = block[block.type]
+    const current = Array.isArray(payload?.children)
+      ? { ...block, [block.type]: { ...payload, children: payload.children.map(rewriteBlock) } }
+      : block
+    return current.type === 'quote' ? quoteToCallout(current) : current
+  }
+  return blocks.map(rewriteBlock)
+}
+
 const convertMarkdownToNotionBlocks = async (markdown: string): Promise<any[]> => {
   const { markdownToBlocks } = await loadNotionDependencies()
-  return markdownToBlocks(markdown)
+  return rewriteAlertQuotesToCallouts(markdownToBlocks(markdown))
 }
 
 const convertThinkingToNotionBlocks = async (thinkingContent: string): Promise<any[]> => {
@@ -540,7 +606,7 @@ const convertThinkingToNotionBlocks = async (thinkingContent: string): Promise<a
     const processedContent = thinkingContent.replace(/<br\s*\/?>/g, '\n')
 
     // 使用 markdownToBlocks 处理思维链内容
-    const childrenBlocks = markdownToBlocks(processedContent)
+    const childrenBlocks = rewriteAlertQuotesToCallouts(markdownToBlocks(processedContent))
 
     return [
       {

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -553,8 +553,8 @@ const isAlertQuoteNode = (quote: Blockquote): boolean => {
   if (firstChild?.type !== 'paragraph') {
     return false
   }
-  const firstNode = (firstChild as Paragraph).children?.[0]
-  return firstNode?.type === 'text' && ALERT_MARKER_RE.test((firstNode as Text).value)
+  const firstNode = firstChild.children?.[0]
+  return firstNode?.type === 'text' && ALERT_MARKER_RE.test(firstNode.value)
 }
 
 // One flag per source blockquote in document order (parents before children),

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -30,7 +30,11 @@ import {
 import type { markdownToBlocks } from '@tryfabric/martian'
 import dayjs from 'dayjs'
 import DOMPurify from 'dompurify'
+import type { Blockquote, Paragraph, Text } from 'mdast'
 import type { appendBlocks } from 'notion-helper'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import { visit } from 'unist-util-visit'
 
 const logger = loggerService.withContext('ExportService')
 
@@ -540,8 +544,30 @@ const UNKNOWN_ALERT_CALLOUT = { emoji: '📝', color: 'gray_background' }
 const stripLeadingNewline = (segment: any): any =>
   segment?.text ? { ...segment, text: { ...segment.text, content: segment.text.content.replace(/^\n/, '') } } : segment
 
+// Detect alert quotes on the source mdast, mirroring the live renderer
+// (remark-github-blockquote-alert): the marker must lead the quote's first
+// paragraph as a plain text node. Source-level detection keeps provenance that
+// martian strips (raw HTML like <code>[!NOTE]</code> becomes plain text).
+const isAlertQuoteNode = (quote: Blockquote): boolean => {
+  const firstChild = quote.children?.[0]
+  if (firstChild?.type !== 'paragraph') {
+    return false
+  }
+  const firstNode = (firstChild as Paragraph).children?.[0]
+  return firstNode?.type === 'text' && ALERT_MARKER_RE.test((firstNode as Text).value)
+}
+
+// One flag per source blockquote in document order (parents before children),
+// consumed in the same order while rewriting martian's quote blocks.
+const collectAlertQuoteFlags = (markdown: string): boolean[] => {
+  const flags: boolean[] = []
+  const tree = unified().use(remarkParse).parse(markdown)
+  visit(tree, 'blockquote', (node) => flags.push(isAlertQuoteNode(node)))
+  return flags
+}
+
 // Drop the marker from the paragraph's rich text segments; marker may share a segment
-// with the body or occupy its own (e.g. bolded marker).
+// with the body or occupy its own (e.g. marker-only paragraph).
 const stripAlertMarker = (segments: any[], markerLength: number): any[] => {
   const [first, ...rest] = segments
   const remainder = first.text.content.slice(markerLength).replace(/^\n/, '')
@@ -551,7 +577,10 @@ const stripAlertMarker = (segments: any[], markerLength: number): any[] => {
   return rest.length > 0 ? [stripLeadingNewline(rest[0]), ...rest.slice(1)] : []
 }
 
-const quoteToCallout = (block: any): any => {
+const quoteToCallout = (block: any, isAlert: boolean): any => {
+  if (!isAlert) {
+    return block
+  }
   const firstChild = block.quote?.children?.[0]
   if (firstChild?.type !== 'paragraph') {
     return block
@@ -576,23 +605,27 @@ const quoteToCallout = (block: any): any => {
 
 // Rewrite GitHub-style alert quotes ("> [!TYPE]") in martian output into native
 // Notion callout blocks; plain quotes are left untouched.
-export const rewriteAlertQuotesToCallouts = (blocks: any[]): any[] => {
+export const rewriteAlertQuotesToCallouts = (blocks: any[], markdown: string): any[] => {
+  const alertFlags = collectAlertQuoteFlags(markdown)
+  let quoteIndex = 0
   const rewriteBlock = (block: any): any => {
     if (!block?.type) {
       return block
     }
-    const payload = block[block.type]
-    const current = Array.isArray(payload?.children)
-      ? { ...block, [block.type]: { ...payload, children: payload.children.map(rewriteBlock) } }
-      : block
-    return current.type === 'quote' ? quoteToCallout(current) : current
+    // Consume the flag before recursing so nested quotes align with the
+    // source AST's document order (parents before children).
+    const rewritten = block.type === 'quote' ? quoteToCallout(block, alertFlags[quoteIndex++] === true) : block
+    const payload = rewritten[rewritten.type]
+    return Array.isArray(payload?.children)
+      ? { ...rewritten, [rewritten.type]: { ...payload, children: payload.children.map(rewriteBlock) } }
+      : rewritten
   }
   return blocks.map(rewriteBlock)
 }
 
 const convertMarkdownToNotionBlocks = async (markdown: string): Promise<any[]> => {
   const { markdownToBlocks } = await loadNotionDependencies()
-  return rewriteAlertQuotesToCallouts(markdownToBlocks(markdown))
+  return rewriteAlertQuotesToCallouts(markdownToBlocks(markdown), markdown)
 }
 
 const convertThinkingToNotionBlocks = async (thinkingContent: string): Promise<any[]> => {
@@ -606,7 +639,7 @@ const convertThinkingToNotionBlocks = async (thinkingContent: string): Promise<a
     const processedContent = thinkingContent.replace(/<br\s*\/?>/g, '\n')
 
     // 使用 markdownToBlocks 处理思维链内容
-    const childrenBlocks = rewriteAlertQuotesToCallouts(markdownToBlocks(processedContent))
+    const childrenBlocks = rewriteAlertQuotesToCallouts(markdownToBlocks(processedContent), processedContent)
 
     return [
       {

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -7,7 +7,7 @@ import type { Message, MessageBlock } from '@renderer/types/newMessage'
 import { AssistantMessageStatus, MessageBlockStatus, MessageBlockType } from '@renderer/types/newMessage'
 import type * as MessageFind from '@renderer/utils/message/find'
 import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // --- Mocks Setup ---
 
@@ -153,6 +153,7 @@ import {
   messagesToMarkdown,
   messageToMarkdown,
   messageToMarkdownWithReasoning,
+  rewriteAlertQuotesToCallouts,
   topicToPlainText
 } from '../ExportService'
 
@@ -815,5 +816,283 @@ describe('ExportService', () => {
       expect(result).toBe('Empty Topic')
       expect(markdownToPlainText).toHaveBeenCalledWith('## Empty Topic')
     })
+  })
+})
+
+// --- Notion alert callout rewrite (issue #16388) ---
+
+// martian renders "> [!TYPE] body" as a quote with an empty rich_text placeholder
+// and the marker+body merged into the first paragraph child (soft break becomes \n)
+const alertTextSegment = (content: string, annotations?: Record<string, unknown>) => ({
+  type: 'text',
+  annotations: {
+    bold: false,
+    italic: false,
+    strikethrough: false,
+    underline: false,
+    code: false,
+    color: 'default',
+    ...annotations
+  },
+  text: { content }
+})
+
+const alertQuoteBlock = (marker: string, body?: string, extraChildren: any[] = []) => ({
+  object: 'block',
+  type: 'quote',
+  quote: {
+    rich_text: [alertTextSegment('')],
+    children: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [alertTextSegment(body ? `${marker}\n${body}` : marker)]
+        }
+      },
+      ...extraChildren
+    ]
+  }
+})
+
+describe('rewriteAlertQuotesToCallouts', () => {
+  it('converts a warning alert quote into a callout with mapped emoji and color', () => {
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!WARNING]', 'Do not commit secrets')])
+
+    expect(block.type).toBe('callout')
+    expect(block.callout.icon).toEqual({ type: 'emoji', emoji: '⚠️' })
+    expect(block.callout.color).toBe('yellow_background')
+    expect(block.callout.rich_text[0].text.content).toBe('Do not commit secrets')
+    expect(block.callout.children).toEqual([])
+  })
+
+  it('leaves plain quotes untouched', () => {
+    const plain = alertQuoteBlock('Just a quote')
+
+    expect(rewriteAlertQuotesToCallouts([plain])).toEqual([plain])
+  })
+
+  it('falls back to a gray memo callout for unknown alert types', () => {
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!CUSTOM]', 'custom alert')])
+
+    expect(block.type).toBe('callout')
+    expect(block.callout.icon.emoji).toBe('📝')
+    expect(block.callout.color).toBe('gray_background')
+    expect(block.callout.rich_text[0].text.content).toBe('custom alert')
+  })
+
+  it('matches alert types case-insensitively', () => {
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!note]', 'hi')])
+
+    expect(block.callout.icon.emoji).toBe('💡')
+    expect(block.callout.color).toBe('blue_background')
+  })
+
+  it('drops a marker that occupies its own segment and keeps the following segment', () => {
+    const boldMarkerQuote = {
+      object: 'block',
+      type: 'quote',
+      quote: {
+        rich_text: [alertTextSegment('')],
+        children: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [alertTextSegment('[!NOTE]', { bold: true }), alertTextSegment('\nstyled marker')]
+            }
+          }
+        ]
+      }
+    }
+
+    const [block] = rewriteAlertQuotesToCallouts([boldMarkerQuote])
+
+    expect(block.type).toBe('callout')
+    expect(block.callout.rich_text).toHaveLength(1)
+    expect(block.callout.rich_text[0].text.content).toBe('styled marker')
+    expect(block.callout.rich_text[0].annotations.bold).toBe(false)
+  })
+
+  it('keeps remaining children and an empty rich_text for a marker-only alert', () => {
+    const bullet = {
+      object: 'block',
+      type: 'bulleted_list_item',
+      bulleted_list_item: { rich_text: [alertTextSegment('bullet a')], children: [] }
+    }
+
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!NOTE]', undefined, [bullet])])
+
+    expect(block.type).toBe('callout')
+    expect(block.callout.rich_text).toEqual([])
+    expect(block.callout.children).toEqual([bullet])
+  })
+
+  it('rewrites alerts nested inside list items in place', () => {
+    const listItem = {
+      object: 'block',
+      type: 'numbered_list_item',
+      numbered_list_item: {
+        rich_text: [alertTextSegment('Step one')],
+        children: [alertQuoteBlock('[!IMPORTANT]', 'critical detail')]
+      }
+    }
+
+    const [block] = rewriteAlertQuotesToCallouts([listItem])
+
+    expect(block.type).toBe('numbered_list_item')
+    expect(block.numbered_list_item.children[0].type).toBe('callout')
+    expect(block.numbered_list_item.children[0].callout.icon.emoji).toBe('⭐')
+  })
+
+  it('keeps later paragraphs as callout children', () => {
+    const secondPara = {
+      object: 'block',
+      type: 'paragraph',
+      paragraph: { rich_text: [alertTextSegment('Second paragraph')] }
+    }
+
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!NOTE]', 'First paragraph', [secondPara])])
+
+    expect(block.callout.rich_text[0].text.content).toBe('First paragraph')
+    expect(block.callout.children).toEqual([secondPara])
+  })
+
+  it('does not mutate the input blocks', () => {
+    const original = alertQuoteBlock('[!WARNING]', 'Do not commit secrets')
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    rewriteAlertQuotesToCallouts([original])
+
+    expect(original).toEqual(snapshot)
+  })
+})
+
+describe('rewriteAlertQuotesToCallouts with real martian output', () => {
+  let markdownToBlocks: (markdown: string) => any[]
+
+  beforeAll(async () => {
+    const actual = (await vi.importActual('@tryfabric/martian')) as { markdownToBlocks: (md: string) => any[] }
+    markdownToBlocks = actual.markdownToBlocks
+  })
+
+  const toBlocks = (markdown: string) => rewriteAlertQuotesToCallouts(markdownToBlocks(markdown))
+
+  const plainText = (richText: any[]) => richText.map((segment) => segment.text?.content ?? '').join('')
+
+  it('AC1: warning alert becomes a yellow ⚠️ callout with no quote residue', () => {
+    const blocks = toBlocks('> [!WARNING]\n> Do not commit secrets')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('callout')
+    expect(blocks[0].callout.icon).toEqual({ type: 'emoji', emoji: '⚠️' })
+    expect(blocks[0].callout.color).toBe('yellow_background')
+    expect(plainText(blocks[0].callout.rich_text)).toBe('Do not commit secrets')
+  })
+
+  it('AC2: all five alert types map to their own icon and color', () => {
+    const markdown = [
+      '> [!NOTE]\n> note body',
+      '> [!TIP]\n> tip body',
+      '> [!IMPORTANT]\n> important body',
+      '> [!WARNING]\n> warning body',
+      '> [!CAUTION]\n> caution body'
+    ].join('\n\n')
+    const expected = [
+      ['💡', 'blue_background'],
+      ['✅', 'green_background'],
+      ['⭐', 'purple_background'],
+      ['⚠️', 'yellow_background'],
+      ['🚫', 'red_background']
+    ]
+
+    const blocks = toBlocks(markdown)
+
+    expect(blocks).toHaveLength(expected.length)
+    blocks.forEach((block, i) => {
+      expect(block.type).toBe('callout')
+      expect(block.callout.icon.emoji).toBe(expected[i][0])
+      expect(block.callout.color).toBe(expected[i][1])
+    })
+  })
+
+  it('AC3: multi-line alert keeps inline formatting and nested bullets', () => {
+    const blocks = toBlocks('> [!NOTE]\n> Line 1.\n> Line 2 with **bold**.\n> - bullet a\n> - bullet b')
+
+    expect(blocks).toHaveLength(1)
+    const { callout } = blocks[0]
+    expect(plainText(callout.rich_text)).toBe('Line 1.\nLine 2 with bold.')
+    expect(callout.rich_text.find((segment) => segment.annotations?.bold)?.text.content).toBe('bold')
+    const bullets = callout.children
+      .filter((block) => block.type === 'bulleted_list_item')
+      .map((block) => plainText(block.bulleted_list_item.rich_text))
+    expect(bullets).toEqual(['bullet a', 'bullet b'])
+  })
+
+  it('AC4: plain quote stays a quote while a following tip becomes a callout', () => {
+    const blocks = toBlocks('> Just a quote\n\n> [!TIP]\n> Try this')
+
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].type).toBe('quote')
+    expect(plainText(blocks[0].quote.children[0].paragraph.rich_text)).toBe('Just a quote')
+    expect(blocks[1].type).toBe('callout')
+    expect(blocks[1].callout.icon.emoji).toBe('✅')
+    expect(plainText(blocks[1].callout.rich_text)).toBe('Try this')
+  })
+
+  it('AC5: unknown alert type falls back to a gray 📝 callout', () => {
+    const blocks = toBlocks('> [!UNKNOWN]\n> custom alert')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('callout')
+    expect(blocks[0].callout.icon.emoji).toBe('📝')
+    expect(blocks[0].callout.color).toBe('gray_background')
+  })
+
+  it('AC6: alert nested in a numbered list step stays inside the step', () => {
+    const blocks = toBlocks('1. Step one\n   > [!IMPORTANT]\n   > critical detail\n2. Step two')
+
+    expect(blocks[0].type).toBe('numbered_list_item')
+    const nested = blocks[0].numbered_list_item.children[0]
+    expect(nested.type).toBe('callout')
+    expect(nested.callout.icon.emoji).toBe('⭐')
+    expect(plainText(nested.callout.rich_text)).toBe('critical detail')
+    expect(blocks[1].type).toBe('numbered_list_item')
+  })
+})
+
+describe('Notion export alert callout wiring', () => {
+  beforeEach(async () => {
+    await preferenceService.set('data.integration.notion.api_key', 'notion-key')
+    await preferenceService.set('data.integration.notion.database_id', 'database-id')
+    await preferenceService.set('data.integration.notion.page_name_key', 'Name')
+    notionMocks.createPage.mockResolvedValue({ id: 'page-id' })
+    notionMocks.appendBlocks.mockResolvedValue(undefined)
+    notionMocks.markdownToBlocks.mockImplementation((markdown: string): any[] =>
+      typeof markdown === 'string' && markdown.includes('[!WARNING]')
+        ? [alertQuoteBlock('[!WARNING]', 'Do not commit secrets')]
+        : [{ markdown }, { markdown: `${markdown}\n` }]
+    )
+  })
+
+  it('rewrites alert quotes on the message body path', async () => {
+    await expect(exportMessageToNotion('Alerts', '> [!WARNING]\n> Do not commit secrets')).resolves.toBe(true)
+
+    const blocks = notionMocks.appendBlocks.mock.calls[0][0].children
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('callout')
+    expect(blocks[0].callout.rich_text[0].text.content).toBe('Do not commit secrets')
+  })
+
+  it('rewrites alert quotes inside the reasoning toggle', async () => {
+    await preferenceService.set('data.integration.notion.export_reasoning', true)
+    const message = createExportView([{ type: 'reasoning', text: 'thinking mentions [!WARNING] marker' }])
+
+    await expect(exportMessageToNotion('Alerts', 'plain body', message)).resolves.toBe(true)
+
+    const blocks = notionMocks.appendBlocks.mock.calls[0][0].children
+    const toggle = blocks.find((block) => block.type === 'toggle')
+    expect(toggle).toBeDefined()
+    expect(toggle.toggle.children[0].type).toBe('callout')
   })
 })

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -855,9 +855,15 @@ const alertQuoteBlock = (marker: string, body?: string, extraChildren: any[] = [
   }
 })
 
+// Source markdown matching alertQuoteBlock's fixture shape
+const alertQuoteSource = (marker: string, body?: string) => `> ${marker}${body ? `\n> ${body}` : ''}`
+
 describe('rewriteAlertQuotesToCallouts', () => {
   it('converts a warning alert quote into a callout with mapped emoji and color', () => {
-    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!WARNING]', 'Do not commit secrets')])
+    const [block] = rewriteAlertQuotesToCallouts(
+      [alertQuoteBlock('[!WARNING]', 'Do not commit secrets')],
+      alertQuoteSource('[!WARNING]', 'Do not commit secrets')
+    )
 
     expect(block.type).toBe('callout')
     expect(block.callout.icon).toEqual({ type: 'emoji', emoji: '⚠️' })
@@ -869,11 +875,14 @@ describe('rewriteAlertQuotesToCallouts', () => {
   it('leaves plain quotes untouched', () => {
     const plain = alertQuoteBlock('Just a quote')
 
-    expect(rewriteAlertQuotesToCallouts([plain])).toEqual([plain])
+    expect(rewriteAlertQuotesToCallouts([plain], alertQuoteSource('Just a quote'))).toEqual([plain])
   })
 
   it('falls back to a gray memo callout for unknown alert types', () => {
-    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!CUSTOM]', 'custom alert')])
+    const [block] = rewriteAlertQuotesToCallouts(
+      [alertQuoteBlock('[!CUSTOM]', 'custom alert')],
+      alertQuoteSource('[!CUSTOM]', 'custom alert')
+    )
 
     expect(block.type).toBe('callout')
     expect(block.callout.icon.emoji).toBe('📝')
@@ -882,13 +891,38 @@ describe('rewriteAlertQuotesToCallouts', () => {
   })
 
   it('matches alert types case-insensitively', () => {
-    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!note]', 'hi')])
+    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!note]', 'hi')], alertQuoteSource('[!note]', 'hi'))
 
     expect(block.callout.icon.emoji).toBe('💡')
     expect(block.callout.color).toBe('blue_background')
   })
 
   it('drops a marker that occupies its own segment and keeps the following segment', () => {
+    const plainMarkerQuote = {
+      object: 'block',
+      type: 'quote',
+      quote: {
+        rich_text: [alertTextSegment('')],
+        children: [
+          {
+            object: 'block',
+            type: 'paragraph',
+            paragraph: {
+              rich_text: [alertTextSegment('[!NOTE]'), alertTextSegment('\nstyled marker')]
+            }
+          }
+        ]
+      }
+    }
+
+    const [block] = rewriteAlertQuotesToCallouts([plainMarkerQuote], '> [!NOTE]\n> styled marker')
+
+    expect(block.type).toBe('callout')
+    expect(block.callout.rich_text).toHaveLength(1)
+    expect(block.callout.rich_text[0].text.content).toBe('styled marker')
+  })
+
+  it('keeps a formatted marker (bold) as a plain quote', () => {
     const boldMarkerQuote = {
       object: 'block',
       type: 'quote',
@@ -906,12 +940,7 @@ describe('rewriteAlertQuotesToCallouts', () => {
       }
     }
 
-    const [block] = rewriteAlertQuotesToCallouts([boldMarkerQuote])
-
-    expect(block.type).toBe('callout')
-    expect(block.callout.rich_text).toHaveLength(1)
-    expect(block.callout.rich_text[0].text.content).toBe('styled marker')
-    expect(block.callout.rich_text[0].annotations.bold).toBe(false)
+    expect(rewriteAlertQuotesToCallouts([boldMarkerQuote], '> **[!NOTE]**\n> styled marker')).toEqual([boldMarkerQuote])
   })
 
   it('keeps remaining children and an empty rich_text for a marker-only alert', () => {
@@ -921,7 +950,10 @@ describe('rewriteAlertQuotesToCallouts', () => {
       bulleted_list_item: { rich_text: [alertTextSegment('bullet a')], children: [] }
     }
 
-    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!NOTE]', undefined, [bullet])])
+    const [block] = rewriteAlertQuotesToCallouts(
+      [alertQuoteBlock('[!NOTE]', undefined, [bullet])],
+      alertQuoteSource('[!NOTE]')
+    )
 
     expect(block.type).toBe('callout')
     expect(block.callout.rich_text).toEqual([])
@@ -938,7 +970,7 @@ describe('rewriteAlertQuotesToCallouts', () => {
       }
     }
 
-    const [block] = rewriteAlertQuotesToCallouts([listItem])
+    const [block] = rewriteAlertQuotesToCallouts([listItem], '1. Step one\n   > [!IMPORTANT]\n   > critical detail')
 
     expect(block.type).toBe('numbered_list_item')
     expect(block.numbered_list_item.children[0].type).toBe('callout')
@@ -952,7 +984,10 @@ describe('rewriteAlertQuotesToCallouts', () => {
       paragraph: { rich_text: [alertTextSegment('Second paragraph')] }
     }
 
-    const [block] = rewriteAlertQuotesToCallouts([alertQuoteBlock('[!NOTE]', 'First paragraph', [secondPara])])
+    const [block] = rewriteAlertQuotesToCallouts(
+      [alertQuoteBlock('[!NOTE]', 'First paragraph', [secondPara])],
+      alertQuoteSource('[!NOTE]', 'First paragraph')
+    )
 
     expect(block.callout.rich_text[0].text.content).toBe('First paragraph')
     expect(block.callout.children).toEqual([secondPara])
@@ -962,7 +997,7 @@ describe('rewriteAlertQuotesToCallouts', () => {
     const original = alertQuoteBlock('[!WARNING]', 'Do not commit secrets')
     const snapshot = JSON.parse(JSON.stringify(original))
 
-    rewriteAlertQuotesToCallouts([original])
+    rewriteAlertQuotesToCallouts([original], alertQuoteSource('[!WARNING]', 'Do not commit secrets'))
 
     expect(original).toEqual(snapshot)
   })
@@ -976,7 +1011,7 @@ describe('rewriteAlertQuotesToCallouts with real martian output', () => {
     markdownToBlocks = actual.markdownToBlocks
   })
 
-  const toBlocks = (markdown: string) => rewriteAlertQuotesToCallouts(markdownToBlocks(markdown))
+  const toBlocks = (markdown: string) => rewriteAlertQuotesToCallouts(markdownToBlocks(markdown), markdown)
 
   const plainText = (richText: any[]) => richText.map((segment) => segment.text?.content ?? '').join('')
 
@@ -1059,6 +1094,53 @@ describe('rewriteAlertQuotesToCallouts with real martian output', () => {
     expect(plainText(nested.callout.rich_text)).toBe('critical detail')
     expect(blocks[1].type).toBe('numbered_list_item')
   })
+
+  it('keeps a code-formatted literal marker as a quote with the code style intact', () => {
+    const blocks = toBlocks('> `[!NOTE]`\n> body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    const segments = blocks[0].quote.children[0].paragraph.rich_text
+    expect(segments[0].annotations.code).toBe(true)
+    expect(segments[0].text.content).toBe('[!NOTE]')
+    expect(plainText(segments)).toBe('[!NOTE]\nbody')
+  })
+
+  it('keeps a link-text marker as a quote with the link intact', () => {
+    const blocks = toBlocks('> [[!NOTE]](https://example.com)\n> body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    const segments = blocks[0].quote.children[0].paragraph.rich_text
+    expect(segments[0].text.content).toBe('[!NOTE]')
+    expect(segments[0].text.link).toEqual({ type: 'url', url: 'https://example.com' })
+  })
+
+  it('keeps a bolded marker as a quote with the bold style intact', () => {
+    const blocks = toBlocks('> **[!NOTE]**\n> body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    const segments = blocks[0].quote.children[0].paragraph.rich_text
+    expect(segments[0].annotations.bold).toBe(true)
+    expect(segments[0].text.content).toBe('[!NOTE]')
+  })
+
+  it('keeps an HTML-code-wrapped marker as a quote with the literal marker intact', () => {
+    const blocks = toBlocks('> <code>[!NOTE]</code>\n> body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    expect(plainText(blocks[0].quote.children[0].paragraph.rich_text)).toContain('[!NOTE]')
+  })
+
+  it('keeps an HTML-span-wrapped marker as a quote with the literal marker intact', () => {
+    const blocks = toBlocks('> <span>[!NOTE]</span>\n> body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    expect(plainText(blocks[0].quote.children[0].paragraph.rich_text)).toContain('[!NOTE]')
+  })
 })
 
 describe('Notion export alert callout wiring', () => {
@@ -1086,7 +1168,7 @@ describe('Notion export alert callout wiring', () => {
 
   it('rewrites alert quotes inside the reasoning toggle', async () => {
     await preferenceService.set('data.integration.notion.export_reasoning', true)
-    const message = createExportView([{ type: 'reasoning', text: 'thinking mentions [!WARNING] marker' }])
+    const message = createExportView([{ type: 'reasoning', text: '> [!WARNING]\n> reasoning alert' }])
 
     await expect(exportMessageToNotion('Alerts', 'plain body', message)).resolves.toBe(true)
 

--- a/src/renderer/services/__tests__/ExportService.test.ts
+++ b/src/renderer/services/__tests__/ExportService.test.ts
@@ -1141,6 +1141,46 @@ describe('rewriteAlertQuotesToCallouts with real martian output', () => {
     expect(blocks[0].type).toBe('quote')
     expect(plainText(blocks[0].quote.children[0].paragraph.rich_text)).toContain('[!NOTE]')
   })
+
+  it('converts an alert nested inside a plain quote while the outer quote stays a quote', () => {
+    const blocks = toBlocks('> outer\n> > [!NOTE]\n> > inner')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('quote')
+    const innerCallout = blocks[0].quote.children.find((child: any) => child.type === 'callout')
+    expect(innerCallout).toBeDefined()
+    expect(innerCallout.callout.icon.emoji).toBe('💡')
+    expect(plainText(innerCallout.callout.rich_text)).toBe('inner')
+  })
+
+  it('keeps a plain quote nested inside an alert as a quote within the callout', () => {
+    const blocks = toBlocks('> [!TIP]\n> tip text\n> > plain inner')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('callout')
+    expect(plainText(blocks[0].callout.rich_text)).toBe('tip text')
+    const nested = blocks[0].callout.children.find((child: any) => child.type === 'quote')
+    expect(nested).toBeDefined()
+    expect(plainText(nested.quote.children[0].paragraph.rich_text)).toBe('plain inner')
+  })
+
+  it('keeps flag order across interleaved plain and alert quotes', () => {
+    const blocks = toBlocks('> plain one\n\n> [!WARNING]\n> careful\n\n> plain two')
+
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0].type).toBe('quote')
+    expect(blocks[1].type).toBe('callout')
+    expect(blocks[1].callout.icon.emoji).toBe('⚠️')
+    expect(blocks[2].type).toBe('quote')
+  })
+
+  it('converts an alert with body on the marker line', () => {
+    const blocks = toBlocks('> [!NOTE] inline body')
+
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0].type).toBe('callout')
+    expect(plainText(blocks[0].callout.rich_text)).toBe(' inline body')
+  })
 })
 
 describe('Notion export alert callout wiring', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:
GitHub-style Markdown alerts (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) render as styled banners in the chat, but on export to Notion every alert collapsed into a plain blockquote — losing the visual hierarchy and semantic meaning.

After this PR:
Every alert in an exported conversation (message body and reasoning content) becomes a native Notion Callout block with a fixed icon + background color per type: NOTE → 💡 blue, TIP → ✅ green, IMPORTANT → ⭐ purple, WARNING → ⚠️ yellow, CAUTION → 🚫 red. Unknown markers fall back to a 📝 gray callout. Plain blockquotes still export as quote blocks, alerts nested inside lists keep their structural position, and inline formatting (bold/italic/links/code) in the alert body is preserved.

Fixes #16388

### Why we need it and why it was done in this way

`@tryfabric/martian` (1.2.4, the latest release) has no callout support at all — blockquotes always convert to Notion `quote` blocks, and the upstream repo has been inactive since 2026-04.

The following tradeoffs were made:
- The rewrite is a pure post-processing pass over martian's output (`rewriteAlertQuotesToCallouts`), so martian stays a plain npm dependency; the change is fully additive and a single-commit revert.
- The alert's first body paragraph becomes the callout's own rich text (the icon renders next to the first body line, matching GitHub's visual), while subsequent blocks (lists, extra paragraphs) move into the callout's children.

The following alternatives were considered:
- Forking or `pnpm patch`-ing martian to teach its converter callouts — rejected: permanent maintenance burden for a change that is purely additive on the library's output.
- Rewriting the markdown before conversion — rejected: alert markers survive martian as literal text in a stable, well-defined position (start of the first paragraph inside the quote), so rewriting after conversion is simpler and leaves the markdown untouched for other export targets.

Links to places where the discussion took place: #16388 (spec), #16230 (original community request)

### Breaking changes

None. Only Notion export output changes; the rewrite only touches quote blocks whose first paragraph starts with a `[!TYPE]` marker.

### Special notes for your reviewer

- `rewriteAlertQuotesToCallouts` is exported only for testing; both call sites live in `ExportService.ts` (`convertMarkdownToNotionBlocks`, `convertThinkingToNotionBlocks`).
- Tests pin the martian output contract: unit tests feed synthetic martian-shaped fixtures, and a second suite runs real martian via `vi.importActual` (bypassing the module mock) over the six acceptance cases from the issue — so a martian upgrade that shifts marker placement fails CI instead of silently corrupting exports.

### Alert detection semantics (source-AST, mirrors the live renderer)

- Detection runs on the source markdown AST (`remark-parse`), not on martian's output blocks: martian strips provenance (raw HTML like `<code>[!NOTE]</code>` becomes an unformatted text segment), so post-block filtering can never match the renderer. The check mirrors `remark-github-blockquote-alert`: the marker must lead the quote's **first paragraph** as a **plain `text` node** — inline-code, link, bold, or raw-HTML-wrapped markers stay plain quotes (regression-tested against real martian).
- Detected flags are consumed in document order (parents before children, matching `unist-util-visit` traversal); quote-in-quote in both directions and interleaved plain/alert quotes are covered by real-martian tests.
- Unknown `[!TYPE]` markers falling back to a gray 📝 callout is **spec behavior from #16388** ("Unknown alert types … fall back to a generic 📝 gray Callout rather than failing the export"), so detection intentionally accepts any `[!WORD]` marker here.
- Only the quote's first paragraph can carry the marker — stricter than the plugin (which also matches markers on later paragraphs), chosen so export errs toward leaving a quote untouched rather than rewriting content the renderer keeps visible.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#codeforhumans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every-programmer-should-know/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Export to Notion now converts GitHub-style Markdown alerts (`> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) into native Notion callout blocks with matching icons and colors, instead of collapsing them into plain quotes.
```

