### PR TITLE
feat(perf-core): main-process performance instrumentation and Main Perf DevTools panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ YOUR_MEMORY_FILE_PATH
 .sessions/
 .devtools
 .omo/
+.superpowers/

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -49,6 +49,37 @@ Both dev and packaged runs write to the **app logs directory** (`~/Library/Logs/
 
 The `slow-*` thresholds are defined in one place — `SLOW_THRESHOLD_MS` in `src/main/core/diagnostics.ts`.
 
+## Main Perf panel
+
+Development builds also ship an interactive panel fed by the span kernel in `src/main/core/perf`.
+
+Open it from any renderer window's DevTools → the `Main Perf` tab. The panel is designed for DevTools' undocked window size, so undock into a separate window first.
+
+| Area | Contents |
+|---|---|
+| Overview | Whole-session thumbnail; drag to zoom a time range, double-click to reset |
+| Main area | Spans grouped by track: track row → same-name group row (count/avg/max) → instances. Shares its time axis with the memory chart below |
+| Memory | main-process rss / heapUsed, one sample every 2s |
+| Processes | `app.getAppMetrics()` CPU and memory for every process, refreshed on demand |
+
+Instrumenting code:
+
+```ts
+import { perf } from '@main/core/perf'
+
+const span = perf.start('knowledge.embed', { track: 'custom', detail: { chunk: 3 } })
+// …
+span.end({ vectors: 128 })
+```
+
+`track` is a fixed enum (`bootstrap` / `ipc` / `db` / `dataapi` / `window` / `custom`). Adding a lane means editing both `PerfTrack` in `src/main/core/perf/types.ts` and `TRACKS` in `resources/devtools/main-perf/panel.js`.
+
+Collection turns on when `NODE_ENV=development` or `CS_DIAGNOSTICS` is set. When off, `perf.start()` returns a shared frozen handle — it allocates nothing and never reads the clock. The panel and its websocket server (127.0.0.1:38998) are development-only.
+
+Every completed span is also written to the Node performance timeline, so attaching Chrome DevTools with `--inspect` and recording a Performance profile shows them in the Timings track.
+
+Grouping rule: the tree follows `parentId`, and within one parent's children, same-name siblings merge into a group row. A group holding a single instance collapses away — which is why `bootstrap`, whose span names are unique, reads as a plain gantt tree with no redundant layer, while `ipc` and `db` aggregate. Concurrent same-name spans are drawn as translucent overlapping bars on the group row (darker = more concurrency); expand the group to see each instance on its own row.
+
 ## Reading the CPU profile
 
 Written to `boot-whenReady.cpuprofile` in the app logs directory (next to `app.<date>.log`; `application.getPath('app.logs')`). Open in Chrome DevTools (Performance → Load profile) or VS Code's built-in `.cpuprofile` viewer. Sort by **self time** for true CPU attribution.

--- a/resources/devtools/main-perf/devtools.html
+++ b/resources/devtools/main-perf/devtools.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <script src="devtools.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/resources/devtools/main-perf/devtools.js
+++ b/resources/devtools/main-perf/devtools.js
@@ -1,0 +1,3 @@
+/* global chrome */
+
+chrome.devtools.panels.create('Main Perf', '', 'panel.html')

--- a/resources/devtools/main-perf/fixtures.js
+++ b/resources/devtools/main-perf/fixtures.js
@@ -1,0 +1,191 @@
+/**
+ * Deterministic demo data for developing the panel without a running main process.
+ * Used only when no PerfDevtoolsService websocket is reachable.
+ */
+
+;(function () {
+  const SESSION_MS = 40000
+  let nextId = 0
+
+  function mulberry32(seed) {
+    return function random() {
+      seed |= 0
+      seed = (seed + 0x6d2b79f5) | 0
+      let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
+
+  const rand = mulberry32(20260815)
+
+  function pick(list) {
+    return list[Math.floor(rand() * list.length)]
+  }
+
+  function span(track, name, startTime, duration, parentId, detail) {
+    return { id: `s${nextId++}`, name, track, parentId, startTime, duration, detail }
+  }
+
+  /** Startup: unique names, real nesting — exercises the collapse-to-tree path. */
+  function bootstrapSpans() {
+    const out = []
+    const boot = span('bootstrap', 'bootstrap', 0, 1284.3)
+    out.push(boot)
+
+    const background = span('bootstrap', 'phase:background', 2.1, 18.7, boot.id)
+    const before = span('bootstrap', 'phase:beforeReady', 21.0, 340.2, boot.id)
+    const when = span('bootstrap', 'phase:whenReady', 361.4, 922.8, boot.id)
+    out.push(background, before, when)
+
+    out.push(
+      span('bootstrap', 'DbService.init', 22.4, 298.1, before.id, { migrations: 3 }),
+      span('bootstrap', 'PreferenceService.init', 320.6, 12.4, before.id),
+      span('bootstrap', 'CacheService.init', 333.1, 7.1, before.id),
+      span('bootstrap', 'BootConfigService.init', 340.3, 2.0, before.id),
+      span('bootstrap', 'KnowledgeService.init', 363.0, 511.9, when.id, { indexes: 7 }),
+      span('bootstrap', 'MainWindowService.init', 875.2, 88.3, when.id),
+      span('bootstrap', 'ShortcutService.init', 963.6, 4.1, when.id),
+      span('bootstrap', 'TrayService.init', 967.8, 13.0, when.id),
+      span('bootstrap', 'MCPService.init', 980.9, 140.2, when.id, { servers: 4 }),
+      span('bootstrap', 'UpdateService.init', 1121.2, 8.4, when.id),
+      span('bootstrap', 'SchedulerService.init', 1129.7, 3.2, when.id)
+    )
+    return out
+  }
+
+  /** Runtime: repeated names, no parents — exercises the grouping path. */
+  function ipcSpans() {
+    const out = []
+    const channels = [
+      { name: 'window.minimize', n: 88, base: 0.3, jitter: 1.8 },
+      { name: 'window.setTitle', n: 64, base: 0.2, jitter: 0.9 },
+      { name: 'shell.openExternal', n: 12, base: 1.4, jitter: 7.0 },
+      { name: 'file.read', n: 52, base: 2.1, jitter: 9.0 },
+      { name: 'notification.show', n: 28, base: 0.8, jitter: 2.2 }
+    ]
+    for (const channel of channels) {
+      for (let i = 0; i < channel.n; i++) {
+        const at = 1500 + rand() * (SESSION_MS - 1500)
+        out.push(span('ipc', channel.name, at, channel.base + rand() * channel.jitter))
+      }
+    }
+    // One channel with a few slow outliers — the case the max column exists for.
+    for (const at of [18400, 25100, 32600]) {
+      out.push(span('ipc', 'file.select', at, at === 18400 ? 184.2 : at === 25100 ? 42.1 : 1.9, undefined, {
+        multi: at === 18400
+      }))
+    }
+    return out
+  }
+
+  /** Bursty and numerous — exercises the density strip. */
+  function dbSpans() {
+    const out = []
+    const statements = ['SELECT topics', 'SELECT messages', 'INSERT messages', 'UPDATE topics', 'SELECT blocks']
+    const bursts = [3000, 9500, 15000, 22000, 27500, 34000]
+    for (const burstAt of bursts) {
+      const size = 120 + Math.floor(rand() * 110)
+      for (let i = 0; i < size; i++) {
+        const at = burstAt + rand() * 2200
+        const slow = rand() > 0.985
+        out.push(span('db', pick(statements), at, slow ? 12 + rand() * 30 : 0.2 + rand() * 2.4))
+      }
+    }
+    for (let i = 0; i < 180; i++) {
+      out.push(span('db', pick(statements), 1500 + rand() * (SESSION_MS - 1500), 0.2 + rand() * 1.6))
+    }
+    return out
+  }
+
+  /** Deliberately overlapping — exercises the merged-bar concurrency rendering. */
+  function dataApiSpans() {
+    const out = []
+    const routes = ['GET /topics', 'GET /messages', 'POST /messages', 'GET /assistants']
+    for (let i = 0; i < 74; i++) {
+      out.push(span('dataapi', pick(routes), 1800 + rand() * (SESSION_MS - 1800), 1 + rand() * 14))
+    }
+    // Two concurrent clusters of the same route.
+    for (const cluster of [4200, 21000]) {
+      for (let i = 0; i < 4; i++) {
+        out.push(span('dataapi', 'GET /topics', cluster + i * 260, 30 + rand() * 38))
+      }
+    }
+    return out
+  }
+
+  function windowSpans() {
+    const out = []
+    const types = ['create:main', 'create:mini', 'create:selection']
+    for (let i = 0; i < 12; i++) {
+      out.push(span('window', pick(types), 2000 + rand() * (SESSION_MS - 2000), 18 + rand() * 110))
+    }
+    return out
+  }
+
+  /** Manual instrumentation with real parent/child nesting inside a repeated name. */
+  function customSpans() {
+    const out = []
+    for (let i = 0; i < 14; i++) {
+      const at = 12000 + i * 900 + rand() * 200
+      const parent = span('custom', 'knowledge.embed', at, 52 + rand() * 44, undefined, { chunk: i })
+      out.push(parent)
+      const children = 1 + Math.floor(rand() * 2)
+      for (let c = 0; c < children; c++) {
+        out.push(span('custom', 'vector.upsert', at + 6 + c * 18, 9 + rand() * 22, parent.id))
+      }
+    }
+    return out
+  }
+
+  function memorySamples() {
+    const out = []
+    let rss = 186 * 1024 * 1024
+    let heap = 78 * 1024 * 1024
+    for (let at = 0; at <= SESSION_MS; at += 2000) {
+      // Knowledge embedding window pushes both up noticeably.
+      const climbing = at >= 12000 && at <= 25000
+      rss += (climbing ? 14 : 4) * 1024 * 1024 * (0.6 + rand() * 0.8)
+      heap += (climbing ? 6 : 1.4) * 1024 * 1024 * (0.5 + rand())
+      if (at === 26000) heap -= 22 * 1024 * 1024 // a GC
+      out.push({
+        at,
+        rss: Math.round(rss),
+        heapUsed: Math.round(heap),
+        heapTotal: Math.round(heap * 1.35),
+        external: Math.round(18 * 1024 * 1024),
+        arrayBuffers: Math.round(6 * 1024 * 1024)
+      })
+    }
+    return out
+  }
+
+  function processes() {
+    return [
+      { pid: 4821, type: 'Browser', name: 'main', cpuPercent: 3.2, memoryKb: 412 * 1024 },
+      { pid: 4830, type: 'Tab', name: 'main window', cpuPercent: 11.8, memoryKb: 386 * 1024 },
+      { pid: 4844, type: 'Tab', name: 'mini window', cpuPercent: 0.6, memoryKb: 74 * 1024 },
+      { pid: 4826, type: 'GPU', name: undefined, cpuPercent: 1.1, memoryKb: 142 * 1024 },
+      { pid: 4851, type: 'Utility', name: 'network', cpuPercent: 0.4, memoryKb: 48 * 1024 },
+      { pid: 4863, type: 'Utility', name: 'storage', cpuPercent: 0.1, memoryKb: 22 * 1024 }
+    ]
+  }
+
+  window.PerfFixtures = {
+    build() {
+      nextId = 0
+      return {
+        spans: [
+          ...bootstrapSpans(),
+          ...ipcSpans(),
+          ...dbSpans(),
+          ...dataApiSpans(),
+          ...windowSpans(),
+          ...customSpans()
+        ],
+        memory: memorySamples(),
+        processes: processes()
+      }
+    }
+  }
+})()

--- a/resources/devtools/main-perf/manifest.json
+++ b/resources/devtools/main-perf/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Cherry Main Perf DevTools",
+  "version": "1.0.0",
+  "manifest_version": 3,
+  "devtools_page": "devtools.html",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; connect-src ws://127.0.0.1:38998"
+  }
+}

--- a/resources/devtools/main-perf/panel.css
+++ b/resources/devtools/main-perf/panel.css
@@ -307,7 +307,7 @@ body {
   background: rgb(var(--color-bar));
 }
 
-/* 分组行：半透明叠加，重叠处自然加深 —— 深浅即并发度 */
+/* Group rows: translucent bars overlay, so overlaps darken — depth of color is concurrency. */
 .bar.is-merged {
   background: rgba(var(--color-bar), 0.42);
 }
@@ -326,7 +326,7 @@ body {
   pointer-events: none;
 }
 
-/* track 折叠且 span 过多时的密度条 */
+/* Density strip for a collapsed track holding too many spans to draw individually. */
 .density {
   position: absolute;
   top: 6px;

--- a/resources/devtools/main-perf/panel.css
+++ b/resources/devtools/main-perf/panel.css
@@ -1,0 +1,514 @@
+:root {
+  color-scheme: light dark;
+  --color-bg: #ffffff;
+  --color-fg: #202124;
+  --color-toolbar-bg: #f1f3f4;
+  --color-panel-muted-bg: #f8f9fa;
+  --color-border: #dadce0;
+  --color-border-soft: #e8eaed;
+  --color-input-bg: #ffffff;
+  --color-button-bg: #f8f9fa;
+  --color-button-hover-bg: #eef1f4;
+  --color-muted: #5f6368;
+  --color-row-hover: #f1f3f4;
+  --color-row-selected: #d7e6fd;
+  --color-track-bg: #eef1f5;
+  --color-fast: #137333;
+  --color-slow: #b06000;
+  --color-bar: 26, 115, 232;
+  --color-bar-slow: #e8952f;
+  --color-rss: #1a73e8;
+  --color-heap: #9334e6;
+  --row-height: 20px;
+  --name-width: 240px;
+  --num-width: 58px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 12px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #111317;
+    --color-fg: #d8dce3;
+    --color-toolbar-bg: #181b21;
+    --color-panel-muted-bg: #0f1115;
+    --color-border: #2b3038;
+    --color-border-soft: #21262e;
+    --color-input-bg: #0f1115;
+    --color-button-bg: #222832;
+    --color-button-hover-bg: #2d3542;
+    --color-muted: #9aa3b2;
+    --color-row-hover: #1b212a;
+    --color-row-selected: #26344a;
+    --color-track-bg: #1a1f27;
+    --color-fast: #89d185;
+    --color-slow: #f0a05a;
+    --color-bar: 97, 160, 216;
+    --color-bar-slow: #d98a45;
+    --color-rss: #5aa9f0;
+    --color-heap: #c07ff0;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  height: 100vh;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr auto auto;
+  overflow: hidden;
+  background: var(--color-bg);
+  color: var(--color-fg);
+}
+
+/* ---------- toolbar ---------- */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  background: var(--color-toolbar-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.toolbar .spacer {
+  flex: 1;
+}
+
+.toolbar button {
+  background: var(--color-button-bg);
+  color: inherit;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 9px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.toolbar button:hover {
+  background: var(--color-button-hover-bg);
+}
+
+.toolbar button.toggle.is-on {
+  border-color: var(--color-rss);
+  color: var(--color-rss);
+}
+
+.toolbar input[type='search'] {
+  flex: 0 1 260px;
+  background: var(--color-input-bg);
+  color: inherit;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font: inherit;
+}
+
+.threshold {
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.threshold input {
+  width: 56px;
+  background: var(--color-input-bg);
+  color: inherit;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 5px;
+  font: inherit;
+}
+
+.count,
+.status {
+  color: var(--color-muted);
+  white-space: nowrap;
+}
+
+.status.is-connected {
+  color: var(--color-fast);
+}
+
+.status.is-error {
+  color: var(--color-slow);
+}
+
+/* ---------- overview ---------- */
+
+.overview {
+  position: relative;
+  height: 52px;
+  background: var(--color-panel-muted-bg);
+  border-bottom: 1px solid var(--color-border);
+  cursor: crosshair;
+  user-select: none;
+}
+
+.overview canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.overview .brush {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background: rgba(var(--color-bar), 0.16);
+  border-left: 2px solid rgb(var(--color-bar));
+  border-right: 2px solid rgb(var(--color-bar));
+  pointer-events: none;
+}
+
+.overview-hint {
+  position: absolute;
+  right: 8px;
+  bottom: 3px;
+  color: var(--color-muted);
+  font-size: 10px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+/* ---------- grid ---------- */
+
+.grid-head {
+  display: flex;
+  background: var(--color-panel-muted-bg);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.grid-head > div {
+  padding: 3px 8px;
+  border-right: 1px solid var(--color-border-soft);
+}
+
+.col-name {
+  width: var(--name-width);
+  flex: none;
+}
+
+.col-num {
+  width: var(--num-width);
+  flex: none;
+  text-align: right;
+}
+
+.col-track {
+  flex: 1;
+  position: relative;
+  border-right: none;
+  overflow: hidden;
+}
+
+.col-track .tick {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--color-border-soft);
+  padding-left: 3px;
+  text-transform: none;
+  white-space: nowrap;
+}
+
+.rows {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.row {
+  display: flex;
+  height: var(--row-height);
+  align-items: center;
+  border-bottom: 1px solid var(--color-border-soft);
+  cursor: default;
+  white-space: nowrap;
+}
+
+.row:hover {
+  background: var(--color-row-hover);
+}
+
+.row.is-selected {
+  background: var(--color-row-selected);
+}
+
+.row.is-track {
+  background: var(--color-track-bg);
+  font-weight: 500;
+}
+
+.row.is-track:hover {
+  background: var(--color-row-hover);
+}
+
+.cell-name {
+  width: var(--name-width);
+  flex: none;
+  padding-left: 8px;
+  border-right: 1px solid var(--color-border-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cell-num {
+  width: var(--num-width);
+  flex: none;
+  text-align: right;
+  padding-right: 8px;
+  border-right: 1px solid var(--color-border-soft);
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.cell-num.is-duration {
+  color: var(--color-fast);
+}
+
+.cell-num.is-slow {
+  color: var(--color-slow);
+}
+
+.cell-bars {
+  flex: 1;
+  position: relative;
+  height: 100%;
+  overflow: hidden;
+}
+
+.twisty {
+  display: inline-block;
+  width: 12px;
+  color: var(--color-muted);
+  cursor: pointer;
+}
+
+.twisty.is-leaf {
+  cursor: default;
+  opacity: 0;
+}
+
+.bar {
+  position: absolute;
+  top: 5px;
+  height: 10px;
+  min-width: 1px;
+  border-radius: 2px;
+  background: rgb(var(--color-bar));
+}
+
+/* 分组行：半透明叠加，重叠处自然加深 —— 深浅即并发度 */
+.bar.is-merged {
+  background: rgba(var(--color-bar), 0.42);
+}
+
+.bar.is-slow {
+  background: var(--color-bar-slow);
+}
+
+.bar-label {
+  position: absolute;
+  left: 4px;
+  top: -1px;
+  font-size: 9px;
+  line-height: 12px;
+  color: #10202f;
+  pointer-events: none;
+}
+
+/* track 折叠且 span 过多时的密度条 */
+.density {
+  position: absolute;
+  top: 6px;
+  height: 8px;
+  border-radius: 1px;
+  background: rgb(var(--color-bar));
+}
+
+.empty {
+  padding: 16px;
+  color: var(--color-muted);
+}
+
+/* ---------- memory ---------- */
+
+.memory {
+  display: flex;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-panel-muted-bg);
+}
+
+.memory-legend {
+  width: calc(var(--name-width) + var(--num-width) * 3);
+  flex: none;
+  border-right: 1px solid var(--color-border-soft);
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: var(--color-muted);
+  font-size: 10px;
+}
+
+.legend-title {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  margin-right: 4px;
+}
+
+.dot-rss {
+  background: var(--color-rss);
+}
+
+.dot-heap {
+  background: var(--color-heap);
+}
+
+.memory-chart {
+  flex: 1;
+  position: relative;
+  height: 72px;
+}
+
+.memory-chart canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.cursor {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--color-fg);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+/* ---------- bottom ---------- */
+
+.bottom {
+  display: flex;
+  height: 168px;
+  border-top: 1px solid var(--color-border);
+}
+
+.detail {
+  flex: 1.3;
+  border-right: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.processes {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.section-head {
+  padding: 3px 10px;
+  background: var(--color-panel-muted-bg);
+  border-bottom: 1px solid var(--color-border-soft);
+  color: var(--color-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.link {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  cursor: pointer;
+  font: inherit;
+  text-transform: none;
+}
+
+.link:hover {
+  color: var(--color-fg);
+}
+
+.detail-body {
+  padding: 8px 10px;
+  overflow: auto;
+  line-height: 1.7;
+  color: var(--color-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+.detail-body strong {
+  color: var(--color-fg);
+  font-weight: 500;
+}
+
+.detail-body .instances {
+  margin-top: 6px;
+  border-top: 1px solid var(--color-border-soft);
+  padding-top: 4px;
+}
+
+.detail-body .instance {
+  cursor: pointer;
+}
+
+.detail-body .instance:hover {
+  color: var(--color-fg);
+}
+
+.processes table {
+  width: 100%;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+}
+
+.processes th,
+.processes td {
+  text-align: left;
+  padding: 2px 10px;
+  border-bottom: 1px solid var(--color-border-soft);
+  font-weight: normal;
+}
+
+.processes th {
+  color: var(--color-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.processes .right {
+  text-align: right;
+}
+
+.processes td.cpu {
+  color: var(--color-heap);
+}
+
+.processes td.mem {
+  color: var(--color-rss);
+}

--- a/resources/devtools/main-perf/panel.html
+++ b/resources/devtools/main-perf/panel.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Main Perf</title>
+    <link rel="stylesheet" href="panel.css" />
+  </head>
+  <body>
+    <header class="toolbar">
+      <button id="live" type="button" class="toggle is-on">● Live</button>
+      <button id="clear" type="button">Clear</button>
+      <input id="filter" type="search" placeholder="Filter track or span name" />
+      <label class="threshold">
+        ≥
+        <input id="threshold" type="number" min="0" step="0.5" value="0" />
+        ms
+      </label>
+      <button id="reset-zoom" type="button" hidden>Reset zoom</button>
+      <span class="spacer"></span>
+      <span id="count" class="count">0 spans</span>
+      <span id="status" class="status">Connecting…</span>
+    </header>
+
+    <section class="overview" id="overview">
+      <canvas id="overview-canvas"></canvas>
+      <div class="brush" id="brush" hidden></div>
+      <div class="overview-hint">拖拽框选时间段 · 双击还原</div>
+    </section>
+
+    <div class="grid-head">
+      <div class="col-name">Track / Span</div>
+      <div class="col-num">count</div>
+      <div class="col-num">avg</div>
+      <div class="col-num">max</div>
+      <div class="col-track" id="ruler"></div>
+    </div>
+
+    <main class="rows" id="rows"></main>
+
+    <section class="memory">
+      <div class="memory-legend">
+        <span class="legend-title">Memory — main</span>
+        <span><i class="dot dot-rss"></i><span id="mem-rss">–</span></span>
+        <span><i class="dot dot-heap"></i><span id="mem-heap">–</span></span>
+      </div>
+      <div class="memory-chart" id="memory-chart">
+        <canvas id="memory-canvas"></canvas>
+        <div class="cursor" id="memory-cursor" hidden></div>
+      </div>
+    </section>
+
+    <footer class="bottom">
+      <section class="detail">
+        <div class="section-head">Detail</div>
+        <div id="detail" class="detail-body">Select a track, group, or span.</div>
+      </section>
+      <section class="processes">
+        <div class="section-head">
+          Processes
+          <button id="refresh-processes" type="button" class="link">↻ refresh</button>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>process</th>
+              <th class="right">cpu</th>
+              <th class="right">memory</th>
+            </tr>
+          </thead>
+          <tbody id="processes"></tbody>
+        </table>
+      </section>
+    </footer>
+
+    <script src="fixtures.js"></script>
+    <script src="panel.js"></script>
+  </body>
+</html>

--- a/resources/devtools/main-perf/panel.html
+++ b/resources/devtools/main-perf/panel.html
@@ -24,7 +24,7 @@
     <section class="overview" id="overview">
       <canvas id="overview-canvas"></canvas>
       <div class="brush" id="brush" hidden></div>
-      <div class="overview-hint">拖拽框选时间段 · 双击还原</div>
+      <div class="overview-hint">Drag to zoom a range · double-click to reset</div>
     </section>
 
     <div class="grid-head">

--- a/resources/devtools/main-perf/panel.js
+++ b/resources/devtools/main-perf/panel.js
@@ -1,0 +1,790 @@
+/* global chrome, PerfFixtures */
+
+const PERF_DEVTOOLS_PORT = 38998
+const RECONNECT_INTERVAL_MS = 1000
+/** A track with more spans than this draws a density strip instead of one bar each. */
+const DENSITY_MIN_SPANS = 400
+const DENSITY_BUCKETS = 240
+/** Instances listed under one group row before truncating. */
+const MAX_INSTANCE_ROWS = 200
+/** Total rows rendered in one pass — the backstop when many tracks are expanded at once. */
+const MAX_RENDERED_ROWS = 1200
+/** Spans at or above this duration render in the warning color. */
+const SLOW_MS = 50
+
+const TRACKS = [
+  { key: 'bootstrap', label: '⚡ Bootstrap' },
+  { key: 'ipc', label: '🔌 IPC' },
+  { key: 'db', label: '🗃 Database' },
+  { key: 'dataapi', label: '🌐 DataApi' },
+  { key: 'window', label: '🪟 Windows' },
+  { key: 'custom', label: '📌 Custom' }
+]
+
+const el = {
+  live: document.getElementById('live'),
+  clear: document.getElementById('clear'),
+  filter: document.getElementById('filter'),
+  threshold: document.getElementById('threshold'),
+  resetZoom: document.getElementById('reset-zoom'),
+  count: document.getElementById('count'),
+  status: document.getElementById('status'),
+  overview: document.getElementById('overview'),
+  overviewCanvas: document.getElementById('overview-canvas'),
+  brush: document.getElementById('brush'),
+  ruler: document.getElementById('ruler'),
+  rows: document.getElementById('rows'),
+  memoryChart: document.getElementById('memory-chart'),
+  memoryCanvas: document.getElementById('memory-canvas'),
+  memoryCursor: document.getElementById('memory-cursor'),
+  memRss: document.getElementById('mem-rss'),
+  memHeap: document.getElementById('mem-heap'),
+  detail: document.getElementById('detail'),
+  processes: document.getElementById('processes'),
+  refreshProcesses: document.getElementById('refresh-processes')
+}
+
+const store = { spans: [], memory: [], processes: [] }
+const ui = {
+  live: true,
+  filter: '',
+  threshold: 0,
+  expanded: new Set(['track:bootstrap']),
+  selected: null,
+  /** null = full extent */
+  domain: null
+}
+
+let socket = null
+let nodeIndex = new Map()
+
+/* ------------------------------------------------------------------ format */
+
+function formatMs(value) {
+  if (value === undefined || value === null) return '–'
+  if (value >= 1000) return `${(value / 1000).toFixed(2)}s`
+  if (value >= 100) return `${value.toFixed(0)}ms`
+  return `${value.toFixed(1)}ms`
+}
+
+function formatOffset(value) {
+  return `+${formatMs(value)}`
+}
+
+function formatBytes(bytes) {
+  if (!bytes) return '–'
+  const mb = bytes / (1024 * 1024)
+  return mb >= 1024 ? `${(mb / 1024).toFixed(2)} GB` : `${mb.toFixed(0)} MB`
+}
+
+/* -------------------------------------------------------------------- data */
+
+function trackLabel(key) {
+  const track = TRACKS.find((item) => item.key === key)
+  return track ? track.label : key
+}
+
+function stats(spans) {
+  if (spans.length === 0) return { count: 0, avg: 0, max: 0, total: 0 }
+  let total = 0
+  let max = 0
+  for (const span of spans) {
+    total += span.duration
+    if (span.duration > max) max = span.duration
+  }
+  return { count: spans.length, avg: total / spans.length, max, total }
+}
+
+function fullExtent() {
+  if (store.spans.length === 0) return { start: 0, end: 1 }
+  let start = Infinity
+  let end = -Infinity
+  for (const span of store.spans) {
+    if (span.startTime < start) start = span.startTime
+    if (span.startTime + span.duration > end) end = span.startTime + span.duration
+  }
+  for (const sample of store.memory) {
+    if (sample.at < start) start = sample.at
+    if (sample.at > end) end = sample.at
+  }
+  return end > start ? { start, end } : { start, end: start + 1 }
+}
+
+function domain() {
+  return ui.domain ?? fullExtent()
+}
+
+function visibleSpans() {
+  const query = ui.filter.trim().toLowerCase()
+  return store.spans.filter((span) => {
+    if (span.duration < ui.threshold) return false
+    if (!query) return true
+    return span.name.toLowerCase().includes(query) || trackLabel(span.track).toLowerCase().includes(query)
+  })
+}
+
+/**
+ * Group name-identical siblings, but only within the same parent scope. A group
+ * holding a single instance collapses away so a genuinely nested track (bootstrap)
+ * renders as a plain tree with no redundant layer.
+ */
+function buildGroups(siblings, childrenOf, scopeKey) {
+  const byName = new Map()
+  for (const span of siblings) {
+    const bucket = byName.get(span.name)
+    if (bucket) bucket.push(span)
+    else byName.set(span.name, [span])
+  }
+
+  const nodes = []
+  for (const [name, spans] of byName) {
+    if (spans.length === 1) {
+      nodes.push(instanceNode(spans[0], childrenOf))
+      continue
+    }
+    nodes.push({
+      kind: 'group',
+      key: `group:${scopeKey}:${name}`,
+      label: name,
+      spans,
+      stats: stats(spans),
+      children: spans.map((span) => instanceNode(span, childrenOf))
+    })
+  }
+  // Timeline order — keeps a genuinely nested track (bootstrap) reading as a gantt tree.
+  return nodes.sort((a, b) => a.spans[0].startTime - b.spans[0].startTime)
+}
+
+function instanceNode(span, childrenOf) {
+  const children = childrenOf(span.id)
+  return {
+    kind: 'instance',
+    key: span.id,
+    label: span.name,
+    span,
+    spans: [span],
+    stats: { count: 1, avg: span.duration, max: span.duration, total: span.duration },
+    children: children.length > 0 ? buildGroups(children, childrenOf, span.id) : []
+  }
+}
+
+function buildTree() {
+  const spans = visibleSpans()
+  const present = new Set(spans.map((span) => span.id))
+  const byParent = new Map()
+  const rootsByTrack = new Map()
+
+  for (const span of spans) {
+    // A span whose parent was filtered out is reparented to its track root.
+    if (span.parentId && present.has(span.parentId)) {
+      const bucket = byParent.get(span.parentId)
+      if (bucket) bucket.push(span)
+      else byParent.set(span.parentId, [span])
+    } else {
+      const bucket = rootsByTrack.get(span.track)
+      if (bucket) bucket.push(span)
+      else rootsByTrack.set(span.track, [span])
+    }
+  }
+
+  const childrenOf = (id) => byParent.get(id) ?? []
+  const spansByTrack = new Map()
+  for (const span of spans) {
+    const bucket = spansByTrack.get(span.track)
+    if (bucket) bucket.push(span)
+    else spansByTrack.set(span.track, [span])
+  }
+
+  return TRACKS.filter((track) => spansByTrack.has(track.key)).map((track) => {
+    const all = spansByTrack.get(track.key)
+    return {
+      kind: 'track',
+      key: `track:${track.key}`,
+      label: track.label,
+      track: track.key,
+      spans: all,
+      stats: stats(all),
+      children: buildGroups(rootsByTrack.get(track.key) ?? [], childrenOf, track.key)
+    }
+  })
+}
+
+/* ----------------------------------------------------------------- render */
+
+/**
+ * A filter narrows the set to what the user asked to see, so everything surviving it
+ * is expanded — otherwise matches stay hidden inside collapsed tracks and the filter
+ * looks broken.
+ */
+function isNarrowed() {
+  return ui.filter.trim() !== '' || ui.threshold > 0
+}
+
+function isExpanded(key) {
+  return isNarrowed() || ui.expanded.has(key)
+}
+
+function positionOf(value) {
+  const view = domain()
+  return ((value - view.start) / (view.end - view.start)) * 100
+}
+
+function renderRuler() {
+  const view = domain()
+  const span = view.end - view.start
+  el.ruler.textContent = ''
+  for (let i = 0; i <= 4; i++) {
+    const tick = document.createElement('span')
+    tick.className = 'tick'
+    tick.style.left = `${i * 20}%`
+    tick.textContent = formatMs(view.start + span * i * 0.2)
+    el.ruler.append(tick)
+  }
+}
+
+function densityBars(spans) {
+  const view = domain()
+  const width = (view.end - view.start) / DENSITY_BUCKETS
+  const buckets = new Array(DENSITY_BUCKETS).fill(0)
+  let peak = 0
+
+  for (const span of spans) {
+    const index = Math.floor((span.startTime - view.start) / width)
+    if (index < 0 || index >= DENSITY_BUCKETS) continue
+    buckets[index] += 1
+    if (buckets[index] > peak) peak = buckets[index]
+  }
+  if (peak === 0) return []
+
+  const nodes = []
+  for (let i = 0; i < DENSITY_BUCKETS; i++) {
+    if (buckets[i] === 0) continue
+    const bar = document.createElement('i')
+    bar.className = 'density'
+    bar.style.left = `${(i / DENSITY_BUCKETS) * 100}%`
+    bar.style.width = `${100 / DENSITY_BUCKETS}%`
+    bar.style.opacity = String(0.25 + 0.75 * (buckets[i] / peak))
+    nodes.push(bar)
+  }
+  return nodes
+}
+
+function spanBars(spans, merged) {
+  const view = domain()
+  const nodes = []
+  for (const span of spans) {
+    const left = positionOf(span.startTime)
+    const width = (span.duration / (view.end - view.start)) * 100
+    if (left > 100 || left + width < 0) continue
+
+    const bar = document.createElement('i')
+    bar.className = 'bar'
+    if (merged) bar.classList.add('is-merged')
+    if (span.duration >= SLOW_MS) bar.classList.add('is-slow')
+    bar.style.left = `${Math.max(0, left)}%`
+    bar.style.width = `${Math.max(0.15, Math.min(100 - Math.max(0, left), width))}%`
+    bar.title = `${span.name} · ${formatMs(span.duration)} @ ${formatOffset(span.startTime)}`
+
+    // Only label bars wide enough to hold text.
+    if (!merged && width > 12) {
+      const label = document.createElement('span')
+      label.className = 'bar-label'
+      label.textContent = `${span.name} · ${formatMs(span.duration)}`
+      bar.append(label)
+    }
+    nodes.push(bar)
+  }
+  return nodes
+}
+
+function renderRow(node, depth) {
+  const row = document.createElement('div')
+  row.className = 'row'
+  row.dataset.key = node.key
+  if (node.kind === 'track') row.classList.add('is-track')
+  if (ui.selected === node.key) row.classList.add('is-selected')
+
+  const name = document.createElement('div')
+  name.className = 'cell-name'
+  name.style.paddingLeft = `${8 + depth * 14}px`
+
+  const twisty = document.createElement('span')
+  twisty.className = 'twisty'
+  const expandable = node.children.length > 0
+  if (expandable) {
+    twisty.textContent = isExpanded(node.key) ? '▾' : '▸'
+    twisty.addEventListener('click', (event) => {
+      event.stopPropagation()
+      toggleExpanded(node.key)
+    })
+  } else {
+    twisty.classList.add('is-leaf')
+    twisty.textContent = '·'
+  }
+  name.append(twisty, document.createTextNode(node.label))
+
+  const count = document.createElement('div')
+  count.className = 'cell-num'
+  count.textContent = node.kind === 'instance' ? '' : String(node.stats.count)
+
+  const avg = document.createElement('div')
+  avg.className = 'cell-num'
+  avg.textContent = node.kind === 'instance' ? '' : formatMs(node.stats.avg)
+
+  const max = document.createElement('div')
+  max.className = 'cell-num is-duration'
+  if (node.stats.max >= SLOW_MS) max.classList.add('is-slow')
+  max.textContent = formatMs(node.stats.max)
+
+  const bars = document.createElement('div')
+  bars.className = 'cell-bars'
+  if (node.kind === 'instance') {
+    bars.append(...spanBars(node.spans, false))
+  } else if (node.spans.length > DENSITY_MIN_SPANS) {
+    bars.append(...densityBars(node.spans))
+  } else {
+    bars.append(...spanBars(node.spans, true))
+  }
+
+  row.append(name, count, avg, max, bars)
+  row.addEventListener('click', () => select(node.key))
+  return row
+}
+
+function flatten(nodes, depth, out) {
+  for (const node of nodes) {
+    out.push({ node, depth })
+    if (!isExpanded(node.key)) continue
+
+    if (node.kind === 'group' && node.children.length > MAX_INSTANCE_ROWS) {
+      for (const child of node.children.slice(0, MAX_INSTANCE_ROWS)) out.push({ node: child, depth: depth + 1 })
+      out.push({ truncated: node.children.length - MAX_INSTANCE_ROWS, depth: depth + 1 })
+      continue
+    }
+    flatten(node.children, depth + 1, out)
+  }
+  return out
+}
+
+function renderRows() {
+  const tree = buildTree()
+  nodeIndex = new Map()
+  indexNodes(tree)
+
+  const fragment = document.createDocumentFragment()
+  const all = flatten(tree, 0, [])
+  const flat = all.slice(0, MAX_RENDERED_ROWS)
+  const hiddenRows = all.length - flat.length
+
+  if (flat.length === 0) {
+    const empty = document.createElement('div')
+    empty.className = 'empty'
+    empty.textContent = store.spans.length === 0 ? 'No spans recorded yet.' : 'No spans match the current filter.'
+    fragment.append(empty)
+  }
+
+  for (const entry of flat) {
+    if (entry.truncated) {
+      const row = document.createElement('div')
+      row.className = 'row'
+      const name = document.createElement('div')
+      name.className = 'cell-name'
+      name.style.paddingLeft = `${8 + entry.depth * 14}px`
+      name.style.opacity = '0.6'
+      name.textContent = `⋮ ${entry.truncated} more`
+      row.append(name)
+      fragment.append(row)
+      continue
+    }
+    fragment.append(renderRow(entry.node, entry.depth))
+  }
+
+  if (hiddenRows > 0) {
+    const notice = document.createElement('div')
+    notice.className = 'empty'
+    notice.textContent = `⋮ ${hiddenRows} more rows hidden — collapse a track or narrow the filter`
+    fragment.append(notice)
+  }
+
+  el.rows.textContent = ''
+  el.rows.append(fragment)
+  el.count.textContent = `${store.spans.length} spans · ${tree.length} tracks`
+}
+
+function indexNodes(nodes) {
+  for (const node of nodes) {
+    nodeIndex.set(node.key, node)
+    indexNodes(node.children)
+  }
+}
+
+/* --------------------------------------------------------------- canvases */
+
+function sizeCanvas(canvas) {
+  const ratio = window.devicePixelRatio || 1
+  const rect = canvas.getBoundingClientRect()
+  canvas.width = Math.max(1, Math.round(rect.width * ratio))
+  canvas.height = Math.max(1, Math.round(rect.height * ratio))
+  const context = canvas.getContext('2d')
+  context.setTransform(ratio, 0, 0, ratio, 0, 0)
+  return { context, width: rect.width, height: rect.height }
+}
+
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+}
+
+function renderOverview() {
+  const { context, width, height } = sizeCanvas(el.overviewCanvas)
+  context.clearRect(0, 0, width, height)
+  if (store.spans.length === 0) return
+
+  const extent = fullExtent()
+  const scale = (value) => ((value - extent.start) / (extent.end - extent.start)) * width
+  const tracks = TRACKS.filter((track) => store.spans.some((span) => span.track === track.key))
+  const laneHeight = 4
+  const gap = 2
+  const top = 4
+
+  context.fillStyle = `rgba(${cssVar('--color-bar')}, 0.75)`
+  tracks.forEach((track, index) => {
+    const y = top + index * (laneHeight + gap)
+    for (const span of store.spans) {
+      if (span.track !== track.key) continue
+      const x = scale(span.startTime)
+      const w = Math.max(1, (span.duration / (extent.end - extent.start)) * width)
+      context.fillRect(x, y, w, laneHeight)
+    }
+  })
+
+  if (store.memory.length > 1) {
+    const peak = Math.max(...store.memory.map((sample) => sample.rss))
+    context.strokeStyle = cssVar('--color-rss')
+    context.lineWidth = 1.2
+    context.globalAlpha = 0.85
+    context.beginPath()
+    store.memory.forEach((sample, index) => {
+      const x = scale(sample.at)
+      const y = height - (sample.rss / peak) * (height - 6) - 2
+      if (index === 0) context.moveTo(x, y)
+      else context.lineTo(x, y)
+    })
+    context.stroke()
+    context.globalAlpha = 1
+  }
+
+  if (ui.domain) {
+    el.brush.hidden = false
+    const left = ((ui.domain.start - extent.start) / (extent.end - extent.start)) * 100
+    const right = ((ui.domain.end - extent.start) / (extent.end - extent.start)) * 100
+    el.brush.style.left = `${left}%`
+    el.brush.style.width = `${Math.max(0.5, right - left)}%`
+  } else {
+    el.brush.hidden = true
+  }
+  el.resetZoom.hidden = !ui.domain
+}
+
+function renderMemory() {
+  const { context, width, height } = sizeCanvas(el.memoryCanvas)
+  context.clearRect(0, 0, width, height)
+
+  const latest = store.memory[store.memory.length - 1]
+  el.memRss.textContent = latest ? `rss ${formatBytes(latest.rss)}` : 'rss –'
+  el.memHeap.textContent = latest ? `heapUsed ${formatBytes(latest.heapUsed)}` : 'heapUsed –'
+  if (store.memory.length < 2) return
+
+  const view = domain()
+  const peak = Math.max(...store.memory.map((sample) => sample.rss)) * 1.05
+  const line = (key, color) => {
+    context.strokeStyle = color
+    context.lineWidth = 1.5
+    context.beginPath()
+    let started = false
+    for (const sample of store.memory) {
+      const x = ((sample.at - view.start) / (view.end - view.start)) * width
+      const y = height - (sample[key] / peak) * (height - 8) - 4
+      if (!started) {
+        context.moveTo(x, y)
+        started = true
+      } else {
+        context.lineTo(x, y)
+      }
+    }
+    context.stroke()
+  }
+
+  line('rss', cssVar('--color-rss'))
+  line('heapUsed', cssVar('--color-heap'))
+}
+
+function renderProcesses() {
+  el.processes.textContent = ''
+  for (const process of store.processes) {
+    const row = document.createElement('tr')
+    const name = document.createElement('td')
+    name.textContent = process.name ? `${process.type} · ${process.name}` : process.type
+    const cpu = document.createElement('td')
+    cpu.className = 'right cpu'
+    cpu.textContent = `${process.cpuPercent.toFixed(1)}%`
+    const memory = document.createElement('td')
+    memory.className = 'right mem'
+    memory.textContent = formatBytes(process.memoryKb * 1024)
+    row.append(name, cpu, memory)
+    el.processes.append(row)
+  }
+}
+
+/* ----------------------------------------------------------------- detail */
+
+function renderDetail() {
+  const node = ui.selected ? nodeIndex.get(ui.selected) : null
+  if (!node) {
+    el.detail.textContent = 'Select a track, group, or span.'
+    return
+  }
+
+  el.detail.textContent = ''
+  const line = (html) => {
+    const div = document.createElement('div')
+    div.innerHTML = html
+    el.detail.append(div)
+    return div
+  }
+
+  if (node.kind === 'instance') {
+    const span = node.span
+    line(`<strong>${span.name}</strong> &nbsp;<span>${trackLabel(span.track)}</span>`)
+    line(`id <strong>${span.id}</strong>`)
+    line(`duration <strong>${formatMs(span.duration)}</strong> &nbsp; start <strong>${formatOffset(span.startTime)}</strong>`)
+    line(`parent <strong>${span.parentId ?? '—'}</strong> &nbsp; children <strong>${node.children.length}</strong>`)
+    if (span.detail) line(`detail <strong>${escapeHtml(JSON.stringify(span.detail))}</strong>`)
+    return
+  }
+
+  line(`<strong>${node.label}</strong>`)
+  line(
+    `count <strong>${node.stats.count}</strong> &nbsp; avg <strong>${formatMs(node.stats.avg)}</strong>` +
+      ` &nbsp; max <strong>${formatMs(node.stats.max)}</strong> &nbsp; total <strong>${formatMs(node.stats.total)}</strong>`
+  )
+
+  const list = document.createElement('div')
+  list.className = 'instances'
+  const sorted = [...node.spans].sort((a, b) => b.duration - a.duration).slice(0, 12)
+  for (const span of sorted) {
+    const item = document.createElement('div')
+    item.className = 'instance'
+    item.innerHTML =
+      `<strong>${formatMs(span.duration)}</strong> @ ${formatOffset(span.startTime)} · ${escapeHtml(span.name)}` +
+      (span.detail ? ` · ${escapeHtml(JSON.stringify(span.detail))}` : '')
+    item.addEventListener('click', () => select(span.id))
+    list.append(item)
+  }
+  if (node.spans.length > sorted.length) {
+    const more = document.createElement('div')
+    more.textContent = `⋮ ${node.spans.length - sorted.length} more instances`
+    more.style.opacity = '0.6'
+    list.append(more)
+  }
+  el.detail.append(list)
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>"]/g, (char) => `&#${char.charCodeAt(0)};`)
+}
+
+/* ------------------------------------------------------------ interaction */
+
+function render() {
+  renderRuler()
+  renderRows()
+  renderOverview()
+  renderMemory()
+  renderProcesses()
+  renderDetail()
+}
+
+function toggleExpanded(key) {
+  if (ui.expanded.has(key)) ui.expanded.delete(key)
+  else ui.expanded.add(key)
+  renderRows()
+}
+
+function select(key) {
+  ui.selected = key
+  for (const row of el.rows.querySelectorAll('.row')) {
+    row.classList.toggle('is-selected', row.dataset.key === key)
+  }
+  renderDetail()
+}
+
+function setStatus(text, className = '') {
+  el.status.textContent = text
+  el.status.className = `status ${className}`.trim()
+}
+
+el.filter.addEventListener('input', () => {
+  ui.filter = el.filter.value
+  renderRows()
+})
+
+el.threshold.addEventListener('input', () => {
+  ui.threshold = Number(el.threshold.value) || 0
+  renderRows()
+})
+
+el.clear.addEventListener('click', () => {
+  send({ type: 'clear' })
+  store.spans = []
+  ui.selected = null
+  ui.domain = null
+  render()
+})
+
+el.live.addEventListener('click', () => {
+  ui.live = !ui.live
+  el.live.classList.toggle('is-on', ui.live)
+  el.live.textContent = ui.live ? '● Live' : '⏸ Paused'
+})
+
+el.resetZoom.addEventListener('click', () => {
+  ui.domain = null
+  render()
+})
+
+el.refreshProcesses.addEventListener('click', () => send({ type: 'metrics' }))
+
+// Overview brush.
+let brushStart = null
+function overviewRatio(event) {
+  const rect = el.overview.getBoundingClientRect()
+  return Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width))
+}
+el.overview.addEventListener('mousedown', (event) => {
+  brushStart = overviewRatio(event)
+})
+el.overview.addEventListener('mousemove', (event) => {
+  if (brushStart === null) return
+  const current = overviewRatio(event)
+  const left = Math.min(brushStart, current)
+  const right = Math.max(brushStart, current)
+  el.brush.hidden = false
+  el.brush.style.left = `${left * 100}%`
+  el.brush.style.width = `${(right - left) * 100}%`
+})
+el.overview.addEventListener('mouseup', (event) => {
+  if (brushStart === null) return
+  const current = overviewRatio(event)
+  const left = Math.min(brushStart, current)
+  const right = Math.max(brushStart, current)
+  brushStart = null
+  if (right - left < 0.005) return
+  const extent = fullExtent()
+  const size = extent.end - extent.start
+  ui.domain = { start: extent.start + left * size, end: extent.start + right * size }
+  render()
+})
+el.overview.addEventListener('dblclick', () => {
+  ui.domain = null
+  render()
+})
+
+// Time cursor shared between the span area and the memory chart.
+function syncCursor(event) {
+  const bars = el.rows.querySelector('.cell-bars') ?? el.memoryChart
+  const rect = bars.getBoundingClientRect()
+  const x = event.clientX - rect.left
+  if (x < 0 || x > rect.width) {
+    el.memoryCursor.hidden = true
+    return
+  }
+  el.memoryCursor.hidden = false
+  el.memoryCursor.style.left = `${x}px`
+}
+el.rows.addEventListener('mousemove', syncCursor)
+el.memoryChart.addEventListener('mousemove', syncCursor)
+el.rows.addEventListener('mouseleave', () => {
+  el.memoryCursor.hidden = true
+})
+
+window.addEventListener('resize', () => {
+  renderOverview()
+  renderMemory()
+})
+
+/* ------------------------------------------------------------- connection */
+
+function send(message) {
+  if (socket && socket.readyState === 1) socket.send(JSON.stringify(message))
+}
+
+function applyMessage(message) {
+  switch (message.type) {
+    case 'snapshot':
+      store.spans = message.spans ?? []
+      store.memory = message.memory ?? []
+      store.processes = message.processes ?? store.processes
+      render()
+      break
+    case 'span':
+      if (!ui.live) return
+      store.spans.push(message.span)
+      renderRows()
+      renderOverview()
+      break
+    case 'memory':
+      if (!ui.live) return
+      store.memory.push(message.sample)
+      renderMemory()
+      renderOverview()
+      break
+    case 'metrics':
+      store.processes = message.processes ?? []
+      renderProcesses()
+      break
+    case 'cleared':
+      store.spans = []
+      render()
+      break
+    default:
+      break
+  }
+}
+
+function connect() {
+  setStatus('Connecting…')
+  socket = new WebSocket(`ws://127.0.0.1:${PERF_DEVTOOLS_PORT}`)
+
+  socket.addEventListener('open', () => setStatus('connected', 'is-connected'))
+  socket.addEventListener('message', (event) => {
+    try {
+      applyMessage(JSON.parse(event.data))
+    } catch {
+      // Ignore malformed frames.
+    }
+  })
+  socket.addEventListener('close', () => {
+    socket = null
+    setStatus('disconnected — retrying', 'is-error')
+    setTimeout(connect, RECONNECT_INTERVAL_MS)
+  })
+  socket.addEventListener('error', () => socket?.close())
+}
+
+function loadDemoData() {
+  const data = PerfFixtures.build()
+  store.spans = data.spans
+  store.memory = data.memory
+  store.processes = data.processes
+  setStatus('demo data (no monitor)', '')
+  render()
+}
+
+// Outside DevTools (a plain browser tab) there is no monitor to reach — show the
+// fixtures instead so the panel can be developed and reviewed standalone.
+if (typeof chrome === 'undefined' || !chrome.devtools) {
+  loadDemoData()
+} else {
+  renderProcesses()
+  connect()
+}

