### PR TITLE
fix(composer): focus input after creating conversations

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -2,6 +2,7 @@ import { basename } from 'node:path'
 
 import { cacheService } from '@data/CacheService'
 import { dataApiService } from '@data/DataApiService'
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import { toast } from '@renderer/services/toast'
 import type { FileMetadata } from '@renderer/types/file'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
@@ -4920,6 +4921,29 @@ describe('AgentComposer', () => {
     fireEvent.click(screen.getByText('close edit dialog'))
 
     expect(mocks.inputAdapterFocus).toHaveBeenCalledTimes(1)
+  })
+
+  it('focuses only the current session composer from the focus event', async () => {
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+    mocks.surfaceFocus.mockClear()
+
+    await act(async () => {
+      await EventEmitter.emit(EVENT_NAMES.FOCUS_CHAT_COMPOSER, { topicId: 'agent-session:other-session' })
+    })
+    expect(mocks.surfaceFocus).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await EventEmitter.emit(EVENT_NAMES.FOCUS_CHAT_COMPOSER, { topicId: 'agent-session:session-1' })
+    })
+    expect(mocks.surfaceFocus).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the active session agent control visible in classic layout', () => {

--- a/src/renderer/hooks/__tests__/useComposerFocusRequest.test.tsx
+++ b/src/renderer/hooks/__tests__/useComposerFocusRequest.test.tsx
@@ -1,0 +1,51 @@
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useEffect, useRef, useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { useComposerFocusRequest } from '../useComposerFocusRequest'
+
+function Composer({ topicId }: { topicId: string }) {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(
+    () =>
+      EventEmitter.on(EVENT_NAMES.FOCUS_CHAT_COMPOSER, (payload) => {
+        if ((payload as { topicId?: string }).topicId === topicId) inputRef.current?.focus()
+      }),
+    [topicId]
+  )
+
+  return <input ref={inputRef} aria-label={`Composer ${topicId}`} />
+}
+
+function Harness() {
+  const [activeTopicId, setActiveTopicId] = useState('topic-1')
+  const requestComposerFocus = useComposerFocusRequest(activeTopicId)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          requestComposerFocus('topic-2')
+          setActiveTopicId('topic-2')
+        }}>
+        New conversation
+      </button>
+      <Composer key={activeTopicId} topicId={activeTopicId} />
+    </>
+  )
+}
+
+describe('useComposerFocusRequest', () => {
+  it('focuses the new composer after a persistent create trigger switches conversations', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.click(screen.getByRole('button', { name: 'New conversation' }))
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: 'Composer topic-2' })).toHaveFocus())
+  })
+})

