### PR TITLE
refactor(code): retire CLI config read IO, broadcast managed-tool status

### DIFF
--- a/src/main/ipc/handlers/__tests__/codeCli.test.ts
+++ b/src/main/ipc/handlers/__tests__/codeCli.test.ts
@@ -1,3 +1,4 @@
+import { codeCliRequestSchemas } from '@shared/ipc/schemas/codeCli'
 import { CodeCli } from '@shared/types/codeCli'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,6 +10,7 @@ import { codeCliHandlers } from '../codeCli'
 const codeCliService = {
   run: vi.fn(),
   writeConfigFiles: vi.fn(),
+  readConfigFiles: vi.fn(),
   getAvailableTerminalsForPlatform: vi.fn()
 }
 
@@ -66,6 +68,41 @@ describe('codeCliHandlers', () => {
 
       expect(codeCliService.run).toHaveBeenCalledWith(input)
       expect(result).toEqual({ success: true })
+    })
+  })
+
+  describe('code_cli.read_config', () => {
+    it('delegates targets to CodeCliService.readConfigFiles and wraps the files', async () => {
+      const files = [{ target: 'claude-settings' as const, path: '/home/u/.claude/settings.json', content: '{}\n' }]
+      codeCliService.readConfigFiles.mockResolvedValue(files)
+
+      const result = await codeCliHandlers['code_cli.read_config']({ targets: ['claude-settings'] }, ctx)
+
+      expect(codeCliService.readConfigFiles).toHaveBeenCalledWith(['claude-settings'])
+      expect(result).toEqual({ files })
+    })
+
+    it('propagates non-ENOENT read errors to the router error model instead of swallowing them', async () => {
+      codeCliService.readConfigFiles.mockRejectedValue(Object.assign(new Error('EACCES'), { code: 'EACCES' }))
+
+      await expect(codeCliHandlers['code_cli.read_config']({ targets: ['codex-auth'] }, ctx)).rejects.toThrow('EACCES')
+    })
+  })
+
+  describe('code_cli.read_config schema', () => {
+    it('rejects a target outside the enum allow-list', () => {
+      const parsed = codeCliRequestSchemas['code_cli.read_config'].input.safeParse({
+        targets: ['claude-settings', '/etc/passwd']
+      })
+      expect(parsed.success).toBe(false)
+    })
+
+    it('deduplicates repeated targets, keeping the first occurrence order', () => {
+      const parsed = codeCliRequestSchemas['code_cli.read_config'].input.safeParse({
+        targets: ['claude-settings', 'codex-config', 'claude-settings']
+      })
+      expect(parsed.success).toBe(true)
+      if (parsed.success) expect(parsed.data.targets).toEqual(['claude-settings', 'codex-config'])
     })
   })
 

--- a/src/main/ipc/handlers/codeCli.ts
+++ b/src/main/ipc/handlers/codeCli.ts
@@ -9,6 +9,10 @@ export const codeCliHandlers: IpcHandlersFor<typeof codeCliRequestSchemas> = {
     // CodeCliService.run() as the single source of truth; the handler just delegates.
     return application.get('CodeCliService').run(input)
   },
