### PR TITLE
perf(code-viewer): share selection listener

### DIFF
--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -2,6 +2,7 @@ import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { useCodeHighlight } from '@renderer/hooks/useCodeHighlight'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { codeViewerSelectionManager } from '@renderer/services/CodeViewerSelectionManager'
 import { getReactStyleFromToken } from '@renderer/utils/shiki'
 import { cn } from '@renderer/utils/style'
 import { uuid } from '@renderer/utils/uuid'
@@ -425,45 +426,39 @@ const CodeViewer = ({
   }, [virtualItems, debouncedHighlightLines, highlight])
 
   // Monitor selection changes, clear stale selection state, and auto-expand in collapsed state
-  const handleSelectionChange = useMemo(
-    () =>
-      debounce(() => {
-        const selection = window.getSelection()
+  const handleSelectionChange = useCallback(
+    (selection: Selection | null) => {
+      if (!selection || !selectionBelongsToViewer(selection)) {
+        savedSelectionRef.current = null
+        return
+      }
 
-        // No valid selection: clear and return
-        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
-          savedSelectionRef.current = null
-          return
+      // In collapsed state, detect multi-line selection and request expand
+      if (!expanded && onRequestExpand) {
+        const saved = saveSelection()
+        if (saved && saved.endLine > saved.startLine) {
+          logger.debug('Multi-line selection detected in collapsed state, requesting expand', {
+            startLine: saved.startLine,
+            endLine: saved.endLine
+          })
+          onRequestExpand()
         }
-
-        // Only handle selections within this CodeViewer
-        if (!selectionBelongsToViewer(selection)) {
-          savedSelectionRef.current = null
-          return
-        }
-
-        // In collapsed state, detect multi-line selection and request expand
-        if (!expanded && onRequestExpand) {
-          const saved = saveSelection()
-          if (saved && saved.endLine > saved.startLine) {
-            logger.debug('Multi-line selection detected in collapsed state, requesting expand', {
-              startLine: saved.startLine,
-              endLine: saved.endLine
-            })
-            onRequestExpand()
-          }
-        }
-      }, 100),
+      }
+    },
     [expanded, onRequestExpand, saveSelection, selectionBelongsToViewer]
   )
+  const selectionChangeHandlerRef = useRef(handleSelectionChange)
+
+  useLayoutEffect(() => {
+    selectionChangeHandlerRef.current = handleSelectionChange
+  }, [handleSelectionChange])
 
   useEffect(() => {
-    document.addEventListener('selectionchange', handleSelectionChange)
-    return () => {
-      document.removeEventListener('selectionchange', handleSelectionChange)
-      handleSelectionChange.cancel()
-    }
-  }, [handleSelectionChange])
+    const scroller = scrollerRef.current
+    if (!scroller) return
+
+    return codeViewerSelectionManager.register(scroller, (selection) => selectionChangeHandlerRef.current(selection))
+  }, [])
 
   // Listen for copy events
   useEffect(() => {

--- a/src/renderer/services/CodeViewerSelectionManager.ts
+++ b/src/renderer/services/CodeViewerSelectionManager.ts
@@ -1,0 +1,66 @@
+import { debounce } from 'es-toolkit/compat'
+
+type SelectionChangeHandler = (selection: Selection | null) => void
+
+export class CodeViewerSelectionManager {
+  private readonly viewers = new Map<HTMLElement, SelectionChangeHandler>()
+  private activeViewer: HTMLElement | null = null
+  private ownerDocument: Document | null = null
+  private readonly handleSelectionChange = debounce(() => this.dispatchSelectionChange(), 100)
+
+  register(viewer: HTMLElement, handler: SelectionChangeHandler): () => void {
+    const previousHandler = this.viewers.get(viewer)
+    this.viewers.set(viewer, handler)
+
+    if (!previousHandler && this.viewers.size === 1) {
+      this.ownerDocument = viewer.ownerDocument
+      this.ownerDocument.addEventListener('selectionchange', this.handleSelectionChange)
+    }
+
+    return () => {
+      if (this.viewers.get(viewer) !== handler) return
+
+      this.viewers.delete(viewer)
+      if (this.activeViewer === viewer) {
+        this.activeViewer = null
+      }
+
+      if (this.viewers.size === 0 && this.ownerDocument) {
+        this.ownerDocument.removeEventListener('selectionchange', this.handleSelectionChange)
+        this.handleSelectionChange.cancel()
+        this.ownerDocument = null
+      }
+    }
+  }
+
+  private dispatchSelectionChange(): void {
+    const selection = this.ownerDocument?.defaultView?.getSelection() ?? null
+    const nextViewer = this.findViewer(selection)
+
+    if (this.activeViewer && this.activeViewer !== nextViewer) {
+      this.viewers.get(this.activeViewer)?.(null)
+    }
+
+    this.activeViewer = nextViewer
+    if (nextViewer) {
+      this.viewers.get(nextViewer)?.(selection)
+    }
+  }
+
+  private findViewer(selection: Selection | null): HTMLElement | null {
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null
+
+    const selectionRoot = selection.getRangeAt(0).commonAncestorContainer
+    let matchedViewer: HTMLElement | null = null
+
+    for (const viewer of this.viewers.keys()) {
+      if (viewer.contains(selectionRoot) && (!matchedViewer || matchedViewer.contains(viewer))) {
+        matchedViewer = viewer
+      }
+    }
+
+    return matchedViewer
+  }
+}
+
+export const codeViewerSelectionManager = new CodeViewerSelectionManager()

--- a/src/renderer/services/__tests__/CodeViewerSelectionManager.test.ts
+++ b/src/renderer/services/__tests__/CodeViewerSelectionManager.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CodeViewerSelectionManager } from '../CodeViewerSelectionManager'
+
+describe('CodeViewerSelectionManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    document.body.replaceChildren()
+    window.getSelection()?.removeAllRanges()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('shares one document listener and routes selection changes to the matching viewer', () => {
+    const manager = new CodeViewerSelectionManager()
+    const firstViewer = document.createElement('div')
+    const secondViewer = document.createElement('div')
+    firstViewer.textContent = 'first'
+    secondViewer.textContent = 'second'
+    document.body.append(firstViewer, secondViewer)
+
+    const addEventListener = vi.spyOn(document, 'addEventListener')
+    const removeEventListener = vi.spyOn(document, 'removeEventListener')
+    const firstHandler = vi.fn()
+    const secondHandler = vi.fn()
+
+    const unregisterFirst = manager.register(firstViewer, firstHandler)
+    const unregisterSecond = manager.register(secondViewer, secondHandler)
+
+    const selection = window.getSelection()!
+    const range = document.createRange()
+    range.selectNodeContents(secondViewer)
+    selection.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+    vi.advanceTimersByTime(100)
+
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'selectionchange')).toHaveLength(1)
+    expect(firstHandler).not.toHaveBeenCalled()
+    expect(secondHandler).toHaveBeenCalledOnce()
+    expect(secondHandler).toHaveBeenCalledWith(selection)
+
+    unregisterFirst()
+    expect(removeEventListener.mock.calls.filter(([type]) => type === 'selectionchange')).toHaveLength(0)
+
+    unregisterSecond()
+    expect(removeEventListener.mock.calls.filter(([type]) => type === 'selectionchange')).toHaveLength(1)
+  })
+
+  it('clears only the previously active viewer when the selection collapses', () => {
+    const manager = new CodeViewerSelectionManager()
+    const viewer = document.createElement('div')
+    viewer.textContent = 'code'
+    document.body.append(viewer)
+    const handler = vi.fn()
+    const unregister = manager.register(viewer, handler)
+
+    const selection = window.getSelection()!
+    const range = document.createRange()
+    range.selectNodeContents(viewer)
+    selection.addRange(range)
+    document.dispatchEvent(new Event('selectionchange'))
+    vi.advanceTimersByTime(100)
+
+    selection.collapseToEnd()
+    document.dispatchEvent(new Event('selectionchange'))
+    vi.advanceTimersByTime(100)
+
+    expect(handler).toHaveBeenLastCalledWith(null)
+    expect(handler).toHaveBeenCalledTimes(2)
+    unregister()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Each mounted `CodeViewer` registered its own debounced `document.selectionchange` listener, so selection work scaled with the number of rendered code blocks.

After this PR:

All `CodeViewer` instances share one debounced document listener through a small viewer registry. Selection changes are dispatched only to the deepest matching viewer, and the global listener is removed when the final viewer unregisters.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18622

### Why we need it and why it was done in this way

The shared registry keeps document-level work constant while preserving each viewer's existing selection and auto-expand behavior. A stable callback ref lets viewers update their behavior without repeatedly registering global listeners.

The following tradeoffs were made:

- The registry keeps one active-viewer reference so stale selection state can be cleared when the selection moves or collapses.
- Dispatch uses the selection range's common ancestor and chooses the deepest registered root, which also handles nested viewers deterministically.

The following alternatives were considered:

- Keeping one listener per viewer was rejected because it preserves the scaling issue.
- Moving selection handling into `CodeBlockView` was rejected because `CodeViewer` owns the selection and auto-expand behavior and is also used outside that component.

Links to places where the discussion took place: #18622

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Added focused multi-viewer coverage for listener deduplication, targeted dispatch, collapsed-selection cleanup, and final-listener teardown.
- `pnpm test:lint`, `pnpm typecheck:web`, formatting, documentation link checks, and the targeted CodeViewer tests pass.
- `pnpm build:check` passes all test assertions but exits after an unrelated unhandled rejection in `ExecutionStreamOverlayService.test.ts`; the same error reproduces when that file is run alone.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
