### PR TITLE
fix(composer): honor deferred structural variants

### DIFF
--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -99,9 +99,14 @@ function DeferredComposerSurface(props: ComposerSurfaceProps) {
     [props.draftTokens, props.text, props.tokens]
   )
 
-  // The fallback cannot rebase token offsets, render the editing header, or grow beyond its fixed
-  // two-line box — hand those states to the runtime instead of serving them badly.
-  const needsRuntime = Boolean(props.editingState) || Boolean(props.draftTokens?.length) || props.text.trim().length > 0
+  // The fallback cannot rebase token offsets, render the editing header, grow beyond its fixed
+  // two-line box, or represent structural variants, so hand those states to the runtime instead.
+  const needsRuntime =
+    Boolean(props.editingState) ||
+    Boolean(props.draftTokens?.length) ||
+    props.text.trim().length > 0 ||
+    Boolean(props.compactWhenSingleLine) ||
+    props.isExpanded
   useEffect(() => {
     if (needsRuntime) requestRuntime()
   }, [needsRuntime, requestRuntime])

--- a/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
@@ -272,6 +272,18 @@ describe('deferred ComposerSurface', () => {
     expect(mocks.runtimeIntent?.hadFocus).toBe(true)
   })
 
+  it('loads the runtime for the compact structural variant', async () => {
+    render(<Harness compactWhenSingleLine />)
+
+    expect(await screen.findByTestId('composer-runtime')).toBeInTheDocument()
+  })
+
+  it('loads the runtime for the expanded structural variant', async () => {
+    render(<Harness isExpanded />)
+
+    expect(await screen.findByTestId('composer-runtime')).toBeInTheDocument()
+  })
+
   it('follows the send-shortcut preference when the caller does not pass one', () => {
     MockUsePreferenceUtils.setPreferenceValue('chat.input.send_message_shortcut', 'Ctrl+Enter')
     render(<Harness sendMessageShortcut={undefined} />)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The deferred composer fallback always rendered the regular, collapsed presentation. A cold composer using `compactWhenSingleLine` or `isExpanded` therefore painted an incompatible shell and shifted once the rich runtime mounted.

After this PR:

- Compact and expanded structural variants request the rich runtime immediately after the initial paint.
- Focused lazy-boundary tests cover both structural states.
- The regular composer still uses the lightweight fallback.

Fixes #18555

### Why we need it and why it was done in this way

Structural presentation is owned by `ComposerSurfaceRuntime`. Loading that runtime for states the fallback cannot represent keeps one source of truth for compact and expanded sizing.

The following tradeoffs were made:

- Compact and expanded composers no longer remain on the lightweight fallback. The runtime request still happens from an effect, so the fallback continues to protect the initial paint.

The following alternatives were considered:

- Duplicating compact and expanded layout calculations in the fallback was rejected because it would create a second structural implementation that could drift from the runtime.

Links to places where the discussion took place: #18555

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm typecheck:web`
- `pnpm exec vitest run --project renderer src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx` — 23 passed
- Targeted Biome format and lint checks — passed
- Full renderer run — 874 files and 9025 tests passed; Vitest still exits with the existing unrelated `Controller is already closed` unhandled rejection from `ExecutionStreamOverlayService.test.ts`, which reproduces when that test is run alone.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The boundary comment now documents every state the fallback cannot represent
- [x] Upgrade: No persisted data or upgrade flow changes
- [x] Documentation: No user-guide update is required for this bug fix
- [x] Self-review: The final diff and focused runtime boundary were reviewed locally

### Release note

```release-note
Fixed compact and expanded composer layouts shifting while the rich editor loads.
```