### PR TITLE
fix(deepseek-harness): respect custom provider endpoints

### DIFF
--- a/src/main/services/deepSeekHarness/__tests__/config.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/config.test.ts
@@ -140,7 +140,7 @@ describe('DeepSeek Harness config transaction', () => {
     ).toThrow('has no DeepSeek Harness compatible endpoint')
   })
 
-  it('uses an advertised Anthropic route when the selected endpoint cannot preserve developer-role support', () => {
+  it('uses the selected OpenAI endpoint regardless of developer-role support', () => {
     const openAiFirstProvider = provider({
       defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
       apiFeatures: { ...DEFAULT_API_FEATURES, developerRole: false },
@@ -154,17 +154,12 @@ describe('DeepSeek Harness config transaction', () => {
     })
 
     expect(resolveDeepSeekHarnessEndpoint(openAiFirstProvider, openAiFirstModel)).toEqual({
-      endpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-      protocol: 'anthropic-messages',
-      baseUrl: 'https://proxy.example/anthropic'
+      endpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      protocol: 'openai-completions',
+      baseUrl: 'https://proxy.example/v1'
     })
 
-    expect(
-      resolveDeepSeekHarnessEndpoint(
-        { ...openAiFirstProvider, apiFeatures: { ...DEFAULT_API_FEATURES, developerRole: true } },
-        openAiFirstModel
-      )
-    ).toEqual({
+    expect(resolveDeepSeekHarnessEndpoint(openAiFirstProvider, model({ endpointTypes: undefined }))).toEqual({
       endpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
       protocol: 'openai-completions',
       baseUrl: 'https://proxy.example/v1'
@@ -183,69 +178,9 @@ describe('DeepSeek Harness config transaction', () => {
         model({ endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES, ENDPOINT_TYPE.ANTHROPIC_MESSAGES] })
       )
     ).toEqual({
-      endpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-      protocol: 'anthropic-messages',
-      baseUrl: 'https://proxy.example/anthropic'
-    })
-  })
-
-  it('rejects direct endpoints whose developer-role limitation cannot be represented by DSH', () => {
-    const providerWithoutDeveloperRole = provider({
-      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
-      apiFeatures: { ...DEFAULT_API_FEATURES, developerRole: false },
-      endpointConfigs: {
-        [ENDPOINT_TYPE.OPENAI_RESPONSES]: { baseUrl: 'https://proxy.example/v1' },
-        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://proxy.example/v1' }
-      }
-    })
-
-    expect(() =>
-      resolveDeepSeekHarnessEndpoint(
-        providerWithoutDeveloperRole,
-        model({ endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES] })
-      )
-    ).toThrow('must be used through the Unified Gateway')
-    expect(() =>
-      resolveDeepSeekHarnessEndpoint(
-        providerWithoutDeveloperRole,
-        model({ reasoning: undefined, endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES] })
-      )
-    ).toThrow('must be used through the Unified Gateway')
-    expect(() =>
-      resolveDeepSeekHarnessEndpoint(
-        { ...providerWithoutDeveloperRole, defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS },
-        model({ endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS] })
-      )
-    ).toThrow('must be used through the Unified Gateway')
-
-    expect(
-      resolveDeepSeekHarnessEndpoint(
-        { ...providerWithoutDeveloperRole, defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS },
-        model({
-          reasoning: undefined,
-          endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
-        })
-      )
-    ).toMatchObject({ endpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS })
-  })
-
-  it('uses pi-ai DeepSeek compatibility for reasoning models on the official chat endpoint', () => {
-    expect(
-      resolveDeepSeekHarnessEndpoint(
-        provider({
-          id: 'deepseek',
-          defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
-          apiFeatures: { ...DEFAULT_API_FEATURES, developerRole: false },
-          endpointConfigs: {
-            [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://api.deepseek.com' }
-          }
-        }),
-        model({ endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS] })
-      )
-    ).toEqual({
-      endpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
-      protocol: 'openai-completions',
-      baseUrl: 'https://api.deepseek.com/v1'
+      endpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      protocol: 'openai-responses',
+      baseUrl: 'https://proxy.example/v1'
     })
   })
 

--- a/src/main/services/deepSeekHarness/config.ts
+++ b/src/main/services/deepSeekHarness/config.ts
@@ -328,29 +328,11 @@ export function resolveDeepSeekHarnessEndpoint(
     Boolean(endpoint && DIRECT_ENDPOINTS.includes(endpoint as (typeof DIRECT_ENDPOINTS)[number]))
   const hasBaseUrl = (endpoint: EndpointType): boolean => Boolean(provider.endpointConfigs?.[endpoint]?.baseUrl)
   const declaredModelEndpoints = model.endpointTypes?.length ? model.endpointTypes.filter(isSupported) : undefined
-  let endpoint = declaredModelEndpoints
+  const endpoint = declaredModelEndpoints
     ? declaredModelEndpoints.find(hasBaseUrl)
     : isSupported(provider.defaultChatEndpoint) && hasBaseUrl(provider.defaultChatEndpoint)
       ? provider.defaultChatEndpoint
       : DIRECT_ENDPOINTS.find(hasBaseUrl)
-
-  const dshMarksModelAsReasoning = typeof projectReasoningEfforts(model) === 'object'
-  const selectedBaseUrl = endpoint ? provider.endpointConfigs?.[endpoint]?.baseUrl : undefined
-  const piAiUsesSystemRole =
-    endpoint === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS && selectedBaseUrl?.includes('deepseek.com')
-  const requiresDeveloperRole =
-    endpoint === ENDPOINT_TYPE.OPENAI_RESPONSES ||
-    (endpoint === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS && dshMarksModelAsReasoning && !piAiUsesSystemRole)
-  if (provider.apiFeatures.developerRole === false && requiresDeveloperRole) {
-    if (
-      declaredModelEndpoints?.includes(ENDPOINT_TYPE.ANTHROPIC_MESSAGES) &&
-      hasBaseUrl(ENDPOINT_TYPE.ANTHROPIC_MESSAGES)
-    ) {
-      endpoint = ENDPOINT_TYPE.ANTHROPIC_MESSAGES
-    } else {
-      throw new Error(`Provider ${provider.id} must be used through the Unified Gateway for DeepSeek Harness`)
-    }
-  }
 
   if (!endpoint) throw new Error(`Provider ${provider.id} has no DeepSeek Harness compatible endpoint`)
   const rawBaseUrl = provider.endpointConfigs?.[endpoint]?.baseUrl


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: DeepSeek Harness rerouted providers without declared developer-role support to Anthropic or required the Unified Gateway, even when their selected OpenAI-compatible endpoint worked.

After this PR: DeepSeek Harness respects the model-selected or provider-default OpenAI endpoint, including custom models without endpoint metadata.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Provider-side role incompatibilities now surface during the actual request instead of being rejected during configuration.

The following alternatives were considered: Automatic Anthropic or Unified Gateway fallback was rejected because capability metadata is not reliable enough for custom providers.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

<!-- optional -->

Validation: 29 focused DeepSeek Harness tests, `pnpm format`, `pnpm lint`, and `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
DeepSeek Harness respects custom provider endpoint selections without forcing Anthropic or Unified Gateway fallback
```
