### PR TITLE
fix(files): keep upload entry available in file type categories

### DIFF
--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -450,7 +450,6 @@ function FilesPage() {
   }, [refetchFileStats, refreshActiveFiles, refreshTrashedFiles, resetActiveFiles, resetTrashedFiles])
 
   const isTrash = filter.kind === 'library' && filter.value === 'trash'
-  const showUploadButton = filter.kind === 'library' && filter.value === 'all'
   const isImageGrid = filter.kind === 'type' && filter.value === 'image'
   const activeFilterLabel =
     filter.kind === 'library'
@@ -935,7 +934,7 @@ function FilesPage() {
                     <Trash2 className="size-3.5" />
                     {t('files.empty_trash')}
                   </Button>
-                ) : showUploadButton ? (
+                ) : (
                   <Button
                     variant="outline"
                     size="sm"
@@ -944,7 +943,7 @@ function FilesPage() {
                     <Upload className="size-3.5 translate-y-px" />
                     <span>{t('files.upload')}</span>
                   </Button>
-                ) : null}
+                )}
               </div>
             }
           />

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -628,6 +628,23 @@ describe('FilesPage file operations', () => {
     })
   })
 
+  it('imports selected files from a type category view', async () => {
+    const fileApi = window.api.file as typeof window.api.file & { select: ReturnType<typeof vi.fn> }
+    fileApi.select = vi.fn().mockResolvedValue([{ path: '/tmp/import-from-text-category.md' }])
+    mockFiles([entry])
+    mockFileStats(statsForEntries([entry]), vi.fn().mockResolvedValue(undefined))
+    render(<FilesPage />)
+
+    fireEvent.click(screen.getByText('files.text'))
+    fireEvent.click(screen.getByText('files.upload'))
+
+    await waitFor(() => {
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_create_internal_entries', {
+        items: [{ source: 'path', path: '/tmp/import-from-text-category.md', cleanupPolicy: 'manual' }]
+      })
+    })
+  })
+
   it('hides upload and shows empty trash in the trash view', async () => {
     mockUseInfiniteQuery.mockImplementation((_path, options) => ({
       pages: (options?.query as { inTrash?: boolean } | undefined)?.inTrash ? [{ items: [trashedEntry] }] : [],
@@ -1138,7 +1155,6 @@ describe('FilesPage file operations', () => {
     expect(await screen.findByAltText('photo.png')).toBeInTheDocument()
     expect(screen.queryByLabelText('files.select_all_short')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('files.select_file')).not.toBeInTheDocument()
-    expect(screen.queryByText('files.upload')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('files.actions')).not.toBeInTheDocument()
 
     fireEvent.contextMenu(screen.getByAltText('photo.png'))


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On the Files page, the "Upload file" button in the top-right header only rendered in the `All files` view. Switching to any type category (`Image` / `Video` / `Audio` / `Text` / `Document` / `Other`) made the upload entry disappear, so users had to navigate back to `All files` just to upload.

After this PR:

The upload button stays in the header for every non-trash view, so uploading works directly from a type category. The trash view is unchanged: it still shows `Empty trash` instead of an upload entry.

The reason this is a bug and not an intentional restriction: drag-and-drop upload on the very same page (`onDragOver` / `onDrop` → `handleImportPaths`) only excludes trash, so the type categories already accepted uploads — only the explicit button was hidden. The two entries were inconsistent; this aligns the button with the drag-and-drop gate.

Note that an uploaded file is categorized by its detected type, so a file whose type does not match the current category will not appear in the current list. That is expected, and this PR deliberately does not add any auto-switching behavior.

Fixes # N/A

### Why we need it and why it was done in this way

`showUploadButton` was hardcoded as `filter.kind === 'library' && filter.value === 'all'`, while the drop handler right below it guards with `if (isTrash) return`. Since the header already renders `isTrash ? <EmptyTrash /> : <Upload />`, the extra condition was the only thing hiding the entry, so it was removed rather than rewritten into an equivalent `!isTrash` flag.

The following tradeoffs were made:

- Kept the change to the single condition instead of restructuring the header actions, to stay minimal and reviewable.
- Removed the now-redundant `showUploadButton` variable instead of setting it to `!isTrash`, which would have left a tautological ternary inside the already-`isTrash`-checked branch.

The following alternatives were considered:

- Showing the button only in categories that accept the dropped type — rejected: the underlying import path does not filter by type, and drag-and-drop does not do this either, so it would introduce a new inconsistency.
- Auto-switching to the matching category after upload — rejected: out of scope for this bug, and it would be a product decision rather than a fix.

Links to places where the discussion took place:

Original user report (V2 bug bash, submitted by 张晨杰, Cherry Studio Agent intake), Windows 11 Home 10.0.26200 (64-bit), Cherry Studio v2 beta.1:

> 文件管理页面中，进入"所有文件"时右上角会显示"上传文件"按钮；切换到"图片、视频、音频、文本、文档、其他"等分类页面后，上传入口消失，用户无法从当前分类直接上传文件，只能先返回"所有文件"页面，增加了不必要的操作路径。

(Translation: on the file management page, the "Upload file" button shows in the top-right corner of "All files"; after switching to the "Image / Video / Audio / Text / Document / Other" category pages, the upload entry disappears, so users cannot upload from the current category and must go back to "All files" first — an unnecessary detour.)

Source record: https://mcnnox2fhjfq.feishu.cn/record/Xx3WrnJm9edl89cqLIjcO6IbnGh

Reproduction:

1. Open the Files page (`All files`) — the "Upload file" button is visible in the top-right corner.
2. Switch to any type category, e.g. `Text`.
3. Before this PR the upload entry is gone; after this PR it stays available and opens the file picker.

### Breaking changes

None.

### Special notes for your reviewer

Test changes:

- Added `imports selected files from a type category view`: switches to the `Text` category, clicks upload, and asserts the import IPC (`file.batch_create_internal_entries`) is called. Verified this test fails without the source change (`Unable to find an element with the text: files.upload`).
- Removed the stale `expect(screen.queryByText('files.upload')).not.toBeInTheDocument()` assertion from the image-grid test, which pinned the buggy behavior.
- The existing `hides upload and shows empty trash in the trash view` test still passes, covering the trash exclusion.

Verification run locally: `pnpm typecheck:web` clean, oxlint and Biome clean on both changed files, `FilesPage.test.tsx` 48/48 passing. `pnpm build:check` is green apart from two failures in `src/renderer/pages/settings/DataSettings/__tests__/` (`legacyV1BrowserData` / `BasicDataSettings` retry-marker cases) that reproduce unchanged on `main` @ c649419df4 and are unrelated to this PR.

No i18n changes — the existing `files.upload` key is reused.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the Files page hiding the upload button in the image/video/audio/text/document/other categories, so files can now be uploaded without returning to All files.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
