### PR TITLE
fix(i18n): translate pending locale strings

### DIFF
--- a/src/renderer/i18n/translate/de-de.json
+++ b/src/renderer/i18n/translate/de-de.json
@@ -1089,8 +1089,8 @@
           "label": "Shell-Befehle ausführen"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Ein Sitzungsziel erstellen, auf das hingearbeitet werden soll",
+          "label": "Ziel erstellen"
         },
         "edit": {
           "description": "Dateien bearbeiten",
@@ -1101,8 +1101,8 @@
           "label": "Dateien suchen"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Das aktuelle Sitzungsziel lesen",
+          "label": "Ziel lesen"
         },
         "grep": {
           "description": "Dateiinhalt durchsuchen",
@@ -1121,16 +1121,16 @@
           "label": "Bild lesen"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Die vollständigen Anweisungen eines aktivierten Skills laden",
+          "label": "Skill-Anweisungen laden"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Aufgabenliste verwalten",
+          "label": "Aufgabenliste verwalten"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Status oder Inhalt des Sitzungsziels aktualisieren",
+          "label": "Ziel aktualisieren"
         },
         "write": {
           "description": "Dateien schreiben",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "CLI-Tool auswählen",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Dieses Terminal erfordert einen benutzerdefinierten Pfad",
     "custom_path_set": "Benutzerdefinierter Terminalpfad erfolgreich festgelegt",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Standard-Agentenmodus",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Verknüpft mehrstufige Werkzeugabläufe über das PTC Code Mode SDK für komplexe Programmieraufgaben.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Behält die vorhandene Standardvorgabe in den gemeinsamen ~/.dsh-Einstellungen bei.",
+          "label": "Harness-Standard"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Nutzt nur eine dauerhafte Shell und einen Texteditor für eine möglichst kleine Werkzeugauswahl.",
+          "label": "Minimal"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Vollständiger Programmieragent mit Dateien, Shell, Suche, Skills, Planung und Subagenten.",
+          "label": "Standard"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "Der Vollzugriff ermöglicht dem Agenten den Zugriff auf Dateien außerhalb des Arbeitsbereichs und überspringt die Bestätigung von Vorgängen. Verwenden Sie ihn nur für vertrauenswürdige Aufgaben.",
+      "permission_mode": "Standardberechtigung",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Erlaubt uneingeschränkten Zugriff ohne Bestätigung von Vorgängen.",
+          "label": "Vollzugriff"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Beschränkt Schreibzugriffe auf Dateien und fragt vor riskanten Vorgängen nach.",
+          "label": "Nur lesen"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Erlaubt Schreibzugriffe im aktuellen DSH-Arbeitsbereich und fragt vor riskanten Vorgängen nach.",
+          "label": "Arbeitsbereich schreiben"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Keine Tools verfügbar",
     "not_installed": "Nicht installiert",
     "open_provider_settings": "Anbieter-Einstellungen öffnen",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Web-UI öffnen",
     "own_login": {
       "title": "{{toolName}} Offiziell"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Suchanbieter…",
     "select_folder": "Ordner auswählen",
     "select_provider_before_launch": "Wählen Sie einen Anbieter aus, bevor Sie {{toolName}} starten",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Bitte wählen Sie zuerst einen Anbieter und ein Modell aus",
     "select_tool_to_start": "Wählen Sie links ein CLI-Tool aus, um mit der Konfiguration zu beginnen",
     "set_custom_path": "Benutzerdefinierten Terminalpfad festlegen",
-    "stop": "[to be translated]:Stop",
+    "stop": "Stoppen",
     "supported_providers": "Unterstützte Anbieter",
     "terminal": "Terminal",
     "terminal_hint": "Wählen Sie, in welchem Terminal die CLI ausgeführt werden soll",
@@ -3550,7 +3550,7 @@
             "label": "Laufzeitmodus",
             "option": {
               "claude_code": "Erweitert: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Schnell: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Visualisierung"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Diagramm",
+    "chart_unsupported": "Dieser Diagrammtyp wird noch nicht unterstützt",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Für diese Tabelle konnte keine Vorschau angezeigt werden."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Die Formel konnte nicht ausgewertet werden",
+    "sheet_tabs_label": "Tabellenblätter",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "Die Dateigröße {{size}} überschreitet das Vorschaulimit von {{limit}}.",
+      "title": "Datei zu groß für die Vorschau"
     }
   }
 }

--- a/src/renderer/i18n/translate/el-gr.json
+++ b/src/renderer/i18n/translate/el-gr.json
@@ -1089,8 +1089,8 @@
           "label": "Εκτέλεση εντολών shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Δημιουργία στόχου συνεδρίας προς επίτευξη",
