### PR TITLE
fix(composer): stop the deferred paste replay from being handled twice

### DIFF
--- a/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
+++ b/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
@@ -2131,8 +2131,11 @@ export default function ComposerSurfaceRuntime({
           insertComposerTokenAtCursor(editor, pendingToken.token)
         }
         if (transfer?.kind === 'paste') {
+          // Do not bubble: ProseMirror listens on the view element itself, while the document-level
+          // paste handler would route the same payload to this composer a second time whenever the
+          // caret has not made it back into the editor.
           editor.view.dom.dispatchEvent(
-            new ClipboardEvent('paste', { clipboardData: transfer.data, bubbles: true, cancelable: true })
+            new ClipboardEvent('paste', { clipboardData: transfer.data, bubbles: false, cancelable: true })
           )
         } else if (transfer?.kind === 'drop') {
           editor.view.dom.dispatchEvent(

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   deferredEditorMinHeight: 46,
   editorContentLineCount: 1,
   editorViewComposing: false,
+  editorViewDom: undefined as HTMLElement | undefined,
   editorScrollHeight: 28,
   insertContent: vi.fn(),
   insertComposerToken: vi.fn(),
@@ -228,6 +229,9 @@ vi.mock('@renderer/components/RichEditor/useRichTextEditorKernel', () => ({
       view: {
         get composing() {
           return mocks.editorViewComposing
+        },
+        get dom() {
+          return mocks.editorViewDom
         },
         dispatch: mocks.dispatch
       },
@@ -441,6 +445,7 @@ describe('ComposerSurface', () => {
     mocks.deferredEditorMinHeight = 46
     mocks.editorContentLineCount = 1
     mocks.editorViewComposing = false
+    mocks.editorViewDom = document.createElement('div')
     mocks.editorScrollHeight = 28
     mocks.insertContent.mockReset()
     mocks.insertComposerToken.mockReset()
@@ -506,6 +511,39 @@ describe('ComposerSurface', () => {
         error: vi.fn()
       }
     })
+  })
+
+  it('replays a deferred paste on the editor view only, not through the document paste handler', async () => {
+    const viewDom = mocks.editorViewDom!
+    document.body.appendChild(viewDom)
+    class FakeClipboardEvent extends Event {
+      clipboardData: unknown
+      constructor(type: string, init: EventInit & { clipboardData?: unknown }) {
+        super(type, init)
+        this.clipboardData = init.clipboardData
+      }
+    }
+    vi.stubGlobal('ClipboardEvent', FakeClipboardEvent)
+    const onView = vi.fn()
+    const onDocument = vi.fn()
+    viewDom.addEventListener('paste', onView)
+    document.addEventListener('paste', onDocument)
+
+    render(
+      <ComposerSurface
+        {...baseProps}
+        deferredIntent={{ transfer: { kind: 'paste', data: { files: [] } as unknown as DataTransfer } }}
+      />
+    )
+
+    // The editor's own listener sits on the view element; the document-level handler in
+    // pasteHandling would hand the same payload to this composer a second time.
+    await waitFor(() => expect(onView).toHaveBeenCalledTimes(1))
+    expect(onDocument).not.toHaveBeenCalled()
+
+    document.removeEventListener('paste', onDocument)
+    viewDom.remove()
+    vi.unstubAllGlobals()
   })
 
   it('defers the editor engine so the composer frame can render first', () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When the composer's rich runtime is still loading, the deferred fallback captures a paste and the runtime replays it later by dispatching a synthetic `ClipboardEvent` on the editor view. That event was created with `bubbles: true`, so besides reaching ProseMirror's own handler it also travelled up to the document-level listener in `pasteHandling`. `handleGlobalPaste` routes a paste to the composer's registered `inputbar` handler whenever `document.activeElement` is not an input, so a replay that fires while the caret has not made it back into the editor is processed twice — clipboard files get attached twice.

After this PR:

The paste replay is dispatched with `bubbles: false`. ProseMirror registers its editor event handlers on the view element itself, so the replay still takes exactly the same path a live paste would, and the document-level handler never sees it.

Fixes #

### Why we need it and why it was done in this way

`prosemirror-view` attaches every handler in its `handlers`/`editHandlers` map directly to `view.dom`, so bubbling was never needed to reach the editor — it only ever exposed the replay to listeners further up the tree. Removing it is therefore the smallest change that closes the double handling, with no effect on the payload the editor receives.

The following tradeoffs were made:

- Only the paste replay stops bubbling. The `drop` replay keeps `bubbles: true` on purpose: it has to reach the React `onDrop` on the `.inputbar` container, and `pasteHandling` only registers a document-level `paste` listener, so `drop` has no equivalent double-routing path.

The following alternatives were considered:

- Guarding the dispatch on the caret being inside the editor: rejected. It would silently drop a captured payload in exactly the case the deferred replay exists to serve, and it leaves the same trap in place for any future replay.
- Marking the event and having `handleGlobalPaste` ignore marked events: rejected as a larger contract for a problem that scoping the dispatch already solves.

Links to places where the discussion took place: reported by @404-Page-Found while reviewing https://github.com/CherryHQ/cherry-studio/pull/18664

### Breaking changes

None.

### Special notes for your reviewer

The regression test attaches the mocked view element to the document and listens on both it and `document`, asserting the editor receives the replay exactly once while the document-level handler receives nothing. It was mutation-checked: restoring `bubbles: true` turns it red.

Split out of #18664 rather than folded into it, since the behaviour predates that PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed clipboard files being attached twice when pasting into the chat composer before its rich editor finished loading.
```
