### PR TITLE
fix(security): gate legacy IPC senders, unsafe-extension open guard, zip-slip containment

### DIFF
--- a/src/main/ai/mcp/McpPackageService.ts
+++ b/src/main/ai/mcp/McpPackageService.ts
@@ -1,6 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { assertZipEntriesWithin } from '@main/utils/zipSafety'
 import * as fs from 'fs'
 import StreamZip from 'node-stream-zip'
 import * as path from 'path'
@@ -27,24 +28,6 @@ export function ensurePathWithin(basePath: string, targetPath: string): string {
   }
 
   return resolvedTarget
-}
-
-/**
- * Guard against zip-slip: `node-stream-zip` writes each entry at `path.join(baseDir, entry.name)`
- * with no containment check, so a name like `../../../foo` would escape `baseDir`. Reject any entry
- * whose resolved destination is outside `baseDir` before extraction. Unlike {@link ensurePathWithin},
- * nested subdirectories are allowed (a DXT archive legitimately contains them).
- *
- * @throws Error if any entry name escapes `baseDir`
- */
-export function assertZipEntriesWithin(entryNames: string[], baseDir: string): void {
-  const root = path.resolve(baseDir)
-  for (const name of entryNames) {
-    const dest = path.resolve(baseDir, name)
-    if (dest !== root && !dest.startsWith(root + path.sep)) {
-      throw new Error(`Unsafe DXT entry path (zip-slip): ${name}`)
-    }
-  }
 }
 
 interface BaseMcpPackageManifest {

--- a/src/main/ai/mcp/__tests__/McpPackageService.test.ts
+++ b/src/main/ai/mcp/__tests__/McpPackageService.test.ts
@@ -11,7 +11,6 @@ vi.mock('@application', async () => {
 const { application } = await import('@application')
 
 const {
-  assertZipEntriesWithin,
   buildResolvedEnv,
   ensurePathWithin,
   McpPackageService,
@@ -92,37 +91,6 @@ describe('ensurePathWithin', () => {
       const target = path.join(baseDir, 'server-name')
       expect(ensurePathWithin(baseDir, target)).toBe(path.resolve(target))
     })
-  })
-})
-
-// C4 (mcp-services-1): node-stream-zip writes each entry at path.join(baseDir, name)
-// with no containment check, so a DXT archive crafted with a `../` entry could
-// overwrite files outside the extraction dir. The guard must reject before extraction.
-describe('assertZipEntriesWithin', () => {
-  const baseDir = path.join('/', 'tmp', 'dxt_extract')
-
-  // Skip on Windows — path separator / resolution semantics differ.
-  const testFn = process.platform === 'win32' ? it.skip : it
-
-  testFn('accepts entries nested inside the base dir', () => {
-    expect(() => assertZipEntriesWithin(['manifest.json', 'server/index.js', 'assets/icon.png'], baseDir)).not.toThrow()
-  })
-
-  testFn('rejects a parent-traversal entry', () => {
-    expect(() => assertZipEntriesWithin(['../escape.txt'], baseDir)).toThrow('zip-slip')
-  })
-
-  testFn('rejects a deep traversal entry mixed with safe entries', () => {
-    expect(() => assertZipEntriesWithin(['manifest.json', '../../../etc/cron.d/evil'], baseDir)).toThrow('zip-slip')
-  })
-
-  testFn('rejects an absolute-path entry', () => {
-    expect(() => assertZipEntriesWithin(['/etc/passwd'], baseDir)).toThrow('zip-slip')
-  })
-
-  testFn('rejects a sibling-prefix entry that is not actually nested', () => {
-    // `/tmp/dxt_extract_evil` shares the base string prefix but is not within the base dir.
-    expect(() => assertZipEntriesWithin(['../dxt_extract_evil/x'], baseDir)).toThrow('zip-slip')
   })
 })
 

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -14,6 +14,7 @@ import { directoryExists } from '@main/utils/legacyFile'
 import { findAllSkillDirectories, findSkillMdPath, parseSkillMetadata } from '@main/utils/markdownParser'
 import { executeCommand } from '@main/utils/processRunner'
 import { getShellEnv } from '@main/utils/shellEnv'
+import { assertZipEntriesWithin } from '@main/utils/zipSafety'
 import type { InstalledSkill, ListSkillsQuery } from '@shared/data/api/schemas/skills'
 import type {
   SkillFileNode,
@@ -928,6 +929,7 @@ export class SkillService {
 
     try {
       const entries = await zip.entries()
+      assertZipEntriesWithin(Object.keys(entries), destDir)
       let totalSize = 0
       let fileCount = 0
 

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -1750,4 +1750,42 @@ describe('SkillService', () => {
       ).toHaveLength(1)
     })
   })
