### PR TITLE
fix(provider-registry): keep CherryIN Grok 4.1 Fast off the Responses endpoint it cannot serve

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -3201,6 +3201,20 @@
       }
     },
     {
+      "apiModelId": "x-ai/grok-4-1-fast-reasoning",
+      "endpointTypes": ["openai-chat-completions", "anthropic-messages"],
+      "modelId": "grok-4-1-fast",
+      "providerId": "cherryin",
+      "reason": "CherryIN advertises openai-response but its relay answers /v1/responses with a 400"
+    },
+    {
+      "apiModelId": "x-ai/grok-4-1-fast-non-reasoning",
+      "endpointTypes": ["openai-chat-completions", "anthropic-messages"],
+      "modelId": "grok-4-1-fast-non-reasoning",
+      "providerId": "cherryin",
+      "reason": "CherryIN advertises openai-response but its relay answers /v1/responses with a 400"
+    },
+    {
       "apiModelId": "qwen/qwen3.5-122b-a10b",
       "capabilities": {
         "remove": ["audio-recognition"]

--- a/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
@@ -112,6 +112,23 @@ describe('deepseek endpoint matrix', () => {
 })
 
 /**
+ * CherryIN's `/v1/models` advertises `openai-response` for both Grok 4.1 Fast SKUs, but its relay
+ * answers `/v1/responses` with `400 Model grok-4-1-fast-reasoning does not support
+ * apiType:***.responses parameter` (a `bad_response_status_code` relayed from upstream, so it is not
+ * an account-level gate — `openai/gpt-5-codex` serves `/v1/responses` on the same key). Both
+ * `/v1/chat/completions` and `/v1/messages` serve these models, so the pin drops Responses only.
+ * See CherryHQ/cherry-studio#18696.
+ */
+describe('cherryin endpoint matrix', () => {
+  it.each(['grok-4-1-fast', 'grok-4-1-fast-non-reasoning'])(
+    'keeps %s off the Responses endpoint CherryIN advertises but cannot serve',
+    (modelId) => {
+      expect(endpointsOf('cherryin', modelId)).toEqual(['openai-chat-completions', 'anthropic-messages'])
+    }
+  )
+})
+
+/**
  * OpenCode Go multiplexes three wire protocols over one base URL, and the protocol per model is
  * published as models.dev's per-model `provider.npm` (`@ai-sdk/openai` → Responses, `@ai-sdk/anthropic`
  * → Messages, inherited `@ai-sdk/openai-compatible` → Chat) — which is what the OpenCode client itself

--- a/packages/provider-registry/src/providers/cherryin.ts
+++ b/packages/provider-registry/src/providers/cherryin.ts
@@ -35,6 +35,23 @@ const deepSeekModelOverrides = [
   }
 ] satisfies Array<Partial<ProviderModelOverride>>
 
+// Chat Completions leads because `endpointTypes[0]` routes in-app chat; Messages keeps the Claude Code
+// driver on its direct route. See the vendor evidence in `provider-endpoint-matrix.test.ts`.
+const grokEndpointCompatibilityOverrides = [
+  {
+    apiModelId: 'x-ai/grok-4-1-fast-reasoning',
+    modelId: 'grok-4-1-fast',
+    endpointTypes: ['openai-chat-completions', 'anthropic-messages'],
+    reason: 'CherryIN advertises openai-response but its relay answers /v1/responses with a 400'
+  },
+  {
+    apiModelId: 'x-ai/grok-4-1-fast-non-reasoning',
+    modelId: 'grok-4-1-fast-non-reasoning',
+    endpointTypes: ['openai-chat-completions', 'anthropic-messages'],
+    reason: 'CherryIN advertises openai-response but its relay answers /v1/responses with a 400'
+  }
+] satisfies Array<Partial<ProviderModelOverride>>
+
 const qwenAudioCompatibilityOverrides = [
   {
     apiModelId: 'qwen/qwen3.5-122b-a10b',
@@ -142,5 +159,5 @@ export default defineProvider({
       official: 'https://open.cherryin.ai'
     }
   },
-  overrides: [...deepSeekModelOverrides, ...qwenAudioCompatibilityOverrides]
+  overrides: [...deepSeekModelOverrides, ...grokEndpointCompatibilityOverrides, ...qwenAudioCompatibilityOverrides]
 })

--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -356,6 +356,22 @@ function presetDeltaToNewUserModel(
   }
 }
 
+/**
+ * A registry `endpointTypes` override lists the endpoints a provider-model can actually be served on,
+ * so a stored row selects WITHIN it instead of past it. That is what heals a row synced before the
+ * override existed: model-list sync writes the provider's advertised list into the same delta layer a
+ * user edit uses, and it only ever adds or removes rows, so a stale delta would otherwise shadow the
+ * correction forever. An empty intersection falls back to the baseline, never to an unreachable model.
+ */
+function selectStoredEndpointTypes(
+  baseline: EndpointType[] | undefined,
+  stored: EndpointType[] | null
+): EndpointType[] | null {
+  if (!stored?.length || !baseline?.length) return stored
+  const servable = stored.filter((endpointType) => baseline.includes(endpointType))
+  return servable.length > 0 ? servable : null
+}
+
 function applyStoredPresetDeltas(baseline: Model, row: UserModelRow): Model {
   return applyUserOverlay(baseline, {
     name: row.name,
@@ -364,7 +380,7 @@ function applyStoredPresetDeltas(baseline: Model, row: UserModelRow): Model {
     capabilities: row.capabilities,
     inputModalities: row.inputModalities,
     outputModalities: row.outputModalities,
-    endpointTypes: row.endpointTypes,
+    endpointTypes: selectStoredEndpointTypes(baseline.endpointTypes, row.endpointTypes),
     contextWindow: row.contextWindow,
     maxInputTokens: row.maxInputTokens,
     maxOutputTokens: row.maxOutputTokens,

--- a/src/main/data/services/__tests__/ModelService.test.ts
+++ b/src/main/data/services/__tests__/ModelService.test.ts
@@ -18,7 +18,7 @@ import {
   CHERRYAI_DEFAULT_UNIQUE_MODEL_ID,
   CHERRYAI_PROVIDER_ID
 } from '@shared/data/presets/cherryai'
-import { createUniqueModelId, MODEL_CAPABILITY } from '@shared/data/types/model'
+import { createUniqueModelId, ENDPOINT_TYPE, MODEL_CAPABILITY } from '@shared/data/types/model'
 import { setupTestDatabase } from '@test-helpers/db'
 import { and, eq, or } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1033,6 +1033,93 @@ describe('ModelService.list — registry enrichment', () => {
       contextWindow: 128_000,
       supportsStreaming: true
     })
+  })
+
+  // Model-list sync writes the provider's advertised endpoints into the same delta layer a user edit
+  // uses, and it only adds/removes rows — so a row synced while CherryIN advertised `openai-response`
+  // for Grok 4.1 Fast would keep routing to the endpoint its relay answers with a 400 (#18696).
+  it('drops a stored endpoint the registry override says the provider cannot serve', async () => {
+    await dbh.db.insert(userProviderTable).values(providerRow('cherryin', 'CherryIN'))
+    await dbh.db.insert(userModelTable).values(
+      modelRow('cherryin', 'x-ai/grok-4-1-fast-reasoning', {
+        presetModelId: 'grok-4-1-fast',
+        name: null,
+        capabilities: null,
+        supportsStreaming: null,
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.OPENAI_RESPONSES]
+      })
+    )
+    lookupModelMock.mockReturnValue({
+      presetModel: { id: 'grok-4-1-fast', name: 'Grok 4.1 Fast Reasoning' },
+      registryOverride: {
+        providerId: 'cherryin',
+        modelId: 'grok-4-1-fast',
+        apiModelId: 'x-ai/grok-4-1-fast-reasoning',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+      },
+      reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
+    })
+
+    const [model] = modelService.list({ providerId: 'cherryin' })
+
+    expect(model.endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS])
+  })
+
+  it('keeps a stored endpoint choice the registry override still serves', async () => {
+    await dbh.db.insert(userProviderTable).values(providerRow('deepseek', 'DeepSeek'))
+    await dbh.db.insert(userModelTable).values(
+      modelRow('deepseek', 'deepseek-v4-flash', {
+        presetModelId: 'deepseek-v4-flash',
+        name: null,
+        capabilities: null,
+        supportsStreaming: null,
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+      })
+    )
+    lookupModelMock.mockReturnValue({
+      presetModel: { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+      registryOverride: {
+        providerId: 'deepseek',
+        modelId: 'deepseek-v4-flash',
+        endpointTypes: [
+          ENDPOINT_TYPE.OPENAI_RESPONSES,
+          ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+          ENDPOINT_TYPE.ANTHROPIC_MESSAGES
+        ]
+      },
+      reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
+    })
+
+    const [model] = modelService.list({ providerId: 'deepseek' })
+
+    expect(model.endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS])
+  })
+
+  it('falls back to the registry list when no stored endpoint survives', async () => {
+    await dbh.db.insert(userProviderTable).values(providerRow('cherryin', 'CherryIN'))
+    await dbh.db.insert(userModelTable).values(
+      modelRow('cherryin', 'x-ai/grok-4-1-fast-non-reasoning', {
+        presetModelId: 'grok-4-1-fast-non-reasoning',
+        name: null,
+        capabilities: null,
+        supportsStreaming: null,
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES]
+      })
+    )
+    lookupModelMock.mockReturnValue({
+      presetModel: { id: 'grok-4-1-fast-non-reasoning', name: 'Grok 4.1 Fast Non-Reasoning' },
+      registryOverride: {
+        providerId: 'cherryin',
+        modelId: 'grok-4-1-fast-non-reasoning',
+        apiModelId: 'x-ai/grok-4-1-fast-non-reasoning',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+      },
+      reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
+    })
+
+    const [model] = modelService.list({ providerId: 'cherryin' })
+
+    expect(model.endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
   })
 
   it('hydrates same-canonical variants through their exact API model ID', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/utils/__tests__/modelSync.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/__tests__/modelSync.test.ts
@@ -41,7 +41,7 @@ describe('fetchResolvedProviderModels', () => {
     })
   })
 
-  it('keeps endpoint types returned by the provider when registry metadata also has endpoint types', async () => {
+  it('keeps endpoint types returned by the provider when the registry declares none', async () => {
     listModelsMock.mockResolvedValueOnce([
       {
         id: 'new-api::agent/deepseek-v3.2',
@@ -56,8 +56,7 @@ describe('fetchResolvedProviderModels', () => {
         id: 'new-api::agent/deepseek-v3.2',
         providerId: 'new-api',
         apiModelId: 'agent/deepseek-v3.2',
-        name: 'DeepSeek V3.2',
-        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+        name: 'DeepSeek V3.2'
       }
     ])
 
@@ -67,6 +66,35 @@ describe('fetchResolvedProviderModels', () => {
       name: 'DeepSeek V3.2',
       endpointTypes: [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
     })
+  })
+
+  // CherryIN advertises `openai-response` for Grok 4.1 Fast and then rejects `/v1/responses` with
+  // `400 ... does not support apiType:***.responses`; the registry override is the only way to keep
+  // the model off that endpoint.
+  it('lets a registry endpoint-type override replace the endpoints the provider advertises', async () => {
+    listModelsMock.mockResolvedValueOnce([
+      {
+        id: 'cherryin::x-ai/grok-4-1-fast-reasoning',
+        providerId: 'cherryin',
+        apiModelId: 'x-ai/grok-4-1-fast-reasoning',
+        name: 'x-ai/grok-4-1-fast-reasoning',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+      }
+    ])
+    dataApiGetMock.mockResolvedValueOnce([
+      {
+        id: 'cherryin::x-ai/grok-4-1-fast-reasoning',
+        providerId: 'cherryin',
+        apiModelId: 'x-ai/grok-4-1-fast-reasoning',
+        presetModelId: 'grok-4-1-fast',
+        name: 'Grok 4.1 Fast Reasoning',
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+      }
+    ])
+
+    const models = await fetchResolvedProviderModels('cherryin')
+
+    expect(models[0]?.endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
   })
 
   it('uses registry reasoning controls while preserving discovered thinking support', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/utils/modelSync.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/modelSync.ts
@@ -130,10 +130,9 @@ async function enrichFetchedModels(providerId: string, fetchedModels: Partial<Mo
     // overwriting with the prettified id. Matched rows (presetModelId set) own the curated name.
     const keepFetchedName = !registry.presetModelId && !!base.name && base.name !== base.apiModelId
 
+    // A resolved row carries `endpointTypes` only from a hand-authored provider-model override, so it
+    // wins — that override is how the registry drops an endpoint an aggregator advertises but rejects.
     for (const field of REGISTRY_FIELDS) {
-      if (field === 'endpointTypes' && base.endpointTypes?.length) {
-        continue
-      }
       if (field === 'name' && keepFetchedName) {
         continue
       }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: every Cherry Studio request for CherryIN's `x-ai/grok-4-1-fast-reasoning` and
`x-ai/grok-4-1-fast-non-reasoning` goes to `/v1/responses` and fails with
`API Error: 400 Model grok-4-1-fast-reasoning does not support apiType:***.responses parameter` —
in-app chat, and the Claude Code Runtime Driver whenever its route falls to the local API Gateway.

After this PR: both SKUs resolve to Chat Completions (with Anthropic Messages selectable), which
CherryIN actually serves, so the models work under the Claude Code driver and in chat — including for
users who added them before this release, whose stored endpoint list is corrected on upgrade rather
than requiring a remove-and-re-add.

Fixes #18696

#### Root cause (reproduced against the live provider, not inferred)

CherryIN's model list advertises an endpoint its relay rejects:

```console
$ curl -s https://open.cherryin.net/v1/models -H "Authorization: Bearer $KEY" | jq '.data[] | select(.id|test("grok-4-1-fast"))'
{ "id": "x-ai/grok-4-1-fast-reasoning",     "supported_endpoint_types": ["openai-response", "anthropic"] }
{ "id": "x-ai/grok-4-1-fast-non-reasoning", "supported_endpoint_types": ["openai-response", "anthropic"] }

$ curl -s https://open.cherryin.net/v1/responses -H "Authorization: Bearer $KEY" \
       -d '{"model":"x-ai/grok-4-1-fast-reasoning","input":"hi","max_output_tokens":16}'
{"error":{"message":"Model grok-4-1-fast-reasoning does not support apiType:***.responses parameter",
          "type":"bad_response_status_code","code":"bad_response_status_code"}}
```

That is the reporter's error string verbatim. On the same key `/v1/chat/completions` and `/v1/messages`
both answer normally for these two models, and `openai/gpt-5-codex` answers `/v1/responses` normally —
so it is neither an account-level gate nor a broken Responses channel, it is these two models.

Cherry Studio then routes exactly as advertised: `normalizeEndpointTypes` stores
`["openai-responses", "anthropic-messages"]` on the model row, and `resolveEffectiveEndpoint` takes
`endpointTypes[0]`, so every request lands on the one endpoint that cannot serve the model. The
Claude Code driver surfaced it first because `anthropic` was not yet advertised when the issue was
filed: `usesAnthropicMessagesEndpoint()` was false, the route fell to the local API Gateway, and the
gateway routes on `endpointTypes[0]` too.

### Why we need it and why it was done in this way

Three commits, one per layer the correction has to pass through.

**1. The registry correction** (`cherryin.ts`). The registry already owns this exact class of
correction for this exact provider — `cherryin.ts` carries `qwenAudioCompatibilityOverrides`
("CherryIN rejects native audio; base Qwen3.5 supports text/image/video input"). This adds the
endpoint equivalent, with the vendor evidence asserted in `provider-endpoint-matrix.test.ts` next to
the existing dashscope/deepseek/opencode matrices.

**2. Making the override reachable on sync** (`modelSync.ts`). `enrichFetchedModels` discarded the
registry's `endpointTypes` whenever the provider advertised its own. A resolved registry row carries
`endpointTypes` **only** from a hand-authored `ProviderModelOverride` (`models.json` has no such
field on any of its 897 models, and `applyPresetAndOverride` leaves it `undefined` unless an override
sets it), so that branch was suppressing nothing but deliberate corrections — and only for
new-api-family providers (cherryin / new-api / aionly), the only ones whose fetcher advertises
endpoint types. `ProviderModelOverride.endpointTypes` was dead for precisely the providers it exists
to correct. Providers with no override still keep their advertised list; the existing test for that
is kept, narrowed to the case it actually describes.

**3. Healing rows that already exist** (`ModelService.ts`). (1) and (2) alone only fix *newly added*
models. Model-list sync writes the provider's advertised list into the same delta layer a user edit
uses, `applyStoredPresetDeltas` replays that delta over the registry baseline, and reconciliation only
adds or removes rows — never updates them. So anyone who already added these models keeps the stale
`["openai-responses", …]` delta shadowing the correction and still gets a 400 after upgrading. The
stored list is now **intersected** with the registry override rather than replacing the baseline
wholesale: the override lists the endpoints a provider-model can actually be served on, so a stored
row selects within that set instead of past it.

| stored delta | ∩ registry override | result |
| --- | --- | --- |
| `[chat, responses]` | `[chat, anthropic]` | `[chat]` — healed |
| `[responses]` | `[chat, anthropic]` | empty → baseline — healed |
| `[responses, anthropic]` | `[chat, anthropic]` | `[anthropic]` — healed |
| deepseek-v4-flash user pick `[chat]` | `[responses, chat, anthropic]` | `[chat]` — user choice kept |

Providers with no override have no baseline list, so the whole path short-circuits and their
behaviour is unchanged. `enrichRowsFromRegistry` is shared by every row-serving path, so `list` and
`getByKey` both heal.

The following tradeoffs were made:

- The pin puts Chat Completions first because `endpointTypes[0]` routes in-app chat, and keeps
  Anthropic Messages second so the Claude Code driver stays on its direct (non-gateway) route.
- The pin will need removing if CherryIN fixes its catalog. The `reason` field records why it exists,
  same as the neighbouring Qwen overrides.
- Intersection means a user can no longer *select* an endpoint the registry says the provider cannot
  serve for that model. That is the intended outcome — the only endpoints an override removes are
  ones that return an error — but it is a real narrowing of the model drawer for those rows.

The following alternatives were considered:

- Swallowing the 400 or retrying on another endpoint — hides a real provider fault and would mask
  future breakage.
- Dropping `openai-responses` from CherryIN's `endpointConfigs` — wrong, `openai/gpt-5-codex` and
  the GPT-5 line need it.
- Letting a registry override outrank the stored delta unconditionally instead of intersecting —
  would overrule genuine endpoint picks for dashscope / deepseek / openrouter users, a clear
  regression.
- A one-off data migration clearing the stale deltas — drizzle migrations are generated from schema
  diffs, so a hand-written data-only migration forks the chain `db:migrations:check` enforces, and it
  would cure only these two models rather than the next instance of the same drift.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18696

### Breaking changes

None.

### Special notes for your reviewer

- The third commit is the one worth the closest look: it changes how a stored `endpointTypes` delta
  composes with a registry override for **every** preset-backed row, not just CherryIN's. The
  short-circuit (`!baseline?.length`) keeps that a no-op for every provider without an override, and
  the `keeps a stored endpoint choice the registry override still serves` test is the regression guard.
- `data/provider-models.json` carries only the 14 generated lines for the two new overrides. A full
  `pnpm generate` re-pulls models.dev/OpenRouter live and produced ~5.5k lines of unrelated catalog
  drift, so that was reverted; `catalog-source-sync` and `biome format` both confirm the retained rows
  match generator output exactly.
- Verified locally: `main` 11894 passed / 62 skipped, `aiCore`+`ui`+`shared`+`provider-registry`+
  `scripts` 2966 passed, `renderer` 8996 passed with 2 failures in
  `src/renderer/pages/settings/DataSettings/__tests__/` that reproduce unchanged on a clean
  `upstream/main` @ `9f88dd48b5`. Red→green confirmed for each fix by reverting it and re-running the
  targeted tests.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: N/A — no user-facing feature or behavior surface changes
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed CherryIN's Grok 4.1 Fast models failing with "API Error: 400 ... does not support apiType:***.responses parameter" in chat and under the Claude Code agent driver. Models added before this release are corrected on upgrade — no need to remove and re-add them.
```

<sub>Original report (internal): 产研团队 dev 表「v2 预览版问题反馈」 record `recvssphNADDBJ` — https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvssphNADDBJ · 提交人 许思寅（代录）· Windows / Cherry Studio v2.0.5 / CherryIN。用户原话：「Windows / Cherry Studio v2.0.5 中，Claude Code Runtime Driver 通过 CherryIN 调用 grok-4-1-fast-reasoning 或 grok-4-1-fast-non-reasoning 时，请求会携带模型不支持的 responses 参数，服务端因此返回 API Error 400，两个模型均无法在该 Agent 驱动中使用。期望驱动按目标模型/端点能力省略不兼容参数并发送受支持的请求。」</sub>
