### PR TITLE
fix(ui-markdown): keep the styles entry in the bundle so formula copy works

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -130,7 +130,8 @@
     "vitest": "^3.2.7"
   },
   "sideEffects": [
-    "**/*.css"
+    "**/*.css",
+    "./src/components/composites/markdown/styles.ts"
   ],
   "engines": {
     "node": ">=18.0.0"

--- a/packages/ui/src/components/composites/markdown/__tests__/markdown-copy-tex.test.tsx
+++ b/packages/ui/src/components/composites/markdown/__tests__/markdown-copy-tex.test.tsx
@@ -20,7 +20,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 import { render } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Markdown } from '../markdown'
 import { withChatPlugins } from '../presets'

--- a/packages/ui/src/components/composites/markdown/__tests__/markdown-copy-tex.test.tsx
+++ b/packages/ui/src/components/composites/markdown/__tests__/markdown-copy-tex.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for the formula-copy regression (#18698, #18665).
+ *
+ * KaTeX's copy-tex contrib attaches a document-level `copy` listener at import
+ * time, so the styles entry (`../styles`, which side-effect-imports copy-tex)
+ * must survive the production bundle. `packages/ui/package.json` previously
+ * whitelisted only CSS files in `sideEffects`, and the bundler tree-shook the
+ * whole styles entry out of release builds: the listener never registered and
+ * mouse-selection copy fell back to the flattened visual text (superscripts
+ * lost, TeX gone). These tests pin both halves of the contract: the entry
+ * actually wires the copy behavior, and the package manifest keeps it
+ * un-shakeable.
+ */
+
+import '../styles'
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Markdown } from '../markdown'
+import { withChatPlugins } from '../presets'
+
+function dispatchCopy(): ReturnType<typeof vi.fn> {
+  const setData = vi.fn()
+  const event = new Event('copy', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'clipboardData', { value: { setData } })
+  document.dispatchEvent(event)
+  return setData
+}
+
+function selectAllOf(element: Element): void {
+  const range = document.createRange()
+  range.selectNodeContents(element)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+describe('markdown styles entry', () => {
+  it('restores TeX with delimiters when a selection over formulas is copied', () => {
+    const { container } = render(
+      <Markdown id="copy-tex" plugins={withChatPlugins()}>
+        {'before $x^2$ mid\n\n$$\n(a+b)^2\n$$'}
+      </Markdown>
+    )
+    const root = container.querySelector('.markdown')
+    expect(root?.querySelector('math')).not.toBeNull()
+
+    selectAllOf(root!)
+    const setData = dispatchCopy()
+
+    expect(setData).toHaveBeenCalledWith('text/plain', 'before $x^2$ mid\n$$(a+b)^2$$')
+    // The html flavor keeps the rendered markup so pasting into Word still works.
+    expect(setData).toHaveBeenCalledWith('text/html', expect.stringContaining('<math'))
+  })
+
+  it('keeps the styles entry covered by the package sideEffects manifest', () => {
+    // vitest may run with the package or the repo root as cwd; find @cherrystudio/ui's manifest either way
+    const pkgPath = [resolve(process.cwd(), 'package.json'), resolve(process.cwd(), 'packages/ui/package.json')].find(
+      (candidate) => {
+        try {
+          return (JSON.parse(readFileSync(candidate, 'utf8')) as { name?: string }).name === '@cherrystudio/ui'
+        } catch {
+          return false
+        }
+      }
+    )
+    expect(pkgPath, 'could not locate packages/ui/package.json').toBeDefined()
+    const pkg = JSON.parse(readFileSync(pkgPath!, 'utf8')) as { sideEffects?: string[] }
+    expect(
+      pkg.sideEffects,
+      'styles.ts side-effect-imports katex copy-tex; without a sideEffects entry the bundler drops it from release builds'
+    ).toContain('./src/components/composites/markdown/styles.ts')
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR: selecting rendered math in a conversation and copying it (Ctrl+C) puts the flattened visual text on the clipboard, so superscripts and formula structure are gone by the time it reaches Word or an editor. v1 produced the TeX source wrapped in `$`/`$$` for the same gesture.

After this PR: copy-tex runs in release builds again and the same selection copies the TeX source with delimiters, with the rendered HTML kept on the clipboard for Word's equation import.

Fixes #18698, fixes #18665

### Why we need it and why it was done in this way

KaTeX's copy-tex contrib attaches its document-level `copy` listener at import time, and v2 imports it from a side-effect-only module: `packages/ui/src/components/composites/markdown/styles.ts`. That entry is not covered by the package's `sideEffects` manifest (CSS files only), so the production bundler treats the entry as shakeable and drops it from the release bundle entirely. The listener never registers, and the copy falls back to the visual text. Dev servers don't tree-shake this path, which is why it only reproduces in packaged builds like v2.0.5.

Verified the mechanism with a minimal rolldown-vite build importing just the styles entry through the same alias the app uses: without the manifest entry the chunk comes out empty (0.02 kB, no copy-tex code, no stylesheet); with it the bundle carries the listener and the CSS (298 kB chunk plus assets).

The following tradeoffs were made:

The fix is a one-line manifest change rather than moving the import into a value-imported module. The styles entry is documented as the side-effect bundle for this composite; the manifest simply contradicted that intent.

The following alternatives were considered:

Moving the copy-tex import into `markdown.tsx` would also survive shaking (its exports are used), but it would load copy-tex for every Markdown consumer even when nobody opts into the styles entry, and it leaves the manifest wrong for any future side-effect module.

Links to places where the discussion took place: #18698, #18665, and the older related reports #14617 and #7210 referenced there.

### Breaking changes

None.

### Special notes for your reviewer

The new test file pins both halves of the contract: importing the styles entry wires the copy behavior end to end (selection over formulas copies `$x^2$` / `$$...$$` plus the HTML flavor), and the manifest keeps covering the entry so it cannot be silently shaken out again. The second test is meta by nature; happy to drop it if you'd rather rely on review discipline.

Note the commit is signed off but not GPG-verified; my signing key isn't on this machine.

### Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests added for the regression (`markdown-copy-tex.test.tsx`, red without the manifest entry)
- [x] `vitest run` on the markdown composite: 54 passed
- [x] oxlint / eslint / biome clean on touched files
