### PR TITLE
fix(agent-composer): stop UNC workspace paths from failing silently

### DIFF
--- a/docs/references/file/file-manager-architecture.md
+++ b/docs/references/file/file-manager-architecture.md
@@ -102,7 +102,7 @@ See the JSDoc for `canonicalizeFilePath` in `src/shared/utils/file/canonicalize.
 
 **URL encoding puts the server in the authority.** `toFileUrl` emits `file://server/share/…` for a UNC path, not `file:////server/share/…`. The leading `//` produced by separator normalization already *is* the URL authority marker, so appending it to `file://` would leave the authority empty and demote the server to path text — a URL Node rejects with `ERR_INVALID_FILE_URL_PATH`. This also makes `toFileUrl` the exact inverse of `fileUrlToPath`, which decodes `file://host/…` to `//host/…`.
 
-**Containment checks degrade, they do not throw.** `isPathWithinAccessiblePath` / `getAccessiblePathRelativePath` (`src/renderer/components/composer/variants/agent/accessiblePath.ts`) canonicalize before comparing. A path that cannot be canonicalized is not *provably* inside anything, so they return `false` / the input unchanged. Containment is a predicate; it must stay total.
+**Containment checks degrade, they do not throw.** `isSamePath` / `isPathInside` / `getRelativePath` (`src/renderer/utils/path.ts`) canonicalize before comparing. A path that cannot be canonicalized is not *provably* inside anything, so they return `false` / `null`. Containment is a predicate; it must stay total. The agent-side wrappers over them (`src/renderer/components/composer/variants/agent/accessiblePath.ts`) inherit this, and `toAccessiblePaths` there applies the same bar up front: a workspace path with no canonical form yields no accessible bases, and logs.
 
 #### Rejected: Unicode (NFC) normalization of `externalPath`
 

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -69,7 +69,7 @@ import type { FileUIPart } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import { getKnowledgeBaseIdsFromParts, withKnowledgeScopePart } from '@shared/data/types/uiParts'
 import type { OutputFor } from '@shared/ipc/types'
-import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
+import type { AbsoluteFilePath } from '@shared/types/file'
 import type { LocalSkill } from '@shared/types/skill'
 import { type CanonicalFilePath, canonicalizeFilePath, createFilePathHandle, toFileUrl } from '@shared/utils/file'
 import { Settings2, Terminal, ToolCase } from 'lucide-react'
@@ -82,7 +82,7 @@ import { QueuedFollowupsDock } from '../QueuedFollowupsDock'
 import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
 import { type FollowupQueueItem, useFollowupQueue } from '../useFollowupQueue'
 import { useInputHistory } from '../useInputHistory'
-import { isPathWithinAccessiblePath } from './agent/accessiblePath'
+import { isPathWithinAccessiblePath, toAccessiblePaths } from './agent/accessiblePath'
 import {
   AgentConversationControls,
   type AgentConversationControlsProps,
@@ -189,23 +189,6 @@ const buildAccessiblePathFilePart = (
     },
     attachment
   )
-}
-
-/**
- * `AgentWorkspacePathSchema` only guarantees a non-empty string, so the stored
- * workspace path is asserted to be an absolute filesystem path here, before it
- * reaches the path helpers. A malformed one yields no accessible paths, which
- * degrades to inlining attachments instead of referencing them — still correct,
- * just less efficient.
- */
-const toAccessiblePaths = (workspacePath: string | undefined): AbsoluteFilePath[] => {
-  if (!workspacePath) return []
-  const parsed = AbsoluteFilePathSchema.safeParse(workspacePath)
-  if (!parsed.success) {
-    logger.warn('Ignoring agent workspace path that is not an absolute filesystem path', { path: workspacePath })
-    return []
-  }
-  return [parsed.data]
 }
 
 const buildAgentFilePartsForAttachments = async (

--- a/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
+++ b/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
@@ -1,7 +1,9 @@
 import type { AbsoluteFilePath } from '@shared/types/file'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
+import type { MockInstance } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getAccessiblePathRelativePath, isPathWithinAccessiblePath } from '../accessiblePath'
+import { getAccessiblePathRelativePath, isPathWithinAccessiblePath, toAccessiblePaths } from '../accessiblePath'
 
 /**
  * `getPathComparisonKey` is the only export here that reads the platform, so it
@@ -22,6 +24,38 @@ afterEach(() => {
 /** Fixture helper — these are shape-valid absolute paths, so the brand is safe to assert. */
 const p = (value: string) => value as AbsoluteFilePath
 const ps = (...values: string[]) => values as AbsoluteFilePath[]
