### PR TITLE
fix(backup): parallelize backup dialog metadata requests

### DIFF
--- a/src/renderer/components/LocalBackupModals.tsx
+++ b/src/renderer/components/LocalBackupModals.tsx
@@ -64,8 +64,10 @@ export function useLocalBackupModal(localBackupDir: string | undefined) {
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/S3Modals.tsx
+++ b/src/renderer/components/S3Modals.tsx
@@ -47,8 +47,10 @@ export function useS3BackupModal() {
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/WebdavModals.tsx
+++ b/src/renderer/components/WebdavModals.tsx
@@ -39,8 +39,10 @@ export function useWebdavBackupModal({ backupMethod }: { backupMethod?: typeof b
 
   const showBackupModal = useCallback(async () => {
     // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
+    const [deviceType, hostname] = await Promise.all([
+      ipcApi.request('system.get_device_type'),
+      window.api.system.getHostname()
+    ])
     const timestamp = dayjs().format('YYYYMMDDHHmmss')
     const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
     setCustomFileName(defaultFileName)

--- a/src/renderer/components/__tests__/BackupModalHooks.test.tsx
+++ b/src/renderer/components/__tests__/BackupModalHooks.test.tsx
@@ -1,0 +1,83 @@
+import { useLocalBackupModal } from '@renderer/components/LocalBackupModals'
+import { useS3BackupModal } from '@renderer/components/S3Modals'
+import { useWebdavBackupModal } from '@renderer/components/WebdavModals'
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockIpcRequest = vi.hoisted(() => vi.fn())
+const mockGetHostname = vi.hoisted(() => vi.fn())
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    request: mockIpcRequest
+  }
+}))
+
+vi.mock('@renderer/services/BackupService', () => ({
+  backupToLocal: vi.fn(),
+  backupToS3: vi.fn(),
+  backupToWebdav: vi.fn()
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+type BackupModalHook = () => {
+  isModalVisible: boolean
+  showBackupModal: () => Promise<void>
+}
+
+async function expectMetadataRequestsToStartTogether(useBackupModal: BackupModalHook) {
+  const deviceType = createDeferred<string>()
+  const hostname = createDeferred<string>()
+  mockIpcRequest.mockReturnValue(deviceType.promise)
+  mockGetHostname.mockReturnValue(hostname.promise)
+
+  const { result } = renderHook(useBackupModal)
+  let opening!: Promise<void>
+  act(() => {
+    opening = result.current.showBackupModal()
+  })
+
+  expect(mockIpcRequest).toHaveBeenCalledWith('system.get_device_type')
+  expect(mockGetHostname).toHaveBeenCalledOnce()
+  expect(result.current.isModalVisible).toBe(false)
+
+  await act(async () => {
+    deviceType.resolve('mac')
+    hostname.resolve('workstation')
+    await opening
+  })
+
+  expect(result.current.isModalVisible).toBe(true)
+}
+
+describe('backup modal metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.api = {
+      ...window.api,
+      system: {
+        ...window.api.system,
+        getHostname: mockGetHostname
+      }
+    } as typeof window.api
+  })
+
+  it('starts S3 metadata requests together', async () => {
+    await expectMetadataRequestsToStartTogether(useS3BackupModal)
+  })
+
+  it('starts local metadata requests together', async () => {
+    await expectMetadataRequestsToStartTogether(() => useLocalBackupModal('/backups'))
+  })
+
+  it('starts WebDAV metadata requests together', async () => {
+    await expectMetadataRequestsToStartTogether(useWebdavBackupModal)
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

S3, local, and WebDAV backup dialogs waited for device type before requesting the hostname, adding two independent IPC round trips to the open path.

After this PR:

Each backup dialog starts both metadata requests together and still waits for both before setting the filename and opening.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Closes #18618

### Why we need it and why it was done in this way

The metadata requests are independent, so `Promise.all` bounds dialog-open latency by the slower request while preserving rejection and visibility behavior.

The following tradeoffs were made:

The same mechanical change remains local to each modal hook to keep the fix explicit and narrowly scoped.

The following alternatives were considered:

A shared filename-metadata helper was not added because there is no existing local pattern and it would be larger than the three request-pair edits.

Links to places where the discussion took place: #18618

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The first `pnpm build:check` run had one unrelated file-tree watcher timeout. The permitted rerun passed the complete gate.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Parallelize backup dialog metadata loading to reduce open latency for S3, local, and WebDAV backups.
```
