### PR TITLE
fix(html-artifacts): preserve popup state across message virtualization

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -1,3 +1,4 @@
+import { HtmlArtifactPopupHost } from '@renderer/components/chat/HtmlArtifactPopupContext'
 import { useChatLayoutMode } from '@renderer/components/chat/layout/ChatLayoutModeContext'
 import { useChatBottomOverlayInset } from '@renderer/components/chat/layout/ChatViewportInsetContext'
 import MultiSelectActionPopup from '@renderer/components/chat/messages/MultiSelectActionPopup'
@@ -720,7 +721,7 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const topPadding = MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX
   const topicImageCaptureWidth = activeTopicImageCaptureAction?.captureWidth
 
-  return (
+  const messageList = (
     <MessagesContainer
       id="messages"
       className={classNames(['messages-container', { 'multi-select-mode': isMultiSelectMode }])}
@@ -888,6 +889,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
       />
     </MessagesContainer>
   )
+
+  return <HtmlArtifactPopupHost>{messageList}</HtmlArtifactPopupHost>
 }
 
 export default MessageList

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -1,5 +1,6 @@
 import { captureScrollable, captureScrollableAsDataUrl } from '@renderer/utils/image'
 import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { HTMLAttributes, ReactNode, Ref } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -44,6 +45,21 @@ const chatLayoutModeMock = vi.hoisted(() => ({
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
   useChatLayoutMode: () => chatLayoutModeMock
 }))
+
+vi.mock('@renderer/components/chat/HtmlArtifactView', async () => {
+  const { useHtmlArtifactPopupContext } = await import('@renderer/components/chat/HtmlArtifactPopupContext')
+
+  return {
+    HtmlArtifactPopupOutlet: () => {
+      const { popupSession } = useHtmlArtifactPopupContext()
+      return popupSession ? (
+        <div role="dialog" aria-label={`${popupSession.title} popup`}>
+          {popupSession.html}
+        </div>
+      ) : null
+    }
+  }
+})
 
 vi.mock('@renderer/components/icons/LoadingIcon', () => ({
   default: () => <div data-testid="loading-icon" />
@@ -127,6 +143,34 @@ vi.mock('../list/MessageAnchorLine', () => ({
 
 vi.mock('../list/MessageGroup', async () => {
   const React = await import('react')
+  const { useHtmlArtifactPopupContext } = await import('@renderer/components/chat/HtmlArtifactPopupContext')
+  const ArtifactLifecycleControl = () => {
+    const popupContext = useHtmlArtifactPopupContext()
+    const artifactId = 'artifact-1'
+    const html = '<script>interactive()</script>'
+    const isApproved = popupContext.approvedInteractiveHtmlById[artifactId] === html
+
+    return isApproved ? (
+      <button
+        type="button"
+        onClick={() =>
+          popupContext.openPopup({
+            artifactId,
+            html,
+            title: 'Interactive artifact',
+            editable: false,
+            kind: 'document',
+            zoom: 100
+          })
+        }>
+        Open artifact
+      </button>
+    ) : (
+      <button type="button" onClick={() => popupContext.approveInteractiveHtml(artifactId, html)}>
+        Approve artifact
+      </button>
+    )
+  }
   const MockMessageGroup = ({
     messages,
     registerMessageElement
@@ -158,6 +202,7 @@ vi.mock('../list/MessageGroup', async () => {
             />
           )
         })}
+        {messages.some((message) => message.id === 'artifact-source') && <ArtifactLifecycleControl />}
         {groupId}
       </div>
     )
@@ -308,6 +353,34 @@ describe('MessageList', () => {
     const { container } = renderMessageList([createMessage('assistant-1', 'assistant')])
 
     expect(container.querySelector('[data-ui~="chat.message-list"]')).toHaveAttribute('id', 'messages')
+  })
+
+  it('keeps artifact popup and approval state when the source virtual row unmounts', async () => {
+    const user = userEvent.setup()
+    const sourceMessage = createMessage('artifact-source', 'assistant')
+    const renderTree = () => (
+      <MessageListProvider value={createValue([sourceMessage])}>
+        <MessageList />
+      </MessageListProvider>
+    )
+    const view = render(renderTree())
+
+    await user.click(screen.getByRole('button', { name: 'Approve artifact' }))
+    await user.click(screen.getByRole('button', { name: 'Open artifact' }))
+    expect(await screen.findByRole('dialog', { name: 'Interactive artifact popup' })).toHaveTextContent(
+      '<script>interactive()</script>'
+    )
+
+    messageVirtualListMocks.renderItemLimit = 0
+    view.rerender(renderTree())
+
+    expect(screen.queryByRole('button', { name: 'Open artifact' })).not.toBeInTheDocument()
+    expect(screen.getByRole('dialog', { name: 'Interactive artifact popup' })).toBeInTheDocument()
+
+    messageVirtualListMocks.renderItemLimit = undefined
+    view.rerender(renderTree())
+
+    expect(screen.getByRole('button', { name: 'Open artifact' })).toBeInTheDocument()
   })
 
   it('keeps search disabled for embedded lists unless explicitly enabled', () => {

--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -15,7 +15,6 @@
  */
 
 import { loggerService } from '@logger'
-import { HtmlArtifactPopupHost } from '@renderer/components/chat/HtmlArtifactPopupContext'
 import type { ReadOnlyComposerFileTokenPreview } from '@renderer/components/composer/tokenView'
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { useIsActiveTurnTarget } from '@renderer/hooks/useIsActiveTurnTarget'
@@ -1522,16 +1521,14 @@ const MessagePartsRenderer: React.FC<Props> = ({ message }) => {
   const { collapseCompletedToolHistory } = useMessageRenderConfig()
 
   return (
-    <HtmlArtifactPopupHost>
-      <MessagePartsRendererContent
-        collapseCompletedToolHistory={collapseCompletedToolHistory}
-        isActiveTurnProcessing={isActiveTurnProcessing}
-        isStreamLive={isStreamLive}
-        isTranslationOverlayActive={isTranslationOverlayActive}
-        message={message}
-        messageParts={messageParts}
-      />
-    </HtmlArtifactPopupHost>
+    <MessagePartsRendererContent
+      collapseCompletedToolHistory={collapseCompletedToolHistory}
+      isActiveTurnProcessing={isActiveTurnProcessing}
+      isStreamLive={isStreamLive}
+      isTranslationOverlayActive={isTranslationOverlayActive}
+      message={message}
+      messageParts={messageParts}
+    />
   )
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Each rendered message owned an `HtmlArtifactPopupHost`, so virtualizing the source row away closed its popup and discarded its interactive HTML approval state.

After this PR:

`MessageList` owns one popup host for the conversation-list lifetime, while standalone artifact views continue to self-host when no shared context exists.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #18552

### Why we need it and why it was done in this way

The following tradeoffs were made:

The host follows the existing `MessageList` lifetime rather than introducing application-global popup state.

The following alternatives were considered:

Keeping per-message hosts would retain the virtualization bug; moving the host to the application shell would make state outlive the current message list.

Links to places where the discussion took place: #18552

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Focused artifact/message suites passed 121 tests. The first `pnpm build:check` hit an unrelated `ReadableContentService.integration.test.ts` timeout; the single authoritative rerun passed all checks and test projects.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
HTML artifact popups and interactive preview approvals now remain available when their source message scrolls out of the virtualized message list.
```
