### PR TITLE
fix(mcp): redact secrets from logging notification message

### DIFF
--- a/src/main/ai/mcp/McpRuntimeService.ts
+++ b/src/main/ai/mcp/McpRuntimeService.ts
@@ -1002,13 +1002,14 @@ export class McpRuntimeService extends BaseService {
 
       // Set up cancelled notification handler
       client.setNotificationHandler(sdk.CancelledNotificationSchema, async (notification) => {
-        logger.debug(`Operation cancelled for server: ${server.name}`, notification.params)
+        logger.debug(`Operation cancelled for server: ${server.name}`, redactSensitive(notification.params))
       })
 
       // Set up logging message notification handler
       client.setNotificationHandler(sdk.LoggingMessageNotificationSchema, async (notification) => {
         const data = notification.params?.data
-        const message = safeSerialize(notification.params.data) ?? 'No data'
+        const redactedData = redactSensitive(data)
+        const message = safeSerialize(redactedData) ?? 'No data'
         logger.debug(`Message from server ${server.name}: ${message}`)
         if (data) {
           this.emitServerLog(server, {
@@ -1016,7 +1017,7 @@ export class McpRuntimeService extends BaseService {
             // FIXME: as McpServerLogEntry['level'] not type safe
             level: (notification.params?.level as McpServerLogEntry['level']) || 'info',
             message,
-            data: redactSensitive(notification.params?.data),
+            data: redactedData,
             source: notification.params?.logger || 'server'
           })
         }

--- a/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpRuntimeService.test.ts
@@ -765,6 +765,54 @@ describe('redactServerKey (issue #18648)', () => {
   })
 })
 
+describe('McpRuntimeService logging notification redaction', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    MockMainCacheServiceUtils.resetMocks()
+    getByIdMock.mockReset()
+  })
+
+  // Regression: `message` was serialized from the RAW notification data while `data` was
+  // redacted, so the secret still reached the debug log, the serverLogs buffer, and the
+  // mcp.server.log broadcast the renderer displays.
+  it('redacts secrets in both message and data of the emitted log entry', async () => {
+    const service = new McpRuntimeService()
+    const server = { id: 'server-1', name: 'srv' } as unknown as McpServer
+    getByIdMock.mockReturnValue(server)
+
+    const loggingSchema = { sentinel: 'logging' }
+    const sdkStub = {
+      ToolListChangedNotificationSchema: {},
+      ResourceListChangedNotificationSchema: {},
+      PromptListChangedNotificationSchema: {},
+      ResourceUpdatedNotificationSchema: {},
+      CancelledNotificationSchema: {},
+      LoggingMessageNotificationSchema: loggingSchema
+    }
+    const client = { setNotificationHandler: vi.fn() }
+    ;(service as any).setupNotificationHandlers(client, server, sdkStub)
+
+    const handler = client.setNotificationHandler.mock.calls.find(([schema]) => schema === loggingSchema)?.[1]
+    expect(handler).toBeDefined()
+    await handler({
+      method: 'notifications/message',
+      params: {
+        level: 'info',
+        logger: 'server',
+        data: { GITHUB_PERSONAL_ACCESS_TOKEN: 'github_pat_secret', note: 'visible' }
+      }
+    })
+
+    const logs = await service.getServerLogs('server-1')
+    expect(logs).toHaveLength(1)
+    const [entry] = logs
+    expect(entry.message).not.toContain('github_pat_secret')
+    expect(entry.message).toContain('<redacted>')
+    expect(entry.message).toContain('visible')
+    expect(entry.data).toMatchObject({ GITHUB_PERSONAL_ACCESS_TOKEN: '<redacted>', note: 'visible' })
+  })
+})
+
 describe('McpRuntimeService.restartServer (issue #16242)', () => {
   beforeEach(() => {
     BaseService.resetInstances()


### PR DESCRIPTION
### What this PR does

Before this PR:

- The `LoggingMessageNotification` handler in `McpRuntimeService` built the log `message` by serializing the **raw** `notification.params.data`, while only the `data` field next to it went through `redactSensitive()`. The raw serialization still reached three sinks: the main-process debug log (`Message from server …`), the in-memory `serverLogs` buffer returned by the `getServerLogs` IPC, and the `mcp.server.log` broadcast — and `McpLogsTab` renders `log.message`, so the settings UI displayed the unredacted copy. This bypasses the redaction contract from #18650 (same class as #18648, at the same debug level the #18650 follow-up scrubbed for `withCache` keys).
- The cancelled-notification handler logged `notification.params` raw at debug level.

After this PR:

- The handler redacts once (`redactSensitive(data)`) and derives both `message` and `data` from the redacted value, closing all three sinks at the single point where the raw value enters.
- Cancelled-notification params go through `redactSensitive()` before logging.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `message` now inherits `redactSensitive`'s 300-char per-string truncation (`…<N more>`), so very verbose server log lines display truncated in the MCP logs tab. `data` already went through the same truncation, so the two fields are now consistent by construction, and the broadcast payload size is bounded as a side effect.
- Notification params arrive from the JSON-RPC wire as parsed JSON, so key-based redaction covers every reachable value shape.

The following alternatives were considered:

- Redacting only at the `emitServerLog` site while keeping the raw debug line — rejected: the debug log is exactly the channel the #18650 follow-up treated as in-scope.
- Redacting the stdio stderr passthrough (`message` from raw stderr text) — not done: key-based redaction cannot apply to free text; this sits on the same out-of-scope boundary #18650 drew for secrets embedded in `args`.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The regression test was proven red-green: with the source hunk reverted, it fails exactly on the leak assertion (`message` contains the raw token); with the fix, the file passes 41/41.
- The remaining `emitServerLog` sites build `message` from fixed template strings (or `error.message`), and their `data` fields are already redacted — swept as part of this change.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) is considered but not required — logs/redaction only, no user-facing feature or usage change.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed a security issue where secrets included in MCP server log notifications could reach the app debug log and the MCP server logs page unredacted; log notification messages are now redacted before logging, storage, and display.
```
