### PR TITLE
fix(local-embedding): verify the cache on disk before reporting the model ready

### DIFF
--- a/src/main/services/localModel/LocalEmbeddingDownloadService.ts
+++ b/src/main/services/localModel/LocalEmbeddingDownloadService.ts
@@ -43,18 +43,24 @@ interface LocalEmbeddingCacheProbe {
  */
 const ONNXRUNTIME_PERCENT = 10
 
+function sourceCacheDir(modelDir: string, sourceId: ModelSourceId): string {
+  // transformers.js FileCache omits the revision segment for `main`, but includes it
+  // otherwise (buildResourcePaths in @huggingface/transformers/src/utils/hub.js).
+  const { revision } = getModelSource(sourceId)
+  return revision === 'main' ? modelDir : path.join(modelDir, revision)
+}
+
+function missingModelFiles(sourceDir: string): string[] {
+  return REQUIRED_MODEL_FILES.map((file) => path.join(sourceDir, file)).filter((file) => !fs.existsSync(file))
+}
+
 function cacheState(modelDir: string): LocalEmbeddingCacheProbe {
   if (!fs.existsSync(modelDir)) return { state: 'absent', missingFiles: [] }
 
   const missingFiles: string[] = []
   for (const sourceId of ALL_MODEL_SOURCE_IDS) {
-    const { revision } = getModelSource(sourceId)
-    // transformers.js FileCache omits the revision segment for `main`, but includes it
-    // otherwise (buildResourcePaths in @huggingface/transformers/src/utils/hub.js).
-    const sourceDir = revision === 'main' ? modelDir : path.join(modelDir, revision)
-    const sourceMissingFiles = REQUIRED_MODEL_FILES.map((file) => path.join(sourceDir, file)).filter(
-      (file) => !fs.existsSync(file)
-    )
+    const sourceDir = sourceCacheDir(modelDir, sourceId)
+    const sourceMissingFiles = missingModelFiles(sourceDir)
     if (sourceMissingFiles.length === 0) {
       return { state: 'ready', completeSource: sourceId, completeDir: sourceDir, missingFiles: [] }
     }
@@ -142,6 +148,12 @@ class LocalEmbeddingDownloadService extends LocalModelDownloadService {
         await application
           .get('EmbeddingInferenceService')
           .loadEmbedding(getModelSource(id), MODEL_REPO, MODEL_DTYPE, (p) => this.broadcastProgress(p), signal)
+        // A resolved load doesn't prove the files landed: confirm with the same on-disk probe
+        // the card reads, or ready/incomplete flip forever and re-download the ~600MB weights.
+        const missingFiles = missingModelFiles(sourceCacheDir(this.modelDir(), id))
+        if (missingFiles.length > 0) {
+          throw new Error(`the download left the cache incomplete (missing ${missingFiles.join(', ')})`)
+        }
         return
       } catch (error) {
         if (signal.aborted) throw error

--- a/src/main/services/localModel/__tests__/LocalEmbeddingDownloadService.test.ts
+++ b/src/main/services/localModel/__tests__/LocalEmbeddingDownloadService.test.ts
@@ -84,13 +84,19 @@ const { localEmbeddingDownloadService } = await import('../LocalEmbeddingDownloa
 const MODELS_ROOT = '/mock/feature.embedding.models'
 const MODEL_DIR = `${MODELS_ROOT}/onnx-community/Qwen3-Embedding-0.6B-ONNX`
 const READY_FILE = 'model_quantized.onnx'
+const REQUIRED_FILES = ['config.json', 'tokenizer_config.json', 'tokenizer.json', `onnx/${READY_FILE}`]
 
 function broadcastSpy() {
   return vi.mocked(application.get('IpcApiService').broadcast)
 }
 
+/** transformers.js omits the revision segment for `main` and includes it otherwise. */
+function revisionCacheDir(revision: string): string {
+  return revision === 'main' ? MODEL_DIR : `${MODEL_DIR}/${revision}`
+}
+
 function modelScopeCachePath(file: string): string {
-  return `${MODEL_DIR}/master/${file}`
+  return `${revisionCacheDir('master')}/${file}`
 }
 
 /** The simulated on-disk tree, shared by the existsSync probe and the rm below. */
@@ -103,6 +109,13 @@ function mockCacheFiles(files: string[]): void {
 
 /** Recursive rm that actually prunes the simulated tree, so a test asserting the weights
  * survived a failure cannot pass just because the probe was pinned to a stale file list. */
+/** What a mirror leaves on disk once its download really completes. Downloads write the
+ * cache, so tests that stub one must too — the post-download probe reads exactly this. */
+function materializeMirrorCache(source: { revision: string }): void {
+  const dir = revisionCacheDir(source.revision)
+  mockCacheFiles([...cachedPaths, MODEL_DIR, ...REQUIRED_FILES.map((file) => `${dir}/${file}`)])
+}
+
 function mockRecursiveRm(target: unknown): Promise<void> {
   const root = String(target)
   for (const path of cachedPaths) {
@@ -122,11 +135,10 @@ describe('LocalEmbeddingDownloadService', () => {
     // clearAllMocks keeps implementations — reset the cache probe so one test's
     // on-disk layout cannot leak into the next (mirror order consults the cache).
     mockCacheFiles([])
+    loadEmbedding.mockImplementation(async (source: { revision: string }) => materializeMirrorCache(source))
   })
 
   describe('ready probe', () => {
-    const requiredFiles = ['config.json', 'tokenizer_config.json', 'tokenizer.json', `onnx/${READY_FILE}`]
-
     it('reports ready for the HuggingFace main-revision cache layout', () => {
       mockCacheFiles([
         MODEL_DIR,
@@ -140,7 +152,7 @@ describe('LocalEmbeddingDownloadService', () => {
     })
 
     it('reports ready for the ModelScope master-revision cache layout', () => {
-      mockCacheFiles([MODEL_DIR, ...requiredFiles.map(modelScopeCachePath)])
+      mockCacheFiles([MODEL_DIR, ...REQUIRED_FILES.map(modelScopeCachePath)])
 
       expect(localEmbeddingDownloadService.getStatus()).toBe('ready')
     })
@@ -196,12 +208,13 @@ describe('LocalEmbeddingDownloadService', () => {
   })
 
   it('drives the progress bar off the .onnx weights only, then reports ready', async () => {
-    loadEmbedding.mockImplementation(async (_source, _repo, _dtype, onProgress) => {
+    loadEmbedding.mockImplementation(async (source, _repo, _dtype, onProgress) => {
       // The tiny sidecar files each sweep 0→100 before the weights start — they must
       // not move the bar; only the .onnx weights (≈99% of the download) drive it.
       onProgress?.({ status: 'progress', file: 'tokenizer.json', progress: 100 })
       onProgress?.({ status: 'progress', file: READY_FILE, progress: 0 })
       onProgress?.({ status: 'progress', file: READY_FILE, progress: 42 })
+      materializeMirrorCache(source)
     })
 
     await localEmbeddingDownloadService.download()
@@ -228,12 +241,13 @@ describe('LocalEmbeddingDownloadService', () => {
   })
 
   it('holds the bar at 100 through the dataless done event instead of snapping to 0', async () => {
-    loadEmbedding.mockImplementation(async (_source, _repo, _dtype, onProgress) => {
+    loadEmbedding.mockImplementation(async (source, _repo, _dtype, onProgress) => {
       // transformers.js brackets the byte stream with dataless 'initiate'/'done' events;
       // only the middle 'progress' events carry loaded/total.
       onProgress?.({ status: 'initiate', file: READY_FILE })
       onProgress?.({ status: 'progress', file: READY_FILE, progress: 100, loaded: 614, total: 614 })
       onProgress?.({ status: 'done', file: READY_FILE })
+      materializeMirrorCache(source)
     })
 
     await localEmbeddingDownloadService.download()
@@ -336,6 +350,40 @@ describe('LocalEmbeddingDownloadService', () => {
         'local_model.download_progress',
         expect.objectContaining({ status: 'error', errorCode: 'download_failed' })
       )
+    })
+
+    it('tries the next mirror when one resolves without leaving the cache on disk', async () => {
+      // transformers.js can serve a model whose files never reached disk (a cache write it
+      // only warns about), and that mirror's revision dir is then unusable for inference.
+      loadEmbedding.mockImplementationOnce(async () => undefined)
+
+      await expect(localEmbeddingDownloadService.download()).resolves.toBe('ready')
+
+      expect(loadEmbedding).toHaveBeenCalledTimes(2)
+      expect(attemptedHost(1)).toContain('modelscope.cn')
+      expect(localEmbeddingDownloadService.getStatus()).toBe('ready')
+    })
+
+    it('never reports ready when no mirror leaves a complete cache', async () => {
+      // The infinite re-download: `ready` was declared off "loadEmbedding resolved", so the
+      // card flashed ready, the next on-disk probe said incomplete, and returning to the
+      // page re-fetched the ~600MB weights — for as long as a sidecar file kept missing.
+      loadEmbedding.mockImplementation(async (source: { revision: string }) => {
+        const dir = revisionCacheDir(source.revision)
+        const landed = REQUIRED_FILES.filter((file) => file !== 'tokenizer.json')
+        mockCacheFiles([...cachedPaths, MODEL_DIR, ...landed.map((file) => `${dir}/${file}`)])
+      })
+
+      const error = await localEmbeddingDownloadService.download().catch((caught) => caught)
+
+      expect(error).toBeInstanceOf(AggregateError)
+      expect(error.message).toContain('tokenizer.json')
+      expect(loadEmbedding).toHaveBeenCalledTimes(2)
+      expect(broadcastSpy()).not.toHaveBeenCalledWith(
+        'local_model.download_progress',
+        expect.objectContaining({ status: 'ready' })
+      )
+      expect(localEmbeddingDownloadService.getStatusInfo()).toEqual({ status: 'error', errorCode: 'download_failed' })
     })
 
     it('does not try the next mirror after a user cancel', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the local embedding model could get stuck alternating between "ready" and "incomplete files", re-downloading the ~600MB weights every time the user came back to the Local Models page.

After this PR: the download only reports `ready` once the files it needs are actually on disk. A mirror that resolves without leaving a complete cache is treated as a failed mirror — the next mirror gets its turn, and if none succeeds the card shows a real download error instead of a false "ready".

Fixes #18603

### Why we need it and why it was done in this way

**Root cause — two disagreeing definitions of "ready".**

- `LocalEmbeddingDownloadService.performDownload()` broadcast `{ status: 'ready', percent: 100 }` as soon as `loadFromFirstReachableMirror()` returned. Its only criterion was "the inference worker's `loadEmbedding` did not throw".
- `modelFilesState()` — which is what the card re-reads whenever the page mounts — runs a full on-disk probe of `REQUIRED_MODEL_FILES` across every mirror's revision cache directory.

Those two never had to agree, and they don't when transformers.js resolves a model whose files never landed on disk. Two paths in `@huggingface/transformers@4.2.0` do exactly that, both non-fatal:

- `utils/model_registry/get_tokenizer_files.js` probes `tokenizer_config.json` with a `Range: bytes=0-0` GET. If that probe fails or the mirror answers non-2xx, `_get_file_metadata` swallows the error (`logger.warn`) and returns `{ exists: false }`, so `get_tokenizer_files` returns `[]` and **`tokenizer.json` is never fetched at all** — while `pipeline()` still resolves.
- `utils/hub.js` `storeCachedResource()` catches cache-write failures and only warns ("Do not crash if unable to add to cache"), so a file can be served in memory and never reach disk.

Either way the user saw: download finishes → card says ready → navigate away and back → probe finds the revision dir missing `tokenizer.json` → `incomplete_cache` → download again → same false ready. An endless ~600MB loop, which matches the reporter's disk state (`tokenizer.json` missing under the ModelScope cache).

**The fix** makes both judgements read one truth. `sourceCacheDir()` / `missingModelFiles()` are extracted from `cacheState()` (no behavior change), and the per-mirror `try` in `loadFromFirstReachableMirror()` re-runs that same probe against the mirror's own revision dir after `loadEmbedding` resolves. Missing files throw, which drops into the existing per-mirror `catch`.

The following tradeoffs were made:

- **A verification failure is a mirror failure, not a terminal one.** It joins the existing fallback path, so a China user whose ModelScope attempt silently skipped the tokenizer still gets a HuggingFace attempt, and an exhausted list produces the existing `AggregateError` with the missing filenames in the message. That keeps the error honest and actionable rather than inventing a new terminal state.
- **The probe runs per mirror, not globally**, so the error names only the files that mirror actually failed to leave behind, instead of listing both revisions' misses.
- **`special_tokens_map.json` was NOT added to `REQUIRED_MODEL_FILES`**, even though the reporter listed it as missing. transformers.js 4.2.0 never requests it — `get_tokenizer_files()` returns `['tokenizer.json', 'tokenizer_config.json']` and nothing else, and `tokenization_utils.js` derives its `special_tokens_map` in memory from `tokenizer_config.json`. There is also no reference to the filename anywhere in this repo. Its absence on disk is normal; requiring it would have turned every healthy install into a permanent `incomplete_cache`.

The following alternatives were considered:

- **Re-probe in `performDownload()` after `loadFromFirstReachableMirror()` returns.** Simpler, but by then the mirror loop is over — the only possible outcome is a hard failure, losing the free retry on the other mirror.
- **Delete the incomplete cache and retry.** Rejected: `cleanupAfterError()` documents that this path must never delete on-disk weights, precisely so a small failure can't cost the user a cached ~600MB model.
- **Relax the probe** (e.g. drop `tokenizer.json` from the required set) so it agrees with the optimistic download. Rejected: inference genuinely needs the tokenizer; that would trade a re-download loop for a broken knowledge base.

Two existing invariants are preserved and covered by their existing tests: nothing is deleted on failure, and an already-complete source is still tried first so a runtime-only repair re-fetches nothing.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18603

### Breaking changes

None.

### Special notes for your reviewer

**Regression tests fail on the unfixed code** — verified by reverting only `LocalEmbeddingDownloadService.ts` and re-running:

```
FAIL > mirror fallback > never reports ready when no mirror leaves a complete cache
  AssertionError: expected 'ready' to be an instance of AggregateError

FAIL > mirror fallback > tries the next mirror when one resolves without leaving the cache on disk
  AssertionError: expected "spy" to be called 2 times, but got 1 times
```

The two new cases are:

- `never reports ready when no mirror leaves a complete cache` — every mirror resolves but leaves `tokenizer.json` off disk (the reporter's exact state). Asserts no `status: 'ready'` broadcast, an `AggregateError` naming `tokenizer.json`, and a terminal `{ status: 'error', errorCode: 'download_failed' }`. Old code broadcast `ready` and resolved.
- `tries the next mirror when one resolves without leaving the cache on disk` — the first mirror resolves writing nothing, the second writes a complete cache; asserts the fallback happens and the end state is genuinely `ready`.

The default `loadEmbedding` mock now materializes that mirror's revision cache on success, which is what a real download does — previously a "successful" download in tests left the simulated disk empty, so the suite could not have caught this class of bug at all.

Self-verification (all green): `pnpm run typecheck:node`, `oxlint` + `eslint` + `biome check` on both changed files, and `vitest run src/main/services/localModel src/main/ai/inference src/main/ai/provider/custom` → 54 files / 441 tests passed.

Reported via the v2 preview feedback board by 许思寅, forwarded from #18603. Original report (macOS, Cherry Studio 2.0.5, China region, ModelScope mirror, Qwen3-Embedding-0.6B): downloading the model shows "ready", then leaving the Local Models page and returning shows "model files incomplete" and starts the download over — `tokenizer.json` and `special_tokens_map.json` were missing from disk.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the local embedding model getting stuck in a loop between "ready" and "model files incomplete", which re-downloaded the ~600MB weights every time the Local Models page was reopened. The download now verifies the files on disk before reporting the model as ready, and falls back to the other mirror (or reports a real error) when they are missing.
```