--- a/src/main/core/README.md
+++ b/src/main/core/README.md
@@ -50,4 +50,5 @@ no longer imported anywhere. It will be removed in a follow-up cleanup PR.
 | `lifecycle/` | IoC container, service lifecycle management, phased bootstrap | [Lifecycle Reference](../../../docs/references/lifecycle/README.md) |
 | `logger/` | Winston-based logging service (preboot singleton, consumed via `@logger` alias) | [logging.md](../../../docs/guides/logging.md) |
 | `paths/` | Path registry: single source of truth for all main-process filesystem paths | [paths/README.md](./paths/README.md) |
+| `perf/` | Span instrumentation kernel and memory sampling: `perf.start()`, ring buffer, perf_hooks timeline, `onSpan` | [diagnostics.md](../../../docs/guides/diagnostics.md) |
 | `preboot/` | Pre-bootstrap synchronous setup (userData resolution, etc.) | [preboot/README.md](./preboot/README.md) |

--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -39,6 +39,7 @@ import { MainWindowService } from '@main/services/MainWindowService'
 import { OAuthRuntimeService } from '@main/services/oauth/runtime/OAuthRuntimeService'
 import { OpenClawService } from '@main/services/OpenClawService'
 import { OvmsManager } from '@main/services/OvmsManager'
