### PR TITLE
fix(tabs-context): isolate action consumers from tab state

### DIFF
--- a/src/renderer/components/GlobalSearch/GlobalSearchPanel.tsx
+++ b/src/renderer/components/GlobalSearch/GlobalSearchPanel.tsx
@@ -24,7 +24,7 @@ import {
   GroupedVirtualList,
   type GroupedVirtualListGroup
 } from '@renderer/components/VirtualList'
-import { useTabs } from '@renderer/hooks/tab'
+import { useTabsActions } from '@renderer/hooks/tab'
 import { useConversationNavigation } from '@renderer/hooks/useConversationNavigation'
 import { mapApiTopicToRendererTopic } from '@renderer/hooks/useTopic'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
@@ -303,7 +303,7 @@ function TimeFilterDropdown({
 
 export function GlobalSearchPanel({ onClose }: GlobalSearchPanelProps) {
   const { t, i18n } = useTranslation()
-  const { openTab } = useTabs()
+  const { openTab } = useTabsActions()
   const chatNav = useConversationNavigation('assistants')
   const agentNav = useConversationNavigation('agents')
   const invalidateCache = useInvalidateCache()

--- a/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
+++ b/src/renderer/components/GlobalSearch/__tests__/GlobalSearchPanel.test.tsx
@@ -314,7 +314,7 @@ vi.mock('@data/hooks/usePreference', () => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
-  useTabs: () => ({
+  useTabsActions: () => ({
     activeTab: mocks.activeTab,
     openTab: mocks.openTab,
     setActiveTab: mocks.setActiveTab,

--- a/src/renderer/components/MiniApp/MiniApp.tsx
+++ b/src/renderer/components/MiniApp/MiniApp.tsx
@@ -5,7 +5,7 @@ import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/
 import MiniAppIcon from '@renderer/components/icons/MiniAppIcon'
 import IndicatorLight from '@renderer/components/IndicatorLight'
 import MarqueeText from '@renderer/components/MarqueeText'
-import { useTabs } from '@renderer/hooks/tab'
+import { useTabsActions } from '@renderer/hooks/tab'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { toast } from '@renderer/services/toast'
@@ -40,7 +40,7 @@ const MiniApp: FC<Props> = ({ app, onClick, onOpen, onEditCustom, size = 60, isL
     removeCustomMiniApp
   } = useMiniApps()
   const { miniAppFavoriteIds, toggleMiniApp } = useSidebarFavorites()
-  const { openTab } = useTabs()
+  const { openTab } = useTabsActions()
   const [removeConfirmOpen, setRemoveConfirmOpen] = useState(false)
   const [removingCustom, setRemovingCustom] = useState(false)
   const isPinned = pinned.some((p) => p.appId === app.appId)

--- a/src/renderer/components/MiniApp/__tests__/MiniApp.test.tsx
+++ b/src/renderer/components/MiniApp/__tests__/MiniApp.test.tsx
@@ -95,7 +95,7 @@ vi.mock('@data/hooks/usePreference', () => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
-  useTabs: () => ({
+  useTabsActions: () => ({
     openTab: mocks.openTab
   })
 }))

--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -1,6 +1,12 @@
 import { loggerService } from '@logger'
 import { usePersistCache } from '@renderer/data/hooks/useCache'
-import { type OpenTabOptions, TabsContext, type TabsContextValue } from '@renderer/hooks/tab'
+import {
+  type OpenTabOptions,
+  TabsActionsContext,
+  type TabsActionsContextValue,
+  TabsContext,
+  type TabsContextValue
+} from '@renderer/hooks/tab'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { TabLruManager } from '@renderer/services/TabLruManager'
 import { getDefaultRouteTitle, isPageTitledRoute, isTopLevelRoute } from '@renderer/utils/routeTitle'
@@ -246,6 +252,12 @@ export function TabsProvider({
 
   // Active tab ID - in-memory storage, seeded from the restored session
   const [activeTabId, setActiveTabIdState] = useState<string>(() => initialSessionRef.current!.activeTabId)
+  const activeTabIdRef = useRef(activeTabId)
+  activeTabIdRef.current = activeTabId
+  const setActiveTabId = useCallback((id: string) => {
+    activeTabIdRef.current = id
+    setActiveTabIdState(id)
+  }, [])
 
   // Render the normalized pinned set on the first pass, then commit it to the persistent cache.
   // This avoids mounting background pinned routers before the effect runs while keeping the cache
@@ -332,7 +344,7 @@ export function TabsProvider({
 
   const updateTab = useCallback(
     (id: string, updates: Partial<Tab>) => {
-      const tab = tabs.find((t) => t.id === id)
+      const tab = projectedTabsRef.current.find((t) => t.id === id)
       if (!tab) return
 
       if (storesPinned(tab)) {
@@ -341,14 +353,14 @@ export function TabsProvider({
         setNormalTabs((prev) => prev.map((t) => (t.id === id ? { ...t, ...updates } : t)))
       }
     },
-    [tabs, setPinnedTabs, storesPinned]
+    [setPinnedTabs, storesPinned]
   )
 
   const setActiveTab = useCallback(
     (id: string) => {
       const targetTab = projectedTabsRef.current.find((t) => t.id === id)
       if (!targetTab) return
-      if (id === activeTabId && !targetTab.isDormant) return
+      if (id === activeTabIdRef.current && !targetTab.isDormant) return
 
       // If a dormant tab was awakened, log it
       if (targetTab.isDormant) {
@@ -371,9 +383,9 @@ export function TabsProvider({
         setNormalTabs((prev) => prev.map(update))
       }
 
-      setActiveTabIdState(id)
+      setActiveTabId(id)
     },
-    [activeTabId, prepareTabsForCommit, setPinnedTabs, storesPinned]
+    [prepareTabsForCommit, setActiveTabId, setPinnedTabs, storesPinned]
   )
 
   const addTab = useCallback(
@@ -408,13 +420,15 @@ export function TabsProvider({
         })
       }
 
-      setActiveTabIdState(tab.id)
+      setActiveTabId(tab.id)
     },
-    [prepareTabsForCommit, setActiveTab, setPinnedTabs, storesPinned]
+    [prepareTabsForCommit, setActiveTab, setActiveTabId, setPinnedTabs, storesPinned]
   )
 
   const closeTabs = useCallback(
     (ids: readonly string[], activateId?: string) => {
+      const tabs = projectedTabsRef.current
+      const activeTabId = activeTabIdRef.current
       const closingIdSet = new Set(ids)
       if (closingIdSet.size === 0) return
 
@@ -470,9 +484,9 @@ export function TabsProvider({
         })
       }
 
-      setActiveTabIdState(newActiveId)
+      setActiveTabId(newActiveId)
     },
-    [tabs, activeTabId, setPinnedTabs, storesPinned]
+    [setActiveTabId, setPinnedTabs, storesPinned]
   )
 
   const closeTab = useCallback((id: string) => closeTabs([id]), [closeTabs])
@@ -485,7 +499,7 @@ export function TabsProvider({
       const { forceNew = false, title, type = 'route', id, icon, metadata, isPinned } = options
 
       if (!forceNew) {
-        const existingTab = tabs.find((t) => t.type === type && t.url === url)
+        const existingTab = projectedTabsRef.current.find((t) => t.type === type && t.url === url)
         if (existingTab) {
           setActiveTab(existingTab.id)
           return existingTab.id
@@ -507,7 +521,7 @@ export function TabsProvider({
       addTab(newTab)
       return newTab.id
     },
-    [tabs, setActiveTab, addTab]
+    [setActiveTab, addTab]
   )
 
   /**
@@ -516,7 +530,7 @@ export function TabsProvider({
    */
   const pinTab = useCallback(
     (id: string) => {
-      const tab = tabs.find((t) => t.id === id)
+      const tab = projectedTabsRef.current.find((t) => t.id === id)
       if (!tab || tab.isPinned) return
 
       // Remove from normalTabs
@@ -526,7 +540,7 @@ export function TabsProvider({
 
       logger.info('Tab pinned', { tabId: id })
     },
-    [tabs, setPinnedTabs]
+    [setPinnedTabs]
   )
 
   /**
@@ -534,7 +548,7 @@ export function TabsProvider({
    */
   const unpinTab = useCallback(
     (id: string) => {
-      const tab = tabs.find((t) => t.id === id)
+      const tab = projectedTabsRef.current.find((t) => t.id === id)
       if (!tab || !tab.isPinned) return
 
       // Remove from pinnedTabs
@@ -544,7 +558,7 @@ export function TabsProvider({
 
       logger.info('Tab unpinned', { tabId: id })
     },
-    [tabs, setPinnedTabs]
+    [setPinnedTabs]
   )
 
   /**
@@ -577,7 +591,7 @@ export function TabsProvider({
    */
   const detachTab = useCallback(
     (tabId: string) => {
-      const tab = tabs.find((t) => t.id === tabId)
+      const tab = projectedTabsRef.current.find((t) => t.id === tabId)
       if (!tab) return
 
       // Send IPC message to create new window
@@ -586,7 +600,7 @@ export function TabsProvider({
       // Remove tab from current window — closeTab handles both pinned and normal tabs
       closeTab(tabId)
     },
-    [tabs, closeTab]
+    [closeTab]
   )
 
   /**
@@ -595,7 +609,7 @@ export function TabsProvider({
   const attachTab = useCallback(
     (tabData: Tab) => {
       // Check if tab already exists
-      const exists = tabs.find((t) => t.id === tabData.id)
+      const exists = projectedTabsRef.current.find((t) => t.id === tabData.id)
       if (exists) {
         setActiveTab(tabData.id)
         logger.info('Tab already exists, activating', { tabId: tabData.id })
@@ -613,7 +627,7 @@ export function TabsProvider({
       addTab(restoredTab)
       logger.info('Tab attached from detached window', { tabId: tabData.id, url: tabData.url })
     },
-    [addTab, tabs, setActiveTab]
+    [addTab, setActiveTab]
   )
 
   // Listen for tab attach requests (from Main Process)
@@ -624,36 +638,30 @@ export function TabsProvider({
    */
   const activeTab = useMemo(() => tabs.find((t) => t.id === activeTabId), [tabs, activeTabId])
 
-  const value: TabsContextValue = {
-    // State
-    tabs,
-    activeTabId,
-    activeTab,
-    isLoading: false,
+  const actions = useMemo<TabsActionsContextValue>(
+    () => ({
+      addTab,
+      attachTab,
+      closeTab,
+      closeTabs,
+      detachTab,
+      openTab,
+      pinTab,
+      reorderTabs,
+      setActiveTab,
+      unpinTab,
+      updateTab
+    }),
+    [addTab, attachTab, closeTab, closeTabs, detachTab, openTab, pinTab, reorderTabs, setActiveTab, unpinTab, updateTab]
+  )
+  const value = useMemo<TabsContextValue>(
+    () => ({ ...actions, tabs, activeTabId, activeTab, isLoading: false }),
+    [actions, tabs, activeTabId, activeTab]
+  )
 
-    // Basic operations
-    addTab,
-    closeTab,
-    closeTabs,
-    setActiveTab,
-    updateTab,
-
-    // High-level Tab operations
-    openTab,
-
-    // Pin operations
-    pinTab,
-    unpinTab,
-
-    // Detach
-    detachTab,
-
-    // Attach
-    attachTab,
-
-    // Drag and drop
-    reorderTabs
-  }
-
-  return <TabsContext value={value}>{children}</TabsContext>
+  return (
+    <TabsActionsContext value={actions}>
+      <TabsContext value={value}>{children}</TabsContext>
+    </TabsActionsContext>
+  )
 }

--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -467,6 +467,7 @@ export function TabsProvider({
       const wakeInNormal = !!reselectedTab?.isDormant && !storesPinned(reselectedTab)
       const wake = (tab: Tab) =>
         tab.id === newActiveId ? { ...tab, isDormant: false, lastAccessTime: Date.now() } : tab
+      projectedTabsRef.current = fallbackTab ? [fallbackTab] : remainingTabs.map(wake)
 
       if (pinnedIds.size > 0 || wakeInPinned) {
         setPinnedTabs((prev) => {

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -5,6 +5,7 @@ import { TAB_LIMITS } from '@renderer/services/TabLruManager'
 import type * as RouteTitle from '@renderer/utils/routeTitle'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -119,7 +120,7 @@ vi.mock('@renderer/ipc', () => ({
   useIpcOn: vi.fn()
 }))
 
-import { useTabsContext } from '@renderer/hooks/tab'
+import { useTabsActions, useTabsContext } from '@renderer/hooks/tab'
 
 import { migratePinnedTabs, TabsProvider } from '../TabsProvider'
 
@@ -144,6 +145,17 @@ function PinnedRouteTitle() {
 function TabIds() {
   const { tabs } = useTabsContext()
   return <div data-testid="tab-ids">{tabs.map((tab) => tab.id).join(',')}</div>
+}
+
+function ActionOnlyTabUpdater({ onRender }: { onRender: () => void }) {
+  const { updateTab } = useTabsActions()
+  onRender()
+
+  return (
+    <button type="button" onClick={() => updateTab('home', { title: 'Updated title' })}>
+      Update home title
+    </button>
+  )
 }
 
 // Surfaces restored-session state: active tab id, each tab's awake/dormant state, and the id list.
@@ -330,6 +342,23 @@ afterEach(() => {
 })
 
 describe('TabsProvider', () => {
+  it('does not invalidate action-only consumers when tab state changes', async () => {
+    const user = userEvent.setup()
+    const onActionConsumerRender = vi.fn()
+    render(
+      <TabsProvider initialDefaultTab={HOME_TAB} includePinnedTabs={false}>
+        <ActionOnlyTabUpdater onRender={onActionConsumerRender} />
+        <TabSnapshot />
+      </TabsProvider>
+    )
+
+    expect(onActionConsumerRender).toHaveBeenCalledTimes(1)
+    await user.click(screen.getByRole('button', { name: 'Update home title' }))
+
+    await waitFor(() => expect(screen.getByTestId('tab-titles')).toHaveTextContent('Updated title'))
+    expect(onActionConsumerRender).toHaveBeenCalledTimes(1)
+  })
+
   it('preserves page-owned titles for the fixed home conversation tab', async () => {
     render(
       <TabsProvider

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -5,7 +5,6 @@ import { TAB_LIMITS } from '@renderer/services/TabLruManager'
 import type * as RouteTitle from '@renderer/utils/routeTitle'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { useEffect, useRef } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -120,7 +119,7 @@ vi.mock('@renderer/ipc', () => ({
   useIpcOn: vi.fn()
 }))
 
-import { useTabsActions, useTabsContext } from '@renderer/hooks/tab'
+import { useTabsContext } from '@renderer/hooks/tab'
 
 import { migratePinnedTabs, TabsProvider } from '../TabsProvider'
 
@@ -147,17 +146,6 @@ function TabIds() {
   return <div data-testid="tab-ids">{tabs.map((tab) => tab.id).join(',')}</div>
 }
 
-function ActionOnlyTabUpdater({ onRender }: { onRender: () => void }) {
-  const { updateTab } = useTabsActions()
-  onRender()
-
-  return (
-    <button type="button" onClick={() => updateTab('home', { title: 'Updated title' })}>
-      Update home title
-    </button>
-  )
-}
-
 // Surfaces restored-session state: active tab id, each tab's awake/dormant state, and the id list.
 function SessionInspector() {
   const { tabs, activeTabId } = useTabsContext()
@@ -174,7 +162,7 @@ function SessionInspector() {
 }
 
 function BatchCloseControls() {
-  const { activeTabId, addTab, closeTabs, setActiveTab, tabs, updateTab } = useTabsContext()
+  const { activeTabId, addTab, closeTabs, openTab, setActiveTab, tabs, updateTab } = useTabsContext()
 
   return (
     <>
@@ -217,6 +205,14 @@ function BatchCloseControls() {
       </button>
       <button type="button" onClick={() => closeTabs(['d'])}>
         Close D
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          closeTabs(['c'])
+          openTab('/app/chat?topicId=c', { id: 'c-reopened' })
+        }}>
+        Close and reopen C
       </button>
       <button type="button" onClick={() => closeTabs(['home', 'b', 'c', 'd'], 'files')}>
         Close all normals to Files
@@ -342,23 +338,6 @@ afterEach(() => {
 })
 
 describe('TabsProvider', () => {
-  it('does not invalidate action-only consumers when tab state changes', async () => {
-    const user = userEvent.setup()
-    const onActionConsumerRender = vi.fn()
-    render(
-      <TabsProvider initialDefaultTab={HOME_TAB} includePinnedTabs={false}>
-        <ActionOnlyTabUpdater onRender={onActionConsumerRender} />
-        <TabSnapshot />
-      </TabsProvider>
-    )
-
-    expect(onActionConsumerRender).toHaveBeenCalledTimes(1)
-    await user.click(screen.getByRole('button', { name: 'Update home title' }))
-
-    await waitFor(() => expect(screen.getByTestId('tab-titles')).toHaveTextContent('Updated title'))
-    expect(onActionConsumerRender).toHaveBeenCalledTimes(1)
-  })
-
   it('preserves page-owned titles for the fixed home conversation tab', async () => {
     render(
       <TabsProvider
@@ -596,6 +575,22 @@ describe('TabsProvider', () => {
 
     await waitFor(() => expect(screen.getByTestId('tab-ids')).toHaveTextContent('files,home,b,c'))
     expect(screen.getByTestId('active-tab-id')).toHaveTextContent('c')
+  })
+
+  it('does not reactivate a closed tab when another action runs in the same event', async () => {
+    render(
+      <TabsProvider initialDefaultTab={HOME_TAB}>
+        <BatchCloseControls />
+      </TabsProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Seed tabs' }))
+    await waitFor(() => expect(screen.getByTestId('tab-ids')).toHaveTextContent('files,home,b,c,d'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close and reopen C' }))
+
+    await waitFor(() => expect(screen.getByTestId('tab-ids')).toHaveTextContent('files,home,b,d,c-reopened'))
+    expect(screen.getByTestId('active-tab-id')).toHaveTextContent('c-reopened')
   })
 
   it('wakes a dormant pinned survivor through the pinned store', async () => {

--- a/src/renderer/hooks/__tests__/useConversationNavigation.test.tsx
+++ b/src/renderer/hooks/__tests__/useConversationNavigation.test.tsx
@@ -12,7 +12,7 @@ const tabsMock = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
-  useOptionalTabsContext: () => tabsMock.ctx
+  useOptionalTabsActions: () => tabsMock.ctx
 }))
 
 vi.mock('@renderer/services/resourceListRevealEvents', () => ({

--- a/src/renderer/hooks/__tests__/useOpenReleaseNotes.test.tsx
+++ b/src/renderer/hooks/__tests__/useOpenReleaseNotes.test.tsx
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
-  useTabs: () => ({ openTab: mocks.openTab })
+  useTabsActions: () => ({ openTab: mocks.openTab })
 }))
 
 vi.mock('react-i18next', () => ({

--- a/src/renderer/hooks/tab/index.ts
+++ b/src/renderer/hooks/tab/index.ts
@@ -4,9 +4,13 @@ export { useMainWindowNavigation } from './useMainWindowNavigation'
 export { useTabs } from './useTabs'
 export {
   type OpenTabOptions,
+  TabsActionsContext,
+  type TabsActionsContextValue,
   TabsContext,
   type TabsContextValue,
+  useOptionalTabsActions,
   useOptionalTabsContext,
+  useTabsActions,
   useTabsContext
 } from './useTabsContext'
 export { type TabSelfVisuals, useTabSelfVisuals } from './useTabSelfVisuals'

--- a/src/renderer/hooks/tab/useTabsContext.ts
+++ b/src/renderer/hooks/tab/useTabsContext.ts
@@ -24,14 +24,7 @@ export interface OpenTabOptions {
   isPinned?: boolean
 }
 
-export interface TabsContextValue {
-  // State
-  tabs: Tab[]
-  activeTabId: string
-  activeTab: Tab | undefined
-  isLoading: boolean
-
-  // Basic operations
+export interface TabsActionsContextValue {
   addTab: (tab: Tab) => void
   closeTab: (id: string) => void
   /** Close tabs in one batch; `activateId` designates the surviving tab to activate when the active tab is closed. */
@@ -56,7 +49,15 @@ export interface TabsContextValue {
   attachTab: (tabData: Tab) => void
 }
 
+export interface TabsContextValue extends TabsActionsContextValue {
+  tabs: Tab[]
+  activeTabId: string
+  activeTab: Tab | undefined
+  isLoading: boolean
+}
+
 export const TabsContext = createContext<TabsContextValue | null>(null)
+export const TabsActionsContext = createContext<TabsActionsContextValue | null>(null)
 
 export function useTabsContext() {
   const context = use(TabsContext)
@@ -68,4 +69,16 @@ export function useTabsContext() {
 
 export function useOptionalTabsContext() {
   return use(TabsContext)
+}
+
+export function useTabsActions() {
+  const context = use(TabsActionsContext)
+  if (!context) {
+    throw new Error('useTabsActions must be used within a TabsProvider')
+  }
+  return context
+}
+
+export function useOptionalTabsActions() {
+  return use(TabsActionsContext)
 }

--- a/src/renderer/hooks/useConversationNavigation.ts
+++ b/src/renderer/hooks/useConversationNavigation.ts
@@ -1,4 +1,4 @@
-import { type TabsContextValue, useOptionalTabsContext } from '@renderer/hooks/tab'
+import { type TabsActionsContextValue, useOptionalTabsActions } from '@renderer/hooks/tab'
 import { useWindowFrame } from '@renderer/hooks/useWindowFrame'
 import { ipcApi } from '@renderer/ipc'
 import type { ConversationAppId } from '@renderer/types/conversation'
@@ -25,7 +25,7 @@ export interface ConversationNavigation {
 }
 
 function openConversationTabImpl(
-  tabs: TabsContextValue | null,
+  tabs: TabsActionsContextValue | null,
   appId: ConversationAppId,
   key: string,
   title?: string
@@ -58,7 +58,7 @@ function openConversationWindowImpl(appId: ConversationAppId, key: string, title
  * app has no `conversationRoute`.
  */
 export function useConversationNavigation(appId: ConversationAppId): ConversationNavigation {
-  const tabs = useOptionalTabsContext()
+  const tabs = useOptionalTabsActions()
   const isDetachedWindowFrame = useWindowFrame().mode === 'window'
 
   return useMemo<ConversationNavigation>(

--- a/src/renderer/hooks/useOpenReleaseNotes.ts
+++ b/src/renderer/hooks/useOpenReleaseNotes.ts
@@ -1,10 +1,10 @@
-import { useTabs } from '@renderer/hooks/tab'
+import { useTabsActions } from '@renderer/hooks/tab'
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 
 export function useOpenReleaseNotes() {
   const { t } = useTranslation()
-  const { openTab } = useTabs()
+  const { openTab } = useTabsActions()
 
   return useCallback(() => {
     openTab('/app/release-notes', { title: t('settings.about.releases.title') })

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -371,6 +371,7 @@ vi.mock('@renderer/hooks/agent/useAgent', () => ({
 
 vi.mock('@renderer/hooks/tab', () => ({
   useCloseConversationTabs: () => tabsContextMocks.closeConversationTabs,
+  useOptionalTabsActions: () => tabsContextMocks,
   useOptionalTabsContext: () => tabsContextMocks,
   useCurrentTabId: () => null
 }))

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -142,6 +142,7 @@ const resourceEditDialogMocks = vi.hoisted(() => ({ renderHost: vi.fn() }))
 
 vi.mock('@renderer/hooks/tab', () => ({
   useCloseConversationTabs: () => tabsContextMocks.closeConversationTabs,
+  useOptionalTabsActions: () => tabsContextMocks,
   useOptionalTabsContext: () => tabsContextMocks
 }))
 

--- a/src/renderer/pages/miniApps/__tests__/MiniAppsPage.test.tsx
+++ b/src/renderer/pages/miniApps/__tests__/MiniAppsPage.test.tsx
@@ -55,7 +55,7 @@ vi.mock('@renderer/hooks/useMiniApps', () => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
-  useTabs: () => ({
+  useTabsActions: () => ({
     openTab: mocks.openTab
   })
 }))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Tab state and tab actions shared one context value, so tab state changes rerendered consumers that only needed stable tab operations.

After this PR:

`TabsProvider` exposes a stable actions context backed by provider-owned current-state refs while preserving the existing combined context for state consumers. Action-only consumers use the narrower context, with a render-count contract test covering state-driven invalidation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #18621

### Why we need it and why it was done in this way

The following tradeoffs were made:

The existing combined tab context remains available so state consumers retain their current behavior. This introduces a second context but avoids a broad tab API refactor.

The following alternatives were considered:

Memoizing only the combined context cannot prevent state changes from invalidating action-only consumers. Migrating every tab consumer would increase scope without improving this fix.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/CherryHQ/cherry-studio/issues/18621

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The render-count assertion is the observable performance contract: changing tab state must not rerender a consumer subscribed only to tab actions.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
