### PR TITLE
fix(window-manager): re-assert alwaysOnTop on every platform after show

### DIFF
--- a/docs/references/window-manager/README.md
+++ b/docs/references/window-manager/README.md
@@ -29,7 +29,7 @@ Per-type metadata in `windowRegistry.ts` is split into three layers. Each field 
 |---|---|---|---|
 | `windowOptions` | Arguments to `new BrowserWindow(...)` — Electron-native constructor options | Electron rejects the build or behaves wrong on construction | `width`, `alwaysOnTop: true`, `frame: false`, `platformOverrides` |
 | `behavior` | Cross-platform, non-hacky declarative behavior that Electron's constructor cannot express | WindowManager behavior diverges from intent (e.g. no auto-hide on blur) | `hideOnBlur`, `alwaysOnTop: { level, relativeLevel }`, `visibleOnAllWorkspaces`, `macShowInDock` |
-| `quirks` | OS-specific hacks / workarounds applied via monkey-patches | Sub-par UX on the specific OS (focus steal, Dock flicker, level demotion) | `macRestoreFocusOnHide`, `macClearHoverOnHide`, `macReapplyAlwaysOnTop` |
+| `quirks` | OS-specific hacks / workarounds applied via monkey-patches | Sub-par UX on the specific OS (focus steal, Dock flicker, level demotion) | `macRestoreFocusOnHide`, `macClearHoverOnHide`, `reapplyAlwaysOnTop` |
 
 **Naming rule (orthogonal to layering)**: any field that is effective only on one platform carries a `mac` / `win` / `linux` prefix — regardless of layer. `behavior.macShowInDock` is a behavior field but its `mac` prefix signals the platform scope; `quirks.macRestoreFocusOnHide` is a hack with the same prefix.
 

