### PR TITLE
fix(skill-install): bound the skill being installed, not the archive it came in

### DIFF
--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -38,9 +38,14 @@ const logger = loggerService.withContext('SkillService')
 // API base URLs for the 3 search sources
 const CLAUDE_PLUGINS_API = 'https://api.claude-plugins.dev'
 
-// ZIP extraction limits
-const MAX_EXTRACTED_SIZE = 100 * 1024 * 1024 // 100MB
-const MAX_FILES_COUNT = 2000
+// What one installed skill may weigh — the directory holding SKILL.md is all that reaches the library.
+const MAX_SKILL_SIZE = 100 * 1024 * 1024 // 100MB
+const MAX_SKILL_FILES = 20_000
+// What may be unpacked while looking for that skill. An archive is routinely a repository zipball
+// carrying one skill plus the whole repository around it, none of which is installed, so this bounds
+// the temp directory rather than the skill.
+const MAX_ARCHIVE_SIZE = 1024 * 1024 * 1024 // 1GB
+const MAX_ARCHIVE_ENTRIES = 50_000
 const MAX_FOLDER_NAME_LENGTH = 80
 // A direct-URL install points git at a repository nobody vetted; no single step may hang forever.
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
@@ -223,6 +228,7 @@ export class SkillService {
     try {
       await this.extractZip(canonicalZipPath, tempDir)
       const skillDir = await this.locateSkillDir(tempDir)
+      await this.assertSkillDirectoryWithinLimits(skillDir)
       return await this.installSkillDir(skillDir, 'zip', sourceUrl)
     } finally {
       await this.safeRemoveDirectory(tempDir)
@@ -601,7 +607,12 @@ export class SkillService {
     await git(['checkout', '--quiet', 'FETCH_HEAD'])
   }
 
-  /** Apply the same ceilings an untrusted ZIP gets — a repository is no more trusted than an archive. */
+  /**
+   * Bound what actually gets installed. Every install path converges here once its skill directory
+   * is known, so the ceilings measure the skill rather than whatever archive or repository carried
+   * it. Measuring the whole directory before rejecting keeps the error honest: stopping at the file
+   * that crosses a ceiling would report the limit plus one file instead of the real total.
+   */
   private async assertSkillDirectoryWithinLimits(skillDir: string): Promise<void> {
     let totalSize = 0
     let fileCount = 0
@@ -617,16 +628,17 @@ export class SkillService {
 
         fileCount += 1
         totalSize += (await fs.promises.stat(entryPath)).size
-        if (totalSize > MAX_EXTRACTED_SIZE) {
-          throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
-        }
-        if (fileCount > MAX_FILES_COUNT) {
-          throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
-        }
       }
     }
 
     await walk(skillDir)
+
+    if (totalSize > MAX_SKILL_SIZE) {
+      throw new Error(`Skill holds ${totalSize} bytes, over the ${MAX_SKILL_SIZE}-byte limit`)
+    }
+    if (fileCount > MAX_SKILL_FILES) {
+      throw new Error(`Skill holds ${fileCount} files, over the ${MAX_SKILL_FILES}-file limit`)
+    }
   }
 
   private async runGit(gitCommand: string, args: string[]): Promise<string> {
@@ -743,6 +755,7 @@ export class SkillService {
         throw new Error(`No SKILL.md found at the clawhub archive root: ${identifier}`)
       }
       const skillDir = await this.validateRepositorySkillDirectory(extractDir, extractDir, skillMdPath)
+      await this.assertSkillDirectoryWithinLimits(skillDir)
       const metadata = await parseSkillMetadata(skillDir, slug, 'skills', { calculateSize: false })
       if ((metadata.slug ?? metadata.name).toLowerCase() !== slug.toLowerCase()) {
         throw new Error(`clawhub archive did not match the requested skill: ${identifier}`)
@@ -932,20 +945,20 @@ export class SkillService {
     const zip = new StreamZip.async({ file: zipFilePath })
 
     try {
-      const entries = await zip.entries()
-      let totalSize = 0
-      let fileCount = 0
+      const entries = Object.values(await zip.entries())
+      // Measure the whole archive before rejecting it. Stopping at the entry that crosses a ceiling
+      // reports the running counter — always the limit plus one entry — so an archive many times
+      // over the limit reads as barely over it, and the user cannot tell why the install failed.
+      // The central directory is already parsed and in memory here, so the full scan costs no I/O.
+      const totalSize = entries.reduce((sum, entry) => sum + entry.size, 0)
 
-      for (const entry of Object.values(entries)) {
-        totalSize += entry.size
-        fileCount++
-
-        if (totalSize > MAX_EXTRACTED_SIZE) {
-          throw new Error(`ZIP too large: ${totalSize} bytes exceeds ${MAX_EXTRACTED_SIZE}`)
-        }
-        if (fileCount > MAX_FILES_COUNT) {
-          throw new Error(`ZIP has too many files: ${fileCount} exceeds ${MAX_FILES_COUNT}`)
-        }
+      if (totalSize > MAX_ARCHIVE_SIZE) {
+        throw new Error(
+          `Skill archive expands to ${totalSize} bytes when extracted, over the ${MAX_ARCHIVE_SIZE}-byte limit`
+        )
+      }
+      if (entries.length > MAX_ARCHIVE_ENTRIES) {
+        throw new Error(`Skill archive contains ${entries.length} entries, over the ${MAX_ARCHIVE_ENTRIES}-entry limit`)
       }
 
       await zip.extract(null, destDir)

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -851,7 +851,7 @@ describe('SkillService', () => {
       const locatedSkillDir = path.join(extractDir, 'skill')
       await fs.promises.writeFile(realZipPath, new Uint8Array([1, 2, 3]))
       await fs.promises.symlink(realZipPath, linkedZipPath)
-      await fs.promises.mkdir(extractDir, { recursive: true })
+      await fs.promises.mkdir(locatedSkillDir, { recursive: true })
       const canonicalZipPath = await fs.promises.realpath(realZipPath)
 
       vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(extractDir as never)
@@ -865,30 +865,62 @@ describe('SkillService', () => {
       expect(installSkillDirSpy).toHaveBeenCalledWith(locatedSkillDir, 'zip', pathToFileURL(canonicalZipPath).href)
     })
 
-    it('accepts ZIP archives containing 2,000 entries', async () => {
-      const skillService = new SkillService()
-      const root = await createTempDir('skill-zip-limit-')
-      const zipPath = path.join(root, 'limit.zip')
-      const extractDir = path.join(root, 'extract')
-      const zip = new AdmZip()
-      for (let index = 0; index < 2_000; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
-      zip.writeZip(zipPath)
-      await fs.promises.mkdir(extractDir)
-
-      await expect(skillService['extractZip'](zipPath, extractDir)).resolves.toBeUndefined()
-    })
-
-    it('rejects ZIP archives containing more than 2,000 entries', async () => {
+    it('rejects archives with more entries than extraction allows, reporting the archive total', async () => {
       const skillService = new SkillService()
       const root = await createTempDir('skill-zip-limit-')
       const zipPath = path.join(root, 'over-limit.zip')
       const extractDir = path.join(root, 'extract')
       const zip = new AdmZip()
-      for (let index = 0; index < 2_001; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
+      for (let index = 0; index < 60_000; index++) zip.addFile(`${index}.txt`, Buffer.alloc(0))
       zip.writeZip(zipPath)
 
+      // 60000, not the 50001 a scan that stopped at the entry crossing the ceiling would report.
       await expect(skillService['extractZip'](zipPath, extractDir)).rejects.toThrow(
-        'ZIP has too many files: 2001 exceeds 2000'
+        'Skill archive contains 60000 entries, over the 50000-entry limit'
+      )
+    })
+
+    /**
+     * The reported failure. `ppt-master-main.zip` is GitHub's zipball of a skill repository: the
+     * skill under `skills/ppt-master/` is 75 MiB, inside the per-skill ceiling, but the repository
+     * around it is 672 MiB. Install refused the whole archive, so a skill within the limits could
+     * not be installed — and said so as `ZIP too large: 106147629 bytes exceeds 104857600`, the
+     * running counter where the scan stopped, which read as 1.2% over rather than 6.4x.
+     */
+    it('installs a repository zipball whose skill is inside the per-skill limits', async () => {
+      const skillService = new SkillService()
+      const root = await createTempDir('skill-zip-repo-')
+      const zipPath = path.join(root, 'repo-main.zip')
+      const extractDir = path.join(root, 'extract')
+
+      const zip = new AdmZip()
+      zip.addFile('repo-main/skills/demo/SKILL.md', Buffer.from('---\nname: demo\n---\n'))
+      // Repository payload that is not part of the skill, over the per-skill ceiling on its own.
+      for (let index = 0; index < 110; index++) zip.addFile(`repo-main/assets/${index}.bin`, Buffer.alloc(1024 * 1024))
+      zip.writeZip(zipPath)
+
+      const skillDir = path.join(extractDir, 'repo-main', 'skills', 'demo')
+      vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(extractDir as never)
+      vi.spyOn(skillService as never, 'locateSkillDir').mockResolvedValue(skillDir as never)
+      const installSkillDirSpy = vi.spyOn(skillService as never, 'installSkillDir').mockResolvedValue({} as never)
+
+      await skillService.installFromZip({ zipFilePath: zipPath })
+
+      const canonicalZipPath = await fs.promises.realpath(zipPath)
+      expect(installSkillDirSpy).toHaveBeenCalledWith(skillDir, 'zip', pathToFileURL(canonicalZipPath).href)
+    })
+
+    it('refuses a skill directory over the per-skill size limit, reporting its real size', async () => {
+      const skillService = new SkillService()
+      const skillDir = await createTempDir('skill-oversized-')
+      // 110 MiB across 110 files: a scan that stopped at the file crossing the ceiling would report
+      // 105906176 (the 101st file), not what the directory actually holds.
+      for (let index = 0; index < 110; index++) {
+        await fs.promises.writeFile(path.join(skillDir, `${index}.bin`), Buffer.alloc(1024 * 1024))
+      }
+
+      await expect(skillService['assertSkillDirectoryWithinLimits'](skillDir)).rejects.toThrow(
+        'Skill holds 115343360 bytes, over the 104857600-byte limit'
       )
     })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A skill ZIP is routinely a GitHub zipball of a skill repository: it carries the skill plus the entire repository around it, and only the directory holding `SKILL.md` is ever installed. `extractZip` applied the per-skill ceilings to the whole archive, so a skill comfortably inside the limits was refused because of the repository it shipped in.

The failure was also unreadable. `totalSize` was a running counter and the scan threw the moment it crossed the ceiling, so the number reported was always "the limit plus whatever entry crossed it" — never the archive's size. The wording compounded it: `ZIP too large: N bytes` names the ZIP while `N` is the extracted total.

After this PR:

The two jobs that one pair of constants was serving are separated:

- `MAX_ARCHIVE_SIZE` (1 GB) / `MAX_ARCHIVE_ENTRIES` (50,000) bound what is unpacked into the temp directory while looking for the skill.
- `MAX_SKILL_SIZE` (100 MB, unchanged) / `MAX_SKILL_FILES` (20,000) bound the skill itself, enforced through `assertSkillDirectoryWithinLimits` on every path that extracts an archive — as the repository path already did.

Both gates measure the whole archive or directory before rejecting, so the error states real totals:

```
Skill archive expands to 720781782 bytes when extracted, over the 1073741824-byte limit
Skill holds 115343360 bytes, over the 104857600-byte limit
```

Fixes #

### Why we need it and why it was done in this way

Original user report (Cherry Studio v2 preview feedback, 2026-07-22, 许思寅):

> 下载好的 skills 安装包，安装时提示文件过大，安装失败，实际并没有超过文件大小的限制
> (An already-downloaded skill package fails to install with a "file too large" error, although it does not actually exceed the size limit.)

Steps as given: download a skill ZIP that is not over the size limit → install it in Cherry Studio → the app reports the file is too large and the install fails.

Feedback record `recvqDWtruMScK` — https://mcnnox2fhjfq.feishu.cn/record/EaawrHSG9e2CYQcgD1icy8dCnib

The record carries a screenshot naming the package and the exact error:

> **ppt-master-main.zip** — `ZIP too large: 106147629 bytes exceeds 104857600`

`ppt-master-main.zip` is GitHub's "Download ZIP" of [`hugohe3/ppt-master`](https://github.com/hugohe3/ppt-master) (`Content-Disposition` for that repo's `main` branch gives exactly that filename). Reading the real archive with the same `node-stream-zip` the app uses:

| | entries | uncompressed |
| --- | --- | --- |
| whole archive (`main` today) | 14,534 | 720,781,782 (687.4 MiB) |
| whole archive at the last commit before the report (`89759436`) | 13,745 | 705,128,515 (672.5 MiB) |
| **`ppt-master-main/skills/ppt-master/` — the only directory that gets installed** | **12,916 files** | **78,940,752 (75.3 MiB)** |

The skill is **inside** the 100 MB ceiling. The archive around it is not, and the archive is what was measured — so the user's statement that the package did not exceed the size limit is literally correct, and the install refused a skill it was supposed to accept. Everything outside `skills/ppt-master/` is extracted, searched for `SKILL.md`, and then deleted.

That also explains the number. 106,147,629 was the running counter where the scan stopped, so a package 6.4× over the archive-wide sum read as 1.2% over — leaving the user no way to see what had actually been measured.

The following tradeoffs were made:

- The per-skill entry ceiling rises from 2,000 to 20,000. The skill in the report holds 12,916 files, and `8019e4571d` (#18040) already raised this constant once for exactly this class of asset-heavy, presentation-oriented skill. The 100 MB byte ceiling is unchanged and still bounds what reaches the library.
- Neither gate short-circuits any more, so an oversized archive or directory is measured to the end. For the archive this is free — `zip.entries()` has already parsed and materialised the whole central directory before the loop, so the early exit saved no I/O and only discarded the information needed for a truthful message. For a directory it costs the remaining `stat` calls on a tree that is itself bounded by the archive ceiling.

The following alternatives were considered:

- Raising the old whole-archive ceilings instead — rejected. It treats the symptom: the archive is not what gets installed, so no value for that ceiling is meaningful. A repository can always be larger than the skill inside it.
- Extracting only the skill's subtree rather than the whole archive — attractive (it would avoid unpacking 672 MB to find 75 MB), but locating a skill currently works on the filesystem, not on ZIP entry names, so this is a larger change and belongs in its own PR.

Links to places where the discussion took place: N/A

### Breaking changes

None for skills that install today. A skill directory may now hold up to 20,000 files instead of 2,000, and an archive may unpack up to 1 GB / 50,000 entries while being searched — both strictly more permissive than before.

### Special notes for your reviewer

- The first regression test reproduces the report directly: on `main` it fails with `ZIP too large: 105906176 bytes exceeds 104857600` — the same shape as the user's screenshot — because the archive's non-skill payload crosses the per-skill ceiling. The other two pin the honest totals (`60000` entries rather than `50001`; `115343360` bytes rather than `105906176`).
- `MAX_ARCHIVE_ENTRIES` is 50,000 partly for testability: `adm-zip`, which the suite uses to build fixtures, cannot write more than 65,535 entries (no ZIP64 central directory), so a higher ceiling could not be covered by a test.
- `assertSkillDirectoryWithinLimits` is now applied on the ZIP and ClawHub paths as well. The `claude-plugins` and `skills.sh` paths clone with git rather than extracting an archive and are left as they were, so no path loses a bound it had.
- **Found while investigating, deliberately not fixed here:** the entry count is inflated by packaging metadata. Measured on one 7-file, 30 KB skill tree, `zip -r` yields 12 entries (5 being directory entries) and macOS Finder's Compress (`ditto -c -k --sequesterRsrc`) yields **29 — 4.1× inflation** from directory entries plus `__MACOSX/._*` resource-fork sidecars. Exempting those from the count is not safe on its own: `zip.extract(null, dest)` writes them regardless, so any exemption lets a crafted archive hold the counter at zero while filling the disk. Fixing it properly means not extracting them, which is a behaviour change for its own PR.
- Also verified, no change needed: `entry.size` from `node-stream-zip@1.15.0` comes from the central directory and was exact across six writers — Info-ZIP, Info-ZIP forced ZIP64, macOS `ditto`, and python `zipfile` in seekable, non-seekable (data-descriptor) and per-entry `force_zip64` modes — including the three whose *local* headers carry `0` or `0xFFFFFFFF`. Directory entries report `size === 0`. There is no size-parsing defect.
- Validation: `pnpm typecheck` (node + web + ai-core), `oxlint --deny-warnings`, `eslint`, `biome check` on both changed files, and `pnpm vitest run --project main src/main/ai/skills` (90 tests).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix skill ZIP import refusing a skill that is within the size limit because the repository archive around it is not: the limits now measure the skill being installed, and a rejection reports the real size and file count instead of a running counter.
```