+          "label": "Δημιουργία στόχου"
         },
         "edit": {
           "description": "Επεξεργασία αρχείων",
@@ -1101,8 +1101,8 @@
           "label": "Εύρεση αρχείων"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Ανάγνωση του τρέχοντος στόχου συνεδρίας",
+          "label": "Ανάγνωση στόχου"
         },
         "grep": {
           "description": "Αναζήτηση περιεχομένου αρχείων",
@@ -1121,16 +1121,16 @@
           "label": "Ανάγνωση εικόνας"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Φόρτωση των πλήρων οδηγιών μιας ενεργοποιημένης δεξιότητας",
+          "label": "Φόρτωση οδηγιών δεξιότητας"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Διαχείριση λίστας εργασιών",
+          "label": "Διαχείριση λίστας εργασιών"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Ενημέρωση της κατάστασης ή του περιεχομένου του στόχου συνεδρίας",
+          "label": "Ενημέρωση στόχου"
         },
         "write": {
           "description": "Εγγραφή αρχείων",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Επιλέξτε το CLI εργαλείο που θέλετε να χρησιμοποιήσετε",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Αυτό το τερματικό απαιτεί τη ρύθμιση προσαρμοσμένης διαδρομής",
     "custom_path_set": "Η προσαρμοσμένη διαδρομή τερματικού ορίστηκε με επιτυχία",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Προεπιλεγμένη λειτουργία agent",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Συνδυάζει εργασία εργαλείων πολλών βημάτων μέσω του PTC Code Mode SDK για σύνθετες εργασίες προγραμματισμού.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Διατηρεί την υπάρχουσα προεπιλογή στις κοινόχρηστες ρυθμίσεις ~/.dsh.",
+          "label": "Προεπιλογή Harness"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Χρησιμοποιεί μόνο ένα μόνιμο shell και έναν επεξεργαστή κειμένου για το μικρότερο δυνατό σύνολο εργαλείων.",
+          "label": "Ελάχιστο"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Πλήρης agent προγραμματισμού με αρχεία, shell, αναζήτηση, δεξιότητες, σχεδιασμό και υπο-agent.",
+          "label": "Τυπικό"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "Η πλήρης πρόσβαση επιτρέπει στον agent να προσπελάζει αρχεία εκτός του χώρου εργασίας και παρακάμπτει την έγκριση ενεργειών. Χρησιμοποιήστε την μόνο για εργασίες που εμπιστεύεστε.",
+      "permission_mode": "Προεπιλεγμένη άδεια",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Επιτρέπει απεριόριστη πρόσβαση χωρίς έγκριση ενεργειών.",
+          "label": "Πλήρης πρόσβαση"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Περιορίζει την εγγραφή αρχείων και ζητά επιβεβαίωση πριν από επικίνδυνες ενέργειες.",
+          "label": "Μόνο για ανάγνωση"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Επιτρέπει εγγραφή στον τρέχοντα χώρο εργασίας DSH και ζητά επιβεβαίωση πριν από επικίνδυνες ενέργειες.",
+          "label": "Εγγραφή στον χώρο εργασίας"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Δεν υπάρχουν διαθέσιμα εργαλεία",
     "not_installed": "Δεν είναι εγκατεστημένο",
     "open_provider_settings": "Άνοιγμα ρυθμίσεων παρόχου",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Άνοιγμα Web UI",
     "own_login": {
       "title": "{{toolName}} Επίσημο"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Αναζήτηση παρόχων…",
     "select_folder": "Επιλογή φακέλου",
     "select_provider_before_launch": "Επιλέξτε έναν πάροχο πριν εκκινήσετε το {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Επιλέξτε πρώτα έναν πάροχο και ένα μοντέλο",
     "select_tool_to_start": "Επιλέξτε ένα εργαλείο CLI από τα αριστερά για να ξεκινήσετε τη διαμόρφωση",
     "set_custom_path": "Ρύθμιση προσαρμοσμένης διαδρομής τερματικού",
-    "stop": "[to be translated]:Stop",
+    "stop": "Διακοπή",
     "supported_providers": "υποστηριζόμενοι πάροχοι",
     "terminal": "τερματικό",
     "terminal_hint": "Επιλέξτε σε ποιο τερματικό θα εκτελέσετε τη γραμμή εντολών",
@@ -3550,7 +3550,7 @@
             "label": "Λειτουργία εκτέλεσης",
             "option": {
               "claude_code": "Προηγμένο: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Γρήγορο: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "προβολή"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Γράφημα",
+    "chart_unsupported": "Αυτός ο τύπος γραφήματος δεν υποστηρίζεται ακόμη",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Δεν ήταν δυνατή η προεπισκόπηση αυτού του υπολογιστικού φύλλου."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Δεν ήταν δυνατή η αξιολόγηση του τύπου",
+    "sheet_tabs_label": "Φύλλα",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "Το μέγεθος αρχείου {{size}} υπερβαίνει το όριο προεπισκόπησης {{limit}}.",
+      "title": "Το αρχείο είναι πολύ μεγάλο για προεπισκόπηση"
     }
   }
 }

--- a/src/renderer/i18n/translate/es-es.json
+++ b/src/renderer/i18n/translate/es-es.json
@@ -1089,8 +1089,8 @@
           "label": "Ejecutar comandos de shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Crear un objetivo de sesión en el que trabajar",
