### PR TITLE
fix(shortcut): accept CapsLock as a shortcut key

### DIFF
--- a/src/renderer/pages/settings/ShortcutSettings.tsx
+++ b/src/renderer/pages/settings/ShortcutSettings.tsx
@@ -69,7 +69,7 @@ const keyCodeToAccelerator: Record<string, ShortcutToken> = {
 }
 
 const passthrough =
-  /^(Page(Up|Down)|Insert|Home|End|Arrow(Up|Down|Left|Right)|F([1-9]|1\d|2[0-4])|Slash|Semicolon|Bracket(Left|Right)|Backslash|Quote|Comma|Minus|Equal)$/
+  /^(Page(Up|Down)|Insert|Home|End|CapsLock|Arrow(Up|Down|Left|Right)|F([1-9]|1\d|2[0-4])|Slash|Semicolon|Bracket(Left|Right)|Backslash|Quote|Comma|Minus|Equal)$/
 
 const usableEndKeys = (code: string): ShortcutToken | null => {
   if (/^Key[A-Z]$/.test(code) || /^(Digit|Numpad)\d$/.test(code)) return normalizeShortcutToken(code) ?? null

--- a/src/shared/utils/__tests__/shortcut.test.ts
+++ b/src/shared/utils/__tests__/shortcut.test.ts
@@ -120,9 +120,15 @@ describe('isValidShortcut', () => {
     expect(isValidShortcut(['Shift', 'Alt', '/'])).toBe(true)
   })
 
-  it('accepts a lone Escape or function key', () => {
+  it('accepts a lone Escape, CapsLock or function key', () => {
     expect(isValidShortcut(['Escape'])).toBe(true)
+    expect(isValidShortcut(['CapsLock'])).toBe(true)
     expect(isValidShortcut(['F5'])).toBe(true)
+  })
+
+  it('rejects other lone non-modifier keys', () => {
+    expect(isValidShortcut(['A'])).toBe(false)
+    expect(isValidShortcut(['Home'])).toBe(false)
   })
 
   it('rejects an empty binding', () => {

--- a/src/shared/utils/shortcut.ts
+++ b/src/shared/utils/shortcut.ts
@@ -62,6 +62,7 @@ export const SHORTCUT_SYMBOLS = ['=', '-', '[', ']', ',', '.', '/', '\\', ';', "
 
 export const SHORTCUT_NAMED_KEYS = [
   'Escape',
+  'CapsLock',
   'Enter',
   'Tab',
   'Space',
@@ -374,7 +375,8 @@ export const isValidShortcut = (binding: ShortcutBinding): boolean => {
 
   const hasModifier = binding.some(isShortcutModifier)
   const hasNonModifier = binding.some((key) => !isShortcutModifier(key))
-  const isSpecialKey = binding.length === 1 && (binding[0] === 'Escape' || isShortcutFunctionKey(binding[0]))
+  const isSpecialKey =
+    binding.length === 1 && (binding[0] === 'Escape' || binding[0] === 'CapsLock' || isShortcutFunctionKey(binding[0]))
 
   return (hasModifier && hasNonModifier) || isSpecialKey
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

> **Stacked on #18688** — base branch is `fix/shortcut-f13-f24`, not `main`. The diff here is the CapsLock commit only. Merge #18688 first; this PR then retargets to `main` automatically.

### What this PR does

Before this PR:

Caps Lock could not be bound as a shortcut. The recorder ignored the keypress entirely — no binding saved, no error, nothing logged.

After this PR:

Caps Lock is accepted as a shortcut key. A lone `CapsLock` is a valid binding, in the same way a lone `Escape` or function key already is, and modifier combinations such as `Ctrl+CapsLock` work too.

Root cause is the same class as #18688: `CapsLock` was not part of the shared shortcut token vocabulary, so `normalizeShortcutToken('CapsLock')` returned `undefined`, the recorder produced an empty binding, and `isValidShortcut` rejected it without any feedback.

Changes:
- `src/shared/utils/shortcut.ts` — add `CapsLock` to `SHORTCUT_NAMED_KEYS`, and allow it as a standalone binding in `isValidShortcut`.
- `src/renderer/pages/settings/ShortcutSettings.tsx` — let the DOM code `CapsLock` through the recorder's `passthrough` filter.

Refs #18667

### Why we need it and why it was done in this way

Caps Lock is the other half of the report in #18667. It is a common remap target for users who consider the key useless in its default role, and it costs nothing to support beyond widening the same vocabulary #18688 widens.

Verified that `globalShortcut.register('CapsLock')` succeeds on macOS with the Electron version this repo pins (Electron's accelerator parsing is case-insensitive here, so the `CapsLock` token spelling reaches the same key code as the documented `Capslock`). Renderer-scope commands go through `getShortcutBindingFromKeyboardEvent`, which picks the token up from the same vocabulary, so both scopes work from one change.

The following tradeoffs were made:

- Caps Lock keeps toggling the OS caps state when pressed; that side effect is not suppressible from the app and is inherent to binding this key.
- Chromium on macOS emits `keydown` for Caps Lock only when the key turns *on*, and `keyup` when it turns *off*. A renderer-scope Caps Lock shortcut therefore fires on every other press there. Windows and Linux emit `keydown` on each press. This is accepted rather than worked around: the alternative would be tracking lock state per platform, which is a lot of machinery for one key.
- `formatKeyDisplay` renders the token as `Capslock`, consistent with how existing named keys such as `PageUp` already render (`Pageup`). Not changed here to avoid a display-only detour.

The following alternatives were considered:

- Rejecting Caps Lock explicitly with a "this key cannot be bound" hint in the recorder. That keeps today's behavior and only makes it visible, which does not serve the users who deliberately want this key.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18667

### Breaking changes

None.

### Special notes for your reviewer

The macOS every-other-press behavior above is the one thing worth a second opinion: if you would rather reject Caps Lock on `darwin` than ship a key that fires on alternating presses, say so and I will gate it by platform.

Verified with `vitest run src/shared/utils/__tests__/shortcut.test.ts src/renderer/pages/settings/__tests__/ShortcutSettings.test.tsx src/renderer/utils/__tests__/command.test.ts` (40 passed). Full `pnpm test` / `pnpm build:check` were not run locally at the author's request; CI covers them.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main` (stacked: targets `fix/shortcut-f13-f24` until #18688 merges)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Caps Lock can now be bound as a shortcut key.
```