+
+describe('toAccessiblePaths', () => {
+  let warnSpy: MockInstance
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(mockRendererLoggerService, 'warn').mockImplementation(() => {})
+  })
+
+  it('accepts a workspace path the containment helpers can actually use', () => {
+    expect(toAccessiblePaths('/workspace')).toEqual(['/workspace'])
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('yields no bases and stays silent when there is no workspace at all', () => {
+    expect(toAccessiblePaths(undefined)).toEqual([])
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects and reports a path that is not absolute', () => {
+    expect(toAccessiblePaths('workspace/docs')).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(expect.any(String), { path: 'workspace/docs' })
+  })
+
+  // A UNC path passes `AbsoluteFilePathSchema` but has no canonical form, so
+  // every containment test against it returns `false`. Accepting it produces a
+  // base that silently matches nothing — the entry point must apply the same
+  // bar the helpers do, and say so.
+  it('rejects and reports a UNC workspace, which no containment test can match', () => {
+    expect(toAccessiblePaths('\\\\server\\share\\project')).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(expect.any(String), { path: '\\\\server\\share\\project' })
+  })
+})
 
 describe('accessiblePath', () => {
   it('treats the base path itself and its descendants as within', () => {
@@ -136,10 +170,15 @@ describe('getPathComparisonKey', () => {
     expect(getPathComparisonKey('/workspace/a\\b.txt')).not.toBe(getPathComparisonKey('/workspace/a/b.txt'))
   })
 
-  it('leaves an un-canonicalizable UNC path spelled as it came in', async () => {
+  // The two spellings of one UNC share reach this function from different token
+  // sources: the listing side is separator-normalized upstream
+  // (`useAgentResourceMentionSource`), drag-and-drop carries the OS spelling.
+  // Neither has a canonical form, so dedup can only fall back to matching them
+  // as strings — which requires folding the fallback.
+  it('dedups the two spellings of an un-canonicalizable UNC path', async () => {
     const { getPathComparisonKey } = await loadWithPlatform(LINUX)
 
-    expect(getPathComparisonKey('\\\\server\\share\\a.txt')).toBe('\\\\server\\share\\a.txt')
+    expect(getPathComparisonKey('\\\\server\\share\\docs')).toBe(getPathComparisonKey('//server/share/docs'))
   })
 
   it('falls back to the raw value for input that is not an absolute path', async () => {

--- a/src/renderer/components/composer/variants/agent/accessiblePath.ts
+++ b/src/renderer/components/composer/variants/agent/accessiblePath.ts
@@ -1,17 +1,47 @@
+/**
+ * Agent-specific policy over the generic renderer path primitives: derive the
+ * accessible bases for a workspace, and match paths against them. Path
+ * semantics (canonicalization, strict containment, un-canonicalizable input)
+ * live in `@renderer/utils/path`.
+ *
+ * Nothing here is an access-control gate — the authoritative one is main-side
+ * `WorkspaceFileGuard.resolveWorkspaceFile`.
+ */
+
+import { loggerService } from '@logger'
 import { getRelativePath, isPathInside, isSamePath, toPathKey } from '@renderer/utils/path'
 import { isMac, isWin } from '@renderer/utils/platform'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import type { PosixRelativeFilePath } from '@shared/utils/file'
 
+const logger = loggerService.withContext('accessiblePath')
+
 /**
- * Agent-specific policy over the generic renderer path primitives: match a path
- * against a list of accessible bases. Path semantics (canonicalization, strict
- * containment, un-canonicalizable input) live in `@renderer/utils/path`.
+ * The accessible bases for an agent workspace path, or `[]` if it cannot serve
+ * as one.
  *
- * Nothing here is an access-control gate — the authoritative one is main-side
- * `WorkspaceFileGuard.resolveWorkspaceFile`.
+ * `AgentWorkspacePathSchema` only guarantees a non-empty string, so the stored
+ * path is checked here before it reaches the helpers below. The bar is the one
+ * those helpers actually apply — a canonical form exists — not merely
+ * `AbsoluteFilePathSchema`, which admits UNC paths that every containment test
+ * then rejects. Returning `[]` is what already happened in that case; logging
+ * is what makes it diagnosable.
+ *
+ * With no accessible bases, workspace attachments are internalized instead of
+ * referenced: `buildFileParts` copies the bytes into Cherry storage and the
+ * model receives a `file://` pointing at that copy, so an agent editing
+ * workspace files in place sees a snapshot at a different path.
  */
+export const toAccessiblePaths = (workspacePath: string | undefined): AbsoluteFilePath[] => {
+  if (!workspacePath) return []
+  const parsed = AbsoluteFilePathSchema.safeParse(workspacePath)
+  if (!parsed.success || toPathKey(parsed.data) === null) {
+    logger.warn('Ignoring agent workspace path that has no canonical form', { path: workspacePath })
+    return []
+  }
+  return [parsed.data]
+}
 
 /** True iff `filePath` is one of `accessiblePaths` or a descendant of one. */
 export const isPathWithinAccessiblePath = (
@@ -41,8 +71,10 @@ export const getAccessiblePathRelativePath = (
 }
 
 /**
- * Case-folding matches the main-side `isPathInside` (`src/main/utils/file/path.ts`):
- * case-insensitive on macOS/Windows (default APFS/NTFS), case-sensitive on Linux.
+ * The default filesystem is case-insensitive on macOS/Windows (APFS/NTFS) and
+ * case-sensitive on Linux. Used only by `getPathComparisonKey` below, whose
+ * docstring explains why that consumer may act on this guess when the
+ * containment helpers above may not.
  */
 const isCaseInsensitivePlatform = isMac || isWin
 
@@ -62,14 +94,20 @@ const isCaseInsensitivePlatform = isMac || isWin
  * (`listDirectoryEntries` inherits the workspace path's spelling, drag-and-drop
  * carries the OS's), so a case mismatch is genuinely reachable.
  *
- * Keying through `toPathKey` rather than folding separators here is what keeps
- * `/workspace/a\b.txt` — one POSIX file — from colliding with `/workspace/a/b.txt`.
- * Input that is not an absolute path, or has no canonical form (UNC), keys on
- * itself: unequal to everything but an identical spelling, which is the right
- * answer for dedup.
+ * Keying through `toPathKey` is what keeps `/workspace/a\b.txt` — one POSIX
+ * file — from colliding with `/workspace/a/b.txt`.
+ *
+ * When there is no canonical form the fallback folds separators, because the
+ * only reason two spellings reach here is that a UNC share arrives one way from
+ * the listing (separator-normalized upstream) and another from drag-and-drop.
+ * Matching them as strings is all dedup can do, and folding is how. The POSIX
+ * hazard the primitives guard against does not apply: a POSIX path with a
+ * backslash in its name canonicalizes fine and never reaches this branch. Only
+ * a non-absolute input could, and the sole one produced here is `''`.
  */
 export const getPathComparisonKey = (value: string): string => {
   const parsed = AbsoluteFilePathSchema.safeParse(value)
-  const key = (parsed.success ? toPathKey(parsed.data) : null) ?? value
+  const canonical = parsed.success ? toPathKey(parsed.data) : null
+  const key = canonical ?? value.replace(/\\/g, '/')
   return isCaseInsensitivePlatform ? key.toLowerCase() : key
 }

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -49,7 +49,7 @@ const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
  *   inside `canonicalizeFilePath` is arguably the real defect, but that function
  *   produces the persisted `file_entry.externalPath` key and changing its output
  *   requires a paired migration — see its "Rule-evolution discipline". Tracked
- *   in #17429.)
+ *   in #18207.)
  *
  * These are predicates, not parsers: a path we cannot canonicalize is simply not
  * provably the same as, or inside, anything. So degrade to `null` rather than
@@ -106,11 +106,12 @@ export const isPathInside = (child: AbsoluteFilePath, parent: AbsoluteFilePath):
  * `/`-separated in-app form, not a claim about where the path came from.
  *
  * The brand is asserted, not re-parsed. `PosixRelativeFilePathSchema` refuses
- * exactly: the empty string (hence `'.'` above, which also matches its reading
- * that `''` is the absence of a path), NUL — already refused by
- * `AbsoluteFilePathSchema` — a leading `/`, which slicing a proper prefix
- * cannot leave behind, and an empty segment, which canonicalization drops. No
- * branch can produce any of them; `path.test.ts` guards that claim per branch.
+ * the empty string (hence `'.'` above, which also matches its reading that `''`
+ * is the absence of a path), NUL — already refused by `AbsoluteFilePathSchema` —
+ * and a leading `/`, which slicing a proper prefix cannot leave behind. Its
+ * per-segment `isValidPosixFileName` check cannot fail here: splitting on `/`
+ * and dropping empty segments already excludes everything that check forbids.
+ * `path.test.ts` guards the claim per branch.
  */
 export const getRelativePath = (from: AbsoluteFilePath, to: AbsoluteFilePath): PosixRelativeFilePath | null => {
   const fromPath = toPathKey(from)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Follow-up to #17718, fixing the two actionable defects and all five of the false comments/docs catalogued in #18631.

**Before this PR:**

`AbsoluteFilePathSchema` accepts UNC (`\\server\share\…`), but `canonicalizeFilePath` throws on it — so a UNC path passes validation and then has no comparison form. Two consequences:

1. **Folder-mention dedup never matched on a UNC share.** The two folder-token sources spell the same share differently (the listing side is separator-normalized upstream, drag-and-drop carries the OS spelling), so `getPathComparisonKey` produced two keys for one folder. The `disabled` flag never engaged and the folder could be inserted repeatedly.
2. **A UNC workspace disabled `file://` references entirely, with no diagnostic.** `toAccessiblePaths` validated against `AbsoluteFilePathSchema` alone. A UNC path passed, so nothing was logged — but every containment test against it returned `false`, so every workspace attachment was inlined as base64.

Plus five comments/docs that state something factually false — two of them load-bearing arguments for `as` assertions.

**After this PR:**

1. `getPathComparisonKey` folds separators in its fallback branch, so both spellings of one un-canonicalizable share produce one key.
2. `toAccessiblePaths` applies the bar the containment helpers actually apply (a canonical form exists) and logs when a workspace path fails it. The returned value is unchanged — `[]` is what already happened; the warning is what makes it diagnosable.
3. The false claims are corrected.

Refs #18631

### Why we need it and why it was done in this way

**The dedup fold is scoped to the fallback branch on purpose.** #17718 removed an unconditional `\` → `/` fold from the path primitives, because on POSIX a backslash is an ordinary filename character and folding it makes `/workspace/a\b.txt` — one file — compare equal to `/workspace/a/b.txt`. That hazard cannot reach this branch: a POSIX path with a backslash in its name canonicalizes fine and never falls back. Only a path with no canonical form does, and matching those as strings is all dedup can do.

**`toAccessiblePaths` rejects rather than making UNC work.** Supporting UNC end-to-end means teaching `canonicalizeFilePath` about UNC roots — but that function produces the persisted `file_entry.externalPath` key, so changing its output requires a paired migration. That belongs to #18207 / #17429, not here. Rejecting is a pure diagnostics addition with zero behaviour change.

**`toAccessiblePaths` moved from `AgentComposer.tsx` into `accessiblePath.ts`.** Deciding which workspace paths can serve as accessible bases is the same policy as matching against them, and it is testable there — `AgentComposer.tsx` had it as a module-private with no coverage.

The following alternatives were considered:

- *Unconditional separator fold in `getPathComparisonKey`* — this is what the code did before #17718, and it merges POSIX backslash filenames with genuinely different paths.
- *Leaving defect B alone* — behaviour is unchanged from before #17718, which skipped UNC bases too. What #17718 added is the *appearance* of validation, and that is worth removing.

### Breaking changes

None. Defect A changes dedup keys only for paths that have no canonical form; defect B's fix changes no return value, only adds a log line.

### Special notes for your reviewer

**Not reproduced on a real network share.** The defects were found by post-merge review of #17718 and the unit-level evidence in #18631 was executed, but the end-to-end Windows behaviour is inferred from it. Worth a sanity check by anyone with a UNC workspace to hand.

**Attribution, for anyone reading #18631:** defect A is *not* a regression from #17718. The pre-#17718 implementation was already broken by a different route — `canonicalize` threw on `\\server\share` and fell back to a folded raw value, while `//server/share` canonicalized *successfully* and had its leading `//` collapsed. Two spellings, two branches, still unequal. The `//`-collapse half of that is #18207.

The non-blocking observations in #18631 are deliberately **not** in this PR and stay on the issue: the `useAgentResourceMentionSource` items (pre-existing, belong to #17429), the `logger.warn` that re-fires inside `useMemo(deps: [session])` — still true after the move — and the test-coverage, typing, simplification and comment-density suggestions.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is not required — the user-visible fix is a bug fix with no new surface; `docs/references/file/file-manager-architecture.md` was updated for contributors.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed agent folder mentions being insertable repeatedly, and workspace file attachments being inlined instead of referenced, when the agent workspace is on a Windows network share (UNC path).
```
