### PR TITLE
feat(web-search): add OpenAI Codex subscription web search

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/OpenAICodexProvider.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/OpenAICodexProvider.test.ts
@@ -1,0 +1,120 @@
+import type { WebSearchProvider } from '@shared/data/preference/preferenceTypes'
+import type { WebSearchExecutionConfig } from '@shared/data/types/webSearch'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  getValidAccessToken: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: mocks.fetch
+  }
+}))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    OAuthRuntimeService: {
+      getValidAccessToken: mocks.getValidAccessToken
+    }
+  })
+})
+
+import { OpenAICodexProvider } from '../api/OpenAICodexProvider'
+
+const fetchMock = mocks.fetch
+const getValidAccessTokenMock = mocks.getValidAccessToken
+
+const runtimeConfig: WebSearchExecutionConfig = {
+  maxResults: 4,
+  excludeDomains: ['example.com'],
+  compression: {
+    method: 'none',
+    cutoffLimit: 2000
+  }
+}
+
+function createProvider(): OpenAICodexProvider {
+  const provider: WebSearchProvider = {
+    id: 'openai-codex',
+    name: 'OpenAI Codex',
+    type: 'oauth',
+    apiKeys: [],
+    capabilities: [{ feature: 'searchKeywords', requiresApiHost: false, requiresApiKey: false }],
+    engines: [],
+    basicAuthUsername: '',
+    basicAuthPassword: ''
+  }
+  return new OpenAICodexProvider(provider, { resolve: vi.fn() } as never)
+}
+
+const SSE_RESPONSE = [
+  'data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Answer with [Source](https://src.example/a) cited.","annotations":[{"type":"url_citation","url":"https://src.example/a","title":"Source A","start_index":11,"end_index":40}]}]}}',
+  '',
+  'data: {"type":"response.done","response":{"output":[]}}',
+  'data: [DONE]'
+].join('\n')
+
+beforeEach(() => {
+  getValidAccessTokenMock.mockResolvedValue({ accessToken: 'codex-token', accountId: 'acct-1' })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('OpenAICodexProvider', () => {
+  it('searches via the codex responses endpoint with OAuth headers and parses results', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(SSE_RESPONSE, { status: 200, headers: { 'Content-Type': 'text/event-stream' } })
+    )
+
+    const response = await createProvider().searchKeywords('what is new', runtimeConfig)
+
+    expect(getValidAccessTokenMock).toHaveBeenCalledWith('openai-codex')
+    expect(fetchMock).toHaveBeenCalledWith('https://chatgpt.com/backend-api/codex/responses', {
+      method: 'POST',
+      body: expect.stringContaining('"tool_choice":"required"'),
+      headers: expect.objectContaining({
+        authorization: 'Bearer codex-token',
+        'chatgpt-account-id': 'acct-1',
+        'openai-beta': 'responses=experimental',
+        originator: 'cherry-studio'
+      }),
+      signal: expect.any(AbortSignal)
+    })
+
+    expect(response.providerId).toBe('openai-codex')
+    expect(response.capability).toBe('searchKeywords')
+    expect(response.inputs).toEqual(['what is new'])
+    expect(response.results).toEqual([
+      {
+        title: 'Source A',
+        content: expect.stringContaining('Answer with'),
+        url: 'https://src.example/a',
+        sourceInput: 'what is new'
+      }
+    ])
+  })
+
+  it('throws a clear error when not signed in to Codex', async () => {
+    getValidAccessTokenMock.mockResolvedValue(null)
+
+    await expect(createProvider().searchKeywords('q', runtimeConfig)).rejects.toThrow(/Not signed in to OpenAI Codex/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces HTTP errors from the codex endpoint', async () => {
+    fetchMock.mockResolvedValue(new Response('rate limited', { status: 429 }))
+
+    await expect(createProvider().searchKeywords('q', runtimeConfig)).rejects.toThrow(/HTTP 429 rate limited/)
+  })
+
+  it('throws when the stream contains no answer or sources', async () => {
+    fetchMock.mockResolvedValue(new Response('data: [DONE]', { status: 200 }))
+
+    await expect(createProvider().searchKeywords('q', runtimeConfig)).rejects.toThrow(/returned no answer or sources/)
+  })
+})

--- a/src/main/services/webSearch/providers/__tests__/factory.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/factory.test.ts
@@ -39,6 +39,7 @@ import { BochaProvider } from '../api/BochaProvider'
 import { ExaProvider } from '../api/ExaProvider'
 import { FetchProvider } from '../api/FetchProvider'
 import { JinaProvider } from '../api/JinaProvider'
+import { OpenAICodexProvider } from '../api/OpenAICodexProvider'
 import { QueritProvider } from '../api/QueritProvider'
 import { SearxngProvider } from '../api/SearxngProvider'
 import { TavilyProvider } from '../api/TavilyProvider'
@@ -74,6 +75,7 @@ describe('createWebSearchProvider', () => {
       'fetch',
       'firecrawl',
       'jina',
+      'openai-codex',
       'querit',
       'searxng',
       'tavily',
@@ -108,5 +110,8 @@ describe('createWebSearchProvider', () => {
         rotationState
       )
     ).toBeInstanceOf(JinaProvider)
+    expect(
+      createWebSearchProvider(createProvider({ id: 'openai-codex', type: 'oauth' }), rotationState)
+    ).toBeInstanceOf(OpenAICodexProvider)
   })
 })