+  'code_cli.read_config': async (input) => {
+    // Non-ENOENT read errors propagate to the router's error model by design.
+    return { files: await application.get('CodeCliService').readConfigFiles(input.targets) }
+  },
   'code_cli.write_config': async (input) => {
     try {
       await application.get('CodeCliService').writeConfigFiles(input.cliTool, input.files)

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -401,16 +401,25 @@ export class OpenClawService extends BaseService {
   }
 
   protected async onReady(): Promise<void> {
+    // Align the probe port with the persisted preference so external gateways on a
+    // custom port are detected before any sync/start runs this session.
+    this.syncGatewayPortFromPreference()
     // Detect externally-started gateways without renderer polling; registerInterval is lifecycle-cleaned.
     this.registerInterval(() => this.probeGatewayTick(), GATEWAY_PROBE_INTERVAL_MS)
+  }
+
+  private syncGatewayPortFromPreference(): void {
+    const port = application.get('PreferenceService').get('feature.openclaw.gateway_port')
+    if (typeof port === 'number' && Number.isInteger(port) && port > 0) this.gatewayPort = port
   }
 
   protected async onStop(): Promise<void> {
     await this.stopGateway()
   }
 
-  /** Single gateway-status-transition point: assign, then broadcast the get_status-shaped payload. */
+  /** Single gateway-status-transition point: assign, then broadcast; same-value calls are not transitions. */
   private setGatewayStatus(status: GatewayStatus): void {
+    if (this.gatewayStatus === status) return
     this.gatewayStatus = status
     this.gatewayTransitionId++
     try {
@@ -456,7 +465,8 @@ export class OpenClawService extends BaseService {
         this.setGatewayStatus('stopped')
       }
     } catch (error) {
-      // Connection refused is the steady state while no gateway runs — probe noise, not an error.
+      // Unreachable gateways surface as an unhealthy result, not an exception; only
+      // unexpected errors land here.
       logger.warn('OpenClaw gateway health probe failed', error as Error)
     }
   }

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -389,6 +389,8 @@ export class OpenClawService extends BaseService {
   private gatewayStatus: GatewayStatus = 'stopped'
   private gatewayPort: number = DEFAULT_GATEWAY_PORT
   private gatewayAuthToken: string = ''
+  // Bumped by every setGatewayStatus; probes discard results from an older generation.
+  private gatewayTransitionId = 0
 
   public get gatewayUrl(): string {
     return `ws://127.0.0.1:${this.gatewayPort}/ws`
@@ -407,18 +409,29 @@ export class OpenClawService extends BaseService {
     await this.stopGateway()
   }
 
-  /** Single gateway-status-transition point: assign, then broadcast the getStatus()-shaped payload. */
+  /** Single gateway-status-transition point: assign, then broadcast the get_status-shaped payload. */
   private setGatewayStatus(status: GatewayStatus): void {
     this.gatewayStatus = status
+    this.gatewayTransitionId++
     try {
-      application.get('IpcApiService').broadcast('openclaw.status_changed', {
-        status: this.gatewayStatus,
-        port: this.gatewayPort
-      })
+      application.get('IpcApiService').broadcast('openclaw.status_changed', { status: this.gatewayStatus })
     } catch (err) {
       // The renderer re-syncs via get_status; a failed broadcast must not abort the transition.
       logger.warn('Failed to broadcast OpenClaw gateway status change', err as Error)
     }
+  }
+
+  /**
+   * Generation snapshot for mid-flight probes: a monotonic transition counter
+   * (covers stop→start cycles that revisit the same status) plus the port,
+   * which can change without a transition via syncConfig.
+   */
+  private gatewayGeneration(): { transitionId: number; port: number } {
+    return { transitionId: this.gatewayTransitionId, port: this.gatewayPort }
+  }
+
+  private gatewayGenerationChanged(before: { transitionId: number; port: number }): boolean {
+    return this.gatewayTransitionId !== before.transitionId || this.gatewayPort !== before.port
   }
 
   /**
@@ -429,12 +442,12 @@ export class OpenClawService extends BaseService {
    */
   private async probeGatewayTick(): Promise<void> {
     if (this.gatewayStatus === 'starting') return
+    const generationBefore = this.gatewayGeneration()
     const statusBefore = this.gatewayStatus
-    const portBefore = this.gatewayPort
     try {
       const { status } = await this.checkGatewayHealth()
-      // A transition (stop/start/port change) that completed mid-probe invalidates its result.
-      if (this.gatewayStatus !== statusBefore || this.gatewayPort !== portBefore) return
+      // Any transition or port change that completed mid-probe invalidates its result.
+      if (this.gatewayGenerationChanged(generationBefore)) return
       if (status === 'healthy' && statusBefore !== 'running') {
         logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
         this.setGatewayStatus('running')
@@ -938,11 +951,11 @@ export class OpenClawService extends BaseService {
       return { status: this.gatewayStatus, port: this.gatewayPort }
     }
 
+    const generationBefore = this.gatewayGeneration()
     const statusBefore = this.gatewayStatus
-    const portBefore = this.gatewayPort
     const { status } = await this.checkGatewayHealth()
-    // A transition (stop/start/port change) that completed mid-probe invalidates its result.
-    if (this.gatewayStatus !== statusBefore || this.gatewayPort !== portBefore) {
+    // Any transition or port change that completed mid-probe invalidates its result.
+    if (this.gatewayGenerationChanged(generationBefore)) {
       return { status: this.gatewayStatus, port: this.gatewayPort }
     }
     if (status === 'healthy' && statusBefore !== 'running') {

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -429,12 +429,16 @@ export class OpenClawService extends BaseService {
    */
   private async probeGatewayTick(): Promise<void> {
     if (this.gatewayStatus === 'starting') return
+    const statusBefore = this.gatewayStatus
+    const portBefore = this.gatewayPort
     try {
       const { status } = await this.checkGatewayHealth()
-      if (status === 'healthy' && this.gatewayStatus !== 'running') {
+      // A transition (stop/start/port change) that completed mid-probe invalidates its result.
+      if (this.gatewayStatus !== statusBefore || this.gatewayPort !== portBefore) return
+      if (status === 'healthy' && statusBefore !== 'running') {
         logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
         this.setGatewayStatus('running')
-      } else if (status === 'unhealthy' && this.gatewayStatus === 'running') {
+      } else if (status === 'unhealthy' && statusBefore === 'running') {
         logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
         this.setGatewayStatus('stopped')
       }

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -409,7 +409,7 @@ export class OpenClawService extends BaseService {
         .get('PreferenceService')
         .subscribeChange('feature.openclaw.gateway_port', () => this.onGatewayPortPreferenceChanged())
     )
-    // Detect externally-started gateways without renderer polling; registerInterval is lifecycle-cleaned.
+    // Report a gateway that died without telling us; registerInterval is lifecycle-cleaned.
     this.registerInterval(() => this.probeGatewayTick(), GATEWAY_PROBE_INTERVAL_MS)
   }
 
@@ -469,13 +469,13 @@ export class OpenClawService extends BaseService {
   }
 
   /**
-   * One periodic probe tick: reconcile the recorded status with the gateway's
-   * actual health so externally-started gateways are discovered (and dead ones
-   * reported) without the renderer polling. `starting` is skipped to match
-   * getStatus()'s guard.
+   * One periodic probe tick: liveness of the gateway this service believes is
+   * running, so a death nobody reported surfaces as an event. Discovery of a
+   * gateway this service never started is a read-time concern — `getStatus()`
+   * probes for it — so an idle service does no background IO.
    */
   private async probeGatewayTick(): Promise<void> {
-    if (this.gatewayStatus === 'starting') return
+    if (this.gatewayStatus !== 'running') return
     const generationBefore = this.gatewayGeneration()
     const statusBefore = this.gatewayStatus
     try {

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -404,13 +404,24 @@ export class OpenClawService extends BaseService {
     // Align the probe port with the persisted preference so external gateways on a
     // custom port are detected before any sync/start runs this session.
     this.syncGatewayPortFromPreference()
+    this.registerDisposable(
+      application
+        .get('PreferenceService')
+        .subscribeChange('feature.openclaw.gateway_port', () => this.onGatewayPortPreferenceChanged())
+    )
     // Detect externally-started gateways without renderer polling; registerInterval is lifecycle-cleaned.
     this.registerInterval(() => this.probeGatewayTick(), GATEWAY_PROBE_INTERVAL_MS)
   }
 
   private syncGatewayPortFromPreference(): void {
     const port = application.get('PreferenceService').get('feature.openclaw.gateway_port')
-    if (typeof port === 'number' && Number.isInteger(port) && port > 0) this.gatewayPort = port
+    if (Number.isInteger(port) && port >= 1 && port <= 65535) this.gatewayPort = port
+  }
+
+  private onGatewayPortPreferenceChanged(): void {
+    // While a gateway runs on the old port, repointing would mislabel it stopped;
+    // adopt the new port once the gateway is idle (the next start/sync uses it anyway).
+    if (this.gatewayStatus === 'stopped' || this.gatewayStatus === 'error') this.syncGatewayPortFromPreference()
   }
 
   protected async onStop(): Promise<void> {
@@ -418,14 +429,15 @@ export class OpenClawService extends BaseService {
   }
 
   /** Single gateway-status-transition point: assign, then broadcast; same-value calls are not transitions. */
-  private setGatewayStatus(status: GatewayStatus): void {
-    if (this.gatewayStatus === status) return
+  private setGatewayStatus(status: GatewayStatus, options?: { force?: boolean }): void {
+    if (!options?.force && this.gatewayStatus === status) return
     this.gatewayStatus = status
     this.gatewayTransitionId++
     try {
       application.get('IpcApiService').broadcast('openclaw.status_changed', { status: this.gatewayStatus })
     } catch (err) {
-      // The renderer re-syncs via get_status; a failed broadcast must not abort the transition.
+      // A lost broadcast is corrected by the next transition or a request-completion
+      // rebroadcast; it must never abort the transition itself.
       logger.warn('Failed to broadcast OpenClaw gateway status change', err as Error)
     }
   }
@@ -449,6 +461,17 @@ export class OpenClawService extends BaseService {
    * reported) without the renderer polling. `starting` is skipped to match
    * getStatus()'s guard.
    */
+  /** Apply a fresh probe result against the pre-probe status (generation already verified by callers). */
+  private reconcileGatewayStatus(health: HealthInfo['status'], statusBefore: GatewayStatus): void {
+    if (health === 'healthy' && statusBefore !== 'running') {
+      logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
+      this.setGatewayStatus('running')
+    } else if (health === 'unhealthy' && statusBefore === 'running') {
+      logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
+      this.setGatewayStatus('stopped')
+    }
+  }
+
   private async probeGatewayTick(): Promise<void> {
     if (this.gatewayStatus === 'starting') return
     const generationBefore = this.gatewayGeneration()
@@ -457,13 +480,7 @@ export class OpenClawService extends BaseService {
       const { status } = await this.checkGatewayHealth()
       // Any transition or port change that completed mid-probe invalidates its result.
       if (this.gatewayGenerationChanged(generationBefore)) return
-      if (status === 'healthy' && statusBefore !== 'running') {
-        logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
-        this.setGatewayStatus('running')
-      } else if (status === 'unhealthy' && statusBefore === 'running') {
-        logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
-        this.setGatewayStatus('stopped')
-      }
+      this.reconcileGatewayStatus(status, statusBefore)
     } catch (error) {
       // Unreachable gateways surface as an unhealthy result, not an exception; only
       // unexpected errors land here.
@@ -733,12 +750,12 @@ export class OpenClawService extends BaseService {
    * Start the OpenClaw Gateway
    */
   public async startGateway(port?: number): Promise<OperationResult> {
-    this.gatewayPort = port ?? DEFAULT_GATEWAY_PORT
-
-    // Prevent concurrent startup calls
+    // Guard before touching the port so a concurrent-start rejection cannot repoint
+    // it, and an omitted port keeps the preference-synced value instead of the default.
     if (this.gatewayStatus === 'starting') {
       return { success: false, message: 'Gateway is already starting' }
     }
+    if (port !== undefined) this.gatewayPort = port
 
     try {
       const runtime = await this.resolveOpenClawRuntime()
@@ -882,6 +899,7 @@ export class OpenClawService extends BaseService {
    * Kills all openclaw processes to ensure clean shutdown.
    */
   public async stopGateway(): Promise<OperationResult> {
+    const transitionBefore = this.gatewayTransitionId
     try {
       this.killAllOpenClawProcesses()
 
@@ -892,6 +910,8 @@ export class OpenClawService extends BaseService {
       }
 
       this.setGatewayStatus('stopped')
+      // A no-op stop (already stopped) still confirms the terminal state to the renderer.
+      if (this.gatewayTransitionId === transitionBefore) this.setGatewayStatus('stopped', { force: true })
       logger.info('Gateway stopped')
       return { success: true }
     } catch (error) {
@@ -965,15 +985,8 @@ export class OpenClawService extends BaseService {
     const statusBefore = this.gatewayStatus
     const { status } = await this.checkGatewayHealth()
     // Any transition or port change that completed mid-probe invalidates its result.
-    if (this.gatewayGenerationChanged(generationBefore)) {
-      return { status: this.gatewayStatus, port: this.gatewayPort }
-    }
-    if (status === 'healthy' && statusBefore !== 'running') {
-      logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
-      this.setGatewayStatus('running')
-    } else if (status === 'unhealthy' && statusBefore === 'running') {
-      logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
-      this.setGatewayStatus('stopped')
+    if (!this.gatewayGenerationChanged(generationBefore)) {
+      this.reconcileGatewayStatus(status, statusBefore)
     }
 
     return {

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -41,6 +41,7 @@ const openclawConfigPath = (): AbsoluteFilePath =>
 const openclawConfigBakPath = () => path.join(openclawConfigDir(), 'openclaw.json.bak')
 const openclawLegacyConfigPath = () => path.join(openclawConfigDir(), 'openclaw.cherry.json')
 const DEFAULT_GATEWAY_PORT = 18790
+const GATEWAY_PROBE_INTERVAL_MS = 5000
 const OPENCLAW_COMMAND_TIMEOUT_MS = 10000
 const OPENCLAW_COMMAND_CAPTURE_LIMIT_BYTES = 1024 * 1024
 const OPENCLAW_SCHEMA_CAPTURE_LIMIT_BYTES = 32 * 1024 * 1024
@@ -397,8 +398,50 @@ export class OpenClawService extends BaseService {
     // IPC handlers migrated to IpcApi (openclaw.*)
   }
 
+  protected async onReady(): Promise<void> {
+    // Detect externally-started gateways without renderer polling; registerInterval is lifecycle-cleaned.
+    this.registerInterval(() => this.probeGatewayTick(), GATEWAY_PROBE_INTERVAL_MS)
+  }
+
   protected async onStop(): Promise<void> {
     await this.stopGateway()
+  }
+
+  /** Single gateway-status-transition point: assign, then broadcast the getStatus()-shaped payload. */
+  private setGatewayStatus(status: GatewayStatus): void {
+    this.gatewayStatus = status
+    try {
+      application.get('IpcApiService').broadcast('openclaw.status_changed', {
+        status: this.gatewayStatus,
+        port: this.gatewayPort
+      })
+    } catch (err) {
+      // The renderer re-syncs via get_status; a failed broadcast must not abort the transition.
+      logger.warn('Failed to broadcast OpenClaw gateway status change', err as Error)
+    }
+  }
+
+  /**
+   * One periodic probe tick: reconcile the recorded status with the gateway's
+   * actual health so externally-started gateways are discovered (and dead ones
+   * reported) without the renderer polling. `starting` is skipped to match
+   * getStatus()'s guard.
+   */
+  private async probeGatewayTick(): Promise<void> {
+    if (this.gatewayStatus === 'starting') return
+    try {
+      const { status } = await this.checkGatewayHealth()
+      if (status === 'healthy' && this.gatewayStatus !== 'running') {
+        logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
+        this.setGatewayStatus('running')
+      } else if (status === 'unhealthy' && this.gatewayStatus === 'running') {
+        logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
+        this.setGatewayStatus('stopped')
+      }
+    } catch (error) {
+      // Connection refused is the steady state while no gateway runs — probe noise, not an error.
+      logger.warn('OpenClaw gateway health probe failed', error as Error)
+    }
   }
 
   /** Resolve the same live executable path the management UI reports. */
@@ -700,14 +743,14 @@ export class OpenClawService extends BaseService {
         }
       }
 
-      this.gatewayStatus = 'starting'
+      this.setGatewayStatus('starting')
 
       await this.startAndWaitForGateway(runtime.path, runtime.env)
-      this.gatewayStatus = 'running'
+      this.setGatewayStatus('running')
       logger.info(`Gateway started on port ${this.gatewayPort}`)
       return { success: true }
     } catch (error) {
-      this.gatewayStatus = 'error'
+      this.setGatewayStatus('error')
       const errorMessage = error instanceof Error ? error.message : String(error)
       logger.error('Failed to start gateway:', error as Error)
       return { success: false, message: errorMessage }
@@ -817,17 +860,17 @@ export class OpenClawService extends BaseService {
 
       const stillRunning = await this.waitForGatewayStop()
       if (stillRunning) {
-        this.gatewayStatus = 'error'
+        this.setGatewayStatus('error')
         return { success: false, message: 'Failed to stop gateway' }
       }
 
-      this.gatewayStatus = 'stopped'
+      this.setGatewayStatus('stopped')
       logger.info('Gateway stopped')
       return { success: true }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
       logger.error('Failed to stop gateway:', error as Error)
-      this.gatewayStatus = 'error'
+      this.setGatewayStatus('error')
       return { success: false, message: errorMessage }
     }
   }
@@ -894,10 +937,10 @@ export class OpenClawService extends BaseService {
     const { status } = await this.checkGatewayHealth()
     if (status === 'healthy' && this.gatewayStatus !== 'running') {
       logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
-      this.gatewayStatus = 'running'
+      this.setGatewayStatus('running')
     } else if (status === 'unhealthy' && this.gatewayStatus === 'running') {
       logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
-      this.gatewayStatus = 'stopped'
+      this.setGatewayStatus('stopped')
     }
 
     return {

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -433,6 +433,8 @@ export class OpenClawService extends BaseService {
     if (!options?.force && this.gatewayStatus === status) return
     this.gatewayStatus = status
     this.gatewayTransitionId++
+    // Becoming idle is the moment a port preference change deferred during a run takes effect.
+    if (status === 'stopped' || status === 'error') this.syncGatewayPortFromPreference()
     try {
       application.get('IpcApiService').broadcast('openclaw.status_changed', { status: this.gatewayStatus })
     } catch (err) {
@@ -455,12 +457,6 @@ export class OpenClawService extends BaseService {
     return this.gatewayTransitionId !== before.transitionId || this.gatewayPort !== before.port
   }
 
-  /**
-   * One periodic probe tick: reconcile the recorded status with the gateway's
-   * actual health so externally-started gateways are discovered (and dead ones
-   * reported) without the renderer polling. `starting` is skipped to match
-   * getStatus()'s guard.
-   */
   /** Apply a fresh probe result against the pre-probe status (generation already verified by callers). */
   private reconcileGatewayStatus(health: HealthInfo['status'], statusBefore: GatewayStatus): void {
     if (health === 'healthy' && statusBefore !== 'running') {
@@ -472,6 +468,12 @@ export class OpenClawService extends BaseService {
     }
   }
 
+  /**
+   * One periodic probe tick: reconcile the recorded status with the gateway's
+   * actual health so externally-started gateways are discovered (and dead ones
+   * reported) without the renderer polling. `starting` is skipped to match
+   * getStatus()'s guard.
+   */
   private async probeGatewayTick(): Promise<void> {
     if (this.gatewayStatus === 'starting') return
     const generationBefore = this.gatewayGeneration()

--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -938,11 +938,17 @@ export class OpenClawService extends BaseService {
       return { status: this.gatewayStatus, port: this.gatewayPort }
     }
 
+    const statusBefore = this.gatewayStatus
+    const portBefore = this.gatewayPort
     const { status } = await this.checkGatewayHealth()
-    if (status === 'healthy' && this.gatewayStatus !== 'running') {
+    // A transition (stop/start/port change) that completed mid-probe invalidates its result.
+    if (this.gatewayStatus !== statusBefore || this.gatewayPort !== portBefore) {
+      return { status: this.gatewayStatus, port: this.gatewayPort }
+    }
+    if (status === 'healthy' && statusBefore !== 'running') {
       logger.info(`Detected externally running gateway on port ${this.gatewayPort}`)
       this.setGatewayStatus('running')
-    } else if (status === 'unhealthy' && this.gatewayStatus === 'running') {
+    } else if (status === 'unhealthy' && statusBefore === 'running') {
       logger.warn(`Gateway on port ${this.gatewayPort} is no longer reachable, marking as stopped`)
       this.setGatewayStatus('stopped')
     }

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -708,6 +708,20 @@ describe('OpenClawService gateway status state machine', () => {
 
       expect(result).toEqual({ status: 'error', port: 18790 })
     })
+
+    it('discards a probe that resolves after a transition completed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const pending = service.getStatus()
+      ;(service as any).gatewayStatus = 'starting' // startGateway began while the probe was pending
+      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+
+      // Returns the newer authoritative state instead of reviving 'running' from the stale probe.
+      await expect(pending).resolves.toEqual({ status: 'starting', port: 18790 })
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
   })
 
   // ─── startGateway ────────────────────────────────────────────

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1081,6 +1081,36 @@ describe('OpenClawService gateway status state machine', () => {
 
       await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
     })
+
+    // A probe result is only valid for the status/port generation it started against.
+    it('discards a healthy probe that resolves after a stop completed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const tick = (service as any).probeGatewayTick()
+      ;(service as any).gatewayStatus = 'stopped' // stopGateway completed while the probe was pending
+      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+      await tick
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+    })
+
+    it('discards a healthy probe when the gateway port changed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const tick = (service as any).probeGatewayTick()
+      ;(service as any).gatewayPort = 18888 // port transition during the probe
+      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+      await tick
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect((service as any).gatewayPort).toBe(18888)
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+    })
   })
 
   // ─── syncConfig ─────────────────────────────────────────────

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1074,6 +1074,36 @@ describe('OpenClawService gateway status state machine', () => {
 
       await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
     })
+
+    // A probe result is only valid for the status/port generation it started against.
+    it('discards a healthy probe that resolves after a stop completed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const tick = (service as any).probeGatewayTick()
+      ;(service as any).gatewayStatus = 'stopped' // stopGateway completed while the probe was pending
+      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+      await tick
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+    })
+
+    it('discards a healthy probe when the gateway port changed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const tick = (service as any).probeGatewayTick()
+      ;(service as any).gatewayPort = 18888 // port transition during the probe
+      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+      await tick
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect((service as any).gatewayPort).toBe(18888)
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+    })
   })
 
   // ─── syncConfig ─────────────────────────────────────────────

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1039,13 +1039,26 @@ describe('OpenClawService gateway status state machine', () => {
       expect(statusPayloads().at(-1)).toEqual({ status: 'stopped' })
     })
 
-    it('does not broadcast when a stop finds the gateway already stopped', async () => {
+    it('confirms stopped on a no-op stop so a stale renderer is corrected', async () => {
       ;(service as any).gatewayStatus = 'stopped'
       checkPortOpenSpy.mockResolvedValue(false)
+      broadcastMock.mockClear()
 
       await expect(service.stopGateway()).resolves.toEqual({ success: true })
 
-      expect(broadcastMock).not.toHaveBeenCalled()
+      // No transition happened, but the request still announces the terminal state.
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped' })
+    })
+
+    it('keeps the current custom port when startGateway is called without one', async () => {
+      ;(service as any).gatewayPort = 18888
+      checkPortOpenSpy.mockResolvedValue(false)
+      findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
+      startAndWaitSpy.mockResolvedValue(undefined)
+
+      await expect(service.startGateway()).resolves.toEqual({ success: true })
+
+      expect((service as any).gatewayPort).toBe(18888)
     })
   })
 
@@ -1069,6 +1082,35 @@ describe('OpenClawService gateway status state machine', () => {
       ;(service as any).syncGatewayPortFromPreference()
 
       expect((service as any).gatewayPort).toBe(18790)
+    })
+
+    it('keeps the current port when the preference value exceeds the valid range', () => {
+      ;(service as any).gatewayPort = 18888
+      vi.mocked(application.get).mockImplementationOnce(() => ({ get: () => 70000 }) as never)
+
+      ;(service as any).syncGatewayPortFromPreference()
+
+      expect((service as any).gatewayPort).toBe(18888)
+    })
+
+    it('adopts a changed custom port while the gateway is idle', () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      vi.mocked(application.get).mockImplementationOnce(
+        () => ({ get: (key: string) => (key === 'feature.openclaw.gateway_port' ? 19999 : undefined) }) as never
+      )
+
+      ;(service as any).onGatewayPortPreferenceChanged()
+
+      expect((service as any).gatewayPort).toBe(19999)
+    })
+
+    it('keeps the running gateway port when the preference changes mid-run', () => {
+      ;(service as any).gatewayStatus = 'running'
+      ;(service as any).gatewayPort = 18888
+
+      ;(service as any).onGatewayPortPreferenceChanged()
+
+      expect((service as any).gatewayPort).toBe(18888)
     })
   })
 

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1038,6 +1038,38 @@ describe('OpenClawService gateway status state machine', () => {
 
       expect(statusPayloads().at(-1)).toEqual({ status: 'stopped' })
     })
+
+    it('does not broadcast when a stop finds the gateway already stopped', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkPortOpenSpy.mockResolvedValue(false)
+
+      await expect(service.stopGateway()).resolves.toEqual({ success: true })
+
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('gateway port preference sync', () => {
+    it('adopts the persisted custom gateway port at readiness', () => {
+      vi.mocked(application.get).mockImplementationOnce(
+        () =>
+          ({
+            get: (key: string) => (key === 'feature.openclaw.gateway_port' ? 18888 : undefined)
+          }) as never
+      )
+
+      ;(service as any).syncGatewayPortFromPreference()
+
+      expect((service as any).gatewayPort).toBe(18888)
+    })
+
+    it('keeps the default port when the preference value is not a positive integer', () => {
+      vi.mocked(application.get).mockImplementationOnce(() => ({ get: () => 'en-US' }) as never)
+
+      ;(service as any).syncGatewayPortFromPreference()
+
+      expect((service as any).gatewayPort).toBe(18790)
+    })
   })
 
   describe('probeGatewayTick (external gateway detection)', () => {

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const binaryManagerMock = vi.hoisted(() => ({ getToolSnapshots: vi.fn() }))
 const crossPlatformSpawnMock = vi.hoisted(() => vi.fn())
 const platformMock = vi.hoisted(() => ({ isWin: false }))
+const broadcastMock = vi.hoisted(() => vi.fn())
 
 function createSpawnChild() {
   return Object.assign(new EventEmitter(), {
@@ -101,6 +102,7 @@ vi.mock('@application', () => ({
         return { broadcastToType: vi.fn(), getWindowsByType: vi.fn(() => []) }
       }
       if (name === 'BinaryManager') return binaryManagerMock
+      if (name === 'IpcApiService') return { broadcast: broadcastMock }
       if (name === 'PreferenceService') return { get: vi.fn(() => 'en-US') }
       throw new Error(`[MockApplication] Unknown service: ${name}`)
     }),
@@ -985,6 +987,92 @@ describe('OpenClawService gateway status state machine', () => {
       expect((service as any).gatewayStatus).toBe('error')
       expect(checkPortOpenSpy).toHaveBeenCalledTimes(3)
       expect(checkHealthSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // ─── status broadcasts + periodic probe ─────────────────────
+
+  describe('gateway status broadcasts', () => {
+    const statusPayloads = () =>
+      broadcastMock.mock.calls.filter((call) => call[0] === 'openclaw.status_changed').map((call) => call[1])
+
+    it('broadcasts starting then running with {status, port} on a successful start', async () => {
+      checkPortOpenSpy.mockResolvedValue(false)
+      findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
+      startAndWaitSpy.mockResolvedValue(undefined)
+
+      await expect(service.startGateway()).resolves.toEqual({ success: true })
+
+      expect(statusPayloads()).toEqual([
+        { status: 'starting', port: 18790 },
+        { status: 'running', port: 18790 }
+      ])
+    })
+
+    it('broadcasts error when the start fails', async () => {
+      checkPortOpenSpy.mockResolvedValue(false)
+      findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
+      startAndWaitSpy.mockRejectedValue(new Error('Gateway timeout'))
+
+      await expect(service.startGateway()).resolves.toMatchObject({ success: false })
+
+      expect(statusPayloads().at(-1)).toEqual({ status: 'error', port: 18790 })
+    })
+
+    it('announces stopped when a stop completes', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      checkPortOpenSpy.mockResolvedValue(false)
+
+      await expect(service.stopGateway()).resolves.toEqual({ success: true })
+
+      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped', port: 18790 })
+    })
+  })
+
+  describe('probeGatewayTick (external gateway detection)', () => {
+    it('discovers an externally-started gateway and broadcasts running', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect((service as any).gatewayStatus).toBe('running')
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'running', port: 18790 })
+    })
+
+    it('marks a dead gateway stopped when the probe goes unhealthy', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped', port: 18790 })
+    })
+
+    it('skips probing while the gateway is starting', async () => {
+      ;(service as any).gatewayStatus = 'starting'
+
+      await (service as any).probeGatewayTick()
+
+      expect(checkHealthSpy).not.toHaveBeenCalled()
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
+
+    it('broadcasts nothing when the probe result matches the recorded status', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
+
+    it('swallows a probe failure instead of throwing', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockRejectedValue(new Error('ECONNREFUSED'))
+
+      await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
     })
   })
 

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -715,12 +715,12 @@ describe('OpenClawService gateway status state machine', () => {
       checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
 
       const pending = service.getStatus()
-      ;(service as any).gatewayStatus = 'starting' // startGateway began while the probe was pending
+      ;(service as any).setGatewayStatus('starting') // startGateway began while the probe was pending
       resolveProbe({ status: 'healthy', gatewayPort: 18790 })
 
       // Returns the newer authoritative state instead of reviving 'running' from the stale probe.
       await expect(pending).resolves.toEqual({ status: 'starting', port: 18790 })
-      expect(broadcastMock).not.toHaveBeenCalled()
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
     })
   })
 
@@ -1010,17 +1010,14 @@ describe('OpenClawService gateway status state machine', () => {
     const statusPayloads = () =>
       broadcastMock.mock.calls.filter((call) => call[0] === 'openclaw.status_changed').map((call) => call[1])
 
-    it('broadcasts starting then running with {status, port} on a successful start', async () => {
+    it('broadcasts starting then running on a successful start', async () => {
       checkPortOpenSpy.mockResolvedValue(false)
       findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
       startAndWaitSpy.mockResolvedValue(undefined)
 
       await expect(service.startGateway()).resolves.toEqual({ success: true })
 
-      expect(statusPayloads()).toEqual([
-        { status: 'starting', port: 18790 },
-        { status: 'running', port: 18790 }
-      ])
+      expect(statusPayloads()).toEqual([{ status: 'starting' }, { status: 'running' }])
     })
 
     it('broadcasts error when the start fails', async () => {
@@ -1030,7 +1027,7 @@ describe('OpenClawService gateway status state machine', () => {
 
       await expect(service.startGateway()).resolves.toMatchObject({ success: false })
 
-      expect(statusPayloads().at(-1)).toEqual({ status: 'error', port: 18790 })
+      expect(statusPayloads().at(-1)).toEqual({ status: 'error' })
     })
 
     it('announces stopped when a stop completes', async () => {
@@ -1039,7 +1036,7 @@ describe('OpenClawService gateway status state machine', () => {
 
       await expect(service.stopGateway()).resolves.toEqual({ success: true })
 
-      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped', port: 18790 })
+      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped' })
     })
   })
 
@@ -1051,7 +1048,7 @@ describe('OpenClawService gateway status state machine', () => {
       await (service as any).probeGatewayTick()
 
       expect((service as any).gatewayStatus).toBe('running')
-      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'running', port: 18790 })
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
     })
 
     it('marks a dead gateway stopped when the probe goes unhealthy', async () => {
@@ -1061,7 +1058,7 @@ describe('OpenClawService gateway status state machine', () => {
       await (service as any).probeGatewayTick()
 
       expect((service as any).gatewayStatus).toBe('stopped')
-      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped', port: 18790 })
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped' })
     })
 
     it('skips probing while the gateway is starting', async () => {
@@ -1089,19 +1086,19 @@ describe('OpenClawService gateway status state machine', () => {
       await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
     })
 
-    // A probe result is only valid for the status/port generation it started against.
+    // A probe result is only valid for the transition/port generation it started against.
     it('discards a healthy probe that resolves after a stop completed mid-flight', async () => {
       ;(service as any).gatewayStatus = 'running'
       let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
       checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
 
       const tick = (service as any).probeGatewayTick()
-      ;(service as any).gatewayStatus = 'stopped' // stopGateway completed while the probe was pending
+      ;(service as any).setGatewayStatus('stopped') // stopGateway completed while the probe was pending
       resolveProbe({ status: 'healthy', gatewayPort: 18790 })
       await tick
 
       expect((service as any).gatewayStatus).toBe('stopped')
-      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
     })
 
     it('discards a healthy probe when the gateway port changed mid-flight', async () => {
@@ -1110,13 +1107,31 @@ describe('OpenClawService gateway status state machine', () => {
       checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
 
       const tick = (service as any).probeGatewayTick()
-      ;(service as any).gatewayPort = 18888 // port transition during the probe
+      ;(service as any).gatewayPort = 18888 // syncConfig-style port change during the probe
       resolveProbe({ status: 'healthy', gatewayPort: 18790 })
       await tick
 
       expect((service as any).gatewayStatus).toBe('stopped')
       expect((service as any).gatewayPort).toBe(18888)
-      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', expect.anything())
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
+    })
+
+    it('discards an unhealthy probe after a restart returned to the same status and port', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
+      checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
+
+      const tick = (service as any).probeGatewayTick()
+      // A full restart completes inside the probe window: same terminal values, newer generation.
+      ;(service as any).setGatewayStatus('stopped')
+      ;(service as any).setGatewayStatus('running')
+      resolveProbe({ status: 'unhealthy', gatewayPort: 18790 }) // stale result from the dying old gateway
+      await tick
+
+      expect((service as any).gatewayStatus).toBe('running')
+      // Exactly the two simulated transitions — the stale probe contributed nothing.
+      const payloads = broadcastMock.mock.calls.filter((c) => c[0] === 'openclaw.status_changed').map((c) => c[1])
+      expect(payloads).toEqual([{ status: 'stopped' }, { status: 'running' }])
     })
   })
 

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1107,10 +1107,27 @@ describe('OpenClawService gateway status state machine', () => {
     it('keeps the running gateway port when the preference changes mid-run', () => {
       ;(service as any).gatewayStatus = 'running'
       ;(service as any).gatewayPort = 18888
+      // A valid changed preference: without the running guard this would be adopted.
+      vi.mocked(application.get).mockImplementationOnce(
+        () => ({ get: (key: string) => (key === 'feature.openclaw.gateway_port' ? 19999 : undefined) }) as never
+      )
 
       ;(service as any).onGatewayPortPreferenceChanged()
 
       expect((service as any).gatewayPort).toBe(18888)
+    })
+
+    it('adopts a port change deferred during a run once the gateway becomes idle', () => {
+      ;(service as any).gatewayStatus = 'running'
+      ;(service as any).gatewayPort = 18888
+      // Preference changed to 19999 mid-run (deferred), then the gateway stopped.
+      vi.mocked(application.get).mockImplementationOnce(
+        () => ({ get: (key: string) => (key === 'feature.openclaw.gateway_port' ? 19999 : undefined) }) as never
+      )
+
+      ;(service as any).setGatewayStatus('stopped')
+
+      expect((service as any).gatewayPort).toBe(19999)
     })
   })
 

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -1131,17 +1131,7 @@ describe('OpenClawService gateway status state machine', () => {
     })
   })
 
-  describe('probeGatewayTick (external gateway detection)', () => {
-    it('discovers an externally-started gateway and broadcasts running', async () => {
-      ;(service as any).gatewayStatus = 'stopped'
-      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 })
-
-      await (service as any).probeGatewayTick()
-
-      expect((service as any).gatewayStatus).toBe('running')
-      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
-    })
-
+  describe('probeGatewayTick (liveness of a running gateway)', () => {
     it('marks a dead gateway stopped when the probe goes unhealthy', async () => {
       ;(service as any).gatewayStatus = 'running'
       checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
@@ -1152,8 +1142,11 @@ describe('OpenClawService gateway status state machine', () => {
       expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped' })
     })
 
-    it('skips probing while the gateway is starting', async () => {
-      ;(service as any).gatewayStatus = 'starting'
+    // The tick only watches what this service believes it owns. Discovering a gateway
+    // started outside the app is getStatus()'s read-time job, so an idle service does
+    // no background IO at all — the interval must not probe on behalf of every user.
+    it.each(['stopped', 'error', 'starting'] as const)('does no IO while %s', async (status) => {
+      ;(service as any).gatewayStatus = status
 
       await (service as any).probeGatewayTick()
 
@@ -1161,9 +1154,9 @@ describe('OpenClawService gateway status state machine', () => {
       expect(broadcastMock).not.toHaveBeenCalled()
     })
 
-    it('broadcasts nothing when the probe result matches the recorded status', async () => {
-      ;(service as any).gatewayStatus = 'stopped'
-      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
+    it('broadcasts nothing while the gateway stays healthy', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 })
 
       await (service as any).probeGatewayTick()
 
@@ -1171,7 +1164,7 @@ describe('OpenClawService gateway status state machine', () => {
     })
 
     it('swallows a probe failure instead of throwing', async () => {
-      ;(service as any).gatewayStatus = 'stopped'
+      ;(service as any).gatewayStatus = 'running'
       checkHealthSpy.mockRejectedValue(new Error('ECONNREFUSED'))
 
       await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
@@ -1192,19 +1185,19 @@ describe('OpenClawService gateway status state machine', () => {
       expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
     })
 
-    it('discards a healthy probe when the gateway port changed mid-flight', async () => {
-      ;(service as any).gatewayStatus = 'stopped'
+    it('discards an unhealthy probe when the gateway port changed mid-flight', async () => {
+      ;(service as any).gatewayStatus = 'running'
       let resolveProbe!: (value: { status: string; gatewayPort: number }) => void
       checkHealthSpy.mockImplementationOnce(() => new Promise((resolve) => (resolveProbe = resolve)))
 
       const tick = (service as any).probeGatewayTick()
       ;(service as any).gatewayPort = 18888 // syncConfig-style port change during the probe
-      resolveProbe({ status: 'healthy', gatewayPort: 18790 })
+      resolveProbe({ status: 'unhealthy', gatewayPort: 18790 }) // result belongs to the old port
       await tick
 
-      expect((service as any).gatewayStatus).toBe('stopped')
+      expect((service as any).gatewayStatus).toBe('running')
       expect((service as any).gatewayPort).toBe(18888)
-      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'running' })
+      expect(broadcastMock).not.toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped' })
     })
 
     it('discards an unhealthy probe after a restart returned to the same status and port', async () => {

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const binaryManagerMock = vi.hoisted(() => ({ getToolSnapshots: vi.fn() }))
 const crossPlatformSpawnMock = vi.hoisted(() => vi.fn())
 const platformMock = vi.hoisted(() => ({ isWin: false }))
+const broadcastMock = vi.hoisted(() => vi.fn())
 
 function createSpawnChild() {
   return Object.assign(new EventEmitter(), {
@@ -101,6 +102,7 @@ vi.mock('@application', () => ({
         return { broadcastToType: vi.fn(), getWindowsByType: vi.fn(() => []) }
       }
       if (name === 'BinaryManager') return binaryManagerMock
+      if (name === 'IpcApiService') return { broadcast: broadcastMock }
       if (name === 'PreferenceService') return { get: vi.fn(() => 'en-US') }
       throw new Error(`[MockApplication] Unknown service: ${name}`)
     }),
@@ -992,6 +994,92 @@ describe('OpenClawService gateway status state machine', () => {
       expect((service as any).gatewayStatus).toBe('error')
       expect(checkPortOpenSpy).toHaveBeenCalledTimes(3)
       expect(checkHealthSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  // ─── status broadcasts + periodic probe ─────────────────────
+
+  describe('gateway status broadcasts', () => {
+    const statusPayloads = () =>
+      broadcastMock.mock.calls.filter((call) => call[0] === 'openclaw.status_changed').map((call) => call[1])
+
+    it('broadcasts starting then running with {status, port} on a successful start', async () => {
+      checkPortOpenSpy.mockResolvedValue(false)
+      findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
+      startAndWaitSpy.mockResolvedValue(undefined)
+
+      await expect(service.startGateway()).resolves.toEqual({ success: true })
+
+      expect(statusPayloads()).toEqual([
+        { status: 'starting', port: 18790 },
+        { status: 'running', port: 18790 }
+      ])
+    })
+
+    it('broadcasts error when the start fails', async () => {
+      checkPortOpenSpy.mockResolvedValue(false)
+      findBinarySpy.mockResolvedValue({ source: 'mise', path: '/mock/bin/openclaw', version: '1.0.0' })
+      startAndWaitSpy.mockRejectedValue(new Error('Gateway timeout'))
+
+      await expect(service.startGateway()).resolves.toMatchObject({ success: false })
+
+      expect(statusPayloads().at(-1)).toEqual({ status: 'error', port: 18790 })
+    })
+
+    it('announces stopped when a stop completes', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      checkPortOpenSpy.mockResolvedValue(false)
+
+      await expect(service.stopGateway()).resolves.toEqual({ success: true })
+
+      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped', port: 18790 })
+    })
+  })
+
+  describe('probeGatewayTick (external gateway detection)', () => {
+    it('discovers an externally-started gateway and broadcasts running', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockResolvedValue({ status: 'healthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect((service as any).gatewayStatus).toBe('running')
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'running', port: 18790 })
+    })
+
+    it('marks a dead gateway stopped when the probe goes unhealthy', async () => {
+      ;(service as any).gatewayStatus = 'running'
+      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect((service as any).gatewayStatus).toBe('stopped')
+      expect(broadcastMock).toHaveBeenCalledWith('openclaw.status_changed', { status: 'stopped', port: 18790 })
+    })
+
+    it('skips probing while the gateway is starting', async () => {
+      ;(service as any).gatewayStatus = 'starting'
+
+      await (service as any).probeGatewayTick()
+
+      expect(checkHealthSpy).not.toHaveBeenCalled()
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
+
+    it('broadcasts nothing when the probe result matches the recorded status', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockResolvedValue({ status: 'unhealthy', gatewayPort: 18790 })
+
+      await (service as any).probeGatewayTick()
+
+      expect(broadcastMock).not.toHaveBeenCalled()
+    })
+
+    it('swallows a probe failure instead of throwing', async () => {
+      ;(service as any).gatewayStatus = 'stopped'
+      checkHealthSpy.mockRejectedValue(new Error('ECONNREFUSED'))
+
+      await expect((service as any).probeGatewayTick()).resolves.toBeUndefined()
     })
   })
 

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -20,12 +20,12 @@ import {
 } from '@shared/types/codeCli'
 import type { OperationResult } from '@shared/types/codeTools'
 import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
-import type { CliConfigWriteFile, FileConfiguredCli } from '@shared/utils/cliConfig'
+import type { CliConfigTarget, CliConfigWriteFile, FileConfiguredCli } from '@shared/utils/cliConfig'
 import { REDACTED, redactRecord } from '@shared/utils/redaction'
 import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 
-import { writeCliConfigFiles } from './configWriter'
+import { type CliConfigReadFile, readCliConfigFiles, writeCliConfigFiles } from './configWriter'
 import { isShellSafeModelId, posixQuote } from './shellQuote'
 import {
   MACOS_TERMINALS,
@@ -351,6 +351,11 @@ export class CodeCliService extends BaseService {
   /** Transactional write of a file-configured CLI's config files (code_cli.write_config). */
   public async writeConfigFiles(cliTool: FileConfiguredCli, files: CliConfigWriteFile[]): Promise<void> {
     return writeCliConfigFiles(cliTool, files)
+  }
+
+  /** Batch read of CLI config files (code_cli.read_config); content === null ⇔ file missing. */
+  public async readConfigFiles(targets: readonly CliConfigTarget[]): Promise<CliConfigReadFile[]> {
+    return readCliConfigFiles(targets)
   }
 
   async run(input: CodeCliRunInput): Promise<OperationResult> {

--- a/src/main/services/codeCli/__tests__/configWriter.test.ts
+++ b/src/main/services/codeCli/__tests__/configWriter.test.ts
@@ -38,7 +38,7 @@ import { application } from '@application'
 import type * as fsUtils from '@main/utils/file/fs'
 import { atomicWriteFile, remove } from '@main/utils/file/fs'
 
-import { writeCliConfigFiles } from '../configWriter'
+import { readCliConfigFiles, writeCliConfigFiles } from '../configWriter'
 
 const isWin = process.platform === 'win32'
 
@@ -190,5 +190,43 @@ describe('writeCliConfigFiles', () => {
 
     expect(await readFile(codexConfig(), 'utf-8')).toBe('config_old = true\n')
     expect(loggerMock.error).toHaveBeenCalledWith(expect.stringContaining('roll back'), expect.any(Error))
+  })
+})
+
+describe('readCliConfigFiles', () => {
+  let home: string
+  const claudeSettings = () => path.join(home, '.claude', 'settings.json')
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(tmpdir(), 'cherry-cli-config-'))
+    vi.mocked(application.getPath).mockImplementation((key: string) => {
+      if (key === 'sys.home') return home
+      throw new Error(`Unexpected getPath(${key})`)
+    })
+  })
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true })
+  })
+
+  it('returns the real content under the spec-resolved absolute path', async () => {
+    await mkdir(path.dirname(claudeSettings()), { recursive: true })
+    await writeFile(claudeSettings(), '{"env":{}}\n')
+
+    await expect(readCliConfigFiles(['claude-settings'])).resolves.toEqual([
+      { target: 'claude-settings', path: claudeSettings(), content: '{"env":{}}\n' }
+    ])
+  })
+
+  it('maps a missing file to content null while still resolving its path', async () => {
+    await expect(readCliConfigFiles(['claude-settings'])).resolves.toEqual([
+      { target: 'claude-settings', path: claudeSettings(), content: null }
+    ])
+  })
+
+  it('rejects on a non-ENOENT read error (EISDIR) instead of treating it as missing', async () => {
+    await mkdir(claudeSettings(), { recursive: true })
+
+    await expect(readCliConfigFiles(['claude-settings'])).rejects.toThrow()
   })
 })

--- a/src/main/services/codeCli/configWriter.ts
+++ b/src/main/services/codeCli/configWriter.ts
@@ -33,6 +33,28 @@ async function readOrNull(absPath: AbsoluteFilePath): Promise<string | null> {
   }
 }
 
+/** One config file's read result for `code_cli.read_config`: `content === null` ⇔ the file does not exist. */
+export interface CliConfigReadFile {
+  target: CliConfigTarget
+  path: AbsoluteFilePath
+  content: string | null
+}
+
+/**
+ * Batch read of CLI config files — the read counterpart of `writeCliConfigFiles`
+ * (same `resolveTargetPath` resolution, so reads and writes address identical paths).
+ * ENOENT maps to `content: null`; any other read error aborts and rethrows.
+ * Duplicate targets are deduplicated by the route schema, not here.
+ */
+export async function readCliConfigFiles(targets: readonly CliConfigTarget[]): Promise<CliConfigReadFile[]> {
+  const files: CliConfigReadFile[] = []
+  for (const target of targets) {
+    const path = resolveTargetPath(target)
+    files.push({ target, path, content: await readOrNull(path) })
+  }
+  return files
+}
+
 /**
  * Transactional batch write of a file-configured CLI's config files — the only
  * disk-write path for `code_cli.write_config`. The target enum is the write

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -66,6 +66,8 @@ export class DeepSeekHarnessService extends BaseService {
   private stoppingChild: ChildProcess | null = null
   private runningPermissionMode: DeepSeekHarnessPermissionMode | undefined
   private readonly startupAbortControllers = new Set<AbortController>()
+  // Bumped by every setStatus broadcast; request paths use it to detect no-op completions.
+  private statusTransitionId = 0
 
   protected async onStop(): Promise<void> {
     await this.stop()
@@ -76,13 +78,15 @@ export class DeepSeekHarnessService extends BaseService {
   }
 
   /** Single status-transition point: assign, then broadcast; same-value calls are not transitions. */
-  private setStatus(status: DeepSeekHarnessStatus): void {
-    if (this.status === status) return
+  private setStatus(status: DeepSeekHarnessStatus, options?: { force?: boolean }): void {
+    if (!options?.force && this.status === status) return
     this.status = status
+    this.statusTransitionId++
     try {
       application.get('IpcApiService').broadcast('deepseek_harness.status_changed', this.getStatus())
     } catch (err) {
-      // The renderer re-syncs via get_status; a failed broadcast must not abort the transition.
+      // A lost broadcast is corrected by the next transition or a request-completion
+      // rebroadcast; it must never abort the transition itself.
       logger.warn('Failed to broadcast DeepSeek Harness status change', err as Error)
     }
   }
@@ -104,6 +108,7 @@ export class DeepSeekHarnessService extends BaseService {
           this.runningPermissionMode === input.permissionMode
         ) {
           const runningChild = this.child
+          const transitionBefore = this.statusTransitionId
           try {
             const { receipt } = await this.syncConfig(input)
             if (
@@ -119,6 +124,9 @@ export class DeepSeekHarnessService extends BaseService {
                   : 'DeepSeek Harness exited while updating its configuration'
               )
             }
+            // Idempotent success broadcasts nothing on its own — rebroadcast so a
+            // renderer that missed an earlier event is corrected by this request.
+            if (this.statusTransitionId === transitionBefore) this.setStatus('running', { force: true })
             return { success: true, url: this.url }
           } catch (error) {
             const message = error instanceof Error ? error.message : 'Failed to update DeepSeek Harness configuration'
@@ -178,10 +186,13 @@ export class DeepSeekHarnessService extends BaseService {
   async stop(): Promise<void> {
     for (const startup of this.startupAbortControllers) startup.abort()
     await this.operationMutex.runExclusive(async () => {
+      const transitionBefore = this.statusTransitionId
       await this.stopOwnedProcessLocked()
       this.url = undefined
       this.runningPermissionMode = undefined
       this.setStatus('stopped')
+      // A no-op stop (already stopped) still confirms the terminal state to the renderer.
+      if (this.statusTransitionId === transitionBefore) this.setStatus('stopped', { force: true })
     })
   }
 

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -75,8 +75,9 @@ export class DeepSeekHarnessService extends BaseService {
     return { status: this.status, ...(this.url ? { url: this.url } : {}) }
   }
 
-  /** Single status-transition point: assign, then broadcast the get_status-shaped payload. */
+  /** Single status-transition point: assign, then broadcast; same-value calls are not transitions. */
   private setStatus(status: DeepSeekHarnessStatus): void {
+    if (this.status === status) return
     this.status = status
     try {
       application.get('IpcApiService').broadcast('deepseek_harness.status_changed', this.getStatus())

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -157,12 +157,14 @@ export class DeepSeekHarnessService extends BaseService {
           this.runningPermissionMode = input.permissionMode
           return { success: true, url }
         } catch (error) {
+          // Terminal state first: the cleanup-driven termination handler must not
+          // broadcast 'stopped' for a failed launch on its way to 'error'.
+          this.url = undefined
+          this.setStatus('error')
           await this.stopOwnedProcessLocked().catch((stopError) => {
             logger.warn('Failed to stop DeepSeek Harness after launch failure', stopError as Error)
           })
           if (receipt) await this.rollbackLaunchConfig(receipt)
-          this.url = undefined
-          this.setStatus('error')
           const message = error instanceof Error ? error.message : 'Failed to start DeepSeek Harness'
           return { success: false, message: sanitizeDiagnostic(message) }
         }
@@ -307,7 +309,9 @@ export class DeepSeekHarnessService extends BaseService {
     this.runningPermissionMode = undefined
     if (this.stoppingChild === child) {
       this.stoppingChild = null
-      this.setStatus('stopped')
+      // A teardown that began after the state already left starting/running (failed-launch
+      // cleanup sets 'error' first) must not revive 'stopped'.
+      if (this.status === 'starting' || this.status === 'running') this.setStatus('stopped')
       return
     }
     if (this.status === 'starting' || this.status === 'running') {

--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -75,6 +75,17 @@ export class DeepSeekHarnessService extends BaseService {
     return { status: this.status, ...(this.url ? { url: this.url } : {}) }
   }
 
+  /** Single status-transition point: assign, then broadcast the get_status-shaped payload. */
+  private setStatus(status: DeepSeekHarnessStatus): void {
+    this.status = status
+    try {
+      application.get('IpcApiService').broadcast('deepseek_harness.status_changed', this.getStatus())
+    } catch (err) {
+      // The renderer re-syncs via get_status; a failed broadcast must not abort the transition.
+      logger.warn('Failed to broadcast DeepSeek Harness status change', err as Error)
+    }
+  }
+
   async start(
     input: DeepSeekHarnessStartInput
   ): Promise<{ success: true; url: string } | { success: false; message: string }> {
@@ -120,8 +131,8 @@ export class DeepSeekHarnessService extends BaseService {
 
         let receipt: DeepSeekHarnessConfigReceipt | undefined
         try {
-          this.status = 'starting'
           this.url = undefined
+          this.setStatus('starting')
           const runtime = await this.resolveRuntime()
           if (startupAbortController.signal.aborted) {
             throw new Error('DeepSeek Harness startup was cancelled')
@@ -141,8 +152,8 @@ export class DeepSeekHarnessService extends BaseService {
           if (!this.child || this.child.exitCode !== null || this.child.signalCode !== null) {
             throw new Error('DeepSeek Harness exited immediately after becoming ready')
           }
-          this.status = 'running'
           this.url = url
+          this.setStatus('running')
           this.runningPermissionMode = input.permissionMode
           return { success: true, url }
         } catch (error) {
@@ -150,8 +161,8 @@ export class DeepSeekHarnessService extends BaseService {
             logger.warn('Failed to stop DeepSeek Harness after launch failure', stopError as Error)
           })
           if (receipt) await this.rollbackLaunchConfig(receipt)
-          this.status = 'error'
           this.url = undefined
+          this.setStatus('error')
           const message = error instanceof Error ? error.message : 'Failed to start DeepSeek Harness'
           return { success: false, message: sanitizeDiagnostic(message) }
         }
@@ -165,9 +176,9 @@ export class DeepSeekHarnessService extends BaseService {
     for (const startup of this.startupAbortControllers) startup.abort()
     await this.operationMutex.runExclusive(async () => {
       await this.stopOwnedProcessLocked()
-      this.status = 'stopped'
       this.url = undefined
       this.runningPermissionMode = undefined
+      this.setStatus('stopped')
     })
   }
 
@@ -278,7 +289,7 @@ export class DeepSeekHarnessService extends BaseService {
     child.once('exit', handleTermination)
     child.once('close', handleTermination)
     child.on('error', (error) => {
-      if (this.child === child && this.status === 'running') this.status = 'error'
+      if (this.child === child && this.status === 'running') this.setStatus('error')
       logger.warn('Managed DeepSeek Harness process error', { message: sanitizeDiagnostic(error.message) })
     })
 
@@ -296,11 +307,11 @@ export class DeepSeekHarnessService extends BaseService {
     this.runningPermissionMode = undefined
     if (this.stoppingChild === child) {
       this.stoppingChild = null
-      this.status = 'stopped'
+      this.setStatus('stopped')
       return
     }
     if (this.status === 'starting' || this.status === 'running') {
-      this.status = 'error'
+      this.setStatus('error')
       logger.warn('Managed DeepSeek Harness process exited unexpectedly', { code, signal })
     }
   }

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -461,6 +461,22 @@ describe('DeepSeekHarnessService', () => {
       expect(statusPayloads().at(-1)).toEqual({ status: 'error' })
     })
 
+    it('does not broadcast stopped while cleaning up a failed launch', async () => {
+      // Timeout failure with the child still alive: cleanup kills it after the
+      // terminal 'error' state is set, and the termination handler must stay quiet.
+      vi.useFakeTimers()
+      spawnChild(() => undefined)
+      const service = new DeepSeekHarnessService()
+      const start = service.start(startInput)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(30_000)
+      const result = await start
+
+      expect(result.success).toBe(false)
+      expect(statusPayloads()).toEqual([{ status: 'starting' }, { status: 'error' }])
+      expect(service.getStatus()).toEqual({ status: 'error' })
+    })
+
     it('broadcasts error immediately when the running child is killed, without waiting for a poll', async () => {
       const child = spawnChild((process) => process.stdout.write('dsh web: http://127.0.0.1:43123\n'))
       const service = new DeepSeekHarnessService()

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -23,7 +23,8 @@ const mocks = vi.hoisted(() => ({
   modelGet: vi.fn(),
   gatewayStart: vi.fn(),
   gatewayEnsureKey: vi.fn(),
-  gatewayGetConfig: vi.fn()
+  gatewayGetConfig: vi.fn(),
+  broadcast: vi.fn()
 }))
 
 vi.mock('node:child_process', async (importOriginal) => ({
@@ -151,6 +152,9 @@ describe('DeepSeekHarnessService', () => {
           ensureValidApiKey: mocks.gatewayEnsureKey,
           getCurrentConfig: mocks.gatewayGetConfig
         }
+      }
+      if (name === 'IpcApiService') {
+        return { broadcast: mocks.broadcast }
       }
       throw new Error(`Unexpected application.get(${name})`)
     })
@@ -427,5 +431,71 @@ describe('DeepSeekHarnessService', () => {
     await expect(start).resolves.toEqual({ success: false, message: 'DeepSeek Harness startup was cancelled' })
     expect(processKill).toHaveBeenCalledWith(-children[0].pid, 'SIGTERM')
     expect(service.getStatus()).toEqual({ status: 'stopped' })
+  })
+
+  describe('status change broadcasts', () => {
+    const statusPayloads = () =>
+      mocks.broadcast.mock.calls
+        .filter(([name]) => name === 'deepseek_harness.status_changed')
+        .map(([, payload]) => payload)
+
+    it('broadcasts starting then running with the get_status payload shape on a successful start', async () => {
+      spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+      const service = new DeepSeekHarnessService()
+
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+
+      expect(statusPayloads()).toEqual([{ status: 'starting' }, { status: 'running', url: 'http://127.0.0.1:43123' }])
+      await service.stop()
+    })
+
+    it('broadcasts error when the launch fails', async () => {
+      spawnChild((child) => {
+        child.stderr.write('boom\n')
+        child.close(1, null)
+      })
+      const service = new DeepSeekHarnessService()
+
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: false })
+
+      expect(statusPayloads().at(-1)).toEqual({ status: 'error' })
+    })
+
+    it('broadcasts error immediately when the running child is killed, without waiting for a poll', async () => {
+      const child = spawnChild((process) => process.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+      const service = new DeepSeekHarnessService()
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+      mocks.broadcast.mockClear()
+
+      child.close(137, null)
+
+      expect(statusPayloads()).toEqual([{ status: 'error' }])
+      expect(service.getStatus()).toEqual({ status: 'error' })
+    })
+
+    it('announces stopped when a stop completes', async () => {
+      spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+      const service = new DeepSeekHarnessService()
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+
+      await service.stop()
+
+      // The owned child's termination handler and stop() both pass through the single
+      // transition point, so the terminal stopped payload may arrive twice — never zero times.
+      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped' })
+      expect(statusPayloads()).toContainEqual({ status: 'stopped' })
+      expect(service.getStatus()).toEqual({ status: 'stopped' })
+    })
+
+    it('completes the transition even when broadcasting fails', async () => {
+      mocks.broadcast.mockImplementation(() => {
+        throw new Error('broadcast transport unavailable')
+      })
+      spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+      const service = new DeepSeekHarnessService()
+
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+      expect(service.getStatus()).toEqual({ status: 'running', url: 'http://127.0.0.1:43123' })
+    })
   })
 })

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -506,6 +506,27 @@ describe('DeepSeekHarnessService', () => {
       expect(service.getStatus()).toEqual({ status: 'stopped' })
     })
 
+    it('rebroadcasts running when a start hits the already-running fast path', async () => {
+      spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
+      const service = new DeepSeekHarnessService()
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+      mocks.broadcast.mockClear()
+
+      await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
+
+      // The idempotent success is not a transition, but a renderer that missed the
+      // original running event must still be corrected by this request.
+      expect(statusPayloads()).toEqual([{ status: 'running', url: 'http://127.0.0.1:43123' }])
+    })
+
+    it('confirms stopped on a no-op stop of an already-stopped harness', async () => {
+      const service = new DeepSeekHarnessService()
+
+      await service.stop()
+
+      expect(statusPayloads()).toEqual([{ status: 'stopped' }])
+    })
+
     it('completes the transition even when broadcasting fails', async () => {
       mocks.broadcast.mockImplementation(() => {
         throw new Error('broadcast transport unavailable')

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -489,17 +489,20 @@ describe('DeepSeekHarnessService', () => {
       expect(service.getStatus()).toEqual({ status: 'error' })
     })
 
-    it('announces stopped when a stop completes', async () => {
+    it('announces stopped exactly once when a stop completes', async () => {
       spawnChild((child) => child.stdout.write('dsh web: http://127.0.0.1:43123\n'))
       const service = new DeepSeekHarnessService()
       await expect(service.start(startInput)).resolves.toMatchObject({ success: true })
 
       await service.stop()
 
-      // The owned child's termination handler and stop() both pass through the single
-      // transition point, so the terminal stopped payload may arrive twice — never zero times.
-      expect(statusPayloads().at(-1)).toEqual({ status: 'stopped' })
-      expect(statusPayloads()).toContainEqual({ status: 'stopped' })
+      // The termination handler and stop() both reach setStatus, but same-value calls
+      // are not transitions — the terminal 'stopped' must broadcast exactly once.
+      expect(statusPayloads()).toEqual([
+        { status: 'starting' },
+        { status: 'running', url: 'http://127.0.0.1:43123' },
+        { status: 'stopped' }
+      ])
       expect(service.getStatus()).toEqual({ status: 'stopped' })
     })
 

--- a/src/renderer/pages/code/cliConfig/__tests__/clear.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/clear.test.ts
@@ -1,5 +1,5 @@
 import { CodeCli } from '@shared/types/codeCli'
-import type { CliConfigWriteFile } from '@shared/utils/cliConfig'
+import type { CliConfigTarget, CliConfigWriteFile } from '@shared/utils/cliConfig'
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 import { parse as parseToml } from 'smol-toml'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -20,25 +20,20 @@ beforeEach(() => {
   existing = {}
   writes = {}
   deletes = []
-  // Clearing still reads the on-disk configs renderer-side to strip the
-  // Cherry-managed keys; only the rewrite crosses to the main process.
-  Object.defineProperty(window, 'api', {
-    configurable: true,
-    value: {
-      resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-      file: {
-        readExternal: vi.fn(async (p: string) => {
-          if (p in existing) return existing[p]
-          throw new Error(`File does not exist: ${p}`)
+  // Clearing still reads the on-disk configs renderer-side (code_cli.read_config)
+  // to strip the Cherry-managed keys; only the rewrite crosses to write_config.
+  mocks.request.mockReset()
+  mocks.request.mockImplementation(async (route: string, input: Record<string, unknown>) => {
+    if (route === 'code_cli.read_config') {
+      // Translate targets back to `/resolved~/…` paths so the strip-semantics fixtures stay unchanged.
+      return {
+        files: (input.targets as CliConfigTarget[]).map((target) => {
+          const resolvedPath = `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`
+          return { target, path: resolvedPath, content: resolvedPath in existing ? existing[resolvedPath] : null }
         })
       }
     }
-  })
-  // Translate the `{ target, content }` batch back to `/resolved~/…` paths so
-  // the strip-semantics fixtures stay unchanged.
-  mocks.request.mockReset()
-  mocks.request.mockImplementation(async (_route: string, input: { files: CliConfigWriteFile[] }) => {
-    for (const file of input.files) {
+    for (const file of input.files as CliConfigWriteFile[]) {
       const resolvedPath = `/resolved${CLI_CONFIG_FILE_SPECS[file.target].path}`
       if ('delete' in file) deletes.push(resolvedPath)
       else writes[resolvedPath] = file.content
@@ -226,10 +221,10 @@ describe('clearCliConfig', () => {
     expect(writes['/resolved~/.gemini/.env']).toBe('# my proxy\nUSER_KEY=keep\n')
   })
 
-  it('qwen: missing config is already clear and sends no IPC', async () => {
+  it('qwen: missing config is already clear and sends no rewrite', async () => {
     await clearCliConfig({ cliTool: CodeCli.QWEN_CODE })
 
-    expect(mocks.request).not.toHaveBeenCalled()
+    expect(mocks.request.mock.calls.some(([route]) => route === 'code_cli.write_config')).toBe(false)
   })
 
   it('qwen: strips managed settings when config exists', async () => {
@@ -259,10 +254,10 @@ describe('clearCliConfig', () => {
     })
   })
 
-  it('kimi: missing config is already clear and sends no IPC', async () => {
+  it('kimi: missing config is already clear and sends no rewrite', async () => {
     await clearCliConfig({ cliTool: CodeCli.KIMI_CODE })
 
-    expect(mocks.request).not.toHaveBeenCalled()
+    expect(mocks.request.mock.calls.some(([route]) => route === 'code_cli.write_config')).toBe(false)
   })
 
   it('kimi: strips Cherry-managed entries when config exists', async () => {
@@ -329,8 +324,9 @@ describe('clearCliConfig', () => {
     existing['/resolved~/.codex/auth.json'] = JSON.stringify({ OPENAI_API_KEY: 'sk', user: 'keep' })
     await clearCliConfig({ cliTool: CodeCli.OPENAI_CODEX })
 
-    expect(mocks.request).toHaveBeenCalledTimes(1)
-    expect(mocks.request).toHaveBeenCalledWith('code_cli.write_config', {
+    const writeCalls = mocks.request.mock.calls.filter(([route]) => route === 'code_cli.write_config')
+    expect(writeCalls).toHaveLength(1)
+    expect(writeCalls[0][1]).toEqual({
       cliTool: CodeCli.OPENAI_CODEX,
       files: [
         { target: 'codex-config', content: expect.stringContaining('user_key = "keep"') },
@@ -341,7 +337,15 @@ describe('clearCliConfig', () => {
 
   it('throws the main-process failure message when the rewrite is rejected', async () => {
     existing['/resolved~/.codex/config.toml'] = 'model_provider = "cherry-deepseek"'
-    mocks.request.mockResolvedValue({ success: false, message: 'disk full' })
+    mocks.request.mockImplementation(async (route: string, input: Record<string, unknown>) => {
+      if (route === 'code_cli.write_config') return { success: false, message: 'disk full' }
+      return {
+        files: (input.targets as CliConfigTarget[]).map((target) => {
+          const resolvedPath = `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`
+          return { target, path: resolvedPath, content: resolvedPath in existing ? existing[resolvedPath] : null }
+        })
+      }
+    })
 
     await expect(clearCliConfig({ cliTool: CodeCli.OPENAI_CODEX })).rejects.toThrow('disk full')
   })

--- a/src/renderer/pages/code/cliConfig/__tests__/draftFiles.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/draftFiles.test.ts
@@ -1,27 +1,23 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CliConfigTarget } from '@shared/utils/cliConfig'
+import { describe, expect, it } from 'vitest'
 
 import { readAndParseDraftFile, validateCliConfigDraftForWrite } from '../draftFiles'
-import { parseTomlOrThrow } from '../file'
+import { type CliConfigReadFiles, parseTomlOrThrow } from '../file'
 import type { CliConfigFileDraft } from '../types'
 
-describe('readAndParseDraftFile (secret redaction on parse failure)', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: {
-        resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-        file: {
-          readExternal: vi.fn(async () => 'api_key = "sk-ant-real-secret"\nbroken=====')
-        }
-      }
-    })
-  })
+function readWith(target: CliConfigTarget, content: string | null): CliConfigReadFiles {
+  return new Map([[target, { path: `/resolved${target}`, content }]])
+}
 
-  it('does not leak the raw secret from a malformed TOML file into the thrown error', async () => {
-    await expect(readAndParseDraftFile('kimi-config', parseTomlOrThrow)).rejects.toThrow(
+describe('readAndParseDraftFile (secret redaction on parse failure)', () => {
+  it('does not leak the raw secret from a malformed TOML file into the thrown error', () => {
+    const read = readWith('kimi-config', 'api_key = "sk-ant-real-secret"\nbroken=====')
+    expect(() => readAndParseDraftFile('kimi-config', parseTomlOrThrow, undefined, read)).toThrow(
       /Failed to parse .*api_key = "<redacted>"/s
     )
-    await expect(readAndParseDraftFile('kimi-config', parseTomlOrThrow)).rejects.not.toThrow(/sk-ant-real-secret/)
+    expect(() => readAndParseDraftFile('kimi-config', parseTomlOrThrow, undefined, read)).not.toThrow(
+      /sk-ant-real-secret/
+    )
   })
 })
 

--- a/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
@@ -2,6 +2,7 @@ import { dataApiService } from '@data/DataApiService'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { CodeCli } from '@shared/types/codeCli'
 import { GEMINI_GATEWAY_MODEL_SUFFIX } from '@shared/utils/apiGateway'
+import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CliConfigFileDraft, CliConfigTarget } from '../index'
@@ -12,6 +13,12 @@ import {
   readCliConfigDraft,
   updateCliConfigDraftConfig
 } from '../index'
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: mocks.request }
+}))
 
 function mockGet(handlers: Record<string, () => unknown>) {
   const prefixes = Object.keys(handlers).sort((a, b) => b.length - a.length)
@@ -61,13 +68,14 @@ async function buildDraft(
 }
 
 beforeEach(() => {
-  Object.defineProperty(window, 'api', {
-    configurable: true,
-    value: {
-      resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-      file: { readExternal: vi.fn(async () => ''), write: vi.fn(async () => {}) }
-    }
-  })
+  // On-disk configs read as empty through code_cli.read_config (old readExternal → '').
+  mocks.request.mockImplementation(async (_route: string, input: { targets: CliConfigTarget[] }) => ({
+    files: input.targets.map((target) => ({
+      target,
+      path: `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`,
+      content: ''
+    }))
+  }))
 })
 
 async function buildCodexDraft(configBlob: Record<string, unknown> = {}): Promise<CliConfigFileDraft[]> {

--- a/src/renderer/pages/code/cliConfig/__tests__/launchModelId.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/launchModelId.test.ts
@@ -1,0 +1,84 @@
+import type { Provider } from '@shared/data/types/provider'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ toastError: vi.fn() }))
+
+vi.mock('@renderer/i18n/resolver', () => ({
+  default: { t: (key: string) => key }
+}))
+
+vi.mock('@renderer/services/LoggerService', () => ({
+  loggerService: { withContext: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }) }
+}))
+
+vi.mock('@renderer/services/toast', () => ({ toast: { error: mocks.toastError } }))
+
+const { resolveLaunchModelId } = await import('../launchModelId')
+
+type ResolveLaunchModelIdArgs = Parameters<typeof resolveLaunchModelId>[0]
+
+const provider = { id: 'anthropic', name: 'Anthropic' } as Provider
+
+function makeArgs(overrides: Partial<ResolveLaunchModelIdArgs> = {}): ResolveLaunchModelIdArgs {
+  return {
+    enabledProvider: provider,
+    currentProviderConfig: { modelId: 'anthropic::claude-sonnet-4-5' },
+    upsertProviderConfig: vi.fn(),
+    setCurrentProvider: vi.fn(),
+    errorToastKey: 'code.select_provider_model',
+    logLabel: 'Invalid test model id configured',
+    ...overrides
+  }
+}
+
+describe('resolveLaunchModelId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the parsed model id for a valid selection, with no side effects', async () => {
+    const args = makeArgs()
+
+    await expect(resolveLaunchModelId(args)).resolves.toEqual({
+      uniqueModelId: 'anthropic::claude-sonnet-4-5',
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-5'
+    })
+    expect(args.upsertProviderConfig).not.toHaveBeenCalled()
+    expect(args.setCurrentProvider).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('toasts and returns null for a missing provider, without touching the config', async () => {
+    const args = makeArgs({ enabledProvider: undefined })
+
+    await expect(resolveLaunchModelId(args)).resolves.toBeNull()
+
+    expect(mocks.toastError).toHaveBeenCalledWith('code.select_provider_model')
+    expect(args.upsertProviderConfig).not.toHaveBeenCalled()
+    expect(args.setCurrentProvider).not.toHaveBeenCalled()
+  })
+
+  it('toasts and returns null for a missing modelId, without touching the config', async () => {
+    const args = makeArgs({ currentProviderConfig: { modelId: null } })
+
+    await expect(resolveLaunchModelId(args)).resolves.toBeNull()
+
+    expect(mocks.toastError).toHaveBeenCalledWith('code.select_provider_model')
+    expect(args.upsertProviderConfig).not.toHaveBeenCalled()
+    expect(args.setCurrentProvider).not.toHaveBeenCalled()
+  })
+
+  it('treats an unparseable modelId as corrupt state: clears the selection, toasts, returns null', async () => {
+    // The preference type only admits well-formed ids; corrupt values exist in
+    // legacy profiles at runtime, which is exactly what this branch recovers from.
+    const corruptModelId = 'corrupt-value' as NonNullable<ResolveLaunchModelIdArgs['currentProviderConfig']>['modelId']
+    const args = makeArgs({ currentProviderConfig: { modelId: corruptModelId } })
+
+    await expect(resolveLaunchModelId(args)).resolves.toBeNull()
+
+    expect(args.upsertProviderConfig).toHaveBeenCalledWith('anthropic', { modelId: null })
+    expect(args.setCurrentProvider).toHaveBeenCalledWith(null)
+    expect(mocks.toastError).toHaveBeenCalledWith('code.select_provider_model')
+  })
+})

--- a/src/renderer/pages/code/cliConfig/__tests__/ownLogin.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/ownLogin.test.ts
@@ -1,4 +1,6 @@
 import { CodeCli } from '@shared/types/codeCli'
+import type { CliConfigTarget } from '@shared/utils/cliConfig'
+import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { readOwnLoginCliConfigDraft } from '../index'
@@ -8,6 +10,12 @@ import {
   buildKimiOwnLoginConfig,
   buildQwenOwnLoginConfig
 } from '../ownLogin'
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: mocks.request }
+}))
 
 describe('ownLogin builders', () => {
   describe('buildCodexOwnLoginConfig', () => {
@@ -118,13 +126,14 @@ describe('ownLogin builders', () => {
 
 describe('readOwnLoginCliConfigDraft (adapter disk-read glue)', () => {
   beforeEach(() => {
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: {
-        resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-        file: { readExternal: vi.fn(async () => ''), write: vi.fn(async () => {}) }
-      }
-    })
+    // On-disk configs read as empty through code_cli.read_config (old readExternal → '').
+    mocks.request.mockImplementation(async (_route: string, input: { targets: CliConfigTarget[] }) => ({
+      files: input.targets.map((target) => ({
+        target,
+        path: `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`,
+        content: ''
+      }))
+    }))
   })
 
   // The raw builder tests above don't exercise the adapter glue: which target file each own-login

--- a/src/renderer/pages/code/cliConfig/__tests__/ownLogin.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/ownLogin.test.ts
@@ -160,4 +160,26 @@ describe('readOwnLoginCliConfigDraft (adapter disk-read glue)', () => {
       /not supported/i
     )
   })
+
+  it('reads only the tool-param file: a failing credential sibling must not abort the draft', async () => {
+    // codex-auth is credential-only and never consumed by the own-login draft; an
+    // EACCES on it must not block rebuilding codex-config's tool params.
+    mocks.request.mockImplementation(async (_route: string, input: { targets: CliConfigTarget[] }) => {
+      if (input.targets.includes('codex-auth')) throw new Error('EACCES: permission denied')
+      return {
+        files: input.targets.map((target) => ({
+          target,
+          path: `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`,
+          content: ''
+        }))
+      }
+    })
+
+    const files = await readOwnLoginCliConfigDraft({ cliTool: CodeCli.OPENAI_CODEX, configBlob: {} })
+
+    expect(files).toHaveLength(1)
+    expect(files[0].target).toBe('codex-config')
+    const requested = mocks.request.mock.calls.flatMap(([, input]) => (input as { targets: CliConfigTarget[] }).targets)
+    expect(requested).not.toContain('codex-auth')
+  })
 })

--- a/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
@@ -1,10 +1,17 @@
 import { dataApiService } from '@data/DataApiService'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { CodeCli } from '@shared/types/codeCli'
+import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CliConfigFileDraft, CliConfigTarget } from '../index'
 import { extractConfigFromCliConfigDraft, extractConnectionFromCliConfigDraft, readCliConfigDraft } from '../index'
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: mocks.request }
+}))
 
 /** Per-path DataApi.get mock (longest-prefix wins so `/api-keys` is not shadowed). */
 function mockGet(handlers: Record<string, () => unknown>) {
@@ -47,13 +54,14 @@ const openaiNamedProvider = {
 } as unknown as Provider
 
 beforeEach(() => {
-  Object.defineProperty(window, 'api', {
-    configurable: true,
-    value: {
-      resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-      file: { readExternal: vi.fn(async () => ''), write: vi.fn(async () => {}) }
-    }
-  })
+  // On-disk configs read as empty through code_cli.read_config (old readExternal → '').
+  mocks.request.mockImplementation(async (_route: string, input: { targets: CliConfigTarget[] }) => ({
+    files: input.targets.map((target) => ({
+      target,
+      path: `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`,
+      content: ''
+    }))
+  }))
 })
 
 /** Build a managed draft via readCliConfigDraft (same builders the write path uses). */

--- a/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
@@ -1290,6 +1290,44 @@ describe('writeCliConfigDraft', () => {
       expect(parsed.env.ANTHROPIC_BASE_URL).toBe(GATEWAY_BASE_URL)
       expect(parsed.env.ANTHROPIC_MODEL).toBe('deepseek:deepseek-chat')
     })
+
+    it('rebuilds purely from a complete draft when every on-disk read fails', async () => {
+      // A complete in-memory draft must not depend on the disk: a transient read
+      // failure (EACCES/EBUSY) must not block a rebuild the draft already covers.
+      const editedDraft = {
+        target: 'claude-settings' as const,
+        label: 'Claude settings',
+        path: '/resolved~/.claude/settings.json',
+        language: 'json' as const,
+        content: JSON.stringify({ theme: 'dark', env: { KEEP: '1' } })
+      }
+      mockGet({ '/models/': () => ({ id: 'deepseek-chat' }) })
+      mocks.request.mockImplementation(async (route: string, input: Record<string, unknown>) => {
+        if (route === 'code_cli.read_config') throw new Error('EACCES: permission denied')
+        for (const file of input.files as CliConfigWriteFile[]) {
+          // This path asserts writes only; delete entries never reach it (the suite pins that).
+          const nextWrite = {
+            path: `/resolved${CLI_CONFIG_FILE_SPECS[file.target].path}`,
+            content: (file as { content: string }).content
+          }
+          written = nextWrite
+          writes.push(nextWrite)
+        }
+        return { success: true }
+      })
+
+      await writeCliConfigDraft({
+        cliTool: CodeCli.CLAUDE_CODE,
+        modelId: 'deepseek::deepseek-chat',
+        files: [editedDraft],
+        gateway
+      })
+
+      const parsed = JSON.parse(written!.content)
+      expect(parsed.theme).toBe('dark')
+      expect(parsed.env.KEEP).toBe('1')
+      expect(parsed.env.ANTHROPIC_AUTH_TOKEN).toBe('cs-sk-gateway')
+    })
   })
 
   describe('clear on disable deletes Cherry-managed keys', () => {

--- a/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
@@ -1,7 +1,7 @@
 import { dataApiService } from '@data/DataApiService'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { CLI_API_GATEWAY_PROVIDER_ID, CodeCli } from '@shared/types/codeCli'
-import type { CliConfigWriteFile } from '@shared/utils/cliConfig'
+import type { CliConfigTarget, CliConfigWriteFile } from '@shared/utils/cliConfig'
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -88,25 +88,22 @@ describe('writeCliConfigDraft', () => {
     written = null
     writes = []
     existing = {}
-    // Draft building still reads config files renderer-side; the mock keeps
-    // resolving `~/…` spec paths to `/resolved~/…` for the `existing` fixture.
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: {
-        resolvePath: vi.fn(async (p: string) => `/resolved${p}`),
-        file: {
-          readExternal: vi.fn(async (absPath: string) => {
-            if (absPath in existing) return existing[absPath]
-            throw new Error(`File does not exist: ${absPath}`)
+    // Draft building still reads on-disk config files renderer-side
+    // (`code_cli.read_config`); the mock keeps resolving `~/…` spec paths to
+    // `/resolved~/…` for the `existing` fixture.
+    mocks.request.mockImplementation(async (route: string, input: Record<string, unknown>) => {
+      if (route === 'code_cli.read_config') {
+        return {
+          files: (input.targets as CliConfigTarget[]).map((target) => {
+            const resolvedPath = `/resolved${CLI_CONFIG_FILE_SPECS[target].path}`
+            return { target, path: resolvedPath, content: resolvedPath in existing ? existing[resolvedPath] : null }
           })
         }
       }
-    })
-    // The disk mutation is main-process now (`code_cli.write_config` carries
-    // a target, never a path). Translate each write target back to the
-    // same `/resolved~/…` path so the content fixtures stay unchanged.
-    mocks.request.mockImplementation(async (_route: string, input: { files: CliConfigWriteFile[] }) => {
-      for (const file of input.files) {
+      // The disk mutation is main-process now (`code_cli.write_config` carries
+      // a target, never a path). Translate each write target back to the
+      // same `/resolved~/…` path so the content fixtures stay unchanged.
+      for (const file of input.files as CliConfigWriteFile[]) {
         if ('delete' in file) throw new Error('writeCliConfigDraft must not delete config files')
         const nextWrite = { path: `/resolved${CLI_CONFIG_FILE_SPECS[file.target].path}`, content: file.content }
         written = nextWrite
@@ -1483,8 +1480,9 @@ describe('writeCliConfigDraft', () => {
       // Before the fix this was swallowed and treated as "file doesn't exist
       // yet", which would silently wipe every unmanaged key from the real file.
       existing['/resolved~/.claude/settings.json'] = JSON.stringify({ hooks: { foo: 'bar' } })
-      vi.mocked(window.api.file.readExternal).mockImplementationOnce(async () => {
-        throw new Error('EACCES: permission denied')
+      mocks.request.mockImplementation(async (route: string) => {
+        if (route === 'code_cli.read_config') throw new Error('EACCES: permission denied')
+        return { success: true }
       })
       mockGet({
         '/providers/anthropic': () => anthropicProvider,
@@ -1498,7 +1496,7 @@ describe('writeCliConfigDraft', () => {
       // Nothing was sent to the main-process writer — the real file (and its
       // unmanaged keys) is untouched. (Snapshot/rollback safety around the
       // write itself is a main-side property, pinned in configWriter tests.)
-      expect(mocks.request).not.toHaveBeenCalled()
+      expect(mocks.request.mock.calls.some(([route]) => route === 'code_cli.write_config')).toBe(false)
     })
   })
 })

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -33,7 +33,8 @@ import {
   readConfigFiles,
   readValidatedJsonOrNull,
   readValidatedTomlOrNull,
-  renderJsonFile
+  renderJsonFile,
+  requireReadFile
 } from './file'
 import {
   applyManagedJsonSettings,
@@ -580,7 +581,7 @@ const geminiAdapter: CliConfigAdapter = {
   async buildClearFiles() {
     const read = await readConfigFiles(this.targets)
     const files: CliConfigWriteFile[] = []
-    const envText = read.get('gemini-env')?.content ?? null
+    const envText = requireReadFile('gemini-env', read).content
     if (envText !== null) {
       const envMap = parseDotenv(envText)
       for (const key of GEMINI_MANAGED_ENV_KEYS) envMap.delete(key)

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -2,21 +2,7 @@ import type { Provider } from '@shared/data/types/provider'
 import { CodeCli, isApiGatewayProviderId, normalizeDeepSeekHarnessSettings } from '@shared/types/codeCli'
 import { formatApiHost } from '@shared/utils/api'
 import { GEMINI_GATEWAY_MODEL_SUFFIX, stripGeminiGatewayModelSuffix } from '@shared/utils/apiGateway'
-import {
-  CLAUDE_SETTINGS_PATH,
-  type CliConfigWriteFile,
-  CODEX_AUTH_PATH,
-  CODEX_CONFIG_PATH,
-  type FileConfiguredCli,
-  GEMINI_ENV_PATH,
-  GEMINI_SETTINGS_PATH,
-  getCliConfigTargets,
-  KIMI_CONFIG_PATH,
-  OPENCODE_CONFIG_PATH,
-  PI_MODELS_PATH,
-  PI_SETTINGS_PATH,
-  QWEN_CONFIG_PATH
-} from '@shared/utils/cliConfig'
+import { type CliConfigWriteFile, type FileConfiguredCli, getCliConfigTargets } from '@shared/utils/cliConfig'
 import { stringify as stringifyToml } from 'smol-toml'
 
 import {
@@ -38,11 +24,10 @@ import { getDraftFile, makeDraftFile, readAndParseDraftFile, readDraftFileText }
 import {
   parseJsonOrThrow,
   parseTomlOrThrow,
-  readExternalOrNull,
+  readConfigFiles,
   readValidatedJsonOrNull,
   readValidatedTomlOrNull,
-  renderJsonFile,
-  resolveAbs
+  renderJsonFile
 } from './file'
 import {
   applyManagedJsonSettings,
@@ -185,10 +170,11 @@ const claudeAdapter: CliConfigAdapter = {
   sanitize: sanitizeClaudeConfigBlob,
   async buildDraft(args, context) {
     const { provider, apiKey, model, configBlob } = context
-    const existing = await readAndParseDraftFile('claude-settings', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('claude-settings', parseJsonOrThrow, args.files, read)
     const baseUrl = resolveClaudeBaseUrl(provider)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'claude-settings',
         renderJsonFile(
           buildClaudeConfig(existing, configBlob, {
@@ -197,7 +183,8 @@ const claudeAdapter: CliConfigAdapter = {
             model,
             writePrimaryModel: args.writePrimaryModel
           })
-        )
+        ),
+        read
       )
     ]
   },
@@ -205,13 +192,15 @@ const claudeAdapter: CliConfigAdapter = {
     if (!context.apiKey) throw new Error('Claude Code config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const existing = await readAndParseDraftFile('claude-settings', parseJsonOrThrow)
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('claude-settings', parseJsonOrThrow, undefined, read)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'claude-settings',
         renderJsonFile(
           buildClaudeConfig(existing, configBlob, { apiKey: '', baseUrl: '', model: '', writePrimaryModel: false })
-        )
+        ),
+        read
       )
     ]
   },
@@ -230,8 +219,8 @@ const claudeAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(CLAUDE_SETTINGS_PATH)
-    const existing = await readValidatedJsonOrNull(absPath, 'Claude Code settings')
+    const read = await readConfigFiles(this.targets)
+    const existing = readValidatedJsonOrNull('claude-settings', read, 'Claude Code settings')
     if (!existing) return []
     const next: Record<string, any> = { ...existing }
     for (const key of CLAUDE_MANAGED_TOP_LEVEL_KEYS) delete next[key]
@@ -292,23 +281,26 @@ const codexAdapter: CliConfigAdapter = {
     if (!responsesUrl) {
       throw new Error('Codex requires an OpenAI Responses API endpoint, which this provider does not expose')
     }
-    const config = await readAndParseDraftFile('codex-config', parseTomlOrThrow, args.files)
-    const auth = await readAndParseDraftFile('codex-auth', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const config = readAndParseDraftFile('codex-config', parseTomlOrThrow, args.files, read)
+    const auth = readAndParseDraftFile('codex-auth', parseJsonOrThrow, args.files, read)
     const providerName = cliProviderKeyName(provider)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'codex-config',
-        stringifyToml(buildCodexConfig(config, { baseUrl: responsesUrl, providerName, model }, configBlob))
+        stringifyToml(buildCodexConfig(config, { baseUrl: responsesUrl, providerName, model }, configBlob)),
+        read
       ),
-      await makeDraftFile('codex-auth', renderJsonFile(buildCodexAuthConfig(auth, apiKey)))
+      makeDraftFile('codex-auth', renderJsonFile(buildCodexAuthConfig(auth, apiKey)), read)
     ]
   },
   assertCredentials(context) {
     if (!context.apiKey) throw new Error('Codex config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const config = await readAndParseDraftFile('codex-config', parseTomlOrThrow)
-    return [await makeDraftFile('codex-config', stringifyToml(buildCodexOwnLoginConfig(config, configBlob)))]
+    const read = await readConfigFiles(this.targets)
+    const config = readAndParseDraftFile('codex-config', parseTomlOrThrow, undefined, read)
+    return [makeDraftFile('codex-config', stringifyToml(buildCodexOwnLoginConfig(config, configBlob)), read)]
   },
   updateDraftConfig(files, connection, configBlob) {
     const config = parseTomlOrThrow(getDraftFile(files, 'codex-config')?.content ?? '')
@@ -331,10 +323,9 @@ const codexAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(CODEX_CONFIG_PATH)
-    const authAbsPath = await resolveAbs(CODEX_AUTH_PATH)
-    const existing = await readValidatedTomlOrNull(absPath, 'Codex config')
-    const existingAuth = await readValidatedJsonOrNull(authAbsPath, 'Codex auth')
+    const read = await readConfigFiles(this.targets)
+    const existing = readValidatedTomlOrNull('codex-config', read, 'Codex config')
+    const existingAuth = readValidatedJsonOrNull('codex-auth', read, 'Codex auth')
     const files: CliConfigWriteFile[] = []
     if (existing) {
       const next: Record<string, any> = {}
@@ -399,10 +390,11 @@ const openCodeAdapter: CliConfigAdapter = {
     // @ai-sdk/anthropic package OpenCode loads expects the /v1 in baseURL and only
     // appends /messages.
     const baseUrl = formatApiHost(provider.endpointConfigs?.[npmInfo.endpointType]?.baseUrl ?? '')
-    const existing = await readAndParseDraftFile('opencode-config', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('opencode-config', parseJsonOrThrow, args.files, read)
     const env = asRecord(configBlob.env)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'opencode-config',
         renderJsonFile(
           buildOpenCodeConfig(
@@ -420,7 +412,8 @@ const openCodeAdapter: CliConfigAdapter = {
               maxOutputTokens: modelRecord?.maxOutputTokens
             }
           )
-        )
+        ),
+        read
       )
     ]
   },
@@ -465,8 +458,8 @@ const openCodeAdapter: CliConfigAdapter = {
     return replaceDraftContent(files, 'opencode-config', renderJsonFile(nextConfig))
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(OPENCODE_CONFIG_PATH)
-    const existing = await readValidatedJsonOrNull(absPath, 'OpenCode config')
+    const read = await readConfigFiles(this.targets)
+    const existing = readValidatedJsonOrNull('opencode-config', read, 'OpenCode config')
     if (!existing) return []
     const next: Record<string, any> = { ...existing }
     for (const key of OPEN_CODE_MANAGED_TOP_LEVEL_KEYS) delete next[key]
@@ -520,8 +513,9 @@ const geminiAdapter: CliConfigAdapter = {
   sanitize: sanitizeGeminiConfigBlob,
   async buildDraft(args, context) {
     const { provider, apiKey, model, configBlob } = context
-    const envText = await readDraftFileText('gemini-env', args.files)
-    const settings = await readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const envText = readDraftFileText('gemini-env', args.files, read)
+    const settings = readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files, read)
     const baseUrl = resolveGeminiBaseUrl(provider)
     const isGateway = isApiGatewayProviderId(provider.id)
     // Gateway addresses carry the sentinel suffix so gemini-cli's model
@@ -529,13 +523,15 @@ const geminiAdapter: CliConfigAdapter = {
     // extractConnection strips it back off for connection matching.
     const settingsModel = isGateway ? `${model}${GEMINI_GATEWAY_MODEL_SUFFIX}` : model
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'gemini-env',
-        renderDotenvFile(buildGeminiEnvConfig(parseDotenv(envText), { apiKey, baseUrl, gateway: isGateway }), envText)
+        renderDotenvFile(buildGeminiEnvConfig(parseDotenv(envText), { apiKey, baseUrl, gateway: isGateway }), envText),
+        read
       ),
-      await makeDraftFile(
+      makeDraftFile(
         'gemini-settings',
-        renderJsonFile(buildGeminiSettingsConfig(settings, { model: settingsModel }, configBlob))
+        renderJsonFile(buildGeminiSettingsConfig(settings, { model: settingsModel }, configBlob)),
+        read
       )
     ]
   },
@@ -543,8 +539,9 @@ const geminiAdapter: CliConfigAdapter = {
     if (!context.apiKey) throw new Error('Gemini CLI config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const settings = await readAndParseDraftFile('gemini-settings', parseJsonOrThrow)
-    return [await makeDraftFile('gemini-settings', renderJsonFile(buildGeminiOwnLoginSettings(settings, configBlob)))]
+    const read = await readConfigFiles(this.targets)
+    const settings = readAndParseDraftFile('gemini-settings', parseJsonOrThrow, undefined, read)
+    return [makeDraftFile('gemini-settings', renderJsonFile(buildGeminiOwnLoginSettings(settings, configBlob)), read)]
   },
   updateDraftConfig(files, connection, configBlob) {
     const envText = getDraftFile(files, 'gemini-env')?.content ?? ''
@@ -575,17 +572,16 @@ const geminiAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
+    const read = await readConfigFiles(this.targets)
     const files: CliConfigWriteFile[] = []
-    const envAbsPath = await resolveAbs(GEMINI_ENV_PATH)
-    const envText = await readExternalOrNull(envAbsPath)
+    const envText = read.get('gemini-env')?.content ?? null
     if (envText !== null) {
       const envMap = parseDotenv(envText)
       for (const key of GEMINI_MANAGED_ENV_KEYS) envMap.delete(key)
       files.push({ target: 'gemini-env', content: renderDotenvFile(envMap, envText) })
     }
 
-    const settingsAbsPath = await resolveAbs(GEMINI_SETTINGS_PATH)
-    const settings = await readValidatedJsonOrNull(settingsAbsPath, 'Gemini CLI settings')
+    const settings = readValidatedJsonOrNull('gemini-settings', read, 'Gemini CLI settings')
     if (!settings) return files
     applyManagedJsonSettings(settings, {}, GEMINI_MANAGED_SETTINGS_KEYS)
     dropSecurityAuthSelectedTypeIfEmpty(settings)
@@ -619,13 +615,15 @@ const qwenAdapter: CliConfigAdapter = {
   async buildDraft(args, context) {
     const { provider, apiKey, model, modelRecord, configBlob } = context
     const baseUrl = resolveOpenAIBaseUrl(provider)
-    const existing = await readAndParseDraftFile('qwen-settings', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('qwen-settings', parseJsonOrThrow, args.files, read)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'qwen-settings',
         renderJsonFile(
           buildQwenConfig(existing, { apiKey, baseUrl, model, modelLabel: modelRecord?.name ?? model }, configBlob)
-        )
+        ),
+        read
       )
     ]
   },
@@ -636,8 +634,9 @@ const qwenAdapter: CliConfigAdapter = {
     }
   },
   async buildOwnLoginDraft(configBlob) {
-    const existing = await readAndParseDraftFile('qwen-settings', parseJsonOrThrow)
-    return [await makeDraftFile('qwen-settings', renderJsonFile(buildQwenOwnLoginConfig(existing, configBlob)))]
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('qwen-settings', parseJsonOrThrow, undefined, read)
+    return [makeDraftFile('qwen-settings', renderJsonFile(buildQwenOwnLoginConfig(existing, configBlob)), read)]
   },
   updateDraftConfig(files, connection, configBlob) {
     const existing = parseJsonOrThrow(getDraftFile(files, 'qwen-settings')?.content ?? '')
@@ -660,8 +659,8 @@ const qwenAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(QWEN_CONFIG_PATH)
-    const existing = await readValidatedJsonOrNull(absPath, 'Qwen Code config')
+    const read = await readConfigFiles(this.targets)
+    const existing = readValidatedJsonOrNull('qwen-settings', read, 'Qwen Code config')
     if (!existing) return []
     const next: Record<string, any> = { ...existing }
     if (next.env && typeof next.env === 'object') {
@@ -700,10 +699,11 @@ const kimiAdapter: CliConfigAdapter = {
   async buildDraft(args, context) {
     const { provider, apiKey, model, modelRecord, configBlob } = context
     const baseUrl = resolveOpenAIBaseUrl(provider)
-    const existing = await readAndParseDraftFile('kimi-config', parseTomlOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('kimi-config', parseTomlOrThrow, args.files, read)
     const providerName = cliProviderKeyName(provider)
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'kimi-config',
         stringifyToml(
           buildKimiConfig(
@@ -717,7 +717,8 @@ const kimiAdapter: CliConfigAdapter = {
             },
             configBlob
           )
-        )
+        ),
+        read
       )
     ]
   },
@@ -728,8 +729,9 @@ const kimiAdapter: CliConfigAdapter = {
     }
   },
   async buildOwnLoginDraft(configBlob) {
-    const existing = await readAndParseDraftFile('kimi-config', parseTomlOrThrow)
-    return [await makeDraftFile('kimi-config', stringifyToml(buildKimiOwnLoginConfig(existing, configBlob)))]
+    const read = await readConfigFiles(this.targets)
+    const existing = readAndParseDraftFile('kimi-config', parseTomlOrThrow, undefined, read)
+    return [makeDraftFile('kimi-config', stringifyToml(buildKimiOwnLoginConfig(existing, configBlob)), read)]
   },
   updateDraftConfig(files, connection, configBlob) {
     const existing = parseTomlOrThrow(getDraftFile(files, 'kimi-config')?.content ?? '')
@@ -754,8 +756,8 @@ const kimiAdapter: CliConfigAdapter = {
     )
   },
   async buildClearFiles() {
-    const absPath = await resolveAbs(KIMI_CONFIG_PATH)
-    const existing = await readValidatedTomlOrNull(absPath, 'Kimi Code config')
+    const read = await readConfigFiles(this.targets)
+    const existing = readValidatedTomlOrNull('kimi-config', read, 'Kimi Code config')
     if (!existing) return []
     const next: Record<string, any> = { ...existing }
     for (const table of ['providers', 'models'] as const) {
@@ -798,13 +800,14 @@ const piAdapter: CliConfigAdapter = {
     const { provider, apiKey, model, modelLabel, modelRecord } = context
     const providerInfo = resolvePiProviderInfo(provider, modelRecord?.endpointTypes)
     const providerKey = `${CHERRY_PROVIDER_PREFIX}${cliProviderKeyName(provider)}`
-    const models = await readAndParseDraftFile('pi-models', parseJsonOrThrow, args.files)
-    const settings = await readAndParseDraftFile('pi-settings', parseJsonOrThrow, args.files)
+    const read = await readConfigFiles(this.targets)
+    const models = readAndParseDraftFile('pi-models', parseJsonOrThrow, args.files, read)
+    const settings = readAndParseDraftFile('pi-settings', parseJsonOrThrow, args.files, read)
     const input: Array<'image' | 'text'> = modelRecord?.inputModalities?.includes('image')
       ? ['text', 'image']
       : ['text']
     return [
-      await makeDraftFile(
+      makeDraftFile(
         'pi-models',
         renderJsonFile(
           buildPiModelsConfig(models, {
@@ -820,9 +823,10 @@ const piAdapter: CliConfigAdapter = {
             providerKey,
             reasoning: Boolean(modelRecord?.reasoning)
           })
-        )
+        ),
+        read
       ),
-      await makeDraftFile('pi-settings', renderJsonFile(buildPiSettingsConfig(settings, { model, providerKey })))
+      makeDraftFile('pi-settings', renderJsonFile(buildPiSettingsConfig(settings, { model, providerKey })), read)
     ]
   },
   assertCredentials(context) {
@@ -833,8 +837,9 @@ const piAdapter: CliConfigAdapter = {
     return files
   },
   async buildClearFiles() {
+    const read = await readConfigFiles(this.targets)
     const files: CliConfigWriteFile[] = []
-    const models = await readValidatedJsonOrNull(await resolveAbs(PI_MODELS_PATH), 'Pi models config')
+    const models = readValidatedJsonOrNull('pi-models', read, 'Pi models config')
     if (models) {
       files.push({
         target: 'pi-models',
@@ -845,7 +850,7 @@ const piAdapter: CliConfigAdapter = {
       })
     }
 
-    const settings = await readValidatedJsonOrNull(await resolveAbs(PI_SETTINGS_PATH), 'Pi settings config')
+    const settings = readValidatedJsonOrNull('pi-settings', read, 'Pi settings config')
     if (settings) {
       const next = { ...settings }
       if (stringValue(next.defaultProvider)?.startsWith(CHERRY_PROVIDER_PREFIX)) {

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -20,7 +20,13 @@ import {
 } from './builders'
 import { CHERRY_PROVIDER_PREFIX, OPEN_CODE_ENDPOINTS, PI_ENDPOINTS } from './constants'
 import { parseDotenv, renderDotenvFile } from './dotenv'
-import { getDraftFile, makeDraftFile, readAndParseDraftFile, readDraftFileText } from './draftFiles'
+import {
+  getDraftFile,
+  makeDraftFile,
+  readAndParseDraftFile,
+  readConfigFilesForDraft,
+  readDraftFileText
+} from './draftFiles'
 import {
   parseJsonOrThrow,
   parseTomlOrThrow,
@@ -170,7 +176,7 @@ const claudeAdapter: CliConfigAdapter = {
   sanitize: sanitizeClaudeConfigBlob,
   async buildDraft(args, context) {
     const { provider, apiKey, model, configBlob } = context
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const existing = readAndParseDraftFile('claude-settings', parseJsonOrThrow, args.files, read)
     const baseUrl = resolveClaudeBaseUrl(provider)
     return [
@@ -281,7 +287,7 @@ const codexAdapter: CliConfigAdapter = {
     if (!responsesUrl) {
       throw new Error('Codex requires an OpenAI Responses API endpoint, which this provider does not expose')
     }
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const config = readAndParseDraftFile('codex-config', parseTomlOrThrow, args.files, read)
     const auth = readAndParseDraftFile('codex-auth', parseJsonOrThrow, args.files, read)
     const providerName = cliProviderKeyName(provider)
@@ -390,7 +396,7 @@ const openCodeAdapter: CliConfigAdapter = {
     // @ai-sdk/anthropic package OpenCode loads expects the /v1 in baseURL and only
     // appends /messages.
     const baseUrl = formatApiHost(provider.endpointConfigs?.[npmInfo.endpointType]?.baseUrl ?? '')
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const existing = readAndParseDraftFile('opencode-config', parseJsonOrThrow, args.files, read)
     const env = asRecord(configBlob.env)
     return [
@@ -513,7 +519,7 @@ const geminiAdapter: CliConfigAdapter = {
   sanitize: sanitizeGeminiConfigBlob,
   async buildDraft(args, context) {
     const { provider, apiKey, model, configBlob } = context
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const envText = readDraftFileText('gemini-env', args.files, read)
     const settings = readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files, read)
     const baseUrl = resolveGeminiBaseUrl(provider)
@@ -615,7 +621,7 @@ const qwenAdapter: CliConfigAdapter = {
   async buildDraft(args, context) {
     const { provider, apiKey, model, modelRecord, configBlob } = context
     const baseUrl = resolveOpenAIBaseUrl(provider)
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const existing = readAndParseDraftFile('qwen-settings', parseJsonOrThrow, args.files, read)
     return [
       makeDraftFile(
@@ -699,7 +705,7 @@ const kimiAdapter: CliConfigAdapter = {
   async buildDraft(args, context) {
     const { provider, apiKey, model, modelRecord, configBlob } = context
     const baseUrl = resolveOpenAIBaseUrl(provider)
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const existing = readAndParseDraftFile('kimi-config', parseTomlOrThrow, args.files, read)
     const providerName = cliProviderKeyName(provider)
     return [
@@ -800,7 +806,7 @@ const piAdapter: CliConfigAdapter = {
     const { provider, apiKey, model, modelLabel, modelRecord } = context
     const providerInfo = resolvePiProviderInfo(provider, modelRecord?.endpointTypes)
     const providerKey = `${CHERRY_PROVIDER_PREFIX}${cliProviderKeyName(provider)}`
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFilesForDraft(this.targets, args.files)
     const models = readAndParseDraftFile('pi-models', parseJsonOrThrow, args.files, read)
     const settings = readAndParseDraftFile('pi-settings', parseJsonOrThrow, args.files, read)
     const input: Array<'image' | 'text'> = modelRecord?.inputModalities?.includes('image')

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -199,7 +199,7 @@ const claudeAdapter: CliConfigAdapter = {
     if (!context.apiKey) throw new Error('Claude Code config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFiles(['claude-settings'])
     const existing = readAndParseDraftFile('claude-settings', parseJsonOrThrow, undefined, read)
     return [
       makeDraftFile(
@@ -305,7 +305,7 @@ const codexAdapter: CliConfigAdapter = {
     if (!context.apiKey) throw new Error('Codex config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFiles(['codex-config'])
     const config = readAndParseDraftFile('codex-config', parseTomlOrThrow, undefined, read)
     return [makeDraftFile('codex-config', stringifyToml(buildCodexOwnLoginConfig(config, configBlob)), read)]
   },
@@ -546,7 +546,7 @@ const geminiAdapter: CliConfigAdapter = {
     if (!context.apiKey) throw new Error('Gemini CLI config is missing the API key')
   },
   async buildOwnLoginDraft(configBlob) {
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFiles(['gemini-settings'])
     const settings = readAndParseDraftFile('gemini-settings', parseJsonOrThrow, undefined, read)
     return [makeDraftFile('gemini-settings', renderJsonFile(buildGeminiOwnLoginSettings(settings, configBlob)), read)]
   },
@@ -641,7 +641,7 @@ const qwenAdapter: CliConfigAdapter = {
     }
   },
   async buildOwnLoginDraft(configBlob) {
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFiles(['qwen-settings'])
     const existing = readAndParseDraftFile('qwen-settings', parseJsonOrThrow, undefined, read)
     return [makeDraftFile('qwen-settings', renderJsonFile(buildQwenOwnLoginConfig(existing, configBlob)), read)]
   },
@@ -736,7 +736,7 @@ const kimiAdapter: CliConfigAdapter = {
     }
   },
   async buildOwnLoginDraft(configBlob) {
-    const read = await readConfigFiles(this.targets)
+    const read = await readConfigFiles(['kimi-config'])
     const existing = readAndParseDraftFile('kimi-config', parseTomlOrThrow, undefined, read)
     return [makeDraftFile('kimi-config', stringifyToml(buildKimiOwnLoginConfig(existing, configBlob)), read)]
   },

--- a/src/renderer/pages/code/cliConfig/draft.ts
+++ b/src/renderer/pages/code/cliConfig/draft.ts
@@ -10,6 +10,7 @@ import { isOllamaProvider, OLLAMA_PLACEHOLDER_AUTH_TOKEN } from '@shared/utils/p
 
 import { getAdapter, sanitizeCliConfigBlob } from './adapters'
 import { makeDraftFile, readDraftFileText, validateCliConfigDraftForWrite } from './draftFiles'
+import { readConfigFiles } from './file'
 import type {
   CliConfigDraftBuildArgs,
   CliConfigFileDraft,
@@ -109,9 +110,9 @@ export async function readCliConfigFiles(
   cliTool: string,
   options: { includeEmpty?: boolean } = {}
 ): Promise<CliConfigFileDraft[]> {
-  const files = await Promise.all(
-    getCliConfigTargets(cliTool).map(async (target) => makeDraftFile(target, await readDraftFileText(target)))
-  )
+  const targets = getCliConfigTargets(cliTool)
+  const read = await readConfigFiles(targets)
+  const files = targets.map((target) => makeDraftFile(target, readDraftFileText(target, undefined, read), read))
   return options.includeEmpty || files.some((file) => file.content.trim()) ? files : []
 }
 

--- a/src/renderer/pages/code/cliConfig/draftFiles.ts
+++ b/src/renderer/pages/code/cliConfig/draftFiles.ts
@@ -1,7 +1,7 @@
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 
 import { parseDotenv } from './dotenv'
-import { type CliConfigReadFiles, parseJsonOrThrow, parseTomlOrThrow } from './file'
+import { type CliConfigReadFiles, parseJsonOrThrow, parseTomlOrThrow, requireReadFile } from './file'
 import type { CliConfigFileDraft, CliConfigTarget } from './types'
 
 export function getDraftFile(
@@ -13,10 +13,8 @@ export function getDraftFile(
 
 /** Draft entry for freshly-rendered content; the path is the main-resolved one from the batch read. */
 export function makeDraftFile(target: CliConfigTarget, content: string, read: CliConfigReadFiles): CliConfigFileDraft {
-  const file = read.get(target)
-  if (!file) throw new Error(`No read result for config target: ${target}`)
   const spec = CLI_CONFIG_FILE_SPECS[target]
-  return { target, label: spec.label, path: file.path, language: spec.language, content }
+  return { target, label: spec.label, path: requireReadFile(target, read).path, language: spec.language, content }
 }
 
 /** Current text of `target`: an in-progress draft overrides the on-disk file ('' when missing on disk). */
@@ -27,7 +25,7 @@ export function readDraftFileText(
 ): string {
   const draft = getDraftFile(files, target)
   if (draft) return draft.content
-  return read.get(target)?.content ?? ''
+  return requireReadFile(target, read).content ?? ''
 }
 
 /** Parse a draft/on-disk config file, wrapping a parse failure with the file's label and path. */
@@ -43,7 +41,7 @@ export function readAndParseDraftFile<T>(
   } catch (err) {
     // parseFn (parseJsonOrThrow/parseTomlOrThrow) already redacts its own message at the source.
     const spec = CLI_CONFIG_FILE_SPECS[target]
-    const path = getDraftFile(files, target)?.path ?? read.get(target)?.path ?? spec.path
+    const path = getDraftFile(files, target)?.path ?? requireReadFile(target, read).path
     const rawMessage = err instanceof Error ? err.message : String(err)
     throw new Error(`Failed to parse ${spec.label} at ${path}: ${rawMessage}`)
   }

--- a/src/renderer/pages/code/cliConfig/draftFiles.ts
+++ b/src/renderer/pages/code/cliConfig/draftFiles.ts
@@ -1,7 +1,7 @@
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 
 import { parseDotenv } from './dotenv'
-import { type CliConfigReadFiles, parseJsonOrThrow, parseTomlOrThrow, requireReadFile } from './file'
+import { type CliConfigReadFiles, parseJsonOrThrow, parseTomlOrThrow, readConfigFiles, requireReadFile } from './file'
 import type { CliConfigFileDraft, CliConfigTarget } from './types'
 
 export function getDraftFile(
@@ -9,6 +9,23 @@ export function getDraftFile(
   target: CliConfigTarget
 ): CliConfigFileDraft | undefined {
   return files?.find((file) => file.target === target)
+}
+
+/**
+ * Read view for a draft rebuild: targets covered by an in-progress draft are served
+ * from it (no disk IO — a failing read must not block a rebuild the draft already
+ * has everything for); only uncovered targets cross to `code_cli.read_config`.
+ */
+export async function readConfigFilesForDraft(
+  targets: readonly CliConfigTarget[],
+  files: CliConfigFileDraft[] | undefined
+): Promise<CliConfigReadFiles> {
+  const read = await readConfigFiles(targets.filter((target) => !getDraftFile(files, target)))
+  for (const target of targets) {
+    const draft = getDraftFile(files, target)
+    if (draft && !read.has(target)) read.set(target, { path: draft.path, content: draft.content })
+  }
+  return read
 }
 
 /** Draft entry for freshly-rendered content; the path is the main-resolved one from the batch read. */

--- a/src/renderer/pages/code/cliConfig/draftFiles.ts
+++ b/src/renderer/pages/code/cliConfig/draftFiles.ts
@@ -1,7 +1,7 @@
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 
 import { parseDotenv } from './dotenv'
-import { parseJsonOrThrow, parseTomlOrThrow, readExternal, resolveAbs } from './file'
+import { type CliConfigReadFiles, parseJsonOrThrow, parseTomlOrThrow } from './file'
 import type { CliConfigFileDraft, CliConfigTarget } from './types'
 
 export function getDraftFile(
@@ -11,37 +11,39 @@ export function getDraftFile(
   return files?.find((file) => file.target === target)
 }
 
-export async function makeDraftFile(target: CliConfigTarget, content: string): Promise<CliConfigFileDraft> {
+/** Draft entry for freshly-rendered content; the path is the main-resolved one from the batch read. */
+export function makeDraftFile(target: CliConfigTarget, content: string, read: CliConfigReadFiles): CliConfigFileDraft {
+  const file = read.get(target)
+  if (!file) throw new Error(`No read result for config target: ${target}`)
   const spec = CLI_CONFIG_FILE_SPECS[target]
-  return {
-    target,
-    label: spec.label,
-    path: await resolveAbs(spec.path),
-    language: spec.language,
-    content
-  }
+  return { target, label: spec.label, path: file.path, language: spec.language, content }
 }
 
-export async function readDraftFileText(target: CliConfigTarget, files?: CliConfigFileDraft[]): Promise<string> {
+/** Current text of `target`: an in-progress draft overrides the on-disk file ('' when missing on disk). */
+export function readDraftFileText(
+  target: CliConfigTarget,
+  files: CliConfigFileDraft[] | undefined,
+  read: CliConfigReadFiles
+): string {
   const draft = getDraftFile(files, target)
   if (draft) return draft.content
-  const spec = CLI_CONFIG_FILE_SPECS[target]
-  return readExternal(await resolveAbs(spec.path))
+  return read.get(target)?.content ?? ''
 }
 
-/** Read + parse a draft/on-disk config file, wrapping a parse failure with the file's label and path. */
-export async function readAndParseDraftFile<T>(
+/** Parse a draft/on-disk config file, wrapping a parse failure with the file's label and path. */
+export function readAndParseDraftFile<T>(
   target: CliConfigTarget,
   parseFn: (content: string) => T,
-  files?: CliConfigFileDraft[]
-): Promise<T> {
-  const content = await readDraftFileText(target, files)
+  files: CliConfigFileDraft[] | undefined,
+  read: CliConfigReadFiles
+): T {
+  const content = readDraftFileText(target, files, read)
   try {
     return parseFn(content)
   } catch (err) {
     // parseFn (parseJsonOrThrow/parseTomlOrThrow) already redacts its own message at the source.
     const spec = CLI_CONFIG_FILE_SPECS[target]
-    const path = getDraftFile(files, target)?.path ?? (await resolveAbs(spec.path))
+    const path = getDraftFile(files, target)?.path ?? read.get(target)?.path ?? spec.path
     const rawMessage = err instanceof Error ? err.message : String(err)
     throw new Error(`Failed to parse ${spec.label} at ${path}: ${rawMessage}`)
   }

--- a/src/renderer/pages/code/cliConfig/file.ts
+++ b/src/renderer/pages/code/cliConfig/file.ts
@@ -23,7 +23,8 @@ export async function readConfigFiles(targets: readonly CliConfigTarget[]): Prom
   return new Map(files.map((file) => [file.target, file]))
 }
 
-function requireReadFile(target: CliConfigTarget, files: CliConfigReadFiles): CliConfigReadFile {
+/** The read entry for `target`; a missing entry is a caller bug (readConfigFiles returns every requested target). */
+export function requireReadFile(target: CliConfigTarget, files: CliConfigReadFiles): CliConfigReadFile {
   const file = files.get(target)
   if (!file) throw new Error(`No read result for config target: ${target}`)
   return file

--- a/src/renderer/pages/code/cliConfig/file.ts
+++ b/src/renderer/pages/code/cliConfig/file.ts
@@ -1,14 +1,12 @@
 import { ipcApi } from '@renderer/ipc'
+import type { OutputFor } from '@shared/ipc/types'
 import type { CliConfigTarget } from '@shared/utils/cliConfig'
 import { redactSecretText } from '@shared/utils/redaction'
 import { parse as parseJsonc, type ParseError } from 'jsonc-parser'
 import { parse as parseToml } from 'smol-toml'
 
 /** One CLI config file as read through `code_cli.read_config`: content === null ⇔ the file does not exist. */
-export interface CliConfigReadFile {
-  path: string
-  content: string | null
-}
+export type CliConfigReadFile = Pick<OutputFor<'code_cli.read_config'>['files'][number], 'path' | 'content'>
 
 /** On-disk view of a batch read, keyed by target. */
 export type CliConfigReadFiles = Map<CliConfigTarget, CliConfigReadFile>

--- a/src/renderer/pages/code/cliConfig/file.ts
+++ b/src/renderer/pages/code/cliConfig/file.ts
@@ -1,30 +1,32 @@
+import { ipcApi } from '@renderer/ipc'
+import type { CliConfigTarget } from '@shared/utils/cliConfig'
 import { redactSecretText } from '@shared/utils/redaction'
 import { parse as parseJsonc, type ParseError } from 'jsonc-parser'
 import { parse as parseToml } from 'smol-toml'
 
-/** Resolve `~`/relative paths to absolute (renderer cannot call application.getPath). */
-export async function resolveAbs(p: string): Promise<string> {
-  return window.api.resolvePath(p)
+/** One CLI config file as read through `code_cli.read_config`: content === null ⇔ the file does not exist. */
+export interface CliConfigReadFile {
+  path: string
+  content: string | null
 }
 
-function isMissingFileError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
-  return message.includes('File does not exist') || message.includes('ENOENT')
+/** On-disk view of a batch read, keyed by target. */
+export type CliConfigReadFiles = Map<CliConfigTarget, CliConfigReadFile>
+
+/**
+ * Batch-read CLI config files through the target-enum IPC route (one round trip
+ * per batch; main resolves each target's absolute path).
+ */
+export async function readConfigFiles(targets: readonly CliConfigTarget[]): Promise<CliConfigReadFiles> {
+  if (!targets.length) return new Map()
+  const { files } = await ipcApi.request('code_cli.read_config', { targets: [...targets] })
+  return new Map(files.map((file) => [file.target, file]))
 }
 
-/** Read an external file as text; returns null (not '') when the file is missing, throws on other read errors. */
-export async function readExternalOrNull(absPath: string): Promise<string | null> {
-  try {
-    return await window.api.file.readExternal(absPath)
-  } catch (error) {
-    if (isMissingFileError(error)) return null
-    throw error
-  }
-}
-
-/** Read an external file as text; returns '' when missing, throws on other read errors. */
-export async function readExternal(absPath: string): Promise<string> {
-  return (await readExternalOrNull(absPath)) ?? ''
+function requireReadFile(target: CliConfigTarget, files: CliConfigReadFiles): CliConfigReadFile {
+  const file = files.get(target)
+  if (!file) throw new Error(`No read result for config target: ${target}`)
+  return file
 }
 
 function parseOrThrow<T>(content: string, label: string, absPath: string, parseFn: (content: string) => T): T {
@@ -39,26 +41,24 @@ function parseOrThrow<T>(content: string, label: string, absPath: string, parseF
   }
 }
 
-/** Read + parse JSONC, throwing a contextual error on a malformed file. */
-export async function readValidatedJson(absPath: string, label: string): Promise<Record<string, any>> {
-  return parseOrThrow(await readExternal(absPath), label, absPath, parseJsonOrThrow)
+/** Parse JSONC from a batch read; returns null (not {}) when the file doesn't exist. */
+export function readValidatedJsonOrNull(
+  target: CliConfigTarget,
+  files: CliConfigReadFiles,
+  label: string
+): Record<string, any> | null {
+  const { path, content } = requireReadFile(target, files)
+  return content === null ? null : parseOrThrow(content, label, path, parseJsonOrThrow)
 }
 
-/** Read + parse TOML, throwing a contextual error on a malformed file. */
-export async function readValidatedToml(absPath: string, label: string): Promise<Record<string, any>> {
-  return parseOrThrow(await readExternal(absPath), label, absPath, parseTomlOrThrow)
-}
-
-/** Like readValidatedJson, but returns null (instead of {}) when the file doesn't exist. */
-export async function readValidatedJsonOrNull(absPath: string, label: string): Promise<Record<string, any> | null> {
-  const content = await readExternalOrNull(absPath)
-  return content === null ? null : parseOrThrow(content, label, absPath, parseJsonOrThrow)
-}
-
-/** Like readValidatedToml, but returns null (instead of {}) when the file doesn't exist. */
-export async function readValidatedTomlOrNull(absPath: string, label: string): Promise<Record<string, any> | null> {
-  const content = await readExternalOrNull(absPath)
-  return content === null ? null : parseOrThrow(content, label, absPath, parseTomlOrThrow)
+/** Parse TOML from a batch read; returns null (not {}) when the file doesn't exist. */
+export function readValidatedTomlOrNull(
+  target: CliConfigTarget,
+  files: CliConfigReadFiles,
+  label: string
+): Record<string, any> | null {
+  const { path, content } = requireReadFile(target, files)
+  return content === null ? null : parseOrThrow(content, label, path, parseTomlOrThrow)
 }
 
 export function parseTomlOrThrow(content: string): Record<string, any> {

--- a/src/renderer/pages/code/cliConfig/index.ts
+++ b/src/renderer/pages/code/cliConfig/index.ts
@@ -21,6 +21,7 @@ export {
 export { validateCliConfigDraftForWrite } from './draftFiles'
 export { formatCliConfigDraftFile, updateCliConfigDraftConfig } from './draftUpdater'
 export { gatewayExpectedModel, gatewayModelIdFromAddress } from './gatewayModel'
+export { resolveLaunchModelId } from './launchModelId'
 export { extractConfigFromCliConfigDraft, extractConnectionFromCliConfigDraft } from './parser'
 export {
   CLAUDE_PERMISSION_MODES,

--- a/src/renderer/pages/code/cliConfig/launchModelId.ts
+++ b/src/renderer/pages/code/cliConfig/launchModelId.ts
@@ -1,0 +1,58 @@
+import i18n from '@renderer/i18n/resolver'
+import { loggerService } from '@renderer/services/LoggerService'
+import { toast } from '@renderer/services/toast'
+import type { CliProviderConfig } from '@shared/data/preference/preferenceTypes'
+import type { Provider } from '@shared/data/types/provider'
+
+import { parseConfiguredModelId } from './applyContext'
+
+const logger = loggerService.withContext('resolveLaunchModelId')
+
+export type ConfiguredCliModelId = NonNullable<ReturnType<typeof parseConfiguredModelId>>
+
+export interface ResolveLaunchModelIdArgs {
+  enabledProvider?: Provider
+  currentProviderConfig?: CliProviderConfig | null
+  upsertProviderConfig: (
+    providerId: string,
+    partial: Pick<CliProviderConfig, 'modelId'> & Partial<CliProviderConfig>
+  ) => Promise<string>
+  setCurrentProvider: (providerId: string | null) => Promise<void>
+  errorToastKey: string
+  logLabel: string
+}
+
+/**
+ * Resolve the configured model id for a managed-tool launch (DeepSeek Harness /
+ * OpenClaw). Returns null when no usable selection exists — after handling the
+ * failure itself: a missing provider/modelId only toasts; an unparseable
+ * modelId is treated as corrupt state and additionally clears the modelId and
+ * the provider selection. (`useLaunchDialogController` keeps its own variant:
+ * it validates the apply context, not the modelId, and preserves gateway
+ * selections for retry.)
+ */
+export async function resolveLaunchModelId({
+  enabledProvider,
+  currentProviderConfig,
+  upsertProviderConfig,
+  setCurrentProvider,
+  errorToastKey,
+  logLabel
+}: ResolveLaunchModelIdArgs): Promise<ConfiguredCliModelId | null> {
+  if (!enabledProvider || !currentProviderConfig?.modelId) {
+    toast.error(i18n.t(errorToastKey))
+    return null
+  }
+  const parsedModelId = parseConfiguredModelId(currentProviderConfig.modelId)
+  if (!parsedModelId) {
+    logger.error(logLabel, {
+      modelId: currentProviderConfig.modelId,
+      providerId: enabledProvider.id
+    })
+    await upsertProviderConfig(enabledProvider.id, { modelId: null })
+    await setCurrentProvider(null)
+    toast.error(i18n.t(errorToastKey))
+    return null
+  }
+  return parsedModelId
+}

--- a/src/renderer/pages/code/components/configEditPanel/__tests__/configDraftState.test.ts
+++ b/src/renderer/pages/code/components/configEditPanel/__tests__/configDraftState.test.ts
@@ -63,11 +63,19 @@ const initialDraftSeed: ConfigDraft = {
 describe('loadInitialConfigDraft (cherry gateway)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // The managed rebuild resolves spec paths renderer-side (makeDraftFile); the
-    // on-disk fixture itself arrives through the mocked readCliConfigFiles.
+    // The managed rebuild batch-reads the on-disk fixture through
+    // code_cli.read_config; loadInitialConfigDraft's other reads go through the
+    // mocked readCliConfigFiles barrel below.
     Object.defineProperty(window, 'api', {
       configurable: true,
-      value: { resolvePath: vi.fn(async (p: string) => `/resolved${p}`) }
+      value: {
+        ipcApi: {
+          request: vi.fn(async () => ({
+            ok: true,
+            data: { files: gatewayWrittenFiles.map(({ target, path, content }) => ({ target, path, content })) }
+          }))
+        }
+      }
     })
     mocks.readCliConfigFiles.mockResolvedValue(gatewayWrittenFiles)
     // Expose the real provider key through DataApi: if the initial load ever

--- a/src/renderer/pages/code/hooks/__tests__/useDeepSeekHarnessController.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useDeepSeekHarnessController.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   request: vi.fn(),
+  useIpcOn: vi.fn(),
+  events: new Map<string, (payload: Record<string, unknown>) => void>(),
   openSmartMiniApp: vi.fn(),
   toastError: vi.fn()
 }))
@@ -13,7 +15,7 @@ vi.mock('@renderer/hooks/useMiniAppPopup', () => ({
   useMiniAppPopup: () => ({ openSmartMiniApp: mocks.openSmartMiniApp })
 }))
 
-vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.request } }))
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.request }, useIpcOn: mocks.useIpcOn }))
 
 vi.mock('@renderer/services/LoggerService', () => ({
   loggerService: { withContext: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }) }
@@ -24,6 +26,12 @@ vi.mock('@renderer/services/toast', () => ({ toast: { error: mocks.toastError } 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
 
 const { useDeepSeekHarnessController } = await import('../useDeepSeekHarnessController')
+
+const emitStatusChanged = (payload: Record<string, unknown>) => {
+  const handler = mocks.events.get('deepseek_harness.status_changed')
+  if (!handler) throw new Error('status_changed handler not registered')
+  handler(payload)
+}
 
 const directProvider = { id: 'anthropic', name: 'Anthropic' } as Provider
 
@@ -46,6 +54,10 @@ describe('useDeepSeekHarnessController', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(Date, 'now').mockReturnValue(1_776_000_000_000)
+    mocks.events.clear()
+    mocks.useIpcOn.mockImplementation((event: string, handler: (payload: Record<string, unknown>) => void) => {
+      mocks.events.set(event, handler)
+    })
     mocks.request.mockImplementation((route: string) => {
       if (route === 'deepseek_harness.get_status') return Promise.resolve({ status: 'stopped' })
       if (route === 'deepseek_harness.start') {
@@ -74,6 +86,10 @@ describe('useDeepSeekHarnessController', () => {
       logo: 'deepseek'
     })
     expect(new URL(descriptor.url).searchParams.get('cherry_navigation_revision')).toBe('1776000000000')
+    // Running state is no longer written locally — it arrives as a main-pushed event.
+    await act(async () => {
+      emitStatusChanged({ status: 'running', url: 'http://127.0.0.1:43123' })
+    })
     expect(result.current.running).toBe(true)
   })
 
@@ -121,7 +137,7 @@ describe('useDeepSeekHarnessController', () => {
     expect(mocks.toastError).toHaveBeenCalledWith('config collision')
   })
 
-  it('polls managed status, reopens the current URL, and stops only through the managed IPC', async () => {
+  it('tracks managed status via pushed events, reopens the current URL, and stops only through the managed IPC', async () => {
     mocks.request.mockImplementation((route: string) => {
       if (route === 'deepseek_harness.get_status') {
         return Promise.resolve({ status: 'running', url: 'http://127.0.0.1:45231' })
@@ -134,10 +150,16 @@ describe('useDeepSeekHarnessController', () => {
 
     await act(async () => result.current.onOpenWebUi())
     expect(mocks.openSmartMiniApp).toHaveBeenCalledOnce()
+
+    // A kill surfaces immediately through the pushed event — no 5s polling wait.
+    await act(async () => {
+      emitStatusChanged({ status: 'error' })
+    })
+    expect(result.current.running).toBe(false)
+
     await act(async () => {
       await result.current.onStop()
     })
     expect(mocks.request).toHaveBeenCalledWith('deepseek_harness.stop')
-    expect(result.current.running).toBe(false)
   })
 })

--- a/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
@@ -34,7 +34,7 @@ describe('useManagedToolStatus', () => {
 
   it('seeds from the get_status snapshot, then follows pushed events (deepseek-harness)', async () => {
     mocks.request.mockResolvedValue({ status: 'running', url: 'http://127.0.0.1:45231' })
-    const { result } = renderHook(() => useManagedToolStatus('deepseek-harness'))
+    const { result } = renderHook(() => useManagedToolStatus('deepseek-harness', true))
 
     await waitFor(() => expect(result.current).toEqual({ status: 'running', url: 'http://127.0.0.1:45231' }))
 
@@ -51,7 +51,7 @@ describe('useManagedToolStatus', () => {
 
   it('carries the snapshot status without a url for openclaw', async () => {
     mocks.request.mockResolvedValue({ status: 'starting' })
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
 
     await waitFor(() => expect(result.current).toEqual({ status: 'starting' }))
 
@@ -63,7 +63,7 @@ describe('useManagedToolStatus', () => {
 
   it("ignores the other tool's events", async () => {
     mocks.request.mockResolvedValue({ status: 'stopped' })
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
     await waitFor(() => expect(result.current).toEqual({ status: 'stopped' }))
 
     await act(async () => {
@@ -74,7 +74,7 @@ describe('useManagedToolStatus', () => {
 
   it('keeps the stopped default when the initial snapshot request fails, and still applies later events', async () => {
     mocks.request.mockRejectedValue(new Error('ipc unavailable'))
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
 
     await act(async () => {})
     expect(result.current).toEqual({ status: 'stopped' })
@@ -88,7 +88,7 @@ describe('useManagedToolStatus', () => {
   it('drops the initial snapshot when an event already delivered newer state', async () => {
     let resolveSnapshot!: (value: { status: string }) => void
     mocks.request.mockImplementationOnce(() => new Promise((resolve) => (resolveSnapshot = resolve)))
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
 
     await act(async () => {
       emit('openclaw.status_changed', { status: 'running' })
@@ -104,7 +104,7 @@ describe('useManagedToolStatus', () => {
   it('retries a failed initial snapshot until it lands', async () => {
     vi.useFakeTimers()
     mocks.request.mockRejectedValueOnce(new Error('service not ready yet')).mockResolvedValueOnce({ status: 'running' })
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0)
@@ -120,7 +120,7 @@ describe('useManagedToolStatus', () => {
   it('applies a retry result even when an event landed between attempts', async () => {
     vi.useFakeTimers()
     mocks.request.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce({ status: 'running' })
-    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', true))
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0)
     })
@@ -137,10 +137,36 @@ describe('useManagedToolStatus', () => {
     expect(result.current).toEqual({ status: 'running' })
   })
 
+  it('reads nothing and ignores events while the tool is not selected', async () => {
+    mocks.request.mockResolvedValue({ status: 'running' })
+    const { result } = renderHook(() => useManagedToolStatus('openclaw', false))
+
+    await act(async () => {})
+    expect(mocks.request).not.toHaveBeenCalled()
+
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'running' })
+    })
+    expect(result.current).toEqual({ status: 'stopped' })
+  })
+
+  it('snapshots when the tool becomes selected, discovering a gateway started outside the app', async () => {
+    mocks.request.mockResolvedValue({ status: 'running' })
+    const { result, rerender } = renderHook(({ enabled }) => useManagedToolStatus('openclaw', enabled), {
+      initialProps: { enabled: false }
+    })
+    await act(async () => {})
+    expect(result.current).toEqual({ status: 'stopped' })
+
+    rerender({ enabled: true })
+
+    await waitFor(() => expect(result.current).toEqual({ status: 'running' }))
+  })
+
   it('stops retrying after the attempt cap', async () => {
     vi.useFakeTimers()
     mocks.request.mockRejectedValue(new Error('ipc unavailable'))
-    renderHook(() => useManagedToolStatus('openclaw'))
+    renderHook(() => useManagedToolStatus('openclaw', true))
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0)
     })

--- a/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  request: vi.fn(),
+  useIpcOn: vi.fn(),
+  events: new Map<string, (payload: Record<string, unknown>) => void>()
+}))
+
+vi.mock('@renderer/ipc', () => ({ ipcApi: { request: mocks.request }, useIpcOn: mocks.useIpcOn }))
+
+vi.mock('@renderer/services/LoggerService', () => ({
+  loggerService: { withContext: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }) }
+}))
+
+const { useManagedToolStatus } = await import('../useManagedToolStatus')
+
+const emit = (event: string, payload: Record<string, unknown>) => {
+  const handler = mocks.events.get(event)
+  if (!handler) throw new Error(`${event} handler not registered`)
+  handler(payload)
+}
+
+describe('useManagedToolStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.events.clear()
+    mocks.useIpcOn.mockImplementation((event: string, handler: (payload: Record<string, unknown>) => void) => {
+      mocks.events.set(event, handler)
+    })
+  })
+
+  it('seeds from the get_status snapshot, then follows pushed events (deepseek-harness)', async () => {
+    mocks.request.mockResolvedValue({ status: 'running', url: 'http://127.0.0.1:45231' })
+    const { result } = renderHook(() => useManagedToolStatus('deepseek-harness'))
+
+    await waitFor(() => expect(result.current).toEqual({ status: 'running', url: 'http://127.0.0.1:45231' }))
+
+    await act(async () => {
+      emit('deepseek_harness.status_changed', { status: 'stopped' })
+    })
+    expect(result.current).toEqual({ status: 'stopped' })
+
+    await act(async () => {
+      emit('deepseek_harness.status_changed', { status: 'running', url: 'http://127.0.0.1:45999' })
+    })
+    expect(result.current).toEqual({ status: 'running', url: 'http://127.0.0.1:45999' })
+  })
+
+  it('carries the snapshot status without a url for openclaw', async () => {
+    mocks.request.mockResolvedValue({ status: 'starting' })
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+
+    await waitFor(() => expect(result.current).toEqual({ status: 'starting' }))
+
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+    })
+    expect(result.current).toEqual({ status: 'running' })
+  })
+
+  it("ignores the other tool's events", async () => {
+    mocks.request.mockResolvedValue({ status: 'stopped' })
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    await waitFor(() => expect(result.current).toEqual({ status: 'stopped' }))
+
+    await act(async () => {
+      emit('deepseek_harness.status_changed', { status: 'running', url: 'http://127.0.0.1:1' })
+    })
+    expect(result.current).toEqual({ status: 'stopped' })
+  })
+
+  it('keeps the stopped default when the initial snapshot request fails, and still applies later events', async () => {
+    mocks.request.mockRejectedValue(new Error('ipc unavailable'))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+
+    await act(async () => {})
+    expect(result.current).toEqual({ status: 'stopped' })
+
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+    })
+    expect(result.current.status).toBe('running')
+  })
+})

--- a/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   request: vi.fn(),
@@ -29,6 +29,8 @@ describe('useManagedToolStatus', () => {
       mocks.events.set(event, handler)
     })
   })
+
+  afterEach(() => vi.useRealTimers())
 
   it('seeds from the get_status snapshot, then follows pushed events (deepseek-harness)', async () => {
     mocks.request.mockResolvedValue({ status: 'running', url: 'http://127.0.0.1:45231' })
@@ -113,6 +115,40 @@ describe('useManagedToolStatus', () => {
       await vi.advanceTimersByTimeAsync(2000)
     })
     expect(result.current).toEqual({ status: 'running' })
-    vi.useRealTimers()
+  })
+
+  it('applies a retry result even when an event landed between attempts', async () => {
+    vi.useFakeTimers()
+    mocks.request.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce({ status: 'running' })
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'error' })
+    })
+    expect(result.current).toEqual({ status: 'error' })
+
+    // The retry is a fresh request issued after the event; its result must heal, not be latched out.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(result.current).toEqual({ status: 'running' })
+  })
+
+  it('stops retrying after the attempt cap', async () => {
+    vi.useFakeTimers()
+    mocks.request.mockRejectedValue(new Error('ipc unavailable'))
+    renderHook(() => useManagedToolStatus('openclaw'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000 * 10)
+    })
+
+    expect(mocks.request.mock.calls.filter(([route]) => route === 'openclaw.get_status')).toHaveLength(5)
   })
 })

--- a/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
@@ -82,4 +82,37 @@ describe('useManagedToolStatus', () => {
     })
     expect(result.current.status).toBe('running')
   })
+
+  it('drops the initial snapshot when an event already delivered newer state', async () => {
+    let resolveSnapshot!: (value: { status: string }) => void
+    mocks.request.mockImplementationOnce(() => new Promise((resolve) => (resolveSnapshot = resolve)))
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+    })
+    expect(result.current).toEqual({ status: 'running' })
+
+    await act(async () => {
+      resolveSnapshot({ status: 'stopped' }) // stale bootstrap reply arriving late
+    })
+    expect(result.current).toEqual({ status: 'running' })
+  })
+
+  it('retries a failed initial snapshot until it lands', async () => {
+    vi.useFakeTimers()
+    mocks.request.mockRejectedValueOnce(new Error('service not ready yet')).mockResolvedValueOnce({ status: 'running' })
+    const { result } = renderHook(() => useManagedToolStatus('openclaw'))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(result.current).toEqual({ status: 'stopped' }) // default while the snapshot fails
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(result.current).toEqual({ status: 'running' })
+    vi.useRealTimers()
+  })
 })

--- a/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useManagedToolStatus.test.ts
@@ -54,7 +54,7 @@ describe('useManagedToolStatus', () => {
     await waitFor(() => expect(result.current).toEqual({ status: 'starting' }))
 
     await act(async () => {
-      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+      emit('openclaw.status_changed', { status: 'running' })
     })
     expect(result.current).toEqual({ status: 'running' })
   })
@@ -78,7 +78,7 @@ describe('useManagedToolStatus', () => {
     expect(result.current).toEqual({ status: 'stopped' })
 
     await act(async () => {
-      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+      emit('openclaw.status_changed', { status: 'running' })
     })
     expect(result.current.status).toBe('running')
   })
@@ -89,7 +89,7 @@ describe('useManagedToolStatus', () => {
     const { result } = renderHook(() => useManagedToolStatus('openclaw'))
 
     await act(async () => {
-      emit('openclaw.status_changed', { status: 'running', port: 18790 })
+      emit('openclaw.status_changed', { status: 'running' })
     })
     expect(result.current).toEqual({ status: 'running' })
 

--- a/src/renderer/pages/code/hooks/__tests__/useOpenClawGatewayController.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useOpenClawGatewayController.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   gatewayPort: undefined as number | undefined,
   requestMock: vi.fn(),
+  useIpcOn: vi.fn(),
+  events: new Map<string, (payload: Record<string, unknown>) => void>(),
   openSmartMiniApp: vi.fn(),
   toastError: vi.fn()
 }))
@@ -19,7 +21,8 @@ vi.mock('@renderer/hooks/useMiniAppPopup', () => ({
 }))
 
 vi.mock('@renderer/ipc', () => ({
-  ipcApi: { request: mocks.requestMock }
+  ipcApi: { request: mocks.requestMock },
+  useIpcOn: mocks.useIpcOn
 }))
 
 vi.mock('@renderer/services/LoggerService', () => ({
@@ -38,6 +41,12 @@ vi.mock('react-i18next', () => ({
 
 const { useOpenClawGatewayController } = await import('../useOpenClawGatewayController')
 
+const emit = (event: string, payload: Record<string, unknown>) => {
+  const handler = mocks.events.get(event)
+  if (!handler) throw new Error(`${event} handler not registered`)
+  handler(payload)
+}
+
 const enabledProvider = { id: 'anthropic', name: 'Anthropic' } as Provider
 
 describe('useOpenClawGatewayController', () => {
@@ -45,6 +54,10 @@ describe('useOpenClawGatewayController', () => {
     vi.clearAllMocks()
     vi.spyOn(Date, 'now').mockReturnValue(1_774_560_000_000)
     mocks.gatewayPort = undefined
+    mocks.events.clear()
+    mocks.useIpcOn.mockImplementation((event: string, handler: (payload: Record<string, unknown>) => void) => {
+      mocks.events.set(event, handler)
+    })
     mocks.requestMock.mockImplementation((route: string) => {
       if (route === 'openclaw.get_status') return Promise.resolve({ status: 'stopped' })
       if (route === 'openclaw.sync_config') return Promise.resolve({ success: true })
@@ -107,6 +120,12 @@ describe('useOpenClawGatewayController', () => {
     })
 
     expect(mocks.requestMock).toHaveBeenCalledWith('openclaw.start_gateway', { port: 18888 })
+
+    // Running state arrives as a main-pushed event, not a local write.
+    await act(async () => {
+      emit('openclaw.status_changed', { status: 'running', port: 18888 })
+    })
+    expect(result.current.running).toBe(true)
   })
 
   // Regression: sync_config writes openclaw.json's gateway.port from the service's in-memory

--- a/src/renderer/pages/code/hooks/__tests__/useOpenClawGatewayController.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useOpenClawGatewayController.test.ts
@@ -123,7 +123,7 @@ describe('useOpenClawGatewayController', () => {
 
     // Running state arrives as a main-pushed event, not a local write.
     await act(async () => {
-      emit('openclaw.status_changed', { status: 'running', port: 18888 })
+      emit('openclaw.status_changed', { status: 'running' })
     })
     expect(result.current.running).toBe(true)
   })

--- a/src/renderer/pages/code/hooks/useDeepSeekHarnessController.ts
+++ b/src/renderer/pages/code/hooks/useDeepSeekHarnessController.ts
@@ -5,14 +5,13 @@ import { toast } from '@renderer/services/toast'
 import type { CliProviderConfig } from '@shared/data/preference/preferenceTypes'
 import type { Provider } from '@shared/data/types/provider'
 import { CodeCli, isApiGatewayProviderId, normalizeDeepSeekHarnessSettings } from '@shared/types/codeCli'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { parseConfiguredModelId } from '../cliConfig'
+import { resolveLaunchModelId } from '../cliConfig'
+import { useManagedToolStatus } from './useManagedToolStatus'
 
 const logger = loggerService.withContext('useDeepSeekHarnessController')
-
-type DeepSeekHarnessStatus = 'stopped' | 'starting' | 'running' | 'error'
 
 interface UseDeepSeekHarnessControllerOptions {
   selectedCliTool: CodeCli
@@ -44,8 +43,9 @@ export function useDeepSeekHarnessController({
 }: UseDeepSeekHarnessControllerOptions): DeepSeekHarnessController {
   const { t } = useTranslation()
   const { openSmartMiniApp } = useMiniAppPopup()
-  const [status, setStatus] = useState<DeepSeekHarnessStatus>('stopped')
-  const [url, setUrl] = useState<string>()
+  // Status comes from main-pushed events (single source of truth); only the local
+  // launching/stopping intents live here, covering the gap until events arrive.
+  const { status, url } = useManagedToolStatus('deepseek-harness')
   const [launching, setLaunching] = useState(false)
   const [stopping, setStopping] = useState(false)
   const isDeepSeekHarness = selectedCliTool === CodeCli.DEEPSEEK_HARNESS
@@ -69,40 +69,29 @@ export function useDeepSeekHarnessController({
   )
 
   const handleLaunch = useCallback(async () => {
-    if (!enabledProvider || !currentProviderConfig?.modelId) {
-      toast.error(t('code.select_provider_model'))
-      return
-    }
-    const parsedModelId = parseConfiguredModelId(currentProviderConfig.modelId)
-    if (!parsedModelId) {
-      logger.error('Invalid DeepSeek Harness model id configured', {
-        modelId: currentProviderConfig.modelId,
-        providerId: enabledProvider.id
-      })
-      await upsertProviderConfig(enabledProvider.id, { modelId: null })
-      await setCurrentProvider(null)
-      toast.error(t('code.select_provider_model'))
-      return
-    }
+    const parsedModelId = await resolveLaunchModelId({
+      enabledProvider,
+      currentProviderConfig,
+      upsertProviderConfig,
+      setCurrentProvider,
+      errorToastKey: 'code.select_provider_model',
+      logLabel: 'Invalid DeepSeek Harness model id configured'
+    })
+    if (!parsedModelId || !enabledProvider) return
 
     try {
       setLaunching(true)
-      setStatus('starting')
       const result = await ipcApi.request('deepseek_harness.start', {
         mode: isApiGatewayProviderId(enabledProvider.id) ? 'gateway' : 'direct',
         uniqueModelId: parsedModelId.uniqueModelId,
         ...settings
       })
       if (!result.success) {
-        setStatus('error')
         toast.error(result.message)
         return
       }
-      setUrl(result.url)
-      setStatus('running')
       openWebUi(result.url)
     } catch (error) {
-      setStatus('error')
       logger.error('Failed to launch DeepSeek Harness', error as Error)
       toast.error(t('code.launch.error'))
     } finally {
@@ -118,8 +107,6 @@ export function useDeepSeekHarnessController({
         toast.error(result.message)
         return false
       }
-      setStatus('stopped')
-      setUrl(undefined)
       return true
     } catch (error) {
       logger.error('Failed to stop DeepSeek Harness', error as Error)
@@ -138,36 +125,12 @@ export function useDeepSeekHarnessController({
       }
       const current = await ipcApi.request('deepseek_harness.get_status')
       if (current.status !== 'running' || !current.url) throw new Error('DeepSeek Harness Web UI is not running')
-      setUrl(current.url)
       openWebUi(current.url)
     } catch (error) {
       logger.error('Failed to open DeepSeek Harness Web UI', error as Error)
       toast.error(t('code.launch.error'))
     }
   }, [openWebUi, t, url])
-
-  useEffect(() => {
-    if (!isDeepSeekHarness) return
-    let cancelled = false
-    const refreshStatus = async () => {
-      try {
-        const current = await ipcApi.request('deepseek_harness.get_status')
-        if (!cancelled) {
-          setStatus(current.status)
-          setUrl(current.url)
-        }
-      } catch (error) {
-        logger.error('Failed to read DeepSeek Harness status', error as Error)
-      }
-    }
-
-    void refreshStatus()
-    const interval = window.setInterval(refreshStatus, 5000)
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [isDeepSeekHarness])
 
   return {
     launching: isDeepSeekHarness && launching,

--- a/src/renderer/pages/code/hooks/useDeepSeekHarnessController.ts
+++ b/src/renderer/pages/code/hooks/useDeepSeekHarnessController.ts
@@ -43,12 +43,12 @@ export function useDeepSeekHarnessController({
 }: UseDeepSeekHarnessControllerOptions): DeepSeekHarnessController {
   const { t } = useTranslation()
   const { openSmartMiniApp } = useMiniAppPopup()
+  const isDeepSeekHarness = selectedCliTool === CodeCli.DEEPSEEK_HARNESS
   // Status comes from main-pushed events (single source of truth); only the local
   // launching/stopping intents live here, covering the gap until events arrive.
-  const { status, url } = useManagedToolStatus('deepseek-harness')
+  const { status, url } = useManagedToolStatus('deepseek-harness', isDeepSeekHarness)
   const [launching, setLaunching] = useState(false)
   const [stopping, setStopping] = useState(false)
-  const isDeepSeekHarness = selectedCliTool === CodeCli.DEEPSEEK_HARNESS
   const settings = useMemo(
     () => normalizeDeepSeekHarnessSettings(currentProviderConfig?.config),
     [currentProviderConfig?.config]

--- a/src/renderer/pages/code/hooks/useManagedToolStatus.ts
+++ b/src/renderer/pages/code/hooks/useManagedToolStatus.ts
@@ -1,0 +1,56 @@
+import { ipcApi, useIpcOn } from '@renderer/ipc'
+import { loggerService } from '@renderer/services/LoggerService'
+import { useEffect, useState } from 'react'
+
+const logger = loggerService.withContext('useManagedToolStatus')
+
+/** The managed-tool lifecycle states shared by DeepSeek Harness and the OpenClaw gateway. */
+export type ManagedToolStatus = 'stopped' | 'starting' | 'running' | 'error'
+
+export type ManagedTool = 'deepseek-harness' | 'openclaw'
+
+export interface ManagedToolStatusState {
+  status: ManagedToolStatus
+  /** Web UI base URL; only DeepSeek Harness reports one. */
+  url?: string
+}
+
+/**
+ * Live status of a main-managed tool: one get_status snapshot on mount, then
+ * main-pushed status_changed events. Crashes and externally-started gateways
+ * surface as they happen — no renderer polling.
+ */
+export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState {
+  const [state, setState] = useState<ManagedToolStatusState>({ status: 'stopped' })
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        if (tool === 'deepseek-harness') {
+          const snapshot = await ipcApi.request('deepseek_harness.get_status')
+          if (!cancelled) setState({ status: snapshot.status, ...(snapshot.url ? { url: snapshot.url } : {}) })
+        } else {
+          const snapshot = await ipcApi.request('openclaw.get_status')
+          if (!cancelled) setState({ status: snapshot.status })
+        }
+      } catch (error) {
+        logger.error(`Failed to read ${tool} status`, error as Error)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [tool])
+
+  // Both subscriptions are registered (hooks cannot be conditional); the
+  // inactive tool's handler is a no-op filter.
+  useIpcOn('deepseek_harness.status_changed', (payload) => {
+    if (tool === 'deepseek-harness') setState({ status: payload.status, ...(payload.url ? { url: payload.url } : {}) })
+  })
+  useIpcOn('openclaw.status_changed', (payload) => {
+    if (tool === 'openclaw') setState({ status: payload.status })
+  })
+
+  return state
+}

--- a/src/renderer/pages/code/hooks/useManagedToolStatus.ts
+++ b/src/renderer/pages/code/hooks/useManagedToolStatus.ts
@@ -19,17 +19,21 @@ const SNAPSHOT_RETRY_MS = 2000
 const SNAPSHOT_MAX_ATTEMPTS = 5
 
 /**
- * Live status of a main-managed tool: one get_status snapshot on mount, then
- * main-pushed status_changed events. Crashes and externally-started gateways
- * surface as they happen — no renderer polling.
+ * Live status of a main-managed tool: a get_status snapshot whenever the tool
+ * becomes the selected one, then main-pushed status_changed events. The
+ * snapshot doubles as the discovery point for a gateway started outside the
+ * app, so nothing polls on either side.
+ *
+ * @param enabled whether this tool is the selected one; false reads nothing.
  */
-export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState {
+export function useManagedToolStatus(tool: ManagedTool, enabled: boolean): ManagedToolStatusState {
   const [state, setState] = useState<ManagedToolStatusState>({ status: 'stopped' })
   // True once an event arrived after the current snapshot request was issued; the
   // in-flight response is then older than that event and must not overwrite it.
   const eventApplied = useRef(false)
 
   useEffect(() => {
+    if (!enabled) return
     let cancelled = false
     let retryTimer: ReturnType<typeof setTimeout> | undefined
     let attempts = 0
@@ -62,18 +66,18 @@ export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState 
       cancelled = true
       if (retryTimer) clearTimeout(retryTimer)
     }
-  }, [tool])
+  }, [tool, enabled])
 
   // Both subscriptions are registered (hooks cannot be conditional); the
   // inactive tool's handler is a no-op filter.
   useIpcOn('deepseek_harness.status_changed', (payload) => {
-    if (tool === 'deepseek-harness') {
+    if (enabled && tool === 'deepseek-harness') {
       eventApplied.current = true
       setState({ status: payload.status, ...(payload.url ? { url: payload.url } : {}) })
     }
   })
   useIpcOn('openclaw.status_changed', (payload) => {
-    if (tool === 'openclaw') {
+    if (enabled && tool === 'openclaw') {
       eventApplied.current = true
       setState({ status: payload.status })
     }

--- a/src/renderer/pages/code/hooks/useManagedToolStatus.ts
+++ b/src/renderer/pages/code/hooks/useManagedToolStatus.ts
@@ -1,6 +1,6 @@
 import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { loggerService } from '@renderer/services/LoggerService'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const logger = loggerService.withContext('useManagedToolStatus')
 
@@ -15,6 +15,8 @@ export interface ManagedToolStatusState {
   url?: string
 }
 
+const SNAPSHOT_RETRY_MS = 2000
+
 /**
  * Live status of a main-managed tool: one get_status snapshot on mount, then
  * main-pushed status_changed events. Crashes and externally-started gateways
@@ -22,34 +24,54 @@ export interface ManagedToolStatusState {
  */
 export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState {
   const [state, setState] = useState<ManagedToolStatusState>({ status: 'stopped' })
+  // An applied event is newer than any in-flight snapshot; set on the event path,
+  // read by the snapshot path to drop stale bootstrap replies.
+  const eventApplied = useRef(false)
 
   useEffect(() => {
     let cancelled = false
-    void (async () => {
+    let retryTimer: ReturnType<typeof setTimeout> | undefined
+    eventApplied.current = false
+
+    const readSnapshot = async (): Promise<void> => {
       try {
         if (tool === 'deepseek-harness') {
           const snapshot = await ipcApi.request('deepseek_harness.get_status')
-          if (!cancelled) setState({ status: snapshot.status, ...(snapshot.url ? { url: snapshot.url } : {}) })
+          if (!cancelled && !eventApplied.current) {
+            setState({ status: snapshot.status, ...(snapshot.url ? { url: snapshot.url } : {}) })
+          }
         } else {
           const snapshot = await ipcApi.request('openclaw.get_status')
-          if (!cancelled) setState({ status: snapshot.status })
+          if (!cancelled && !eventApplied.current) setState({ status: snapshot.status })
         }
       } catch (error) {
+        // A failed snapshot leaves the default 'stopped' rendering with no event to
+        // correct it (e.g. mount racing service readiness) — retry until it lands.
         logger.error(`Failed to read ${tool} status`, error as Error)
+        if (!cancelled && !eventApplied.current) retryTimer = setTimeout(readSnapshot, SNAPSHOT_RETRY_MS)
       }
-    })()
+    }
+
+    void readSnapshot()
     return () => {
       cancelled = true
+      if (retryTimer) clearTimeout(retryTimer)
     }
   }, [tool])
 
   // Both subscriptions are registered (hooks cannot be conditional); the
   // inactive tool's handler is a no-op filter.
   useIpcOn('deepseek_harness.status_changed', (payload) => {
-    if (tool === 'deepseek-harness') setState({ status: payload.status, ...(payload.url ? { url: payload.url } : {}) })
+    if (tool === 'deepseek-harness') {
+      eventApplied.current = true
+      setState({ status: payload.status, ...(payload.url ? { url: payload.url } : {}) })
+    }
   })
   useIpcOn('openclaw.status_changed', (payload) => {
-    if (tool === 'openclaw') setState({ status: payload.status })
+    if (tool === 'openclaw') {
+      eventApplied.current = true
+      setState({ status: payload.status })
+    }
   })
 
   return state

--- a/src/renderer/pages/code/hooks/useManagedToolStatus.ts
+++ b/src/renderer/pages/code/hooks/useManagedToolStatus.ts
@@ -16,6 +16,7 @@ export interface ManagedToolStatusState {
 }
 
 const SNAPSHOT_RETRY_MS = 2000
+const SNAPSHOT_MAX_ATTEMPTS = 5
 
 /**
  * Live status of a main-managed tool: one get_status snapshot on mount, then
@@ -24,16 +25,17 @@ const SNAPSHOT_RETRY_MS = 2000
  */
 export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState {
   const [state, setState] = useState<ManagedToolStatusState>({ status: 'stopped' })
-  // An applied event is newer than any in-flight snapshot; set on the event path,
-  // read by the snapshot path to drop stale bootstrap replies.
+  // True once an event arrived after the current snapshot request was issued; the
+  // in-flight response is then older than that event and must not overwrite it.
   const eventApplied = useRef(false)
 
   useEffect(() => {
     let cancelled = false
     let retryTimer: ReturnType<typeof setTimeout> | undefined
-    eventApplied.current = false
+    let attempts = 0
 
     const readSnapshot = async (): Promise<void> => {
+      eventApplied.current = false // every request supersedes earlier events
       try {
         if (tool === 'deepseek-harness') {
           const snapshot = await ipcApi.request('deepseek_harness.get_status')
@@ -48,7 +50,10 @@ export function useManagedToolStatus(tool: ManagedTool): ManagedToolStatusState 
         // A failed snapshot leaves the default 'stopped' rendering with no event to
         // correct it (e.g. mount racing service readiness) — retry until it lands.
         logger.error(`Failed to read ${tool} status`, error as Error)
-        if (!cancelled && !eventApplied.current) retryTimer = setTimeout(readSnapshot, SNAPSHOT_RETRY_MS)
+        attempts += 1
+        if (!cancelled && !eventApplied.current && attempts < SNAPSHOT_MAX_ATTEMPTS) {
+          retryTimer = setTimeout(readSnapshot, SNAPSHOT_RETRY_MS)
+        }
       }
     }
 

--- a/src/renderer/pages/code/hooks/useOpenClawGatewayController.ts
+++ b/src/renderer/pages/code/hooks/useOpenClawGatewayController.ts
@@ -6,14 +6,13 @@ import { toast } from '@renderer/services/toast'
 import type { CliProviderConfig } from '@shared/data/preference/preferenceTypes'
 import type { Provider } from '@shared/data/types/provider'
 import { CodeCli } from '@shared/types/codeCli'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { parseConfiguredModelId } from '../cliConfig'
+import { resolveLaunchModelId } from '../cliConfig'
+import { useManagedToolStatus } from './useManagedToolStatus'
 
 const logger = loggerService.withContext('useOpenClawGatewayController')
-
-type OpenClawGatewayStatus = 'stopped' | 'starting' | 'running' | 'error'
 
 interface UseOpenClawGatewayControllerOptions {
   selectedCliTool: CodeCli
@@ -46,7 +45,9 @@ export function useOpenClawGatewayController({
   const { t } = useTranslation()
   const { openSmartMiniApp } = useMiniAppPopup()
   const [gatewayPort] = usePreference('feature.openclaw.gateway_port')
-  const [status, setStatus] = useState<OpenClawGatewayStatus>('stopped')
+  // Status comes from main-pushed events (single source of truth); only the local
+  // launching/stopping intents live here, covering the gap until events arrive.
+  const { status } = useManagedToolStatus('openclaw')
   const [launching, setLaunching] = useState(false)
   const [stopping, setStopping] = useState(false)
   const isOpenClawTool = selectedCliTool === CodeCli.OPENCLAW
@@ -66,62 +67,41 @@ export function useOpenClawGatewayController({
   }, [openSmartMiniApp])
 
   const handleLaunch = useCallback(async () => {
-    if (!enabledProvider || !currentProviderConfig?.modelId) {
-      toast.error(t('openclaw.error.select_provider_model'))
-      return
-    }
+    const parsedModelId = await resolveLaunchModelId({
+      enabledProvider,
+      currentProviderConfig,
+      upsertProviderConfig,
+      setCurrentProvider,
+      errorToastKey: 'openclaw.error.select_provider_model',
+      logLabel: 'Invalid OpenClaw model id configured'
+    })
+    if (!parsedModelId) return
 
-    const parsedModelId = parseConfiguredModelId(currentProviderConfig.modelId)
-    if (!parsedModelId) {
-      logger.error('Invalid OpenClaw model id configured', {
-        modelId: currentProviderConfig.modelId,
-        toolId: selectedCliTool,
-        providerId: enabledProvider.id
-      })
-      await upsertProviderConfig(enabledProvider.id, { modelId: null })
-      await setCurrentProvider(null)
-      toast.error(t('openclaw.error.select_provider_model'))
-      return
-    }
     try {
       setLaunching(true)
-      setStatus('starting')
       const syncResult = await ipcApi.request('openclaw.sync_config', {
         uniqueModelId: parsedModelId.uniqueModelId,
         port: gatewayPort
       })
       if (!syncResult.success) {
-        setStatus('error')
         toast.error(syncResult.message)
         return
       }
 
       const startResult = await ipcApi.request('openclaw.start_gateway', { port: gatewayPort })
       if (!startResult.success) {
-        setStatus('error')
         toast.error(startResult.message)
         return
       }
 
       await openDashboard()
-      setStatus('running')
     } catch (err) {
-      setStatus('error')
       logger.error('Failed to launch OpenClaw dashboard:', err as Error)
       toast.error(t('code.launch.error'))
     } finally {
       setLaunching(false)
     }
-  }, [
-    currentProviderConfig,
-    enabledProvider,
-    gatewayPort,
-    openDashboard,
-    selectedCliTool,
-    setCurrentProvider,
-    upsertProviderConfig,
-    t
-  ])
+  }, [currentProviderConfig, enabledProvider, gatewayPort, openDashboard, setCurrentProvider, upsertProviderConfig, t])
 
   const handleStop = useCallback(async () => {
     try {
@@ -131,7 +111,6 @@ export function useOpenClawGatewayController({
         toast.error(result.message)
         return
       }
-      setStatus('stopped')
     } catch (err) {
       logger.error('Failed to stop OpenClaw gateway:', err as Error)
       toast.error(t('code.launch.error'))
@@ -148,29 +127,6 @@ export function useOpenClawGatewayController({
       toast.error(t('code.launch.error'))
     }
   }, [openDashboard, t])
-
-  useEffect(() => {
-    if (!isOpenClawTool) return
-
-    let cancelled = false
-    const refreshStatus = async () => {
-      try {
-        const nextStatus = await ipcApi.request('openclaw.get_status')
-        if (!cancelled) {
-          setStatus(nextStatus.status)
-        }
-      } catch (error) {
-        logger.error('Failed to read OpenClaw gateway status:', error as Error)
-      }
-    }
-
-    void refreshStatus()
-    const interval = window.setInterval(refreshStatus, 5000)
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [isOpenClawTool])
 
   return {
     launching,

--- a/src/renderer/pages/code/hooks/useOpenClawGatewayController.ts
+++ b/src/renderer/pages/code/hooks/useOpenClawGatewayController.ts
@@ -45,12 +45,12 @@ export function useOpenClawGatewayController({
   const { t } = useTranslation()
   const { openSmartMiniApp } = useMiniAppPopup()
   const [gatewayPort] = usePreference('feature.openclaw.gateway_port')
+  const isOpenClawTool = selectedCliTool === CodeCli.OPENCLAW
   // Status comes from main-pushed events (single source of truth); only the local
   // launching/stopping intents live here, covering the gap until events arrive.
-  const { status } = useManagedToolStatus('openclaw')
+  const { status } = useManagedToolStatus('openclaw', isOpenClawTool)
   const [launching, setLaunching] = useState(false)
   const [stopping, setStopping] = useState(false)
-  const isOpenClawTool = selectedCliTool === CodeCli.OPENCLAW
 
   const openDashboard = useCallback(async () => {
     const dashboardUrl = await ipcApi.request('openclaw.get_dashboard_url')

--- a/src/shared/ipc/schemas/codeCli.ts
+++ b/src/shared/ipc/schemas/codeCli.ts
@@ -58,6 +58,23 @@ export const codeCliRequestSchemas = {
     input: codeCliRunInputSchema,
     output: operationResultSchema
   }),
+  'code_cli.read_config': defineRoute({
+    // Targets, not paths — the same enum allow-list as write_config. Duplicate
+    // targets are deduplicated here (first occurrence wins): one entry per file.
+    input: z.object({
+      targets: z.array(z.enum(CLI_CONFIG_TARGET_IDS)).transform((targets) => [...new Set(targets)])
+    }),
+    // content === null ⇔ the file does not exist (ENOENT); other read errors reject.
+    output: z.object({
+      files: z.array(
+        z.object({
+          target: z.enum(CLI_CONFIG_TARGET_IDS),
+          path: z.string(),
+          content: z.string().nullable()
+        })
+      )
+    })
+  }),
   'code_cli.write_config': defineRoute({
     // Targets, not paths: the enum is the write allow-list, and main resolves
     // each target to its spec path itself — a compromised renderer cannot point

--- a/src/shared/ipc/schemas/deepSeekHarness.ts
+++ b/src/shared/ipc/schemas/deepSeekHarness.ts
@@ -37,3 +37,9 @@ export const deepSeekHarnessRequestSchemas = {
     output: z.object({ status: deepSeekHarnessStatusSchema, url: z.string().url().optional() })
   })
 }
+
+// ── Event schemas ──
+export type DeepSeekHarnessEventSchemas = {
+  /** Fired on every status transition; payload is identical in shape to get_status. */
+  'deepseek_harness.status_changed': { status: z.infer<typeof deepSeekHarnessStatusSchema>; url?: string }
+}

--- a/src/shared/ipc/schemas/ipcSchemas.ts
+++ b/src/shared/ipc/schemas/ipcSchemas.ts
@@ -21,7 +21,7 @@ import { miniAppRequestSchemas } from './miniApp'
 import { type NavigationEventSchemas, navigationRequestSchemas } from './navigation'
 import { type NotificationEventSchemas, notificationRequestSchemas } from './notification'
 import { type OAuthEventSchemas, oauthRequestSchemas } from './oauth'
-import { openclawRequestSchemas } from './openclaw'
+import { type OpenClawEventSchemas, openclawRequestSchemas } from './openclaw'
 import { ovmsRequestSchemas } from './ovms'
 import { printRequestSchemas } from './print'
 import { profileRequestSchemas } from './profile'
@@ -104,6 +104,7 @@ export type IpcEventSchemas = AiEventSchemas &
   NavigationEventSchemas &
   NotificationEventSchemas &
   OAuthEventSchemas &
+  OpenClawEventSchemas &
   QuickAssistantEventSchemas &
   SelectionEventSchemas &
   SystemEventSchemas &

--- a/src/shared/ipc/schemas/ipcSchemas.ts
+++ b/src/shared/ipc/schemas/ipcSchemas.ts
@@ -8,7 +8,7 @@ import { type ChannelEventSchemas, channelRequestSchemas } from './channel'
 import { cherryinRequestSchemas } from './cherryin'
 import { citationRequestSchemas } from './citation'
 import { codeCliRequestSchemas } from './codeCli'
-import { deepSeekHarnessRequestSchemas } from './deepSeekHarness'
+import { type DeepSeekHarnessEventSchemas, deepSeekHarnessRequestSchemas } from './deepSeekHarness'
 import { diagnosticsRequestSchemas } from './diagnostics'
 import { exportRequestSchemas } from './export'
 import { externalAppRequestSchemas } from './externalApp'
@@ -97,6 +97,7 @@ export type IpcEventSchemas = AiEventSchemas &
   BackupEventSchemas &
   BinaryEventSchemas &
   ChannelEventSchemas &
+  DeepSeekHarnessEventSchemas &
   FileEventSchemas &
   LocalModelEventSchemas &
   McpEventSchemas &

--- a/src/shared/ipc/schemas/ipcSchemas.ts
+++ b/src/shared/ipc/schemas/ipcSchemas.ts
@@ -21,7 +21,7 @@ import { miniAppRequestSchemas } from './miniApp'
 import { type NavigationEventSchemas, navigationRequestSchemas } from './navigation'
 import { type NotificationEventSchemas, notificationRequestSchemas } from './notification'
 import { type OAuthEventSchemas, oauthRequestSchemas } from './oauth'
-import { openclawRequestSchemas } from './openclaw'
+import { type OpenClawEventSchemas, openclawRequestSchemas } from './openclaw'
 import { ovmsRequestSchemas } from './ovms'
 import { printRequestSchemas } from './print'
 import { profileRequestSchemas } from './profile'
@@ -106,6 +106,7 @@ export type IpcEventSchemas = AiEventSchemas &
   NavigationEventSchemas &
   NotificationEventSchemas &
   OAuthEventSchemas &
+  OpenClawEventSchemas &
   QuickAssistantEventSchemas &
   ScreenshotEventSchemas &
   SelectionEventSchemas &

--- a/src/shared/ipc/schemas/ipcSchemas.ts
+++ b/src/shared/ipc/schemas/ipcSchemas.ts
@@ -8,7 +8,7 @@ import { type ChannelEventSchemas, channelRequestSchemas } from './channel'
 import { cherryinRequestSchemas } from './cherryin'
 import { citationRequestSchemas } from './citation'
 import { codeCliRequestSchemas } from './codeCli'
-import { deepSeekHarnessRequestSchemas } from './deepSeekHarness'
+import { type DeepSeekHarnessEventSchemas, deepSeekHarnessRequestSchemas } from './deepSeekHarness'
 import { diagnosticsRequestSchemas } from './diagnostics'
 import { exportRequestSchemas } from './export'
 import { externalAppRequestSchemas } from './externalApp'
@@ -99,6 +99,7 @@ export type IpcEventSchemas = AiEventSchemas &
   BackupEventSchemas &
   BinaryEventSchemas &
   ChannelEventSchemas &
+  DeepSeekHarnessEventSchemas &
   FileEventSchemas &
   LocalModelEventSchemas &
   McpEventSchemas &

--- a/src/shared/ipc/schemas/openclaw.ts
+++ b/src/shared/ipc/schemas/openclaw.ts
@@ -39,5 +39,5 @@ export const openclawRequestSchemas = {
 // ── Event schemas ──
 export type OpenClawEventSchemas = {
   /** Fired on every gateway-status transition (incl. probe-detected external gateways). */
-  'openclaw.status_changed': { status: z.infer<typeof openclawStatusSchema>; port: number }
+  'openclaw.status_changed': { status: z.infer<typeof openclawStatusSchema> }
 }

--- a/src/shared/ipc/schemas/openclaw.ts
+++ b/src/shared/ipc/schemas/openclaw.ts
@@ -11,6 +11,8 @@ import { operationResultSchema } from './common'
  */
 
 // ── Request schemas ──
+const openclawStatusSchema = z.enum(['stopped', 'starting', 'running', 'error'])
+
 export const openclawRequestSchemas = {
   'openclaw.start_gateway': defineRoute({
     input: z.object({ port: z.number().int().min(1).max(65535).optional() }),
@@ -22,7 +24,7 @@ export const openclawRequestSchemas = {
   }),
   'openclaw.get_status': defineRoute({
     input: z.void(),
-    output: z.object({ status: z.enum(['stopped', 'starting', 'running', 'error']) })
+    output: z.object({ status: openclawStatusSchema })
   }),
   'openclaw.get_dashboard_url': defineRoute({
     input: z.void(),
@@ -32,4 +34,10 @@ export const openclawRequestSchemas = {
     input: z.object({ uniqueModelId: UniqueModelIdSchema, port: z.number().optional() }),
     output: operationResultSchema
   })
+}
+
+// ── Event schemas ──
+export type OpenClawEventSchemas = {
+  /** Fired on every gateway-status transition (incl. probe-detected external gateways). */
+  'openclaw.status_changed': { status: z.infer<typeof openclawStatusSchema>; port: number }
 }


### PR DESCRIPTION
### What this PR does

Two architecture cleanups in the Code Mate area, one commit series each:

**C1 — CLI config reads through `code_cli.read_config`** (`uvm`, `rto`)
- New IpcApi route with the same target-enum allow-list as `write_config`: renderer sends targets, never paths; main resolves each target's absolute path and returns raw text (`content: null` ⇔ ENOENT; other read errors reject). Duplicate targets are deduplicated at the schema layer.
- The renderer `cliConfig` layer retires `resolveAbs` (`window.api.resolvePath`), `readExternal*` (`window.api.file.readExternal`), and the error-message sniffing (`isMissingFileError`). Each draft build is now one batched round trip instead of two legacy calls per file. The parser functions (`parseJsonOrThrow` / `parseTomlOrThrow` / …) stay renderer-side pure functions, byte-for-byte unchanged.

**C2 — managed-tool status: renderer polling → main-pushed events** (`nwq`, `nms`, `rqs`)
- `DeepSeekHarnessService`: all seven status transitions flow through `setStatus`, broadcasting `deepseek_harness.status_changed` with the exact `get_status` payload shape; a failed broadcast is swallowed with a warn and never aborts a transition. A killed child now surfaces as `error` immediately instead of up to 5s later.
- `OpenClawService`: same convergence via `setGatewayStatus` + `openclaw.status_changed` (`{status, port}`), plus a lifecycle-owned 5s health probe (`registerInterval`) so externally-started gateways are still discovered — without the renderer polling. `getStatus()` keeps its read-time probe for instant snapshots.
- Renderer: shared `useManagedToolStatus` (snapshot + event subscription) replaces both controllers' `setInterval` polling and local status state; only the local `launching`/`stopping` intents remain. The duplicated invalid-model recovery sequence collapses into `resolveLaunchModelId` (`useLaunchDialogController` keeps its distinct apply-context variant intentionally).

Before this PR: config reads went through legacy `App_ResolvePath` + `File_ReadExternal` with error-message text sniffing, and both managed-tool controllers polled `get_status` every 5 seconds.

After this PR: reads and writes are symmetric target-enum IPC, and status is pushed by the process that owns the state machine.

Stacked on #18656 (`refactor/shared-redaction`) — will be retargeted to `main` after that merges.

### Why we need it and why it was done this way

The following tradeoffs were made:
- Reads return raw text + path, not parsed structures — the ~1500 lines of parser tests stay renderer-side where they belong (D2).
- The OpenClaw probe keeps `getStatus()`'s read-time detection AND adds the 5s main-side interval — belt and braces, so external-gateway detection cannot regress (D6).
- Status has a single source (main events); the renderer keeps only `launching`/`stopping` booleans, whose union with `starting` covers the click-to-event gap (D9).

The following alternatives were considered:
- Unifying main-side config writes (C3) — deferred to its own task (`08-16-codemate-main-config-writer`); this PR only lays the seam.
- A strategy-table launch controller merge — rejected until a 4th managed tool appears (D5).
- Migrating `window.api.file.selectFolder` — out of scope, pure range control (D3).

### Breaking changes

None intended. Pure refactor with no user-visible behavior change except status/crash feedback becoming immediate instead of up to 5s delayed.

### Special notes for your reviewer

- Subagent design-conformance review: 2 rounds per task half (C1, C2), final verdict zero findings; AC1–AC10 table with file:line/test evidence in the task's review-report.
- Per-commit bisectability verified (each snapshot compiles standalone).
- No new i18n keys; locales untouched.

### Checklist

- [x] Compiles and passes lint/tests locally (task-touched files clean; local lint noise traced solely to an unrelated leftover worktree, CI unaffected)
- [x] Unit tests added/updated for the IPC read contract, transition broadcasts, probe semantics, shared hook, and recovery helper
- [x] Conventional commits, signed + DCO