### PR TITLE
fix(provider-registry): restore SiliconFlow referral link

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -86,7 +86,7 @@
       "id": "silicon",
       "metadata": {
         "website": {
-          "apiKey": "https://cloud.siliconflow.cn/",
+          "apiKey": "https://cloud.siliconflow.cn/i/d1nTBKXU",
           "docs": "https://docs.siliconflow.cn/",
           "models": "https://cloud.siliconflow.cn/models",
           "official": "https://www.siliconflow.cn"
@@ -2073,5 +2073,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "cde3bb6539c1f8fa"
+  "version": "7dd1ae83c85245f9"
 }

--- a/packages/provider-registry/src/__tests__/silicon-referral-link.test.ts
+++ b/packages/provider-registry/src/__tests__/silicon-referral-link.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, it } from 'vitest'
+
+import { ProviderListSchema } from '../schemas/provider'
+
+const dataDir = join(fileURLToPath(import.meta.url), '..', '..', '..', 'data')
+const providers = ProviderListSchema.parse(JSON.parse(readFileSync(join(dataDir, 'providers.json'), 'utf8'))).providers
+
+it('keeps the SiliconFlow API key link on the Cherry Studio referral URL', () => {
+  expect(providers.find((provider) => provider.id === 'silicon')?.metadata.website.apiKey).toBe(
+    'https://cloud.siliconflow.cn/i/d1nTBKXU'
+  )
+})

--- a/packages/provider-registry/src/providers/silicon.ts
+++ b/packages/provider-registry/src/providers/silicon.ts
@@ -53,7 +53,7 @@ export default openaiCompatible({
   reasoningFormat: { type: 'openai-chat' },
   anthropic: 'https://api.siliconflow.cn',
   website: {
-    apiKey: 'https://cloud.siliconflow.cn/',
+    apiKey: 'https://cloud.siliconflow.cn/i/d1nTBKXU',
     docs: 'https://docs.siliconflow.cn/',
     models: 'https://cloud.siliconflow.cn/models',
     official: 'https://www.siliconflow.cn'

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -411,7 +411,7 @@
     }
   ],
   "providers": {
-    "version": "cde3bb6539c1f8fa",
+    "version": "7dd1ae83c85245f9",
     "count": 62,
     "entries": [
       {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The SiliconFlow "Get API Key" action opened the provider homepage without the Cherry Studio referral code.

After this PR:

It opens `https://cloud.siliconflow.cn/i/d1nTBKXU`, and a catalog contract test protects the referral URL.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The referral stays in the provider-registry source and generated catalog so the existing UI data flow remains unchanged.

The following alternatives were considered:

Changing renderer link handling was not needed because it already reads `provider.websites.apiKey`.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validated with targeted provider-registry tests, `pnpm lint`, `pnpm format`, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Restored the SiliconFlow referral link used by the Get API Key action.
```