+import { PerfDevtoolsService } from '@main/services/perfDevtools'
 import { ProtocolService } from '@main/services/protocol/ProtocolService'
 import { ProxyService } from '@main/services/proxy/ProxyService'
 import { PythonService } from '@main/services/PythonService'
@@ -77,6 +78,7 @@ import { WebviewService } from '@main/services/WebviewService'
  */
 export const services = {
   MainNetworkDevtoolsService,
+  PerfDevtoolsService,
   WindowManager,
   DbService,
   CacheService,

--- a/src/main/core/lifecycle/BaseService.ts
+++ b/src/main/core/lifecycle/BaseService.ts
@@ -8,22 +8,23 @@ import { type ErrorStrategy, isActivatable, isPausable, LifecycleState, type Ser
 
 const logger = loggerService.withContext('Lifecycle')
 
-/**
- * Abstract base class for all lifecycle-managed services
- * Provides lifecycle hooks and state management.
- * All services are singletons - attempting to instantiate twice will throw an error.
- */
 export type InitPhaseName = 'onInit' | 'onReady'
 
 /**
- * 由 LifecycleManager 注入的初始化阶段计时钩子：给定阶段名，返回一个结束函数。
- * 用回调而非直接依赖 `@main/core/perf`，是为了让 BaseService 不背上基础设施
- * 依赖 —— 它是几乎所有服务测试的基类，多一个静态 import 就会打穿大量 partial mock。
+ * Init-phase timing hook injected by LifecycleManager: given a phase name, returns its ender.
+ * A callback rather than a direct `@main/core/perf` dependency keeps BaseService free of
+ * infrastructure imports — it is the base class of nearly every service test, and one more
+ * static import breaks a great many partial mocks.
  */
 export type InitPhaseMeasure = (name: InitPhaseName) => () => void
 
 const noopMeasure: InitPhaseMeasure = () => () => {}
 
+/**
+ * Abstract base class for all lifecycle-managed services
+ * Provides lifecycle hooks and state management.
+ * All services are singletons - attempting to instantiate twice will throw an error.
+ */
 export abstract class BaseService {
   /** Track instantiated service classes to prevent duplicate instantiation */
   private static instances = new WeakSet<object>()
@@ -290,8 +291,12 @@ export abstract class BaseService {
     await this.runInitPhase('onReady', () => this.onReady(), measure)
   }
 
-  /** 计时在 finally 里收口，失败的启动同样留下它的耗时。 */
-  private async runInitPhase(name: InitPhaseName, run: () => Promise<void>, measure: InitPhaseMeasure): Promise<void> {
+  /** The ender runs in `finally`, so a failed startup still records what it cost. */
+  private async runInitPhase(
+    name: InitPhaseName,
+    run: () => Promise<void> | void,
+    measure: InitPhaseMeasure
+  ): Promise<void> {
     const end = measure(name)
     try {
       await run()

--- a/src/main/core/lifecycle/BaseService.ts
+++ b/src/main/core/lifecycle/BaseService.ts
@@ -13,6 +13,17 @@ const logger = loggerService.withContext('Lifecycle')
  * Provides lifecycle hooks and state management.
  * All services are singletons - attempting to instantiate twice will throw an error.
  */
+export type InitPhaseName = 'onInit' | 'onReady'
+
+/**
+ * 由 LifecycleManager 注入的初始化阶段计时钩子：给定阶段名，返回一个结束函数。
+ * 用回调而非直接依赖 `@main/core/perf`，是为了让 BaseService 不背上基础设施
+ * 依赖 —— 它是几乎所有服务测试的基类，多一个静态 import 就会打穿大量 partial mock。
+ */
+export type InitPhaseMeasure = (name: InitPhaseName) => () => void
+
+const noopMeasure: InitPhaseMeasure = () => () => {}
+
 export abstract class BaseService {
   /** Track instantiated service classes to prevent duplicate instantiation */
   private static instances = new WeakSet<object>()
@@ -258,15 +269,15 @@ export abstract class BaseService {
    * Internal method to execute initialization
    * Called by LifecycleManager
    */
-  public async _doInit(): Promise<void> {
+  public async _doInit(measure: InitPhaseMeasure = noopMeasure): Promise<void> {
     if (DIAGNOSTICS_ENABLED) {
       const name = getServiceName(this.constructor as ServiceConstructor)
       const t0 = performance.now()
       this._state = LifecycleState.Initializing
-      await this.onInit()
+      await this.runInitPhase('onInit', () => this.onInit(), measure)
       const t1 = performance.now()
       this._state = LifecycleState.Ready
-      await this.onReady()
+      await this.runInitPhase('onReady', () => this.onReady(), measure)
       const t2 = performance.now()
       logger.info(
         `[Diagnostics/_doInit] ${name}  onInit=${(t1 - t0).toFixed(1)}ms  onReady=${(t2 - t1).toFixed(1)}ms  total=${(t2 - t0).toFixed(1)}ms`
@@ -274,9 +285,19 @@ export abstract class BaseService {
       return
     }
     this._state = LifecycleState.Initializing
-    await this.onInit()
+    await this.runInitPhase('onInit', () => this.onInit(), measure)
     this._state = LifecycleState.Ready
-    await this.onReady()
+    await this.runInitPhase('onReady', () => this.onReady(), measure)
+  }
+
+  /** 计时在 finally 里收口，失败的启动同样留下它的耗时。 */
+  private async runInitPhase(name: InitPhaseName, run: () => Promise<void>, measure: InitPhaseMeasure): Promise<void> {
+    const end = measure(name)
+    try {
+      await run()
+    } finally {
+      end()
+    }
   }
 
   /**

--- a/src/main/core/lifecycle/LifecycleManager.ts
+++ b/src/main/core/lifecycle/LifecycleManager.ts
@@ -100,7 +100,7 @@ export class LifecycleManager extends EventEmitter {
   private phaseEpoch = 0
   private serviceSpans: Map<string, ServiceSpan> = new Map()
 
-  /** perf 埋点：bootstrap 泳道的根与各阶段 span，服务 span 挂在对应阶段下。 */
+  /** perf instrumentation: the bootstrap lane root and per-phase spans; service spans hang off their phase. */
   private bootstrapSpan: PerfSpanHandle | null = null
   private readonly phaseSpans = new Map<Phase, PerfSpanHandle>()
 
@@ -175,7 +175,7 @@ export class LifecycleManager extends EventEmitter {
 
     const phaseStart = performance.now()
     this.phaseEpoch = phaseStart
-    // 根 span 在第一个阶段开始时建立，最后一个阶段结束时收口。
+    // The root span opens with the first phase and closes when the last one completes.
     this.bootstrapSpan ??= perf.start('bootstrap', { track: 'bootstrap' })
     this.phaseSpans.set(phase, perf.start(`phase:${phase}`, { track: 'bootstrap', parent: this.bootstrapSpan }))
     const lagSampler = DIAGNOSTICS_ENABLED ? new EventLoopLagSampler() : null

--- a/src/main/core/lifecycle/LifecycleManager.ts
+++ b/src/main/core/lifecycle/LifecycleManager.ts
@@ -8,6 +8,7 @@ import {
   formatPhaseProfile,
   type ServiceSpan
 } from '@main/core/diagnostics'
+import { perf, type PerfSpanHandle } from '@main/core/perf'
 
 import { SERVICE_STOP_TIMEOUT_MS } from './constants'
 import { DependencyResolver, type PhaseAdjustment } from './DependencyResolver'
@@ -99,6 +100,10 @@ export class LifecycleManager extends EventEmitter {
   private phaseEpoch = 0
   private serviceSpans: Map<string, ServiceSpan> = new Map()
 
+  /** perf 埋点：bootstrap 泳道的根与各阶段 span，服务 span 挂在对应阶段下。 */
+  private bootstrapSpan: PerfSpanHandle | null = null
+  private readonly phaseSpans = new Map<Phase, PerfSpanHandle>()
+
   /** Tracks services that were paused due to cascade from another service */
   private pausedByCascade: Map<string, Set<string>> = new Map()
   /** Tracks services that were stopped due to cascade from another service */
@@ -170,6 +175,9 @@ export class LifecycleManager extends EventEmitter {
 
     const phaseStart = performance.now()
     this.phaseEpoch = phaseStart
+    // 根 span 在第一个阶段开始时建立，最后一个阶段结束时收口。
+    this.bootstrapSpan ??= perf.start('bootstrap', { track: 'bootstrap' })
+    this.phaseSpans.set(phase, perf.start(`phase:${phase}`, { track: 'bootstrap', parent: this.bootstrapSpan }))
     const lagSampler = DIAGNOSTICS_ENABLED ? new EventLoopLagSampler() : null
     lagSampler?.start(phaseStart)
     const cpuProfiler = DIAGNOSTICS_ENABLED && phase === Phase.WhenReady ? new CpuProfiler() : null
@@ -193,6 +201,12 @@ export class LifecycleManager extends EventEmitter {
     // Track overall initialization order
     for (const layer of layers) {
       this.initializationOrder.push(...layer)
+    }
+
+    this.phaseSpans.get(phase)?.end({ serviceCount })
+    if (phase === Phase.WhenReady) {
+      this.bootstrapSpan?.end()
+      this.bootstrapSpan = null
     }
 
     const phaseDuration = performance.now() - phaseStart
@@ -312,7 +326,18 @@ export class LifecycleManager extends EventEmitter {
 
       // Call initialization with timing
       const start = performance.now()
-      await instance._doInit()
+      const serviceSpan = perf.start(serviceName, {
+        track: 'bootstrap',
+        parent: this.phaseSpans.get(this.servicePhase.get(serviceName) as Phase)
+      })
+      try {
+        await instance._doInit((name) => {
+          const phaseSpan = perf.start(name, { track: 'bootstrap', parent: serviceSpan })
+          return () => phaseSpan.end()
+        })
+      } finally {
+        serviceSpan.end()
+      }
       const duration = performance.now() - start
       this.serviceTiming.set(serviceName, duration)
       if (DIAGNOSTICS_ENABLED) {

--- a/src/main/core/lifecycle/__tests__/perfIntegration.test.ts
+++ b/src/main/core/lifecycle/__tests__/perfIntegration.test.ts
@@ -1,5 +1,5 @@
 import { BaseService, type InitPhaseMeasure } from '@main/core/lifecycle'
-import { PerfRecorder } from '@main/core/perf'
+import { PerfRecorder, type PerfSpanHandle } from '@main/core/perf'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 class SampleService extends BaseService {
@@ -16,10 +16,11 @@ class FailingService extends BaseService {
 type Initable = { _doInit(measure?: InitPhaseMeasure): Promise<void> }
 
 /**
- * LifecycleManager 注入的那个钩子的等价物 —— 这里直接用真 recorder，
- * 断言的是「服务的 onInit / onReady 会成为服务 span 的子节点」这个契约。
+ * The equivalent of the hook LifecycleManager injects, wired to a real recorder so the
+ * assertion is on the contract itself: a service's onInit / onReady become children of
+ * that service's span.
  */
-function spanMeasure(recorder: PerfRecorder, parent: { id: string }): InitPhaseMeasure {
+function spanMeasure(recorder: PerfRecorder, parent: PerfSpanHandle): InitPhaseMeasure {
   return (name) => {
     const span = recorder.start(name, { track: 'bootstrap', parent })
     return () => span.end()

--- a/src/main/core/lifecycle/__tests__/perfIntegration.test.ts
+++ b/src/main/core/lifecycle/__tests__/perfIntegration.test.ts
@@ -1,0 +1,91 @@
+import { BaseService, type InitPhaseMeasure } from '@main/core/lifecycle'
+import { PerfRecorder } from '@main/core/perf'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+class SampleService extends BaseService {
+  protected async onInit(): Promise<void> {}
+  protected async onReady(): Promise<void> {}
+}
+
+class FailingService extends BaseService {
+  protected async onInit(): Promise<void> {
+    throw new Error('boom')
+  }
+}
+
+type Initable = { _doInit(measure?: InitPhaseMeasure): Promise<void> }
+
+/**
+ * LifecycleManager 注入的那个钩子的等价物 —— 这里直接用真 recorder，
+ * 断言的是「服务的 onInit / onReady 会成为服务 span 的子节点」这个契约。
+ */
+function spanMeasure(recorder: PerfRecorder, parent: { id: string }): InitPhaseMeasure {
+  return (name) => {
+    const span = recorder.start(name, { track: 'bootstrap', parent })
+    return () => span.end()
+  }
+}
+
+function tickingRecorder() {
+  let time = 0
+  return new PerfRecorder({ enabled: true, now: () => (time += 5) })
+}
+
+describe('BaseService init phase measurement', () => {
+  beforeEach(() => BaseService.resetInstances())
+  afterEach(() => BaseService.resetInstances())
+
+  it('measures onInit and onReady in order', async () => {
+    const seen: string[] = []
+    const service = new SampleService()
+
+    await (service as unknown as Initable)._doInit((name) => {
+      seen.push(`start:${name}`)
+      return () => seen.push(`end:${name}`)
+    })
+
+    expect(seen).toEqual(['start:onInit', 'end:onInit', 'start:onReady', 'end:onReady'])
+  })
+
+  it('needs no hook at all — an un-instrumented _doInit() still runs both phases', async () => {
+    const service = new SampleService()
+    await expect((service as unknown as Initable)._doInit()).resolves.toBeUndefined()
+    expect(service.state).toBe('ready')
+  })
+
+  it('produces onInit and onReady as children of the service span', async () => {
+    const recorder = tickingRecorder()
+    const service = new SampleService()
+    const serviceSpan = recorder.start('SampleService', { track: 'bootstrap' })
+
+    await (service as unknown as Initable)._doInit(spanMeasure(recorder, serviceSpan))
+    serviceSpan.end()
+
+    const spans = recorder.snapshot()
+    expect(spans.find((span) => span.name === 'onInit')?.parentId).toBe(serviceSpan.id)
+    expect(spans.find((span) => span.name === 'onReady')?.parentId).toBe(serviceSpan.id)
+    expect(spans.find((span) => span.name === 'onInit')?.track).toBe('bootstrap')
+  })
+
+  it('closes the onInit span even when the service throws, so a failed boot still shows its cost', async () => {
+    const recorder = tickingRecorder()
+    const service = new FailingService()
+    const serviceSpan = recorder.start('FailingService', { track: 'bootstrap' })
+
+    await expect((service as unknown as Initable)._doInit(spanMeasure(recorder, serviceSpan))).rejects.toThrow('boom')
+
+    const init = recorder.snapshot().find((span) => span.name === 'onInit')
+    expect(init).toBeDefined()
+    expect(init?.duration).toBeGreaterThan(0)
+  })
+
+  it('records nothing when the recorder is disabled', async () => {
+    const recorder = new PerfRecorder({ enabled: false })
+    const service = new SampleService()
+    const serviceSpan = recorder.start('SampleService', { track: 'bootstrap' })
+
+    await (service as unknown as Initable)._doInit(spanMeasure(recorder, serviceSpan))
+
+    expect(recorder.snapshot()).toEqual([])
+  })
+})

--- a/src/main/core/lifecycle/index.ts
+++ b/src/main/core/lifecycle/index.ts
@@ -1,4 +1,4 @@
-export { BaseService } from './BaseService'
+export { BaseService, type InitPhaseMeasure, type InitPhaseName } from './BaseService'
 export { allOf, anyOf, not, onArch, onCpuVendor, onEnvVar, onPlatform, when } from './conditions'
 export { SERVICE_STOP_TIMEOUT_MS, SHUTDOWN_TIMEOUT_MS } from './constants'
 export { Conditional, DependsOn, ErrorHandling, Injectable, Priority, ServicePhase } from './decorators'

--- a/src/main/core/perf/PerfRecorder.ts
+++ b/src/main/core/perf/PerfRecorder.ts
@@ -1,6 +1,5 @@
 import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
 import { Emitter, type Event } from '@main/core/lifecycle'
-import { isDev } from '@main/core/platform'
 
 import type { PerfDetail, PerfSpan, PerfSpanHandle, PerfStartOptions, PerfTrack } from './types'
 
@@ -28,8 +27,12 @@ export class PerfRecorder {
 
   private readonly maxSpans: number
   private readonly now: () => number
-  private readonly _onSpan = new Emitter<PerfSpan>()
-  readonly onSpan: Event<PerfSpan> = this._onSpan.event
+  /**
+   * 懒建：LifecycleManager 依赖 perf，而 perf 从 lifecycle barrel 取 Emitter，构成
+   * 循环导入。把 Emitter 的解引用推迟到订阅时，就不依赖 barrel 里的声明顺序。
+   */
+  private emitter: Emitter<PerfSpan> | null = null
+  readonly onSpan: Event<PerfSpan> = (listener) => (this.emitter ??= new Emitter<PerfSpan>()).event(listener)
 
   private buffer: PerfSpan[] = []
   private head = 0
@@ -81,7 +84,7 @@ export class PerfRecorder {
     }
 
     this.writeTimeline(span)
-    this._onSpan.fire(span)
+    this.emitter?.fire(span)
   }
 
   /**
@@ -103,4 +106,11 @@ export class PerfRecorder {
   }
 }
 
-export const perf = new PerfRecorder({ enabled: isDev || DIAGNOSTICS_ENABLED })
+/**
+ * 直接读 env 而非 `isDev` from `@main/core/platform`：本模块被 lifecycle 基座导入，
+ * 模块求值时读任何外部模块的导出，都会变成每个服务测试的 partial mock 的必填项。
+ * `diagnostics.ts` 自读 `CS_DIAGNOSTICS` 是同一个理由。
+ */
+const PERF_ENABLED = process.env.NODE_ENV === 'development' || DIAGNOSTICS_ENABLED
+
+export const perf = new PerfRecorder({ enabled: PERF_ENABLED })

--- a/src/main/core/perf/PerfRecorder.ts
+++ b/src/main/core/perf/PerfRecorder.ts
@@ -1,0 +1,106 @@
+import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
+import { Emitter, type Event } from '@main/core/lifecycle'
+import { isDev } from '@main/core/platform'
+
+import type { PerfDetail, PerfSpan, PerfSpanHandle, PerfStartOptions, PerfTrack } from './types'
+
+const DEFAULT_MAX_SPANS = 5000
+const DEFAULT_TRACK: PerfTrack = 'custom'
+
+/** 关闭时返回的共享句柄：不分配对象、不读时钟、不生成 id。 */
+const NOOP_HANDLE: PerfSpanHandle = Object.freeze({
+  id: '',
+  end() {}
+})
+
+interface PerfRecorderOptions {
+  enabled: boolean
+  maxSpans?: number
+  now?: () => number
+}
+
+/**
+ * 扁平 span + 可选父引用的埋点内核。完成的 span 有两个出口：自有环形缓冲
+ * （供 Main Perf 面板）与 Node 标准 timeline（供 `--inspect` 下的原生 Performance 面板）。
+ */
+export class PerfRecorder {
+  readonly enabled: boolean
+
+  private readonly maxSpans: number
+  private readonly now: () => number
+  private readonly _onSpan = new Emitter<PerfSpan>()
+  readonly onSpan: Event<PerfSpan> = this._onSpan.event
+
+  private buffer: PerfSpan[] = []
+  private head = 0
+  private nextId = 0
+
+  constructor(options: PerfRecorderOptions) {
+    this.enabled = options.enabled
+    this.maxSpans = options.maxSpans ?? DEFAULT_MAX_SPANS
+    this.now = options.now ?? (() => performance.now())
+  }
+
+  start(name: string, options?: PerfStartOptions): PerfSpanHandle {
+    if (!this.enabled) return NOOP_HANDLE
+
+    const id = `p${this.nextId++}`
+    const startTime = this.now()
+    const track = options?.track ?? DEFAULT_TRACK
+    const parentId = options?.parent?.id || undefined
+    const startDetail = options?.detail
+    let ended = false
+
+    return {
+      id,
+      end: (endDetail?: PerfDetail) => {
+        if (ended) return
+        ended = true
+        const detail = startDetail || endDetail ? { ...startDetail, ...endDetail } : undefined
+        this.record({ id, name, track, parentId, startTime, duration: this.now() - startTime, detail })
+      }
+    }
+  }
+
+  snapshot(): readonly PerfSpan[] {
+    if (this.buffer.length < this.maxSpans) return [...this.buffer]
+    return [...this.buffer.slice(this.head), ...this.buffer.slice(0, this.head)]
+  }
+
+  clear(): void {
+    this.buffer = []
+    this.head = 0
+  }
+
+  private record(span: PerfSpan): void {
+    if (this.buffer.length < this.maxSpans) {
+      this.buffer.push(span)
+    } else {
+      this.buffer[this.head] = span
+      this.head = (this.head + 1) % this.maxSpans
+    }
+
+    this.writeTimeline(span)
+    this._onSpan.fire(span)
+  }
+
+  /**
+   * detail 走结构化克隆，含函数等不可克隆值时整条 measure 都不会写入 —— 退回不带
+   * detail 再写一次，保证 timeline 不因附加信息而丢条目。
+   */
+  private writeTimeline(span: PerfSpan): void {
+    const start = span.startTime
+    const end = span.startTime + span.duration
+    try {
+      performance.measure(span.name, { start, end, detail: span.detail })
+    } catch {
+      try {
+        performance.measure(span.name, { start, end })
+      } catch {
+        // timeline 是附加出口，写不进去也不该影响采集。
+      }
+    }
+  }
+}
+
+export const perf = new PerfRecorder({ enabled: isDev || DIAGNOSTICS_ENABLED })

--- a/src/main/core/perf/PerfRecorder.ts
+++ b/src/main/core/perf/PerfRecorder.ts
@@ -6,7 +6,7 @@ import type { PerfDetail, PerfSpan, PerfSpanHandle, PerfStartOptions, PerfTrack 
 const DEFAULT_MAX_SPANS = 5000
 const DEFAULT_TRACK: PerfTrack = 'custom'
 
-/** 关闭时返回的共享句柄：不分配对象、不读时钟、不生成 id。 */
+/** Shared handle returned while disabled: allocates nothing, reads no clock, mints no id. */
 const NOOP_HANDLE: PerfSpanHandle = Object.freeze({
   id: '',
   end() {}
@@ -19,8 +19,9 @@ interface PerfRecorderOptions {
 }
 
 /**
- * 扁平 span + 可选父引用的埋点内核。完成的 span 有两个出口：自有环形缓冲
- * （供 Main Perf 面板）与 Node 标准 timeline（供 `--inspect` 下的原生 Performance 面板）。
+ * Flat spans with an optional parent reference. A completed span has two outlets: this
+ * recorder's own ring buffer (feeding the Main Perf panel) and the Node performance
+ * timeline (feeding the native Performance panel when attached with `--inspect`).
  */
 export class PerfRecorder {
   readonly enabled: boolean
@@ -28,8 +29,9 @@ export class PerfRecorder {
   private readonly maxSpans: number
   private readonly now: () => number
   /**
-   * 懒建：LifecycleManager 依赖 perf，而 perf 从 lifecycle barrel 取 Emitter，构成
-   * 循环导入。把 Emitter 的解引用推迟到订阅时，就不依赖 barrel 里的声明顺序。
+   * Created lazily. LifecycleManager depends on perf while perf pulls Emitter from the
+   * lifecycle barrel, so the two modules form an import cycle; deferring the Emitter
+   * dereference to first subscription keeps this independent of the barrel's export order.
    */
   private emitter: Emitter<PerfSpan> | null = null
   readonly onSpan: Event<PerfSpan> = (listener) => (this.emitter ??= new Emitter<PerfSpan>()).event(listener)
@@ -88,8 +90,9 @@ export class PerfRecorder {
   }
 
   /**
-   * detail 走结构化克隆，含函数等不可克隆值时整条 measure 都不会写入 —— 退回不带
-   * detail 再写一次，保证 timeline 不因附加信息而丢条目。
+   * `detail` is structured-cloned, and a non-cloneable value (a function, say) drops the
+   * whole measure rather than just the detail. Retry without it so the timeline never
+   * loses an entry over its optional payload.
    */
   private writeTimeline(span: PerfSpan): void {
     const start = span.startTime
@@ -100,16 +103,17 @@ export class PerfRecorder {
       try {
         performance.measure(span.name, { start, end })
       } catch {
-        // timeline 是附加出口，写不进去也不该影响采集。
+        // The timeline is a secondary outlet; failing to write it must not affect collection.
       }
     }
   }
 }
 
 /**
- * 直接读 env 而非 `isDev` from `@main/core/platform`：本模块被 lifecycle 基座导入，
- * 模块求值时读任何外部模块的导出，都会变成每个服务测试的 partial mock 的必填项。
- * `diagnostics.ts` 自读 `CS_DIAGNOSTICS` 是同一个理由。
+ * Reads the env var directly instead of `isDev` from `@main/core/platform`: the lifecycle
+ * substrate imports this module, so reading any external module's export at evaluation time
+ * would make it a required key in every service test's partial mock. `diagnostics.ts` reads
+ * `CS_DIAGNOSTICS` itself for the same reason.
  */
 const PERF_ENABLED = process.env.NODE_ENV === 'development' || DIAGNOSTICS_ENABLED
 

--- a/src/main/core/perf/__tests__/PerfRecorder.test.ts
+++ b/src/main/core/perf/__tests__/PerfRecorder.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { PerfRecorder } from '../PerfRecorder'
+
+/** 可控时钟：每次调用返回队列里的下一个值，用尽后停在最后一个。 */
+function clockOf(...values: number[]) {
+  let index = 0
+  return () => values[Math.min(index++, values.length - 1)]
+}
+
+/** 单调递增时钟，步长固定。 */
+function tickingClock(step = 1) {
+  let value = 0
+  return () => (value += step)
+}
+
+describe('PerfRecorder disabled', () => {
+  it('records nothing and never touches the clock', () => {
+    const now = vi.fn(() => 0)
+    const recorder = new PerfRecorder({ enabled: false, now })
+
+    const handle = recorder.start('anything')
+    handle.end()
+
+    expect(recorder.snapshot()).toEqual([])
+    expect(now).not.toHaveBeenCalled()
+  })
+
+  it('returns the same frozen handle every time so a hot path allocates nothing', () => {
+    const recorder = new PerfRecorder({ enabled: false })
+    expect(recorder.start('a')).toBe(recorder.start('b'))
+  })
+})
+
+describe('PerfRecorder enabled', () => {
+  it('measures duration from the injected clock', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(100, 350) })
+
+    recorder.start('DbService.init').end()
+
+    const [span] = recorder.snapshot()
+    expect(span.startTime).toBe(100)
+    expect(span.duration).toBe(250)
+  })
+
+  it('defaults an unspecified track to custom', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(0, 1) })
+    recorder.start('thing').end()
+    expect(recorder.snapshot()[0].track).toBe('custom')
+  })
+
+  it('links a child span to its parent by id', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: tickingClock() })
+
+    const parent = recorder.start('phase:beforeReady', { track: 'bootstrap' })
+    const child = recorder.start('DbService.init', { track: 'bootstrap', parent })
+    child.end()
+    parent.end()
+
+    const childSpan = recorder.snapshot().find((span) => span.name === 'DbService.init')
+    expect(childSpan?.parentId).toBe(parent.id)
+  })
+
+  it('leaves parentId undefined for a top-level span', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: tickingClock() })
+    recorder.start('root').end()
+    expect(recorder.snapshot()[0].parentId).toBeUndefined()
+  })
+
+  it('merges the detail passed to end() over the one passed to start()', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(0, 1) })
+
+    recorder.start('embed', { detail: { chunk: 1, model: 'a' } }).end({ model: 'b', vectors: 42 })
+
+    expect(recorder.snapshot()[0].detail).toEqual({ chunk: 1, model: 'b', vectors: 42 })
+  })
+
+  it('ignores a second end() so a double-ended span cannot be double counted', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(0, 5, 900) })
+
+    const handle = recorder.start('once')
+    handle.end()
+    handle.end()
+
+    expect(recorder.snapshot()).toHaveLength(1)
+    expect(recorder.snapshot()[0].duration).toBe(5)
+  })
+
+  it('drops the oldest spans once the ring buffer is full, keeping insertion order', () => {
+    const recorder = new PerfRecorder({ enabled: true, maxSpans: 3, now: () => 0 })
+
+    for (const name of ['a', 'b', 'c', 'd', 'e']) recorder.start(name).end()
+
+    expect(recorder.snapshot().map((span) => span.name)).toEqual(['c', 'd', 'e'])
+  })
+
+  it('keeps insertion order after the ring wraps more than once', () => {
+    const recorder = new PerfRecorder({ enabled: true, maxSpans: 3, now: () => 0 })
+
+    for (const name of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) recorder.start(name).end()
+
+    expect(recorder.snapshot().map((span) => span.name)).toEqual(['e', 'f', 'g'])
+  })
+
+  it('emits onSpan exactly once per completed span, not on start', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(0, 1) })
+    const seen: string[] = []
+    recorder.onSpan((span) => seen.push(span.name))
+
+    const handle = recorder.start('emitted')
+    expect(seen).toEqual([])
+    handle.end()
+
+    expect(seen).toEqual(['emitted'])
+  })
+
+  it('clear() empties the buffer', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: tickingClock() })
+    recorder.start('a').end()
+    recorder.clear()
+    expect(recorder.snapshot()).toEqual([])
+  })
+
+  it('still records the span when a non-cloneable detail breaks performance.measure', () => {
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(0, 1) })
+
+    // A function value makes structuredClone throw inside performance.measure.
+    expect(() => recorder.start('uncloneable', { detail: { onDone: () => undefined } }).end()).not.toThrow()
+    expect(recorder.snapshot()).toHaveLength(1)
+    expect(performance.getEntriesByName('uncloneable', 'measure')).toHaveLength(1)
+  })
+
+  it('writes each completed span to the perf_hooks timeline', () => {
+    const measure = vi.spyOn(performance, 'measure').mockImplementation(() => undefined as never)
+    const recorder = new PerfRecorder({ enabled: true, now: clockOf(10, 60) })
+
+    recorder.start('timeline').end()
+
+    expect(measure).toHaveBeenCalledWith('timeline', expect.objectContaining({ start: 10, end: 60 }))
+    measure.mockRestore()
+  })
+})

