### PR TITLE
fix(chat-branch): create real branches from leaf messages

### DIFF
--- a/docs/references/chat/message-tree.md
+++ b/docs/references/chat/message-tree.md
@@ -45,12 +45,12 @@ the indexed root *lookup* key.
 
 ### Persisted awaiting-input branches
 
-Starting a branch below an assistant uses `POST /messages/:id/branches` to persist a distinct
-empty successful `role = 'user'` leaf. Every request creates a node: multiple empty reservations
-below one assistant are intentional branch points, not duplicates. Awaiting-input state is
-derived from that structure — no draft marker is stored. The conversation list hides empty
-successful user rows, while `getTree` projects empty user leaves as `isAwaitingInput` for the
-flow canvas.
+Starting a branch below an assistant uses `POST /messages/:id/branches` to persist empty successful
+`role = 'user'` leaves. A leaf assistant gets two children so its first reservation forms a real
+branch; an assistant that already has a child gets one new node. Multiple empty reservations below
+one assistant are intentional branch points, not duplicates. Awaiting-input state is derived from
+that structure — no draft marker is stored. The conversation list hides empty successful user rows,
+while `getTree` projects empty user leaves as `isAwaitingInput` for the flow canvas.
 
 An idle reservation becomes the topic's active node. During a live stream the renderer sends
 `activate: false`, so creating the reservation cannot move the active stream path. If the user
@@ -72,7 +72,7 @@ reserved-branch submission before any write, closing renderer timing races.
 | Every content message has a non-null parent | **DB CHECK** `message_root_parent_check` `((role = 'root') = (parent_id IS NULL))` — a content row (`role != 'root'`) with a null parent is rejected at the storage layer, not by convention. First-turn content messages get `parentId = <virtual root>`. |
 | `role = 'root'` ⇔ `parentId IS NULL` | Same **DB CHECK** `message_root_parent_check`. `createRootMessageTx` (runtime) / `ChatMigrator` (migration) are the sole *writers* of the root row, but the biconditional itself is enforced structurally. |
 | `activeNodeId` is never the virtual root | `NULL` for an empty topic, otherwise a content message; read paths drop the root from the active path. |
