### PR TITLE
fix(agent-migration): stop an uncopyable memory entry from aborting migration

### DIFF
--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import type * as FsPromises from 'node:fs/promises'
 import {
   access,
@@ -714,6 +715,66 @@ describe('agentsFilesystemMigration', () => {
       'workspace content'
     )
   })
+
+  it.runIf(process.platform !== 'win32')(
+    'keeps migrating when an Agent target that is also its own legacy workspace holds an identity symlink',
+    async () => {
+      const { tempRoot, agentsDataRoot } = await createFixture()
+      const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
+      await mkdir(path.join(agentDataPath, 'memory'), { recursive: true })
+      await writeFile(path.join(agentDataPath, 'SOUL.md'), 'legacy soul')
+      await writeFile(path.join(agentDataPath, 'memory', 'JOURNAL.jsonl'), '{"note":"kept"}\n')
+      await writeFile(path.join(tempRoot, 'shared-fact.md'), 'shared knowledge')
+      await symlink(path.join(tempRoot, 'shared-fact.md'), path.join(agentDataPath, 'memory', 'FACT.md'))
+
+      const externalSession = sessionPlan(agentsDataRoot, agentDataPath, {
+        sourceSessionId: 'session_external',
+        finalSessionId: FINAL_LATEST_SESSION_ID,
+        createdAt: Date.parse('2026-07-22T00:00:00Z'),
+        updatedAt: Date.parse('2026-07-23T00:00:00Z'),
+        managed: false
+      })
+
+      await expect(
+        stageLegacyAgentFiles({
+          agentsDataRoot,
+          agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+          sessions: [externalSession]
+        })
+      ).resolves.toEqual({ skippedTargetCount: 0 })
+
+      expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('legacy soul')
+      expect(await readFile(path.join(agentDataPath, 'memory', 'JOURNAL.jsonl'), 'utf8')).toBe('{"note":"kept"}\n')
+      expect((await lstat(path.join(agentDataPath, 'memory', 'FACT.md'))).isSymbolicLink()).toBe(true)
+    }
+  )
+
+  it.runIf(process.platform !== 'win32')(
+    'migrates the rest of an identity directory that holds an entry which cannot be copied',
+    async () => {
+      const { agentsDataRoot, legacyWorkspace } = await createFixture()
+      await mkdir(path.join(legacyWorkspace, 'memory'), { recursive: true })
+      await writeFile(path.join(legacyWorkspace, 'memory', 'FACT.md'), 'remember this')
+      execFileSync('mkfifo', [path.join(legacyWorkspace, 'memory', 'agent-memory.pipe')])
+
+      const session = sessionPlan(agentsDataRoot, legacyWorkspace, {
+        sourceSessionId: 'session_latest',
+        finalSessionId: FINAL_LATEST_SESSION_ID,
+        createdAt: Date.parse('2026-07-22T00:00:00Z'),
+        updatedAt: Date.parse('2026-07-23T00:00:00Z')
+      })
+
+      await stageLegacyAgentFiles({
+        agentsDataRoot,
+        agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+        sessions: [session]
+      })
+
+      const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
+      expect(await readFile(path.join(agentDataPath, 'memory', 'FACT.md'), 'utf8')).toBe('remember this')
+      await expect(access(path.join(agentDataPath, 'memory', 'agent-memory.pipe'))).rejects.toThrow()
+    }
+  )
 
   it('copies the shared workspace content only into the most recently active managed session', async () => {
     const { agentsDataRoot, legacyWorkspace } = await createFixture()

--- a/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
+++ b/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
@@ -306,12 +306,12 @@ async function materializeIdentityEntry(sourcePath: string, destinationPath: str
 }
 
 async function copyIdentityEntry(sourcePath: string, destinationPath: string): Promise<CopyEntryResult | undefined> {
-  const sourceSnapshot = await identityCopySourceSnapshot(sourcePath)
+  const sourceSnapshot = await identityCopySnapshot(sourcePath)
   if (!sourceSnapshot) return undefined
 
-  const existingDestination = await filesystemEntrySnapshot(destinationPath)
+  const existingDestination = await identityCopySnapshot(destinationPath)
   if (existingDestination) {
-    if (existingDestination.fingerprint !== sourceSnapshot.copiedFingerprint) {
+    if (existingDestination.copiedFingerprint !== sourceSnapshot.copiedFingerprint) {
       throw new Error(`Legacy Agent identity destination conflict: ${destinationPath}`)
     }
     logger.info('Reusing identical identity entry created after migration target cleanup', {
@@ -333,15 +333,15 @@ async function copyIdentityEntry(sourcePath: string, destinationPath: string): P
       throw new Error(`Legacy Agent identity changed while being copied: ${sourcePath}`)
     }
 
-    const stagingSnapshot = await requiredFilesystemEntrySnapshot(stagingPath)
-    if (stagingSnapshot.fingerprint !== sourceSnapshot.copiedFingerprint) {
+    const stagingSnapshot = await requiredIdentityCopySnapshot(stagingPath)
+    if (stagingSnapshot.copiedFingerprint !== sourceSnapshot.copiedFingerprint) {
       throw new Error(`Legacy Agent identity copy verification failed: ${sourcePath}`)
     }
 
     const racedDestinationStat = await lstatIfExists(destinationPath)
     if (racedDestinationStat) {
-      const racedDestinationSnapshot = await requiredFilesystemEntrySnapshot(destinationPath)
-      if (racedDestinationSnapshot.fingerprint !== sourceSnapshot.copiedFingerprint) {
+      const racedDestinationSnapshot = await identityCopySnapshot(destinationPath)
+      if (racedDestinationSnapshot?.copiedFingerprint !== sourceSnapshot.copiedFingerprint) {
         throw new Error(`Legacy Agent identity destination conflict: ${destinationPath}`)
       }
       logger.info('Reusing identical identity entry from an earlier migration attempt', {
@@ -357,8 +357,11 @@ async function copyIdentityEntry(sourcePath: string, destinationPath: string): P
       try {
         await publishStagedWorkspaceEntry(stagingPath, destinationPath)
       } catch (error) {
-        const racedDestinationSnapshot = await filesystemEntrySnapshot(destinationPath)
-        if (!racedDestinationSnapshot || racedDestinationSnapshot.fingerprint !== sourceSnapshot.copiedFingerprint) {
+        const racedDestinationSnapshot = await identityCopySnapshot(destinationPath)
+        if (
+          !racedDestinationSnapshot ||
+          racedDestinationSnapshot.copiedFingerprint !== sourceSnapshot.copiedFingerprint
+        ) {
           throw error
         }
         return {
@@ -1104,18 +1107,28 @@ async function filesystemEntryStatsWithQueue(
   return { fileCount, byteCount }
 }
 
-async function identityCopySourceSnapshot(targetPath: string): Promise<CopySourceSnapshot | undefined> {
+// `materializeIdentityEntry` reproduces only regular files and directories, so
+// every other entry has to stay out of the fingerprint as well.
+function isCopyableIdentityStat(targetStat: BigIntStats): boolean {
+  return targetStat.isFile() || targetStat.isDirectory()
+}
+
+/**
+ * Fingerprint an identity tree as it looks once copied. Both sides of an
+ * identity copy go through this so the source, the private staging tree and an
+ * existing destination stay comparable.
+ */
+async function identityCopySnapshot(targetPath: string): Promise<CopySourceSnapshot | undefined> {
   const targetStat = await lstatBigIntIfExists(targetPath)
   if (!targetStat) return undefined
 
-  const kind = filesystemEntryKind(targetStat)
-  const copiedHash = createHash('sha256')
-
-  if (kind === 'symlink') {
-    logger.warn('Skipping identity symlink while snapshotting Agent migration source', { targetPath })
+  if (!isCopyableIdentityStat(targetStat)) {
+    logger.warn('Skipping identity entry that cannot be copied during Agent migration', { targetPath })
     return undefined
   }
 
+  const kind = targetStat.isFile() ? 'file' : 'directory'
+  const copiedHash = createHash('sha256')
   updateFingerprintField(copiedHash, kind)
   let fileCount = 0
   let byteCount = 0
@@ -1130,10 +1143,10 @@ async function identityCopySourceSnapshot(targetPath: string): Promise<CopySourc
     entries.sort()
     for (const entry of entries) {
       const childPath = path.join(targetPath, entry)
-      const childSnapshot = await identityCopySourceSnapshot(childPath)
+      const childSnapshot = await identityCopySnapshot(childPath)
       if (!childSnapshot) {
         const childStat = await lstatBigIntIfExists(childPath)
-        if (childStat?.isSymbolicLink()) continue
+        if (childStat && !isCopyableIdentityStat(childStat)) continue
         throw new Error(`Legacy Agent identity source changed while being scanned: ${childPath}`)
       }
       updateFingerprintField(copiedHash, entry)
@@ -1148,6 +1161,14 @@ async function identityCopySourceSnapshot(targetPath: string): Promise<CopySourc
     fileCount,
     byteCount
   }
+}
+
+async function requiredIdentityCopySnapshot(targetPath: string): Promise<CopySourceSnapshot> {
+  const snapshot = await identityCopySnapshot(targetPath)
+  if (!snapshot) {
+    throw new Error(`Agent migration fingerprint source disappeared: ${targetPath}`)
+  }
+  return snapshot
 }
 
 async function workspaceSourceSnapshot(sourcePath: string): Promise<WorkspaceSourceSnapshot | undefined> {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`copyIdentityEntry` fingerprinted the two sides of an identity copy with two different functions that disagreed about which entries the copy reproduces:

- the source went through `identityCopySourceSnapshot`, which skips every entry `materializeIdentityEntry` cannot reproduce;
- the private staging tree and any existing destination went through `filesystemEntrySnapshot`, which counts symlinks, and shares `filesystemEntryKind`, which throws `Unsupported Agent migration fingerprint entry type` on sockets, fifos and device nodes.

A single such entry under `memory/` therefore aborted the whole v2 migration:

- a symlinked `memory/FACT.md` failed with `Legacy Agent identity destination conflict` whenever the destination already existed. That is not a corner case: a v1 Agent whose workspace is already its v2 Agent-data directory keeps its target (`preserveExactSource`), so source and destination are literally the same tree and the mismatch is guaranteed;
- a socket or fifo anywhere under `memory/` failed with `Unsupported Agent migration fingerprint entry type` while snapshotting the source, before anything was copied.

After this PR:

Both sides share one `identityCopySnapshot`. Every entry the copy cannot reproduce — symlink, socket, fifo, device node — is skipped and logged on both sides, so the fingerprints stay comparable and the rest of the identity directory migrates normally. The un-copyable entry is left untouched at the source.

Fixes # N/A

### Why we need it and why it was done in this way

An identity entry that cannot be copied is a filesystem shape, not a data-integrity problem. Aborting the whole upgrade over one such entry is a much worse outcome than skipping it with a warning, and the source tree is never modified, so nothing is lost.

The two fingerprint functions produce the same hash for a tree that contains only regular files and directories, which is why the plain cases pass today and only trees containing an un-copyable entry diverge. Unifying them is the smallest change that makes the mismatch impossible rather than papering over it at each comparison site.

The following tradeoffs were made:

- `identityCopySnapshot` replaces `filesystemEntrySnapshot` only inside `copyIdentityEntry`. Claude config, Claude session and ordinary workspace copies keep their existing snapshot helpers, since they materialize entries under different rules.
- IO failures (`EACCES` and friends) still propagate and abort migration. Those mean "this entry is copyable but unreadable right now", and swallowing them would also swallow conditions like `ENOSPC` (#17830) and silently produce Agents with no identity. Left as a known adjacent gap rather than widened here.
- `materializeIdentityEntry` is unchanged: it already warns and skips these entries. Only the snapshot side lacked the matching rule.

The following alternatives were considered:

- Passing `skipSymlinks: true` to the destination-side `filesystemEntrySnapshot` calls. Rejected: it fixes only the symlink half, leaves the socket/fifo throw in place, and keeps two functions that have to be kept in agreement by hand.
- Wrapping the `copyIdentityEntry` call in a try/catch and skipping the entry on any error. Rejected: it would also swallow genuine conflicts and disk-full errors.

Links to places where the discussion took place:

None

### Breaking changes

None.

### Special notes for your reviewer

Reported from the Cherry Studio community group (2026-07-29, user 漆黑之梦, relayed by 许思寅): the v2 migration kept failing until `FACT.md` was removed, after which it succeeded, and putting the file back afterwards was harmless. That specific report is against `v2.0.0-rc.1`, whose identity copy treated source metadata (`dev:ino:size:mtimeNs:ctimeNs`) as an integrity invariant, and it is already fixed by #17947 and #18101 in `v2.0.2`. Chasing it on current `main` surfaced this remaining variant of the same class, which is what this PR fixes.

Both new tests fail on `main` without the source change:

- `keeps migrating when an Agent target that is also its own legacy workspace holds an identity symlink` → `Legacy Agent identity destination conflict`
- `migrates the rest of an identity directory that holds an entry which cannot be copied` → `Unsupported Agent migration fingerprint entry type`

Validation on the final commit:

- `vitest run src/main/data/migration/v2/migrators/__tests__/` — 566 passed, 1 skipped
- `pnpm typecheck` — pass
- `oxlint --deny-warnings` on both changed files — 0 warnings, 0 errors
- `pnpm test:lint` — 0 errors
- `pnpm build:check` — `lint` and `docs:check-links` pass. The full suite reports 2 failures in `src/renderer/pages/settings/DataSettings/__tests__/` (`legacyV1BrowserData` and `BasicDataSettings` retry-marker cases); both reproduce unchanged on `main` at 0ad2fca8fa and are unrelated to this change.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent data migration no longer aborts when an Agent's memory directory contains an entry that cannot be copied, such as a symlinked FACT.md, a socket or a fifo. Such entries are now skipped with a warning and the rest of the Agent's identity files migrate normally.
```