--- a/src/main/core/perf/__tests__/PerfRecorder.test.ts
+++ b/src/main/core/perf/__tests__/PerfRecorder.test.ts
@@ -1,18 +1,54 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { PerfRecorder } from '../PerfRecorder'
 
-/** 可控时钟：每次调用返回队列里的下一个值，用尽后停在最后一个。 */
+/** Scripted clock: each call yields the next value, then holds at the last one. */
 function clockOf(...values: number[]) {
   let index = 0
   return () => values[Math.min(index++, values.length - 1)]
 }
 
-/** 单调递增时钟，步长固定。 */
+/** Monotonic clock with a fixed step. */
 function tickingClock(step = 1) {
   let value = 0
   return () => (value += step)
 }
+
+describe('shared perf recorder gating', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('stays off in a production build so shipped users pay nothing', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('CS_DIAGNOSTICS', '')
+    vi.resetModules()
+
+    const { perf } = await import('../PerfRecorder')
+
+    expect(perf.enabled).toBe(false)
+  })
+
+  it('turns on in development', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.resetModules()
+
+    const { perf } = await import('../PerfRecorder')
+
+    expect(perf.enabled).toBe(true)
+  })
+
+  it('turns on in a packaged build when CS_DIAGNOSTICS is set', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('CS_DIAGNOSTICS', '1')
+    vi.resetModules()
+
+    const { perf } = await import('../PerfRecorder')
+
+    expect(perf.enabled).toBe(true)
+  })
+})
 
 describe('PerfRecorder disabled', () => {
   it('records nothing and never touches the clock', () => {

--- a/src/main/core/perf/__tests__/memory.test.ts
+++ b/src/main/core/perf/__tests__/memory.test.ts
@@ -1,0 +1,63 @@
+import { app } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { collectProcessMetrics, sampleMemory } from '../memory'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() })
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: { getAppMetrics: vi.fn() }
+}))
+
+describe('sampleMemory', () => {
+  it('carries the process memory numbers through unchanged', () => {
+    const usage = {
+      rss: 431_000_000,
+      heapTotal: 220_000_000,
+      heapUsed: 176_000_000,
+      external: 18_000_000,
+      arrayBuffers: 6_000_000
+    }
+    const spy = vi.spyOn(process, 'memoryUsage').mockReturnValue(usage as NodeJS.MemoryUsage)
+
+    expect(sampleMemory(() => 1234)).toEqual({ at: 1234, ...usage })
+
+    spy.mockRestore()
+  })
+})
+
+describe('collectProcessMetrics', () => {
+  beforeEach(() => {
+    vi.mocked(app.getAppMetrics).mockReset()
+  })
+
+  it('flattens Electron metrics into pid/type/cpu/memory rows', () => {
+    vi.mocked(app.getAppMetrics).mockReturnValue([
+      { pid: 4821, type: 'Browser', cpu: { percentCPUUsage: 3.25 }, memory: { workingSetSize: 421_888 } },
+      {
+        pid: 4830,
+        type: 'Tab',
+        name: 'main window',
+        cpu: { percentCPUUsage: 11.8 },
+        memory: { workingSetSize: 395_264 }
+      }
+    ] as unknown as Electron.ProcessMetric[])
+
+    expect(collectProcessMetrics()).toEqual([
+      { pid: 4821, type: 'Browser', name: undefined, cpuPercent: 3.25, memoryKb: 421_888 },
+      { pid: 4830, type: 'Tab', name: 'main window', cpuPercent: 11.8, memoryKb: 395_264 }
+    ])
+  })
+
+  it('returns an empty list instead of throwing when Electron cannot report metrics', () => {
+    vi.mocked(app.getAppMetrics).mockImplementation(() => {
+      throw new Error('app is not ready')
+    })
+
+    expect(collectProcessMetrics()).toEqual([])
+  })
+})

