### PR TITLE
feat(chat-messages): add copy-as-new-conversation action

### DIFF
--- a/src/renderer/components/chat/messages/frame/__tests__/messageMenuBarActions.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/messageMenuBarActions.test.tsx
@@ -791,10 +791,32 @@ describe('messageMenuBarActions', () => {
     })
   })
 
-  it('hides new branch from user message menus', () => {
+  it('copies the selected assistant path from beside the new branch action', async () => {
+    const copyBranchToNewTopic = vi.fn()
+    const notifySuccess = vi.fn()
+    const context = createActionContext({
+      actions: {
+        copyBranchToNewTopic,
+        notifySuccess,
+        startMessageBranch: vi.fn()
+      } as MessageListActions
+    })
+
+    const menuActions = resolveMessageMenuBarMenuActions(context)
+
+    expect(menuActions.slice(0, 2).map((action) => action.id)).toEqual(['new-branch', 'copy-to-new-topic'])
+
+    await executeMessageMenuBarAction('copy-to-new-topic', context)
+
+    expect(copyBranchToNewTopic).toHaveBeenCalledWith('message-1')
+    expect(notifySuccess).toHaveBeenCalledWith('chat.message.flow.copy_topic.created')
+  })
+
+  it('hides branch actions from user message menus', () => {
     const menuActions = resolveMessageMenuBarMenuActions(
       createActionContext({
         actions: {
+          copyBranchToNewTopic: vi.fn(),
           startMessageBranch: vi.fn(),
           toggleMultiSelectMode: vi.fn()
         } as MessageListActions,

--- a/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
+++ b/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
@@ -23,6 +23,7 @@ import {
   AtSign,
   Check,
   CirclePause,
+  CopyPlus,
   FilePenLine,
   Languages,
   ListChecks,
@@ -196,6 +197,11 @@ registerCommand('message.abortTranslation', async ({ actions, message }) => {
 registerCommand('message.newBranch', async ({ actions, message, t }) => {
   await actions.startMessageBranch?.(message.id)
   actions.notifySuccess?.(t('chat.message.new.branch.created'))
+})
+
+registerCommand('message.copyToNewTopic', async ({ actions, message, t }) => {
+  await actions.copyBranchToNewTopic?.(message.id)
+  actions.notifySuccess?.(t('chat.message.flow.copy_topic.created'))
 })
 
 registerCommand('message.multiSelect', ({ actions }) => {
@@ -441,6 +447,17 @@ registerAction({
     if (!actions.startMessageBranch || !isAssistantMessage) return false
     return true
   }
+})
+
+registerAction({
+  id: 'copy-to-new-topic',
+  commandId: 'message.copyToNewTopic',
+  label: ({ t }) => t('chat.message.flow.copy_topic.label'),
+  icon: <CopyPlus size={15} />,
+  group: 'write',
+  order: 25,
+  surface: 'menu',
+  availability: ({ actions, isAssistantMessage }) => !!actions.copyBranchToNewTopic && isAssistantMessage
 })
 
 registerAction({

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -402,6 +402,7 @@ export interface MessageListActions {
   getMessageDeleteAvailability?: (messageId: string) => MessageDeleteAvailability
   deleteMessage?: (messageId: string, options?: DeleteMessageOptions) => void | Promise<void>
   startMessageBranch?: (messageId: string) => void | Promise<void>
+  copyBranchToNewTopic?: (messageId: string) => void | Promise<void>
   setActiveBranch?: (messageId: string) => void | Promise<void>
   deleteMessageGroup?: (messageIds: readonly string[]) => void | Promise<void>
   deleteMessageGroupWithConfirm?: (messageIds: readonly string[]) => void | Promise<void>

--- a/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
+++ b/src/renderer/pages/home/messages/__tests__/homeMessageListAdapter.test.tsx
@@ -1,5 +1,6 @@
 import type { MessageListProviderValue, MessageListRuntime } from '@renderer/components/chat/messages/types'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
+import { mockUseMutation } from '@test-mocks/renderer/useDataApi'
 import { act, render, waitFor } from '@testing-library/react'
 import { type ReactNode, useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -664,6 +665,35 @@ describe('useHomeMessageListProviderValue topic image actions', () => {
 
     expect(onStartBranchDraft).toHaveBeenCalledWith('assistant-old')
     expect(chatWriteMock.setActiveNode).not.toHaveBeenCalled()
+  })
+
+  it('copies a message path into a new topic through the topic duplicate endpoint', async () => {
+    const copyBranchToNewTopicTrigger = vi.fn().mockResolvedValue(createTopic('copied-topic'))
+    let value: MessageListProviderValue | undefined
+
+    await mockUseMutation.withImplementation(
+      () => ({
+        trigger: copyBranchToNewTopicTrigger,
+        isLoading: false,
+        error: undefined
+      }),
+      async () => {
+        render(
+          <MessageListAdapterHarness topic={createTopic('topic-a')} onValue={(nextValue) => (value = nextValue)} />
+        )
+
+        await waitFor(() => expect(value).toBeDefined())
+        await value?.actions.copyBranchToNewTopic?.('assistant-old')
+      }
+    )
+
+    expect(mockUseMutation).toHaveBeenCalledWith('POST', '/topics/:id/duplicate', {
+      refresh: ['/topics']
+    })
+    expect(copyBranchToNewTopicTrigger).toHaveBeenCalledWith({
+      params: { id: 'topic-a' },
+      body: { nodeId: 'assistant-old' }
+    })
   })
 
   it('keeps a message translation active until its final update is persisted', async () => {

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -1,4 +1,5 @@
 import { dataApiService } from '@data/DataApiService'
+import { useMutation } from '@data/hooks/useDataApi'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import { useMessageEditing } from '@renderer/components/chat/editing/MessageEditingContext'
@@ -100,6 +101,9 @@ export function useHomeMessageListProviderValue({
 }: HomeMessageListParams): MessageListProviderValue {
   const topicId = topic.id
   const assistantId = topic.assistantId
+  const { trigger: copyBranchToNewTopicTrigger } = useMutation('POST', '/topics/:id/duplicate', {
+    refresh: ['/topics']
+  })
   const [messageNavigation] = usePreference('chat.message.navigation_mode')
   const { t } = useTranslation()
   const normalInteractionsEnabled = imageActionConsumer !== 'capture'
@@ -699,6 +703,16 @@ export function useHomeMessageListProviderValue({
     [onStartBranchDraft, requireChatWrite]
   )
 
+  const copyBranchToNewTopic = useCallback<NonNullable<MessageListActions['copyBranchToNewTopic']>>(
+    async (messageId) => {
+      await copyBranchToNewTopicTrigger({
+        params: { id: topicId },
+        body: { nodeId: messageId }
+      })
+    },
+    [copyBranchToNewTopicTrigger, topicId]
+  )
+
   const setActiveBranch = useCallback<NonNullable<MessageListActions['setActiveBranch']>>(
     (messageId) => requireChatWrite('setActiveBranch').setActiveBranch(messageId),
     [requireChatWrite]
@@ -863,6 +877,7 @@ export function useHomeMessageListProviderValue({
       getMessageDeleteAvailability: normalInteractionsEnabled ? getMessageDeleteAvailability : undefined,
       deleteMessage: normalInteractionsEnabled ? deleteMessage : undefined,
       startMessageBranch,
+      copyBranchToNewTopic: normalInteractionsEnabled ? copyBranchToNewTopic : undefined,
       setActiveBranch,
       deleteMessageGroup,
       deleteMessageGroupWithConfirm,
@@ -881,6 +896,7 @@ export function useHomeMessageListProviderValue({
       bindMessageRuntime,
       bindRuntime,
       canStartNewContext,
+      copyBranchToNewTopic,
       getMessageDeleteAvailability,
       deleteMessage,
       deleteMessageGroup,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The Home assistant-message menu allowed users to start a branch, but copying the conversation path into a new conversation was only available from the branch-management panel.

After this PR:

The Home assistant-message menu shows **Copy as New Conversation** immediately after **New Branch**. The action copies the root-to-selected-message path through the existing topic duplicate endpoint, refreshes the topic list, and reports success through the shared message-action feedback path.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

None

### Why we need it and why it was done in this way

The message list should expose the same conversation-copy capability at the point where users already manage message branches. The mutation is injected by the Home message adapter so the shared message UI remains capability-driven and does not depend on Home-specific DataApi routes.

The following tradeoffs were made:

- The action is limited to Home assistant-message menus, matching the existing **New Branch** placement.
- The copied conversation keeps the existing duplicate behavior: it retains the source name, does not automatically open, and copies only the root-to-selected-message path.

The following alternatives were considered:

- Calling the topic duplicate endpoint directly from the shared message menu was rejected because it would couple shared UI to Home topic persistence.
- Adding another permanent toolbar icon was rejected to avoid increasing message-toolbar density.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

Validation completed:

- `pnpm format`
- `pnpm lint` (including typecheck and i18n checks)

Focused regression tests were added but not executed. `pnpm test`, `pnpm build:check`, and manual UI verification were not run under the workspace verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added a Copy as New Conversation action next to New Branch in assistant message menus.
```