+          "label": "Crear objetivo"
         },
         "edit": {
           "description": "Editar archivos",
@@ -1101,8 +1101,8 @@
           "label": "Buscar archivos"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Leer el objetivo de la sesión actual",
+          "label": "Leer objetivo"
         },
         "grep": {
           "description": "Buscar contenido en archivos",
@@ -1121,16 +1121,16 @@
           "label": "Leer imagen"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Cargar las instrucciones completas de una habilidad habilitada",
+          "label": "Cargar instrucciones de la habilidad"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Gestionar la lista de tareas",
+          "label": "Gestionar la lista de tareas"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Actualizar el estado o el contenido del objetivo de la sesión",
+          "label": "Actualizar objetivo"
         },
         "write": {
           "description": "Escribir archivos",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Seleccione la herramienta de línea de comandos que desea utilizar",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "CLI de Gemini",
       "github_copilot_cli": "CLI de GitHub Copilot",
       "kimi_code": "Código Kimi",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Este terminal necesita una ruta personalizada",
     "custom_path_set": "Configuración de ruta de terminal personalizada exitosa",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Modo de agente predeterminado",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Combina el trabajo de herramientas en varios pasos mediante el SDK PTC Code Mode para tareas de programación complejas.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Conserva el preajuste predeterminado existente en la configuración compartida de ~/.dsh.",
+          "label": "Predeterminado de Harness"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Usa únicamente un shell persistente y un editor de texto para ofrecer el conjunto de herramientas más reducido.",
+          "label": "Mínimo"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Agente de programación completo con archivos, shell, búsqueda, habilidades, planificación y subagentes.",
+          "label": "Estándar"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "El acceso total permite al agente acceder a archivos fuera del espacio de trabajo y omite la aprobación de operaciones. Úsalo solo para tareas de confianza.",
+      "permission_mode": "Permiso predeterminado",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Permite acceso sin restricciones y sin aprobación de operaciones.",
+          "label": "Acceso total"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Restringe la escritura de archivos y solicita confirmación antes de operaciones arriesgadas.",
+          "label": "Solo lectura"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Permite escribir en el espacio de trabajo DSH actual y solicita confirmación antes de operaciones arriesgadas.",
+          "label": "Escritura en el espacio de trabajo"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "No hay herramientas disponibles",
     "not_installed": "No instalado",
     "open_provider_settings": "Configuración del proveedor abierto",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Abrir la interfaz web",
     "own_login": {
       "title": "{{toolName}} Oficial"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Proveedores de búsqueda…",
     "select_folder": "Seleccionar carpeta",
     "select_provider_before_launch": "Seleccione un proveedor antes de lanzar {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Selecciona primero un proveedor y un modelo",
     "select_tool_to_start": "Seleccione una herramienta CLI de la izquierda para comenzar la configuración",
     "set_custom_path": "Establecer ruta de terminal personalizada",
-    "stop": "[to be translated]:Stop",
+    "stop": "Detener",
     "supported_providers": "Proveedores de servicios compatibles",
     "terminal": "terminal",
     "terminal_hint": "Elige qué aplicación de terminal utilizar para ejecutar la CLI",
@@ -3550,7 +3550,7 @@
             "label": "Modo de ejecución",
             "option": {
               "claude_code": "Avanzado: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Rápido: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Visualización"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Gráfico",
+    "chart_unsupported": "Este tipo de gráfico todavía no es compatible",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "No se pudo previsualizar esta hoja de cálculo."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "No se pudo evaluar la fórmula",
+    "sheet_tabs_label": "Hojas",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "El tamaño del archivo {{size}} supera el límite de vista previa de {{limit}}.",
+      "title": "El archivo es demasiado grande para previsualizarlo"
     }
   }
 }

--- a/src/renderer/i18n/translate/fr-fr.json
+++ b/src/renderer/i18n/translate/fr-fr.json
@@ -1089,8 +1089,8 @@
           "label": "Exécuter des commandes shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Créer un objectif de session à atteindre",
+          "label": "Créer un objectif"
         },
         "edit": {
           "description": "Modifier des fichiers",
@@ -1101,8 +1101,8 @@
           "label": "Trouver des fichiers"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Lire l’objectif de la session en cours",
+          "label": "Lire l’objectif"
         },
         "grep": {
           "description": "Rechercher dans le contenu des fichiers",
@@ -1121,16 +1121,16 @@
           "label": "Lire une image"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Charger les instructions complètes d’une compétence activée",
+          "label": "Charger les instructions de la compétence"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Gérer la liste des tâches",
+          "label": "Gérer la liste des tâches"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Mettre à jour l’état ou le contenu de l’objectif de session",
+          "label": "Mettre à jour l’objectif"
         },
         "write": {
           "description": "Écrire des fichiers",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Sélectionnez l'outil CLI à utiliser",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "CLI GitHub Copilot",
       "kimi_code": "Code Kimi",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Ce terminal nécessite la configuration d’un chemin personnalisé",
     "custom_path_set": "Paramétrage personnalisé du chemin du terminal réussi",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Mode d’agent par défaut",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Combine des opérations d’outils en plusieurs étapes via le SDK PTC Code Mode pour les tâches de programmation complexes.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Conserve le préréglage par défaut existant dans les paramètres ~/.dsh partagés.",
+          "label": "Harness par défaut"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "N’utilise qu’un shell persistant et un éditeur de texte afin de limiter au maximum les outils disponibles.",
+          "label": "Minimal"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Agent de programmation complet avec fichiers, shell, recherche, compétences, planification et sous-agents.",
+          "label": "Standard"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "L’accès complet permet à l’agent d’accéder aux fichiers en dehors de l’espace de travail et ignore l’approbation des opérations. Utilisez-le uniquement pour des tâches fiables.",
+      "permission_mode": "Autorisation par défaut",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Autorise un accès sans restriction et sans approbation des opérations.",
+          "label": "Accès complet"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Restreint l’écriture de fichiers et demande confirmation avant les opérations risquées.",
+          "label": "Lecture seule"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Autorise l’écriture dans l’espace de travail DSH actuel et demande confirmation avant les opérations risquées.",
+          "label": "Écriture dans l’espace de travail"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Aucun outil disponible",
     "not_installed": "Non installé",
     "open_provider_settings": "Ouvrir les paramètres du fournisseur",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Ouvrir l’interface Web",
     "own_login": {
       "title": "{{toolName}} Officiel"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Rechercher des fournisseurs…",
     "select_folder": "Sélectionner le dossier",
     "select_provider_before_launch": "Sélectionnez un fournisseur avant de lancer {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Veuillez d’abord sélectionner un fournisseur et un modèle",
     "select_tool_to_start": "Sélectionnez un outil CLI à gauche pour commencer la configuration",
     "set_custom_path": "Définir un chemin de terminal personnalisé",
-    "stop": "[to be translated]:Stop",
+    "stop": "Arrêter",
     "supported_providers": "fournisseurs pris en charge",
     "terminal": "Terminal",
     "terminal_hint": "Choisissez l'application de terminal dans laquelle exécuter le CLI",
@@ -3550,7 +3550,7 @@
             "label": "Mode d’exécution",
             "option": {
               "claude_code": "Avancé : Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Rapide : Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Visualisation"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Graphique",
+    "chart_unsupported": "Ce type de graphique n’est pas encore pris en charge",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Impossible d’afficher un aperçu de cette feuille de calcul."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Impossible d’évaluer la formule",
+    "sheet_tabs_label": "Feuilles",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "La taille du fichier {{size}} dépasse la limite d’aperçu de {{limit}}.",
+      "title": "Fichier trop volumineux pour être prévisualisé"
     }
   }
 }