--- a/src/renderer/hooks/useComposerFocusRequest.ts
+++ b/src/renderer/hooks/useComposerFocusRequest.ts
@@ -1,0 +1,20 @@
+import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export function useComposerFocusRequest(activeTopicId: string | null | undefined) {
+  const requestedTopicIdRef = useRef<string | null>(null)
+  const [requestVersion, setRequestVersion] = useState(0)
+
+  useEffect(() => {
+    const requestedTopicId = requestedTopicIdRef.current
+    if (!requestedTopicId || requestedTopicId !== activeTopicId) return
+
+    requestedTopicIdRef.current = null
+    void EventEmitter.emit(EVENT_NAMES.FOCUS_CHAT_COMPOSER, { topicId: requestedTopicId })
+  }, [activeTopicId, requestVersion])
+
+  return useCallback((topicId: string) => {
+    requestedTopicIdRef.current = topicId
+    setRequestVersion((version) => version + 1)
+  }, [])
+}

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -26,12 +26,13 @@ import { useCommandHandler } from '@renderer/hooks/command'
 import { useAgentSessionsSource } from '@renderer/hooks/resourceViewSources'
 import { useCloseConversationTabs, useCurrentTabId, useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
 import { useClassicLayoutRightPaneOpen } from '@renderer/hooks/useClassicLayoutRightPaneOpen'
+import { useComposerFocusRequest } from '@renderer/hooks/useComposerFocusRequest'
 import { useConversationCenterSurface } from '@renderer/hooks/useConversationCenterSurface'
 import { useConversationShellPaneState } from '@renderer/hooks/useConversationShellPaneState'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { ResourceListRevealPayload } from '@renderer/services/resourceListRevealEvents'
 import { toast } from '@renderer/services/toast'
-import { buildAgentFileWorkspaceKey } from '@renderer/utils/agentSession'
+import { buildAgentFileWorkspaceKey, buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import { cn } from '@renderer/utils/style'
@@ -122,6 +123,9 @@ const AgentPage = () => {
   )
   const { agents, isLoading: isAgentsLoading } = useAgents()
   const [activeSessionId, setActiveSessionIdState] = useState<string | null>(() => routeActiveSessionId)
+  const requestComposerFocus = useComposerFocusRequest(
+    activeSessionId ? buildAgentSessionTopicId(activeSessionId) : null
+  )
   const syncedRouteActiveSessionIdRef = useRef(routeActiveSessionId)
   const ownerFallbackRequestIdRef = useRef(0)
   // Page-initiated selection writes the tab URL — the conversation's sole identity channel —
@@ -405,8 +409,9 @@ const AgentPage = () => {
       }
       setActiveSession(session)
       closeSurface()
+      requestComposerFocus(buildAgentSessionTopicId(session.id))
     },
-    [closeSurface, rememberLastUsedSession, setActiveSession]
+    [closeSurface, rememberLastUsedSession, requestComposerFocus, setActiveSession]
   )
 
   const resolveEmptySession = useCallback(

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -331,6 +331,7 @@ vi.mock('@renderer/hooks/tab', () => ({
 
 vi.mock('@renderer/services/EventService', () => ({
   EVENT_NAMES: {
+    FOCUS_CHAT_COMPOSER: 'FOCUS_CHAT_COMPOSER',
     GLOBAL_SEARCH_SELECT_AGENT_SESSION: 'GLOBAL_SEARCH_SELECT_AGENT_SESSION',
     GLOBAL_SEARCH_SELECT_AGENT_SESSION_MESSAGE: 'GLOBAL_SEARCH_SELECT_AGENT_SESSION_MESSAGE',
     SHOW_ASSISTANTS: 'SHOW_ASSISTANTS',
@@ -1720,6 +1721,11 @@ describe('AgentPage', () => {
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-empty-latest'))
     expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
     expect(agentPageMocks.invalidateCache).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(EventEmitter.emit).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', {
+        topicId: 'agent-session:session-empty-latest'
+      })
+    )
   })
 
   it('excludes the just-deleted session from reuse so the post-delete replacement creates a fresh one', async () => {
@@ -1853,6 +1859,11 @@ describe('AgentPage', () => {
       })
     )
     expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-composer-empty')
+    await waitFor(() =>
+      expect(EventEmitter.emit).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', {
+        topicId: 'agent-session:session-composer-empty'
+      })
+    )
   })
 
   it('prevents duplicate empty session creation from rapid classic-layout composer clicks', async () => {

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -26,6 +26,7 @@ import { useCurrentTabId, useIsActiveTab, useTabSelfVisuals } from '@renderer/ho
 import { useAssistants } from '@renderer/hooks/useAssistant'
 import { toCreateAssistantDtoFromCatalogPreset } from '@renderer/hooks/useAssistantCatalogPresets'
 import { useClassicLayoutRightPaneOpen } from '@renderer/hooks/useClassicLayoutRightPaneOpen'
+import { useComposerFocusRequest } from '@renderer/hooks/useComposerFocusRequest'
 import { useConversationCenterSurface } from '@renderer/hooks/useConversationCenterSurface'
 import { useConversationShellPaneState } from '@renderer/hooks/useConversationShellPaneState'
 import { useModelById } from '@renderer/hooks/useModel'
@@ -231,6 +232,7 @@ const HomePage: FC = () => {
   const visibleTopic = isMessageOnlyView
     ? routeTopic
     : (activeTopic ?? (isActiveTopicLoading ? lastVisibleTopicRef.current : undefined) ?? undefined)
+  const requestComposerFocus = useComposerFocusRequest(visibleTopic?.id)
   const resourceConversationKey = useMemo(() => {
     if (visibleTopic?.id) return `topic:${visibleTopic.id}`
     return 'empty'
@@ -366,6 +368,14 @@ const HomePage: FC = () => {
     [closeSurface, setActiveTopic]
   )
 
+  const activateCreatedTopic = useCallback(
+    (topic: Topic) => {
+      setActiveTopicAndCloseResourceView(topic)
+      requestComposerFocus(topic.id)
+    },
+    [requestComposerFocus, setActiveTopicAndCloseResourceView]
+  )
+
   const resolveAssistantIdForSelection = useCallback(
     async (selection: AssistantConversationSelection) => {
       if (selection.type === 'assistant') return selection.assistantId
@@ -394,7 +404,7 @@ const HomePage: FC = () => {
         const result = await reuseOrCreateTopic(assistantId)
         const rendererTopic = mapApiTopicToRendererTopic(result.topic)
 
-        setActiveTopicAndCloseResourceView(rendererTopic)
+        activateCreatedTopic(rendererTopic)
         if (result.created) {
           void refreshTopics().catch((err) => {
             logger.warn('Failed to refresh topics after assistant picker topic create', err as Error)
@@ -407,7 +417,7 @@ const HomePage: FC = () => {
         isCreatingTopicRef.current = false
       }
     },
-    [refreshTopics, resolveAssistantIdForSelection, reuseOrCreateTopic, setActiveTopicAndCloseResourceView, t]
+    [activateCreatedTopic, refreshTopics, resolveAssistantIdForSelection, reuseOrCreateTopic, t]
   )
 
   const resolveEmptyTopic = useCallback(
@@ -440,7 +450,7 @@ const HomePage: FC = () => {
       isCreatingTopicRef.current = true
       try {
         const topic = await resolveEmptyTopic(payload, options)
-        setActiveTopicAndCloseResourceView(topic)
+        activateCreatedTopic(topic)
         return topic
       } catch (err) {
         logger.error('Failed to create empty topic', err as Error)
@@ -450,7 +460,7 @@ const HomePage: FC = () => {
         isCreatingTopicRef.current = false
       }
     },
-    [resolveEmptyTopic, setActiveTopicAndCloseResourceView, t]
+    [activateCreatedTopic, resolveEmptyTopic, t]
   )
 
   const createAndActivateFreshTopic = useCallback(
@@ -462,7 +472,7 @@ const HomePage: FC = () => {
         const topic = await createTopic({
           ...(selection.assistantId ? { assistantId: selection.assistantId } : {})
         })
-        setActiveTopicAndCloseResourceView(mapApiTopicToRendererTopic(topic))
+        activateCreatedTopic(mapApiTopicToRendererTopic(topic))
         void refreshTopics().catch((err) => {
           logger.warn('Failed to refresh topics after fresh topic create', err as Error)
         })
@@ -473,7 +483,7 @@ const HomePage: FC = () => {
         isCreatingTopicRef.current = false
       }
     },
-    [createTopic, refreshTopics, resolveNewTopicAssistantTarget, setActiveTopicAndCloseResourceView, t]
+    [activateCreatedTopic, createTopic, refreshTopics, resolveNewTopicAssistantTarget, t]
   )
 
   const handleCreateEmptyTopic = useCallback(

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -687,6 +687,7 @@ vi.mock('@renderer/components/history/HistoryRecordsView', () => ({
 
 vi.mock('@renderer/services/EventService', () => ({
   EVENT_NAMES: {
+    FOCUS_CHAT_COMPOSER: 'FOCUS_CHAT_COMPOSER',
     SHOW_ASSISTANTS: 'SHOW_ASSISTANTS',
     GLOBAL_SEARCH_SELECT_TOPIC: 'GLOBAL_SEARCH_SELECT_TOPIC',
     GLOBAL_SEARCH_SELECT_TOPIC_MESSAGE: 'GLOBAL_SEARCH_SELECT_TOPIC_MESSAGE',
@@ -1470,6 +1471,11 @@ describe('HomePage', () => {
     await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-empty-latest'))
     expect(homeMocks.createTopic).not.toHaveBeenCalled()
     expect(homeMocks.refreshTopics).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(EventEmitter.emit).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', {
+        topicId: 'topic-empty-latest'
+      })
+    )
   })
 
   it('creates and activates a fresh empty topic from the classic-layout composer button when no empty topic exists', async () => {
@@ -1498,6 +1504,11 @@ describe('HomePage', () => {
     await waitFor(() => expect(homeMocks.createTopic).toHaveBeenCalledWith({ assistantId: 'assistant-1' }))
     expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-composer-empty')
     expect(homeMocks.refreshTopics).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(EventEmitter.emit).toHaveBeenCalledWith('FOCUS_CHAT_COMPOSER', {
+        topicId: 'topic-composer-empty'
+      })
+    )
   })
 
   it('creates a new topic when the assistant latest topic is chatted-in with a blank name (auto-naming off) in the classic-layout picker', async () => {

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1694,6 +1694,7 @@ describe('HomePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select topic next' }))
 
     await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-next'))
+    expect(EventEmitter.emit).not.toHaveBeenCalledWith(EVENT_NAMES.FOCUS_CHAT_COMPOSER, expect.anything())
     expect(homeMocks.setShowSidebar).not.toHaveBeenCalledWith(false)
     expect(screen.getByTestId('pane-open')).toHaveTextContent('true')
   })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Creating or reusing an empty conversation from the persistent Chat or Agent navigation left keyboard focus on the create button, so users had to click the composer before typing.

After this PR:

Chat and Agent creation flows request focus for the newly activated conversation. The request waits until the target conversation is active and then uses the existing targeted composer-focus event, without changing focus behavior for ordinary conversation switches.

Fixes: N/A

### Why we need it and why it was done in this way

The persistent create controls do not unmount after activation, so browser focus remains on them while the conversation composer is replaced. A shared renderer hook now records the requested conversation id and emits the existing `FOCUS_CHAT_COMPOSER` event only after that id becomes active. Chat and Agent composers already filter this event by their own topic id, keeping ownership of the actual input focus inside the composer surface.

The following tradeoffs were made:

- The hook uses a small request version state in addition to the pending id so reusing an already-active empty conversation can still trigger focus.
- Focus remains opt-in from creation flows; ordinary history and sidebar selection paths are intentionally unchanged.

The following alternatives were considered:

- Adding `autoFocus` to composer inputs was rejected because it would also steal focus during ordinary session switches and unrelated remounts.
- Focusing directly from create-button handlers was rejected because the target composer may not be mounted yet.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The implementation reuses the existing `FOCUS_CHAT_COMPOSER` event and composer focus action rather than introducing another focus mechanism.
- The shared hook is located under `src/renderer/hooks/` and is covered by a DOM focus regression test.
- Focused validation: 4 Vitest files / 259 tests, `pnpm typecheck:web`, Biome, ESLint, Oxlint, and `git diff --check` all pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Chat and Agent conversations now focus the message composer after they are created.
```