--- a/src/main/services/webSearch/providers/__tests__/openaiCodexSearch.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/openaiCodexSearch.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCodexWebSearchBody, CODEX_WEB_SEARCH_MODEL, parseCodexWebSearchResponse } from '../api/openaiCodexSearch'
+
+const SSE_FIXTURE = [
+  'data: {"type":"response.output_item.done","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The answer starts here and cites [Example](https://example.com/article) for details.","annotations":[{"type":"url_citation","url":"https://example.com/article","title":"Example Article","start_index":30,"end_index":56}]}]}}',
+  '',
+  'data: {"type":"response.output_item.done","item":{"type":"web_search_call","id":"ws_1","action":{"sources":[{"url":"https://example.org/second","title":"Second Source"}]}}}',
+  '',
+  'data: {"type":"response.done","response":{"output":[]}}',
+  'data: [DONE]'
+].join('\n')
+
+describe('buildCodexWebSearchBody', () => {
+  it('builds a codex responses body with the terra model and required web_search tool', () => {
+    const body = buildCodexWebSearchBody('hello world', { maxResults: 4, excludeDomains: ['bad.example'] })
+
+    expect(body.model).toBe(CODEX_WEB_SEARCH_MODEL)
+    expect(body.store).toBe(false)
+    expect(body.stream).toBe(true)
+    expect(body.tool_choice).toBe('required')
+    expect(body.tools).toEqual([{ type: 'web_search', filters: { blocked_domains: ['bad.example'] } }])
+    expect(body.input).toEqual([{ role: 'user', content: [{ type: 'input_text', text: 'hello world' }] }])
+    expect(body.include).toContain('web_search_call.action.sources')
+  })
+
+  it('omits domain filters when none are excluded', () => {
+    const body = buildCodexWebSearchBody('q')
+    expect(body.tools).toEqual([{ type: 'web_search' }])
+  })
+
+  it('injects source-count and domain guidance into instructions', () => {
+    const body = buildCodexWebSearchBody('q', { maxResults: 7, excludeDomains: ['x.com'] })
+    const instructions = body.instructions as string
+    expect(instructions).toContain('Prefer around 7 distinct sources.')
+    expect(instructions).toContain('Do not use sources from: x.com.')
+  })
+})
+
+describe('parseCodexWebSearchResponse', () => {
+  it('parses an SSE stream into answer and cited results', () => {
+    const output = parseCodexWebSearchResponse(SSE_FIXTURE, 4)
+
+    expect(output.answer).toContain('The answer starts here')
+    expect(output.results).toHaveLength(2)
+    expect(output.results[0]).toEqual({
+      title: 'Example Article',
+      url: 'https://example.com/article',
+      content: expect.stringContaining('cites')
+    })
+    expect(output.results[1]).toEqual({
+      title: 'Second Source',
+      url: 'https://example.org/second',
+      content: ''
+    })
+  })
+
+  it('parses a single JSON object response', () => {
+    const json = JSON.stringify({
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: 'Plain answer.',
+              annotations: [
+                {
+                  type: 'url_citation',
+                  url: 'https://a.example/x?utm_source=openai',
+                  title: 'A',
+                  start_index: 0,
+                  end_index: 4
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+    const output = parseCodexWebSearchResponse(json, 4)
+
+    expect(output.answer).toBe('Plain answer.')
+    expect(output.results).toHaveLength(1)
+    expect(output.results[0].url).toBe('https://a.example/x')
+  })
+
+  it('deduplicates results by cleaned url and caps at maxResults', () => {
+    const dup = JSON.stringify({
+      output: [
+        {
+          type: 'message',
+          content: [
+            {
+              type: 'output_text',
+              text: 'x',
+              annotations: [
+                { type: 'url_citation', url: 'https://a.example/1?utm_source=openai', title: 'A1' },
+                { type: 'url_citation', url: 'https://a.example/1', title: 'A1 dup' },
+                { type: 'url_citation', url: 'https://b.example/2', title: 'B2' },
+                { type: 'url_citation', url: 'https://c.example/3', title: 'C3' }
+              ]
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(parseCodexWebSearchResponse(dup, 2).results).toHaveLength(2)
+    expect(parseCodexWebSearchResponse(dup, 20).results.map((r) => r.url)).toEqual([
+      'https://a.example/1',
+      'https://b.example/2',
+      'https://c.example/3'
+    ])
+  })
+
+  it('falls back to web_search_call sources when no url_citation annotations exist', () => {
+    const json = JSON.stringify({
+      output: [
+        {
+          type: 'web_search_call',
+          action: {
+            sources: [{ url: 'https://only.example', title: 'Only', caption: 'Cap' }]
+          }
+        }
+      ]
+    })
+
+    const output = parseCodexWebSearchResponse(json, 4)
+    expect(output.results).toEqual([{ title: 'Only', url: 'https://only.example', content: '' }])
+  })
+
+  it('throws on malformed JSON object payloads', () => {
+    expect(() => parseCodexWebSearchResponse('{not json', 4)).toThrow(/invalid JSON/)
+  })
+
+  it('returns empty answer and results for an empty stream', () => {
+    const output = parseCodexWebSearchResponse('data: [DONE]', 4)
+    expect(output.answer).toBe('')
+    expect(output.results).toEqual([])
+  })
+})

--- a/src/main/services/webSearch/providers/api/OpenAICodexProvider.ts
+++ b/src/main/services/webSearch/providers/api/OpenAICodexProvider.ts
@@ -1,0 +1,81 @@
+import { application } from '@application'
+import { buildCodexRequestHeaders } from '@main/ai/provider/codex'
+import { defaultAppHeaders } from '@main/utils/http'
+import { OPENAI_CODEX_PROVIDER_ID } from '@shared/data/presets/codex'
+import type { WebSearchExecutionConfig, WebSearchResponse } from '@shared/data/types/webSearch'
+import { net } from 'electron'
+
+import { BaseWebSearchProvider } from '../base/BaseWebSearchProvider'
+import {
+  buildCodexWebSearchBody,
+  CODEX_WEB_SEARCH_RESPONSES_URL,
+  parseCodexWebSearchResponse
+} from './openaiCodexSearch'
+
+const SEARCH_TIMEOUT_MS = 60_000
+
+/**
+ * Web search through the user's ChatGPT subscription (Plus/Pro): the codex
+ * responses endpoint with a server-side `web_search` tool. No API key needed —
+ * credentials come from the OpenAI Codex OAuth sign-in managed by
+ * `OAuthRuntimeService` (the same session the codex chat provider uses).
+ */
+export class OpenAICodexProvider extends BaseWebSearchProvider {
+  async searchKeywords(
+    query: string,
+    config: WebSearchExecutionConfig,
+    httpOptions?: RequestInit
+  ): Promise<WebSearchResponse> {
+    const creds = await application.get('OAuthRuntimeService').getValidAccessToken(OPENAI_CODEX_PROVIDER_ID)
+    if (!creds?.accessToken) {
+      throw new Error('Not signed in to OpenAI Codex. Open the provider settings and sign in first.')
+    }
+
+    const response = await net.fetch(CODEX_WEB_SEARCH_RESPONSES_URL, {
+      method: 'POST',
+      body: JSON.stringify(
+        buildCodexWebSearchBody(query, {
+          maxResults: config.maxResults,
+          excludeDomains: config.excludeDomains
+        })
+      ),
+      headers: {
+        ...defaultAppHeaders(),
+        'Content-Type': 'application/json',
+        ...Object.fromEntries(
+          buildCodexRequestHeaders(undefined, {
+            accessToken: creds.accessToken,
+            accountId: creds.accountId ?? null
+          }).entries()
+        )
+      },
+      signal: httpOptions?.signal
+        ? AbortSignal.any([AbortSignal.timeout(SEARCH_TIMEOUT_MS), httpOptions.signal])
+        : AbortSignal.timeout(SEARCH_TIMEOUT_MS)
+    })
+
+    if (!response.ok) {
+      await this.throwHttpError('OpenAI Codex search failed', response)
+    }
+
+    const rawText = await response.text()
+    const output = parseCodexWebSearchResponse(rawText, config.maxResults)
+
+    if (!output.answer && output.results.length === 0) {
+      throw new Error('OpenAI Codex web_search returned no answer or sources')
+    }
+
+    return {
+      query,
+      providerId: this.provider.id,
+      capability: 'searchKeywords',
+      inputs: [query],
+      results: output.results.map((result) => ({
+        title: result.title,
+        content: result.content,
+        url: result.url,
+        sourceInput: query
+      }))
+    }
+  }
+}

--- a/src/main/services/webSearch/providers/api/openaiCodexSearch.ts
+++ b/src/main/services/webSearch/providers/api/openaiCodexSearch.ts
@@ -1,0 +1,248 @@
+/**
+ * Request shaping + streaming response parsing for the OpenAI Codex web search
+ * capability — ChatGPT subscription web search via the codex responses
+ * endpoint (`chatgpt.com/backend-api/codex/responses`). Kept free of the
+ * electron/app import graph so it can be unit-tested directly.
+ */
+
+/**
+ * The model that runs the server-side `web_search` call and writes the cited
+ * summary. Hardcoded to the newest mid-tier ("terra") model in the shipped
+ * `openai-codex` provider catalog — the same pick pi-web-access's model
+ * preference (mid-tier terra, excluding pro/ultra price tiers) resolves to
+ * today. If the catalog changes, revisit: prefer the newest model whose id
+ * contains "terra", then the newest bare `gpt-N(.M)` id.
+ */
+export const CODEX_WEB_SEARCH_MODEL = 'gpt-5.6-terra'
+
+export const CODEX_WEB_SEARCH_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses'
+
+export interface CodexWebSearchOptions {
+  /** Preferred number of distinct sources to return (capped at 20). */
+  maxResults?: number
+  /** Domains the search must not use. */
+  excludeDomains?: string[]
+}
+
+export interface CodexWebSearchResult {
+  title: string
+  content: string
+  url: string
+}
+
+export interface CodexWebSearchOutput {
+  answer: string
+  results: CodexWebSearchResult[]
+}
+
+function buildInstructions(options: CodexWebSearchOptions): string {
+  const lines = [
+    'Search the web and return a concise answer grounded only in the web results.',
+    'Include clickable source citations in the response text when possible.'
+  ]
+
+  if (typeof options.maxResults === 'number' && Number.isFinite(options.maxResults) && options.maxResults > 0) {
+    lines.push(`Prefer around ${Math.min(Math.floor(options.maxResults), 20)} distinct sources.`)
+  }
+
+  if (options.excludeDomains?.length) {
+    lines.push(`Do not use sources from: ${options.excludeDomains.join(', ')}.`)
+  }
+
+  return lines.join(' ')
+}
+
+/** Build the codex responses request body for a web search call. */
+export function buildCodexWebSearchBody(query: string, options: CodexWebSearchOptions = {}): Record<string, unknown> {
+  const tool: Record<string, unknown> = { type: 'web_search' }
+  if (options.excludeDomains?.length) {
+    tool.filters = { blocked_domains: options.excludeDomains }
+  }
+
+  return {
+    model: CODEX_WEB_SEARCH_MODEL,
+    instructions: buildInstructions(options),
+    input: [{ role: 'user', content: [{ type: 'input_text', text: query }] }],
+    tools: [tool],
+    include: ['web_search_call.action.sources'],
+    store: false,
+    stream: true,
+    tool_choice: 'required',
+    parallel_tool_calls: true
+  }
+}
+
+interface RawSearchResult {
+  title: string
+  url: string
+  content: string
+}
+
+function cleanSourceUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    if (url.searchParams.get('utm_source') !== 'openai') return rawUrl
+    url.searchParams.delete('utm_source')
+    return url.toString()
+  } catch {
+    return rawUrl.replace(/[?&]utm_source=openai$/, '')
+  }
+}
+
+function extractSnippetAround(text: string, start: unknown, end: unknown): string {
+  if (typeof start !== 'number' || typeof end !== 'number' || !text) return ''
+  const before = Math.max(0, start - 100)
+  const after = Math.min(text.length, end + 100)
+  const snippet = text
+    .slice(before, after)
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .trim()
+  return snippet.length > 300 ? `${snippet.slice(0, 297)}...` : snippet
+}
+
+function addResult(results: RawSearchResult[], seen: Set<string>, url: unknown, title: unknown, content = ''): void {
+  if (typeof url !== 'string' || url.trim().length === 0) return
+  const cleanUrl = cleanSourceUrl(url)
+  if (seen.has(cleanUrl)) return
+  seen.add(cleanUrl)
+  results.push({
+    title: typeof title === 'string' && title.trim().length > 0 ? title : cleanUrl,
+    url: cleanUrl,
+    content
+  })
+}
+
+function extractAnswer(output: unknown[]): string {
+  const parts: string[] = []
+  for (const item of output) {
+    if (!item || typeof item !== 'object' || (item as { type?: unknown }).type !== 'message') continue
+    const content = (item as { content?: unknown }).content
+    if (!Array.isArray(content)) continue
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue
+      const text = (part as { text?: unknown }).text
+      if (typeof text === 'string' && text.trim().length > 0) parts.push(text)
+    }
+  }
+  return parts.join('\n').trim()
+}
+
+function extractSearchResults(output: unknown[], maxResults: number | undefined): RawSearchResult[] {
+  const results: RawSearchResult[] = []
+  const seenUrls = new Set<string>()
+
+  for (const item of output) {
+    if (!item || typeof item !== 'object' || (item as { type?: unknown }).type !== 'message') continue
+    const content = (item as { content?: unknown }).content
+    if (!Array.isArray(content)) continue
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue
+      const text = typeof (part as { text?: unknown }).text === 'string' ? (part as { text: string }).text : ''
+      const annotations = (part as { annotations?: unknown }).annotations
+      if (!Array.isArray(annotations)) continue
+      for (const annotation of annotations) {
+        if (
+          !annotation ||
+          typeof annotation !== 'object' ||
+          (annotation as { type?: unknown }).type !== 'url_citation'
+        ) {
+          continue
+        }
+        addResult(
+          results,
+          seenUrls,
+          (annotation as { url?: unknown }).url,
+          (annotation as { title?: unknown }).title,
+          extractSnippetAround(
+            text,
+            (annotation as { start_index?: unknown }).start_index,
+            (annotation as { end_index?: unknown }).end_index
+          )
+        )
+      }
+    }
+  }
+
+  for (const item of output) {
+    if (!item || typeof item !== 'object' || (item as { type?: unknown }).type !== 'web_search_call') continue
+    const value = item as { action?: unknown; sources?: unknown; results?: unknown }
+    const actionSources =
+      value.action && typeof value.action === 'object' ? (value.action as { sources?: unknown }).sources : undefined
+    for (const group of [actionSources, value.sources, value.results]) {
+      if (!Array.isArray(group)) continue
+      for (const source of group) {
+        if (!source || typeof source !== 'object') continue
+        const record = source as Record<string, unknown>
+        addResult(results, seenUrls, record.url ?? record.source_website_url, record.title ?? record.caption)
+      }
+    }
+  }
+
+  if (typeof maxResults === 'number' && Number.isFinite(maxResults) && maxResults > 0) {
+    return results.slice(0, Math.min(Math.floor(maxResults), 20))
+  }
+  return results
+}
+
+/**
+ * Parse a codex responses web search payload — either a single JSON object or
+ * an SSE stream of `data:` lines — into the cited answer and source list.
+ */
+export function parseCodexWebSearchResponse(rawText: string, maxResults?: number): CodexWebSearchOutput {
+  const trimmed = rawText.trim()
+
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`OpenAI Codex search returned invalid JSON: ${message}`)
+    }
+    let output: unknown[]
+    if (Array.isArray(parsed)) {
+      output = parsed
+    } else {
+      const record = parsed as Record<string, unknown> | null
+      output = record && Array.isArray(record.output) ? record.output : []
+    }
+    return {
+      answer: extractAnswer(output),
+      results: extractSearchResults(output, maxResults)
+    }
+  }
+
+  const outputItems: unknown[] = []
+  let completedResponse: Record<string, unknown> | null = null
+  for (const line of trimmed.split('\n')) {
+    if (!line.startsWith('data: ')) continue
+    const data = line.slice(6).trim()
+    if (!data || data === '[DONE]') continue
+    try {
+      const parsed = JSON.parse(data) as Record<string, unknown>
+      if (parsed.type === 'response.output_item.done' && parsed.item) outputItems.push(parsed.item)
+      if (
+        (parsed.type === 'response.done' || parsed.type === 'response.completed') &&
+        parsed.response &&
+        typeof parsed.response === 'object'
+      ) {
+        completedResponse = parsed.response as Record<string, unknown>
+      }
+    } catch {
+      // Skip malformed SSE lines; the final response event carries the output.
+    }
+  }
+
+  let output: unknown[]
+  if (completedResponse) {
+    output = Array.isArray(completedResponse.output) ? completedResponse.output : []
+    if (output.length === 0) output = outputItems
+  } else {
+    output = outputItems
+  }
+
+  return {
+    answer: extractAnswer(output),
+    results: extractSearchResults(output, maxResults)
+  }
+}

--- a/src/main/services/webSearch/providers/registry.ts
+++ b/src/main/services/webSearch/providers/registry.ts
@@ -6,6 +6,7 @@ import { ExaProvider } from './api/ExaProvider'
 import { FetchProvider } from './api/FetchProvider'
 import { FirecrawlProvider } from './api/FirecrawlProvider'
 import { JinaProvider } from './api/JinaProvider'
+import { OpenAICodexProvider } from './api/OpenAICodexProvider'
 import { QueritProvider } from './api/QueritProvider'
 import { SearxngProvider } from './api/SearxngProvider'
 import { TavilyProvider } from './api/TavilyProvider'
@@ -28,5 +29,6 @@ export const WEB_SEARCH_PROVIDER_REGISTRY = {
   querit: QueritProvider,
   fetch: FetchProvider,
   jina: JinaProvider,
-  firecrawl: FirecrawlProvider
+  firecrawl: FirecrawlProvider,
+  'openai-codex': OpenAICodexProvider
 } as const satisfies Record<WebSearchProvider['id'], WebSearchProviderConstructor>

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -8635,6 +8635,7 @@
           "fetch": "Built-in URL fetch provider. Fetches web page content from a URL to enrich search results.",
           "firecrawl": "Firecrawl crawler and search service, optimized to turn websites into Markdown.",
           "jina": "Jina Reader search and read APIs for retrieving clean web content.",
+          "openai_codex": "Web search through your ChatGPT subscription (Plus/Pro) via the OpenAI Codex endpoint. No API key needed — sign in to OpenAI Codex first.",
           "querit": "Querit search and contents APIs for AI apps, retrieving web results and page content.",
           "searxng": "Self-hostable free internet metasearch engine across many sources.",
           "tavily": "Search engine optimized for LLMs.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -8635,6 +8635,7 @@
           "fetch": "内置 URL 获取服务商，用于从指定 URL 获取网页内容，适合补全搜索结果正文。",
           "firecrawl": "Firecrawl 网页抓取与搜索服务，支持将网页转换为 Markdown 格式。",
           "jina": "Jina Reader 搜索与阅读接口，用于检索并提取网页正文。",
+          "openai_codex": "通过 ChatGPT 订阅（Plus/Pro）调用 OpenAI Codex 联网搜索，无需额外 API Key，需先登录 OpenAI Codex 账号。",
           "querit": "Querit 搜索与内容接口，用于关键词检索与网页正文提取。",
           "searxng": "可自托管的免费互联网元搜索引擎，聚合多个搜索源。",
           "tavily": "专为 LLM 优化的搜索引擎。",

--- a/src/renderer/utils/webSearchProviderMeta.ts
+++ b/src/renderer/utils/webSearchProviderMeta.ts
@@ -84,6 +84,12 @@ const WEB_SEARCH_PROVIDER_DISPLAY_META: Record<WebSearchProviderId, WebSearchPro
     iconRef: providerIconRef('firecrawl'),
     officialWebsite: 'https://firecrawl.dev',
     apiKeyWebsite: 'https://firecrawl.dev/app/api-keys'
+  },
+  'openai-codex': {
+    descriptionKey: 'settings.tool.websearch.provider_description.openai_codex',
+    // Reuse the OpenAI mark; consistent with the provider icon alias in @cherrystudio/ui.
+    iconRef: providerIconRef('openai'),
+    officialWebsite: 'https://chatgpt.com'
   }
 }
 

--- a/src/shared/data/preference/preferenceTypes.ts
+++ b/src/shared/data/preference/preferenceTypes.ts
@@ -198,7 +198,7 @@ export const parseTranslateBidirectionalPair = (value: readonly [string, string]
 // WebSearch Types
 // ============================================================================
 
-export const WEB_SEARCH_PROVIDER_TYPES = ['api', 'mcp'] as const
+export const WEB_SEARCH_PROVIDER_TYPES = ['api', 'mcp', 'oauth'] as const
 
 export type WebSearchProviderType = (typeof WEB_SEARCH_PROVIDER_TYPES)[number]
 
@@ -212,7 +212,8 @@ export const WEB_SEARCH_PROVIDER_IDS = [
   'querit',
   'fetch',
   'jina',
-  'firecrawl'
+  'firecrawl',
+  'openai-codex'
 ] as const
 
 export type WebSearchProviderId = (typeof WEB_SEARCH_PROVIDER_IDS)[number]

--- a/src/shared/data/presets/webSearchProviders.ts
+++ b/src/shared/data/presets/webSearchProviders.ts
@@ -194,6 +194,17 @@ export const WEB_SEARCH_PROVIDER_PRESET_MAP = {
         apiHost: 'https://api.firecrawl.dev'
       }
     ]
+  },
+  'openai-codex': {
+    name: 'OpenAI Codex',
+    type: 'oauth',
+    capabilities: [
+      {
+        feature: 'searchKeywords',
+        requiresApiHost: false,
+        requiresApiKey: false
+      }
+    ]
   }
 } as const satisfies Record<WebSearchProviderId, WebSearchProviderPresetConfig>
 