--- a/src/renderer/i18n/translate/ja-jp.json
+++ b/src/renderer/i18n/translate/ja-jp.json
@@ -1089,8 +1089,8 @@
           "label": "シェルコマンドを実行"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "達成するセッション目標を作成",
+          "label": "目標を作成"
         },
         "edit": {
           "description": "ファイルを編集",
@@ -1101,8 +1101,8 @@
           "label": "ファイルを検索"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "現在のセッション目標を読み取る",
+          "label": "目標を読み取る"
         },
         "grep": {
           "description": "ファイル内容を検索",
@@ -1121,16 +1121,16 @@
           "label": "画像を読み取る"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "有効なスキルの完全な手順を読み込む",
+          "label": "スキルの手順を読み込む"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "タスクリストを管理",
+          "label": "タスクリストを管理"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "セッション目標の状態または内容を更新",
+          "label": "目標を更新"
         },
         "write": {
           "description": "ファイルを書き込む",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "使用する CLI ツールを選択してください",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "この端末にはカスタムパスを設定する必要があります",
     "custom_path_set": "カスタムターミナルパスの設定が成功しました",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "デフォルトのエージェントモード",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "PTC Code Mode SDK を介して複数ステップのツール操作を組み合わせ、複雑なコーディングタスクに対応します。",
+          "label": "PTC コード"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "共有の ~/.dsh 設定にある既存のデフォルトプリセットを維持します。",
+          "label": "Harness のデフォルト"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "ツール構成を最小限にするため、永続シェルとテキストエディターのみを使用します。",
+          "label": "最小"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "ファイル、シェル、検索、スキル、計画、サブエージェントを備えた完全なコーディングエージェントです。",
+          "label": "標準"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "フルアクセスでは、エージェントがワークスペース外のファイルにアクセスでき、操作の承認が省略されます。信頼できるタスクにのみ使用してください。",
+      "permission_mode": "デフォルトの権限",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "操作の承認なしで無制限のアクセスを許可します。",
+          "label": "フルアクセス"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "ファイルへの書き込みを制限し、危険な操作の前に確認を求めます。",
+          "label": "読み取り専用"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "現在の DSH ワークスペースへの書き込みを許可し、危険な操作の前に確認を求めます。",
+          "label": "ワークスペースへの書き込み"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "ツールは利用できません",
     "not_installed": "インストールされていません",
     "open_provider_settings": "プロバイダー設定を開く",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Web UI を開く",
     "own_login": {
       "title": "{{toolName}} 公式"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "検索プロバイダー…",
     "select_folder": "フォルダーを選択",
     "select_provider_before_launch": "{{toolName}}を起動する前にプロバイダーを選択してください",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "最初にプロバイダーとモデルを選択してください",
     "select_tool_to_start": "左側から設定を開始するCLIツールを選択してください",
     "set_custom_path": "カスタムターミナルパスを設定",
-    "stop": "[to be translated]:Stop",
+    "stop": "停止",
     "supported_providers": "サポートされているプロバイダー",
     "terminal": "端末",
     "terminal_hint": "CLIを実行するターミナルアプリケーションを選択してください",
@@ -3550,7 +3550,7 @@
             "label": "実行モード",
             "option": {
               "claude_code": "高度：Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "高速：Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "可視化"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "グラフ",
+    "chart_unsupported": "このグラフ形式はまだサポートされていません",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "このスプレッドシートをプレビューできませんでした。"
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "数式を評価できませんでした",
+    "sheet_tabs_label": "シート",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "ファイルサイズ {{size}} はプレビュー上限の {{limit}} を超えています。",
+      "title": "ファイルが大きすぎてプレビューできません"
     }
   }
 }

--- a/src/renderer/i18n/translate/pt-pt.json
+++ b/src/renderer/i18n/translate/pt-pt.json
@@ -1089,8 +1089,8 @@
           "label": "Executar comandos do terminal"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Criar um objetivo de sessão a alcançar",