--- a/src/main/core/perf/index.ts
+++ b/src/main/core/perf/index.ts
@@ -1,0 +1,10 @@
+export { perf, PerfRecorder } from './PerfRecorder'
+export type {
+  MemorySample,
+  PerfDetail,
+  PerfSpan,
+  PerfSpanHandle,
+  PerfStartOptions,
+  PerfTrack,
+  ProcessMetric
+} from './types'

--- a/src/main/core/perf/index.ts
+++ b/src/main/core/perf/index.ts
@@ -1,3 +1,4 @@
+export { collectProcessMetrics, sampleMemory } from './memory'
 export { perf, PerfRecorder } from './PerfRecorder'
 export type {
   MemorySample,

--- a/src/main/core/perf/memory.ts
+++ b/src/main/core/perf/memory.ts
@@ -1,0 +1,38 @@
+import { loggerService } from '@logger'
+import { app } from 'electron'
+
+import type { MemorySample, ProcessMetric } from './types'
+
+const logger = loggerService.withContext('perfMemory')
+
+/** main 进程自身的内存切片。调用成本约几微秒，可以按秒级频率采。 */
+export function sampleMemory(now: () => number = () => performance.now()): MemorySample {
+  const usage = process.memoryUsage()
+  return {
+    at: now(),
+    rss: usage.rss,
+    heapTotal: usage.heapTotal,
+    heapUsed: usage.heapUsed,
+    external: usage.external,
+    arrayBuffers: usage.arrayBuffers
+  }
+}
+
+/**
+ * 全进程（main / renderer / GPU / utility）的 CPU 与内存。
+ * 比 `process.memoryUsage()` 贵得多，只在面板主动请求时调用，不要放进定时器。
+ */
+export function collectProcessMetrics(): ProcessMetric[] {
+  try {
+    return app.getAppMetrics().map((metric) => ({
+      pid: metric.pid,
+      type: metric.type,
+      name: metric.name,
+      cpuPercent: metric.cpu.percentCPUUsage,
+      memoryKb: metric.memory.workingSetSize
+    }))
+  } catch (error) {
+    logger.warn('Failed to collect app metrics', error as Error)
+    return []
+  }
+}

--- a/src/main/core/perf/memory.ts
+++ b/src/main/core/perf/memory.ts
@@ -5,7 +5,7 @@ import type { MemorySample, ProcessMetric } from './types'
 
 const logger = loggerService.withContext('perfMemory')
 
-/** main 进程自身的内存切片。调用成本约几微秒，可以按秒级频率采。 */
+/** A slice of this process's own memory. Costs a few microseconds, so second-level sampling is fine. */
 export function sampleMemory(now: () => number = () => performance.now()): MemorySample {
   const usage = process.memoryUsage()
   return {
@@ -19,8 +19,8 @@ export function sampleMemory(now: () => number = () => performance.now()): Memor
 }
 
 /**
- * 全进程（main / renderer / GPU / utility）的 CPU 与内存。
- * 比 `process.memoryUsage()` 贵得多，只在面板主动请求时调用，不要放进定时器。
+ * CPU and memory for every process (main / renderer / GPU / utility).
+ * Far more expensive than `process.memoryUsage()` — call it on panel request only, never on a timer.
  */
 export function collectProcessMetrics(): ProcessMetric[] {
   try {

--- a/src/main/core/perf/types.ts
+++ b/src/main/core/perf/types.ts
@@ -1,22 +1,22 @@
 /**
- * 面板泳道。新增泳道 = 在这里加一个成员 + 在 resources/devtools/main-perf/panel.js
- * 的 TRACKS 里补图标。
+ * Panel lane. Adding a lane means adding a member here AND an icon entry in
+ * TRACKS in resources/devtools/main-perf/panel.js.
  */
 export type PerfTrack = 'bootstrap' | 'ipc' | 'db' | 'dataapi' | 'window' | 'custom'
 
-/** 附加信息，必须是 JSON 可序列化的值。 */
+/** Extra context attached to a span. Must hold JSON-serializable values only. */
 export type PerfDetail = Record<string, unknown>
 
 export interface PerfSpanHandle {
   readonly id: string
-  /** 重复调用是无操作。detail 与 start 时的 detail 浅合并。 */
+  /** A second call is a no-op. `detail` is shallow-merged over the one given to `start()`. */
   end(detail?: PerfDetail): void
 }
 
 export interface PerfStartOptions {
-  /** 归属泳道，决定面板里的分组。默认 'custom'。 */
+  /** Lane this span belongs to, which drives panel grouping. Defaults to 'custom'. */
   track?: PerfTrack
-  /** 父 span 句柄，用于在面板中还原层级。不传即为该 track 的顶层。 */
+  /** Parent handle, used to rebuild hierarchy in the panel. Omit for a lane-level span. */
   parent?: PerfSpanHandle
   detail?: PerfDetail
 }
@@ -26,7 +26,7 @@ export interface PerfSpan {
   name: string
   track: PerfTrack
   parentId?: string
-  /** ms since timeOrigin，与 perf_hooks 同基准 */
+  /** ms since timeOrigin — the same base as perf_hooks entries. */
   startTime: number
   duration: number
   detail?: PerfDetail

--- a/src/main/core/perf/types.ts
+++ b/src/main/core/perf/types.ts
@@ -1,0 +1,51 @@
+/**
+ * 面板泳道。新增泳道 = 在这里加一个成员 + 在 resources/devtools/main-perf/panel.js
+ * 的 TRACKS 里补图标。
+ */
+export type PerfTrack = 'bootstrap' | 'ipc' | 'db' | 'dataapi' | 'window' | 'custom'
+
+/** 附加信息，必须是 JSON 可序列化的值。 */
+export type PerfDetail = Record<string, unknown>
+
+export interface PerfSpanHandle {
+  readonly id: string
+  /** 重复调用是无操作。detail 与 start 时的 detail 浅合并。 */
+  end(detail?: PerfDetail): void
+}
+
+export interface PerfStartOptions {
+  /** 归属泳道，决定面板里的分组。默认 'custom'。 */
+  track?: PerfTrack
+  /** 父 span 句柄，用于在面板中还原层级。不传即为该 track 的顶层。 */
+  parent?: PerfSpanHandle
+  detail?: PerfDetail
+}
+
+export interface PerfSpan {
+  id: string
+  name: string
+  track: PerfTrack
+  parentId?: string
+  /** ms since timeOrigin，与 perf_hooks 同基准 */
+  startTime: number
+  duration: number
+  detail?: PerfDetail
+}
+
+export interface MemorySample {
+  /** ms since timeOrigin */
+  at: number
+  heapUsed: number
+  heapTotal: number
+  rss: number
+  external: number
+  arrayBuffers: number
+}
+
+export interface ProcessMetric {
+  pid: number
+  type: string
+  name?: string
+  cpuPercent: number
+  memoryKb: number
+}

--- a/src/main/services/perfDevtools/PerfDevtoolsService.ts
+++ b/src/main/services/perfDevtools/PerfDevtoolsService.ts
@@ -11,15 +11,15 @@ import type { WebSocketServer } from 'ws'
 const logger = loggerService.withContext('PerfDevtoolsService')
 
 /**
- * 面板连接的固定 localhost 端口。
- * 与 resources/devtools/main-perf/panel.js 的 PERF_DEVTOOLS_PORT 保持一致。
+ * Fixed localhost port the bundled panel connects to.
+ * Keep in sync with PERF_DEVTOOLS_PORT in resources/devtools/main-perf/panel.js.
  */
 export const PERF_DEVTOOLS_DEFAULT_PORT = 38998
 
 const MEMORY_SAMPLE_INTERVAL_MS = 2000
 const MAX_MEMORY_SAMPLES = 900
 
-/** WebSocket 中本服务用到的那一小部分，便于测试替身。 */
+/** The slice of WebSocket this service uses, so tests can substitute a fake. */
 interface PanelSocket {
   readyState: number
   send(payload: string): void
@@ -28,8 +28,8 @@ interface PanelSocket {
 }
 
 /**
- * 开发期性能面板的后端：把 core/perf 的 span 与内存采样推给打包的
- * Main Perf DevTools 扩展。仅在开发模式启用。
+ * Backend for the development-only performance panel: streams core/perf spans and memory
+ * samples to the bundled Main Perf DevTools extension. Development mode only.
  */
 @Injectable('PerfDevtoolsService')
 @ServicePhase(Phase.Background)
@@ -40,7 +40,7 @@ export class PerfDevtoolsService extends BaseService {
   private readonly allowedOrigins = new Set<string>()
   private readonly memory: MemorySample[] = []
 
-  /** recorder 可注入，测试才能用可控时钟而不碰全局单例。 */
+  /** The recorder is injectable so tests can drive a controlled clock without touching the singleton. */
   constructor(private readonly recorder: PerfRecorder = perf) {
     super()
   }
@@ -57,8 +57,9 @@ export class PerfDevtoolsService extends BaseService {
   }
 
   /**
-   * 与 MainNetworkDevtoolsService 同因：Background 阶段在 app.whenReady() 之前跑，
-   * onInit 里取 session.defaultSession 会抛。onAllReady 时 app 已就绪。
+   * Same reason as MainNetworkDevtoolsService: the Background phase runs before
+   * app.whenReady(), so reaching session.defaultSession in onInit would throw.
+   * By onAllReady the app is ready.
    */
   protected async onAllReady(): Promise<void> {
     await installBundledDevtools('main-perf', 'Main Perf', (extension) => {

--- a/src/main/services/perfDevtools/PerfDevtoolsService.ts
+++ b/src/main/services/perfDevtools/PerfDevtoolsService.ts
@@ -1,0 +1,184 @@
+import type { AddressInfo } from 'node:net'
+
+import { loggerService } from '@logger'
+import { installBundledDevtools } from '@main/core/devtools'
+import { BaseService, Conditional, Injectable, Phase, Priority, ServicePhase, when } from '@main/core/lifecycle'
+import { collectProcessMetrics, type MemorySample, perf, type PerfRecorder, sampleMemory } from '@main/core/perf'
+import { isDev } from '@main/core/platform'
+import type WebSocket from 'ws'
+import type { WebSocketServer } from 'ws'
+
+const logger = loggerService.withContext('PerfDevtoolsService')
+
+/**
+ * 面板连接的固定 localhost 端口。
+ * 与 resources/devtools/main-perf/panel.js 的 PERF_DEVTOOLS_PORT 保持一致。
+ */
+export const PERF_DEVTOOLS_DEFAULT_PORT = 38998
+
+const MEMORY_SAMPLE_INTERVAL_MS = 2000
+const MAX_MEMORY_SAMPLES = 900
+
+/** WebSocket 中本服务用到的那一小部分，便于测试替身。 */
+interface PanelSocket {
+  readyState: number
+  send(payload: string): void
+  close(code?: number, reason?: string): void
+  on(event: string, listener: (...args: never[]) => void): void
+}
+
+/**
+ * 开发期性能面板的后端：把 core/perf 的 span 与内存采样推给打包的
+ * Main Perf DevTools 扩展。仅在开发模式启用。
+ */
+@Injectable('PerfDevtoolsService')
+@ServicePhase(Phase.Background)
+@Priority(0)
+@Conditional(when(() => isDev, 'development mode'))
+export class PerfDevtoolsService extends BaseService {
+  private readonly clients = new Set<PanelSocket>()
+  private readonly allowedOrigins = new Set<string>()
+  private readonly memory: MemorySample[] = []
+
+  /** recorder 可注入，测试才能用可控时钟而不碰全局单例。 */
+  constructor(private readonly recorder: PerfRecorder = perf) {
+    super()
+  }
+
+  protected async onInit(): Promise<void> {
+    this.registerDisposable(this.recorder.onSpan((span) => this.broadcast({ type: 'span', span })))
+    this.registerInterval(() => this.pushMemorySample(), MEMORY_SAMPLE_INTERVAL_MS)
+
+    try {
+      await this.startWebSocketServer()
+    } catch (error) {
+      logger.error('Failed to start Main Perf DevTools websocket server', error as Error)
+    }
+  }
+
+  /**
+   * 与 MainNetworkDevtoolsService 同因：Background 阶段在 app.whenReady() 之前跑，
+   * onInit 里取 session.defaultSession 会抛。onAllReady 时 app 已就绪。
+   */
+  protected async onAllReady(): Promise<void> {
+    await installBundledDevtools('main-perf', 'Main Perf', (extension) => {
+      this.registerOrigin(`chrome-extension://${extension.id}`)
+    })
+  }
+
+  private registerOrigin(origin: string): void {
+    this.allowedOrigins.add(normalizeOrigin(origin))
+  }
+
+  private pushMemorySample(): void {
+    const sample = sampleMemory()
+    this.memory.push(sample)
+    if (this.memory.length > MAX_MEMORY_SAMPLES) this.memory.shift()
+    this.broadcast({ type: 'memory', sample })
+  }
+
+  private handleConnection(socket: PanelSocket, origin: string | undefined): void {
+    if (!origin || !this.allowedOrigins.has(normalizeOrigin(origin))) {
+      socket.close(1008, 'Unauthorized origin')
+      return
+    }
+
+    this.clients.add(socket)
+    socket.send(
+      JSON.stringify({
+        type: 'snapshot',
+        spans: this.recorder.snapshot(),
+        memory: this.memory,
+        processes: collectProcessMetrics()
+      })
+    )
+    socket.on('message', ((raw: unknown) => this.handleClientMessage(socket, String(raw))) as never)
+    socket.on('close', (() => this.clients.delete(socket)) as never)
+    socket.on('error', (() => this.clients.delete(socket)) as never)
+  }
+
+  private handleClientMessage(socket: PanelSocket, raw: string): void {
+    let message: unknown
+    try {
+      message = JSON.parse(raw)
+    } catch {
+      return
+    }
+    if (!message || typeof message !== 'object') return
+
+    const type = (message as { type?: unknown }).type
+    if (type === 'clear') {
+      this.recorder.clear()
+      this.broadcast({ type: 'cleared' })
+      return
+    }
+    if (type === 'metrics') {
+      socket.send(JSON.stringify({ type: 'metrics', processes: collectProcessMetrics() }))
+    }
+  }
+
+  private async startWebSocketServer(port = PERF_DEVTOOLS_DEFAULT_PORT): Promise<number> {
+    const { WebSocketServer } = await import('ws')
+    const server = new WebSocketServer({ host: '127.0.0.1', port })
+
+    server.on('error', (error) => logger.error('Main Perf DevTools websocket server error', error))
+    server.on('connection', (socket: WebSocket, request) => {
+      this.handleConnection(socket as unknown as PanelSocket, request.headers.origin)
+    })
+
+    try {
+      await waitForServerListening(server)
+    } catch (error) {
+      server.close()
+      throw error
+    }
+
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Main Perf DevTools websocket server did not expose a TCP port')
+    }
+    const listeningPort = (address as AddressInfo).port
+    logger.info(`Main Perf DevTools websocket server listening on 127.0.0.1:${listeningPort}`)
+
+    this.registerDisposable(() => {
+      for (const client of this.clients) client.close()
+      this.clients.clear()
+      server.close()
+    })
+
+    return listeningPort
+  }
+
+  private broadcast(message: unknown): void {
+    if (this.clients.size === 0) return
+    const payload = JSON.stringify(message)
+    for (const client of this.clients) {
+      if (client.readyState === 1) client.send(payload)
+    }
+  }
+}
+
+function normalizeOrigin(origin: string): string {
+  return origin.replace(/\/$/, '')
+}
+
+function waitForServerListening(server: WebSocketServer): Promise<void> {
+  if (server.address()) return Promise.resolve()
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.off('listening', handleListening)
+      server.off('error', handleError)
+    }
+    const handleListening = () => {
+      cleanup()
+      resolve()
+    }
+    const handleError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+    server.once('listening', handleListening)
+    server.once('error', handleError)
+  })
+}

--- a/src/main/services/perfDevtools/__tests__/PerfDevtoolsService.test.ts
+++ b/src/main/services/perfDevtools/__tests__/PerfDevtoolsService.test.ts
@@ -24,7 +24,7 @@ vi.mock('@main/core/devtools', () => ({ installBundledDevtools: vi.fn() }))
 
 import { PerfDevtoolsService } from '../PerfDevtoolsService'
 
-/** 最小 WebSocket 替身：记录发出的帧，并能模拟面板发来的消息。 */
+/** Minimal WebSocket stand-in: records outgoing frames and can replay panel messages. */
 class FakeSocket extends EventEmitter {
   readyState = 1
   sent: string[] = []
@@ -43,7 +43,7 @@ class FakeSocket extends EventEmitter {
   }
 }
 
-/** 触达服务内部的连接处理，避免真的开端口。 */
+/** Reaches the service's connection handling without opening a real port. */
 interface ServiceInternals {
   handleConnection(socket: FakeSocket, origin: string | undefined): void
   registerOrigin(origin: string): void
@@ -51,7 +51,7 @@ interface ServiceInternals {
 
 function createService(recorder: PerfRecorder) {
   const service = new PerfDevtoolsService(recorder)
-  // onInit 会开端口，这里只订阅 span 流，等价于 onInit 里那一句。
+  // onInit would bind a port; subscribe to the span stream only — the same line onInit runs.
   recorder.onSpan((span) => (service as unknown as { broadcast(m: unknown): void }).broadcast({ type: 'span', span }))
   return service as unknown as ServiceInternals
 }

--- a/src/main/services/perfDevtools/__tests__/PerfDevtoolsService.test.ts
+++ b/src/main/services/perfDevtools/__tests__/PerfDevtoolsService.test.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'node:events'
+
+import { BaseService } from '@main/core/lifecycle'
+import { PerfRecorder } from '@main/core/perf'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() })
+  }
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getAppMetrics: vi.fn(() => []),
+    isReady: vi.fn(() => true),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    whenReady: vi.fn(() => Promise.resolve())
+  }
+}))
+
+vi.mock('@main/core/devtools', () => ({ installBundledDevtools: vi.fn() }))
+
+import { PerfDevtoolsService } from '../PerfDevtoolsService'
+
+/** 最小 WebSocket 替身：记录发出的帧，并能模拟面板发来的消息。 */
+class FakeSocket extends EventEmitter {
+  readyState = 1
+  sent: string[] = []
+  closedWith: number | null = null
+
+  send(payload: string) {
+    this.sent.push(payload)
+  }
+
+  close(code?: number) {
+    this.closedWith = code ?? 1000
+  }
+
+  frames(): Array<Record<string, unknown>> {
+    return this.sent.map((raw) => JSON.parse(raw))
+  }
+}
+
+/** 触达服务内部的连接处理，避免真的开端口。 */
+interface ServiceInternals {
+  handleConnection(socket: FakeSocket, origin: string | undefined): void
+  registerOrigin(origin: string): void
+}
+
+function createService(recorder: PerfRecorder) {
+  const service = new PerfDevtoolsService(recorder)
+  // onInit 会开端口，这里只订阅 span 流，等价于 onInit 里那一句。
+  recorder.onSpan((span) => (service as unknown as { broadcast(m: unknown): void }).broadcast({ type: 'span', span }))
+  return service as unknown as ServiceInternals
+}
+
+function tickingRecorder() {
+  let time = 0
+  return new PerfRecorder({ enabled: true, now: () => (time += 10) })
+}
+
+describe('PerfDevtoolsService websocket protocol', () => {
+  let recorder: PerfRecorder
+
+  beforeEach(() => {
+    BaseService.resetInstances()
+    recorder = tickingRecorder()
+  })
+
+  afterEach(() => {
+    BaseService.resetInstances()
+    vi.clearAllMocks()
+  })
+
+  it('rejects a connection whose origin was never installed', () => {
+    const service = createService(recorder)
+    const socket = new FakeSocket()
+
+    service.handleConnection(socket, 'chrome-extension://someone-else')
+
+    expect(socket.closedWith).toBe(1008)
+    expect(socket.sent).toEqual([])
+  })
+
+  it('rejects a connection carrying no origin at all', () => {
+    const service = createService(recorder)
+    const socket = new FakeSocket()
+
+    service.handleConnection(socket, undefined)
+
+    expect(socket.closedWith).toBe(1008)
+  })
+
+  it('sends the full snapshot to an allowed origin on connect', () => {
+    recorder.start('DbService.init', { track: 'bootstrap' }).end()
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+
+    service.handleConnection(socket, 'chrome-extension://abc')
+
+    const [frame] = socket.frames()
+    expect(frame.type).toBe('snapshot')
+    expect(frame.spans).toHaveLength(1)
+    expect(frame).toHaveProperty('memory')
+    expect(frame).toHaveProperty('processes')
+  })
+
+  it('streams each newly completed span to connected panels', () => {
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+    service.handleConnection(socket, 'chrome-extension://abc')
+    socket.sent.length = 0
+
+    recorder.start('window.minimize', { track: 'ipc' }).end()
+
+    expect(socket.frames()).toEqual([
+      { type: 'span', span: expect.objectContaining({ name: 'window.minimize', track: 'ipc' }) }
+    ])
+  })
+
+  it('clears the recorder and tells every panel when a panel asks to clear', () => {
+    recorder.start('stale').end()
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+    service.handleConnection(socket, 'chrome-extension://abc')
+    socket.sent.length = 0
+
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'clear' })))
+
+    expect(recorder.snapshot()).toEqual([])
+    expect(socket.frames()).toEqual([{ type: 'cleared' }])
+  })
+
+  it('answers a metrics request on demand', () => {
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+    service.handleConnection(socket, 'chrome-extension://abc')
+    socket.sent.length = 0
+
+    socket.emit('message', Buffer.from(JSON.stringify({ type: 'metrics' })))
+
+    expect(socket.frames()).toEqual([{ type: 'metrics', processes: [] }])
+  })
+
+  it('ignores a malformed frame instead of throwing', () => {
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+    service.handleConnection(socket, 'chrome-extension://abc')
+
+    expect(() => socket.emit('message', Buffer.from('not json'))).not.toThrow()
+  })
+
+  it('stops streaming to a socket after it closes', () => {
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const socket = new FakeSocket()
+    service.handleConnection(socket, 'chrome-extension://abc')
+    socket.sent.length = 0
+    socket.emit('close')
+
+    recorder.start('after-close').end()
+
+    expect(socket.sent).toEqual([])
+  })
+
+  it('keeps serving other panels after one of them errors out', () => {
+    const service = createService(recorder)
+    service.registerOrigin('chrome-extension://abc')
+    const broken = new FakeSocket()
+    const healthy = new FakeSocket()
+    service.handleConnection(broken, 'chrome-extension://abc')
+    service.handleConnection(healthy, 'chrome-extension://abc')
+    broken.sent.length = 0
+    healthy.sent.length = 0
+    broken.emit('error', new Error('socket died'))
+
+    recorder.start('after-error').end()
+
+    expect(broken.sent).toEqual([])
+    expect(healthy.frames()).toHaveLength(1)
+  })
+})

