### PR TITLE
fix(shortcut): accept F13-F24 as shortcut keys

### DIFF
--- a/src/renderer/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/pages/settings/ShortcutSettings.tsx
@@ -69,7 +69,7 @@ const keyCodeToAccelerator: Record<string, ShortcutToken> = {
 }
 
 const passthrough =
-  /^(Page(Up|Down)|Insert|Home|End|Arrow(Up|Down|Left|Right)|F([1-9]|1[0-9])|Slash|Semicolon|Bracket(Left|Right)|Backslash|Quote|Comma|Minus|Equal)$/
+  /^(Page(Up|Down)|Insert|Home|End|Arrow(Up|Down|Left|Right)|F([1-9]|1\d|2[0-4])|Slash|Semicolon|Bracket(Left|Right)|Backslash|Quote|Comma|Minus|Equal)$/
 
 const usableEndKeys = (code: string): ShortcutToken | null => {
   if (/^Key[A-Z]$/.test(code) || /^(Digit|Numpad)\d$/.test(code)) return normalizeShortcutToken(code) ?? null

--- a/src/shared/utils/__tests__/shortcut.test.ts
+++ b/src/shared/utils/__tests__/shortcut.test.ts
@@ -68,6 +68,8 @@ describe('normalizeShortcutToken', () => {
     expect(normalizeShortcutToken('a')).toBe('A')
     expect(normalizeShortcutToken('f3')).toBe('F3')
     expect(normalizeShortcutToken('f12')).toBe('F12')
+    expect(normalizeShortcutToken('F13')).toBe('F13')
+    expect(normalizeShortcutToken('f24')).toBe('F24')
   })
 
   it('covers the lowercase fallback branch for special tokens', () => {
@@ -79,7 +81,7 @@ describe('normalizeShortcutToken', () => {
 
   it('returns undefined for unrecognized input', () => {
     expect(normalizeShortcutToken('NotAKey')).toBeUndefined()
-    expect(normalizeShortcutToken('F13')).toBeUndefined()
+    expect(normalizeShortcutToken('F25')).toBeUndefined()
     expect(normalizeShortcutToken('Key1')).toBeUndefined()
   })
 })

--- a/src/shared/utils/shortcut.ts
+++ b/src/shared/utils/shortcut.ts
@@ -43,7 +43,19 @@ export const SHORTCUT_FUNCTION_KEYS = [
   'F9',
   'F10',
   'F11',
-  'F12'
+  'F12',
+  'F13',
+  'F14',
+  'F15',
+  'F16',
+  'F17',
+  'F18',
+  'F19',
+  'F20',
+  'F21',
+  'F22',
+  'F23',
+  'F24'
 ] as const
 
 export const SHORTCUT_SYMBOLS = ['=', '-', '[', ']', ',', '.', '/', '\\', ';', "'", '`'] as const
@@ -198,7 +210,7 @@ export const normalizeShortcutToken = (value: string): ShortcutToken | undefined
     return upper
   }
 
-  if (/^F(?:[1-9]|1[0-2])$/.test(upper) && isShortcutToken(upper)) {
+  if (/^F(?:[1-9]|1\d|2[0-4])$/.test(upper) && isShortcutToken(upper)) {
     return upper as ShortcutFunctionKey
   }
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

F13–F24 could not be bound in the shortcut recorder. Pressing F13 (e.g. mapped from another key via PowerToys) did nothing at all — no binding was saved, no error was shown, nothing was logged. This is a regression from v1.9.13.

After this PR:

F13–F24 are accepted as shortcut keys, on every platform. They are valid Electron accelerators, so both the global (main-process) and in-window (renderer) registration paths work with no further changes.

Root cause: the shared shortcut token vocabulary stopped at F12.
- `SHORTCUT_FUNCTION_KEYS` listed only `F1`–`F12`, and `normalizeShortcutToken` matched `^F(?:[1-9]|1[0-2])$`.
- The recorder's `passthrough` regex did allow `F13`–`F19`, but the following `convertKeyToAccelerator('F13')` returned `undefined`, so the end key was dropped, the binding came out empty, `isValidShortcut` rejected it, and the recorder bailed out silently. `F20`–`F24` were rejected one step earlier by that same regex.

Changes:
- `src/shared/utils/shortcut.ts` — extend `SHORTCUT_FUNCTION_KEYS` to `F24` and widen the normalize regex to `^F(?:[1-9]|1\d|2[0-4])$`.
- `src/renderer/pages/settings/ShortcutSettings.tsx` — widen the recorder `passthrough` regex to cover `F20`–`F24`.
- `src/shared/utils/__tests__/shortcut.test.ts` — the suite asserted `normalizeShortcutToken('F13')` is `undefined`, which pinned the bug as expected behavior; it now asserts F13/F24 normalize and F25 is rejected.

Fixes #18667

### Why we need it and why it was done in this way

F13–F24 are the standard target for key remapping tools (PowerToys Keyboard Manager, QMK/VIA keyboards, macro pads) precisely because no physical keyboard sends them by default, which makes them the natural choice for application shortcuts. Rejecting them removes the one key range users specifically reserve for this.

The fix widens the existing token vocabulary rather than adding a special case, so every consumer — the recorder, renderer keybinding matching via `getShortcutBindingFromKeyboardEvent`, and main-process `globalShortcut` registration via the token `join('+')` — picks it up from one place.

The following tradeoffs were made:

- The upper bound is `F24`, matching the Electron accelerator range. Anything beyond that would fail at `globalShortcut.register` anyway.
- The bare-function-key rule in `isValidShortcut` (a single function key is a valid modifier-less shortcut) is unchanged, so `F13` alone binds just like `F5` alone does today.

The following alternatives were considered:

- Only fixing the recorder's `passthrough` regex: insufficient — the token vocabulary is the actual gate, and renderer-side matching would still have failed to resolve the binding.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18667

### Breaking changes

None.

### Special notes for your reviewer

The issue also mentions Caps Lock not being recognized. That is deliberately out of scope here: Caps Lock is an OS-level toggle whose `keydown` semantics differ from a held modifier, and it needs its own discussion.

Verified with `vitest run src/shared/utils/__tests__/shortcut.test.ts src/renderer/pages/settings/__tests__/ShortcutSettings.test.tsx` (32 passed). Full `pnpm test` / `pnpm build:check` were not run locally at the author's request; CI covers them.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed F13–F24 not being accepted by the shortcut recorder.
```
