### PR TITLE
fix(readme): restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,11 +278,11 @@ We believe the Enterprise Edition will become your team's AI productivity engine
 
 # ⭐️ Star History
 
-<a href="https://www.star-history.com/#CherryHQ/cherry-studio&Date">
+<a href="https://star-history.dera.page/#CherryHQ/cherry-studio&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CherryHQ/cherry-studio&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CherryHQ/cherry-studio&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CherryHQ/cherry-studio&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CherryHQ/cherry-studio&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CherryHQ/cherry-studio&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CherryHQ/cherry-studio&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README is broken and currently renders nothing. This updates the chart link and image sources to a working replacement so the README shows the project's star history again.

The rebadge link and all other sections stay unchanged.