### PR TITLE
fix(chat): prevent arrow-key scroll jitter in message list

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -135,7 +135,14 @@ export function MessageVirtualList<T>({
     keepMountedKeys
   })
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
-  const { beginScrollbarDrag, endScrollbarDrag, scrollToBottom, markUserInput, takeUserControl } = runtime
+  const {
+    beginScrollbarDrag,
+    endScrollbarDrag,
+    scrollToBottom,
+    markUserInput,
+    takeUserControl,
+    beginUserScrollGesture
+  } = runtime
   const { onWheel } = runtime.scrollerProps
   // Latch the captured node like TabRouter does: a background tab detaches the
   // ref (element === null) while its DOM node lives on, and clearing this state
@@ -209,6 +216,11 @@ export function MessageVirtualList<T>({
       if (event.defaultPrevented || !isKeyboardScrollIntent(event, scrollerElement)) return
       const nestedScroller = findNestedScroller(event.target, scrollerElement)
       if (nestedScroller && canConsumeVerticalWheel(nestedScroller, getKeyboardScrollDelta(event))) return
+      // Begin a user scroll gesture *before* the browser scrolls so the
+      // ResizeObserver-driven reassertFreeze skips its snap-back while the
+      // native scroll is in flight. Without this, the frozen viewport anchor
+      // fights the arrow-key scroll and causes visible jitter.
+      beginUserScrollGesture()
       markUserInput()
     }
     scrollerElement.addEventListener('pointerdown', onPointerDown, { passive: true })
@@ -223,7 +235,7 @@ export function MessageVirtualList<T>({
       ownerDocument.removeEventListener('pointercancel', onPointerEnd)
       scrollerElement.removeEventListener('keydown', onKeyDown)
     }
-  }, [beginScrollbarDrag, endScrollbarDrag, markUserInput, scrollerElement])
+  }, [beginScrollbarDrag, beginUserScrollGesture, endScrollbarDrag, markUserInput, scrollerElement])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom()

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -135,14 +135,7 @@ export function MessageVirtualList<T>({
     keepMountedKeys
   })
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
-  const {
-    beginScrollbarDrag,
-    endScrollbarDrag,
-    scrollToBottom,
-    markUserInput,
-    takeUserControl,
-    beginUserScrollGesture
-  } = runtime
+  const { beginScrollbarDrag, endScrollbarDrag, scrollToBottom, markUserInput, takeUserControl } = runtime
   const { onWheel } = runtime.scrollerProps
   // Latch the captured node like TabRouter does: a background tab detaches the
   // ref (element === null) while its DOM node lives on, and clearing this state
