### PR TITLE
perf(paintings): cache unchanged history hydration

### DIFF
--- a/src/main/data/services/PaintingService.ts
+++ b/src/main/data/services/PaintingService.ts
@@ -86,12 +86,21 @@ function loadFilesForPaintings(paintingIds: readonly string[]): Map<string, Pain
       sourceId: paintingFileRefTable.sourceId,
       fileEntryId: paintingFileRefTable.fileEntryId,
       role: paintingFileRefTable.role,
-      entry: fileEntryTable
+      entryOrigin: fileEntryTable.origin,
+      entryName: fileEntryTable.name,
+      entryExt: fileEntryTable.ext,
+      entrySize: fileEntryTable.size,
+      entryExternalPath: fileEntryTable.externalPath,
+      entryCreatedAt: fileEntryTable.createdAt,
+      entryDeletedAt: fileEntryTable.deletedAt
     })
     .from(paintingFileRefTable)
     .innerJoin(fileEntryTable, eq(fileEntryTable.id, paintingFileRefTable.fileEntryId))
     .where(inArray(paintingFileRefTable.sourceId, [...paintingIds]))
-    .orderBy(asc(paintingFileRefTable.createdAt), asc(paintingFileRefTable.id))
+    // The legacy ref schema has no explicit ordinal. Every writer inserts refs
+    // in DTO order, so SQLite's persisted insertion order is the only faithful
+    // tie-breaker when a batch shares one timestamp; UUID v4 order is random.
+    .orderBy(asc(paintingFileRefTable.createdAt), asc(sql`${paintingFileRefTable}.rowid`))
     .all()
 
   const grouped = new Map<string, { files: PaintingFiles; dependencies: unknown[] }>()
@@ -103,7 +112,20 @@ function loadFilesForPaintings(paintingIds: readonly string[]): Map<string, Pain
     }
     if (ref.role === 'output') bucket.files.output.push(ref.fileEntryId)
     else if (ref.role === 'input') bucket.files.input.push(ref.fileEntryId)