--- a/src/main/services/perfDevtools/index.ts
+++ b/src/main/services/perfDevtools/index.ts
@@ -1,0 +1,1 @@
+export { PERF_DEVTOOLS_DEFAULT_PORT, PerfDevtoolsService } from './PerfDevtoolsService'


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Main-process performance observation was three disconnected things: `core/diagnostics.ts` (CPU profiler, event-loop lag sampler, `CS_DIAGNOSTICS`-gated), hand-written `performance.now()` pairs scattered across `LifecycleManager` / `BaseService` / `IpcApiService` / `WindowManager` / `DbService` / DataApi `ApiServer`, and no memory dimension at all. Every new observation point repeated the same "read clock → subtract → format a log string" ritual, and the results only ever reached a log file.

After this PR:

A shared span kernel plus an interactive DevTools panel. This is **P1** of the design — it lands the infrastructure and fills the `bootstrap` lane only; the IPC / DB / DataApi / Window probes migrate in P2.

- **`src/main/core/perf/`** — flat spans with an optional parent reference:

  ```ts
  const span = perf.start('knowledge.embed', { track: 'custom', detail: { chunk: 3 } })
  span.end({ vectors: 128 })
  ```

  A completed span goes two places: a ring buffer feeding the panel, and `performance.measure()` so it shows up in the Timings track of a native Chrome DevTools Performance recording under `--inspect`. When disabled, `perf.start()` returns a shared frozen handle — no allocation, no clock read.