+          "label": "Criar objetivo"
         },
         "edit": {
           "description": "Editar ficheiros",
@@ -1101,8 +1101,8 @@
           "label": "Procurar ficheiros"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Ler o objetivo atual da sessão",
+          "label": "Ler objetivo"
         },
         "grep": {
           "description": "Pesquisar conteúdos de ficheiros",
@@ -1121,16 +1121,16 @@
           "label": "Ler imagem"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Carregar as instruções completas de uma competência ativada",
+          "label": "Carregar instruções da competência"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Gerir a lista de tarefas",
+          "label": "Gerir a lista de tarefas"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Atualizar o estado ou o conteúdo do objetivo da sessão",
+          "label": "Atualizar objetivo"
         },
         "write": {
           "description": "Escrever ficheiros",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Selecione a ferramenta de linha de comando a ser utilizada",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "CLI do Gemini",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Este terminal requer a definição de um caminho personalizado",
     "custom_path_set": "Configuração personalizada do caminho do terminal bem-sucedida",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Modo de agente predefinido",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Combina trabalho de ferramentas em vários passos através do SDK PTC Code Mode para tarefas de programação complexas.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Mantém a predefinição existente nas definições partilhadas de ~/.dsh.",
+          "label": "Predefinição do Harness"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Utiliza apenas uma shell persistente e um editor de texto para disponibilizar o conjunto mínimo de ferramentas.",
+          "label": "Mínimo"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Agente de programação completo com ficheiros, shell, pesquisa, competências, planeamento e subagentes.",
+          "label": "Padrão"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "O acesso total permite ao agente aceder a ficheiros fora do espaço de trabalho e ignora a aprovação de operações. Utilize-o apenas para tarefas em que confia.",
+      "permission_mode": "Permissão predefinida",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Permite acesso sem restrições e sem aprovação de operações.",
+          "label": "Acesso total"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Restringe a escrita de ficheiros e pede confirmação antes de operações de risco.",
+          "label": "Apenas leitura"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Permite a escrita no espaço de trabalho DSH atual e pede confirmação antes de operações de risco.",
+          "label": "Escrita no espaço de trabalho"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Nenhuma ferramenta disponível",
     "not_installed": "Não instalado",
     "open_provider_settings": "Abrir configurações do fornecedor",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Abrir a interface Web",
     "own_login": {
       "title": "{{toolName}} Oficial"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Fornecedores de pesquisa…",
     "select_folder": "Selecionar pasta",
     "select_provider_before_launch": "Selecione um fornecedor antes de iniciar {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Selecione primeiro um fornecedor e um modelo",
     "select_tool_to_start": "Selecione uma ferramenta de CLI à esquerda para começar a configurar",
     "set_custom_path": "Definir caminho personalizado do terminal",
-    "stop": "[to be translated]:Stop",
+    "stop": "Parar",
     "supported_providers": "Fornecedores de serviço suportados",
     "terminal": "terminal",
     "terminal_hint": "Escolha em qual aplicação de terminal executar a CLI",
@@ -3550,7 +3550,7 @@
             "label": "Modo de execução",
             "option": {
               "claude_code": "Avançado: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Rápido: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Visualização"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Gráfico",
+    "chart_unsupported": "Este tipo de gráfico ainda não é suportado",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Não foi possível pré-visualizar esta folha de cálculo."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Não foi possível avaliar a fórmula",
+    "sheet_tabs_label": "Folhas",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "O tamanho do ficheiro {{size}} excede o limite de pré-visualização de {{limit}}.",
+      "title": "Ficheiro demasiado grande para pré-visualizar"
     }
   }
 }

--- a/src/renderer/i18n/translate/ro-ro.json
+++ b/src/renderer/i18n/translate/ro-ro.json
@@ -1089,8 +1089,8 @@
           "label": "Rulează comenzi shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Creează un obiectiv de sesiune de urmărit",
+          "label": "Creează obiectiv"
         },
         "edit": {
           "description": "Editează fișiere",
@@ -1101,8 +1101,8 @@
           "label": "Găsește fișiere"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Citește obiectivul sesiunii curente",
+          "label": "Citește obiectivul"
         },
         "grep": {
           "description": "Caută în conținutul fișierelor",
@@ -1121,16 +1121,16 @@
           "label": "Citește imaginea"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Încarcă instrucțiunile complete ale unei abilități activate",
+          "label": "Încarcă instrucțiunile abilității"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Gestionează lista de sarcini",
+          "label": "Gestionează lista de sarcini"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Actualizează starea sau conținutul obiectivului sesiunii",
+          "label": "Actualizează obiectivul"
         },
         "write": {
           "description": "Scrie fișiere",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Selectează instrumentul CLI de utilizat",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "CLI Gemini",
       "github_copilot_cli": "CLI GitHub Copilot",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Calea personalizată este necesară pentru acest terminal",
     "custom_path_set": "Calea personalizată a terminalului a fost setată cu succes",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Mod implicit pentru agent",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Combină lucrul cu instrumente în mai mulți pași prin SDK-ul PTC Code Mode pentru sarcini complexe de programare.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Păstrează presetarea implicită existentă în setările comune ~/.dsh.",
+          "label": "Setarea implicită Harness"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Folosește doar un shell persistent și un editor de text pentru cel mai restrâns set de instrumente.",
+          "label": "Minimal"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Agent de programare complet, cu fișiere, shell, căutare, abilități, planificare și subagenți.",
+          "label": "Standard"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "Accesul complet permite agentului să acceseze fișiere din afara spațiului de lucru și omite aprobarea operațiunilor. Folosește-l numai pentru sarcini de încredere.",
+      "permission_mode": "Permisiune implicită",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Permite acces nerestricționat fără aprobarea operațiunilor.",
+          "label": "Acces complet"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Restricționează scrierea fișierelor și solicită confirmare înaintea operațiunilor riscante.",
+          "label": "Doar citire"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Permite scrierea în spațiul de lucru DSH curent și solicită confirmare înaintea operațiunilor riscante.",
+          "label": "Scriere în spațiul de lucru"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Nu există instrumente disponibile",
     "not_installed": "Neinstalat",
     "open_provider_settings": "Deschide setările furnizorului",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Deschide interfața web",
     "own_login": {
       "title": "{{toolName}} Oficial"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Furnizori de căutare…",
     "select_folder": "Selectează directorul",
     "select_provider_before_launch": "Selectează un furnizor înainte de a porni {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Selectează mai întâi un furnizor și un model",
     "select_tool_to_start": "Selectează un instrument CLI din stânga pentru a începe configurarea",
     "set_custom_path": "Setează calea personalizată a terminalului",
-    "stop": "[to be translated]:Stop",
+    "stop": "Oprește",
     "supported_providers": "Furnizori acceptați",
     "terminal": "Terminal",
     "terminal_hint": "Alege în ce aplicație terminal să rulezi CLI-ul",
@@ -3550,7 +3550,7 @@
             "label": "Mod de rulare",
             "option": {
               "claude_code": "Avansat: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Rapid: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Vizualizare"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Diagramă",
+    "chart_unsupported": "Acest tip de diagramă nu este încă acceptat",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Această foaie de calcul nu a putut fi previzualizată."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Formula nu a putut fi evaluată",
+    "sheet_tabs_label": "Foi",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "Dimensiunea fișierului {{size}} depășește limita de previzualizare de {{limit}}.",
+      "title": "Fișier prea mare pentru previzualizare"
     }
   }
 }