-| An awaiting-input branch is an empty successful user leaf | `MessageService.reserveBranch` creates one distinct row per request. `createUserMessageWithPlaceholders(mode = 'fill-reserved')` revalidates the leaf and atomically fills it with its assistant placeholder(s). |
+| An awaiting-input branch is an empty successful user leaf | `MessageService.reserveBranch` creates two distinct rows for a leaf anchor, otherwise one. `createUserMessageWithPlaceholders(mode = 'fill-reserved')` revalidates the selected leaf and atomically fills it with its assistant placeholder(s). |
 | Deleting an awaiting-input node must never delete a message that was filled meanwhile | Canvas requests `DELETE /messages/:id?awaitingInputOnly=true`; `MessageService.delete` revalidates empty parts, success status, user role, and absence of live children before deleting it. |
 | The virtual root is deletable only via topic deletion | `delete()` hard-rejects it (see below); the topic FK `ON DELETE CASCADE` is the only path that removes it. |
 

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -1136,11 +1136,10 @@ export class MessageService {
   }
 
   /**
-   * Persist a distinct empty branch below an assistant message.
+   * Persist empty branch nodes below an assistant message.
    *
-   * Reserved branches are intentional user-created tree nodes: repeated calls below
-   * the same anchor always create another row. `activate=false` lets the branch manager
-   * place a reservation without moving the topic away from a currently streaming path.
+   * A leaf gets two children so the first reservation forms a real branch; an anchor
+   * with children gets one. `activate=false` keeps the current streaming path active.
    */
   reserveBranch(anchorId: string, activate: boolean = true): Message {
     const message = application.get('DbService').withWriteTx((tx) => {
@@ -1157,21 +1156,31 @@ export class MessageService {
         throw DataApiErrorFactory.invalidOperation('reserve branch', 'the branch anchor must be an assistant message')
       }
 
+      const hasChild =
+        tx
+          .select({ id: messageTable.id })
+          .from(messageTable)
+          .where(and(eq(messageTable.parentId, anchor.id), isNull(messageTable.deletedAt)))
+          .limit(1)
+          .get() !== undefined
       const createdAt = Date.now()
-      const [row] = tx
-        .insert(messageTable)
-        .values({
-          topicId: anchor.topicId,
-          parentId: anchor.id,
-          role: 'user',
-          data: { parts: [] },
-          status: 'success',
-          siblingsGroupId: 0,
-          createdAt,
-          updatedAt: createdAt
-        })
-        .returning()
-        .all()
+      const reservation: typeof messageTable.$inferInsert = {
+        topicId: anchor.topicId,
+        parentId: anchor.id,
+        role: 'user',
+        data: { parts: [] },
+        status: 'success',
+        siblingsGroupId: 0,
+        createdAt,
+        updatedAt: createdAt
+      }
+
+      // A leaf needs two children for the new reservation to form a real branch.
+      if (!hasChild) {
+        tx.insert(messageTable).values(reservation).run()
+      }
+
+      const [row] = tx.insert(messageTable).values(reservation).returning().all()
 
       const topicService = getDataService('TopicService')
 

--- a/src/main/data/services/__tests__/MessageService.test.ts
+++ b/src/main/data/services/__tests__/MessageService.test.ts
@@ -2476,6 +2476,33 @@ describe('MessageService', () => {
   })
 
   describe('reserveBranch', () => {
+    it('creates two empty children when the anchor is a leaf', async () => {
+      const rootId = await seedTopicWithRoot('topic-reserve-leaf')
+      const prompt = messageService.create('topic-reserve-leaf', {
+        parentId: rootId,
+        role: 'user',
+        data: mainText('question'),
+        status: 'success'
+      })
+      const anchor = messageService.create('topic-reserve-leaf', {
+        parentId: prompt.id,
+        role: 'assistant',
+        data: mainText('answer'),
+        status: 'success'
+      })
+
+      const activeReservation = messageService.reserveBranch(anchor.id)
+      const children = messageService.getChildrenByParentId(anchor.id)
+      const [topic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, 'topic-reserve-leaf'))
+
+      expect(children).toHaveLength(2)
+      expect(children.every((message) => message.role === 'user')).toBe(true)
+      expect(children.every((message) => message.status === 'success')).toBe(true)
+      expect(children.every((message) => (message.data.parts?.length ?? 0) === 0)).toBe(true)
+      expect(children.map((message) => message.id)).toContain(activeReservation.id)
+      expect(topic.activeNodeId).toBe(activeReservation.id)
+    })
+
     it('persists every reservation and only activates when requested', async () => {
       const { anchor, awaitingInput } = await seedAwaitingInputBranch('topic-reserve-branch')
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Starting a branch from a leaf assistant message persisted only one empty user child.
- That single child extended the existing path instead of forming a real branch.

After this PR:

- Starting a branch from a leaf assistant message atomically creates two empty user children and activates the selected reservation.
- Starting a branch from an assistant that already has a child continues to add exactly one empty node.
- The message-tree contract and regression coverage document both cases.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

A branch point needs at least two children. Deriving leaf state in `MessageService` keeps the rule atomic and shared by every branch-creation surface, while preserving the existing behavior for non-leaf anchors.

The following tradeoffs were made:

- The first reservation below a leaf intentionally leaves two empty awaiting-input nodes so either branch can be selected and filled later.

The following alternatives were considered:

- Calling the endpoint twice from the renderer was rejected because the operation would not be atomic and other branch-creation surfaces could diverge.
- Passing an `isLastMessage` flag from the renderer was rejected because the service can derive the authoritative topology from SQLite.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

- Validation passed: `pnpm lint`, `pnpm format`, `pnpm typecheck:node`, and `git diff --check`.
- Not run under the workspace verification policy: tests, `pnpm build:check`, or interactive Electron UI verification.
- Commit `503e3bc43d` is SSH-signed, DCO-signed off, and reported as Verified by GitHub.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string `action required`.
2. If no release note is required, write `NONE`.
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write `NONE`.
-->

```release-note
Starting a branch from the latest assistant message now creates a real two-way branch instead of a linear empty continuation.
```