- **`src/main/core/perf/memory.ts`** — `sampleMemory()` (main-process rss/heap) and `collectProcessMetrics()` (`app.getAppMetrics()`, every process).

- **`src/main/services/perfDevtools/`** — dev-only lifecycle service; WebSocket on 127.0.0.1:38998 with extension-origin allowlisting, mirroring `MainNetworkDevtoolsService`.

- **`resources/devtools/main-perf/`** — the panel itself (vanilla HTML/CSS/JS, no build step, follows the DevTools light/dark theme). Overview strip with drag-to-zoom, a span tree/gantt sharing its time axis with the memory chart, a detail pane, and a process table.

- **`LifecycleManager` / `BaseService`** — bootstrap, each phase, each service, and each service's `onInit` / `onReady` now emit spans, which is what populates the `bootstrap` lane.

Fixes #

### Why we need it and why it was done in this way

The panel's central design problem was that two kinds of spans want two different tree shapes. Startup spans are unique and genuinely nested (`phase:beforeReady` → `DbService.init`), so they want a causal tree. Runtime spans are repetitive and parentless (`window.minimize` × 88), so they want aggregation by name. Grouping unconditionally by name would destroy the startup hierarchy; not grouping would make the runtime lanes unreadable.

Resolved with one rule: **the tree follows `parentId`, and within a single parent's children, same-name siblings merge into a group row; a group holding one instance collapses away.** `bootstrap` therefore renders as a plain gantt tree with no redundant layer, while `ipc`/`db` aggregate — and because a group row carries `count / avg / max` *and* draws each instance at its real time position, the aggregate view and the timeline view are the same row. No view toggle needed.