--- a/src/renderer/i18n/translate/ru-ru.json
+++ b/src/renderer/i18n/translate/ru-ru.json
@@ -1089,8 +1089,8 @@
           "label": "Выполнять команды shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Создать цель для работы в рамках сеанса",
+          "label": "Создать цель"
         },
         "edit": {
           "description": "Редактировать файлы",
@@ -1101,8 +1101,8 @@
           "label": "Искать файлы"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Прочитать цель текущего сеанса",
+          "label": "Прочитать цель"
         },
         "grep": {
           "description": "Искать содержимое файлов",
@@ -1121,16 +1121,16 @@
           "label": "Прочитать изображение"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Загрузить полные инструкции включённого навыка",
+          "label": "Загрузить инструкции навыка"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Управлять списком задач",
+          "label": "Управлять списком задач"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Обновить состояние или содержание цели сеанса",
+          "label": "Обновить цель"
         },
         "write": {
           "description": "Записывать файлы",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Выберите CLI-инструмент для использования",
     "cli_tools": {
       "claude_code": "Клод Код",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Этот терминал требует установки пользовательского пути",
     "custom_path_set": "Пользовательский путь терминала успешно установлен",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Режим агента по умолчанию",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Объединяет многоэтапную работу с инструментами через SDK PTC Code Mode для сложных задач программирования.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Сохраняет существующий набор параметров по умолчанию в общих настройках ~/.dsh.",
+          "label": "Настройки Harness по умолчанию"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Использует только постоянную оболочку и текстовый редактор, чтобы свести набор инструментов к минимуму.",
+          "label": "Минимальный"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Полнофункциональный агент программирования с файлами, оболочкой, поиском, навыками, планированием и субагентами.",
+          "label": "Стандартный"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "Полный доступ позволяет агенту обращаться к файлам за пределами рабочей области и пропускает подтверждение операций. Используйте его только для задач, которым доверяете.",
+      "permission_mode": "Разрешение по умолчанию",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Предоставляет неограниченный доступ без подтверждения операций.",
+          "label": "Полный доступ"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Запрещает запись в файлы и запрашивает подтверждение перед рискованными операциями.",
+          "label": "Только чтение"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Разрешает запись в текущую рабочую область DSH и запрашивает подтверждение перед рискованными операциями.",
+          "label": "Запись в рабочую область"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Нет доступных инструментов",
     "not_installed": "Не установлено",
     "open_provider_settings": "Открыть настройки провайдера",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Открыть веб-интерфейс",
     "own_login": {
       "title": "Официальный вход {{toolName}}"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Поиск провайдеров…",
     "select_folder": "Выберите папку",
     "select_provider_before_launch": "Выберите провайдер перед запуском {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Сначала выберите провайдера и модель",
     "select_tool_to_start": "Выберите инструмент CLI слева, чтобы начать настройку",
     "set_custom_path": "Настройка пользовательского пути терминала",
-    "stop": "[to be translated]:Stop",
+    "stop": "Остановить",
     "supported_providers": "Поддерживаемые провайдеры",
     "terminal": "терминал",
     "terminal_hint": "Выберите, в каком терминале запускать интерфейс командной строки",
@@ -3550,7 +3550,7 @@
             "label": "Режим выполнения",
             "option": {
               "claude_code": "Расширенный: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Быстрый: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Визуализация"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Диаграмма",
+    "chart_unsupported": "Этот тип диаграммы пока не поддерживается",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Не удалось открыть предварительный просмотр этой таблицы."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Не удалось вычислить формулу",
+    "sheet_tabs_label": "Листы",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "Размер файла {{size}} превышает ограничение предварительного просмотра {{limit}}.",
+      "title": "Файл слишком велик для предварительного просмотра"
     }
   }
 }

--- a/src/renderer/i18n/translate/vi-vn.json
+++ b/src/renderer/i18n/translate/vi-vn.json
@@ -1089,8 +1089,8 @@
           "label": "Chạy lệnh shell"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "Tạo mục tiêu cần đạt được trong phiên",
+          "label": "Tạo mục tiêu"
         },
         "edit": {
           "description": "Sửa tập tin",
@@ -1101,8 +1101,8 @@
           "label": "Tìm tập tin"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "Đọc mục tiêu của phiên hiện tại",
+          "label": "Đọc mục tiêu"
         },
         "grep": {
           "description": "Tìm kiếm nội dung tập tin",
@@ -1121,16 +1121,16 @@
           "label": "Đọc hình ảnh"
         },
         "skill": {
-          "description": "[to be translated]:Load the full instructions of an enabled skill",
-          "label": "[to be translated]:Load skill instructions"
+          "description": "Tải hướng dẫn đầy đủ của một kỹ năng đã bật",
+          "label": "Tải hướng dẫn kỹ năng"
         },
         "todo_write": {
-          "description": "[to be translated]:Manage the task list",
-          "label": "[to be translated]:Manage the task list"
+          "description": "Quản lý danh sách tác vụ",
+          "label": "Quản lý danh sách tác vụ"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "Cập nhật trạng thái hoặc nội dung của mục tiêu phiên",
+          "label": "Cập nhật mục tiêu"
         },
         "write": {
           "description": "Ghi tập tin",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "Chọn công cụ CLI để sử dụng",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Mã Kimi",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "Terminal này yêu cầu đường dẫn tùy chỉnh",
     "custom_path_set": "Đường dẫn terminal tùy chỉnh đã được đặt thành công",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "Chế độ tác nhân mặc định",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "Kết hợp công việc công cụ nhiều bước thông qua SDK PTC Code Mode cho các tác vụ lập trình phức tạp.",
+          "label": "PTC Code"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "Giữ nguyên cấu hình đặt trước mặc định hiện có trong phần cài đặt ~/.dsh dùng chung.",
+          "label": "Mặc định của Harness"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "Chỉ sử dụng shell duy trì liên tục và trình soạn thảo văn bản để có phạm vi công cụ nhỏ nhất.",
+          "label": "Tối giản"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "Tác nhân lập trình đầy đủ với tệp, shell, tìm kiếm, kỹ năng, lập kế hoạch và tác nhân phụ.",
+          "label": "Tiêu chuẩn"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "Toàn quyền truy cập cho phép tác nhân truy cập các tệp bên ngoài không gian làm việc và bỏ qua bước phê duyệt thao tác. Chỉ sử dụng cho những tác vụ bạn tin tưởng.",
+      "permission_mode": "Quyền mặc định",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "Cho phép truy cập không hạn chế mà không cần phê duyệt thao tác.",
+          "label": "Toàn quyền truy cập"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "Hạn chế ghi tệp và yêu cầu xác nhận trước các thao tác rủi ro.",
+          "label": "Chỉ đọc"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "Cho phép ghi trong không gian làm việc DSH hiện tại và yêu cầu xác nhận trước các thao tác rủi ro.",
+          "label": "Ghi trong không gian làm việc"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "Không có công cụ nào khả dụng",
     "not_installed": "Chưa cài đặt",
     "open_provider_settings": "Mở cài đặt nhà cung cấp",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "Mở giao diện web",
     "own_login": {
       "title": "{{toolName}} Chính thức"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "Tìm kiếm nhà cung cấp…",
     "select_folder": "Chọn thư mục",
     "select_provider_before_launch": "Chọn một nhà cung cấp trước khi khởi chạy {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "Vui lòng chọn nhà cung cấp và mô hình trước",
     "select_tool_to_start": "Chọn một công cụ CLI từ bên trái để bắt đầu cấu hình",
     "set_custom_path": "Đặt đường dẫn terminal tùy chỉnh",
-    "stop": "[to be translated]:Stop",
+    "stop": "Dừng",
     "supported_providers": "Nhà cung cấp được hỗ trợ",
     "terminal": "Thiết bị đầu cuối",
     "terminal_hint": "Chọn ứng dụng terminal để chạy CLI",
@@ -3550,7 +3550,7 @@
             "label": "Chế độ chạy",
             "option": {
               "claude_code": "Nâng cao: Claude Agent",
-              "dsh": "[to be translated]:DeepSeek Harness",
+              "dsh": "DeepSeek Harness",
               "pi": "Nhanh: Pi"
             }
           },
@@ -9040,16 +9040,16 @@
     "visualization": "Trực quan hóa"
   },
   "xlsx_preview": {
-    "chart": "[to be translated]:Chart",
-    "chart_unsupported": "[to be translated]:This chart type isn't supported yet",
+    "chart": "Biểu đồ",
+    "chart_unsupported": "Loại biểu đồ này chưa được hỗ trợ",
     "error": {
-      "description": "[to be translated]:This spreadsheet couldn't be previewed."
+      "description": "Không thể xem trước bảng tính này."
     },
-    "formula_not_evaluated": "[to be translated]:Formula couldn't be evaluated",
-    "sheet_tabs_label": "[to be translated]:Sheets",
+    "formula_not_evaluated": "Không thể tính giá trị công thức",
+    "sheet_tabs_label": "Trang tính",
     "too_large": {
-      "description": "[to be translated]:File size {{size}} exceeds the {{limit}} preview limit.",
-      "title": "[to be translated]:File too large to preview"
+      "description": "Kích thước tệp {{size}} vượt quá giới hạn xem trước {{limit}}.",
+      "title": "Tệp quá lớn để xem trước"
     }
   }
 }