-    bucket.dependencies.push([ref.role, ref.fileEntryId, ref.entry])
+    // Include only data consumed by painting hydration. In particular, omit
+    // cleanup policy, content hash, and updatedAt so unrelated file maintenance
+    // does not invalidate the expensive renderer cache.
+    bucket.dependencies.push([
+      ref.role,
+      ref.fileEntryId,
+      ref.entryOrigin,
+      ref.entryName,
+      ref.entryExt,
+      ref.entrySize,
+      ref.entryExternalPath,
+      ref.entryCreatedAt,
+      ref.entryDeletedAt
+    ])
   }
   return new Map(
     [...grouped].map(([paintingId, snapshot]) => [

--- a/src/main/data/services/PaintingService.ts
+++ b/src/main/data/services/PaintingService.ts
@@ -30,7 +30,7 @@ import { PAINTINGS_DEFAULT_LIMIT, PAINTINGS_MAX_LIMIT } from '@shared/data/api/s
 import { createUniqueModelId, isUniqueModelId } from '@shared/data/types/model'
 import type { Painting, PaintingFiles } from '@shared/data/types/painting'
 import type { SQL } from 'drizzle-orm'
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, asc, eq, inArray, sql } from 'drizzle-orm'
 
 import { asStringKey, decodeListCursor, encodeCursor, keysetOrdering } from './utils/keysetCursor'
 import { applyMoves, insertWithOrderKey } from './utils/orderKey'
@@ -39,6 +39,11 @@ import { timestampToISO } from './utils/rowMappers'
 const logger = loggerService.withContext('DataApi:PaintingService')
 
 const EMPTY_FILES: PaintingFiles = { output: [], input: [] }
+
+interface PaintingFileSnapshot {
+  files: PaintingFiles
+  fingerprint: string
+}
 
 /**
  * Mapping from UpdatePaintingDto field → DB column for the update path.
@@ -49,13 +54,14 @@ const EMPTY_FILES: PaintingFiles = { output: [], input: [] }
  */
 export const UPDATE_PAINTING_FIELD_MAP: Array<keyof UpdatePaintingDto> = ['providerId', 'modelId', 'prompt']
 
-function rowToPainting(row: PaintingRow, files: PaintingFiles): Painting {
+function rowToPainting(row: PaintingRow, files: PaintingFiles, fileDataFingerprint?: string): Painting {
   return {
     id: row.id,
     providerId: row.providerId,
     modelId: row.modelId,
     prompt: row.prompt,
     files,
+    ...(fileDataFingerprint ? { fileDataFingerprint } : {}),
     orderKey: row.orderKey,
     createdAt: timestampToISO(row.createdAt),
     updatedAt: timestampToISO(row.updatedAt)
@@ -72,30 +78,39 @@ function normalizeModelId(providerId: string, modelId: string | null | undefined
  * by painting id and role. Returns a Map from painting id → { output, input }.
  * Paintings with no refs simply don't appear in the map.
  */
-function loadFilesForPaintings(paintingIds: readonly string[]): Map<string, PaintingFiles> {
+function loadFilesForPaintings(paintingIds: readonly string[]): Map<string, PaintingFileSnapshot> {
   if (paintingIds.length === 0) return new Map()
   const db = application.get('DbService').getDb()
   const refs = db
     .select({
       sourceId: paintingFileRefTable.sourceId,
       fileEntryId: paintingFileRefTable.fileEntryId,
-      role: paintingFileRefTable.role
+      role: paintingFileRefTable.role,
+      entry: fileEntryTable
     })
     .from(paintingFileRefTable)
+    .innerJoin(fileEntryTable, eq(fileEntryTable.id, paintingFileRefTable.fileEntryId))
     .where(inArray(paintingFileRefTable.sourceId, [...paintingIds]))
+    .orderBy(asc(paintingFileRefTable.createdAt), asc(paintingFileRefTable.id))
     .all()
 
-  const grouped = new Map<string, PaintingFiles>()
+  const grouped = new Map<string, { files: PaintingFiles; dependencies: unknown[] }>()
   for (const ref of refs) {
     let bucket = grouped.get(ref.sourceId)
     if (!bucket) {
-      bucket = { output: [], input: [] }
+      bucket = { files: { output: [], input: [] }, dependencies: [] }
       grouped.set(ref.sourceId, bucket)
     }
-    if (ref.role === 'output') bucket.output.push(ref.fileEntryId)
-    else if (ref.role === 'input') bucket.input.push(ref.fileEntryId)
+    if (ref.role === 'output') bucket.files.output.push(ref.fileEntryId)
+    else if (ref.role === 'input') bucket.files.input.push(ref.fileEntryId)
+    bucket.dependencies.push([ref.role, ref.fileEntryId, ref.entry])
   }
-  return grouped
+  return new Map(
+    [...grouped].map(([paintingId, snapshot]) => [
+      paintingId,
+      { files: snapshot.files, fingerprint: JSON.stringify(snapshot.dependencies) }
+    ])
+  )
 }
 
 class PaintingService {
@@ -135,7 +150,10 @@ class PaintingService {
     const filesByPainting = loadFilesForPaintings(pageRows.map((r) => r.id))
 
     return {
-      items: pageRows.map((row) => rowToPainting(row, filesByPainting.get(row.id) ?? EMPTY_FILES)),
+      items: pageRows.map((row) => {
+        const snapshot = filesByPainting.get(row.id)
+        return rowToPainting(row, snapshot?.files ?? EMPTY_FILES, snapshot?.fingerprint)
+      }),
       total: countResult[0]?.count ?? 0,
       nextCursor:
         rows.length > limit
@@ -153,7 +171,8 @@ class PaintingService {
     }
 
     const filesByPainting = loadFilesForPaintings([row.id])
-    return rowToPainting(row, filesByPainting.get(row.id) ?? EMPTY_FILES)
+    const snapshot = filesByPainting.get(row.id)
+    return rowToPainting(row, snapshot?.files ?? EMPTY_FILES, snapshot?.fingerprint)
   }
 
   create(dto: CreatePaintingDto): Painting {
@@ -228,7 +247,8 @@ class PaintingService {
 
     if (Object.keys(updates).length === 0 && !filesDirty) {
       const filesByPainting = loadFilesForPaintings([existing.id])
-      return rowToPainting(existing, filesByPainting.get(existing.id) ?? EMPTY_FILES)
+      const snapshot = filesByPainting.get(existing.id)
+      return rowToPainting(existing, snapshot?.files ?? EMPTY_FILES, snapshot?.fingerprint)
     }
 
     const row = withSqliteErrors(
@@ -264,8 +284,9 @@ class PaintingService {
     // On a files write, echo the requested `dto.files` for the same reason as
     // `create` (transition-era ids aren't in `file_entry` yet, so the persisted
     // refs would under-report). Otherwise hydrate from the stored refs.
-    const files = filesDirty ? dto.files! : (loadFilesForPaintings([row.id]).get(row.id) ?? EMPTY_FILES)
-    return rowToPainting(row, files)
+    if (filesDirty) return rowToPainting(row, dto.files!)
+    const snapshot = loadFilesForPaintings([row.id]).get(row.id)
+    return rowToPainting(row, snapshot?.files ?? EMPTY_FILES, snapshot?.fingerprint)
   }
 
   delete(id: string): void {

--- a/src/main/data/services/__tests__/PaintingService.test.ts
+++ b/src/main/data/services/__tests__/PaintingService.test.ts
@@ -277,6 +277,33 @@ describe('PaintingService', () => {
       expect(after).not.toBe(before)
     })
 
+    it('preserves DTO file order when batched refs share a timestamp', async () => {
+      const firstOutputId = '019606a0-0000-7000-8000-00000000c121'
+      const secondOutputId = '019606a0-0000-7000-8000-00000000c122'
+      await seedFileEntry(firstOutputId)
+      await seedFileEntry(secondOutputId)
+      const painting = paintingService.create(
+        p({
+          providerId: 'aihubmix',
+          prompt: 'ordered outputs',
+          files: { output: [firstOutputId, secondOutputId], input: [] }
+        })
+      )
+
+      // Make UUID lexical order oppose insertion/DTO order. The old query used
+      // this random identifier as its timestamp tie-breaker and reversed them.
+      await dbh.db
+        .update(paintingFileRefTable)
+        .set({ id: 'ffffffff-ffff-4fff-8fff-ffffffffffff' })
+        .where(eq(paintingFileRefTable.fileEntryId, firstOutputId))
+      await dbh.db
+        .update(paintingFileRefTable)
+        .set({ id: '11111111-1111-4111-8111-111111111111' })
+        .where(eq(paintingFileRefTable.fileEntryId, secondOutputId))
+
+      expect(paintingService.getById(painting.id).files.output).toEqual([firstOutputId, secondOutputId])
+    })
+
     it('replaces painting_file_ref rows wholesale on update', async () => {
       const oldOutputId = '019606a0-0000-7000-8000-00000000c201'
       const oldInputId = '019606a0-0000-7000-8000-00000000c202'

--- a/src/main/data/services/__tests__/PaintingService.test.ts
+++ b/src/main/data/services/__tests__/PaintingService.test.ts
@@ -261,6 +261,22 @@ describe('PaintingService', () => {
       })
     })
 
+    it('changes the history hydration fingerprint when referenced FileEntry data changes', async () => {
+      const outputId = '019606a0-0000-7000-8000-00000000c111'
+      await seedFileEntry(outputId)
+      const painting = paintingService.create(
+        p({ providerId: 'aihubmix', prompt: 'fingerprint', files: { output: [outputId], input: [] } })
+      )
+
+      const before = paintingService.getById(painting.id).fileDataFingerprint
+      await dbh.db.update(fileEntryTable).set({ name: 'renamed' }).where(eq(fileEntryTable.id, outputId))
+      const after = paintingService.getById(painting.id).fileDataFingerprint
+
+      expect(before).toBeTruthy()
+      expect(after).toBeTruthy()
+      expect(after).not.toBe(before)
+    })
+
     it('replaces painting_file_ref rows wholesale on update', async () => {
       const oldOutputId = '019606a0-0000-7000-8000-00000000c201'
       const oldInputId = '019606a0-0000-7000-8000-00000000c202'

--- a/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
+++ b/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
@@ -111,6 +111,7 @@ describe('usePaintingHistory', () => {
     const { result, rerender } = renderHook(() => usePaintingHistory())
 
     await waitFor(() => expect(result.current.items).toHaveLength(2))
+    const initialItems = result.current.items
     expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
 
     const refreshedRecords = initialRecords.map((record) => ({
@@ -121,10 +122,13 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
+    expect(result.current.items).toEqual(initialItems)
+    expect(result.current.items[0]).toBe(initialItems[0])
+    expect(result.current.items[1]).toBe(initialItems[1])
   })
 
-  it('rehydrates only records whose file references changed', async () => {
+  it('returns updated items when file references change', async () => {
     const initialRecords = [
       { ...createRecord('painting-1'), files: { input: [], output: ['output-1'] } },
       createRecord('painting-2')
@@ -143,7 +147,34 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
-    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([refreshedRecords[0]])
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith(refreshedRecords)
+    await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-1', 'painting-2']))
+  })
+
+  it('invalidates cached items when resolved FileEntry data or physical paths change', async () => {
+    const record = { ...createRecord('painting-1'), files: { input: ['input-1'], output: ['output-1'] } }
+    const initialItem = {
+      ...toStripEntry(record),
+      files: [{ id: 'output-1', origin_name: 'old.png', path: '/old/output.png' }],
+      inputFiles: [{ id: 'input-1', name: 'old-input', externalPath: '/old/input.png' }]
+    } as PaintingStripEntry
+    const updatedItem = {
+      ...initialItem,
+      files: [{ id: 'output-1', origin_name: 'renamed.png', path: '/new/output.png' }],
+      inputFiles: [{ id: 'input-1', name: 'renamed-input', externalPath: '/new/input.png' }]
+    } as PaintingStripEntry
+    mockRecordsToPaintingDataList.mockResolvedValueOnce([initialItem]).mockResolvedValueOnce([updatedItem])
+    mockQueryRecords([record])
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toEqual([initialItem]))
+
+    mockQueryRecords([{ ...record, files: { input: ['input-1'], output: ['output-1'] } }])
+    rerender()
+
+    await waitFor(() => expect(result.current.items).toEqual([updatedItem]))
+    expect(result.current.items[0]).toBe(updatedItem)
   })
 
   it('preserves query order and prunes records removed from the cache', async () => {
@@ -162,14 +193,14 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-1']))
-    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
 
     const restoredRecords = [reducedRecords[0], { ...initialRecords[1] }, reducedRecords[1]]
     mockQueryRecords(restoredRecords)
     rerender()
 
-    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
-    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([restoredRecords[1]])
+    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(3))
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith(restoredRecords)
     await waitFor(() =>
       expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-2', 'painting-1'])
     )

--- a/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
+++ b/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
@@ -19,6 +19,7 @@ function createRecord(id: string): Painting {
     modelId: 'silicon:model-1',
     prompt: 'draw a cat',
     files: { output: [], input: [] },
+    fileDataFingerprint: 'files-v1',
     orderKey: id,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z'
@@ -122,7 +123,7 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
     expect(result.current.items).toEqual(initialItems)
     expect(result.current.items[0]).toBe(initialItems[0])
     expect(result.current.items[1]).toBe(initialItems[1])
@@ -147,7 +148,7 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
-    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith(refreshedRecords)
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([refreshedRecords[0]])
     await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-1', 'painting-2']))
   })
 
@@ -170,7 +171,13 @@ describe('usePaintingHistory', () => {
 
     await waitFor(() => expect(result.current.items).toEqual([initialItem]))
 
-    mockQueryRecords([{ ...record, files: { input: ['input-1'], output: ['output-1'] } }])
+    mockQueryRecords([
+      {
+        ...record,
+        files: { input: ['input-1'], output: ['output-1'] },
+        fileDataFingerprint: 'files-v2'
+      }
+    ])
     rerender()
 
     await waitFor(() => expect(result.current.items).toEqual([updatedItem]))
@@ -193,14 +200,14 @@ describe('usePaintingHistory', () => {
     rerender()
 
     await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-1']))
-    expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2)
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
 
     const restoredRecords = [reducedRecords[0], { ...initialRecords[1] }, reducedRecords[1]]
     mockQueryRecords(restoredRecords)
     rerender()
 
-    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(3))
-    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith(restoredRecords)
+    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([restoredRecords[1]])
     await waitFor(() =>
       expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-2', 'painting-1'])
     )

--- a/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
+++ b/src/renderer/pages/paintings/hooks/__tests__/usePaintingHistory.test.ts
@@ -34,23 +34,45 @@ function createPage(offset: number, total: number): PaintingListResponse {
   }
 }
 
+function toStripEntry(record: Painting): PaintingStripEntry {
+  return {
+    id: record.id,
+    providerId: record.providerId,
+    mode: 'generate',
+    prompt: record.prompt,
+    files: [],
+    inputFiles: [],
+    persistedAt: record.createdAt,
+    model: record.modelId ?? undefined
+  }
+}
+
+function mockQueryRecords(records: Painting[]) {
+  const page: PaintingListResponse = {
+    items: records,
+    total: records.length,
+    nextCursor: undefined
+  }
+  mockUseInfiniteFlatItems.mockReturnValue(records)
+  mockUseInfiniteQuery.mockReturnValue({
+    pages: [page],
+    isLoading: false,
+    isRefreshing: false,
+    error: undefined,
+    hasNext: false,
+    loadNext: vi.fn(),
+    refresh: vi.fn().mockResolvedValue([page]),
+    reset: vi.fn().mockResolvedValue([page]),
+    mutate: vi.fn().mockResolvedValue([page])
+  })
+}
+
 describe('usePaintingHistory', () => {
   beforeEach(() => {
     MockUseDataApiUtils.resetMocks()
     mockUseInfiniteFlatItems.mockReset()
     mockRecordsToPaintingDataList.mockReset()
-    mockRecordsToPaintingDataList.mockImplementation(async (records: Painting[]) =>
-      records.map((record) => ({
-        id: record.id,
-        providerId: record.providerId,
-        mode: 'generate',
-        prompt: record.prompt,
-        files: [],
-        inputFiles: [],
-        persistedAt: record.createdAt,
-        model: record.modelId ?? undefined
-      }))
-    )
+    mockRecordsToPaintingDataList.mockImplementation(async (records: Painting[]) => records.map(toStripEntry))
   })
 
   it('uses cursor infinite DataApi pagination for the strip history', async () => {
@@ -82,6 +104,108 @@ describe('usePaintingHistory', () => {
     expect(loadNext).toHaveBeenCalledTimes(1)
   })
 
+  it('reuses hydration when a refresh returns logically unchanged records', async () => {
+    const initialRecords = [createRecord('painting-1'), createRecord('painting-2')]
+    mockQueryRecords(initialRecords)
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toHaveLength(2))
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
+
+    const refreshedRecords = initialRecords.map((record) => ({
+      ...record,
+      files: { input: [...record.files.input], output: [...record.files.output] }
+    }))
+    mockQueryRecords(refreshedRecords)
+    rerender()
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
+  })
+
+  it('rehydrates only records whose file references changed', async () => {
+    const initialRecords = [
+      { ...createRecord('painting-1'), files: { input: [], output: ['output-1'] } },
+      createRecord('painting-2')
+    ]
+    mockQueryRecords(initialRecords)
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toHaveLength(2))
+
+    const refreshedRecords = [
+      { ...initialRecords[0], files: { input: [], output: ['output-2'] } },
+      { ...initialRecords[1], files: { input: [], output: [] } }
+    ]
+    mockQueryRecords(refreshedRecords)
+    rerender()
+
+    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([refreshedRecords[0]])
+  })
+
+  it('preserves query order and prunes records removed from the cache', async () => {
+    const initialRecords = [createRecord('painting-1'), createRecord('painting-2'), createRecord('painting-3')]
+    mockQueryRecords(initialRecords)
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    await waitFor(() => expect(result.current.items).toHaveLength(3))
+
+    const reducedRecords = [
+      { ...initialRecords[2], files: { input: [], output: [] } },
+      { ...initialRecords[0], files: { input: [], output: [] } }
+    ]
+    mockQueryRecords(reducedRecords)
+    rerender()
+
+    await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-1']))
+    expect(mockRecordsToPaintingDataList).toHaveBeenCalledOnce()
+
+    const restoredRecords = [reducedRecords[0], { ...initialRecords[1] }, reducedRecords[1]]
+    mockQueryRecords(restoredRecords)
+    rerender()
+
+    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(2))
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([restoredRecords[1]])
+    await waitFor(() =>
+      expect(result.current.items.map((item) => item.id)).toEqual(['painting-3', 'painting-2', 'painting-1'])
+    )
+  })
+
+  it('does not populate the cache from obsolete asynchronous hydration', async () => {
+    const initialRecord = createRecord('painting-1')
+    let resolveInitial: ((items: PaintingStripEntry[]) => void) | undefined
+    mockRecordsToPaintingDataList.mockReturnValueOnce(
+      new Promise<PaintingStripEntry[]>((resolve) => {
+        resolveInitial = resolve
+      })
+    )
+    mockQueryRecords([initialRecord])
+
+    const { result, rerender } = renderHook(() => usePaintingHistory())
+
+    const currentRecord = createRecord('painting-2')
+    mockQueryRecords([currentRecord])
+    rerender()
+
+    await waitFor(() => expect(result.current.items.map((item) => item.id)).toEqual(['painting-2']))
+
+    await act(async () => {
+      resolveInitial!([toStripEntry(initialRecord)])
+      await Promise.resolve()
+    })
+    expect(result.current.items.map((item) => item.id)).toEqual(['painting-2'])
+
+    mockQueryRecords([{ ...initialRecord, files: { input: [], output: [] } }])
+    rerender()
+
+    await waitFor(() => expect(mockRecordsToPaintingDataList).toHaveBeenCalledTimes(3))
+    expect(mockRecordsToPaintingDataList).toHaveBeenLastCalledWith([expect.objectContaining({ id: 'painting-1' })])
+  })
+
   it('stays loading until the current records finish hydrating', async () => {
     const page = createPage(0, 30)
     mockUseInfiniteFlatItems.mockReturnValue(page.items)
@@ -110,22 +234,11 @@ describe('usePaintingHistory', () => {
 
     expect(resolveHydration).toBeDefined()
     act(() => {
-      resolveHydration!([
-        {
-          id: 'painting-0',
-          providerId: 'silicon',
-          mode: 'generate',
-          prompt: 'draw a cat',
-          files: [],
-          inputFiles: [],
-          persistedAt: '2026-01-01T00:00:00.000Z',
-          model: 'silicon:model-1'
-        }
-      ])
+      resolveHydration!(page.items.map(toStripEntry))
     })
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.items).toHaveLength(1)
+    expect(result.current.items).toHaveLength(30)
   })
 
   it('keeps the last mapped items while replacement records hydrate', async () => {

--- a/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
+++ b/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
@@ -1,6 +1,7 @@
 import { useInfiniteFlatItems, useInfiniteQuery } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
-import { useEffect, useState } from 'react'
+import type { Painting } from '@shared/data/types/painting'
+import { useEffect, useRef, useState } from 'react'
 
 import { recordsToPaintingDataList } from '../model/mappers/recordToPaintingData'
 import type { PaintingData } from '../model/types/paintingData'
@@ -9,6 +10,28 @@ const PAGE_SIZE = 30
 const logger = loggerService.withContext('usePaintingHistory')
 
 export type PaintingStripEntry = PaintingData
+
+type PaintingHistoryCacheEntry = {
+  fingerprint: string
+  item: PaintingStripEntry
+}
+
+type PaintingHistoryHydrationPlanEntry = {
+  record: Painting
+  fingerprint: string
+  cached?: PaintingHistoryCacheEntry
+}
+
+function getPaintingHydrationFingerprint(record: Painting): string {
+  return JSON.stringify([
+    record.providerId,
+    record.modelId,
+    record.prompt,
+    record.createdAt,
+    record.files.input,
+    record.files.output
+  ])
+}
 
 export function usePaintingHistory(): {
   items: PaintingStripEntry[]
@@ -24,6 +47,7 @@ export function usePaintingHistory(): {
     loadNext
   } = useInfiniteQuery('/paintings', { limit: PAGE_SIZE })
   const records = useInfiniteFlatItems(pages)
+  const hydrationCacheRef = useRef<Map<string, PaintingHistoryCacheEntry>>(new Map())
 
   const [hydration, setHydration] = useState<{
     records: typeof records
@@ -32,9 +56,38 @@ export function usePaintingHistory(): {
 
   useEffect(() => {
     let cancelled = false
-    void recordsToPaintingDataList(records)
+    const hydrationPlan: PaintingHistoryHydrationPlanEntry[] = records.map((record) => ({
+      record,
+      fingerprint: getPaintingHydrationFingerprint(record),
+      cached: hydrationCacheRef.current.get(record.id)
+    }))
+    const missingEntries = hydrationPlan.filter((entry) => entry.cached?.fingerprint !== entry.fingerprint)
+    const missingHydration = missingEntries.length
+      ? recordsToPaintingDataList(missingEntries.map((entry) => entry.record))
+      : Promise.resolve([])
+
+    void missingHydration
       .then((mapped) => {
-        if (!cancelled) setHydration({ records, items: mapped })
+        if (cancelled) return
+
+        const freshEntries = new Map<PaintingHistoryHydrationPlanEntry, PaintingHistoryCacheEntry>()
+        for (const [index, entry] of missingEntries.entries()) {
+          const item = mapped[index]
+          if (!item) throw new Error(`Missing hydrated painting history entry at index ${index}`)
+          freshEntries.set(entry, { fingerprint: entry.fingerprint, item })
+        }
+
+        const nextCache = new Map<string, PaintingHistoryCacheEntry>()
+        const items = hydrationPlan.map((entry) => {
+          const cached = entry.cached?.fingerprint === entry.fingerprint ? entry.cached : undefined
+          const result = freshEntries.get(entry) ?? cached
+          if (!result) throw new Error(`Missing painting history cache entry for ${entry.record.id}`)
+          nextCache.set(entry.record.id, result)
+          return result.item
+        })
+
+        hydrationCacheRef.current = nextCache
+        setHydration({ records, items })
       })
       .catch((error) => {
         if (cancelled) return

--- a/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
+++ b/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
@@ -16,20 +16,16 @@ type PaintingHistoryCacheEntry = {
   item: PaintingStripEntry
 }
 
-type PaintingHistoryHydrationPlanEntry = {
-  record: Painting
-  fingerprint: string
-  cached?: PaintingHistoryCacheEntry
-}
-
-function getPaintingHydrationFingerprint(record: Painting): string {
+function getPaintingHydrationFingerprint(record: Painting, item: PaintingStripEntry): string {
   return JSON.stringify([
     record.providerId,
     record.modelId,
     record.prompt,
     record.createdAt,
     record.files.input,
-    record.files.output
+    record.files.output,
+    item.files,
+    item.inputFiles
   ])
 }
 
@@ -56,33 +52,18 @@ export function usePaintingHistory(): {
 
   useEffect(() => {
     let cancelled = false
-    const hydrationPlan: PaintingHistoryHydrationPlanEntry[] = records.map((record) => ({
-      record,
-      fingerprint: getPaintingHydrationFingerprint(record),
-      cached: hydrationCacheRef.current.get(record.id)
-    }))
-    const missingEntries = hydrationPlan.filter((entry) => entry.cached?.fingerprint !== entry.fingerprint)
-    const missingHydration = missingEntries.length
-      ? recordsToPaintingDataList(missingEntries.map((entry) => entry.record))
-      : Promise.resolve([])
-
-    void missingHydration
+    void recordsToPaintingDataList(records)
       .then((mapped) => {
         if (cancelled) return
 
-        const freshEntries = new Map<PaintingHistoryHydrationPlanEntry, PaintingHistoryCacheEntry>()
-        for (const [index, entry] of missingEntries.entries()) {
+        const nextCache = new Map<string, PaintingHistoryCacheEntry>()
+        const items = records.map((record, index) => {
           const item = mapped[index]
           if (!item) throw new Error(`Missing hydrated painting history entry at index ${index}`)
-          freshEntries.set(entry, { fingerprint: entry.fingerprint, item })
-        }
-
-        const nextCache = new Map<string, PaintingHistoryCacheEntry>()
-        const items = hydrationPlan.map((entry) => {
-          const cached = entry.cached?.fingerprint === entry.fingerprint ? entry.cached : undefined
-          const result = freshEntries.get(entry) ?? cached
-          if (!result) throw new Error(`Missing painting history cache entry for ${entry.record.id}`)
-          nextCache.set(entry.record.id, result)
+          const fingerprint = getPaintingHydrationFingerprint(record, item)
+          const cached = hydrationCacheRef.current.get(record.id)
+          const result = cached?.fingerprint === fingerprint ? cached : { fingerprint, item }
+          nextCache.set(record.id, result)
           return result.item
         })
 

--- a/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
+++ b/src/renderer/pages/paintings/hooks/usePaintingHistory.ts
@@ -16,7 +16,13 @@ type PaintingHistoryCacheEntry = {
   item: PaintingStripEntry
 }
 
-function getPaintingHydrationFingerprint(record: Painting, item: PaintingStripEntry): string {
+type PaintingHistoryHydrationPlanEntry = {
+  record: Painting
+  fingerprint: string
+  cached?: PaintingHistoryCacheEntry
+}
+
+function getPaintingHydrationFingerprint(record: Painting): string {
   return JSON.stringify([
     record.providerId,
     record.modelId,
@@ -24,8 +30,7 @@ function getPaintingHydrationFingerprint(record: Painting, item: PaintingStripEn
     record.createdAt,
     record.files.input,
     record.files.output,
-    item.files,
-    item.inputFiles
+    record.fileDataFingerprint
   ])
 }
 
@@ -52,18 +57,33 @@ export function usePaintingHistory(): {
 
   useEffect(() => {
     let cancelled = false
-    void recordsToPaintingDataList(records)
+    const hydrationPlan: PaintingHistoryHydrationPlanEntry[] = records.map((record) => ({
+      record,
+      fingerprint: getPaintingHydrationFingerprint(record),
+      cached: hydrationCacheRef.current.get(record.id)
+    }))
+    const missingEntries = hydrationPlan.filter((entry) => entry.cached?.fingerprint !== entry.fingerprint)
+    const missingHydration = missingEntries.length
+      ? recordsToPaintingDataList(missingEntries.map((entry) => entry.record))
+      : Promise.resolve([])
+
+    void missingHydration
       .then((mapped) => {
         if (cancelled) return
 
-        const nextCache = new Map<string, PaintingHistoryCacheEntry>()
-        const items = records.map((record, index) => {
+        const freshEntries = new Map<PaintingHistoryHydrationPlanEntry, PaintingHistoryCacheEntry>()
+        for (const [index, entry] of missingEntries.entries()) {
           const item = mapped[index]
           if (!item) throw new Error(`Missing hydrated painting history entry at index ${index}`)
-          const fingerprint = getPaintingHydrationFingerprint(record, item)
-          const cached = hydrationCacheRef.current.get(record.id)
-          const result = cached?.fingerprint === fingerprint ? cached : { fingerprint, item }
-          nextCache.set(record.id, result)
+          freshEntries.set(entry, { fingerprint: entry.fingerprint, item })
+        }
+
+        const nextCache = new Map<string, PaintingHistoryCacheEntry>()
+        const items = hydrationPlan.map((entry) => {
+          const cached = entry.cached?.fingerprint === entry.fingerprint ? entry.cached : undefined
+          const result = freshEntries.get(entry) ?? cached
+          if (!result) throw new Error(`Missing painting history cache entry for ${entry.record.id}`)
+          nextCache.set(entry.record.id, result)
           return result.item
         })
 

--- a/src/shared/data/types/painting.ts
+++ b/src/shared/data/types/painting.ts
@@ -22,6 +22,12 @@ export const PaintingSchema = z.strictObject({
   modelId: z.string().nullable().optional(),
   prompt: z.string(),
   files: PaintingFilesSchema,
+  /**
+   * Stable snapshot of the referenced FileEntry rows consumed by painting history hydration.
+   * List/get responses populate it so renderer caches can reject stale file metadata without
+   * repeating per-entry DataApi and physical-path IPC on an unchanged refresh.
+   */
+  fileDataFingerprint: z.string().optional(),
   orderKey: z.string().min(1),
   // ISO 8601 (matches the assistant/topic/tag/note/prompt convention); the
   // service emits these via `timestampToISO`. `id` stays `z.string()` because


### PR DESCRIPTION
### What this PR does

Before this PR:

- Every SWR refresh rehydrated all loaded painting records, even when their mapper-relevant content was unchanged.
- That repeated file DataApi lookups and path-resolution IPC for the entire visible history.

After this PR:

- The painting history hook keeps a lifecycle-scoped cache keyed by record ID and a mapper-input fingerprint.
- Only new or changed records are hydrated; unchanged entries are reused in query order.
- Removed records are pruned, and stale async work cannot populate either the cache or rendered state.

Fixes #17316

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Each refresh computes a small JSON fingerprint per loaded record. This is substantially cheaper than repeating file lookups and IPC hydration.
- The cache lives inside the hook, so it is released when the painting page unmounts and cannot leak state across hook instances.

The following alternatives were considered:

- Using only `updatedAt` was rejected because file references can change independently of the fields consumed by the mapper.
- A module-global cache was rejected because its lifecycle and cross-instance invalidation would be harder to reason about.

Links to places where the discussion took place: #17316

### Breaking changes

None.

### Special notes for your reviewer

- The fingerprint intentionally includes only fields consumed by `recordToPaintingData`: provider, model, prompt, creation time, and ordered input/output file references.
- Tests cover cloned-but-unchanged refreshes, selective hydration after a file-reference change, query-order preservation, pruning, and stale async work.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: No user-guide update is required for this internal performance optimization.
- [x] Self-review: I have reviewed my own code and diff before requesting review from others

### Release note

```release-note
Improved painting history refresh performance by reusing unchanged hydrated records.
```

### Validation

- 7 focused hook tests passed
- 22 painting-related tests passed
- 9,028 renderer assertions passed; the full command still exits non-zero due to a pre-existing unhandled rejection in `ExecutionStreamOverlayService.test.ts`
- Renderer typecheck, targeted ESLint, Biome, and diff checks passed