--- a/tests/__mocks__/main/application.ts
+++ b/tests/__mocks__/main/application.ts
@@ -72,6 +72,13 @@ const mockIpcApiService = {
   broadcastToType: vi.fn()
 }
 
+/** Minimal OAuthRuntimeService mock — defaults to not-signed-in (`null`). */
+const mockOAuthRuntimeService = {
+  getValidAccessToken: vi.fn(() => null),
+  logout: vi.fn(),
+  isSignedIn: vi.fn(() => false)
+}
+
 /** Minimal JobManager mock for handler registration and startup enqueues. */
 export const mockJobManager = {
   registerHandler: vi.fn(),
@@ -88,6 +95,7 @@ export const defaultServiceInstances = {
   MainWindowService: mockMainWindowService,
   WindowManager: mockWindowManager,
   IpcApiService: mockIpcApiService,
+  OAuthRuntimeService: mockOAuthRuntimeService,
   JobManager: mockJobManager
 } as const
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Cherry Studio web search supported API and MCP providers, but users with an existing ChatGPT/Codex subscription could not use web search without configuring a separate search API key.

After this PR:

- Adds an `openai-codex` OAuth web search provider.
- Reuses the existing OpenAI Codex OAuth access token and account ID.
- Calls the Codex Responses endpoint with the server-side `web_search` tool.
- Parses SSE/JSON responses, citations, and web search sources.
- Adds localized provider metadata and focused unit/provider tests.

### Why we need it and why it was done in this way

This lets signed-in ChatGPT/Codex users use web search through their existing subscription session, without requiring additional OpenAI API search quota or a separate API key. The provider is isolated from the regular API-key providers and shares the existing OAuth runtime and request-header implementation.

The search request currently uses `gpt-5.6-terra`, matching the intended mid-tier Codex web-search model selection.

The following tradeoffs were made:

- The model is currently a stable provider-side default rather than a user-configurable search model.
- Source extraction accepts both citation annotations and `web_search_call.action.sources` for compatibility with Codex response variants.

The following alternatives were considered:

- Requiring an OpenAI API key was rejected because the goal is to use the user's existing ChatGPT/Codex subscription.

### Breaking changes

None.

### Special notes for your reviewer

- Requires the user to be signed in to OpenAI Codex in Cherry Studio.
- No additional web-search API key is required.
- Manually verified on macOS with the development build and a live search request.

### Verification

- `pnpm lint`
- `pnpm test`
- `pnpm format`
- `pnpm build:check`
- Full Vitest suite: 24,366 passed, 62 skipped

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The implementation and tests were reviewed locally
- [x] Upgrade: No upgrade or migration is required
- [ ] Documentation: A user-guide update is not included in this PR
- [ ] Self-review: Will review the final GitHub diff before marking ready for review

### Release note

```release-note
Add OpenAI Codex subscription-backed web search without requiring a separate search API key.
```