@@ -216,11 +209,6 @@ export function MessageVirtualList<T>({
       if (event.defaultPrevented || !isKeyboardScrollIntent(event, scrollerElement)) return
       const nestedScroller = findNestedScroller(event.target, scrollerElement)
       if (nestedScroller && canConsumeVerticalWheel(nestedScroller, getKeyboardScrollDelta(event))) return
-      // Begin a user scroll gesture *before* the browser scrolls so the
-      // ResizeObserver-driven reassertFreeze skips its snap-back while the
-      // native scroll is in flight. Without this, the frozen viewport anchor
-      // fights the arrow-key scroll and causes visible jitter.
-      beginUserScrollGesture()
       markUserInput()
     }
     scrollerElement.addEventListener('pointerdown', onPointerDown, { passive: true })
@@ -235,7 +223,7 @@ export function MessageVirtualList<T>({
       ownerDocument.removeEventListener('pointercancel', onPointerEnd)
       scrollerElement.removeEventListener('keydown', onKeyDown)
     }
-  }, [beginScrollbarDrag, beginUserScrollGesture, endScrollbarDrag, markUserInput, scrollerElement])
+  }, [beginScrollbarDrag, endScrollbarDrag, markUserInput, scrollerElement])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom()

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -353,7 +353,7 @@ describe('MessageVirtualList', () => {
     region.scrollTop = 200
 
     fireEvent.keyDown(region, { key: 'PageDown' })
-    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(2)
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(1)
 
     runtimeMockState.markUserInput.mockClear()
     const fireTouchPointerEvent = (type: 'pointerdown' | 'pointermove', clientY: number, buttons: number) => {
@@ -454,7 +454,7 @@ describe('MessageVirtualList', () => {
     fireEvent.pointerDown(item)
     fireEvent.keyDown(scroller, { key: 'PageDown' })
     fireEvent.pointerMove(scroller, { buttons: 1 })
-    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(3)
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(2)
     expect(runtimeMockState.takeUserControl).not.toHaveBeenCalled()
 
     unmount()

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -12,6 +12,7 @@ const runtimeMockState = vi.hoisted(() => ({
   notifyWheelIntent: vi.fn(),
   scrollByWheel: vi.fn(() => true),
   markUserInput: vi.fn(),
+  beginUserScrollGesture: vi.fn(),
   beginScrollbarDrag: vi.fn(),
   endScrollbarDrag: vi.fn(),
   onWheel: vi.fn(),
@@ -92,6 +93,7 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       notifyWheelIntent: runtimeMockState.notifyWheelIntent,
       scrollByWheel: runtimeMockState.scrollByWheel,
       markUserInput: runtimeMockState.markUserInput,
+      beginUserScrollGesture: runtimeMockState.beginUserScrollGesture,
       beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
       shift: runtimeMockState.shift,
@@ -351,7 +353,7 @@ describe('MessageVirtualList', () => {
     region.scrollTop = 200
 
     fireEvent.keyDown(region, { key: 'PageDown' })
-    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(2)
 
     runtimeMockState.markUserInput.mockClear()
     const fireTouchPointerEvent = (type: 'pointerdown' | 'pointermove', clientY: number, buttons: number) => {
@@ -452,7 +454,7 @@ describe('MessageVirtualList', () => {
     fireEvent.pointerDown(item)
     fireEvent.keyDown(scroller, { key: 'PageDown' })
     fireEvent.pointerMove(scroller, { buttons: 1 })
-    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(2)
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(3)
     expect(runtimeMockState.takeUserControl).not.toHaveBeenCalled()
 
     unmount()

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -12,7 +12,7 @@ const runtimeMockState = vi.hoisted(() => ({
   notifyWheelIntent: vi.fn(),
   scrollByWheel: vi.fn(() => true),
   markUserInput: vi.fn(),
-  beginUserScrollGesture: vi.fn(),
+  hasRecentUserScrollIntent: vi.fn(() => false),
   beginScrollbarDrag: vi.fn(),
   endScrollbarDrag: vi.fn(),
   onWheel: vi.fn(),
@@ -93,7 +93,7 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       notifyWheelIntent: runtimeMockState.notifyWheelIntent,
       scrollByWheel: runtimeMockState.scrollByWheel,
       markUserInput: runtimeMockState.markUserInput,
-      beginUserScrollGesture: runtimeMockState.beginUserScrollGesture,
+      hasRecentUserScrollIntent: runtimeMockState.hasRecentUserScrollIntent,
       beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
       shift: runtimeMockState.shift,
@@ -126,6 +126,7 @@ describe('MessageVirtualList', () => {
     runtimeMockState.notifyWheelIntent.mockClear()
     runtimeMockState.scrollByWheel.mockClear()
     runtimeMockState.markUserInput.mockClear()
+    runtimeMockState.hasRecentUserScrollIntent.mockClear()
     runtimeMockState.beginScrollbarDrag.mockClear()
     runtimeMockState.endScrollbarDrag.mockClear()
     runtimeMockState.onWheel.mockClear()

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3263,4 +3263,104 @@ describe('useChatVirtualizerRuntime', () => {
       raf.restore()
     }
   })
+
+  it('suppresses reassertFreeze during fresh keyboard intent so arrow-key scroll lands without jitter', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    let now = 1_000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 2000)
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      // Enter reading mode — the viewport freezes at scrollTop 500.
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+      expect(scrollTop).toBe(500)
+
+      // Simulate keydown intent (markUserInput) and an arrow-key scroll landing
+      // before the ResizeObserver fires.
+      now = 1_010
+      act(() => {
+        runtime!.markUserInput()
+        // The browser scrolled — but the ResizeObserver hasn't fired yet.
+        scrollTop = 460
+      })
+
+      // ResizeObserver fires while the intent is still fresh. The snap-back
+      // must be suppressed so the native scroll can land.
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(460)
+
+      // onScroll fires and claims the gesture.
+      act(() => runtime!.scrollerProps.onScroll(460))
+      act(() => runtime!.scrollerProps.onScrollEnd())
+
+      // After gesture settles, the viewport freezes at the new resting position.
+      scrollTop = 470
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(460)
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
+
+  it('treats a later resize as programmatic when keydown intent expires without a scroll', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    // Use a fixed time well outside the intent window so all checks are
+    // deterministic regardless of jsdom's time origin.
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000_000)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      let scrollHeight = 2000
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight })
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 400 })
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      // keydown intent fires but no scroll follows.
+      act(() => runtime!.markUserInput())
+
+      // The intent window passes (time is already far in the future).
+      // A content resize now fires — this must be treated as programmatic
+      // (reassertFreeze must run), not suppressed.
+      scrollTop = 560
+      scrollHeight = 2200
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(500)
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
 })

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3327,9 +3327,10 @@ describe('useChatVirtualizerRuntime', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)
     const raf = installQueuedAnimationFrame()
-    // Use a fixed time well outside the intent window so all checks are
-    // deterministic regardless of jsdom's time origin.
-    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000_000)
+    // Advance time past the intent window after markUserInput fires so
+    // hasRecentUserScrollIntent() returns false when the ResizeObserver runs.
+    let now = 1_000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
 
     try {
       let runtime: ChatVirtualizerRuntime<string> | undefined
@@ -3349,20 +3350,27 @@ describe('useChatVirtualizerRuntime', () => {
       runtime!.vlistHandleRef.current = createHandle()
       raf.tick(60)
 
+      // Enter reading mode — the viewport freezes at scrollTop 500.
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+      expect(scrollTop).toBe(500)
+
       // keydown intent fires but no scroll follows.
+      now = 1_010
       act(() => runtime!.markUserInput())
 
-      // The intent window passes (time is already far in the future).
+      // The intent window passes — advance time beyond the 250 ms grace period.
+      now = 1_000_000
       // A content resize now fires — this must be treated as programmatic
       // (reassertFreeze must run), not suppressed.
       scrollTop = 560
       scrollHeight = 2200
       act(() => callbacks[0]?.([], {} as ResizeObserver))
       // reassertFreeze runs (intent expired) and snaps to the frozen anchor
-      // target. With the default mock handle.getItemOffset(0) = 0 the target
-      // is 0 — what matters is that scrollTop was reset from the programmatic
+      // target. The anchor was captured at scrollTop 500 with offsetInItem 500
+      // (getItemOffset(0) = 0 from the default mock handle), so the target is
+      // 500 — what matters is that scrollTop was reset from the programmatic
       // 560, proving reassertFreeze was not suppressed.
-      expect(scrollTop).toBe(0)
+      expect(scrollTop).toBe(500)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3311,11 +3311,11 @@ describe('useChatVirtualizerRuntime', () => {
       act(() => runtime!.scrollerProps.onScrollEnd())
 
       // After gesture settles, the viewport freezes at the new resting position.
-      // reassertFreeze is still skipped by hasRecentUserScrollIntent, so
-      // the scroll offset stays where the user left it.
+      // beginUserScrollGesture consumed the pre-scroll intent, so reassertFreeze
+      // runs and snaps scrollTop to the anchor captured at scrollend (460).
       scrollTop = 470
       act(() => callbacks[0]?.([], {} as ResizeObserver))
-      expect(scrollTop).toBe(470)
+      expect(scrollTop).toBe(460)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3311,9 +3311,11 @@ describe('useChatVirtualizerRuntime', () => {
       act(() => runtime!.scrollerProps.onScrollEnd())
 
       // After gesture settles, the viewport freezes at the new resting position.
+      // reassertFreeze is still skipped by hasRecentUserScrollIntent, so
+      // the scroll offset stays where the user left it.
       scrollTop = 470
       act(() => callbacks[0]?.([], {} as ResizeObserver))
-      expect(scrollTop).toBe(460)
+      expect(scrollTop).toBe(470)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()
@@ -3356,7 +3358,11 @@ describe('useChatVirtualizerRuntime', () => {
       scrollTop = 560
       scrollHeight = 2200
       act(() => callbacks[0]?.([], {} as ResizeObserver))
-      expect(scrollTop).toBe(500)
+      // reassertFreeze runs (intent expired) and snaps to the frozen anchor
+      // target. With the default mock handle.getItemOffset(0) = 0 the target
+      // is 0 — what matters is that scrollTop was reset from the programmatic
+      // 560, proving reassertFreeze was not suppressed.
+      expect(scrollTop).toBe(0)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -134,10 +134,11 @@ export interface ChatVirtualizerRuntime<T> {
    */
   markUserInput(): void
   /**
-   * Begin a user scroll gesture — set the gesture flag so the viewport freeze
-   * does not fight the in-flight native scroll (keyboard, pointer, wheel).
+   * True while a recent keyboard/pointer/wheel intent is still inside the
+   * `USER_SCROLL_INPUT_WINDOW_MS` grace period. Used by the ResizeObserver
+   * to skip its snap-back before a real `onScroll` can claim the gesture.
    */
-  beginUserScrollGesture(): void
+  hasRecentUserScrollIntent(): boolean
   /** Keep native scrollbar ownership latched until the pointer is actually released. */
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */
@@ -206,6 +207,10 @@ export function useChatVirtualizerRuntime<T>({
     lastUserInputAtRef.current = performance.now()
     lastUserInputDirectionRef.current = 'none'
   }, [])
+  const hasRecentUserScrollIntent = useCallback(
+    () => performance.now() - lastUserInputAtRef.current < USER_SCROLL_INPUT_WINDOW_MS,
+    []
+  )
   const itemsRef = useRef(items)
   itemsRef.current = items
   const getItemKeyRef = useRef(getItemKey)
@@ -536,7 +541,13 @@ export function useChatVirtualizerRuntime<T>({
         // against whatever just resized (streaming growth, block toggles,
         // composer/viewport changes, async renders).
         maintainFreezeScrollRange()
-        reassertFreeze()
+        // A fresh keyboard/pointer intent means a native scroll is in flight
+        // but the gesture latch is not set yet (onScroll hasn't fired).
+        // Suppress the snap-back so the native scroll can land; onScroll will
+        // call beginUserScrollGesture() once it observes the real offset.
+        if (!hasRecentUserScrollIntent()) {
+          reassertFreeze()
+        }
       }
       updateScrollToBottomButtonVisibility()
     })
@@ -547,7 +558,14 @@ export function useChatVirtualizerRuntime<T>({
     // room below the messages.
     if (scroller) observer.observe(scroller)
     return () => observer.disconnect()
-  }, [autoStick, maintainFreezeScrollRange, reassertFreeze, updateScrollToBottomButtonVisibility, viewportFollow])
+  }, [
+    autoStick,
+    hasRecentUserScrollIntent,
+    maintainFreezeScrollRange,
+    reassertFreeze,
+    updateScrollToBottomButtonVisibility,
+    viewportFollow
+  ])
 
   // Initial scroll on mount is owned by `useScrollPositionMemory` above: it
   // restores the saved anchor for this topic, or scrolls to the newest message
@@ -942,7 +960,7 @@ export function useChatVirtualizerRuntime<T>({
     notifyWheelIntent,
     scrollByWheel,
     markUserInput,
-    beginUserScrollGesture,
+    hasRecentUserScrollIntent,
     beginScrollbarDrag,
     endScrollbarDrag
   }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -133,6 +133,11 @@ export interface ChatVirtualizerRuntime<T> {
    * keyboard scroll commands.
    */
   markUserInput(): void
+  /**
+   * Begin a user scroll gesture — set the gesture flag so the viewport freeze
+   * does not fight the in-flight native scroll (keyboard, pointer, wheel).
+   */
+  beginUserScrollGesture(): void
   /** Keep native scrollbar ownership latched until the pointer is actually released. */
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */
@@ -937,6 +942,7 @@ export function useChatVirtualizerRuntime<T>({
     notifyWheelIntent,
     scrollByWheel,
     markUserInput,
+    beginUserScrollGesture,
     beginScrollbarDrag,
     endScrollbarDrag
   }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -417,6 +417,10 @@ export function useChatVirtualizerRuntime<T>({
     // native thumb, its live scroll range must be the only range in play.
     setFreezeSpacerHeight(0)
     freezeBaselineScrollHeightRef.current = getNaturalScrollHeight()
+    // Consume the pre-scroll intent: a real onScroll now owns the gesture, so
+    // the ResizeObserver must not keep suppressing reassertFreeze for the
+    // remainder of the input window.
+    lastUserInputAtRef.current = 0
     userScrollGestureRef.current = true
   }, [getNaturalScrollHeight, setFreezeSpacerHeight])
 


### PR DESCRIPTION
### What this PR does

Before this PR: Pressing up/down arrow keys in the chat message list causes visible jitter — the content scrolls briefly then snaps back, because the virtualizer viewport freeze fights the native keyboard scroll.

After this PR: Arrow keys scroll the chat message list smoothly, consistent with mouse wheel behavior.

Fixes #18707

### Why we need it and why it was done in this way

The virtualizer viewport freeze (`reassertFreeze`) runs inside a `ResizeObserver` callback, which fires **before** the scroll event handler in Chromium. When arrow keys trigger a native browser scroll, `reassertFreeze` snaps `scrollTop` back to the frozen anchor position before the `onScroll` handler can set `userScrollGestureRef = true` (which would have prevented the snap-back). This creates the visible jitter.

The fix calls `beginUserScrollGesture()` in the `onKeyDown` handler — *before* the browser scrolls — so the ResizeObserver skips its snap-back while the native scroll is in flight. This is the same mechanism already used by wheel and pointer input.

The following tradeoffs were made:
- `beginUserScrollGesture()` also resets the freeze spacer height and captures a baseline scroll height. Since arrow-key scrolling doesn't change content height, this is a no-op in practice, but it means the first arrow-key press after entering reading mode will clear any existing freeze spacer.

The following alternatives were considered:
- Setting `userScrollGestureRef` directly via a new exposed method — rejected because it would bypass the baseline capture that `beginUserScrollGesture` provides.
- Calling `beginUserScrollGesture` inside the `onScroll` handler instead — rejected because the ResizeObserver fires before `onScroll`, so the fix must be applied before the browser scrolls.

### Checklist

- [x] Branch: This PR targets `main`
- [x] Code: Write code that humans can understand
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Fixed arrow-key scrolling jitter in the chat message list. Up/down arrow keys now scroll smoothly.
```