--- a/src/renderer/i18n/translate/zh-tw.json
+++ b/src/renderer/i18n/translate/zh-tw.json
@@ -1089,8 +1089,8 @@
           "label": "執行 Shell 命令"
         },
         "create_goal": {
-          "description": "[to be translated]:Create a session goal to work toward",
-          "label": "[to be translated]:Create goal"
+          "description": "建立要達成的工作階段目標",
+          "label": "建立目標"
         },
         "edit": {
           "description": "編輯檔案",
@@ -1101,8 +1101,8 @@
           "label": "尋找檔案"
         },
         "get_goal": {
-          "description": "[to be translated]:Read the current session goal",
-          "label": "[to be translated]:Read goal"
+          "description": "讀取目前的工作階段目標",
+          "label": "讀取目標"
         },
         "grep": {
           "description": "搜尋檔案內容",
@@ -1129,8 +1129,8 @@
           "label": "管理任務清單"
         },
         "update_goal": {
-          "description": "[to be translated]:Update the session goal status or objective",
-          "label": "[to be translated]:Update goal"
+          "description": "更新工作階段目標的狀態或內容",
+          "label": "更新目標"
         },
         "write": {
           "description": "寫入檔案",
@@ -2227,7 +2227,7 @@
     "cli_tool_placeholder": "選擇要使用的 CLI 工具",
     "cli_tools": {
       "claude_code": "Claude Code",
-      "deepseek_harness": "[to be translated]:DeepSeek Harness",
+      "deepseek_harness": "DeepSeek Harness",
       "gemini_cli": "Gemini CLI",
       "github_copilot_cli": "GitHub Copilot CLI",
       "kimi_code": "Kimi Code",
@@ -2251,39 +2251,39 @@
     "custom_path_required": "此終端機需要設定自訂路徑",
     "custom_path_set": "自訂終端機路徑設定成功",
     "deepseek_harness": {
-      "agent_preset": "[to be translated]:Default agent mode",
+      "agent_preset": "預設智能體模式",
       "agent_presets": {
         "code": {
-          "description": "[to be translated]:Combines multi-step tool work through the PTC Code Mode SDK for complex coding tasks.",
-          "label": "[to be translated]:PTC Code"
+          "description": "透過 PTC Code Mode SDK 組合多步驟工具操作，適用於複雜的程式設計任務。",
+          "label": "PTC 程式碼"
         },
         "inherit": {
-          "description": "[to be translated]:Keeps the existing default preset in the shared ~/.dsh settings.",
-          "label": "[to be translated]:Harness default"
+          "description": "保留共用 ~/.dsh 設定中現有的預設設定。",
+          "label": "Harness 預設"
         },
         "minimal": {
-          "description": "[to be translated]:Uses only a persistent shell and text editor for the smallest tool surface.",
-          "label": "[to be translated]:Minimal"
+          "description": "僅使用持續性 Shell 和文字編輯器，以維持最精簡的工具範圍。",
+          "label": "極簡"
         },
         "standard": {
-          "description": "[to be translated]:Full coding agent with files, shell, search, skills, planning, and subagents.",
-          "label": "[to be translated]:Standard"
+          "description": "完整的程式設計智能體，包含檔案、Shell、搜尋、技能、規劃和子智能體。",
+          "label": "標準"
         }
       },
-      "danger_warning": "[to be translated]:Full access lets the agent reach files outside the workspace and skips operation approval. Use it only for tasks you trust.",
-      "permission_mode": "[to be translated]:Default permission",
+      "danger_warning": "完全存取可讓智能體存取工作區以外的檔案並略過操作核准。僅用於你信任的任務。",
+      "permission_mode": "預設權限",
       "permission_modes": {
         "danger-full-access": {
-          "description": "[to be translated]:Allows unrestricted access without operation approval.",
-          "label": "[to be translated]:Full access"
+          "description": "允許不受限制地存取，且不需核准操作。",
+          "label": "完全存取"
         },
         "read-only": {
-          "description": "[to be translated]:Restricts file writes and asks before risky operations.",
-          "label": "[to be translated]:Read only"
+          "description": "限制寫入檔案，並在執行有風險的操作前要求確認。",
+          "label": "唯讀"
         },
         "workspace-write": {
-          "description": "[to be translated]:Allows writes in the current DSH workspace and asks before risky operations.",
-          "label": "[to be translated]:Workspace write"
+          "description": "允許寫入目前的 DSH 工作區，並在執行有風險的操作前要求確認。",
+          "label": "寫入工作區"
         }
       }
     },
@@ -2337,7 +2337,7 @@
     "no_tools": "目前沒有工具",
     "not_installed": "未安裝",
     "open_provider_settings": "開啟供應商設定",
-    "open_web_ui": "[to be translated]:Open Web UI",
+    "open_web_ui": "開啟 Web UI",
     "own_login": {
       "title": "{{toolName}} 官方"
     },
@@ -2347,10 +2347,10 @@
     "search_provider_placeholder": "搜尋供應商…",
     "select_folder": "選擇資料夾",
     "select_provider_before_launch": "請選擇一個供應商後啟動 {{toolName}}",
-    "select_provider_model": "[to be translated]:Please select a provider and model first",
+    "select_provider_model": "請先選擇供應商和模型",
     "select_tool_to_start": "從左側選擇一個 CLI 工具開始設定",
     "set_custom_path": "設定自訂終端機路徑",
-    "stop": "[to be translated]:Stop",
+    "stop": "停止",
     "supported_providers": "支援的供應商",
     "terminal": "終端機",
     "terminal_hint": "選擇執行命令的終端機應用程式",


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Ten non-base locale catalogs contained 378 `[to be translated]` placeholders for Agent tools, DeepSeek Harness settings, and spreadsheet preview messages.

After this PR:

Those placeholders contain locale-specific translations while preserving product names and interpolation variables.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Placeholder-prefixed English text was visible to users of affected locales. Each value was translated in its UI context, and the change was restricted to values that still carried the placeholder marker.

The following tradeoffs were made:

Existing translated strings were left unchanged to keep the diff focused and avoid unrelated wording churn.

The following alternatives were considered:

Leaving the placeholders for a later automated translation run was rejected because the strings are already user-visible.

Links to places where the discussion took place: None

### Breaking changes

N/A

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Validation completed with `pnpm lint`, `pnpm i18n:check`, placeholder scanning, JSON parsing, and interpolation-variable comparison. Tests and `pnpm build:check` were not run because this change only updates locale JSON values.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Translate previously untranslated Agent, DeepSeek Harness, and spreadsheet preview text across supported locales.
```