--- a/docs/references/window-manager/window-manager-platform.md
+++ b/docs/references/window-manager/window-manager-platform.md
@@ -18,9 +18,9 @@ Some OS-specific behaviors are tedious to hand-roll at every call site (e.g. the
 |---|---|---|
 | `macRestoreFocusOnHide: boolean` | `hide()`, `close()` | Before invoking the native method, iterate every visible focusable `BrowserWindow` and `setFocusable(false)`; restore them 50ms later. Prevents other windows from being brought to the front when this one disappears. |
 | `macClearHoverOnHide: boolean` | `hide()` | After invoking the native `hide()`, send `webContents.sendInputEvent({ type: 'mouseMove', x: -1, y: -1 })` to clear any residual hover state. |
-| `macReapplyAlwaysOnTop: boolean` | `show()`, `showInactive()` | After invoking the native method, call `setAlwaysOnTop(true, level, relativeLevel)` with values read from `behavior.alwaysOnTop` (single source of truth). When `behavior.alwaysOnTop.level` is unset, falls back to `'floating'`. Compensates for macOS level resets between hide/show. |
+| `reapplyAlwaysOnTop: boolean` | `show()`, `showInactive()` | After invoking the native method, call `setAlwaysOnTop(true, level, relativeLevel)` with values read from `behavior.alwaysOnTop` (single source of truth). When `behavior.alwaysOnTop.level` is unset, falls back to `'floating'`. Compensates for macOS level resets between hide/show, and for Windows' last-writer-wins topmost z-order (the `level` argument is ignored there). |
 
-All quirks are macOS-only: on other platforms the methods are left untouched, and `window.hide === originalHide` (identity preserved).
+The `mac`-prefixed quirks are macOS-only: on other platforms those methods are left untouched, and `window.hide === originalHide` (identity preserved). `reapplyAlwaysOnTop` patches `show()` / `showInactive()` on every platform.
 
 ### Example
 
@@ -39,7 +39,7 @@ All quirks are macOS-only: on other platforms the methods are left untouched, an
   quirks: {
     macRestoreFocusOnHide: true,
     macClearHoverOnHide: true,
-    macReapplyAlwaysOnTop: true              // boolean switch; reads level from behavior above
+    reapplyAlwaysOnTop: true                 // boolean switch; reads level from behavior above
   }
 }
 ```
@@ -67,7 +67,7 @@ The domain service carries none of this code.
 | Field | Type | What it does |
 |---|---|---|
 | `hideOnBlur` | `boolean` | Installs a blur listener that calls `window.hide()` (with optional runtime override via `wm.behavior.setHideOnBlur(id, enabled)`). |
-| `alwaysOnTop` | `{ level?: AlwaysOnTopLevel, relativeLevel?: number }` | Supplies the `level` / `relativeLevel` to `setAlwaysOnTop` calls — the single source of truth, read by: (1) the initial application after create (when `windowOptions.alwaysOnTop` is `true`), (2) `wm.behavior.setAlwaysOnTop(id, enabled)` runtime calls, (3) the `macReapplyAlwaysOnTop` quirk. |
+| `alwaysOnTop` | `{ level?: AlwaysOnTopLevel, relativeLevel?: number }` | Supplies the `level` / `relativeLevel` to `setAlwaysOnTop` calls — the single source of truth, read by: (1) the initial application after create (when `windowOptions.alwaysOnTop` is `true`), (2) `wm.behavior.setAlwaysOnTop(id, enabled)` runtime calls, (3) the `reapplyAlwaysOnTop` quirk. |
 | `visibleOnAllWorkspaces` | `{ enabled: boolean } & VisibleOnAllWorkspacesOptions` | Runs `window.setVisibleOnAllWorkspaces(enabled, options)` once on create. Windows whose true/false options differ per call should *not* declare this (e.g. SelectionAction) — drive directly on `BrowserWindow` instead. |
 | `macShowInDock` | `boolean` | macOS-only default for whether a window of this type CONTRIBUTES to Dock visibility (Dock shown iff any alive window contributes). Existence-based, not visibility-based: hiding a contributing window does NOT hide the Dock (Cmd+W semantics). When omitted, defaults to `true`. `false` is for helper windows (floating panels, menu-bar style overlays) that should never affect the Dock. Runtime override via `wm.behavior.setMacShowInDockByType(type, value)` — set it to `false` before `window.hide()` to enter tray mode, `true` before `window.show()` to leave. No-op on Windows/Linux. |
 

--- a/src/main/core/window/__tests__/WindowManager.quirks.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.quirks.test.ts
@@ -207,7 +207,7 @@ vi.mock('../windowRegistry', () => {
       quirks: {
         macRestoreFocusOnHide: true,
         macClearHoverOnHide: true,
-        macReapplyAlwaysOnTop: true
+        reapplyAlwaysOnTop: true
       }
     },
     // Pooled action with only restoreFocusOnHide (like SelectionAction)
@@ -233,7 +233,7 @@ vi.mock('../windowRegistry', () => {
       lifecycle: 'default',
       htmlPath: 'floatingTop/index.html',
       windowOptions: {},
-      quirks: { macReapplyAlwaysOnTop: true }
+      quirks: { reapplyAlwaysOnTop: true }
     },
     // behavior.hideOnBlur — singleton, declarative blur→hide
     blurHider: {
@@ -512,9 +512,9 @@ describe('WindowManager quirks — applyQuirks monkey-patching', () => {
     })
   })
 
-  // ─── macReapplyAlwaysOnTop ──────────────────────────────────
+  // ─── reapplyAlwaysOnTop ──────────────────────────────────
 
-  describe('macReapplyAlwaysOnTop', () => {
+  describe('reapplyAlwaysOnTop', () => {
     it('re-applies setAlwaysOnTop(true, level) after show()', () => {
       wm.open('toolbar' as never)
       const toolbar = firstWindow()
@@ -569,27 +569,42 @@ describe('WindowManager quirks — applyQuirks monkey-patching', () => {
     })
   })
 
-  // ─── Non-mac identity check ─────────────────────────────────
+  // ─── Non-mac platform boundaries ────────────────────────────
 
   describe('non-mac platforms', () => {
-    it('does NOT patch any method when isMac=false — identity preserved', () => {
+    it('leaves the mac-only hide/close quirks unpatched — identity preserved', () => {
       platform.isMac = false
       platform.isLinux = true
 
       wm.open('toolbar' as never)
       const toolbar = firstWindow()
 
-      // Capture the mock fn refs stored at construction time
-      const hideMock = toolbar.hide
-      const closeMock = toolbar.close
-      const showMock = toolbar.show
-      const showInactiveMock = toolbar.showInactive
+      // A patched method is a plain arrow wrapper; an untouched one is still the
+      // constructor's vi mock.
+      expect(vi.isMockFunction(toolbar.hide)).toBe(true)
+      expect(vi.isMockFunction(toolbar.close)).toBe(true)
 
-      // After applyQuirks on non-mac: methods must remain the original mock fns
-      expect(toolbar.hide).toBe(hideMock)
-      expect(toolbar.close).toBe(closeMock)
-      expect(toolbar.show).toBe(showMock)
-      expect(toolbar.showInactive).toBe(showInactiveMock)
+      toolbar.hide()
+      expect(toolbar.webContents.sendInputEvent).not.toHaveBeenCalled()
+    })
+
+    it('still re-applies setAlwaysOnTop after show()/showInactive() on Windows', () => {
+      // Regression for #18092: the selection toolbar sank behind third-party
+      // topmost windows because this re-assert used to be gated on isMac, and
+      // Windows resolves topmost z-order by whoever asserted it last.
+      platform.isMac = false
+      platform.isWin = true
+
+      wm.open('toolbar' as never)
+      const toolbar = firstWindow()
+
+      toolbar.setAlwaysOnTop.mockClear()
+      toolbar.show()
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
+
+      toolbar.setAlwaysOnTop.mockClear()
+      toolbar.showInactive()
+      expect(toolbar.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver')
     })
   })
 
@@ -721,7 +736,7 @@ describe('WindowManager quirks — applyQuirks monkey-patching', () => {
       const win = firstWindow()
 
       // The initial call from applyWindowBehavior (pre-quirk-patch) uses 2 args.
-      // Subsequent patched show() calls also re-apply via the macReapplyAlwaysOnTop
+      // Subsequent patched show() calls also re-apply via the reapplyAlwaysOnTop
       // quirk — but 'topWithLevel' does not declare that quirk, so show()s do
       // not add more setAlwaysOnTop calls. Filter by the 2-arg shape to assert
       // the initial application specifically.

--- a/src/main/core/window/behavior.ts
+++ b/src/main/core/window/behavior.ts
@@ -47,8 +47,9 @@ export function applyWindowBehavior(
   // ── Initial alwaysOnTop with level/relativeLevel ─────────────────────
   // Electron's `new BrowserWindow({ alwaysOnTop: true })` enables the flag but
   // cannot accept a level. We enhance it here once so the level takes effect
-  // before any show happens. The macReapplyAlwaysOnTop quirk (if set) will
-  // keep re-applying on subsequent show/showInactive to survive macOS demotion.
+  // before any show happens. The reapplyAlwaysOnTop quirk (if set) will keep
+  // re-applying on subsequent show/showInactive to survive macOS level demotion
+  // and Windows topmost z-order churn.
   if (windowOptions.alwaysOnTop === true && behavior.alwaysOnTop) {
     const { level, relativeLevel } = behavior.alwaysOnTop
     if (level !== undefined && relativeLevel !== undefined) {

--- a/src/main/core/window/quirks.ts
+++ b/src/main/core/window/quirks.ts
@@ -12,8 +12,8 @@ import { BrowserWindow } from 'electron'
  * `.on/.once`, etc.) remain untouched.
  *
  * Distinct from `applyWindowBehavior`: this module holds **OS-specific hacks**
- * (workarounds for macOS bugs). Non-hacky declarative behavior (hideOnBlur,
- * initial setVisibleOnAllWorkspaces, etc.) lives in `behavior.ts`.
+ * (workarounds for OS window-manager bugs). Non-hacky declarative behavior
+ * (hideOnBlur, initial setVisibleOnAllWorkspaces, etc.) lives in `behavior.ts`.
  *
  * Must be called AFTER `applyWindowBehavior` so that the behavior layer's
  * initial setter calls (e.g. the first `setAlwaysOnTop(true, level)`) do not
@@ -22,7 +22,7 @@ import { BrowserWindow } from 'electron'
  * @param window - The BrowserWindow instance
  * @param quirks - The OS workaround flags (undefined skips all work)
  * @param behavior - The declarative behavior layer, consulted for the level
- *   to re-apply under `macReapplyAlwaysOnTop` (single source of truth for
+ *   to re-apply under `reapplyAlwaysOnTop` (single source of truth for
  *   level/relativeLevel — see `behavior.alwaysOnTop`).
  */
 export function applyWindowQuirks(
@@ -72,20 +72,21 @@ export function applyWindowQuirks(
     }
   }
 
-  // ── macReapplyAlwaysOnTop ────────────────────────────────────────────
-  // Why:   On macOS, the level passed to setAlwaysOnTop() is not sticky
-  //        across hide/show cycles — after the next show() the level can
-  //        silently demote, causing the window to slide behind fullscreen
-  //        apps or the menu bar.
+  // ── reapplyAlwaysOnTop ───────────────────────────────────────────────
+  // Why:   [macOS] the level passed to setAlwaysOnTop() is not sticky across
+  //        hide/show cycles — after the next show() it can silently demote,
+  //        sliding the window behind fullscreen apps or the menu bar.
+  //        [Windows] z-order among topmost windows is last-writer-wins, so a
+  //        window that only asserts topmost at creation ends up behind any
+  //        third-party floating window shown after it.
   // Does:  After show() / showInactive(), re-applies
   //        setAlwaysOnTop(true, level, relativeLevel) with values read from
-  //        `behavior.alwaysOnTop` (single source of truth).
-  // When:  Windows that must retain an elevated stacking level (screen-saver
-  //        for overlays on top of fullscreen apps; floating otherwise).
+  //        `behavior.alwaysOnTop` (single source of truth). The level argument
+  //        is macOS-only; Windows ignores it and just re-asserts topmost.
+  // When:  Window types that must retain an elevated stacking level
+  //        (screen-saver for overlays on top of fullscreen apps; floating otherwise).
   //        No-op when `behavior.alwaysOnTop.level` / `relativeLevel` are unset.
-  //
-  // [macOS] Show-path methods (show/showInactive): post-hook re-applies alwaysOnTop level.
-  if (isMac && quirks.macReapplyAlwaysOnTop) {
+  if (quirks.reapplyAlwaysOnTop) {
     // When behavior doesn't declare a level, fall back to 'floating' explicitly
     // rather than relying on Electron's internal default — this keeps the
     // re-apply call signature stable across Electron upgrades.

--- a/src/main/core/window/types.ts
+++ b/src/main/core/window/types.ts
@@ -202,7 +202,7 @@ export interface WindowBehavior {
    * of truth for `level` / `relativeLevel`. Consumed at three points:
    *   1. Initial application after window create (when `windowOptions.alwaysOnTop` is true).
    *   2. `wm.behavior.setAlwaysOnTop(id, enabled)` runtime calls.
-   *   3. `quirks.macReapplyAlwaysOnTop` re-application after show/showInactive.
+   *   3. `quirks.reapplyAlwaysOnTop` re-application after show/showInactive.
    */
   alwaysOnTop?: {
     level?: AlwaysOnTopLevel
@@ -261,13 +261,17 @@ export interface WindowQuirks {
   macClearHoverOnHide?: boolean
 
   /**
-   * [macOS] Re-apply `setAlwaysOnTop(true, level, relativeLevel)` after every
-   * `show()`/`showInactive()` call, because macOS silently demotes the level
-   * across show cycles. Pure boolean switch — the actual level/relativeLevel
-   * are read from `behavior.alwaysOnTop` (single source of truth).
-   * No-op when `behavior.alwaysOnTop.level` is unset.
+   * Re-apply `setAlwaysOnTop(true, level, relativeLevel)` after every
+   * `show()`/`showInactive()` call. Pure boolean switch — the actual
+   * level/relativeLevel are read from `behavior.alwaysOnTop` (single source of
+   * truth). No-op when `behavior.alwaysOnTop.level` is unset.
+   *
+   * - [macOS] the level silently demotes across show cycles.
+   * - [Windows] z-order among topmost windows is decided by whoever called
+   *   `SetWindowPos(HWND_TOPMOST)` last, so a window that never re-asserts ends
+   *   up behind third-party floating windows created after it.
    */
-  macReapplyAlwaysOnTop?: boolean
+  reapplyAlwaysOnTop?: boolean
 }
 
 /** Common fields shared by all window type metadata variants */

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -316,7 +316,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // blur handler and its internal `isPinnedQuickAssistant` flag.
       // `new BrowserWindow({ alwaysOnTop: true })` cannot accept a level — the
       // floating level is applied by applyWindowBehavior on create, and kept
-      // across show cycles by the macReapplyAlwaysOnTop quirk below.
+      // across show cycles by the reapplyAlwaysOnTop quirk below.
       alwaysOnTop: { level: 'floating' },
       // Quick window is visible across all workspaces and over fullscreen apps.
       // `skipTransformProcessType: true` prevents TransformProcessType(UIElement)
@@ -328,9 +328,10 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       macShowInDock: false
     },
     quirks: {
-      // Re-apply the floating level after every show/showInactive — macOS silently
-      // demotes it across cycles. The actual level is read from `behavior.alwaysOnTop`.
-      macReapplyAlwaysOnTop: true
+      // Re-assert topmost after every show/showInactive — macOS silently demotes the
+      // level across cycles, Windows lets later topmost windows stack above.
+      // The actual level is read from `behavior.alwaysOnTop`.
+      reapplyAlwaysOnTop: true
     }
   },
 
@@ -431,7 +432,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
     quirks: {
       macRestoreFocusOnHide: true,
       macClearHoverOnHide: true,
-      macReapplyAlwaysOnTop: true
+      reapplyAlwaysOnTop: true
     }
   },
 

--- a/src/main/services/selection/SelectionService.ts
+++ b/src/main/services/selection/SelectionService.ts
@@ -597,8 +597,10 @@ export class SelectionService extends BaseService implements Activatable {
       y: posY
     })
 
-    // setAlwaysOnTop(true, 'screen-saver') is re-applied by the macReapplyAlwaysOnTop
-    // quirk after every show()/showInactive() call (see WindowManager.applyQuirks).
+    // setAlwaysOnTop(true, 'screen-saver') is re-applied on every platform by the
+    // reapplyAlwaysOnTop quirk after each show()/showInactive() call (see
+    // WindowManager.applyQuirks) — on Windows that re-assert is what keeps the
+    // toolbar above third-party topmost windows.
 
     if (!isMac) {
       this.toolbarWindow!.show()


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: on Windows, the selection-assistant toolbar was drawn **behind** other always-on-top windows. Any third-party floating window (a sticky note, a translator overlay, a video player in PiP…) shown after the toolbar window was created would cover it, so selecting text produced a toolbar the user could not see or click.

After this PR: the toolbar re-asserts topmost on every show, so it comes back to the front of the topmost band each time it appears.

Fixes #18092

### Why we need it and why it was done in this way

`WindowQuirks.macReapplyAlwaysOnTop` already existed to re-apply `setAlwaysOnTop(true, level)` after `show()` / `showInactive()`, but `quirks.ts` gated the whole monkey-patch behind `isMac`:

```ts
if (isMac && quirks.macReapplyAlwaysOnTop) { … }
```

`SelectionToolbar` declares `windowOptions.alwaysOnTop: true` + `behavior.alwaysOnTop: { level: 'screen-saver' }`, but with the gate active on Windows that topmost flag was only asserted **once**, by `applyWindowBehavior` at window-create time. Windows resolves z-order *within* the topmost band by whoever called `SetWindowPos(HWND_TOPMOST)` last, so every third-party topmost window shown afterwards stacked above the toolbar — and `SelectionService.showToolbarAtPosition` never re-asserts (its Windows branch is a bare `this.toolbarWindow!.show()`). The comment there even claimed the quirk would replay the call after show, which was only true on macOS; that stale comment is corrected here too.

The fix is to make the re-assert platform-neutral: drop the `isMac` gate and rename the quirk `macReapplyAlwaysOnTop` → `reapplyAlwaysOnTop`. The rename is required by the window-manager naming rule already documented in [`docs/references/window-manager/README.md`](docs/references/window-manager/README.md) — a `mac` / `win` / `linux` prefix means the field is effective on that platform only. Docs and the three in-code cross-references (`behavior.ts`, `types.ts`, `SelectionService.ts`) were updated with it.

The following tradeoffs were made:

- **Renamed outright instead of keeping a `macReapplyAlwaysOnTop` alias.** There are exactly two call sites in the registry; an alias would be speculative surface area for no consumer.
- **The `level` argument is unchanged.** Electron's `setAlwaysOnTop` level parameter is a macOS concept; Windows ignores it and treats every level as plain topmost. Passing `'screen-saver'` on Windows is therefore inert — the *re-assert itself* is what fixes the z-order, not the level.
- **The quirk now also runs on Linux.** Re-asserting `_NET_WM_STATE_ABOVE` on X11 is idempotent, and on Wayland `setAlwaysOnTop` is effectively a no-op, so this is neutral there rather than a targeted fix.

The following alternatives were considered:

- **Add a separate `winReapplyAlwaysOnTop` flag, toolbar-only.** Rejected: it encodes the same intent twice and leaves QuickAssistant (which has the identical last-writer-wins exposure on Windows) unfixed.
- **Call `setAlwaysOnTop` directly in `SelectionService.showToolbarAtPosition`'s Windows branch.** Rejected: that is exactly the per-call-site hand-rolling the `quirks` layer exists to replace, and it would fix one window while the declarative flag keeps lying about the others.

### Breaking changes

None for users. Internal type-level rename only: `WindowQuirks.macReapplyAlwaysOnTop` → `WindowQuirks.reapplyAlwaysOnTop`. Both call sites (`QuickAssistant`, `SelectionToolbar` in `windowRegistry.ts`) are updated in this PR; there are no other references in the tree.

### Special notes for your reviewer

**QuickAssistant regression check** (the other consumer of this quirk, `level: 'floating'`) — I verified this is safe rather than assuming it:

- It declares `windowOptions.alwaysOnTop: true` (`windowRegistry.ts`), so the re-assert restates a flag the window already has — idempotent.
- `QuickAssistantService` contains no `setAlwaysOnTop` call anywhere. The pin feature only changes the blur→hide policy; nothing ever turns always-on-top *off*, so there is no state the post-show re-assert could clobber.
- Its `proceedShow()` calls `window.show()` on the normal path and again on the Windows minimize-recovery path; both now end with `setAlwaysOnTop(true, 'floating')`, which on Windows means the panel is raised within the topmost band on each show — the intended behavior for a floating assistant.

**Verification.** `WindowManager.quirks.test.ts` gains a case asserting that with `isMac = false, isWin = true` the toolbar still re-applies `setAlwaysOnTop(true, 'screen-saver')` after both `show()` and `showInactive()`. I confirmed it is not vacuous: restoring the `isMac &&` gate turns that single test red (1 failed / 34 passed) and removing it turns it green again.

While in that file I also repaired the adjacent `non-mac platforms` test, which could never fail — it captured the method references *after* `applyQuirks` had run and then compared them to themselves. It now asserts the mac-only `hide`/`close` patches are absent via `vi.isMockFunction`, plus a behavioral check that hiding on non-mac fires no `sendInputEvent`.

**Windows behavior is not verified on real hardware** (this was developed on macOS). The change is pure main-process window plumbing with no visual/renderer surface, so the evidence is the unit test above plus Win32 topmost z-order semantics. Someone on Windows reproducing #18092 confirming the toolbar now stays in front would be a welcome extra check before merge.

**Local gates:** `pnpm test:lint` exit 0 (37 pre-existing warnings, none in the touched files); `typecheck:node` clean; `vitest --project main` 11868 passed / 62 skipped; remaining projects 2964 passed. Two renderer tests fail (`DataSettings/__tests__/BasicDataSettings.test.tsx`, `DataSettings/__tests__/legacyV1BrowserData.test.ts`) — I confirmed both fail identically on a clean checkout of the base commit; they are unrelated to this change.

### Original user report

Sourced from the V2 preview feedback base ([record](https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My), `recvrBAsaXXLoV`), reported by 许思寅 (upstream GitHub author `fjyjf`), P2 / UI / Windows / source version V2.0.1:

> On Windows, the selection-assistant toolbar sits at a lower window level than other always-on-top floating windows, so the toolbar becomes invisible or unusable.

Repro: 1. open another always-on-top floating window; 2. select text in an application; 3. the selection toolbar appears behind it.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. — N/A, this restores the documented behavior of an existing feature; the developer-facing `docs/references/window-manager/` pages are updated in this PR.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the selection assistant toolbar being hidden behind other always-on-top windows on Windows.
```