Spans without a parent are organized by a `track` (a fixed enum), not by a synthetic parent span — a fake parent would have a meaningless `duration` spanning the whole session.

The following tradeoffs were made:

- **`BaseService` takes a callback, not a `perf` import.** The first attempt had `_doInit` accept a `PerfSpanHandle`. That broke 8 test files at load and 42 test cases: `BaseService` is the base class of nearly every service test, so one more static import invalidates a great many partial mocks. Inverted to `_doInit(measure?: InitPhaseMeasure)` taking `(name) => () => void`, injected by `LifecycleManager`, which already depends on perf.
- **`core/perf` reads `process.env.NODE_ENV` instead of importing `isDev`.** Same cause — the lifecycle substrate imports this module, so reading any external module's export at evaluation time makes it a required key in every service test's mock. `diagnostics.ts` reads `CS_DIAGNOSTICS` itself for exactly this reason.
- **`PerfRecorder`'s `Emitter` is created lazily.** `LifecycleManager → perf → lifecycle barrel` is an import cycle, and lint forbids deep-importing past a barrel, so deferring the dereference to first subscription keeps this independent of the barrel's export order.
- **Concurrent same-name spans overlay as translucent bars rather than lane-packing.** Row height stays constant; lane packing made a single row grow to ~116px under 9-way concurrency and eat the viewport. Precise concurrency is read by expanding the group.
- **No true row virtualization.** Two caps instead: 200 instances per group, 1200 rows per render. Bars are already viewport-culled.
- **Existing diagnostics timing is left untouched**, so bootstrap is double-timed until P2 removes the old path.

The following alternatives were considered:

- A flame chart for the main area — rejected because the panel's frequent uses are "find the slowest" and "check a number", both table operations, and flame charts' strength (finding CPU gaps) is already covered by `boot-whenReady.cpuprofile`.
- Nested spans via `AsyncLocalStorage` — rejected for its cost and mental overhead; hierarchy is passed explicitly instead.
- A separate "Aggregated" tab beside "Timeline" — made unnecessary by the scoped-grouping rule above.

Links to places where the discussion took place: design doc at `docs/superpowers/specs/2026-08-15-main-perf-infrastructure-design.md` (not committed — local scratch), which records each decision and the deviations found during implementation.

### Breaking changes

None for users. One internal signature change: `BaseService._doInit()` now accepts an optional `measure` callback. All ~180 existing call sites pass no arguments and are unaffected.

### Special notes for your reviewer

**The canvas drawing is the one unverified part.** The overview thumbnail and the memory chart were only exercised under jsdom, where canvas is stubbed — so `renderOverview()` and `renderMemory()` have literally never executed. Everything else (grouping rule, density strip, filtering, expand/collapse, row budget) is covered by a jsdom smoke pass and unit tests.

To review the panel: `pnpm dev` → F12 → **Undock into separate window** (it is designed for the undocked size) → `Main Perf` tab. Expect a green `connected` status and a four-level `bootstrap → phase:beforeReady → DbService.init → onInit / onReady` tree.

The panel also runs standalone with built-in fixtures for UI work without launching the app: `open resources/devtools/main-perf/panel.html`.

Adding a lane means editing `PerfTrack` in `src/main/core/perf/types.ts` **and** `TRACKS` in `resources/devtools/main-perf/panel.js`. The port 38998 is likewise duplicated in the service and the panel, each with a comment pointing at the other — same approach as `main-network`'s 38997.

Known follow-ups, deliberately out of scope: the 5000-span ring buffer cap needs re-evaluation once the DB probe lands (a burst can produce a thousand spans a minute), and the hardcoded port could use discovery.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
