### PR TITLE
fix(main-bundle): restore createOpenAI in packaged builds

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -10,6 +10,7 @@ import { parse } from 'yaml'
 // assert not supported by biome
 // import pkg from './package.json' assert { type: 'json' }
 import pkg from './package.json'
+import { chunkExportGuardPlugin } from './scripts/checkChunkExports'
 import { uiContractPlugin } from './scripts/uiContract/vitePlugin'
 import { parseReleaseHistory, validateCurrentReleaseHistory } from './src/shared/utils/releaseNotes'
 
@@ -56,7 +57,7 @@ export const isMainExternalModule = (id: string) => {
 
 export default defineConfig({
   main: {
-    plugins: [...visualizerPlugin('main')],
+    plugins: [chunkExportGuardPlugin(), ...visualizerPlugin('main')],
     resolve: {
       alias: {
         '@main': resolve('src/main'),
@@ -81,8 +82,14 @@ export default defineConfig({
       rollupOptions: {
         external: isMainExternalModule,
         output: {
-          // conf removes its containing file from require.cache; isolate it so the app entry stays cached.
-          manualChunks: (id) => (id.includes('/node_modules/conf/') ? 'electron-store-conf' : undefined)
+          manualChunks: (id) => {
+            // conf removes its containing file from require.cache; isolate it so the app entry stays cached.
+            if (id.includes('/node_modules/conf/')) return 'electron-store-conf'
+            // rolldown drops this chunk's named exports when it merges with a re-export-only
+            // facade chunk, leaving createOpenAI undefined at runtime. Keep it alone.
+            if (id.includes('/node_modules/@ai-sdk/openai/')) return 'ai-sdk-openai'
+            return undefined
+          }
         },
         onwarn(warning, warn) {
           if (warning.code === 'COMMONJS_VARIABLE_IN_ESM') return

--- a/scripts/__tests__/checkChunkExports.test.ts
+++ b/scripts/__tests__/checkChunkExports.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Contract for the main-build chunk guard: reading a member the target chunk never
+ * exports must fail the build, and both real export forms rolldown emits must pass.
+ *
+ * CI does not run `electron-vite build`, so without this the guard's regexes can rot
+ * against a rolldown output change and every check still goes green.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { chunkExportGuardPlugin } from '../checkChunkExports'
+
+const FACADE = `const require_target = require("./target.js");
+exports.createOpenAI = require_target.createOpenAI;`
+
+/** What rolldown emitted for the merged facade chunk: only an unrelated `default`. */
+const TARGET_WITHOUT_EXPORT = `const require_main = require("./main.js");
+Object.defineProperty(exports, "default", {
+	enumerable: true,
+	get: function() {
+		return require_main.require_token_util();
+	}
+});`
+
+const run = (bundle: Record<string, string>) => {
+  const plugin = chunkExportGuardPlugin()
+  const hook = plugin.generateBundle as (
+    this: { error: (message: string) => never },
+    options: unknown,
+    bundle: unknown
+  ) => void
+  hook.call(
+    {
+      error: (message) => {
+        throw new Error(message)
+      }
+    },
+    {},
+    Object.fromEntries(Object.entries(bundle).map(([fileName, code]) => [fileName, { type: 'chunk', code }]))
+  )
+}
+
+describe('chunkExportGuardPlugin', () => {
+  it('fails when a chunk reads a member its target never exports', () => {
+    expect(() => run({ 'facade.js': FACADE, 'target.js': TARGET_WITHOUT_EXPORT })).toThrow(
+      'facade.js reads "createOpenAI" from target.js, which does not export it'
+    )
+  })
+
+  it('passes when the target assigns the member onto exports', () => {
+    expect(() =>
+      run({ 'facade.js': FACADE, 'target.js': 'function createOpenAI() {}\nexports.createOpenAI = createOpenAI;' })
+    ).not.toThrow()
+  })
+
+  it('passes when the target defines the member as an exports getter', () => {
+    expect(() =>
+      run({
+        'facade.js': FACADE,
+        'target.js': 'Object.defineProperty(exports, "createOpenAI", { get: function() { return null; } });'
+      })
+    ).not.toThrow()
+  })
+})

--- a/scripts/checkChunkExports.ts
+++ b/scripts/checkChunkExports.ts
@@ -1,0 +1,44 @@
+import type { Plugin } from 'vite'
+
+/**
+ * Fails the build when a chunk reads a binding its target chunk never exports.
+ *
+ * Rolldown can merge a re-export-only facade chunk into a real one and emit only the
+ * facade's exports, so the importer resolves `undefined` at runtime with no build error.
+ * That shipped a dead OpenAI provider in 2.0.6.
+ */
+export function chunkExportGuardPlugin(): Plugin {
+  const REQUIRE_RE = /^const ([A-Za-z0-9_$]+) = require\("\.\/([^"]+)"\);$/gm
+  const MEMBER_RE = /([A-Za-z0-9_$]+)\.([A-Za-z0-9_$]+)/g
+  const EXPORT_RE = /(?:exports\.([A-Za-z0-9_$]+)\s*=|Object\.defineProperty\(exports,\s*"([^"]+)")/g
+
+  return {
+    name: 'cherry-chunk-export-guard',
+    generateBundle(_options, bundle) {
+      const exportsOf = new Map<string, Set<string>>()
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'chunk') continue
+        const names = new Set<string>()
+        for (const [, assigned, defined] of output.code.matchAll(EXPORT_RE)) names.add(assigned ?? defined)
+        exportsOf.set(fileName, names)
+      }
+
+      const broken = new Set<string>()
+      for (const [fileName, output] of Object.entries(bundle)) {
+        if (output.type !== 'chunk') continue
+        const deps = new Map<string, string>()
+        for (const [, local, dep] of output.code.matchAll(REQUIRE_RE)) deps.set(local, dep)
+        for (const [, local, member] of output.code.matchAll(MEMBER_RE)) {
+          const dep = deps.get(local)
+          if (dep && !exportsOf.get(dep)?.has(member)) {
+            broken.add(`${fileName} reads "${member}" from ${dep}, which does not export it`)
+          }
+        }
+      }
+
+      if (broken.size > 0) {
+        this.error(`Broken cross-chunk imports:\n  ${[...broken].join('\n  ')}`)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: in packaged builds, any provider routed to the native `openai` adapter (official OpenAI, Codex, TokenHub, and other providers whose selected endpoint is `openai-responses`) failed with `ProviderCreationError: Failed to create provider "openai"` / `TypeError: (intermediate value).createOpenAI is not a function`. DMXAPI was broken unconditionally. Rolldown had merged the re-export-only facade chunk generated for `@vercel/oidc`'s `token-util` (both statically required into `main.js` and dynamically imported) into the `@ai-sdk/openai` chunk, then emitted only the facade's `default` export — so `createOpenAI` existed in the chunk but was never exported, and both `initialization.ts` and `dmxapiProvider` read `undefined`.

After this PR: `@ai-sdk/openai` gets its own `manualChunks` group so it can no longer be merged with a facade chunk, and a new `chunkExportGuardPlugin` fails the main build whenever a chunk reads a binding its target chunk does not export.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A — reported directly via an error report against 2.0.6.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The `manualChunks` entry is a workaround for an upstream rolldown defect, not a root-cause fix; it is annotated as such so it can be dropped once the toolchain moves on. It costs ~0.1 MB of extra main-bundle output.
- The guard plugin scans emitted chunk code with regexes rather than bundle metadata, because rolldown's `OutputChunk` has no `importedBindings` and the emitted code is the only ground truth for this defect. It adds ~0.5 s to the main build (1.35 s → 1.92 s) and is wired to `main` only, since renderer output is ESM where a missing export fails loudly at load time.

The following alternatives were considered:

- Bumping `rolldown-vite` 7.3.0 → 7.3.1: no effect, both pin `rolldown@1.0.0-beta.53`.
- Overriding `rolldown` to 1.2.4 under `rolldown-vite`: the build cannot start (`rolldown-vite` imports `viteWasmFallbackPlugin` from `rolldown/experimental`, removed upstream).
- Moving to `vite@8.2.1` (bundles rolldown ~1.2.1) + `electron-vite@6.0.0-beta.1`: verified to fix the defect with the `manualChunks` entry removed, but blocked on a beta `electron-vite`, a config-resolution crash on our renderer plugin array, rolldown 1.2 dropping the function form of `external`, and vite-7 peer ranges across vitest / react-swc / tanstack-router / tailwind. Left as a separate migration.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Verification was done against real build output, since no unit test can observe this class of defect:

- Reproduced the exact broken chunk in the shipped 2.0.6 `app.asar` and again from current `main`.
- With the fix, the emitted chunk exports `createOpenAI`, and `require()`-ing the facade chunk in Node returns a working provider (`typeof createOpenAI === 'function'`, `provider.chat` / `provider.responses` present).
- Removing the `manualChunks` entry makes the guard fail the build with the two real offenders (`dist-*.js` and `dmxapiProvider-*.js`), confirming it is not vacuous.
- Scanned all three bundles for this defect class after the fix: main 145 chunks, preload 3, renderer 3771 — 0 broken cross-chunk reads.

Two other pure re-export facade chunks remain in the main bundle (`@vercel/oidc` `token-util`, `https-proxy-agent`); which package they might swallow next depends on the chunk graph, which is why the guard is generic rather than a package allowlist.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix providers using the native OpenAI adapter (official OpenAI, Codex, TokenHub, DMXAPI, and any provider on an `openai-responses` endpoint) failing to start with `Failed to create provider "openai"`.
```
