### PR TITLE
perf(chat-scroll): reuse measured message heights across remounts

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -263,6 +263,7 @@ export function MessageVirtualList<T>({
                 data={runtime.wrappedItems}
                 itemSize={estimateSize}
                 bufferSize={Math.max(200, overscan * (estimateSize ?? 200))}
+                cache={runtime.restoredSizeCache}
                 shift={runtime.shift}
                 keepMounted={runtime.keepMounted}
                 startMargin={topPadding}

--- a/src/renderer/components/chat/messages/list/__tests__/useScrollPositionMemory.test.ts
+++ b/src/renderer/components/chat/messages/list/__tests__/useScrollPositionMemory.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   computeScrollAnchor,
+  readScrollSizes,
   resolveRestoreTarget,
   type ScrollPositionMemoryInputs,
   useScrollPositionMemory
@@ -85,6 +86,37 @@ describe('resolveRestoreTarget', () => {
   })
 })
 
+describe('readScrollSizes', () => {
+  // Heights are addressed by index, so any list the snapshot was not measured
+  // against would assign them to the wrong messages.
+  const snapshot = { sizes: [10, 20, 30] }
+  const save = (over: Record<string, unknown> = {}) =>
+    cacheService.set('chat.scroll_sizes.t1', { snapshot, count: 3, firstKey: 'g0', lastKey: 'g2', ...over })
+
+  beforeEach(() => MockCacheUtils.resetMocks())
+
+  it('restores the measured heights for the same list', () => {
+    save()
+    expect(readScrollSizes('t1', ['g0', 'g1', 'g2'])).toBe(snapshot)
+  })
+
+  it('drops the heights when an older page was prepended', () => {
+    save()
+    expect(readScrollSizes('t1', ['older', 'g0', 'g1', 'g2'])).toBeUndefined()
+  })
+
+  it('drops the heights when a boundary message was replaced at the same count', () => {
+    save()
+    expect(readScrollSizes('t1', ['g0', 'g1', 'edited'])).toBeUndefined()
+  })
+
+  it('restores nothing without a topic or items', () => {
+    save()
+    expect(readScrollSizes(undefined, ['g0', 'g1', 'g2'])).toBeUndefined()
+    expect(readScrollSizes('t1', [])).toBeUndefined()
+  })
+})
+
 describe('useScrollPositionMemory', () => {
   let rafQueue: Array<() => void>
 
@@ -103,6 +135,7 @@ describe('useScrollPositionMemory', () => {
     findItemIndex: ReturnType<typeof vi.fn>
     getItemOffset: ReturnType<typeof vi.fn>
     scrollToIndex: ReturnType<typeof vi.fn>
+    cache: object
   }
   let following: boolean
   let enterFollowingAfterRestore: ReturnType<typeof vi.fn>
@@ -141,7 +174,7 @@ describe('useScrollPositionMemory', () => {
     MockCacheUtils.resetMocks()
 
     scroller = { scrollTop: 0, scrollHeight: 1000, clientHeight: 400 }
-    handle = { findItemIndex: vi.fn(), getItemOffset: vi.fn(), scrollToIndex: vi.fn() }
+    handle = { findItemIndex: vi.fn(), getItemOffset: vi.fn(), scrollToIndex: vi.fn(), cache: {} }
     following = false
     enterFollowingAfterRestore = vi.fn()
     enterReadingForRestore = vi.fn()
@@ -223,17 +256,39 @@ describe('useScrollPositionMemory', () => {
     handle.findItemIndex.mockReturnValue(2)
     handle.getItemOffset.mockReturnValue(100)
     const nowSpy = vi.spyOn(Date, 'now')
+    const anchorWrites = () =>
+      vi.mocked(cacheService.set).mock.calls.filter(([key]) => key === 'chat.scroll_anchor.t1').length
 
     nowSpy.mockReturnValue(1000)
     act(() => result.current.save()) // first throttled save → writes
     nowSpy.mockReturnValue(1100) // 100ms later, inside the 200ms window
     act(() => result.current.save()) // throttled out
-    expect(cacheService.set).toHaveBeenCalledTimes(1)
+    expect(anchorWrites()).toBe(1)
 
     act(() => result.current.save(true)) // immediate save bypasses the throttle
-    expect(cacheService.set).toHaveBeenCalledTimes(2)
+    expect(anchorWrites()).toBe(2)
 
     nowSpy.mockRestore()
+  })
+
+  it('snapshots measured heights only at rest, tagged with the list it was measured against', () => {
+    const { result } = renderHook(() => useScrollPositionMemory(buildInputs()))
+    flushRaf()
+
+    handle.findItemIndex.mockReturnValue(2)
+    handle.getItemOffset.mockReturnValue(100)
+    handle.cache = { sizes: [1, 2, 3] }
+
+    act(() => result.current.save())
+    expect(cacheService.set).not.toHaveBeenCalledWith('chat.scroll_sizes.t1', expect.anything())
+
+    act(() => result.current.save(true))
+    expect(cacheService.set).toHaveBeenCalledWith('chat.scroll_sizes.t1', {
+      snapshot: handle.cache,
+      count: 3,
+      firstKey: 'g0',
+      lastKey: 'g2'
+    })
   })
 
   it('saves null when the list is following', () => {

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -32,12 +32,12 @@ import {
   useRef,
   useState
 } from 'react'
-import type { VListHandle } from 'virtua'
+import type { CacheSnapshot, VListHandle } from 'virtua'
 
 import { getDistanceToBottom, getRealBottom, isMoreThanOneViewportFromBottom } from './scrollGeometry'
 import { clampForwardedWheelDelta, findOutermostVerticalScrollContainer } from './ScrollOwnershipContext'
 import { useAutoStickToBottom } from './useAutoStickToBottom'
-import { useScrollPositionMemory } from './useScrollPositionMemory'
+import { readScrollSizes, useScrollPositionMemory } from './useScrollPositionMemory'
 import { useSmoothScrollAnimation } from './useSmoothScrollAnimation'
 import { type FollowingReason, type ReadingReason, useViewportFollowState } from './useViewportFollowState'
 
@@ -115,6 +115,8 @@ export interface ChatVirtualizerRuntime<T> {
   wrappedRenderItem(item: WrappedItem<T>, index: number): ReactElement
   /** True only for the render where older items were prepended. */
   shift: boolean
+  /** Heights measured on a previous mount of this topic; virtua reads it once. */
+  restoredSizeCache: CacheSnapshot | undefined
   keepMounted: readonly number[]
   scrollerProps: ScrollerEventHandlers
   isScrollToBottomButtonVisible: boolean
@@ -493,6 +495,13 @@ export function useChatVirtualizerRuntime<T>({
   }, [])
 
   // ---- per-topic scroll position memory -------------------------------
+
+  // virtua takes a size cache at mount only, so this resolves on the first
+  // render that has items — an earlier empty render would mount without it.
+  const restoredSizeCacheRef = useRef<CacheSnapshot | undefined>(undefined)
+  if (!restoredSizeCacheRef.current && dataKeys.length > 0) {
+    restoredSizeCacheRef.current = readScrollSizes(topicId, dataKeys)
+  }
 
   const { save: saveScrollPosition } = useScrollPositionMemory({
     topicId,
@@ -928,6 +937,7 @@ export function useChatVirtualizerRuntime<T>({
     wrappedItems,
     wrappedRenderItem: wrappedRenderItem as ChatVirtualizerRuntime<T>['wrappedRenderItem'],
     shift,
+    restoredSizeCache: restoredSizeCacheRef.current,
     keepMounted,
     scrollerProps,
     isScrollToBottomButtonVisible,

--- a/src/renderer/components/chat/messages/list/useScrollPositionMemory.ts
+++ b/src/renderer/components/chat/messages/list/useScrollPositionMemory.ts
@@ -24,7 +24,7 @@
 import { cacheService } from '@data/CacheService'
 import type { ChatScrollAnchor } from '@shared/data/cache/cacheValueTypes'
 import { type RefObject, useCallback, useEffect, useRef } from 'react'
-import type { VListHandle } from 'virtua'
+import type { CacheSnapshot, VListHandle } from 'virtua'
 
 export type { ChatScrollAnchor }
 
@@ -126,7 +126,21 @@ export interface ScrollPositionMemory {
 }
 
 const cacheKeyFor = (topicId: string) => `chat.scroll_anchor.${topicId}` as const
+const sizesKeyFor = (topicId: string) => `chat.scroll_sizes.${topicId}` as const
 const SAVE_THROTTLE_MS = 200
+
+/**
+ * Measured heights for this exact item list, or `undefined` when nothing usable
+ * is stored. Read during render — virtua only accepts a size cache at mount.
+ */
+export function readScrollSizes(topicId: string | undefined, itemKeys: readonly string[]): CacheSnapshot | undefined {
+  if (!topicId || itemKeys.length === 0) return undefined
+  const saved = cacheService.get(sizesKeyFor(topicId))
+  if (!saved) return undefined
+  const matchesList =
+    saved.count === itemKeys.length && saved.firstKey === itemKeys[0] && saved.lastKey === itemKeys[itemKeys.length - 1]
+  return matchesList ? (saved.snapshot as CacheSnapshot) : undefined
+}
 
 export function useScrollPositionMemory(inputs: ScrollPositionMemoryInputs): ScrollPositionMemory {
   // Keep the latest inputs addressable from the stable callbacks/effect.
@@ -155,6 +169,20 @@ export function useScrollPositionMemory(inputs: ScrollPositionMemoryInputs): Scr
       getOffsetAtIndex: (index) => handle.getItemOffset(index)
     })
     cacheService.set(cacheKeyFor(i.topicId), anchor)
+
+    // Only at rest: `immediate` comes from onScrollEnd, when every row the user
+    // just passed has been measured. Snapshotting on every throttled scroll tick
+    // would pay for a whole-list copy mid-gesture and capture the same sizes.
+    if (!immediate) return
+    const firstKey = i.getDataKeyAtIndex(0)
+    const lastKey = i.getDataKeyAtIndex(i.itemCount - 1)
+    if (!firstKey || !lastKey) return
+    cacheService.set(sizesKeyFor(i.topicId), {
+      snapshot: handle.cache,
+      count: i.itemCount,
+      firstKey,
+      lastKey
+    })
   }, [])
 
   // Restore once, as soon as the (remounted) list has items.

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -130,6 +130,8 @@ export type UseCacheSchema = {
   // Message-list scroll position memory, keyed per topic / agent session.
   // `null` = follow the latest message (at bottom or never scrolled).
   'chat.scroll_anchor.${topicId}': CacheValueTypes.ChatScrollAnchor | null
+  // Measured message heights, so a remount does not re-estimate the whole list.
+  'chat.scroll_sizes.${topicId}': CacheValueTypes.ChatScrollSizes | null
 
   // Knowledge recall test query history (session-only)
   'knowledge.recall.search_queries': Record<string, string[]>
@@ -220,6 +222,7 @@ export const DefaultUseCache: UseCacheSchema = {
     modelMultiSelectMode: false
   },
   'chat.scroll_anchor.${topicId}': null,
+  'chat.scroll_sizes.${topicId}': null,
   'knowledge.recall.search_queries': {},
   'notes.active_file_path': undefined,
 

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -131,6 +131,25 @@ export interface ChatScrollAnchor {
   offset: number
 }
 
+/**
+ * Measured message heights for a chat topic / agent-session message list.
+ *
+ * Without this the virtualizer re-estimates every message on each remount, and
+ * replaces each estimate with its real height as it is scrolled into view —
+ * every replacement is a visible scroll correction.
+ *
+ * The snapshot addresses messages by index, so it is only valid for the exact
+ * item list it was measured against; `count` / `firstKey` / `lastKey` must all
+ * match at mount or the heights would land on the wrong messages.
+ */
+export interface ChatScrollSizes {
+  /** virtua `CacheSnapshot`. Opaque here: `@shared` cannot import renderer libs. */
+  snapshot: object
+  count: number
+  firstKey: string
+  lastKey: string
+}
+
 export interface CacheComposerSerializedToken {
   id: string
   kind: ComposerMessageTokenKind | 'promptVariable'


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The virtualizer discarded every measured message height on each remount (topic switch, tab switch) and re-measured the whole list as it was scrolled again, re-running layout for messages whose size was already known.

After this PR:

Measured heights are snapshotted per topic in the Memory cache when scrolling comes to rest and restored at mount, so reopening a conversation reuses the measurements instead of re-deriving them.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

**This does not fix #18589 or #18356.** It reduces renderer work on one path; the scrolling complaint in those issues is main-thread cost during rendering and is untouched here. See "Special notes" for why an earlier version of this description claimed otherwise.

### Why we need it and why it was done in this way

Re-measuring a long conversation from scratch on every remount is avoidable work, and message groups here are large (real heights 547px p50 / 3133px p90 / 6755px max), so each re-measurement drags layout and style recalculation with it. `virtua` accepts a size cache only at mount, so the restore resolves on the first render that has items rather than in an effect; because the snapshot addresses items by index, it is guarded by list identity (`count` + `firstKey` + `lastKey`) so a pagination prepend can never map heights onto the wrong messages.

The following tradeoffs were made:

- Memory tier only — `CacheSnapshot` is opaque and version-bound, so it must never be persisted across releases; it is typed as `object` in `@shared`, which cannot import renderer libraries.
- Snapshots are taken only at scroll rest (`onScrollEnd`), not on every throttled scroll tick, to avoid a whole-list copy mid-gesture.
- Only revisits benefit; a first visit has nothing measured to reuse.

The following alternatives were considered:

Raising the static `estimateSize` from 400, upgrading `virtua` 0.49.1 → 0.50.1, and patching `virtua`'s resize-compensation predicate were all measured and none produced an improvement, so none are included here.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18589

### Breaking changes

None. The new cache key is memory-tier and per topic, so there is nothing persisted, migrated, or user-visible to roll back.

### Special notes for your reviewer

**Correction to the original description.** It claimed this stopped the view "jerking" while scrolling back through history, based on a metric counting `scrollTop` moving against the commanded scroll direction (reported as 12.5% → 1.6%). That metric is wrong for this purpose: correct compensation *also* moves `scrollTop` while holding content still, so it measures compensation volume, not anything the user sees. Re-measured by sampling the pinned message's viewport position every animation frame — the granularity at which anything is actually painted — content moves at most one wheel tick (100px) per frame in every arm, with or without this change. A `+2679px` `scrollTop` write moved the visible content by `0px`. There was no visible jump to fix.

What is measurable is renderer work on the revisit path, against a control arm with the restore disabled (same scenario and scroll script, 98-message topic, one run per arm):

| revisit | main-thread task time | layout count | style recalcs | dropped frames | p99 frame |
|---|---|---|---|---|---|
| restore disabled | 5.21s | 376 | 603 | 3.6% | 175ms |
| restore enabled | 3.68s | 312 | 526 | 2.7% | 150ms |

Single run per arm, so treat the magnitude as indicative rather than settled. If reviewers would rather not carry an optimization at this confidence level, closing this is a reasonable call — the code is self-contained and the measurement notes are the more durable output.

One pre-existing assertion in the touched test counted raw `cacheService.set` calls; it now asserts on the anchor key it actually cares about, so it no longer breaks when a second key is written.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