+
+  describe('extractZip (zip-slip guard)', () => {
+    const callExtractZip = (service: SkillService, zipPath: string, destDir: string) =>
+      (service as unknown as { extractZip: (z: string, d: string) => Promise<void> }).extractZip(zipPath, destDir)
+
+    it('rejects entries that escape the destination dir before extracting', async () => {
+      const skillService = new SkillService()
+      const zipDir = await createTempDir('skill-zipslip-')
+      const destDir = await createTempDir('skill-dest-')
+      const zip = new AdmZip()
+      zip.addFile('SKILL.md', Buffer.from('---\nname: x\n---\n'))
+      zip.addFile('../../../evil-slip-marker.sh', Buffer.from('pwn'))
+      const zipPath = path.join(zipDir, 'skill.zip')
+      zip.writeZip(zipPath)
+
+      // node-stream-zip rejects malicious names itself ('Malicious entry') and the
+      // explicit guard is defense-in-depth — either layer rejecting satisfies the contract.
+      await expect(callExtractZip(skillService, zipPath, destDir)).rejects.toThrow(/zip-slip|Malicious entry/)
+
+      // Nothing was written — not the safe entry, and no marker escaped beside destDir.
+      expect(fs.existsSync(path.join(destDir, 'SKILL.md'))).toBe(false)
+      expect(fs.existsSync(path.join(destDir, '..', 'evil-slip-marker.sh'))).toBe(false)
+    })
+
+    it('extracts a well-formed skill zip', async () => {
+      const skillService = new SkillService()
+      const zipDir = await createTempDir('skill-zip-ok-')
+      const destDir = await createTempDir('skill-dest-')
+      const zip = new AdmZip()
+      zip.addFile('SKILL.md', Buffer.from('---\nname: x\n---\n'))
+      zip.addFile('nested/helper.md', Buffer.from('# helper'))
+      const zipPath = path.join(zipDir, 'skill.zip')
+      zip.writeZip(zipPath)
+
+      await callExtractZip(skillService, zipPath, destDir)
+      await expect(fs.promises.readFile(path.join(destDir, 'SKILL.md'), 'utf-8')).resolves.toContain('name: x')
+    })
+  })
 })

--- a/src/main/core/application/Application.ts
+++ b/src/main/core/application/Application.ts
@@ -13,9 +13,10 @@ import {
 } from '@main/core/lifecycle'
 import { buildPathRegistry, type PathKey, type PathMap, shouldAutoEnsure } from '@main/core/paths/pathRegistry'
 import { isDev, isLinux, isMac, isPortable, isWin } from '@main/core/platform'
+import { handleGuarded } from '@main/core/security/guardedIpc'
 import { bootConfigService } from '@main/data/bootConfig'
 import { IpcChannel } from '@shared/IpcChannel'
