### PR TITLE
fix(composer): collapse selection after clearing input

### DIFF
--- a/src/renderer/components/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/composer/ComposerTokenNode.tsx
@@ -50,6 +50,15 @@ function deleteComposerTokenRange(editor: Editor, from: number, to: number) {
   return true
 }
 
+function deleteAllComposerContent(editor: Editor) {
+  if (!(editor.state.selection instanceof AllSelection)) return false
+
+  // Tiptap's deleteRange keeps AllSelection mapped onto the empty document; ProseMirror's
+  // selection-aware transaction collapses it back to a text cursor.
+  editor.view.dispatch(editor.state.tr.deleteSelection().scrollIntoView())
+  return true
+}
+
 function deleteComposerTokenNearSelection(editor: Editor, nodeName: string, direction: -1 | 1) {
   const { selection } = editor.state
 
@@ -312,8 +321,9 @@ export const ComposerTokenNode = Node.create<ComposerTokenNodeOptions>({
 
   addKeyboardShortcuts() {
     return {
-      Backspace: () => deleteComposerTokenNearSelection(this.editor, this.name, -1),
-      Delete: () => deleteComposerTokenNearSelection(this.editor, this.name, 1)
+      Backspace: () =>
+        deleteAllComposerContent(this.editor) || deleteComposerTokenNearSelection(this.editor, this.name, -1),
+      Delete: () => deleteAllComposerContent(this.editor) || deleteComposerTokenNearSelection(this.editor, this.name, 1)
     }
   },
 

--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -2,7 +2,7 @@ import { COMPOSER_FILE_KIND, FILE_TYPE, type FileMetadata } from '@renderer/type
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { Editor } from '@tiptap/core'
-import { AllSelection, NodeSelection, Selection } from '@tiptap/pm/state'
+import { AllSelection, NodeSelection, Selection, TextSelection } from '@tiptap/pm/state'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode, useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1374,4 +1374,23 @@ describe('ComposerToken', () => {
     await waitFor(() => expect(editor!.state.selection).toBeInstanceOf(AllSelection))
     expect(screen.queryByLabelText('${city}')).toBeNull()
   })
+
+  it.each(['Backspace', 'Delete'])(
+    'collapses an all-selection after deleting the whole composer with %s',
+    async (key) => {
+      let editor: Editor | null = null
+      render(<ComposerEditorHarness text="draft" onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+      await waitFor(() => expect(editor).not.toBeNull())
+
+      fireEvent.keyDown(editor!.view.dom, { key: 'a', ctrlKey: true })
+      expect(editor!.state.selection).toBeInstanceOf(AllSelection)
+
+      fireEvent.keyDown(editor!.view.dom, { key })
+
+      expect(serializeComposerDocument(editor!).text).toBe('')
+      expect(editor!.state.selection).toBeInstanceOf(TextSelection)
+      expect(editor!.state.selection.empty).toBe(true)
+    }
+  )
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Selecting all composer content and pressing Backspace or Delete cleared the content but could leave the editor in an `AllSelection`, making the empty caret appear selected.

<img width="1184" height="270" alt="PixPin_2026-08-15_13-48-01" src="https://github.com/user-attachments/assets/17212249-24e9-4c27-836e-913ecd2bfe1d" />

After this PR:

Deleting a fully selected composer clears the content and collapses the selection to a normal empty text cursor.

<img width="1020" height="270" alt="PixPin_2026-08-15_13-46-21" src="https://github.com/user-attachments/assets/66ec33be-6e07-4e11-ba05-a55bb467386d" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Tiptap's range deletion maps an `AllSelection` onto the empty document. The composer now handles that exact selection state with ProseMirror's selection-aware transaction, which clears the document and resolves the selection to a text cursor. Existing token-aware Backspace and Delete behavior remains unchanged for every other selection type.

The following tradeoffs were made:

- The behavior is limited to `AllSelection` so partial selections and adjacent token deletion retain their existing paths.
- Both Backspace and Delete share the same helper to keep their behavior consistent.

The following alternatives were considered:

- Explicitly resetting the selection after Tiptap's range deletion was considered, but ProseMirror's native `deleteSelection()` transaction already owns the correct selection mapping without an extra corrective transaction.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Regression coverage exercises both Backspace and Delete after selecting all composer content.
- No user-guide update is required for this focused bug fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the composer caret remaining in an all-selected state after clearing the entire input.
```
