### PR TITLE
fix(dsh-runtime): surface web search citations and result cards

### DIFF
--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -2,6 +2,7 @@ import type {
   AssistantMessage,
   CallId,
   ContentBlock,
+  ImageBlock,
   MessageId,
   StreamChunk,
   ToolResultMessage
@@ -176,7 +177,66 @@ describe('DshStreamAdapter', () => {
       input: { command: 'ls' },
       providerMetadata: { cherry: { transport: DSH_TRANSPORT } }
     })
-    expect(chunks[2]).toMatchObject({ toolCallId: 'c1', output: [{ type: 'text', text: 'file.txt' }] })
+    expect(chunks[2]).toMatchObject({ toolCallId: 'c1', output: 'file.txt' })
+  })
+
+  it('unwraps an all-text tool result into its structured payload', () => {
+    const { adapter, chunks } = makeAdapter()
+    const results = [{ id: 'dsh-1', url: 'https://a.com/x', title: 'A', content: 'a' }]
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'web_search', arguments: '{}' })
+    )
+    adapter.handleEvent(
+      envelope('tool/result', {
+        turn: 1,
+        step: 1,
+        message: toolResultMessage('c1', [{ type: 'text', text: JSON.stringify(results) }])
+      })
+    )
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'tool-output-available', output: results })
+  })
+
+  it('reports the MCP identity behind a bridged tool wire name', () => {
+    const { adapter, chunks } = makeAdapter()
+    adapter.handleEvent(
+      envelope('tool/call', {
+        turn: 1,
+        step: 1,
+        callId: callId('c1'),
+        name: 'mcp__cherry-tools__web_search',
+        arguments: '{}'
+      })
+    )
+
+    expect(chunks[0]).toMatchObject({
+      providerMetadata: {
+        cherry: { tool: { type: 'mcp', name: 'web_search', serverId: 'cherry-tools', serverName: 'cherry-tools' } }
+      }
+    })
+  })
+
+  it('keeps a mixed-content tool result as MCP content blocks', () => {
+    const { adapter, chunks } = makeAdapter()
+    const content: ContentBlock[] = [
+      { type: 'text', text: '{"ok":true}' },
+      {
+        type: 'image',
+        attachment: {
+          attachmentId: 'att-1' as ImageBlock['attachment']['attachmentId'],
+          mediaType: 'image/png',
+          bytes: 4,
+          width: 1,
+          height: 1
+        }
+      }
+    ]
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'screenshot', arguments: '{}' })
+    )
+    adapter.handleEvent(envelope('tool/result', { turn: 1, step: 1, message: toolResultMessage('c1', content) }))
+
+    expect(chunks.at(-1)).toMatchObject({ type: 'tool-output-available', output: content })
   })
 
   it('degrades malformed tool arguments JSON to an empty input', () => {

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -26,6 +26,7 @@ import type {} from '@deepseek-ai/dsh-plan-mode'
 import type { SessionEvent, SessionEventMap, TurnEndReason } from '@deepseek-ai/dsh-session'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
 import type { AgentSessionApiRetryInfo } from '@shared/ai/agentSessionApiRetry'
+import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk } from '@shared/data/types/message'
 
 import type { AgentRuntimeEvent } from '../types'
@@ -68,10 +69,15 @@ export interface DshStreamSink {
 }
 
 function toolProviderMetadata(toolName: string, extra: Record<string, unknown> = {}) {
+  // Bridged MCP tools keep their `mcp__server__tool` wire name; report the MCP identity behind it
+  // so the renderer routes them to the same cards it gives Claude Code's MCP results.
+  const mcp = parseFunctionCallToolName(toolName)
   return {
     cherry: {
       transport: DSH_TRANSPORT,
-      tool: { type: 'builtin', name: toolName }
+      tool: mcp
+        ? { type: 'mcp', name: mcp.toolPart, serverId: mcp.serverPart, serverName: mcp.serverPart }
+        : { type: 'builtin', name: toolName }
     },
     dsh: { toolName, ...extra }
   }
@@ -357,7 +363,7 @@ export class DshStreamAdapter {
     this.sink.enqueue({
       type: 'tool-output-available',
       toolCallId,
-      output,
+      output: normalizeToolOutput(output),
       dynamic: true,
       providerExecuted: true,
       providerMetadata: toolProviderMetadata(toolName)
@@ -528,6 +534,23 @@ function parseToolArguments(raw: string): Record<string, unknown> {
     return isRecord(parsed) ? parsed : {}
   } catch {
     return {}
+  }
+}
+
+/**
+ * dsh wraps every tool result in MCP content blocks, so an all-text result hides its payload
+ * inside a JSON string. Unwrap it the way the Claude Code adapter does, so downstream consumers
+ * (tool cards, citation resolution, persisted projection) see one shape across runtimes.
+ */
+function normalizeToolOutput(output: ContentBlock[]): unknown {
+  const texts = output.filter((entry): entry is Extract<ContentBlock, { type: 'text' }> => entry.type === 'text')
+  if (texts.length === 0 || texts.length !== output.length) return output
+
+  const text = texts.map((entry) => entry.text).join('\n')
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
   }
 }
 

--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -348,14 +348,28 @@ describe('withToolCitationTags', () => {
     expect(content).toContain('2</sup>](https://b.com/y)')
   })
 
-  it('resolves the comma-list marker form models write instead of chaining', () => {
+  it.each([
+    ['comma list', 'Fact. [cite:abc-1, abc-2]'],
+    ['padded ids', 'Fact. [cite: abc-1][cite: abc-2 ]'],
+    ['padded comma list', 'Fact. [cite: abc-1, abc-2]'],
+    ['repeated cite prefix', 'Fact. [cite: abc-1, cite: abc-2]'],
+    ['semicolon separator', 'Fact. [cite:abc-1; abc-2]']
+  ])('resolves the near-miss marker form models write instead of chaining: %s', (_label, input) => {
     const mc = resolveMessageCitations([webToolPart(webResults('abc'))])
-    const { content, cited } = withToolCitationTags('Fact. [cite:abc-1, abc-2]', mc)
+    const { content, cited } = withToolCitationTags(input, mc)
 
     expect(content).toContain('1</sup>](https://a.com/x)')
     expect(content).toContain('2</sup>](https://b.com/y)')
     expect(content).not.toContain('[cite:')
     expect(cited.map((c) => c.number)).toEqual([1, 2])
+  })
+
+  it('leaves a bracket holding no id alone', () => {
+    const mc = resolveMessageCitations([webToolPart(webResults('abc'))])
+    const { content } = withToolCitationTags('Fact. [cite:] and [cite: ]', mc)
+
+    expect(content).toContain('[cite:]')
+    expect(content).toContain('[cite: ]')
   })
 
   it('leaves unknown ids literal', () => {

--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -348,6 +348,16 @@ describe('withToolCitationTags', () => {
     expect(content).toContain('2</sup>](https://b.com/y)')
   })
 
+  it('resolves the comma-list marker form models write instead of chaining', () => {
+    const mc = resolveMessageCitations([webToolPart(webResults('abc'))])
+    const { content, cited } = withToolCitationTags('Fact. [cite:abc-1, abc-2]', mc)
+
+    expect(content).toContain('1</sup>](https://a.com/x)')
+    expect(content).toContain('2</sup>](https://b.com/y)')
+    expect(content).not.toContain('[cite:')
+    expect(cited.map((c) => c.number)).toEqual([1, 2])
+  })
+
   it('leaves unknown ids literal', () => {
     const mc = resolveMessageCitations([webToolPart(webResults('abc'))])
     const { content, cited } = withToolCitationTags('Fact. [cite:zzz-9]', mc)
@@ -491,7 +501,7 @@ describe('stripCitationMarkers', () => {
   })
 
   it('preserves canonical markers in inline and fenced code', () => {
-    const input = '`[cite:abc-1]`\n```txt\n[cite:def-2]\n```\nOutside [cite:abc-1]'
-    expect(stripCitationMarkers(input)).toBe('`[cite:abc-1]`\n```txt\n[cite:def-2]\n```\nOutside')
+    const input = '`[cite:abc-1]`\n```txt\n[cite:def-2, def-3]\n```\nOutside [cite:abc-1, abc-2]'
+    expect(stripCitationMarkers(input)).toBe('`[cite:abc-1]`\n```txt\n[cite:def-2, def-3]\n```\nOutside')
   })
 })

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -362,25 +362,28 @@ function createCitationLookup(citations: MessageCitations): {
 }
 
 /**
- * Rewrite the comma-list form models keep producing — `[cite:a, b, c]` — into the chained
- * `[cite:a][cite:b][cite:c]` the prompt asks for, so every consumer sees one marker shape.
+ * Rewrite whatever a model puts inside a `[cite:…]` bracket into the chained `[cite:a][cite:b]`
+ * the prompt asks for. Models keep inventing near-misses — padding, comma lists, a repeated
+ * `cite:` per id — so read the bracket as a bag of ids rather than matching one spelling at a
+ * time: every id-shaped token in it is an id, and a bracket holding none is left alone.
  */
-function expandMarkerLists(content: string): string {
+function canonicalizeMarkers(content: string): string {
   return mapMarkdownOutsideCode(content, (text) =>
-    text.replace(/\[cite:([\w-]+(?:[ \t]*,[ \t]*[\w-]+)+)\]/g, (_match, ids: string) =>
-      ids
-        .split(',')
-        .map((id) => `[cite:${id.trim()}]`)
-        .join('')
-    )
+    text.replace(/\[cite:[^\]\n]*\]/g, (marker) => {
+      const ids = marker
+        .slice('[cite:'.length, -1)
+        .match(/[\w-]+/g)
+        ?.filter((id) => id !== 'cite')
+      return ids?.length ? ids.map((id) => `[cite:${id}]`).join('') : marker
+    })
   )
 }
 
 function normalizeMarkerContent(content: string, markerNumberMap: Map<number, Citation>): string {
-  const expanded = expandMarkerLists(content)
+  const canonical = canonicalizeMarkers(content)
   return markerNumberMap.size > 0
-    ? normalizeCitationMarks(expanded, markerNumberMap, WEB_SEARCH_SOURCE.AISDK)
-    : expanded
+    ? normalizeCitationMarks(canonical, markerNumberMap, WEB_SEARCH_SOURCE.AISDK)
+    : canonical
 }
 
 function collapseMarkerRuns(text: string, byMarker: ReadonlyMap<string, Citation>): string {
@@ -403,7 +406,7 @@ export function resolveCitationMarkerParts(
   citations: MessageCitations
 ): ResolvedCitationMarkers[] {
   if (citations.byId.size === 0) {
-    return contents.map((content) => ({ content: expandMarkerLists(content), byMarker: new Map(), cited: [] }))
+    return contents.map((content) => ({ content: canonicalizeMarkers(content), byMarker: new Map(), cited: [] }))
   }
 
   const { lookup, markerNumberMap } = createCitationLookup(citations)
@@ -493,7 +496,7 @@ export function toExportableCitations(
  * without inventing a second, conflicting sequence.
  */
 export function stripCitationMarkers(content: string): string {
-  return mapMarkdownOutsideCode(expandMarkerLists(content), (text) => text.replace(CITATION_MARKER_PATTERN, ''))
+  return mapMarkdownOutsideCode(canonicalizeMarkers(content), (text) => text.replace(CITATION_MARKER_PATTERN, ''))
 }
 
 /**

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -361,8 +361,26 @@ function createCitationLookup(citations: MessageCitations): {
   return { lookup, markerNumberMap }
 }
 
+/**
+ * Rewrite the comma-list form models keep producing — `[cite:a, b, c]` — into the chained
+ * `[cite:a][cite:b][cite:c]` the prompt asks for, so every consumer sees one marker shape.
+ */
+function expandMarkerLists(content: string): string {
+  return mapMarkdownOutsideCode(content, (text) =>
+    text.replace(/\[cite:([\w-]+(?:[ \t]*,[ \t]*[\w-]+)+)\]/g, (_match, ids: string) =>
+      ids
+        .split(',')
+        .map((id) => `[cite:${id.trim()}]`)
+        .join('')
+    )
+  )
+}
+
 function normalizeMarkerContent(content: string, markerNumberMap: Map<number, Citation>): string {
-  return markerNumberMap.size > 0 ? normalizeCitationMarks(content, markerNumberMap, WEB_SEARCH_SOURCE.AISDK) : content
+  const expanded = expandMarkerLists(content)
+  return markerNumberMap.size > 0
+    ? normalizeCitationMarks(expanded, markerNumberMap, WEB_SEARCH_SOURCE.AISDK)
+    : expanded
 }
 
 function collapseMarkerRuns(text: string, byMarker: ReadonlyMap<string, Citation>): string {
@@ -385,7 +403,7 @@ export function resolveCitationMarkerParts(
   citations: MessageCitations
 ): ResolvedCitationMarkers[] {
   if (citations.byId.size === 0) {
-    return contents.map((content) => ({ content, byMarker: new Map(), cited: [] }))
+    return contents.map((content) => ({ content: expandMarkerLists(content), byMarker: new Map(), cited: [] }))
   }
 
   const { lookup, markerNumberMap } = createCitationLookup(citations)
@@ -475,7 +493,7 @@ export function toExportableCitations(
  * without inventing a second, conflicting sequence.
  */
 export function stripCitationMarkers(content: string): string {
-  return mapMarkdownOutsideCode(content, (text) => text.replace(CITATION_MARKER_PATTERN, ''))
+  return mapMarkdownOutsideCode(expandMarkerLists(content), (text) => text.replace(CITATION_MARKER_PATTERN, ''))
 }
 
 /**


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

In DSH agent replies, `cherry-tools` web search produced neither citations nor a usable tool card. Citation markers stayed on screen as raw `[cite:id]` text, and the tool call rendered as a generic "MCP Server Tool — cherry-tools:web_search" card dumping the escaped result JSON.

Two independent causes:

1. `DshStreamAdapter` emitted tool results as the raw MCP content blocks dsh reports, tagged `cherry.tool = { type: 'builtin', name: <full wire name> }`. Every consumer downstream therefore saw a serialized JSON text block under a generic identity: `webSearchOutputSchema` could not parse it, and `chooseTool` could not match `mcp__cherry-tools__web_search` to the web search card, so it fell through to `UnknownToolRenderer`.
2. The `[cite:...]` marker regexes accepted exactly one spelling — `[cite:<single-id>]`. Models write near-misses around it: `[cite:a, b]` (DeepSeek), `[cite: a]` and `[cite: a, cite: b]` (Gemini 3.6 Flash). None matched, so those markers stayed literal even once the results parsed.

After this PR:

1. `DshStreamAdapter` unwraps an all-text tool result into its structured payload and reports the MCP identity behind a bridged `mcp__server__tool` wire name — both of which the Claude Code adapter already did. DSH tool results now reach the renderer in the same shape as Claude Code's, so citations resolve and `web_search` routes to `MessageWebSearchToolTitle` with favicons and a real result count.
2. Citation markers are canonicalized by reading the bracket rather than matching a spelling: every id-shaped token inside `[cite:...]` is treated as an id, and a bracket holding none is left untouched.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18754

### Why we need it and why it was done in this way

Both halves of cause 1 are the same defect: the dsh adapter under-reported what the Claude Code adapter already reports. `ClaudeCodeStreamAdapter.normalizeToolResult` parses all-text results into their payload, and `mergeToolDisplayMetadata` resolves `mcp__server__tool` into `{ type: 'mcp', name, serverId, serverName }`. Fixing dsh at the same seam makes the two runtimes converge, so no renderer code needed to learn a dsh-specific shape.

The following tradeoffs were made:

- Marker canonicalization stays in the renderer rather than being pushed into prompt wording alone. The prompt already asks for the chained form and the model still deviates; more importantly, a prompt change cannot repair messages already persisted.
- Canonicalization mangles a bracket that contains prose (`[cite: see note]` becomes two unresolved markers). Accepted: models inventing separators is far more likely than models writing prose inside a cite bracket, and a discriminator would turn one rule back into a list of special cases.
- Third-party MCP tools called through dsh now render through the generic MCP card instead of the agent timeline's unknown-tool renderer. This matches Claude Code's existing behavior for the same tools.

The following alternatives were considered:

- Recovering the serialized JSON inside the renderer's citation resolver (the original approach in this PR) was rejected: it fixed only citations, left the tool card broken, and taught `utils/message` a shape that exists solely because one runtime adapter dropped it.
- Declaring `outputSchema` on the cherry builtin MCP tools so the server emits `structuredContent` does not help here: `BridgeToolDescriptor` has no field to carry it, `packages/dsh-bridge/src/plugin.ts` collapses tool output to a single text block by design, and dsh's `ContentBlock` union has no structured variant.
- Enumerating each observed marker spelling with its own regex was rejected after the third variant appeared; it does not converge as models change.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18754

### Breaking changes

None.

### Special notes for your reviewer

Commits are split by concern and can be reviewed independently:

- `68310c63aa` — dsh adapter output shape and tool identity.
- `24f6d0f58b` — runtime-neutral `[cite:...]` marker canonicalization.

Not verified in a live dsh session. Both fixes are derived statically and covered by unit tests; confirming the web search card on screen still needs a real `web_search` call in a running instance.

Validation:

- `npx vitest run src/main/ai/runtime/dsh` — 134 passed.
- `npx vitest run src/renderer/utils/message/__tests__/citations.test.ts` — 53 passed.
- `npx vitest run` over `citation.test.ts`, `export.test.ts`, `find.test.ts`, `ExportService.test.ts`, `MainTextBlock.test.tsx`, `MessagePartsRenderer.test.tsx`, `composerClipboard.test.ts`, and `src/renderer/components/chat/messages/tools` — all passed.
- `pnpm lint` — passed. `pnpm docs:check-links` — passed.
- Full `pnpm test` was run on the first commit (12,031 + 9,314 + 3,014 passed) but not re-run for the second; CI covers it.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed DSH agent web search: results now render as a source card with clickable links, and inline citation markers resolve instead of showing raw [cite:id] text.
```
