### PR TITLE
fix(composer): focus input after creating a new topic

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -1178,26 +1178,28 @@ const ChatComposerInner = ({
   )
 
   const createEmptyTopic = useCallback(
-    (payload?: AddNewTopicPayload) => {
+    async (payload?: AddNewTopicPayload) => {
       if (isAssistantLoading || hasMissingPersistedAssistant) return
-      void onCreateEmptyTopic?.(payload ?? (selectedAssistantId ? { assistantId: selectedAssistantId } : undefined))
+      await onCreateEmptyTopic?.(payload ?? (selectedAssistantId ? { assistantId: selectedAssistantId } : undefined))
+      actionsRef.current.focus('end')
     },
-    [hasMissingPersistedAssistant, isAssistantLoading, onCreateEmptyTopic, selectedAssistantId]
+    [hasMissingPersistedAssistant, isAssistantLoading, onCreateEmptyTopic, selectedAssistantId, actionsRef]
   )
 
   const addNewTopic = useCallback(
-    (payload?: AddNewTopicPayload) => {
+    async (payload?: AddNewTopicPayload) => {
       if (onCreateEmptyTopic) {
-        createEmptyTopic(payload)
+        await createEmptyTopic(payload)
         return
       }
-      void onNewTopic?.(payload)
+      await onNewTopic?.(payload)
+      actionsRef.current.focus('end')
     },
-    [createEmptyTopic, onCreateEmptyTopic, onNewTopic]
+    [createEmptyTopic, onCreateEmptyTopic, onNewTopic, actionsRef]
   )
 
   const handleNewTopicShortcut = useCallback(() => {
-    addNewTopic()
+    void addNewTopic()
   }, [addNewTopic])
   const hasNewTopicAction = Boolean(onCreateEmptyTopic || onNewTopic)
   const newTopicDisabled = Boolean(onCreateEmptyTopic) && (isAssistantLoading || hasMissingPersistedAssistant)
@@ -1229,7 +1231,7 @@ const ChatComposerInner = ({
         filterText: label,
         searchAliases: getQuickPanelSearchAliases(t, 'chat.conversation.new', ['new chat']),
         action: () => {
-          addNewTopic()
+          void addNewTopic()
         }
       })
     }
@@ -1247,7 +1249,7 @@ const ChatComposerInner = ({
               disabled: newTopicDisabled,
               customizePlacement: 'leading' as const,
               requiresPanel: false,
-              onSelect: () => addNewTopic()
+              onSelect: () => void addNewTopic()
             }
           ]
         : []),

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -3135,6 +3135,34 @@ describe('ChatComposer', () => {
     expect(onNewTopic).not.toHaveBeenCalled()
   })
 
+  it('focuses the input after a new topic shortcut fires the parent action (regression: #18712)', async () => {
+    const onCreateEmptyTopic = vi.fn().mockResolvedValue(undefined)
+    mocks.focusComposer.mockReset()
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} onCreateEmptyTopic={onCreateEmptyTopic} />)
+
+    act(() => {
+      mocks.commandHandlers.get('topic.create')?.()
+    })
+
+    await waitFor(() => expect(onCreateEmptyTopic).toHaveBeenCalledOnce())
+    expect(mocks.focusComposer).toHaveBeenCalledWith('end')
+  })
+
+  it('focuses the input after a new topic shortcut through onNewTopic (regression: #18712)', async () => {
+    const onNewTopic = vi.fn().mockResolvedValue(undefined)
+    mocks.focusComposer.mockReset()
+
+    render(<ChatComposer topic={topic} onSend={vi.fn()} onNewTopic={onNewTopic} />)
+
+    act(() => {
+      mocks.commandHandlers.get('topic.create')?.()
+    })
+
+    await waitFor(() => expect(onNewTopic).toHaveBeenCalledOnce())
+    expect(mocks.focusComposer).toHaveBeenCalledWith('end')
+  })
+
   it('renders selectors below the surface in draft home mode', () => {
     render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
 


### PR DESCRIPTION
## Summary

Fixes #18712

After clicking the **New Chat** button or pressing `Ctrl+N` (`Cmd+N` on macOS), keyboard focus stayed on the create control instead of moving to the message input bar. Users had to click into the composer before they could start typing — breaking the common `New Chat → start typing` flow.

## Root cause

In `ChatComposer.tsx`, the parent callbacks that create a new topic (`onCreateEmptyTopic` / `onNewTopic`) were invoked fire-and-forget:

```ts
const createEmptyTopic = useCallback((payload?) => {
  if (...) return
  void onCreateEmptyTopic?.(...)    // ← never awaited
}, [...])

const addNewTopic = useCallback((payload?) => {
  if (onCreateEmptyTopic) {
    createEmptyTopic(payload)
    return
  }
  void onNewTopic?.(payload)        // ← never awaited
}, [...])
```

So the topic got created, but the composer was never asked to focus afterwards. The neighbouring `handleStartNewContext` already did the right thing — it `await`s `chatWrite.startNewContext()` and then calls `actionsRef.current.focus('end')`. The new-topic path was simply missing the same second half.

## Fix

Make `addNewTopic` / `createEmptyTopic` `async`, `await` the parent callback, then call the existing `actionsRef.current.focus('end')`. All call sites that fire `addNewTopic()` from event handlers now `void` the returned promise so React/QuickPanel don't complain about unhandled promises.

This is a small, surgical change — it reuses the focus path that already exists for the "clear context" action and applies it to the "new topic" action.

## Regression tests

Two new tests in `ChatComposer.test.tsx`:

- `focuses the input after a new topic shortcut fires the parent action (regression: #18712)` — covers the `onCreateEmptyTopic` path
- `focuses the input after a new topic shortcut through onNewTopic (regression: #18712)` — covers the `onNewTopic` path

Both trigger the `topic.create` command handler (same path the Ctrl+N shortcut uses) and assert `focusComposer` is called with `'end'` once the parent action resolves.

## How to verify manually

1. Open Cherry Studio.
2. Press `Ctrl+N` (or click **New Chat**).
3. Start typing immediately — keystrokes should land in the message input bar without an extra click.

## Checklist

- [x] Issue linked: #18712
- [x] Tests added covering both code paths
- [x] No new dependencies
- [x] Reuses existing `actionsRef.current.focus('end')` — no new focus logic introduced