-import { app, dialog, ipcMain } from 'electron'
+import { app, dialog } from 'electron'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { ServiceRegistry } from './serviceRegistry'
@@ -528,17 +529,17 @@ export class Application {
    * All application lifecycle operations exposed to renderer live here.
    */
   private registerApplicationIpc(): void {
-    ipcMain.handle(IpcChannel.Application_Relaunch, (_, options?: Electron.RelaunchOptions) => {
+    handleGuarded(IpcChannel.Application_Relaunch, (_, options?: Electron.RelaunchOptions) => {
       this.relaunch(options)
     })
 
-    ipcMain.handle(IpcChannel.Application_PreventQuit, (_, reason: string): string => {
+    handleGuarded(IpcChannel.Application_PreventQuit, (_, reason: string): string => {
       const hold = this.preventQuit(reason)
       this.ipcQuitHolds.set(hold.id, hold)
       return hold.id
     })
 
-    ipcMain.handle(IpcChannel.Application_AllowQuit, (_, holdId: string) => {
+    handleGuarded(IpcChannel.Application_AllowQuit, (_, holdId: string) => {
       const hold = this.ipcQuitHolds.get(holdId)
       if (hold) {
         hold.dispose()

--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -375,7 +375,12 @@ export class LoggerService {
   }
 
   /**
-   * Register IPC handler for renderer process logging
+   * Register IPC handler for renderer process logging.
+   *
+   * Deliberately NOT routed through `handleGuarded` (unlike other legacy IPC):
+   * this runs at module-eval time via the constructor, and importing the
+   * `validateSender` chain would pull `@application` into core/logger's init
+   * order. The channel only forwards log lines — no privileged action.
    */
   private registerIpcHandler(): void {
     ipcMain.handle(

--- a/src/main/core/security/__tests__/guardedIpc.test.ts
+++ b/src/main/core/security/__tests__/guardedIpc.test.ts
@@ -1,0 +1,66 @@
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { application } from '@application'
+import { IpcError } from '@shared/ipc/errors/IpcError'
+import type { IpcMainInvokeEvent } from 'electron'
+import { ipcMain } from 'electron'
+import { describe, expect, it, vi } from 'vitest'
+
+import { assertTrustedSender, handleGuarded } from '../guardedIpc'
+
+const APP_ROOT = resolve(application.getPath('app.root'))
+const indexUrl = pathToFileURL(join(APP_ROOT, 'index.html')).href
+
+// `parent` defaults to null (a top-level frame); pass a non-null frame to model a sub-frame.
+const evt = (type: string, url: string | null, parent: unknown = null): IpcMainInvokeEvent =>
+  ({
+    sender: { getType: () => type },
+    senderFrame: url === null ? null : { url, parent }
+  }) as unknown as IpcMainInvokeEvent
+
+describe('assertTrustedSender', () => {
+  it('passes a top-level frame on an app page', () => {
+    expect(() => assertTrustedSender(evt('window', indexUrl), 'File_Read', APP_ROOT)).not.toThrow()
+  })
+
+  it('rejects a webview guest with FORBIDDEN_SENDER', () => {
+    const rejection = () => assertTrustedSender(evt('webview', indexUrl), 'File_Read', APP_ROOT)
+    expect(rejection).toThrow(IpcError)
+    expect(rejection).toThrow('untrusted sender')
+  })
+
+  it('rejects a sub-frame even when its url is an app page', () => {
+    const parentFrame = { url: indexUrl }
+    expect(() => assertTrustedSender(evt('window', indexUrl, parentFrame), 'File_Read', APP_ROOT)).toThrow(
+      'untrusted sender'
+    )
+  })
+
+  it('rejects a foreign file: page opened in an app window', () => {
+    const foreignUrl = pathToFileURL(join(tmpdir(), 'evil.html')).href
+    expect(() => assertTrustedSender(evt('window', foreignUrl), 'File_Read', APP_ROOT)).toThrow('untrusted sender')
+  })
+})
+
+describe('handleGuarded', () => {
+  it('registers through ipcMain.handle and gates before the handler runs', () => {
+    const handle = vi.mocked(ipcMain.handle)
+    handle.mockClear()
+    const handler = vi.fn(() => 'ok')
+
+    handleGuarded('File_Read', handler)
+    expect(handle).toHaveBeenCalledOnce()
+    const [, wrapped] = handle.mock.calls[0]
+
+    // Trusted sender: args pass through and the handler result returns.
+    const event = evt('window', indexUrl)
+    expect(wrapped(event, 'a', 1)).toBe('ok')
+    expect(handler).toHaveBeenCalledWith(event, 'a', 1)
+
+    // Untrusted sender: rejects before the handler is reached.
+    expect(() => wrapped(evt('webview', indexUrl), 'a')).toThrow(IpcError)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/core/security/guardedIpc.ts
+++ b/src/main/core/security/guardedIpc.ts
@@ -1,0 +1,39 @@
+import { loggerService } from '@logger'
+import { IpcError, IpcErrorCode } from '@shared/ipc/errors/IpcError'
+import type { IpcMainInvokeEvent } from 'electron'
+import { ipcMain } from 'electron'
+
+import { validateSender } from './validateSender'
+
+/**
+ * Throw {@link IpcErrorCode.FORBIDDEN_SENDER} unless `event` comes from the app's own
+ * top-level renderer frame. Extracted from {@link handleGuarded} so the decision is
+ * unit-testable without Electron IPC registration.
+ */
+export function assertTrustedSender(event: IpcMainInvokeEvent, channel: string, appRootDir?: string): void {
+  if (validateSender(event, appRootDir)) return
+  // Lazy: this module sits below core/logger in the import graph, so the logger
+  // context must not be created at module-eval time.
+  loggerService.withContext('GuardedIpc').warn('Rejected legacy IPC request from untrusted sender', {
+    channel,
+    senderType: event.sender.getType(),
+    senderUrl: event.senderFrame?.url
+  })
+  throw new IpcError(IpcErrorCode.FORBIDDEN_SENDER, `Rejected IPC request from untrusted sender: ${channel}`)
+}
+
+/**
+ * `ipcMain.handle` wrapper that funnels every legacy (pre-IpcApi) channel through the
+ * same source-trust gate as IpcApi/DataApi/Preference/Cache — all frames can send IPC
+ * while MiniApps load remote URLs, so callers are verified before handlers run.
+ */
+export function handleGuarded(
+  channel: string,
+  handler: (event: IpcMainInvokeEvent, ...args: any[]) => any,
+  appRootDir?: string
+): void {
+  ipcMain.handle(channel, (event, ...args) => {
+    assertTrustedSender(event, channel, appRootDir)
+    return handler(event, ...args)
+  })
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2,13 +2,14 @@ import path from 'node:path'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { handleGuarded } from '@main/core/security/guardedIpc'
 import {
   listDirectory as searchListDirectory,
   listDirectoryEntries as searchListDirectoryEntries
 } from '@main/services/file'
 import { hasWritePermission, isPathInside, untildify } from '@main/utils/legacyFile'
 import { IpcChannel } from '@shared/IpcChannel'
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { BrowserWindow, dialog } from 'electron'
 
 import { skillService } from './ai/skills/SkillService'
 import { appService } from './services/AppService'
@@ -37,10 +38,10 @@ export async function registerIpc() {
   // })
 
   // MainWindow_Reload handler moved into MainWindowService.registerIpcHandlers.
-  // Application_Quit is registered by Application.registerApplicationIpc()
+  // Application lifecycle handlers live in core/application/Application.ts (registerApplicationIpc).
 
   // spell check languages
-  ipcMain.handle(IpcChannel.App_SetSpellCheckLanguages, (_, languages: string[]) => {
+  handleGuarded(IpcChannel.App_SetSpellCheckLanguages, (_, languages: string[]) => {
     if (languages.length === 0) {
       return
     }
@@ -52,17 +53,17 @@ export async function registerIpc() {
   })
 
   // launch on boot
-  ipcMain.handle(IpcChannel.App_SetLaunchOnBoot, async (_, isLaunchOnBoot: boolean) => {
+  handleGuarded(IpcChannel.App_SetLaunchOnBoot, async (_, isLaunchOnBoot: boolean) => {
     await appService.setAppLaunchOnBoot(isLaunchOnBoot)
   })
 
   // // theme
-  // ipcMain.handle(IpcChannel.App_SetTheme, (_, theme: ThemeMode) => {
+  // handleGuarded(IpcChannel.App_SetTheme, (_, theme: ThemeMode) => {
   //   themeService.setTheme(theme)
   // })
 
   // Select app data path
-  ipcMain.handle(IpcChannel.App_Select, async (_, options: Electron.OpenDialogOptions) => {
+  handleGuarded(IpcChannel.App_Select, async (_, options: Electron.OpenDialogOptions) => {
     try {
       const { canceled, filePaths } = await dialog.showOpenDialog(options)
       if (canceled || filePaths.length === 0) {
@@ -75,117 +76,117 @@ export async function registerIpc() {
     }
   })
 
-  ipcMain.handle(IpcChannel.App_HasWritePermission, async (_, filePath: string) => {
+  handleGuarded(IpcChannel.App_HasWritePermission, async (_, filePath: string) => {
     const hasPermission = await hasWritePermission(filePath)
     return hasPermission
   })
 
-  ipcMain.handle(IpcChannel.App_ResolvePath, async (_, filePath: string) => {
+  handleGuarded(IpcChannel.App_ResolvePath, async (_, filePath: string) => {
     return path.resolve(untildify(filePath))
   })
 
   // Check if a path is inside another path (proper parent-child relationship)
-  ipcMain.handle(IpcChannel.App_IsPathInside, async (_, childPath: string, parentPath: string) => {
+  handleGuarded(IpcChannel.App_IsPathInside, async (_, childPath: string, parentPath: string) => {
     return isPathInside(childPath, parentPath)
   })
 
   // Application_Relaunch is registered by Application.registerApplicationIpc()
 
   // zip
-  ipcMain.handle(IpcChannel.Zip_Decompress, (_, text: Buffer) => decompress(text))
+  handleGuarded(IpcChannel.Zip_Decompress, (_, text: Buffer) => decompress(text))
 
   // system
-  ipcMain.handle(IpcChannel.System_GetHostname, getHostname)
+  handleGuarded(IpcChannel.System_GetHostname, getHostname)
   // Git Bash has no IPC: the Claude Code runtime resolves it in-process via
   // autoDiscoverGitBash() (ai/runtime/claudeCode/settingsBuilder.ts).
 
   // backup
-  ipcMain.handle(IpcChannel.Backup_Backup, backupManager.backup.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_Restore, backupManager.restore.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_BackupToWebdav, async (event, config) => {
+  handleGuarded(IpcChannel.Backup_Backup, backupManager.backup.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_Restore, backupManager.restore.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_BackupToWebdav, async (event, config) => {
     const { result, cleanupError } = await backupManager.backupToWebdav(event, config)
     return { result, cleanupFailed: cleanupError !== null }
   })
-  ipcMain.handle(IpcChannel.Backup_RestoreFromWebdav, backupManager.restoreFromWebdav.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_ListWebdavFiles, backupManager.listWebdavFiles.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_CheckConnection, backupManager.checkConnection.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_CreateDirectory, backupManager.createDirectory.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_DeleteWebdavFile, backupManager.deleteWebdavFile.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_BackupToLocalDir, async (event, fileName, config) => {
+  handleGuarded(IpcChannel.Backup_RestoreFromWebdav, backupManager.restoreFromWebdav.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_ListWebdavFiles, backupManager.listWebdavFiles.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_CheckConnection, backupManager.checkConnection.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_CreateDirectory, backupManager.createDirectory.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_DeleteWebdavFile, backupManager.deleteWebdavFile.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_BackupToLocalDir, async (event, fileName, config) => {
     const { result, cleanupError } = await backupManager.backupToLocalDir(event, fileName, config)
     return { result, cleanupFailed: cleanupError !== null }
   })
-  ipcMain.handle(IpcChannel.Backup_RestoreFromLocalBackup, backupManager.restoreFromLocalBackup.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_ListLocalBackupFiles, backupManager.listLocalBackupFiles.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_DeleteLocalBackupFile, backupManager.deleteLocalBackupFile.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_BackupToS3, async (event, config) => {
+  handleGuarded(IpcChannel.Backup_RestoreFromLocalBackup, backupManager.restoreFromLocalBackup.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_ListLocalBackupFiles, backupManager.listLocalBackupFiles.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_DeleteLocalBackupFile, backupManager.deleteLocalBackupFile.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_BackupToS3, async (event, config) => {
     const { result, cleanupError } = await backupManager.backupToS3(event, config)
     return { result, cleanupFailed: cleanupError !== null }
   })
-  ipcMain.handle(IpcChannel.Backup_RestoreFromS3, backupManager.restoreFromS3.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_ListS3Files, backupManager.listS3Files.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_DeleteS3File, backupManager.deleteS3File.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_CreateLanTransferBackup, backupManager.createLanTransferBackup.bind(backupManager))
-  ipcMain.handle(IpcChannel.Backup_DeleteLanTransferBackup, backupManager.deleteLanTransferBackup.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_RestoreFromS3, backupManager.restoreFromS3.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_ListS3Files, backupManager.listS3Files.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_DeleteS3File, backupManager.deleteS3File.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_CreateLanTransferBackup, backupManager.createLanTransferBackup.bind(backupManager))
+  handleGuarded(IpcChannel.Backup_DeleteLanTransferBackup, backupManager.deleteLanTransferBackup.bind(backupManager))
 
   // file
-  ipcMain.handle(IpcChannel.File_Open, fileManager.open.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_OpenPath, fileManager.openPath.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Save, fileManager.save.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Select, fileManager.selectFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_ReadExternal, fileManager.readExternalFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_DeleteExternalFile, fileManager.deleteExternalFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_DeleteExternalDir, fileManager.deleteExternalDir.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Move, fileManager.moveFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_MoveDir, fileManager.moveDir.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Rename, fileManager.renameFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_RenameDir, fileManager.renameDir.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Get, fileManager.getFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_SelectFolder, fileManager.selectFolder.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_CreateTempFile, fileManager.createTempFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Mkdir, fileManager.mkdir.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_Write, fileManager.writeFile.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_SaveImage, fileManager.saveImage.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_BinaryImage, fileManager.binaryImage.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_ListDirectory, (_e, dirPath, options) => searchListDirectory(dirPath, options))
-  ipcMain.handle(IpcChannel.File_ListDirectoryEntries, (_e, dirPath, options) =>
+  handleGuarded(IpcChannel.File_Open, fileManager.open.bind(fileManager))
+  handleGuarded(IpcChannel.File_OpenPath, fileManager.openPath.bind(fileManager))
+  handleGuarded(IpcChannel.File_Save, fileManager.save.bind(fileManager))
+  handleGuarded(IpcChannel.File_Select, fileManager.selectFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_ReadExternal, fileManager.readExternalFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_DeleteExternalFile, fileManager.deleteExternalFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_DeleteExternalDir, fileManager.deleteExternalDir.bind(fileManager))
+  handleGuarded(IpcChannel.File_Move, fileManager.moveFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_MoveDir, fileManager.moveDir.bind(fileManager))
+  handleGuarded(IpcChannel.File_Rename, fileManager.renameFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_RenameDir, fileManager.renameDir.bind(fileManager))
+  handleGuarded(IpcChannel.File_Get, fileManager.getFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_SelectFolder, fileManager.selectFolder.bind(fileManager))
+  handleGuarded(IpcChannel.File_CreateTempFile, fileManager.createTempFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_Mkdir, fileManager.mkdir.bind(fileManager))
+  handleGuarded(IpcChannel.File_Write, fileManager.writeFile.bind(fileManager))
+  handleGuarded(IpcChannel.File_SaveImage, fileManager.saveImage.bind(fileManager))
+  handleGuarded(IpcChannel.File_BinaryImage, fileManager.binaryImage.bind(fileManager))
+  handleGuarded(IpcChannel.File_ListDirectory, (_e, dirPath, options) => searchListDirectory(dirPath, options))
+  handleGuarded(IpcChannel.File_ListDirectoryEntries, (_e, dirPath, options) =>
     searchListDirectoryEntries(dirPath, options)
   )
-  ipcMain.handle(IpcChannel.File_CheckFileName, fileManager.fileNameGuard.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_ValidateNotesDirectory, fileManager.validateNotesDirectory.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_BatchUploadMarkdown, fileManager.batchUploadMarkdownFiles.bind(fileManager))
-  ipcMain.handle(IpcChannel.File_ShowInFolder, fileManager.showInFolder.bind(fileManager))
+  handleGuarded(IpcChannel.File_CheckFileName, fileManager.fileNameGuard.bind(fileManager))
+  handleGuarded(IpcChannel.File_ValidateNotesDirectory, fileManager.validateNotesDirectory.bind(fileManager))
+  handleGuarded(IpcChannel.File_BatchUploadMarkdown, fileManager.batchUploadMarkdownFiles.bind(fileManager))
+  handleGuarded(IpcChannel.File_ShowInFolder, fileManager.showInFolder.bind(fileManager))
 
   // fs
-  ipcMain.handle(IpcChannel.Fs_Read, FileService.readFile.bind(FileService))
-  ipcMain.handle(IpcChannel.Fs_ReadText, FileService.readTextFileWithAutoEncoding.bind(FileService))
+  handleGuarded(IpcChannel.Fs_Read, FileService.readFile.bind(FileService))
+  handleGuarded(IpcChannel.Fs_ReadText, FileService.readTextFileWithAutoEncoding.bind(FileService))
 
   // aes
-  ipcMain.handle(IpcChannel.Aes_Decrypt, (_, encryptedData: string, iv: string, secretKey: string) =>
+  handleGuarded(IpcChannel.Aes_Decrypt, (_, encryptedData: string, iv: string, secretKey: string) =>
     decrypt(encryptedData, iv, secretKey)
   )
 
   //copilot
-  ipcMain.handle(IpcChannel.Copilot_GetAuthMessage, copilotService.getAuthMessage.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetCopilotToken, copilotService.getCopilotToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_SaveCopilotToken, copilotService.saveCopilotToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetToken, copilotService.getToken.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_Logout, copilotService.logout.bind(copilotService))
-  ipcMain.handle(IpcChannel.Copilot_GetUser, copilotService.getUser.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_GetAuthMessage, copilotService.getAuthMessage.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_GetCopilotToken, copilotService.getCopilotToken.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_SaveCopilotToken, copilotService.saveCopilotToken.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_GetToken, copilotService.getToken.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_Logout, copilotService.logout.bind(copilotService))
+  handleGuarded(IpcChannel.Copilot_GetUser, copilotService.getUser.bind(copilotService))
 
   // nutstore
-  ipcMain.handle(IpcChannel.Nutstore_GetSsoUrl, NutstoreService.getNutstoreSSOUrl.bind(NutstoreService))
-  ipcMain.handle(IpcChannel.Nutstore_DecryptToken, (_, token: string) => NutstoreService.decryptToken(token))
-  ipcMain.handle(IpcChannel.Nutstore_GetDirectoryContents, (_, token: string, path: string) =>
+  handleGuarded(IpcChannel.Nutstore_GetSsoUrl, NutstoreService.getNutstoreSSOUrl.bind(NutstoreService))
+  handleGuarded(IpcChannel.Nutstore_DecryptToken, (_, token: string) => NutstoreService.decryptToken(token))
+  handleGuarded(IpcChannel.Nutstore_GetDirectoryContents, (_, token: string, path: string) =>
     NutstoreService.getDirectoryContents(token, path)
   )
 
   // ExternalApps
-  ipcMain.handle(IpcChannel.ExternalApps_DetectInstalled, () => externalAppsService.detectInstalledApps())
+  handleGuarded(IpcChannel.ExternalApps_DetectInstalled, () => externalAppsService.detectInstalledApps())
 
   // Global Skills: install / uninstall / install-from-zip / install-from-directory / list-local
   // migrated to IpcApi (skill.*). read-file / list-files stay on legacy IPC (roadmap placeholders).
-  ipcMain.handle(IpcChannel.Skill_ReadFile, async (_, skillId: string, filename: string) => {
+  handleGuarded(IpcChannel.Skill_ReadFile, async (_, skillId: string, filename: string) => {
     try {
       const data = await skillService.readFile(skillId, filename)
       return { success: true, data }
@@ -195,7 +196,7 @@ export async function registerIpc() {
     }
   })
 
-  ipcMain.handle(IpcChannel.Skill_ListFiles, async (_, skillId: string) => {
+  handleGuarded(IpcChannel.Skill_ListFiles, async (_, skillId: string) => {
     try {
       const data = await skillService.listFiles(skillId)
       return { success: true, data }

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -12,12 +12,13 @@
  * Electron dialog, with no validation layer of its own. Introducing
  * `AbsoluteFilePathSchema.parse()` would add new throw sites to a module that is
  * already `@deprecated` and slated for deletion, changing v1 behavior instead of
- * migrating it. The casts only feed `getFileType`, which reads the extension. */
+ * migrating it. The casts only feed `getFileType` (extension reads) and the
+ * `safeOpen` handoff in `openPath`. */
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { isWin } from '@main/core/platform'
 import { t } from '@main/i18n'
-import { assertOutsideManagedStorageMutation } from '@main/services/file'
+import { assertOutsideManagedStorageMutation, safeOpen } from '@main/services/file'
 import { getFileType } from '@main/utils/file'
 import {
   checkName,
@@ -687,10 +688,9 @@ class FileStorage {
   }
 
   public openPath = async (_: Electron.IpcMainInvokeEvent, path: string): Promise<void> => {
-    const resolved = await shell.openPath(resolveHomeRelativeFilePath(path))
-    if (resolved !== '') {
-      throw new Error(resolved)
-    }
+    // Same unsafe-extension policy as the gated `file.open` route (safeOpen). Narrowing
+    // to OS-execute-only extensions is a pending product call — see PRD D2.
+    return safeOpen(resolveHomeRelativeFilePath(path) as AbsoluteFilePath)
   }
 
   /**

--- a/src/main/services/LegacyBackupManager.ts
+++ b/src/main/services/LegacyBackupManager.ts
@@ -30,6 +30,7 @@ import { type AtomicWriteStream, createAtomicWriteStream } from '@main/utils/fil
 import { IdleTimeoutController } from '@main/utils/IdleTimeoutController'
 import { isPathInside, resolveAndValidatePath } from '@main/utils/legacyFile'
 import { getDeviceType, getHostname } from '@main/utils/system'
+import { assertZipEntriesWithin } from '@main/utils/zipSafety'
 import { IpcChannel } from '@shared/IpcChannel'
 import {
   BACKUP_ACTIVE_WRITERS_ERROR_CODE,
@@ -868,6 +869,7 @@ class BackupManager {
       const zip = new StreamZip.async({ file: backupPath })
       try {
         onProgress({ stage: 'extracting', progress: 15, total: 100 })
+        assertZipEntriesWithin(Object.keys(await zip.entries()), extractionDir)
         await zip.extract(null, extractionDir)
       } finally {
         await zip.close()

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -47,6 +47,19 @@ describe('FileStorage', () => {
     })
   })
 
+  describe('openPath', () => {
+    it('opens a file with a safe extension via the system default app', async () => {
+      vi.mocked(shell.openPath).mockResolvedValue('')
+      await fileStorage.openPath(event, '/mock/notes/report.md')
+      expect(shell.openPath).toHaveBeenCalledWith('/mock/notes/report.md')
+    })
+
+    it('refuses script extensions before reaching the OS handler', async () => {
+      await expect(fileStorage.openPath(event, '/mock/notes/report.py')).rejects.toThrow('Refusing to open .py')
+      expect(shell.openPath).not.toHaveBeenCalled()
+    })
+  })
+
   describe('writeFile', () => {
     let tmpFile: string
 

--- a/src/main/services/__tests__/LegacyBackupManager.test.ts
+++ b/src/main/services/__tests__/LegacyBackupManager.test.ts
@@ -72,6 +72,7 @@ const {
   mockRandomUUID,
   mockZipExtract,
   mockZipClose,
+  mockZipEntries,
   MockStreamZipAsync
 } = vi.hoisted(() => {
   const mockChannelHold = { dispose: vi.fn() }
@@ -80,6 +81,7 @@ const {
   const mockAgentSessionHold = { dispose: vi.fn() }
   const mockZipExtract = vi.fn()
   const mockZipClose = vi.fn()
+  const mockZipEntries = vi.fn(async () => ({}))
   return {
     mockLogger: {
       debug: vi.fn(),
@@ -122,8 +124,9 @@ const {
     mockRandomUUID: vi.fn(),
     mockZipExtract,
     mockZipClose,
+    mockZipEntries,
     MockStreamZipAsync: vi.fn(function () {
-      return { extract: mockZipExtract, close: mockZipClose }
+      return { entries: mockZipEntries, extract: mockZipExtract, close: mockZipClose }
     })
   }
 })
@@ -1204,6 +1207,19 @@ describe('BackupManager direct v2 data compatibility', () => {
     )
 
     expect(mockZipExtract).toHaveBeenCalledOnce()
+    expect(mockZipClose).toHaveBeenCalledOnce()
+    expect(mockWriteRestoreJournal).not.toHaveBeenCalled()
+  })
+
+  it('rejects a backup ZIP whose entries escape the extraction dir (zip-slip)', async () => {
+    mockZipEntries.mockResolvedValueOnce({ '../../../evil.sh': { size: 4 }, 'metadata.json': { size: 2 } })
+
+    await expect(backupManager.restore({} as Electron.IpcMainInvokeEvent, '/backup/evil.zip')).rejects.toThrow(
+      'zip-slip'
+    )
+
+    // The rejection happens before any entry is written and the archive is still closed.
+    expect(mockZipExtract).not.toHaveBeenCalled()
     expect(mockZipClose).toHaveBeenCalledOnce()
     expect(mockWriteRestoreJournal).not.toHaveBeenCalled()
   })

--- a/src/main/utils/__tests__/zipSafety.test.ts
+++ b/src/main/utils/__tests__/zipSafety.test.ts
@@ -1,0 +1,40 @@
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { assertZipEntriesWithin } from '../zipSafety'
+
+// C4 (mcp-services-1): node-stream-zip writes each entry at path.join(baseDir, name)
+// with no containment check, so an archive crafted with a `../` entry could
+// overwrite files outside the extraction dir. The guard must reject before extraction.
+describe('assertZipEntriesWithin', () => {
+  const baseDir = path.join('/', 'tmp', 'extract')
+
+  // Skip on Windows — path separator / resolution semantics differ.
+  const testFn = process.platform === 'win32' ? it.skip : it
+
+  testFn('accepts entries nested inside the base dir', () => {
+    expect(() => assertZipEntriesWithin(['manifest.json', 'server/index.js', 'assets/icon.png'], baseDir)).not.toThrow()
+  })
+
+  testFn('accepts the base dir itself (directory entries)', () => {
+    expect(() => assertZipEntriesWithin(['.'], baseDir)).not.toThrow()
+  })
+
+  testFn('rejects a parent-traversal entry', () => {
+    expect(() => assertZipEntriesWithin(['../escape.txt'], baseDir)).toThrow('zip-slip')
+  })
+
+  testFn('rejects a deep traversal entry mixed with safe entries', () => {
+    expect(() => assertZipEntriesWithin(['manifest.json', '../../../etc/cron.d/evil'], baseDir)).toThrow('zip-slip')
+  })
+
+  testFn('rejects an absolute-path entry', () => {
+    expect(() => assertZipEntriesWithin(['/etc/passwd'], baseDir)).toThrow('zip-slip')
+  })
+
+  testFn('rejects a sibling-prefix entry that is not actually nested', () => {
+    // `/tmp/extract_evil` shares the base string prefix but is not within the base dir.
+    expect(() => assertZipEntriesWithin(['../extract_evil/x'], baseDir)).toThrow('zip-slip')
+  })
+})

--- a/src/main/utils/zipSafety.ts
+++ b/src/main/utils/zipSafety.ts
@@ -1,0 +1,20 @@
+import path from 'node:path'
+
+/**
+ * Defense-in-depth zip-slip guard: node-stream-zip rejects malicious names at parse
+ * time (`validateName`), but nothing at the extract() call boundary enforces
+ * containment — this keeps the guarantee independent of lib internals or config
+ * (`skipEntryNameValidation`). Nested subdirectories are allowed (archives
+ * legitimately contain them).
+ *
+ * @throws Error if any entry name escapes `baseDir`
+ */
+export function assertZipEntriesWithin(entryNames: string[], baseDir: string): void {
+  const root = path.resolve(baseDir)
+  for (const name of entryNames) {
+    const dest = path.resolve(baseDir, name)
+    if (dest !== root && !dest.startsWith(root + path.sep)) {
+      throw new Error(`Unsafe zip entry path (zip-slip): ${name}`)
+    }
+  }
+}

--- a/tests/main.setup.ts
+++ b/tests/main.setup.ts
@@ -95,6 +95,7 @@ vi.mock('electron', () => {
     },
     shell: {
       openExternal: vi.fn(),
+      openPath: vi.fn(),
       showItemInFolder: vi.fn(),
       trashItem: vi.fn()
     },


### PR DESCRIPTION
### What this PR does

Before this PR:

- All 65 legacy `ipcMain.handle` registrations in `registerIpc()` (the `File_*`/`Fs_*`/`Backup_*`/`Nutstore`/`Copilot`/`Skill`/… cluster) plus the three `Application` lifecycle channels ran with **no sender validation** — a compromised renderer (XSS, embedded frame) could invoke them directly, and `Fs_Read`/`File_Write` accept arbitrary absolute paths.
- Legacy `File_OpenPath` bypassed the unsafe-extension guard that the gated `file.open` route already enforces (`safeOpen` → `isDangerExt`), so the OS default handler could be invoked on any file type.
- Backup restore and skill ZIP install called `zip.extract()` with no containment check at the call boundary (only node-stream-zip's internal parse-time `validateName` stood in the way).

After this PR:

- Every one of those registrations routes through `handleGuarded` (`src/main/core/security/guardedIpc.ts`), which runs the same `validateSender` source-trust gate as IpcApi/DataApi/Preference/Cache and rejects untrusted senders (webview guests, sub-frames, foreign `file:` pages) with `FORBIDDEN_SENDER`. `App_LogToMain` is deliberately excluded (module-eval circular-import hazard — comment in place); `BaseService.ipcHandle` sugar channels are a documented follow-up.
- `FileStorage.openPath` delegates to `safeOpen`, aligning legacy and v2 policy: dangerous extensions (`.exe/.bat/.command/.desktop/.py/.js/.sh/.svg/…`) are rejected with `OPEN_BLOCKED_UNSAFE_TYPE` before `shell.openPath`.
- `assertZipEntriesWithin` moved from `McpPackageService` to `src/main/utils/zipSafety.ts` and is asserted before `zip.extract` in `LegacyBackupManager.restoreUnlocked` and `SkillService.extractZip` — defense-in-depth independent of lib internals.

### Why we need it and why it was done in way

The following tradeoffs were made:

- **Wrapper, not migration**: gating the legacy channels via a wrapper is a few lines and zero behavior change for legitimate callers (all come from the app's top-level frame); full migration to `file.*` IpcApi routes stays the long-term direction.
- **`App_LogToMain` left ungated**: `LoggerService` registers at module-eval time; importing the `validateSender` → `@application` chain there is a bootstrap hazard. The channel only forwards log lines (no privileged action).
- **Zip guards as defense-in-depth**: node-stream-zip 1.15.0 already rejects classic traversal/absolute names at parse time (`validateName`), so the guards protect against lib-internal changes/config (`skipEntryNameValidation`) rather than an open hole — same rationale as the existing `McpPackageService` guard.

The following alternatives were considered:

- Full migration of the 65 channels to IpcApi in this PR (rejected: 20+ renderer call sites, unreviewable scope).
- Legacy-only danger list (OS-execute extensions only, allowing `.py/.js/.sh/.svg`) — see breaking changes; flagged for a product call.

### Breaking changes

**Behavior change — product decision requested (D2)**: opening agent-workspace outputs or attachments with extensions `.py`, `.js`, `.sh`, `.svg` (and other script/exec types) via "open with default app" now fails with `OPEN_BLOCKED_UNSAFE_TYPE`. Escape hatches: "Show in folder" (deliberately unguarded) and open-in-editor remain available. This matches the existing `file.open` v2 policy; if product prefers a narrower legacy list (OS-execute-only), it is a one-line switch in `FileStorage.openPath` — decided during review.

### Special notes for your reviewer

- Ordering inside each guard: `validateSender` runs before the handler; zip containment runs after `zip.entries()` and before `zip.extract`, inside `try` so `zip.close()` still fires.
- Tests: real AdmZip-built malicious archive (traversal entry) rejected before any write for skills; mocked-entry rejection-before-extract for backup restore (that suite fully mocks node-stream-zip); guard unit tests moved to `utils/__tests__/zipSafety.test.ts`.
- Full audit trail: `.trellis/tasks/08-17-legacy-ipc-zipslip-hardening/prd.md` (Decision Register D1–D5).

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: Left the code cleaner than found (guard extracted to shared util)
- [x] Upgrade: no upgrade impact (no schema/migration changes)
- [x] Documentation: user-visible behavior change flagged in Breaking changes; docs update deferred to the product decision
- [x] Self-review: reviewed via subagent review (verdict CLEAN, 0 major/medium) before opening

```release-note
Security hardening: legacy IPC channels now reject untrusted renderer senders, "open with default app" refuses dangerous file types (e.g. `.exe`, `.bat`, `.command`, `.py`, `.js`, `.sh`, `.svg`) — use "Show in folder" for those, and archive extraction enforces zip-entry containment before unpacking.
```

---

### Regression verification (round 2 — pre-review)

**Static audit (subagent, exhaustive window × sender matrix)**: verdict `NO-REGRESSION` — 0 confirmed, 0 risk. All 14 window/context types audited: every legitimate caller of the gated channels (Main / SubWindow / QuickAssistant / Selection windows) loads pages whose top-level URL is necessarily in `validateSender`'s trust set (same `loadWindowContent` path as the already-production-gated IpcApi/DataApi/Preference/Cache); every untrusted context (MiniApp/artifact webviews, OAuth popups, iframes, Print/McpBrowser data-URL views) either has no preload surface at all or only ever called these channels maliciously — rejection is the intended hardening, not a break. OAuth flows postMessage back to the main frame before invoking IPC; migration/relocation windows only use their own dedicated channels. `openPath` error-contract change has zero message-matching consumers; registration order and the NodeTraceService dev patch interplay are unchanged; zip guard has no false-positive surface on benign archives; backup mutex/lock release path on guard-throw is identical to the existing error path.

**Live smoke (dev instance over CDP, current code)**: app boots cleanly (no import-cycle/TDZ); `fs.readText` passes the gate from both the main window and a SubWindow (22050 chars); `file.openPath` on a safe extension runs the full chain to `shell.openPath`; on `.py` it is rejected with `Refusing to open .py` — guard confirmed live in the real invoke path.

Known adjacent surface (pre-existing, untouched here, recorded as follow-up): the `http://file/` window-open handler in `MainWindowService` calls `shell.openPath` directly without the unsafe-extension policy.


### Full-feature CDP regression (round 3, live app)

All fix-involved feature groups exercised end-to-end on a live dev instance over CDP — **22 PASS / 0 regressions**:

- **S1 gate passthrough (every channel group)**: fs read/readText (main **and** SubWindow), file checkFileName/listDirectory, System_GetHostname, Zip_Decompress (handler reached), Application PreventQuit→AllowQuit roundtrip (net-zero), Aes_Decrypt, ExternalApps detect (3), Backup listLocalBackupFiles, Copilot (soft).
- **S2 policy**: openPath `.md` full chain to shell; `.py`/`.command` blocked (`Refusing to open`); showInFolder passthrough.
- **S4 E2E attack**: `backup.restore()` with a real malicious zip (`../../../evil.sh` entry) → rejected (`Malicious entry`), **no relaunch** (PID stable), no escaped marker on disk.
- **S5 E2E attack**: `ipcApi.request('skill.install_from_zip', evil zip)` → rejected envelope, no escaped marker.
- Known limitation confirmed (pre-existing, not touched by this PR): a same-origin sandboxed iframe calling `parent.api.*` still succeeds — the invoke's `senderFrame` is the trusted top frame because the contextBridge closure executes in the parent. Closing that vector is the S3 follow-up (legacy HTML-preview iframe hardening), tracked separately; this PR neither introduces nor worsens it.
