### PR TITLE
feat(agent-session): label runtime-started turns with their origin

### DIFF
--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -140,6 +140,12 @@ waking after background work). `startReceiveOnlyTurn` publishes it to the shared
 cache under `agent.session.turn_origin.${sessionId}.${messageId}` — live session
 status like the api-retry state, not conversation content — so the transcript can
 label a turn that has no user message above it while the session is open.
+If a user turn is live when the runtime starts its own — even an admitted one, since
+dsh runs a queued goal round ahead of a prompt it has already accepted — the user turn
+is deferred: its stream is suspended, the receive-only turn takes the connection, and
+the user turn is relaunched afterwards with its admission preserved (no re-send).
+Content the runtime produces for the deferred turn before its stream reopens is
+buffered on the execution and replayed by `flush-transition`.
 A normal turn whose stream is still `unopened` is queued for the same reason;
 steering is only valid after that turn's stream is `open`. Redirect also requires
 both the current turn and incoming input to be interactive. Delivery, channel,

--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -134,6 +134,12 @@ Stop is now the only abort source). `enqueueUserMessage()`:
 
 A receive-only autonomous generation never accepts a redirect. Follow-ups
 remain in `pendingTurns` until terminal persistence releases runtime ownership.
+The runtime's `autonomous-turn-state: started` event names why it opened the turn
+(`AutonomousTurnOrigin`: a dsh goal round with its round number, or Claude Code
+waking after background work). `startReceiveOnlyTurn` publishes it to the shared
+cache under `agent.session.turn_origin.${sessionId}.${messageId}` — live session
+status like the api-retry state, not conversation content — so the transcript can
+label a turn that has no user message above it while the session is open.
 A normal turn whose stream is still `unopened` is queued for the same reason;
 steering is only valid after that turn's stream is `open`. Redirect also requires
 both the current turn and incoming input to be interactive. Delivery, channel,

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "@codemirror/view": "6.39.16",
     "@dagrejs/dagre": "^3.0.0",
     "@deepseek-ai/dsh-compaction-basic": "0.1.0-rc.7",
+    "@deepseek-ai/dsh-goal": "0.1.0-rc.7",
     "@deepseek-ai/dsh-llm": "0.1.0-rc.7",
     "@deepseek-ai/dsh-llm-retry": "0.1.0-rc.7",
     "@deepseek-ai/dsh-plan-mode": "0.1.0-rc.7",

--- a/packages/dsh-bridge/__tests__/plugin.test.ts
+++ b/packages/dsh-bridge/__tests__/plugin.test.ts
@@ -247,10 +247,12 @@ describe('cherry bridge plugin', () => {
         events: [
           {
             type: 'tool/call',
+            seq: 7,
             data: { callId: 'exit-plan-call-1', name: 'exit_plan_mode', arguments: JSON.stringify({ plan }) }
           },
           {
             type: 'tool/call',
+            seq: 9,
             data: { callId: 'exit-plan-call-2', name: 'exit_plan_mode', arguments: JSON.stringify({ plan }) }
           }
         ]
@@ -293,7 +295,7 @@ describe('cherry bridge plugin', () => {
     await expect
       .poll(() => host.requests.find((request) => request.method === 'question/ask'))
       .toMatchObject({
-        params: { sessionId: 'session-1', callId: 'exit-plan-call-2' }
+        params: { sessionId: 'session-1', callId: 'exit-plan-call-2', sessionEventSeq: 9 }
       })
     await expect(answer).resolves.toEqual({})
   })
@@ -303,7 +305,11 @@ describe('cherry bridge plugin', () => {
       method === 'approval/ask' ? { outcome: 'rejected', rejectionReason: 'use a copy instead' } : {}
     )
     const followup = vi.fn()
-    const agent = { id: 'session-1', followup, session: { events: [] } } as unknown as Agent
+    const agent = {
+      id: 'session-1',
+      followup,
+      session: { events: [{ type: 'approval/asked', seq: 12, data: { id: 'ask-1', toolName: 'bash' } }] }
+    } as unknown as Agent
     let approvalHandler: ((request: ApprovalRequest) => Promise<ApprovalOutcome>) | undefined
     const on = vi.fn((event: string, handler: unknown) => {
       if (event === 'approval/request') {
@@ -327,6 +333,10 @@ describe('cherry bridge plugin', () => {
         reason: 'needs approval'
       } as ApprovalRequest)
     ).resolves.toBe('rejected')
+    expect(host.requests.find((request) => request.method === 'approval/ask')?.params).toMatchObject({
+      sessionId: 'session-1',
+      sessionEventSeq: 12
+    })
     expect(followup).not.toHaveBeenCalled()
     await vi.waitFor(() => expect(followup).toHaveBeenCalledOnce())
     expect(followup).toHaveBeenCalledWith(

--- a/packages/dsh-bridge/src/plugin.ts
+++ b/packages/dsh-bridge/src/plugin.ts
@@ -26,6 +26,7 @@ import {
   type BridgeCommandResult,
   type BridgeContextUsage,
   type BridgeHostParams,
+  type BridgePluginRequestMap,
   type BridgePolicy,
   type BridgeSubagentChild,
   type BridgeToolDescriptor
@@ -301,7 +302,7 @@ export function apply(ctx: Context): void {
               'question/ask',
               {
                 sessionId: request.agent?.id ?? '',
-                callId: correlatePlanReviewCallId(request),
+                ...correlatePlanReviewCall(request),
                 questions: request.questions
               },
               request.signal
@@ -419,6 +420,7 @@ export function apply(ctx: Context): void {
         'approval/ask',
         {
           sessionId: req.agent.id,
+          sessionEventSeq: req.agent.session.events.at(-1)!.seq,
           toolName: req.toolName,
           callId: req.callId,
           args: correlateCallArguments(req),
@@ -471,7 +473,9 @@ function correlateCallArguments(req: ApprovalRequest): unknown {
 }
 
 /** Correlate the plan-review question with the newest matching durable tool call. */
-function correlatePlanReviewCallId(request: AskUserQuestionRequest): string {
+function correlatePlanReviewCall(
+  request: AskUserQuestionRequest
+): Pick<BridgePluginRequestMap['question/ask']['params'], 'callId' | 'sessionEventSeq'> {
   const review = request.questions.length === 1 ? request.questions[0] : undefined
   const plan = review?.intent?.kind === 'plan-review' ? review.detail : undefined
   if (!request.agent || typeof plan !== 'string') {
@@ -484,7 +488,7 @@ function correlatePlanReviewCallId(request: AskUserQuestionRequest): string {
     if (event.type !== 'tool/call' || event.data.name !== 'exit_plan_mode') continue
     try {
       const args = JSON.parse(event.data.arguments) as { plan?: unknown } | null
-      if (args?.plan === plan) return String(event.data.callId)
+      if (args?.plan === plan) return { callId: event.data.callId, sessionEventSeq: event.seq }
     } catch {
       continue
     }

--- a/packages/dsh-bridge/src/protocol.ts
+++ b/packages/dsh-bridge/src/protocol.ts
@@ -13,6 +13,8 @@
 
 // Wire-safe by design (dsh keeps this subpath free of cordis imports), and pinned to
 // the same rc at both ends — safe to put on the wire, unlike the wider ContentBlock.
+import type { CallId } from '@deepseek-ai/dsh-llm'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import type { AskUserQuestionAnswer, AskUserQuestionItem } from '@deepseek-ai/dsh-user-questions/types'
 
 export type {
@@ -135,7 +137,14 @@ export interface BridgePluginRequestMap {
     result: { kind: 'allow' } | { kind: 'deny'; ruleId: 'user-data-sqlite-write'; reason: string }
   }
   'approval/ask': {
-    params: { sessionId: string; toolName: string; callId?: string; args?: unknown; reason?: string }
+    params: {
+      sessionId: string
+      sessionEventSeq: SessionEvent['seq']
+      toolName: string
+      callId?: CallId
+      args?: unknown
+      reason?: string
+    }
     result: { outcome: 'allowed-once' | 'rejected'; rejectionReason?: string }
   }
   'tool/call': {
@@ -147,8 +156,9 @@ export interface BridgePluginRequestMap {
   'question/ask': {
     params: {
       sessionId: string
+      sessionEventSeq: SessionEvent['seq']
       /** Exact `exit_plan_mode` call correlated from the plugin's authoritative session log. */
-      callId: string
+      callId: CallId
       questions: AskUserQuestionItem[]
     }
     result: AskUserQuestionAnswer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       '@deepseek-ai/dsh-compaction-basic':
         specifier: 0.1.0-rc.7
         version: 0.1.0-rc.7(f519e9ab3c16060968f3852a830521b6)
+      '@deepseek-ai/dsh-goal':
+        specifier: 0.1.0-rc.7
+        version: 0.1.0-rc.7(9616cea51a4bea931c5522310292a042)
       '@deepseek-ai/dsh-llm':
         specifier: 0.1.0-rc.7
         version: 0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.0-rc.7(@deepseek-ai/cordis@4.0.1)))

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -99,13 +99,6 @@ const CONTEXT_USAGE_REFRESH_THROTTLE_MS = 3_000
 const BACKGROUND_FLOW_HANDOFF_TTL_MS = 60_000
 const BACKGROUND_FLOW_PUBLISH_THROTTLE_MS = 150
 
-/**
- * Adapter-level grace period after a host turn ends. Matches the adapter's
- * `POST_HOST_TURN_GRACE_MS` — used as a safety net in `startReceiveOnlyTurn`
- * to prevent autonomous goal-round content from creating a spurious bubble.
- */
-const POST_HOST_TURN_GRACE_MS = 500
-
 function knowledgeScopeEquals(left: readonly string[], right: readonly string[]): boolean {
   if (left.length !== right.length) return false
   const rightIds = new Set(right)
@@ -241,8 +234,6 @@ type AgentSessionRuntimeEntry = {
   connectionLoop?: Promise<void>
   lastResumeToken?: string
   idleTimer?: ReturnType<typeof setTimeout>
-  /** Timestamp of the last host turn's terminal status; drives the post-turn grace period. */
-  lastHostTurnEndedAt?: number
   /** Throttle stamp for {@link AgentSessionRuntimeService.refreshContextUsageOnDemand}. */
   lastContextUsageRefreshAt?: number
   /** Single-flight marker for context-usage reads on the current connection. */
@@ -787,9 +778,6 @@ export class AgentSessionRuntimeService extends BaseService {
     if (!entry) return
 
     this.clearIdleTimer(entry)
-    // User sent a message — clear the post-turn grace period so the adapter can handle
-    // any subsequent autonomous turns normally.
-    entry.lastHostTurnEndedAt = undefined
     // Message attributes ride the payloads themselves: a redirect carries them through the driver
     // round-trip (steer-boundary/steer-undelivered), a queued follow-up carries them on its queue item.
     const headless = opts.headless === true
@@ -865,15 +853,8 @@ export class AgentSessionRuntimeService extends BaseService {
       if (!executionOwnsTurn || completedTurn?.turnId !== expectedTurnId) return
     }
     if (completedTurn) this.markFlowMessagePersisted(entry, completedTurn.assistantMessageId)
-    // Capture before the transition — after, execution may be idle.
-    const wasHostTurn = entry.runtimeState.execution.kind === 'turn'
     if (completedTurn) {
       this.applyRuntimeStateEvent(entry, { type: 'turn-terminal', turn: completedTurn, status })
-    }
-    // Record when a host turn just ended so the adapter grace period can suppress
-    // the goal-round-driver's autonomous turn that fires immediately after.
-    if (wasHostTurn && entry.runtimeState.execution.kind === 'idle') {
-      entry.lastHostTurnEndedAt = Date.now()
     }
 
     // Connection stays warm across turns (no per-turn close) — only `closeSession`/idle TTL tears it
@@ -2629,19 +2610,6 @@ export class AgentSessionRuntimeService extends BaseService {
       entry.runtimeState.execution.kind !== 'autonomous-turn' ||
       entry.runtimeState.execution.turn
     ) {
-      return
-    }
-    // Safety net: suppress autonomous turns that fire within the grace period after a
-    // host turn ended, UNLESS background work is active (a legitimate autonomous wake-up).
-    // The adapter-level grace period is the primary guard; this catches any autonomous
-    // content that leaks through (e.g. a race where the adapter's hostTurnEndedAt was
-    // cleared before the event was processed).
-    if (
-      entry.lastHostTurnEndedAt !== undefined &&
-      Date.now() - entry.lastHostTurnEndedAt < POST_HOST_TURN_GRACE_MS &&
-      !hasAgentSessionRuntimeBackgroundWork(entry.runtimeState)
-    ) {
-      this.applyRuntimeStateEvent(entry, { type: 'autonomous-turn-abandoned' })
       return
     }
     const { modelId, knowledgeBaseIds, fastMode } = this.connectionTarget(entry)

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -99,6 +99,13 @@ const CONTEXT_USAGE_REFRESH_THROTTLE_MS = 3_000
 const BACKGROUND_FLOW_HANDOFF_TTL_MS = 60_000
 const BACKGROUND_FLOW_PUBLISH_THROTTLE_MS = 150
 
+/**
+ * Adapter-level grace period after a host turn ends. Matches the adapter's
+ * `POST_HOST_TURN_GRACE_MS` — used as a safety net in `startReceiveOnlyTurn`
+ * to prevent autonomous goal-round content from creating a spurious bubble.
+ */
+const POST_HOST_TURN_GRACE_MS = 500
+
 function knowledgeScopeEquals(left: readonly string[], right: readonly string[]): boolean {
   if (left.length !== right.length) return false
   const rightIds = new Set(right)
@@ -234,6 +241,8 @@ type AgentSessionRuntimeEntry = {
   connectionLoop?: Promise<void>
   lastResumeToken?: string
   idleTimer?: ReturnType<typeof setTimeout>
+  /** Timestamp of the last host turn's terminal status; drives the post-turn grace period. */
+  lastHostTurnEndedAt?: number
   /** Throttle stamp for {@link AgentSessionRuntimeService.refreshContextUsageOnDemand}. */
   lastContextUsageRefreshAt?: number
   /** Single-flight marker for context-usage reads on the current connection. */
@@ -778,6 +787,9 @@ export class AgentSessionRuntimeService extends BaseService {
     if (!entry) return
 
     this.clearIdleTimer(entry)
+    // User sent a message — clear the post-turn grace period so the adapter can handle
+    // any subsequent autonomous turns normally.
+    entry.lastHostTurnEndedAt = undefined
     // Message attributes ride the payloads themselves: a redirect carries them through the driver
     // round-trip (steer-boundary/steer-undelivered), a queued follow-up carries them on its queue item.
     const headless = opts.headless === true
@@ -853,8 +865,15 @@ export class AgentSessionRuntimeService extends BaseService {
       if (!executionOwnsTurn || completedTurn?.turnId !== expectedTurnId) return
     }
     if (completedTurn) this.markFlowMessagePersisted(entry, completedTurn.assistantMessageId)
+    // Capture before the transition — after, execution may be idle.
+    const wasHostTurn = entry.runtimeState.execution.kind === 'turn'
     if (completedTurn) {
       this.applyRuntimeStateEvent(entry, { type: 'turn-terminal', turn: completedTurn, status })
+    }
+    // Record when a host turn just ended so the adapter grace period can suppress
+    // the goal-round-driver's autonomous turn that fires immediately after.
+    if (wasHostTurn && entry.runtimeState.execution.kind === 'idle') {
+      entry.lastHostTurnEndedAt = Date.now()
     }
 
     // Connection stays warm across turns (no per-turn close) — only `closeSession`/idle TTL tears it
@@ -2610,6 +2629,14 @@ export class AgentSessionRuntimeService extends BaseService {
       entry.runtimeState.execution.kind !== 'autonomous-turn' ||
       entry.runtimeState.execution.turn
     ) {
+      return
+    }
+    // Safety net: suppress autonomous turns that fire within the grace period after a
+    // host turn ended. The adapter-level grace period is the primary guard; this catches
+    // any autonomous content that leaks through (e.g. a race where the adapter's
+    // hostTurnEndedAt was cleared before the event was processed).
+    if (entry.lastHostTurnEndedAt !== undefined && Date.now() - entry.lastHostTurnEndedAt < POST_HOST_TURN_GRACE_MS) {
+      this.applyRuntimeStateEvent(entry, { type: 'autonomous-turn-abandoned' })
       return
     }
     const { modelId, knowledgeBaseIds, fastMode } = this.connectionTarget(entry)

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2632,10 +2632,15 @@ export class AgentSessionRuntimeService extends BaseService {
       return
     }
     // Safety net: suppress autonomous turns that fire within the grace period after a
-    // host turn ended. The adapter-level grace period is the primary guard; this catches
-    // any autonomous content that leaks through (e.g. a race where the adapter's
-    // hostTurnEndedAt was cleared before the event was processed).
-    if (entry.lastHostTurnEndedAt !== undefined && Date.now() - entry.lastHostTurnEndedAt < POST_HOST_TURN_GRACE_MS) {
+    // host turn ended, UNLESS background work is active (a legitimate autonomous wake-up).
+    // The adapter-level grace period is the primary guard; this catches any autonomous
+    // content that leaks through (e.g. a race where the adapter's hostTurnEndedAt was
+    // cleared before the event was processed).
+    if (
+      entry.lastHostTurnEndedAt !== undefined &&
+      Date.now() - entry.lastHostTurnEndedAt < POST_HOST_TURN_GRACE_MS &&
+      !hasAgentSessionRuntimeBackgroundWork(entry.runtimeState)
+    ) {
       this.applyRuntimeStateEvent(entry, { type: 'autonomous-turn-abandoned' })
       return
     }

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -40,6 +40,7 @@ import {
   AGENT_SESSION_SLASH_COMMANDS_CACHE_KEY,
   type AgentSessionSlashCommand
 } from '@shared/ai/agentSessionSlashCommands'
+import { AGENT_SESSION_TURN_ORIGIN_CACHE_KEY } from '@shared/ai/agentSessionTurnOrigin'
 import type { AgentEntity, UpdateAgentDto } from '@shared/data/api/schemas/agents'
 import type { AgentSessionMessageEntity } from '@shared/data/types/agent'
 import type { CherryMessagePart, CherryUIMessage, MessageSnapshot } from '@shared/data/types/message'
@@ -1779,6 +1780,7 @@ export class AgentSessionRuntimeService extends BaseService {
         this.applyRuntimeStateEvent(entry, {
           type: 'autonomous-turn-state',
           state: 'started',
+          origin: event.origin,
           deferCurrentTurn: turnLive,
           contextTurn: turn
         })
@@ -2787,6 +2789,7 @@ export class AgentSessionRuntimeService extends BaseService {
     ) {
       return
     }
+    const { origin } = entry.runtimeState.execution
     const { modelId, serviceTier, knowledgeBaseIds, fastMode, trustedNotifyChannels } = this.connectionTarget(entry)
     const syntheticMessage = createSyntheticUserMessage(entry.sessionId)
 
@@ -2814,6 +2817,10 @@ export class AgentSessionRuntimeService extends BaseService {
     }
 
     const assistantMessageId = assistantMessage.id
+    // No user message explains this turn; the badge reads the origin off the live session cache.
+    application
+      .get('CacheService')
+      .setShared(AGENT_SESSION_TURN_ORIGIN_CACHE_KEY(entry.sessionId, assistantMessageId), origin)
     const turnId = crypto.randomUUID()
     const receiveOnlyTurn: AgentSessionTurn = {
       turnId,

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1689,7 +1689,10 @@ export class AgentSessionRuntimeService extends BaseService {
         const turn = this.currentTurn(entry)
         if (
           execution.kind === 'steer-transition' ||
-          (execution.kind === 'autonomous-turn' && !hasAgentSessionRuntimeOpenStream(entry.runtimeState, turn))
+          (execution.kind === 'autonomous-turn' && !hasAgentSessionRuntimeOpenStream(entry.runtimeState, turn)) ||
+          // An admitted turn relaunched after a receive-only generation: the runtime may already be
+          // answering its prompt before the renderer reattaches its stream.
+          (execution.kind === 'turn' && execution.stream === 'unopened' && execution.admission === 'admitted')
         ) {
           this.applyRuntimeStateEvent(entry, { type: 'buffer-chunk', chunk: event.chunk })
           break
@@ -1772,10 +1775,10 @@ export class AgentSessionRuntimeService extends BaseService {
           break
         }
         // Runtime-generated content is already streaming. The autonomous execution state buffers
-        // chunks until its receive-only stream exists and owns any still-unadmitted user turn.
+        // chunks until its receive-only stream exists and owns the current user turn meanwhile — even
+        // an admitted one: dsh runs a queued goal round before the prompt it has already accepted.
         const turn = this.currentTurn(entry)
         const turnLive = turn !== undefined && this.isTurnLive(entry, turn)
-        if (turnLive && turn && isAgentSessionRuntimeTurnAdmitted(entry.runtimeState, turn)) break
         if (entry.runtimeState.execution.kind === 'steer-transition') break
         this.applyRuntimeStateEvent(entry, {
           type: 'autonomous-turn-state',
@@ -1786,7 +1789,7 @@ export class AgentSessionRuntimeService extends BaseService {
         })
         this.clearIdleTimer(entry)
         if (turnLive && turn) {
-          this.deferUnadmittedTurnForReceiveOnly(entry, turn)
+          this.deferTurnForReceiveOnly(entry, turn)
         } else {
           this.requestRuntimeLaunch(entry, 'receive-only')
         }
@@ -2699,19 +2702,14 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   /**
-   * Runtime-generated content can arrive in the narrow window after a user turn's renderer stream
-   * opened but before its prompt was admitted. Detach that empty execution, keep the turn object
+   * Runtime-generated content can arrive after a user turn's renderer stream opened but before the
+   * runtime produced anything for it — the prompt may not be admitted yet, or (dsh) a queued goal
+   * round runs ahead of the admitted prompt. Detach that empty execution, keep the turn object
    * queued, and let the receive-only generation own the connection first.
    */
-  private deferUnadmittedTurnForReceiveOnly(entry: AgentSessionRuntimeEntry, turn: AgentSessionTurn): void {
+  private deferTurnForReceiveOnly(entry: AgentSessionRuntimeEntry, turn: AgentSessionTurn): void {
     const execution = entry.runtimeState.execution
-    if (
-      execution.kind !== 'autonomous-turn' ||
-      execution.deferredTurn !== turn ||
-      isAgentSessionRuntimeTurnAdmitted(entry.runtimeState, turn)
-    ) {
-      return
-    }
+    if (execution.kind !== 'autonomous-turn' || execution.deferredTurn !== turn) return
     const suspended = application.get('AiStreamManager').suspendUnadmittedRuntimeTurn(entry.topicId)
     try {
       turn.controller?.close()

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -2557,11 +2557,13 @@ export class AgentSessionRuntimeService extends BaseService {
             if (this.isCurrentEntry(entry)) {
               this.applyRuntimeStateEvent(entry, { type: 'launch-finished', target })
               if (target === 'receive-only') {
+                // A turn deferred behind this launch (or restored by an abandon) has no stream yet,
+                // whatever its admission: an admitted relaunch reopens the stream without re-sending.
                 const turn = this.currentTurn(entry)
                 if (
                   entry.runtimeState.execution.kind === 'turn' &&
+                  entry.runtimeState.execution.stream === 'unopened' &&
                   turn &&
-                  !isAgentSessionRuntimeTurnAdmitted(entry.runtimeState, turn) &&
                   this.isTurnLive(entry, turn)
                 ) {
                   this.requestRuntimeLaunch(entry, 'deferred-turn')

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1683,21 +1683,7 @@ export class AgentSessionRuntimeService extends BaseService {
         // Any content chunk means the retried request succeeded and the stream resumed — clear the
         // ephemeral retry status (backoff windows produce no chunks, so this never fires mid-retry).
         this.clearApiRetry(entry)
-        // During a transition A1a is closed, or the receive-only stream is not open yet. Buffer the
-        // chunks so `flush-transition` can replay them into the exact successor stream in order.
-        const execution = entry.runtimeState.execution
-        const turn = this.currentTurn(entry)
-        if (
-          execution.kind === 'steer-transition' ||
-          (execution.kind === 'autonomous-turn' && !hasAgentSessionRuntimeOpenStream(entry.runtimeState, turn)) ||
-          // An admitted turn relaunched after a receive-only generation: the runtime may already be
-          // answering its prompt before the renderer reattaches its stream.
-          (execution.kind === 'turn' && execution.stream === 'unopened' && execution.admission === 'admitted')
-        ) {
-          this.applyRuntimeStateEvent(entry, { type: 'buffer-chunk', chunk: event.chunk })
-          break
-        }
-        if (turn?.controller && this.isTurnLive(entry, turn)) this.enqueueTurnChunk(entry, turn, event.chunk)
+        this.deliverRuntimeChunk(entry, event.chunk)
         break
       }
       case 'tool-approval-request':
@@ -2315,22 +2301,13 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   private handleToolApprovalRequest(entry: AgentSessionRuntimeEntry, request: AgentRuntimeToolApprovalRequest): void {
-    const turn = this.currentTurn(entry)
     if (request.presentation === 'stream') {
       const chunk: UIMessageChunk = {
         type: 'tool-approval-request',
         approvalId: request.approvalId,
         toolCallId: request.toolCallId
       }
-      if (
-        entry.runtimeState.execution.kind === 'steer-transition' ||
-        (entry.runtimeState.execution.kind === 'autonomous-turn' &&
-          !hasAgentSessionRuntimeOpenStream(entry.runtimeState, turn))
-      ) {
-        this.applyRuntimeStateEvent(entry, { type: 'buffer-chunk', chunk })
-      } else if (turn?.controller && this.isTurnLive(entry, turn)) {
-        this.enqueueTurnChunk(entry, turn, chunk)
-      } else {
+      if (!this.deliverRuntimeChunk(entry, chunk)) {
         logger.warn('Live tool approval request lost its turn stream', {
           sessionId: entry.sessionId,
           approvalId: request.approvalId
@@ -2445,6 +2422,23 @@ export class AgentSessionRuntimeService extends BaseService {
       message: turn.userMessage,
       systemReminder: turn.systemReminder === true
     })
+  }
+
+  private deliverRuntimeChunk(entry: AgentSessionRuntimeEntry, chunk: UIMessageChunk): boolean {
+    const execution = entry.runtimeState.execution
+    const turn = this.currentTurn(entry)
+    // Approval cards and content share the same handoff while a successor stream is opening.
+    if (
+      execution.kind === 'steer-transition' ||
+      (execution.kind === 'autonomous-turn' && !hasAgentSessionRuntimeOpenStream(entry.runtimeState, turn)) ||
+      (execution.kind === 'turn' && execution.stream === 'unopened' && execution.admission === 'admitted')
+    ) {
+      this.applyRuntimeStateEvent(entry, { type: 'buffer-chunk', chunk })
+      return true
+    }
+    if (!turn?.controller || !this.isTurnLive(entry, turn)) return false
+    this.enqueueTurnChunk(entry, turn, chunk)
+    return true
   }
 
   private enqueueTurnChunk(entry: AgentSessionRuntimeEntry, turn: AgentSessionTurn, chunk: UIMessageChunk): void {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.subagentWake.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.subagentWake.test.ts
@@ -193,7 +193,7 @@ describe('subagent settlement wake (incident replay)', () => {
     })
 
     // Settlement wake: the runtime opens its own turn and starts streaming immediately.
-    handleRuntimeEvent({ type: 'autonomous-turn-state', state: 'started' })
+    handleRuntimeEvent({ type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } })
     handleRuntimeEvent({ type: 'chunk', chunk: { type: 'text-start', id: 'w1' } })
     handleRuntimeEvent({ type: 'chunk', chunk: { type: 'text-delta', id: 'w1', delta: 'wake report part 1' } })
 

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2736,6 +2736,40 @@ describe('AgentSessionRuntimeService', () => {
       void service.closeSession('session-1')
     })
 
+    it('relaunches a deferred admitted turn when the receive-only placeholder cannot be saved', async () => {
+      // Abandoning the receive-only turn restores the admitted prompt; without a relaunch it would
+      // sit with no stream while dsh answers it.
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const entry = getEntry(service)
+      const send = vi.fn()
+      entry.connection = {
+        send,
+        close: vi.fn(),
+        events: [],
+        reconcile: vi.fn().mockResolvedValue('current'),
+        refreshTraceContext: vi.fn()
+      }
+      const hostTurn = entry.currentTurn
+      entry.runtimeState.execution = { ...entry.runtimeState.execution, stream: 'open', admission: 'admitted' }
+      mocks.startRuntimeTurn.mockClear()
+      mocks.saveMessage.mockImplementationOnce(() => {
+        throw new Error('disk full')
+      })
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'goal-round', round: 1 }
+      })
+      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
+
+      expect(entry.runtimeState.execution).toMatchObject({ kind: 'turn', turn: hostTurn, admission: 'admitted' })
+      expect(mocks.startRuntimeTurn.mock.calls[0][0].request.messageId).toBe(hostTurn.assistantMessageId)
+      expect(send).not.toHaveBeenCalled()
+      void service.closeSession('session-1')
+    })
+
     it('keeps a receive-only wake interactive when the background work started from an interactive turn', async () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1', ['kb-1']) })

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2668,72 +2668,141 @@ describe('AgentSessionRuntimeService', () => {
       void service.closeSession('session-1')
     })
 
-    it('defers an admitted host turn behind a goal round and resumes it without re-sending the prompt', async () => {
-      // dsh accepted the prompt, then ran a queued goal round first. The round must open its own
-      // receive-only turn (not stream into the prompt's), and the prompt's reply — which can start
-      // before the renderer reattaches — must reach the resumed host turn.
-      const service = new AgentSessionRuntimeService()
-      service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
-      const entry = getEntry(service)
-      const send = vi.fn()
-      entry.connection = {
-        send,
-        close: vi.fn(),
-        events: [],
-        reconcile: vi.fn().mockResolvedValue('current'),
-        refreshTraceContext: vi.fn()
-      }
-      const hostTurn = entry.currentTurn
-      entry.runtimeState.execution = { ...entry.runtimeState.execution, stream: 'open', admission: 'admitted' }
-      mocks.startRuntimeTurn.mockClear()
+    it.each(['before-persistence', 'before-reopen', 'after-reopen'] as const)(
+      'settles a deferred reply that finishes %s without re-sending',
+      async (finished) => {
+        // dsh accepted the prompt, then ran a queued goal round first. The round must open its own
+        // receive-only turn (not stream into the prompt's), and the prompt's reply — which can start
+        // before the renderer reattaches — must reach the resumed host turn.
+        const service = new AgentSessionRuntimeService()
+        service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+        const entry = getEntry(service)
+        const send = vi.fn()
+        entry.connection = {
+          send,
+          close: vi.fn(),
+          events: [],
+          reconcile: vi.fn().mockResolvedValue('current'),
+          refreshTraceContext: vi.fn()
+        }
+        const hostTurn = entry.currentTurn
+        entry.runtimeState.execution = { ...entry.runtimeState.execution, stream: 'open', admission: 'admitted' }
+        mocks.startRuntimeTurn.mockClear()
 
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'autonomous-turn-state',
+          state: 'started',
+          origin: { kind: 'goal-round', round: 1 }
+        })
+        expect(entry.runtimeState.execution).toMatchObject({
+          kind: 'autonomous-turn',
+          deferredTurn: hostTurn,
+          deferredAdmission: 'admitted'
+        })
+        expect(mocks.suspendUnadmittedRuntimeTurn).toHaveBeenCalledWith('agent-session:session-1')
+        await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
+        const receiveOnlyTurn = entry.currentTurn
+        expect(receiveOnlyTurn).not.toBe(hostTurn)
+        const reader = service
+          .openTurnStream({
+            sessionId: 'session-1',
+            turnId: receiveOnlyTurn.turnId,
+            signal: new AbortController().signal
+          })
+          .getReader()
+        await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+
+        ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'finished' })
+        ;(service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
+        await expect(reader.read()).resolves.toMatchObject({ done: true })
+        // The prompt's answer arrives while the round is still awaiting persistence.
+        ;(service as any).handleRuntimeEvent(entry, {
+          type: 'chunk',
+          chunk: { type: 'text-delta', id: 'reply', delta: '我很好' }
+        })
+        if (finished === 'before-persistence') (service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
+        void terminalListener(mocks.startRuntimeTurn.mock.calls[0][0]).onDone({ status: 'success', isTopicDone: true })
+        await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(2))
+
+        expect(entry.runtimeState.execution).toMatchObject({
+          kind: 'turn',
+          turn: hostTurn,
+          admission: 'admitted',
+          buffer: [{ type: 'text-delta', id: 'reply', delta: '我很好' }]
+        })
+        if (finished === 'before-reopen') (service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
+        const hostReader = service
+          .openTurnStream({ sessionId: 'session-1', turnId: hostTurn.turnId, signal: new AbortController().signal })
+          .getReader()
+        await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'start' } })
+        await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: '我很好' } })
+        if (finished === 'after-reopen') (service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
+        expect(entry.runtimeState.execution).toMatchObject({ stream: 'awaiting-persistence' })
+        await expect(hostReader.read()).resolves.toMatchObject({ done: true })
+        expect(send).not.toHaveBeenCalled()
+        void service.closeSession('session-1')
+      }
+    )
+
+    it('keeps an admitted turn approval pending until its stream reopens', async () => {
+      const service = new AgentSessionRuntimeService()
+      const handle = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const entry = getEntry(service)
+      entry.runtimeState.execution = { ...entry.runtimeState.execution, admission: 'admitted' }
+      const send = vi.fn()
+      entry.connection = { send, close: vi.fn(), events: [] }
+      const decisions: unknown[] = []
+      toolApprovalRegistry.register({
+        approvalId: 'deferred-approval',
+        sessionId: 'session-1',
+        toolCallId: 'deferred-call',
+        toolName: 'Bash',
+        originalInput: { command: 'pwd' },
+        presentation: 'stream',
+        resolve: (decision) => decisions.push(decision)
+      })
       ;(service as any).handleRuntimeEvent(entry, {
-        type: 'autonomous-turn-state',
-        state: 'started',
-        origin: { kind: 'goal-round', round: 1 }
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'deferred-call',
+          toolName: 'Bash',
+          input: { command: 'pwd' }
+        }
       })
-      expect(entry.runtimeState.execution).toMatchObject({
-        kind: 'autonomous-turn',
-        deferredTurn: hostTurn,
-        deferredAdmission: 'admitted'
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'tool-approval-request',
+        request: {
+          approvalId: 'deferred-approval',
+          toolCallId: 'deferred-call',
+          toolName: 'Bash',
+          input: { command: 'pwd' },
+          presentation: 'stream'
+        }
       })
-      expect(mocks.suspendUnadmittedRuntimeTurn).toHaveBeenCalledWith('agent-session:session-1')
-      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
-      const receiveOnlyTurn = entry.currentTurn
-      expect(receiveOnlyTurn).not.toBe(hostTurn)
+      expect(decisions).toEqual([])
       const reader = service
         .openTurnStream({
           sessionId: 'session-1',
-          turnId: receiveOnlyTurn.turnId,
+          turnId: handle.turnId,
           signal: new AbortController().signal
         })
         .getReader()
-      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
-
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'finished' })
-      ;(service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
-      await expect(reader.read()).resolves.toMatchObject({ done: true })
-      // The prompt's answer arrives while the round is still awaiting persistence.
-      ;(service as any).handleRuntimeEvent(entry, {
-        type: 'chunk',
-        chunk: { type: 'text-delta', id: 'reply', delta: '我很好' }
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' } })
+      await expect(reader.read()).resolves.toMatchObject({
+        value: { type: 'tool-input-available', toolCallId: 'deferred-call' }
       })
-      void terminalListener(mocks.startRuntimeTurn.mock.calls[0][0]).onDone({ status: 'success', isTopicDone: true })
-      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(2))
-
-      expect(entry.runtimeState.execution).toMatchObject({
-        kind: 'turn',
-        turn: hostTurn,
-        admission: 'admitted',
-        buffer: [{ type: 'text-delta', id: 'reply', delta: '我很好' }]
+      await expect(reader.read()).resolves.toMatchObject({
+        value: {
+          type: 'tool-approval-request',
+          approvalId: 'deferred-approval',
+          toolCallId: 'deferred-call'
+        }
       })
-      const hostReader = service
-        .openTurnStream({ sessionId: 'session-1', turnId: hostTurn.turnId, signal: new AbortController().signal })
-        .getReader()
-      await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'start' } })
-      await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: '我很好' } })
+      toolApprovalRegistry.dispatch('deferred-approval', { approved: true })
+      expect(decisions).toEqual([expect.objectContaining({ approved: true })])
       expect(send).not.toHaveBeenCalled()
-      void service.closeSession('session-1')
+      await service.closeSession('session-1')
     })
 
     it('relaunches a deferred admitted turn when the receive-only placeholder cannot be saved', async () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2588,7 +2588,11 @@ describe('AgentSessionRuntimeService', () => {
       service.markTurnTerminal('session-1', 'success')
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
 
       const receiveOnlyTurn = entry.currentTurn
@@ -2635,6 +2639,35 @@ describe('AgentSessionRuntimeService', () => {
       void service.closeSession('session-1')
     })
 
+    it('publishes the runtime’s origin for the receive-only assistant message', async () => {
+      // The turn has no user message; the origin is the transcript's only explanation for it.
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const entry = getEntry(service)
+      entry.connection = {
+        send: vi.fn(),
+        close: vi.fn(),
+        events: [],
+        reconcile: vi.fn().mockResolvedValue('current'),
+        refreshTraceContext: vi.fn()
+      }
+      service.markTurnTerminal('session-1', 'success')
+      mocks.cacheSetShared.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'goal-round', round: 2 }
+      })
+      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalled())
+
+      expect(mocks.cacheSetShared).toHaveBeenCalledWith(
+        `agent.session.turn_origin.session-1.${entry.currentTurn.assistantMessageId}`,
+        { kind: 'goal-round', round: 2 }
+      )
+      void service.closeSession('session-1')
+    })
+
     it('keeps a receive-only wake interactive when the background work started from an interactive turn', async () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1', ['kb-1']) })
@@ -2652,7 +2685,11 @@ describe('AgentSessionRuntimeService', () => {
       service.markTurnTerminal('session-1', 'success')
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       // Chunks stream while the wake turn's stream is not open yet — buffered, not dropped.
       ;(service as any).handleRuntimeEvent(entry, {
         type: 'chunk',
@@ -2696,7 +2733,11 @@ describe('AgentSessionRuntimeService', () => {
       ;(service as any).handleRuntimeEvent(entry, { type: 'background-work-state', active: true })
       service.markTurnTerminal('session-1', 'success')
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
 
       expect(entry.currentTurn).toMatchObject({ headless: true })
@@ -2719,7 +2760,11 @@ describe('AgentSessionRuntimeService', () => {
       mocks.suspendUnadmittedRuntimeTurn.mockReturnValueOnce(suspended.promise)
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       ;(service as any).handleRuntimeEvent(entry, {
         type: 'chunk',
         chunk: { type: 'text-delta', id: 'wake-early', delta: 'finished before projection' }
@@ -2775,7 +2820,11 @@ describe('AgentSessionRuntimeService', () => {
       })
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
 
       await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
       expect(entry.runtimeState.execution).toMatchObject({
@@ -2809,7 +2858,11 @@ describe('AgentSessionRuntimeService', () => {
       entry.connection = connection
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' }, connection)
+      ;(service as any).handleRuntimeEvent(
+        entry,
+        { type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } },
+        connection
+      )
       await vi.waitFor(() =>
         expect(entry.runtimeState.execution).toMatchObject({ kind: 'autonomous-turn', turn: expect.anything() })
       )
@@ -2836,7 +2889,11 @@ describe('AgentSessionRuntimeService', () => {
       }
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
 
       const receiveOnlyTurn = entry.currentTurn
@@ -2886,7 +2943,11 @@ describe('AgentSessionRuntimeService', () => {
       entry.connection = connection
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' }, connection)
+      ;(service as any).handleRuntimeEvent(
+        entry,
+        { type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } },
+        connection
+      )
       ;(service as any).handleRuntimeEvent(
         entry,
         { type: 'chunk', chunk: { type: 'text-delta', id: 'wake-1', delta: 'background finished' } },
@@ -2957,7 +3018,11 @@ describe('AgentSessionRuntimeService', () => {
       markEntryTurnAdmitted(entry)
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
 
       expect(entry.runtimeState.execution.kind).toBe('turn')
       expect(mocks.startRuntimeTurn).not.toHaveBeenCalled()
@@ -2987,7 +3052,11 @@ describe('AgentSessionRuntimeService', () => {
       await expect(originalReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
       await vi.waitFor(() => expect(connection.reconcile).toHaveBeenCalledTimes(1))
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' }, connection)
+      ;(service as any).handleRuntimeEvent(
+        entry,
+        { type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } },
+        connection
+      )
       ;(service as any).handleRuntimeEvent(
         entry,
         { type: 'chunk', chunk: { type: 'text-delta', id: 'wake-1', delta: 'background finished' } },
@@ -3055,7 +3124,11 @@ describe('AgentSessionRuntimeService', () => {
       }
       mocks.startRuntimeTurn.mockClear()
 
-      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'started' })
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
       await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
       const receiveOnlyTurn = entry.currentTurn
 

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -2668,6 +2668,74 @@ describe('AgentSessionRuntimeService', () => {
       void service.closeSession('session-1')
     })
 
+    it('defers an admitted host turn behind a goal round and resumes it without re-sending the prompt', async () => {
+      // dsh accepted the prompt, then ran a queued goal round first. The round must open its own
+      // receive-only turn (not stream into the prompt's), and the prompt's reply — which can start
+      // before the renderer reattaches — must reach the resumed host turn.
+      const service = new AgentSessionRuntimeService()
+      service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+      const entry = getEntry(service)
+      const send = vi.fn()
+      entry.connection = {
+        send,
+        close: vi.fn(),
+        events: [],
+        reconcile: vi.fn().mockResolvedValue('current'),
+        refreshTraceContext: vi.fn()
+      }
+      const hostTurn = entry.currentTurn
+      entry.runtimeState.execution = { ...entry.runtimeState.execution, stream: 'open', admission: 'admitted' }
+      mocks.startRuntimeTurn.mockClear()
+
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'goal-round', round: 1 }
+      })
+      expect(entry.runtimeState.execution).toMatchObject({
+        kind: 'autonomous-turn',
+        deferredTurn: hostTurn,
+        deferredAdmission: 'admitted'
+      })
+      expect(mocks.suspendUnadmittedRuntimeTurn).toHaveBeenCalledWith('agent-session:session-1')
+      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(1))
+      const receiveOnlyTurn = entry.currentTurn
+      expect(receiveOnlyTurn).not.toBe(hostTurn)
+      const reader = service
+        .openTurnStream({
+          sessionId: 'session-1',
+          turnId: receiveOnlyTurn.turnId,
+          signal: new AbortController().signal
+        })
+        .getReader()
+      await expect(reader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+
+      ;(service as any).handleRuntimeEvent(entry, { type: 'autonomous-turn-state', state: 'finished' })
+      ;(service as any).handleRuntimeEvent(entry, { type: 'turn-complete' })
+      await expect(reader.read()).resolves.toMatchObject({ done: true })
+      // The prompt's answer arrives while the round is still awaiting persistence.
+      ;(service as any).handleRuntimeEvent(entry, {
+        type: 'chunk',
+        chunk: { type: 'text-delta', id: 'reply', delta: '我很好' }
+      })
+      void terminalListener(mocks.startRuntimeTurn.mock.calls[0][0]).onDone({ status: 'success', isTopicDone: true })
+      await vi.waitFor(() => expect(mocks.startRuntimeTurn).toHaveBeenCalledTimes(2))
+
+      expect(entry.runtimeState.execution).toMatchObject({
+        kind: 'turn',
+        turn: hostTurn,
+        admission: 'admitted',
+        buffer: [{ type: 'text-delta', id: 'reply', delta: '我很好' }]
+      })
+      const hostReader = service
+        .openTurnStream({ sessionId: 'session-1', turnId: hostTurn.turnId, signal: new AbortController().signal })
+        .getReader()
+      await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'start' } })
+      await expect(hostReader.read()).resolves.toMatchObject({ value: { type: 'text-delta', delta: '我很好' } })
+      expect(send).not.toHaveBeenCalled()
+      void service.closeSession('session-1')
+    })
+
     it('keeps a receive-only wake interactive when the background work started from an interactive turn', async () => {
       const service = new AgentSessionRuntimeService()
       service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1', ['kb-1']) })
@@ -3009,23 +3077,6 @@ describe('AgentSessionRuntimeService', () => {
       expect(entry.runtimeState.execution).toMatchObject({ kind: 'turn', turn: entry.currentTurn })
 
       void service.closeSession('session-1')
-    })
-
-    it('ignores a receive-only signal while an admitted turn is live', () => {
-      const service = new AgentSessionRuntimeService()
-      service.beginTurn(baseTurnInput)
-      const entry = getEntry(service)
-      markEntryTurnAdmitted(entry)
-      mocks.startRuntimeTurn.mockClear()
-
-      ;(service as any).handleRuntimeEvent(entry, {
-        type: 'autonomous-turn-state',
-        state: 'started',
-        origin: { kind: 'background-work' }
-      })
-
-      expect(entry.runtimeState.execution.kind).toBe('turn')
-      expect(mocks.startRuntimeTurn).not.toHaveBeenCalled()
     })
 
     it('lets a receive-only generation finish before admitting a user turn that was still reconciling', async () => {

--- a/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
+++ b/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
@@ -322,6 +322,34 @@ describe('agentSessionRuntimeState', () => {
     expect(flushed.effects).toEqual([{ type: 'deliver-buffer', turn: admitted, chunks: [reply] }])
   })
 
+  it.each([
+    { status: 'success' as const },
+    { status: 'paused' as const },
+    { status: 'error' as const, error: 'provider failed' }
+  ])('delivers an early reply before settling its $status outcome when the stream reopens', (outcome) => {
+    const current = turn('deferred')
+    const reply = { type: 'text-delta', id: 'reply', delta: 'answer' } as const
+    let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>(current)
+    state = transitionAgentSessionRuntime(state, { type: 'turn-admitted', turn: current }).state
+    state = transitionAgentSessionRuntime(state, { type: 'buffer-chunk', chunk: reply }).state
+    state = transitionAgentSessionRuntime(state, { type: 'runtime-terminal', outcome }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: current }).state
+
+    const flushed = transitionAgentSessionRuntime(state, { type: 'flush-transition' })
+    expect(flushed.effects).toEqual([
+      { type: 'deliver-buffer', turn: current, chunks: [reply] },
+      { type: 'settle-turn', turn: current, outcome }
+    ])
+    expect(flushed.state.execution).toMatchObject({ stream: 'awaiting-persistence', admission: 'admitted' })
+    expect(transitionAgentSessionRuntime(flushed.state, { type: 'flush-transition' }).effects).toEqual([])
+    const persisted = transitionAgentSessionRuntime(flushed.state, {
+      type: 'turn-terminal',
+      turn: current,
+      status: outcome.status
+    })
+    expect(persisted.state.execution).toEqual({ kind: 'idle', lastTurn: current })
+  })
+
   it('keeps a deferred admitted turn admitted when the receive-only placeholder is abandoned', () => {
     // startReceiveOnlyTurn abandons the autonomous turn when its placeholder save fails; restoring
     // the host turn as `pending` would re-send a prompt dsh already accepted.

--- a/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
+++ b/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
@@ -276,6 +276,52 @@ describe('agentSessionRuntimeState', () => {
     expect(result.effects).toContainEqual({ type: 'schedule-launch', target: 'deferred-turn' })
   })
 
+  it('keeps a deferred admitted turn admitted and replays what the runtime answered before its stream reopened', () => {
+    // dsh runs a queued goal round ahead of a prompt it already accepted. Relaunching the deferred
+    // turn as `pending` would re-send that prompt; dropping the reply that lands before the renderer
+    // reattaches would lose it (the goal round's content used to be attributed to the prompt instead).
+    const admitted = turn('user')
+    const receiveOnly = turn('wake')
+    let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>(admitted)
+    state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-admitted', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, {
+      type: 'autonomous-turn-state',
+      state: 'started',
+      origin: { kind: 'goal-round', round: 1 },
+      deferCurrentTurn: true
+    }).state
+    expect(state.execution).toMatchObject({
+      kind: 'autonomous-turn',
+      deferredTurn: admitted,
+      deferredAdmission: 'admitted'
+    })
+
+    state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: receiveOnly }).state
+    state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-state', state: 'finished' }).state
+    state = transitionAgentSessionRuntime(state, { type: 'runtime-terminal', outcome: { status: 'success' } }).state
+    // The prompt's own answer starts while the receive-only turn is still awaiting persistence.
+    const reply = { type: 'text-delta', id: 'reply', delta: '我很好' } as const
+    state = transitionAgentSessionRuntime(state, { type: 'buffer-chunk', chunk: reply }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-terminal', turn: receiveOnly, status: 'success' }).state
+
+    expect(state.execution).toEqual({
+      kind: 'turn',
+      turn: admitted,
+      stream: 'unopened',
+      admission: 'admitted',
+      buffer: [reply]
+    })
+
+    // The buffer is handed over by `flush-transition`, which runs after the stream's `start` chunk.
+    const reopened = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: admitted })
+    expect(reopened.effects).toEqual([])
+    const flushed = transitionAgentSessionRuntime(reopened.state, { type: 'flush-transition' })
+    expect(flushed.state.execution).toEqual({ kind: 'turn', turn: admitted, stream: 'open', admission: 'admitted' })
+    expect(flushed.effects).toEqual([{ type: 'deliver-buffer', turn: admitted, chunks: [reply] }])
+  })
+
   it('does not replace a running receive-only launch while restoring its deferred turn', () => {
     const deferred = turn('user')
     const receiveOnly = turn('wake')

--- a/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
+++ b/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
@@ -322,6 +322,60 @@ describe('agentSessionRuntimeState', () => {
     expect(flushed.effects).toEqual([{ type: 'deliver-buffer', turn: admitted, chunks: [reply] }])
   })
 
+  it('keeps a deferred admitted turn admitted when the receive-only placeholder is abandoned', () => {
+    // startReceiveOnlyTurn abandons the autonomous turn when its placeholder save fails; restoring
+    // the host turn as `pending` would re-send a prompt dsh already accepted.
+    const admitted = turn('user')
+    let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>(admitted)
+    state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-admitted', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, {
+      type: 'autonomous-turn-state',
+      state: 'started',
+      origin: { kind: 'goal-round', round: 1 },
+      deferCurrentTurn: true
+    }).state
+
+    const restored = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-abandoned' })
+    expect(restored.state.execution).toEqual({
+      kind: 'turn',
+      turn: admitted,
+      stream: 'unopened',
+      admission: 'admitted'
+    })
+  })
+
+  it('routes the host reply to the deferred turn once the receive-only generation released ownership', () => {
+    // The reply can arrive before the receive-only stream is ever created; it must not be attributed
+    // to the autonomous message's buffer (nor dropped once that turn is terminal).
+    const admitted = turn('user')
+    const receiveOnly = turn('wake')
+    let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>(admitted)
+    state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, { type: 'turn-admitted', turn: admitted }).state
+    state = transitionAgentSessionRuntime(state, {
+      type: 'autonomous-turn-state',
+      state: 'started',
+      origin: { kind: 'goal-round', round: 1 },
+      deferCurrentTurn: true
+    }).state
+    state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
+    const roundChunk = { type: 'text-delta', id: 'round', delta: 'A' } as const
+    state = transitionAgentSessionRuntime(state, { type: 'buffer-chunk', chunk: roundChunk }).state
+    state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-state', state: 'finished' }).state
+    const reply = { type: 'text-delta', id: 'reply', delta: '我很好' } as const
+    state = transitionAgentSessionRuntime(state, { type: 'buffer-chunk', chunk: reply }).state
+    state = transitionAgentSessionRuntime(state, { type: 'runtime-terminal', outcome: { status: 'success' } }).state
+    const late = { type: 'text-delta', id: 'reply', delta: '。' } as const
+    state = transitionAgentSessionRuntime(state, { type: 'buffer-chunk', chunk: late }).state
+
+    expect(state.execution).toMatchObject({
+      kind: 'autonomous-turn',
+      buffer: [roundChunk],
+      deferredBuffer: [reply, late]
+    })
+  })
+
   it('does not replace a running receive-only launch while restoring its deferred turn', () => {
     const deferred = turn('user')
     const receiveOnly = turn('wake')

--- a/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
+++ b/src/main/ai/agentSession/__tests__/agentSessionRuntimeState.test.ts
@@ -210,7 +210,8 @@ describe('agentSessionRuntimeState', () => {
     let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>()
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
-      state: 'started'
+      state: 'started',
+      origin: { kind: 'background-work' }
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
     state = transitionAgentSessionRuntime(state, {
@@ -248,6 +249,7 @@ describe('agentSessionRuntimeState', () => {
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
       state: 'started',
+      origin: { kind: 'background-work' },
       deferCurrentTurn: true
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
@@ -281,6 +283,7 @@ describe('agentSessionRuntimeState', () => {
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
       state: 'started',
+      origin: { kind: 'background-work' },
       deferCurrentTurn: true
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
@@ -331,11 +334,13 @@ describe('agentSessionRuntimeState', () => {
     }).state
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
-      state: 'started'
+      state: 'started',
+      origin: { kind: 'background-work' }
     }).state
     const duplicateAutonomous = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
-      state: 'started'
+      state: 'started',
+      origin: { kind: 'background-work' }
     })
     state = transitionAgentSessionRuntime(state, {
       type: 'connection-occupancy',
@@ -458,12 +463,24 @@ describe('agentSessionRuntimeState', () => {
     expect(result.effects[0]).toMatchObject({ type: 'log-invalid-transition' })
   })
 
+  it('carries the runtime’s origin into the autonomous execution state', () => {
+    // startReceiveOnlyTurn reads it off the execution; dropping it here would persist no origin.
+    const state = transitionAgentSessionRuntime(createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>(), {
+      type: 'autonomous-turn-state',
+      state: 'started',
+      origin: { kind: 'goal-round', round: 3 }
+    }).state
+
+    expect(state.execution).toMatchObject({ kind: 'autonomous-turn', origin: { kind: 'goal-round', round: 3 } })
+  })
+
   it('derives current turn and autonomous ownership from the execution union', () => {
     const receiveOnly = turn('wake')
     let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>()
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
-      state: 'started'
+      state: 'started',
+      origin: { kind: 'background-work' }
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
 
@@ -476,7 +493,8 @@ describe('agentSessionRuntimeState', () => {
     let state = createAgentSessionRuntimeState<Turn, PendingTurn, Reservation>()
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
-      state: 'started'
+      state: 'started',
+      origin: { kind: 'background-work' }
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state
     state = transitionAgentSessionRuntime(state, { type: 'turn-stream-opened', turn: receiveOnly }).state
@@ -504,6 +522,7 @@ describe('agentSessionRuntimeState', () => {
     state = transitionAgentSessionRuntime(state, {
       type: 'autonomous-turn-state',
       state: 'started',
+      origin: { kind: 'background-work' },
       deferCurrentTurn: true
     }).state
     state = transitionAgentSessionRuntime(state, { type: 'autonomous-turn-created', turn: receiveOnly }).state

--- a/src/main/ai/agentSession/agentSessionRuntimeState.ts
+++ b/src/main/ai/agentSession/agentSessionRuntimeState.ts
@@ -61,6 +61,8 @@ export type AgentSessionRuntimeExecution<TTurn, TReservation> =
       admission: AgentSessionRuntimeAdmissionPhase
       reservation?: TReservation
       terminal?: AgentSessionTerminalOutcome
+      /** Content of an already-admitted turn that arrived before its relaunched stream opened. */
+      buffer?: UIMessageChunk[]
     }
   | {
       kind: 'steer-transition'
@@ -81,6 +83,10 @@ export type AgentSessionRuntimeExecution<TTurn, TReservation> =
       turn?: TTurn
       contextTurn?: TTurn
       deferredTurn?: TTurn
+      /** The deferred turn's admission when it was deferred; an admitted prompt must not be re-sent. */
+      deferredAdmission?: AgentSessionRuntimeAdmissionPhase
+      /** The deferred turn's content that the runtime produced before its stream was relaunched. */
+      deferredBuffer?: UIMessageChunk[]
       ownership: 'active' | 'released'
       buffer: UIMessageChunk[]
       stream: AgentSessionRuntimeStreamPhase
@@ -209,7 +215,8 @@ function resumeAfterAutonomous<TTurn, TPendingTurn, TReservation>(
           kind: 'turn',
           turn: execution.deferredTurn,
           stream: 'unopened',
-          admission: 'pending'
+          admission: execution.deferredAdmission ?? 'pending',
+          ...(execution.deferredBuffer?.length ? { buffer: execution.deferredBuffer } : {})
         },
         launch: canSchedule ? { kind: 'scheduled', target: 'deferred-turn' } : state.launch,
         lastTerminal: execution.settled
@@ -299,8 +306,7 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
       if (event.state === 'started') {
         if (state.execution.kind === 'autonomous-turn') return { state, effects: [] }
         if (state.execution.kind === 'steer-transition') return invalid(state, event)
-        const deferredTurn =
-          event.deferCurrentTurn && state.execution.kind === 'turn' ? state.execution.turn : undefined
+        const deferred = event.deferCurrentTurn && state.execution.kind === 'turn' ? state.execution : undefined
         return {
           state: {
             ...state,
@@ -308,7 +314,7 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
               kind: 'autonomous-turn',
               origin: event.origin,
               ...(event.contextTurn ? { contextTurn: event.contextTurn } : {}),
-              ...(deferredTurn ? { deferredTurn } : {}),
+              ...(deferred ? { deferredTurn: deferred.turn, deferredAdmission: deferred.admission } : {}),
               ownership: 'active',
               buffer: [],
               stream: 'unopened'
@@ -375,21 +381,40 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
         state: { ...state, execution: { ...state.execution, admission: 'admitted' } },
         effects: []
       }
-    case 'buffer-chunk':
+    case 'buffer-chunk': {
+      const execution = state.execution
+      // An admitted turn the runtime resumed before its relaunched stream opened.
+      if (execution.kind === 'turn' && execution.stream === 'unopened' && execution.admission === 'admitted') {
+        return {
+          state: { ...state, execution: { ...execution, buffer: [...(execution.buffer ?? []), event.chunk] } },
+          effects: []
+        }
+      }
+      // A receive-only generation has ended; anything after it belongs to the deferred admitted turn.
+      if (execution.kind === 'autonomous-turn' && execution.deferredTurn && execution.stream !== 'unopened') {
+        return {
+          state: {
+            ...state,
+            execution: { ...execution, deferredBuffer: [...(execution.deferredBuffer ?? []), event.chunk] }
+          },
+          effects: []
+        }
+      }
       if (
-        (state.execution.kind !== 'steer-transition' && state.execution.kind !== 'autonomous-turn') ||
-        state.execution.stream !== 'unopened' ||
-        state.execution.terminal
+        (execution.kind !== 'steer-transition' && execution.kind !== 'autonomous-turn') ||
+        execution.stream !== 'unopened' ||
+        execution.terminal
       ) {
         return invalid(state, event)
       }
       return {
         state: {
           ...state,
-          execution: { ...state.execution, buffer: [...state.execution.buffer, event.chunk] }
+          execution: { ...execution, buffer: [...execution.buffer, event.chunk] }
         },
         effects: []
       }
+    }
     case 'runtime-terminal': {
       const execution = state.execution
       if (execution.kind === 'turn') {
@@ -442,6 +467,14 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
     case 'flush-transition': {
       const execution = state.execution
       if (execution.kind === 'turn') {
+        // A deferred admitted turn: hand over what the runtime answered before this stream reopened.
+        if (execution.stream === 'open' && execution.buffer?.length) {
+          const { buffer, ...rest } = execution
+          return {
+            state: { ...state, execution: rest },
+            effects: [{ type: 'deliver-buffer', turn: execution.turn, chunks: buffer }]
+          }
+        }
         if (execution.stream !== 'open' || !execution.terminal) return { state, effects: [] }
         return {
           state: {

--- a/src/main/ai/agentSession/agentSessionRuntimeState.ts
+++ b/src/main/ai/agentSession/agentSessionRuntimeState.ts
@@ -336,7 +336,9 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
                 kind: 'turn',
                 turn: state.execution.deferredTurn,
                 stream: 'unopened',
-                admission: 'pending'
+                // An admitted prompt must not be re-sent because the receive-only placeholder failed.
+                admission: state.execution.deferredAdmission ?? 'pending',
+                ...(state.execution.deferredBuffer?.length ? { buffer: state.execution.deferredBuffer } : {})
               }
             : { kind: 'idle', ...(state.execution.contextTurn ? { lastTurn: state.execution.contextTurn } : {}) }
         },
@@ -390,8 +392,13 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
           effects: []
         }
       }
-      // A receive-only generation has ended; anything after it belongs to the deferred admitted turn.
-      if (execution.kind === 'autonomous-turn' && execution.deferredTurn && execution.stream !== 'unopened') {
+      // The receive-only generation has released ownership (or ended): anything after it belongs to
+      // the deferred admitted turn, even if the receive-only stream itself was never created.
+      if (
+        execution.kind === 'autonomous-turn' &&
+        execution.deferredTurn &&
+        (execution.ownership === 'released' || execution.terminal !== undefined || execution.stream !== 'unopened')
+      ) {
         return {
           state: {
             ...state,

--- a/src/main/ai/agentSession/agentSessionRuntimeState.ts
+++ b/src/main/ai/agentSession/agentSessionRuntimeState.ts
@@ -1,4 +1,5 @@
 import type { NotifyChannel } from '@main/ai/runtime/agentMcpServers'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import type { UIMessageChunk } from 'ai'
 
 import type { AgentRuntimeConnection, AgentRuntimeUserInput } from '../runtime/types'
@@ -75,6 +76,8 @@ export type AgentSessionRuntimeExecution<TTurn, TReservation> =
     }
   | {
       kind: 'autonomous-turn'
+      /** Why the runtime opened this turn; persisted on the receive-only assistant message. */
+      origin: AutonomousTurnOrigin
       turn?: TTurn
       contextTurn?: TTurn
       deferredTurn?: TTurn
@@ -110,10 +113,12 @@ export type AgentSessionRuntimeStateEvent<TTurn, TPendingTurn, TReservation> =
   | { type: 'steer-boundary'; inputs: AgentRuntimeUserInput[]; headless: boolean }
   | {
       type: 'autonomous-turn-state'
-      state: 'started' | 'finished'
+      state: 'started'
+      origin: AutonomousTurnOrigin
       deferCurrentTurn?: boolean
       contextTurn?: TTurn
     }
+  | { type: 'autonomous-turn-state'; state: 'finished' }
   | { type: 'autonomous-turn-abandoned' }
   | { type: 'autonomous-turn-created'; turn: TTurn }
   | { type: 'continuation-turn-created'; turn: TTurn }
@@ -301,6 +306,7 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
             ...state,
             execution: {
               kind: 'autonomous-turn',
+              origin: event.origin,
               ...(event.contextTurn ? { contextTurn: event.contextTurn } : {}),
               ...(deferredTurn ? { deferredTurn } : {}),
               ownership: 'active',

--- a/src/main/ai/agentSession/agentSessionRuntimeState.ts
+++ b/src/main/ai/agentSession/agentSessionRuntimeState.ts
@@ -87,6 +87,7 @@ export type AgentSessionRuntimeExecution<TTurn, TReservation> =
       deferredAdmission?: AgentSessionRuntimeAdmissionPhase
       /** The deferred turn's content that the runtime produced before its stream was relaunched. */
       deferredBuffer?: UIMessageChunk[]
+      deferredTerminal?: AgentSessionTerminalOutcome
       ownership: 'active' | 'released'
       buffer: UIMessageChunk[]
       stream: AgentSessionRuntimeStreamPhase
@@ -216,7 +217,8 @@ function resumeAfterAutonomous<TTurn, TPendingTurn, TReservation>(
           turn: execution.deferredTurn,
           stream: 'unopened',
           admission: execution.deferredAdmission ?? 'pending',
-          ...(execution.deferredBuffer?.length ? { buffer: execution.deferredBuffer } : {})
+          ...(execution.deferredBuffer?.length ? { buffer: execution.deferredBuffer } : {}),
+          ...(execution.deferredTerminal ? { terminal: execution.deferredTerminal } : {})
         },
         launch: canSchedule ? { kind: 'scheduled', target: 'deferred-turn' } : state.launch,
         lastTerminal: execution.settled
@@ -338,7 +340,8 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
                 stream: 'unopened',
                 // An admitted prompt must not be re-sent because the receive-only placeholder failed.
                 admission: state.execution.deferredAdmission ?? 'pending',
-                ...(state.execution.deferredBuffer?.length ? { buffer: state.execution.deferredBuffer } : {})
+                ...(state.execution.deferredBuffer?.length ? { buffer: state.execution.deferredBuffer } : {}),
+                ...(state.execution.deferredTerminal ? { terminal: state.execution.deferredTerminal } : {})
               }
             : { kind: 'idle', ...(state.execution.contextTurn ? { lastTurn: state.execution.contextTurn } : {}) }
         },
@@ -457,6 +460,18 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
         return { state, effects: [] }
       }
       if (execution.kind === 'autonomous-turn') {
+        if (
+          execution.deferredTurn &&
+          execution.deferredAdmission === 'admitted' &&
+          execution.ownership === 'released' &&
+          (execution.terminal || execution.stream === 'awaiting-persistence' || execution.stream === 'settled')
+        ) {
+          if (execution.deferredTerminal) return { state, effects: [] }
+          return {
+            state: { ...state, execution: { ...execution, deferredTerminal: event.outcome } },
+            effects: []
+          }
+        }
         if (execution.stream === 'unopened') {
           if (execution.terminal) return { state, effects: [] }
           return resumeAfterAutonomous(state, { ...execution, terminal: event.outcome })
@@ -474,27 +489,19 @@ export function transitionAgentSessionRuntime<TTurn, TPendingTurn, TReservation>
     case 'flush-transition': {
       const execution = state.execution
       if (execution.kind === 'turn') {
-        // A deferred admitted turn: hand over what the runtime answered before this stream reopened.
-        if (execution.stream === 'open' && execution.buffer?.length) {
-          const { buffer, ...rest } = execution
-          return {
-            state: { ...state, execution: rest },
-            effects: [{ type: 'deliver-buffer', turn: execution.turn, chunks: buffer }]
-          }
+        if (execution.stream !== 'open' || (!execution.buffer?.length && !execution.terminal)) {
+          return { state, effects: [] }
         }
-        if (execution.stream !== 'open' || !execution.terminal) return { state, effects: [] }
+        const { buffer, terminal, ...rest } = execution
         return {
           state: {
             ...state,
-            execution: {
-              kind: 'turn',
-              turn: execution.turn,
-              stream: 'awaiting-persistence',
-              admission: execution.admission,
-              ...(execution.reservation ? { reservation: execution.reservation } : {})
-            }
+            execution: { ...rest, stream: terminal ? 'awaiting-persistence' : 'open' }
           },
-          effects: [{ type: 'settle-turn', turn: execution.turn, outcome: execution.terminal }]
+          effects: [
+            ...(buffer?.length ? [{ type: 'deliver-buffer', turn: execution.turn, chunks: buffer } as const] : []),
+            ...(terminal ? [{ type: 'settle-turn', turn: execution.turn, outcome: terminal } as const] : [])
+          ]
         }
       }
       if (execution.kind === 'steer-transition') {

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -160,7 +160,11 @@ vi.mock('../streamAdapter', async (importActual) => {
           const isContent = message.type === 'stream_event' || message.type === 'assistant' || message.type === 'user'
           if (!isContent) return { type: 'continue' }
           this.autonomous = true
-          this.options.statusSink.emit({ type: 'autonomous-turn-state', state: 'started' })
+          this.options.statusSink.emit({
+            type: 'autonomous-turn-state',
+            state: 'started',
+            origin: { kind: 'background-work' }
+          })
           this.beginTurn()
         }
         if (message.type === 'truncate-now') {

--- a/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/streamAdapter.test.ts
@@ -1973,7 +1973,9 @@ describe('ClaudeCodeStreamAdapter', () => {
         streamEvent({ type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'woke up' } })
       )
 
-      expect(statusEvents).toEqual([{ type: 'autonomous-turn-state', state: 'started' }])
+      expect(statusEvents).toEqual([
+        { type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } }
+      ])
       expect(parts.some((part) => part.type === 'text-delta' && part.delta === 'woke up')).toBe(true)
       expect(adapter.isTurnActive).toBe(true)
     })
@@ -1988,7 +1990,7 @@ describe('ClaudeCodeStreamAdapter', () => {
 
       expect(result).toMatchObject({ type: 'result', sessionId: 'resume-wake' })
       expect(statusEvents).toEqual([
-        { type: 'autonomous-turn-state', state: 'started' },
+        { type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } },
         { type: 'autonomous-turn-state', state: 'finished' }
       ])
       expect(loggerMocks.warn).not.toHaveBeenCalledWith(
@@ -2021,7 +2023,11 @@ describe('ClaudeCodeStreamAdapter', () => {
         })
       ])
       expect(parts).toEqual([])
-      expect(statusEvents).not.toContainEqual({ type: 'autonomous-turn-state', state: 'started' })
+      expect(statusEvents).not.toContainEqual({
+        type: 'autonomous-turn-state',
+        state: 'started',
+        origin: { kind: 'background-work' }
+      })
     })
 
     it('holds init metadata until a turn opens, since it is turn content', () => {

--- a/src/main/ai/runtime/claudeCode/streamAdapter.ts
+++ b/src/main/ai/runtime/claudeCode/streamAdapter.ts
@@ -652,7 +652,7 @@ export class ClaudeCodeStreamAdapter {
       }
       // Parentless content with no turn open is Claude waking the main agent after background work.
       // Translate that SDK protocol into the runtime-neutral receive-only contract.
-      this.statusSink.emit({ type: 'autonomous-turn-state', state: 'started' })
+      this.statusSink.emit({ type: 'autonomous-turn-state', state: 'started', origin: { kind: 'background-work' } })
       this.beginTurn()
       this.autonomousTurn = true
     }

--- a/src/main/ai/runtime/dsh/DshBridgeServer.ts
+++ b/src/main/ai/runtime/dsh/DshBridgeServer.ts
@@ -19,7 +19,8 @@ import type {
   BridgePluginRequestMap,
   BridgeToolCallResult
 } from '@cherrystudio/dsh-bridge'
-import type { JsonRpcLineTransport } from '@deepseek-ai/dsh-sdk-protocol'
+import type { JsonRpcLineTransport, SessionEventNotification } from '@deepseek-ai/dsh-sdk-protocol'
+import type { SessionEvent } from '@deepseek-ai/dsh-session'
 import { loggerService } from '@logger'
 import { toolApprovalRegistry } from '@main/ai/toolApproval/ToolApprovalRegistry'
 import type { CherryToolMeta } from '@shared/data/types/uiParts'
@@ -36,7 +37,10 @@ export interface DshBridgeServerOptions {
   /** Agent-session id — keys the neutral approval registry so close()/abort target the right approvals. */
   sessionId: string
   /** Push a runtime-neutral event into the connection queue; the host owns presentation. */
-  emit: (event: AgentRuntimeEvent) => void
+  emit: (
+    event: AgentRuntimeEvent,
+    source: { sessionId: SessionEventNotification['sessionId']; seq: SessionEvent['seq'] }
+  ) => void
   /** Resolve responder availability at ask-time so warm connections follow the current turn. */
   getInteractionState: () => { userResponse: 'stream' | 'message' | 'unavailable' }
   /** Dispatch one registered dsh native tool into Cherry's in-process MCP bridge. */
@@ -322,17 +326,20 @@ export class DshBridgeServer {
       // Only surface the approval card when the request is actually pending; a synchronous
       // resolve already settled the promise, and emitting would leave an unanswerable card.
       if (!pending) return
-      this.options.emit({
-        type: 'tool-approval-request',
-        request: {
-          approvalId,
-          toolCallId,
-          toolName,
-          input: { ...input },
-          presentation,
-          providerMetadata: { cherry: { transport: DSH_TRANSPORT, toolName } satisfies CherryToolMeta }
-        }
-      })
+      this.options.emit(
+        {
+          type: 'tool-approval-request',
+          request: {
+            approvalId,
+            toolCallId,
+            toolName,
+            input: { ...input },
+            presentation,
+            providerMetadata: { cherry: { transport: DSH_TRANSPORT, toolName } satisfies CherryToolMeta }
+          }
+        },
+        { sessionId: ask.sessionId, seq: ask.sessionEventSeq }
+      )
     })
   }
 
@@ -380,19 +387,22 @@ export class DshBridgeServer {
         }
       })
       if (!pending) return
-      this.options.emit({
-        type: 'tool-approval-request',
-        request: {
-          approvalId,
-          toolCallId,
-          toolName: 'exit_plan_mode',
-          input: { ...input },
-          presentation,
-          providerMetadata: {
-            cherry: { transport: DSH_TRANSPORT, toolName: 'exit_plan_mode' } satisfies CherryToolMeta
+      this.options.emit(
+        {
+          type: 'tool-approval-request',
+          request: {
+            approvalId,
+            toolCallId,
+            toolName: 'exit_plan_mode',
+            input: { ...input },
+            presentation,
+            providerMetadata: {
+              cherry: { transport: DSH_TRANSPORT, toolName: 'exit_plan_mode' } satisfies CherryToolMeta
+            }
           }
-        }
-      })
+        },
+        { sessionId: ask.sessionId, seq: ask.sessionEventSeq }
+      )
     })
   }
 

--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -11,6 +11,7 @@ import {
 } from '@cherrystudio/dsh-bridge'
 import type { TokenUsage } from '@deepseek-ai/dsh-llm'
 import type { HarnessClient, NotificationSubscription } from '@deepseek-ai/dsh-sdk-client'
+import type { SessionEventNotification } from '@deepseek-ai/dsh-sdk-protocol'
 import type { SessionEvent, TurnEndReason } from '@deepseek-ai/dsh-session'
 import { loggerService } from '@logger'
 import { ensureAgentDataDirectory } from '@main/ai/agents/agentDataDirectory'
@@ -48,7 +49,7 @@ import type {
   AgentSessionUsageCapture
 } from '../types'
 import { buildDshCompositionYaml, resolveDshRuntimeBinPath } from './compositionBuilder'
-import { DshBridgeServer } from './DshBridgeServer'
+import { DshBridgeServer, type DshBridgeServerOptions } from './DshBridgeServer'
 import {
   buildDshCherryToolBridge,
   buildDshCherryToolName,
@@ -71,6 +72,8 @@ import { type DshProviderInjection, resolveDshProviderInjectionFromSnapshot, use
 
 const logger = loggerService.withContext('DshRuntimeConnection')
 
+type BridgeEventSource = Parameters<DshBridgeServerOptions['emit']>[1]
+
 const DSH_TOOL_DESCRIPTORS: readonly DshBuiltinToolDescriptor[] = getDshRuntimeBuiltinTools(process.platform)
 const DSH_READ_TOOLS = DSH_TOOL_DESCRIPTORS.filter((tool) => tool.permissionClass === 'read').map((tool) => tool.name)
 const DSH_EDIT_TOOLS = DSH_TOOL_DESCRIPTORS.filter((tool) => tool.permissionClass === 'edit').map((tool) => tool.name)
@@ -92,6 +95,11 @@ if (DSH_SHELL_TOOL_NAME) {
 export class DshRuntimeConnection implements AgentRuntimeConnection {
   private readonly generation = randomUUID()
   private readonly eventQueue = new AsyncEventQueue<AgentRuntimeEvent>()
+  private readonly sessionEventSeqs = new Map<SessionEventNotification['sessionId'], SessionEvent['seq']>()
+  private readonly pendingBridgeEvents: Array<{
+    event: AgentRuntimeEvent
+    source: BridgeEventSource
+  }> = []
   private readonly committedInvocationIds = new Set<string>()
   private readonly adapter = new DshStreamAdapter({
     enqueue: (chunk) => {
@@ -157,9 +165,13 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
     this.subagents = new DshSubagentCoordinator(input.sessionId, this.buildSubagentSink())
   }
 
-  /** Bridge-socket events. A stream-presented approval whose `tool/call` has not landed yet would
-   *  truncate the turn accumulator instead of showing a card, so materialize its tool part first. */
-  private emitBridgeEvent(event: AgentRuntimeEvent): void {
+  // The socket can outrun session notifications; provenance must land before approval content.
+  private emitBridgeEvent(event: AgentRuntimeEvent, source: BridgeEventSource): void {
+    if (this.closed) return
+    if ((this.sessionEventSeqs.get(source.sessionId) ?? -1) < source.seq) {
+      this.pendingBridgeEvents.push({ event, source })
+      return
+    }
     if (event.type === 'tool-approval-request' && event.request.presentation === 'stream') {
       this.adapter.ensureToolCall(event.request.toolCallId, event.request.toolName, event.request.input)
     }
@@ -351,7 +363,7 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
 
       this.bridge = new DshBridgeServer({
         sessionId: this.input.sessionId,
-        emit: (event) => this.emitBridgeEvent(event),
+        emit: (event, source) => this.emitBridgeEvent(event, source),
         getInteractionState: () =>
           application.get('AgentSessionRuntimeService').getInteractionState(this.input.sessionId),
         onToolCall: (name, args, signal) => toolBridge.callTool(name, args, signal),
@@ -604,6 +616,8 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
   async close(): Promise<void> {
     if (this.closed) return
     this.closed = true
+    this.pendingBridgeEvents.length = 0
+    this.sessionEventSeqs.clear()
     this.subagents.close()
     // Deny any approval still awaiting a renderer decision so its held tool
     // promise resolves instead of hanging past teardown.
@@ -704,13 +718,18 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
           // Every other session in this process is a descendant (or one racing its
           // started/lifecycle signal); the coordinator buffers until a binding lands.
           this.subagents.handleChildEvent(params.sessionId, event)
-          continue
+        } else {
+          this.traceRecorder?.handleEvent(event)
+          this.adapter.handleEvent(event)
         }
-        this.traceRecorder?.handleEvent(event)
-        this.adapter.handleEvent(event)
+        this.sessionEventSeqs.set(params.sessionId, event.seq)
+        for (const pending of this.pendingBridgeEvents.splice(0)) {
+          this.emitBridgeEvent(pending.event, pending.source)
+        }
       }
     } catch (error) {
       if (this.closed) return
+      this.pendingBridgeEvents.length = 0
       logger.error('dsh notification stream failed', error as Error)
       this.eventQueue.push({ type: 'error', error })
       this.eventQueue.close()

--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -102,10 +102,10 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
     onTurnEnd: (reason) => this.handleTurnEnd(reason),
     onCompaction: (event) => this.eventQueue.push(event),
     onApiRetry: (retry) => this.eventQueue.push({ type: 'api-retry', retry }),
-    onAutonomousTurnState: (state) => {
+    onAutonomousTurnState: (event) => {
       // Reconcile treats a goal round like any live turn: policy swaps wait for idle.
-      if (state === 'started') this.markTurnActive()
-      this.eventQueue.push({ type: 'autonomous-turn-state', state })
+      if (event.state === 'started') this.markTurnActive()
+      this.eventQueue.push({ type: 'autonomous-turn-state', ...event })
     },
     onPlanMode: (active) => this.handlePlanModeFold(active)
   })

--- a/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
@@ -24,6 +24,7 @@ interface Harness {
   socket: net.Socket
   transport: JsonRpcLineTransport
   events: AgentRuntimeEvent[]
+  eventSources: Array<Parameters<DshBridgeServerOptions['emit']>[1]>
   lifecycleEdges: Array<BridgeNotificationMap['subagent/lifecycle']>
   nextRequest: () => Promise<HostRequest>
 }
@@ -36,19 +37,23 @@ function makeServer(
     Promise.reject(new Error('unexpected tool call')),
   readyTimeoutMs?: number,
   onGuardCheck: DshBridgeServerOptions['onGuardCheck'] = async () => ({ kind: 'allow' })
-): { server: DshBridgeServer; events: AgentRuntimeEvent[]; lifecycleEdges: Harness['lifecycleEdges'] } {
+): Pick<Harness, 'server' | 'events' | 'eventSources' | 'lifecycleEdges'> {
   const events: AgentRuntimeEvent[] = []
+  const eventSources: Harness['eventSources'] = []
   const lifecycleEdges: Harness['lifecycleEdges'] = []
   const server = new DshBridgeServer({
     sessionId: SESSION_ID,
-    emit: (event) => events.push(event),
+    emit: (event, source) => {
+      events.push(event)
+      eventSources.push(source)
+    },
     getInteractionState: () => ({ userResponse }),
     onToolCall,
     onGuardCheck,
     onSubagentLifecycle: (edge) => lifecycleEdges.push(edge),
     ...(readyTimeoutMs === undefined ? {} : { readyTimeoutMs })
   })
-  return { server, events, lifecycleEdges }
+  return { server, events, eventSources, lifecycleEdges }
 }
 
 /** Connect a JSON-RPC peer that records host requests; authenticates unless a token is given. */
@@ -99,11 +104,11 @@ async function makeHarness(
   onToolCall?: (name: string, args: unknown, signal: AbortSignal) => Promise<{ text: string; data?: unknown }>,
   onGuardCheck?: DshBridgeServerOptions['onGuardCheck']
 ): Promise<Harness> {
-  const { server, events, lifecycleEdges } = makeServer(userResponse, onToolCall, undefined, onGuardCheck)
+  const { server, events, eventSources, lifecycleEdges } = makeServer(userResponse, onToolCall, undefined, onGuardCheck)
   await server.listen()
   const plugin = await connectPlugin(server)
   await server.whenReady()
-  const harness: Harness = { server, events, lifecycleEdges, ...plugin }
+  const harness: Harness = { server, events, eventSources, lifecycleEdges, ...plugin }
   harnesses.push(harness)
   return harness
 }
@@ -363,12 +368,14 @@ describe('DshBridgeServer', () => {
     const harness = await makeHarness()
     const ask = harness.transport.request('approval/ask', {
       sessionId: SESSION_ID,
+      sessionEventSeq: 17,
       toolName: 'bash',
       callId: 'call-9',
       args: { command: 'echo hi' }
     })
 
     await vi.waitFor(() => expect(harness.events).toHaveLength(1))
+    expect(harness.eventSources).toEqual([{ sessionId: SESSION_ID, seq: 17 }])
     const event = harness.events[0]
     expect(event.type).toBe('tool-approval-request')
     if (event.type !== 'tool-approval-request') throw new Error('unreachable')
@@ -450,6 +457,7 @@ describe('DshBridgeServer', () => {
     const harness = await makeHarness()
     const ask = harness.transport.request('question/ask', {
       sessionId: SESSION_ID,
+      sessionEventSeq: 21,
       callId: 'exit-plan-call-1',
       questions: [
         {
@@ -466,7 +474,7 @@ describe('DshBridgeServer', () => {
     await vi.waitFor(() => expect(harness.events).toHaveLength(1))
     const event = harness.events[0]
     if (event.type !== 'tool-approval-request') throw new Error('unreachable')
-    // Anchored to the streamed exit_plan_mode call so the card lands on its tool row.
+    expect(harness.eventSources).toEqual([{ sessionId: SESSION_ID, seq: 21 }])
     expect(event.request).toMatchObject({
       toolCallId: 'exit-plan-call-1',
       toolName: 'exit_plan_mode',

--- a/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
@@ -1,7 +1,7 @@
 import { trace } from '@opentelemetry/api'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { AgentRuntimeConnectInput, AgentRuntimeTraceContext } from '../../types'
+import type { AgentRuntimeConnectInput, AgentRuntimeEvent, AgentRuntimeTraceContext } from '../../types'
 
 interface FakeSpan {
   name: string
@@ -329,39 +329,107 @@ describe('DshRuntimeConnection tracing', () => {
     }
   )
 
-  it('opens the plan-review tool part before its raced tool/call event', async () => {
-    const connection = await new DshRuntimeConnection(connectInput).start()
-    const events = connection.events[Symbol.asyncIterator]()
-    await expect(events.next()).resolves.toMatchObject({ value: { type: 'resume-token' } })
-    await connection.send({ message: {} } as never)
+  it.each([
+    { origin: 'host', nativeCall: true },
+    { origin: 'goal', nativeCall: true },
+    { origin: 'host', nativeCall: false },
+    { origin: 'goal', nativeCall: false }
+  ])(
+    'orders a bridge-first approval after its $origin provenance (native call: $nativeCall)',
+    async ({ origin, nativeCall }) => {
+      const connection = await new DshRuntimeConnection(connectInput).start()
+      const events: AgentRuntimeEvent[] = []
+      const consume = (async () => {
+        for await (const event of connection.events) events.push(event)
+      })()
+      await drain()
+      events.length = 0
+      await connection.send({ message: {} } as never)
 
-    const { emit } = vi.mocked(DshBridgeServer).mock.calls[0][0]
-    emit({
-      type: 'tool-approval-request',
-      request: {
-        approvalId: 'approval-1',
-        toolCallId: 'call-1',
-        toolName: 'exit_plan_mode',
-        input: { plan: '# Ship it' },
-        presentation: 'stream'
+      const { emit } = vi.mocked(DshBridgeServer).mock.calls[0][0]
+      emit(
+        {
+          type: 'tool-approval-request',
+          request: {
+            approvalId: 'approval-1',
+            toolCallId: 'call-1',
+            toolName: 'exit_plan_mode',
+            input: { plan: '# Ship it' },
+            presentation: 'stream'
+          }
+        },
+        { sessionId: 'session-1', seq: 4 }
+      )
+      await drain()
+      expect(events).toEqual([])
+      subscription.push({
+        method: 'session.event',
+        params: {
+          sessionId: 'child-1',
+          event: { type: 'turn/start', seq: 100, time: 0, data: { turn: 1 } }
+        }
+      })
+      await drain()
+      expect(events).toEqual([])
+      for (const [index, event] of [
+        { type: 'turn/start', data: { turn: 1 } },
+        { type: 'step/start', data: { turn: 1, step: 1 } },
+        {
+          type: 'user/message',
+          data: {
+            id: 'input-1',
+            role: 'user',
+            content: [],
+            source: origin === 'host' ? { kind: 'user' } : { kind: 'goal', goalId: 'goal-1', revision: 1, round: 1 }
+          }
+        },
+        nativeCall
+          ? {
+              type: 'tool/call',
+              data: { turn: 1, step: 1, callId: 'call-1', name: 'exit_plan_mode', arguments: '{"plan":"# Ship it"}' }
+            }
+          : {
+              type: 'approval/asked',
+              data: { id: 'native-approval-1', toolName: 'exit_plan_mode' }
+            }
+      ].entries()) {
+        subscription.push({
+          method: 'session.event',
+          params: {
+            sessionId: 'session-1',
+            event: { ...event, seq: index + 1, time: 0 }
+          }
+        })
       }
-    })
-
-    await expect(events.next()).resolves.toMatchObject({
-      value: { type: 'chunk', chunk: { type: 'tool-input-start', toolCallId: 'call-1' } }
-    })
-    await expect(events.next()).resolves.toMatchObject({
-      value: {
-        type: 'chunk',
-        chunk: { type: 'tool-input-available', toolCallId: 'call-1', input: { plan: '# Ship it' } }
-      }
-    })
-    await expect(events.next()).resolves.toMatchObject({
-      value: { type: 'tool-approval-request', request: { approvalId: 'approval-1' } }
-    })
-
-    await connection.close()
-  })
+      await drain()
+      expect(events).toMatchObject([
+        ...(origin === 'goal'
+          ? [{ type: 'autonomous-turn-state', state: 'started', origin: { kind: 'goal-round', round: 1 } }]
+          : []),
+        { type: 'chunk', chunk: { type: 'tool-input-start', toolCallId: 'call-1' } },
+        { type: 'chunk', chunk: { type: 'tool-input-available', toolCallId: 'call-1', input: { plan: '# Ship it' } } },
+        { type: 'tool-approval-request', request: { approvalId: 'approval-1' } }
+      ])
+      events.length = 0
+      emit(
+        {
+          type: 'tool-approval-request',
+          request: {
+            approvalId: 'approval-2',
+            toolCallId: 'call-1',
+            toolName: 'exit_plan_mode',
+            input: { plan: '# Ship it' },
+            presentation: 'stream'
+          }
+        },
+        { sessionId: 'session-1', seq: 4 }
+      )
+      await drain()
+      expect(events).toEqual([expect.objectContaining({ type: 'tool-approval-request' })])
+      await connection.close()
+      await consume
+    }
+  )
 
   it('sends cross-Session provenance and forged instructions inside the untrusted delivery boundary', async () => {
     const connection = await new DshRuntimeConnection(connectInput).start()

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -120,6 +120,71 @@ describe('DshStreamAdapter', () => {
     expect(onTurnEnd).toHaveBeenCalledWith({ kind: 'completed' })
   })
 
+  it('suppresses autonomous turn within grace period after host turn ends', () => {
+    vi.useFakeTimers()
+    try {
+      const { adapter, onAutonomousTurnState, onTurnEnd } = makeAdapter()
+      // Host-prompted turn
+      adapter.beginTurn()
+      adapter.handleEvent(envelope('turn/start', { turn: 1 }))
+      adapter.handleEvent(chunkEnvelope(1, 1, { type: 'block-start', index: 0, blockType: 'text' }))
+      adapter.handleEvent(chunkEnvelope(1, 1, { type: 'text-delta', index: 0, text: 'answer' }))
+      adapter.handleEvent(envelope('turn/end', { turn: 1, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState).not.toHaveBeenCalled()
+      expect(onTurnEnd).toHaveBeenCalledWith({ kind: 'completed' })
+
+      // Goal-round content arrives within 500ms of host turn end
+      vi.advanceTimersByTime(100)
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      adapter.handleEvent(chunkEnvelope(2, 1, { type: 'block-start', index: 0, blockType: 'text' }))
+      adapter.handleEvent(chunkEnvelope(2, 1, { type: 'text-delta', index: 0, text: 'goal work' }))
+
+      // Autonomous turn should be suppressed — no 'started' event
+      expect(onAutonomousTurnState).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('allows autonomous turn after grace period expires', () => {
+    vi.useFakeTimers()
+    try {
+      const { adapter, onAutonomousTurnState } = makeAdapter()
+      // Host-prompted turn
+      adapter.beginTurn()
+      adapter.handleEvent(envelope('turn/start', { turn: 1 }))
+      adapter.handleEvent(envelope('turn/end', { turn: 1, reason: { kind: 'completed' } }))
+
+      // More than 500ms after host turn end
+      vi.advanceTimersByTime(600)
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      adapter.handleEvent(chunkEnvelope(2, 1, { type: 'block-start', index: 0, blockType: 'text' }))
+      adapter.handleEvent(chunkEnvelope(2, 1, { type: 'text-delta', index: 0, text: 'late work' }))
+
+      // Autonomous turn should proceed normally
+      expect(onAutonomousTurnState).toHaveBeenCalledWith('started')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('never suppresses autonomous turns without a preceding host turn', () => {
+    vi.useFakeTimers()
+    try {
+      const { adapter, onAutonomousTurnState } = makeAdapter()
+      // Autonomous turn arrives without any preceding host turn — no grace period
+      adapter.handleEvent(envelope('turn/start', { turn: 1 }))
+      adapter.handleEvent(chunkEnvelope(1, 1, { type: 'block-start', index: 0, blockType: 'text' }))
+      adapter.handleEvent(chunkEnvelope(1, 1, { type: 'text-delta', index: 0, text: 'autonomous work' }))
+
+      // Should always proceed — no hostTurnEndedAt was ever set
+      expect(onAutonomousTurnState).toHaveBeenCalledWith('started')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('swallows a content-less turn instead of fabricating an empty one', () => {
     // A stale goal round rejected at pre-step: turn/start → turn/end {blocked}, zero content.
     const { adapter, chunks, onTurnEnd, onAutonomousTurnState } = makeAdapter()

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -41,7 +41,9 @@ function makeAdapter() {
   const onTurnEnd = vi.fn(() => order.push('turn-end'))
   const onCompaction = vi.fn()
   const onApiRetry = vi.fn()
-  const onAutonomousTurnState = vi.fn((state: 'started' | 'finished') => order.push(`autonomous:${state}`))
+  const onAutonomousTurnState = vi.fn((event: { state: 'started' | 'finished' }) =>
+    order.push(`autonomous:${event.state}`)
+  )
   const onPlanMode = vi.fn()
   const adapter = new DshStreamAdapter({
     enqueue: (chunk) => {
@@ -117,7 +119,7 @@ describe('DshStreamAdapter', () => {
 
     // `started` precedes the first chunk; `finished` precedes the terminal onTurnEnd.
     expect(order).toEqual(['autonomous:started', 'text-start', 'text-delta', 'autonomous:finished', 'turn-end'])
-    expect(onAutonomousTurnState.mock.calls.map((call) => call[0])).toEqual(['started', 'finished'])
+    expect(onAutonomousTurnState.mock.calls.map((call) => call[0].state)).toEqual(['started', 'finished'])
     expect(onTurnEnd).toHaveBeenCalledWith({ kind: 'completed' })
   })
 
@@ -130,6 +132,116 @@ describe('DshStreamAdapter', () => {
     expect(chunks).toHaveLength(0)
     expect(onTurnEnd).not.toHaveBeenCalled()
     expect(onAutonomousTurnState).not.toHaveBeenCalled()
+  })
+
+  describe('turn provenance from the entering user/message batch', () => {
+    /** dsh appends the entering batch inside step 1, before the model call. */
+    const entering = (turn: number, step: number, ...sources: unknown[]) => [
+      envelope('step/start', { turn, step }),
+      ...sources.map((source, index) =>
+        rawEvent('user/message', { id: `um-${turn}-${index}`, role: 'user', content: [], source })
+      )
+    ]
+    const hostPrompt = { kind: 'user' }
+    const goalRound = (round: number) => ({ kind: 'goal', goalId: 'g-1', revision: 1, round })
+    const injectedContext = { kind: 'plugin', plugin: 'agent-instructions' }
+    const text = (turn: number, step: number, value: string) => [
+      chunkEnvelope(turn, step, { type: 'block-start', index: 0, blockType: 'text' }),
+      chunkEnvelope(turn, step, { type: 'text-delta', index: 0, text: value })
+    ]
+    const deltas = (chunks: CherryUIMessageChunk[]) =>
+      chunks.filter((chunk) => chunk.type === 'text-delta').map((chunk) => (chunk as { delta: string }).delta)
+
+    const hostTurn = (adapter: DshStreamAdapter, turn: number, value: string) => {
+      adapter.beginTurn()
+      adapter.handleEvent(envelope('turn/start', { turn }))
+      for (const event of [...entering(turn, 1, hostPrompt), ...text(turn, 1, value)]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn, reason: { kind: 'completed' } }))
+    }
+
+    it('opens a goal round after the host turn as an autonomous turn tagged with its round', () => {
+      // #18755: the round followed no prompt, so the transcript must say why it exists — and must
+      // still carry its content, since the round really ran.
+      const { adapter, chunks, order, onTurnEnd, onAutonomousTurnState } = makeAdapter()
+      hostTurn(adapter, 1, 'answer')
+      order.length = 0
+
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      for (const event of [...entering(2, 1, goalRound(1)), ...text(2, 1, 'goal work')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 2, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState).toHaveBeenCalledWith({ state: 'started', origin: { kind: 'goal-round', round: 1 } })
+      expect(order).toEqual(['autonomous:started', 'text-start', 'text-delta', 'autonomous:finished', 'turn-end'])
+      expect(deltas(chunks)).toEqual(['answer', 'goal work'])
+      expect(onTurnEnd).toHaveBeenCalledTimes(2)
+    })
+
+    it('keeps a goal round that races a fresh host prompt out of that prompt’s turn', () => {
+      // The host opens its stream at beginTurn(), but dsh may run a queued goal round first. That
+      // round must open its own receive-only turn; the prompt's content lands in the prompt's turn.
+      const { adapter, chunks, onTurnEnd, onAutonomousTurnState } = makeAdapter()
+      hostTurn(adapter, 1, 'answer')
+      onTurnEnd.mockClear()
+
+      adapter.beginTurn()
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      for (const event of [...entering(2, 1, goalRound(1)), ...text(2, 1, 'goal work')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 2, reason: { kind: 'completed' } }))
+      adapter.handleEvent(envelope('turn/start', { turn: 3 }))
+      for (const event of [...entering(3, 1, hostPrompt), ...text(3, 1, 'reply')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 3, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState.mock.calls.map((call) => call[0])).toEqual([
+        { state: 'started', origin: { kind: 'goal-round', round: 1 } },
+        { state: 'finished' }
+      ])
+      expect(deltas(chunks)).toEqual(['answer', 'goal work', 'reply'])
+      expect(onTurnEnd).toHaveBeenCalledTimes(2)
+    })
+
+    it('tags autonomous turns that are not goal rounds as background work', () => {
+      const { adapter, onAutonomousTurnState } = makeAdapter()
+      hostTurn(adapter, 1, 'answer')
+
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      for (const event of [...entering(2, 1, injectedContext), ...text(2, 1, 'notice')]) adapter.handleEvent(event)
+
+      expect(onAutonomousTurnState).toHaveBeenCalledWith({ state: 'started', origin: { kind: 'background-work' } })
+    })
+
+    it('classifies a host turn whose batch also carries injected context', () => {
+      // claim() returns [injected context…, the claimed prompt]: the prompt is not the first entry.
+      const { adapter, chunks, onTurnEnd, onAutonomousTurnState } = makeAdapter()
+      adapter.beginTurn()
+      adapter.handleEvent(envelope('turn/start', { turn: 1 }))
+      for (const event of [...entering(1, 1, injectedContext, hostPrompt), ...text(1, 1, 'answer')]) {
+        adapter.handleEvent(event)
+      }
+      adapter.handleEvent(envelope('turn/end', { turn: 1, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState).not.toHaveBeenCalled()
+      expect(deltas(chunks)).toEqual(['answer'])
+      expect(onTurnEnd).toHaveBeenCalledWith({ kind: 'completed' })
+    })
+
+    it('does not let mid-turn input reclassify an open goal round as the host turn', () => {
+      // Only the entering batch classifies. A later step's `user` input flipping the round to a host
+      // turn would skip `finished` and leave the host's queued prompt unowned.
+      const { adapter, onAutonomousTurnState } = makeAdapter()
+      hostTurn(adapter, 1, 'answer')
+      adapter.beginTurn()
+
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      for (const event of [...entering(2, 1, goalRound(1)), ...text(2, 1, 'goal work')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('step/end', { turn: 2, step: 1 }))
+      for (const event of [...entering(2, 2, hostPrompt), ...text(2, 2, 'more')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 2, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState.mock.calls.map((call) => call[0])).toEqual([
+        { state: 'started', origin: { kind: 'goal-round', round: 1 } },
+        { state: 'finished' }
+      ])
+    })
   })
 
   it('maps reasoning blocks to reasoning chunks', () => {

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -199,6 +199,31 @@ describe('DshStreamAdapter', () => {
       expect(onTurnEnd).toHaveBeenCalledTimes(2)
     })
 
+    it('does not let a host prompt sent during an already-classified goal round take over that round', () => {
+      // The user replies right after the host turn ended: dsh has already opened round 1 (its entering
+      // batch is in) when `beginTurn()` fires. Seen live: the round's content landed under the user's
+      // prompt with no badge, and the prompt's own reply was dropped.
+      const { adapter, chunks, onTurnEnd, onAutonomousTurnState } = makeAdapter()
+      hostTurn(adapter, 1, 'answer')
+      onTurnEnd.mockClear()
+
+      adapter.handleEvent(envelope('turn/start', { turn: 2 }))
+      for (const event of entering(2, 1, goalRound(1))) adapter.handleEvent(event)
+      adapter.beginTurn()
+      for (const event of text(2, 1, 'E')) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 2, reason: { kind: 'completed' } }))
+      adapter.handleEvent(envelope('turn/start', { turn: 3 }))
+      for (const event of [...entering(3, 1, hostPrompt), ...text(3, 1, '我很好')]) adapter.handleEvent(event)
+      adapter.handleEvent(envelope('turn/end', { turn: 3, reason: { kind: 'completed' } }))
+
+      expect(onAutonomousTurnState.mock.calls.map((call) => call[0])).toEqual([
+        { state: 'started', origin: { kind: 'goal-round', round: 1 } },
+        { state: 'finished' }
+      ])
+      expect(deltas(chunks)).toEqual(['answer', 'E', '我很好'])
+      expect(onTurnEnd).toHaveBeenCalledTimes(2)
+    })
+
     it('tags autonomous turns that are not goal rounds as background work', () => {
       const { adapter, onAutonomousTurnState } = makeAdapter()
       hostTurn(adapter, 1, 'answer')

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -145,6 +145,7 @@ describe('DshStreamAdapter', () => {
     const hostPrompt = { kind: 'user' }
     const goalRound = (round: number) => ({ kind: 'goal', goalId: 'g-1', revision: 1, round })
     const injectedContext = { kind: 'plugin', plugin: 'agent-instructions' }
+    const runtimeContext = { kind: 'plugin', plugin: '@deepseek-ai/dsh-system-prompt' }
     const text = (turn: number, step: number, value: string) => [
       chunkEnvelope(turn, step, { type: 'block-start', index: 0, blockType: 'text' }),
       chunkEnvelope(turn, step, { type: 'text-delta', index: 0, text: value })
@@ -234,17 +235,21 @@ describe('DshStreamAdapter', () => {
       expect(onAutonomousTurnState).toHaveBeenCalledWith({ state: 'started', origin: { kind: 'background-work' } })
     })
 
-    it('classifies a host turn whose batch also carries injected context', () => {
-      // claim() returns [injected context…, the claimed prompt]: the prompt is not the first entry.
-      const { adapter, chunks, onTurnEnd, onAutonomousTurnState } = makeAdapter()
+    it.each([
+      { position: 'before', sources: [injectedContext, hostPrompt] },
+      { position: 'after', sources: [hostPrompt, runtimeContext] },
+      { position: 'around', sources: [injectedContext, hostPrompt, runtimeContext] }
+    ])('keeps the host stream when context appears $position the prompt', ({ sources }) => {
+      const { adapter, chunks, order, onTurnEnd, onAutonomousTurnState } = makeAdapter()
       adapter.beginTurn()
       adapter.handleEvent(envelope('turn/start', { turn: 1 }))
-      for (const event of [...entering(1, 1, injectedContext, hostPrompt), ...text(1, 1, 'answer')]) {
+      for (const event of [...entering(1, 1, ...sources), ...text(1, 1, 'answer')]) {
         adapter.handleEvent(event)
       }
       adapter.handleEvent(envelope('turn/end', { turn: 1, reason: { kind: 'completed' } }))
 
       expect(onAutonomousTurnState).not.toHaveBeenCalled()
+      expect(order).toEqual(['text-start', 'text-delta', 'turn-end'])
       expect(deltas(chunks)).toEqual(['answer'])
       expect(onTurnEnd).toHaveBeenCalledWith({ kind: 'completed' })
     })

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -33,6 +33,14 @@ import type { AgentRuntimeEvent } from '../types'
 /** dsh transport tag consumed by the renderer's tool-part routing. */
 export const DSH_TRANSPORT = AGENT_RUNTIME_CAPABILITIES.dsh.transport
 
+/**
+ * Grace period after a host-prompted turn ends during which autonomous turns are suppressed.
+ * The DSH goal-round-driver can fire immediately after `turn/end`; suppressing it prevents
+ * a spurious "Processing" bubble from appearing before the user replies. Legitimate autonomous
+ * work (background subagent completions, deferred wake-ups) has longer latency and is unaffected.
+ */
+const POST_HOST_TURN_GRACE_MS = 500
+
 export interface DshInvocationMetrics {
   timeFirstTokenMs?: number
   timeCompletionMs: number
@@ -120,6 +128,8 @@ export class DshStreamAdapter {
   private turnActive = false
   /** The current turn was opened by runtime content (a goal round), not a host prompt. */
   private autonomousTurn = false
+  /** Timestamp of the last host-prompted turn's `turn/end`; drives the post-turn grace period. */
+  private hostTurnEndedAt?: number
 
   constructor(private readonly sink: DshStreamSink) {}
 
@@ -127,6 +137,7 @@ export class DshStreamAdapter {
   beginTurn(): void {
     this.turnActive = true
     this.autonomousTurn = false
+    this.hostTurnEndedAt = undefined
   }
 
   /** Roll back a `beginTurn()` whose prompt never reached the runtime. */
@@ -138,6 +149,12 @@ export class DshStreamAdapter {
   /** Content with no host-opened turn = the runtime started its own (goal-round) turn. */
   private ensureTurnOpen(): void {
     if (this.turnActive) return
+    // Suppress autonomous turns that fire within the grace period after a host turn ended.
+    // The DSH goal-round-driver starts a new round almost immediately after `turn/end`; this
+    // prevents a spurious "Processing" bubble from appearing before the user replies.
+    if (this.hostTurnEndedAt !== undefined && Date.now() - this.hostTurnEndedAt < POST_HOST_TURN_GRACE_MS) {
+      return
+    }
     this.sink.onAutonomousTurnState('started')
     this.turnActive = true
     this.autonomousTurn = true
@@ -180,6 +197,10 @@ export class DshStreamAdapter {
           this.autonomousTurn = false
           // Ownership release must precede the terminal turn-complete (host contract).
           this.sink.onAutonomousTurnState('finished')
+        } else {
+          // Host-prompted turn ended: start the grace period so the goal-round-driver's
+          // immediate autonomous content does not create a spurious new bubble.
+          this.hostTurnEndedAt = Date.now()
         }
         this.sink.onTurnEnd(event.data.reason)
         return

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -191,17 +191,15 @@ export class DshStreamAdapter {
     this.autonomousTurn = true
   }
 
-  /**
-   * Classify the open turn from its entering `user/message` batch, which dsh appends right after
-   * `step/start` and before the model call, so it always precedes the turn's first content. The
-   * batch is `[injected context…, the claimed prompt]`, so the last recognised source wins.
-   */
+  // Entering context can surround the claimed prompt; once claimed, host ownership is final.
   private classifyEnteringMessage(source: MessageSource): void {
     if (source.kind === 'user') {
       // The host's queued prompt was claimed by this turn. A `user` message dsh raised on its own
       // is left to open an autonomous turn, as before.
       if (!this.hostPromptPending) return
       this.hostPromptPending = false
+      this.enteringTurn = false
+      this.turnOrigin = undefined
       this.turnActive = true
       this.autonomousTurn = false
       return

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -16,16 +16,20 @@
  * - `turn/end` → sink callback with the wire reason
  * - `compaction/start|summary|end` → host compaction runtime events via the sink
  * - `llm/retry` / `llm/retry-started` → failed-attempt accounting and retry timing
- * - content with no host-opened turn → autonomous-turn lifecycle (goal rounds)
+ * - `user/message` (entering batch) → classifies the turn as host-prompted or autonomous
+ * - content with no host-opened turn → autonomous-turn lifecycle
  */
-// The dsh-compaction-basic / dsh-llm-retry / dsh-plan-mode imports load their SessionEventMap merges.
+// The dsh-compaction-basic / dsh-llm-retry / dsh-plan-mode imports load their SessionEventMap
+// merges; dsh-goal loads its MessageSourceMap merge.
 import type {} from '@deepseek-ai/dsh-compaction-basic'
-import type { CallId, ContentBlock, TokenUsage } from '@deepseek-ai/dsh-llm'
+import type {} from '@deepseek-ai/dsh-goal'
+import type { CallId, ContentBlock, MessageSource, TokenUsage } from '@deepseek-ai/dsh-llm'
 import type {} from '@deepseek-ai/dsh-llm-retry'
 import type {} from '@deepseek-ai/dsh-plan-mode'
 import type { SessionEvent, SessionEventMap, TurnEndReason } from '@deepseek-ai/dsh-session'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
 import type { AgentSessionApiRetryInfo } from '@shared/ai/agentSessionApiRetry'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk } from '@shared/data/types/message'
 
@@ -60,12 +64,20 @@ export interface DshStreamSink {
   onApiRetry(retry: AgentSessionApiRetryInfo): void
   /** Compaction lifecycle (`compaction/start|end`) mapped to host runtime events. */
   onCompaction(event: DshCompactionRuntimeEvent): void
-  /** A runtime-started turn (goal round): `started` fires before the turn's first chunk,
-   *  `finished` before its `onTurnEnd` — the host opens/settles a receive-only stream. */
-  onAutonomousTurnState(state: 'started' | 'finished'): void
+  /** A runtime-started turn: `started` fires before the turn's first chunk with why the runtime
+   *  opened it, `finished` before its `onTurnEnd` — the host opens/settles a receive-only stream. */
+  onAutonomousTurnState(event: { state: 'started'; origin: AutonomousTurnOrigin } | { state: 'finished' }): void
   /** Committed `plan/mode` fold (last one wins). `false` after an approved exit —
    *  the connection re-opens its policy since Cherry's stored mode is not rewritten. */
   onPlanMode(active: boolean): void
+}
+
+/**
+ * An automatic goal-round continuation, which the `goal-round-driver` queues without user input.
+ * Round 0 is the goal statement itself, not a driven round.
+ */
+function isGoalRoundSource(source: MessageSource): source is Extract<MessageSource, { kind: 'goal' }> {
+  return source.kind === 'goal' && source.round > 0
 }
 
 function toolProviderMetadata(toolName: string, extra: Record<string, unknown> = {}) {
@@ -126,6 +138,12 @@ export class DshStreamAdapter {
   private turnActive = false
   /** The current turn was opened by runtime content (a goal round), not a host prompt. */
   private autonomousTurn = false
+  /** A host prompt is queued but no turn has claimed it yet — dsh may run other turns first. */
+  private hostPromptPending = false
+  /** Why the runtime opened the current turn on its own, read off its entering batch. */
+  private turnOrigin?: AutonomousTurnOrigin
+  /** Still reading the open turn's entering `user/message` batch; later input never reclassifies. */
+  private enteringTurn = false
 
   constructor(private readonly sink: DshStreamSink) {}
 
@@ -134,12 +152,14 @@ export class DshStreamAdapter {
     this.startedTools.clear()
     this.turnActive = true
     this.autonomousTurn = false
+    this.hostPromptPending = true
   }
 
   /** Roll back a `beginTurn()` whose prompt never reached the runtime. */
   abortTurn(): void {
     this.turnActive = false
     this.autonomousTurn = false
+    this.hostPromptPending = false
   }
 
   /**
@@ -153,12 +173,38 @@ export class DshStreamAdapter {
     this.handleToolCall({ callId: callId as CallId, name: toolName, arguments: JSON.stringify(input) })
   }
 
-  /** Content with no host-opened turn = the runtime started its own (goal-round) turn. */
+  /** Content with no host-opened turn = the runtime started its own turn. */
   private ensureTurnOpen(): void {
     if (this.turnActive) return
-    this.sink.onAutonomousTurnState('started')
+    // A turn whose entering batch never reached us (bridge-first approval, legacy log) is still
+    // runtime-started; the neutral reason is the honest fallback.
+    this.sink.onAutonomousTurnState({ state: 'started', origin: this.turnOrigin ?? { kind: 'background-work' } })
     this.turnActive = true
     this.autonomousTurn = true
+  }
+
+  /**
+   * Classify the open turn from its entering `user/message` batch, which dsh appends right after
+   * `step/start` and before the model call, so it always precedes the turn's first content. The
+   * batch is `[injected context…, the claimed prompt]`, so the last recognised source wins.
+   */
+  private classifyEnteringMessage(source: MessageSource): void {
+    if (source.kind === 'user') {
+      // The host's queued prompt was claimed by this turn. A `user` message dsh raised on its own
+      // is left to open an autonomous turn, as before.
+      if (!this.hostPromptPending) return
+      this.hostPromptPending = false
+      this.turnActive = true
+      this.autonomousTurn = false
+      return
+    }
+    this.turnOrigin = isGoalRoundSource(source)
+      ? { kind: 'goal-round', round: source.round }
+      : { kind: 'background-work' }
+    // Not the host's turn even if a prompt is queued: dsh runs this one first, so it must open its
+    // own receive-only stream rather than consume the one the host's prompt will own.
+    this.turnActive = false
+    this.autonomousTurn = false
   }
 
   handleEvent(event: SessionEvent): void {
@@ -169,9 +215,16 @@ export class DshStreamAdapter {
         // Host turns clear in beginTurn, before cross-channel events can race. Preserve a bridge-first
         // synthetic call here; an ordinary autonomous turn is still inactive and clears normally.
         if (!this.turnActive) this.startedTools.clear()
+        this.turnOrigin = undefined
+        this.enteringTurn = true
         this.resetStepTiming()
         return
+      case 'user/message':
+        if (this.enteringTurn) this.classifyEnteringMessage(event.data.source)
+        return
       case 'step/start':
+        // dsh appends the entering batch inside step 1 only; later steps carry mid-turn input.
+        if (event.data.step > 1) this.enteringTurn = false
         this.startProviderAttempt(event.data, true)
         return
       case 'assistant/chunk':
@@ -192,6 +245,8 @@ export class DshStreamAdapter {
         return
       case 'turn/end': {
         this.flushPendingProviderUsage()
+        this.turnOrigin = undefined
+        this.enteringTurn = false
         // A turn that never carried content (a stale goal round rejected at pre-step)
         // has nothing to settle — surfacing it would fabricate an empty host turn.
         if (!this.turnActive) return
@@ -199,7 +254,7 @@ export class DshStreamAdapter {
         if (this.autonomousTurn) {
           this.autonomousTurn = false
           // Ownership release must precede the terminal turn-complete (host contract).
-          this.sink.onAutonomousTurnState('finished')
+          this.sink.onAutonomousTurnState({ state: 'finished' })
         }
         this.sink.onTurnEnd(event.data.reason)
         return
@@ -228,10 +283,9 @@ export class DshStreamAdapter {
         this.sink.onPlanMode(event.data.active)
         return
       default:
-        // user/message, todo/write, request/*, approval/*,
-        // compaction/prune, session/end-seed, and merge-extended types the union
-        // does not know: the unknown-event MUST-refuse rule applies to log
-        // reconstruction (the runtime's job), not here.
+        // todo/write, request/*, approval/*, compaction/prune, session/end-seed,
+        // and merge-extended types the union does not know: the unknown-event
+        // MUST-refuse rule applies to log reconstruction (the runtime's job), not here.
         return
     }
   }

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -140,6 +140,8 @@ export class DshStreamAdapter {
   private autonomousTurn = false
   /** A host prompt is queued but no turn has claimed it yet — dsh may run other turns first. */
   private hostPromptPending = false
+  /** `beginTurn()` opened the current turn for the host (as opposed to leaving a runtime turn alone). */
+  private hostClaimedTurn = false
   /** Why the runtime opened the current turn on its own, read off its entering batch. */
   private turnOrigin?: AutonomousTurnOrigin
   /** Still reading the open turn's entering `user/message` batch; later input never reclassifies. */
@@ -149,17 +151,23 @@ export class DshStreamAdapter {
 
   /** Mark the next turn as host-prompted; called by the connection before each bridge prompt. */
   beginTurn(): void {
+    this.hostPromptPending = true
+    // A runtime-started turn is already under way (classified from its entering batch, or open):
+    // the prompt queues behind it in dsh, so it must not take over that turn's stream.
+    if (this.turnOrigin !== undefined || (this.turnActive && this.autonomousTurn)) return
     this.startedTools.clear()
     this.turnActive = true
     this.autonomousTurn = false
-    this.hostPromptPending = true
+    this.hostClaimedTurn = true
   }
 
   /** Roll back a `beginTurn()` whose prompt never reached the runtime. */
   abortTurn(): void {
+    this.hostPromptPending = false
+    if (!this.hostClaimedTurn) return
+    this.hostClaimedTurn = false
     this.turnActive = false
     this.autonomousTurn = false
-    this.hostPromptPending = false
   }
 
   /**
@@ -205,6 +213,7 @@ export class DshStreamAdapter {
     // own receive-only stream rather than consume the one the host's prompt will own.
     this.turnActive = false
     this.autonomousTurn = false
+    this.hostClaimedTurn = false
   }
 
   handleEvent(event: SessionEvent): void {
@@ -247,6 +256,7 @@ export class DshStreamAdapter {
         this.flushPendingProviderUsage()
         this.turnOrigin = undefined
         this.enteringTurn = false
+        this.hostClaimedTurn = false
         // A turn that never carried content (a stale goal round rejected at pre-step)
         // has nothing to settle — surfacing it would fabricate an empty host turn.
         if (!this.turnActive) return

--- a/src/main/ai/runtime/types.ts
+++ b/src/main/ai/runtime/types.ts
@@ -5,6 +5,7 @@ import type { AgentSessionBackgroundTasks } from '@shared/ai/agentSessionBackgro
 import type { AgentSessionCompactionAnchorData, AgentSessionCompactionTrigger } from '@shared/ai/agentSessionCompaction'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
 import type { AgentSessionSlashCommand } from '@shared/ai/agentSessionSlashCommands'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import type { Tool } from '@shared/ai/tool'
 import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSessionMessages'
 import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
@@ -161,9 +162,11 @@ export type AgentRuntimeEvent =
    *  the persisted assistant message that owns `rootToolCallId`; they never open a new main turn. */
   | { type: 'background-flow-chunk'; rootToolCallId: string; chunk: UIMessageChunk }
   /** Runtime-generated content started without a host-admitted user turn. `started` atomically
-   *  transfers generation ownership and asks the host to open a receive-only transcript turn;
-   *  `finished` releases ownership after the SDK result, independently from turn completion. */
-  | { type: 'autonomous-turn-state'; state: 'started' | 'finished' }
+   *  transfers generation ownership and asks the host to open a receive-only transcript turn,
+   *  carrying why the runtime opened it so the transcript can say so; `finished` releases
+   *  ownership after the SDK result, independently from turn completion. */
+  | { type: 'autonomous-turn-state'; state: 'started'; origin: AutonomousTurnOrigin }
+  | { type: 'autonomous-turn-state'; state: 'finished' }
   | { type: 'error'; error: unknown }
 
 /**

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -953,8 +953,9 @@ export class AiStreamManager extends BaseService {
   }
 
   /**
-   * Detach one not-yet-admitted runtime execution without terminalizing its reserved assistant row.
-   * The runtime closes the upstream stream immediately after this call, then waits for the returned
+   * Detach one runtime execution that has produced nothing yet (prompt not admitted, or admitted but
+   * queued behind a runtime-started turn) without terminalizing its reserved assistant row. The
+   * runtime closes the upstream stream immediately after this call, then waits for the returned
    * promise before opening the receive-only generation that preempted it.
    */
   async suspendUnadmittedRuntimeTurn(topicId: string): Promise<void> {

--- a/src/renderer/components/chat/messages/frame/MessageHeader.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageHeader.tsx
@@ -5,8 +5,9 @@ import { useTheme } from '@renderer/hooks/useTheme'
 import type { Model } from '@renderer/types/model'
 import { getModelLogoRef } from '@renderer/utils/model'
 import { firstLetter, removeLeadingEmoji } from '@renderer/utils/naming'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import dayjs from 'dayjs'
-import { ArrowUpRight, MousePointerClick, Sparkle } from 'lucide-react'
+import { ArrowUpRight, Bot, MousePointerClick, Sparkle, Target } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -31,6 +32,24 @@ interface Props {
   actionsSlot?: ReactNode
   contentSlot?: ReactNode
   footerSlot?: ReactNode
+}
+
+/** Why a runtime opened an assistant turn with no user message; the transcript's only explanation. */
+export const AutonomousTurnOriginBadge: FC<{ origin: AutonomousTurnOrigin }> = ({ origin }) => {
+  const { t } = useTranslation()
+  const label =
+    origin.kind === 'goal-round'
+      ? t('agent.session_turn_origin.goal_round', { round: origin.round })
+      : t('agent.session_turn_origin.background_work')
+  const Icon = origin.kind === 'goal-round' ? Target : Bot
+  return (
+    <Tooltip content={label}>
+      <span className="flex h-5 min-w-0 max-w-[min(18rem,45vw)] items-center gap-1 text-foreground-tertiary text-xs">
+        <Icon aria-hidden="true" className="size-3.5 shrink-0" />
+        <span className="min-w-0 truncate">{label}</span>
+      </span>
+    </Tooltip>
+  )
 }
 
 export const AgentSessionDeliveryBadge: FC<{
@@ -166,6 +185,7 @@ const MessageHeader: FC<Props> = memo(
               {username}
             </span>
             {!isAssistantMessage && delivery && <AgentSessionDeliveryBadge delivery={delivery} />}
+            {isAssistantMessage && message.turnOrigin && <AutonomousTurnOriginBadge origin={message.turnOrigin} />}
             {isAssistantMessage && showModelIdentity && displayModelName && (
               <span className="flex min-w-0 shrink items-center gap-1 text-foreground-tertiary text-xs leading-5">
                 <span aria-hidden="true" className="shrink-0">

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
@@ -74,8 +74,11 @@ vi.mock('../../MessageListProvider', () => ({
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, values?: { agent?: string; session?: string }) =>
-      key === 'agent.session_delivery.from' ? `From ${values?.agent} / ${values?.session}` : key
+    t: (key: string, values?: { agent?: string; session?: string; round?: number }) => {
+      if (key === 'agent.session_delivery.from') return `From ${values?.agent} / ${values?.session}`
+      if (key === 'agent.session_turn_origin.goal_round') return `Goal round ${values?.round}`
+      return key
+    }
   })
 }))
 
@@ -117,6 +120,20 @@ describe('MessageHeader', () => {
     const { container } = render(<MessageHeader message={createMessage()} />)
 
     expect(container.querySelector('.message-body-column')).toBeNull()
+  })
+
+  it('explains a runtime-started assistant turn with its origin', () => {
+    // A goal round has no user message above it; the badge is the transcript's only explanation.
+    const { getByText } = render(
+      <MessageHeader message={createMessage('assistant', { turnOrigin: { kind: 'goal-round', round: 2 } })} />
+    )
+    expect(getByText('Goal round 2')).toBeTruthy()
+  })
+
+  it('renders no origin badge for a prompted assistant turn', () => {
+    const { queryByText } = render(<MessageHeader message={createMessage('assistant')} />)
+    expect(queryByText(/Goal round/)).toBeNull()
+    expect(queryByText('agent.session_turn_origin.background_work')).toBeNull()
   })
 
   it('shows the snapshot assistant name without repeating the model beside it', () => {

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -6,6 +6,7 @@ import type { MessageExportView } from '@renderer/types/messageExport'
 import type { McpTool } from '@renderer/types/tool'
 import type { Topic } from '@renderer/types/topic'
 import type { AgentSessionDelivery } from '@shared/ai/agentSessionDelivery'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import type {
   ChatMessageStyle,
   MultiModelGridPopoverTrigger,
@@ -213,6 +214,7 @@ export interface MessageListItem {
   isActiveBranch?: boolean
   stats?: MessageStats
   delivery?: AgentSessionDelivery
+  turnOrigin?: AutonomousTurnOrigin
   mentions?: Array<{
     id: string
     name: string

--- a/src/renderer/components/chat/messages/utils/messageListItem.ts
+++ b/src/renderer/components/chat/messages/utils/messageListItem.ts
@@ -57,7 +57,8 @@ export function toMessageListItem(message: CherryUIMessage, ctx: MessageListItem
     siblingsGroupId: metadata.siblingsGroupId,
     isActiveBranch: metadata.isActiveBranch,
     stats: statsFromMetadata(message.metadata),
-    delivery: metadata.delivery
+    delivery: metadata.delivery,
+    turnOrigin: metadata.turnOrigin
   }
 }
 

--- a/src/renderer/hooks/__tests__/useAgentSessionParts.test.ts
+++ b/src/renderer/hooks/__tests__/useAgentSessionParts.test.ts
@@ -289,6 +289,33 @@ describe('useAgentSessionParts', () => {
     ])
   })
 
+  it('labels a runtime-started message from the live turn-origin cache', () => {
+    // The persisted row carries nothing that explains the turn; the badge reads the session cache.
+    const row = {
+      id: 'message-1',
+      sessionId: 'session-1',
+      role: 'assistant',
+      data: { parts: [{ type: 'text', text: 'Round work' }] },
+      searchableText: '',
+      status: 'success',
+      modelId: null,
+      messageSnapshot: null,
+      stats: null,
+      runtimeResumeToken: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z'
+    } as AgentSessionMessageEntity
+    mockAgentSessionPartsDataApi([{ items: [row] }])
+    MockUseCacheUtils.setSharedCacheValue('agent.session.turn_origin.session-1.message-1', {
+      kind: 'goal-round',
+      round: 2
+    })
+
+    const { result } = renderHook(() => useAgentSessionParts('session-1'))
+
+    expect(result.current.messages[0].metadata?.turnOrigin).toEqual({ kind: 'goal-round', round: 2 })
+  })
+
   it('reprojects only the message whose live flow parts changed', () => {
     const rowFor = (id: string): AgentSessionMessageEntity =>
       ({

--- a/src/renderer/hooks/useAgentSessionParts.ts
+++ b/src/renderer/hooks/useAgentSessionParts.ts
@@ -13,6 +13,7 @@
 import { useSharedCacheSelector } from '@renderer/data/hooks/useCache'
 import { useDataChange, useInfiniteFlatItems, useMutation } from '@renderer/data/hooks/useDataApi'
 import { AGENT_SESSION_FLOW_PARTS_CACHE_KEY } from '@shared/ai/agentSessionFlowParts'
+import { AGENT_SESSION_TURN_ORIGIN_CACHE_KEY, type AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import type { CursorPaginationResponse } from '@shared/data/api/types'
 import type { AgentSessionMessageEntity } from '@shared/data/types/agent'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
@@ -24,6 +25,7 @@ const PAGE_SIZE = 50
 
 interface CachedAgentSessionMessage {
   liveParts: CherryMessagePart[] | undefined
+  turnOrigin: AutonomousTurnOrigin | undefined
   message: CherryUIMessage
   modelId: AgentSessionMessageEntity['modelId']
   role: AgentSessionMessageEntity['role']
@@ -121,6 +123,16 @@ export function useAgentSessionParts(sessionId: string, options: { enabled?: boo
     [loadedMessageIds]
   )
   const flowParts = useSharedCacheSelector(flowPartsKeys, selectFlowParts)
+  const turnOriginKeys = useMemo(
+    () => loadedMessageIds.map((messageId) => AGENT_SESSION_TURN_ORIGIN_CACHE_KEY(sessionId, messageId)),
+    [loadedMessageIds, sessionId]
+  )
+  const selectTurnOrigins = useCallback(
+    (values: readonly (AutonomousTurnOrigin | null | undefined)[]) =>
+      Object.fromEntries(loadedMessageIds.map((messageId, index) => [messageId, values[index] ?? undefined])),
+    [loadedMessageIds]
+  )
+  const turnOrigins = useSharedCacheSelector(turnOriginKeys, selectTurnOrigins)
 
   const messageProjectionRef = useRef<
     | {
@@ -142,6 +154,7 @@ export function useAgentSessionParts(sessionId: string, options: { enabled?: boo
       const nextById = new Map<string, CachedAgentSessionMessage>()
       const nextMessages = sourceRows.map((row) => {
         const liveParts = flowParts[row.id]
+        const turnOrigin = turnOrigins[row.id]
         const cached = previousById?.get(row.id)
         if (
           cached?.sessionId === row.sessionId &&
@@ -149,16 +162,19 @@ export function useAgentSessionParts(sessionId: string, options: { enabled?: boo
           cached.role === row.role &&
           cached.status === row.status &&
           cached.modelId === row.modelId &&
-          cached.liveParts === liveParts
+          cached.liveParts === liveParts &&
+          cached.turnOrigin === turnOrigin
         ) {
           nextById.set(row.id, cached)
           return cached.message
         }
 
         const message = toAgentSessionUIMessage(row)
-        const projectedMessage = liveParts ? { ...message, parts: liveParts } : message
+        const withOrigin = turnOrigin ? { ...message, metadata: { ...message.metadata, turnOrigin } } : message
+        const projectedMessage = liveParts ? { ...withOrigin, parts: liveParts } : withOrigin
         nextById.set(row.id, {
           liveParts,
+          turnOrigin,
           message: projectedMessage,
           modelId: row.modelId,
           role: row.role,
@@ -181,7 +197,7 @@ export function useAgentSessionParts(sessionId: string, options: { enabled?: boo
       }
       return stableMessages
     },
-    [flowParts, projectionOwnerToken]
+    [flowParts, turnOrigins, projectionOwnerToken]
   )
 
   const messages = useMemo<CherryUIMessage[]>(() => {

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Verarbeitet",
   "agent.session_delivery.status.delivering": "Wird zugestellt",
   "agent.session_delivery.status.failed": "Fehlgeschlagen",
+  "agent.session_turn_origin.background_work": "Nach Hintergrundarbeit fortgesetzt",
+  "agent.session_turn_origin.goal_round": "Zielrunde {{round}}",
   "agent.settings.permissionMode.title": "Berechtigungsmodus",
   "agent.settings.skills.addMore": "Skills verwalten",
   "agent.settings.tooling.mcp.toggle": "{{name}} umschalten",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Ολοκληρώθηκε",
   "agent.session_delivery.status.delivering": "Παραδίδεται",
   "agent.session_delivery.status.failed": "Απέτυχε",
+  "agent.session_turn_origin.background_work": "Συνέχεια μετά από εργασία στο παρασκήνιο",
+  "agent.session_turn_origin.goal_round": "Γύρος στόχου {{round}}",
   "agent.settings.permissionMode.title": "Λειτουργία Αδειών",
   "agent.settings.skills.addMore": "Διαχείριση δεξιοτήτων",
   "agent.settings.tooling.mcp.toggle": "Εναλλαγή {{name}}",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Consumed",
   "agent.session_delivery.status.delivering": "Delivering",
   "agent.session_delivery.status.failed": "Failed",
+  "agent.session_turn_origin.background_work": "Continued after background work",
+  "agent.session_turn_origin.goal_round": "Goal round {{round}}",
   "agent.settings.permissionMode.title": "Permission Mode",
   "agent.settings.skills.addMore": "Manage Skills",
   "agent.settings.tooling.mcp.toggle": "Toggle {{name}}",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Procesado",
   "agent.session_delivery.status.delivering": "Entregando",
   "agent.session_delivery.status.failed": "Fallido",
+  "agent.session_turn_origin.background_work": "Continuado tras trabajo en segundo plano",
+  "agent.session_turn_origin.goal_round": "Ronda de objetivo {{round}}",
   "agent.settings.permissionMode.title": "Modo de permisos",
   "agent.settings.skills.addMore": "Gestionar habilidades",
   "agent.settings.tooling.mcp.toggle": "Alternar {{name}}",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Traité",
   "agent.session_delivery.status.delivering": "En cours de livraison",
   "agent.session_delivery.status.failed": "Échec",
+  "agent.session_turn_origin.background_work": "Poursuivi après un travail en arrière-plan",
+  "agent.session_turn_origin.goal_round": "Tour d’objectif {{round}}",
   "agent.settings.permissionMode.title": "Mode d'autorisation",
   "agent.settings.skills.addMore": "Gérer les compétences",
   "agent.settings.tooling.mcp.toggle": "Basculer {{name}}",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "処理済み",
   "agent.session_delivery.status.delivering": "配信中",
   "agent.session_delivery.status.failed": "失敗",
+  "agent.session_turn_origin.background_work": "バックグラウンド作業の完了後に継続",
+  "agent.session_turn_origin.goal_round": "ゴールラウンド {{round}}",
   "agent.settings.permissionMode.title": "パーミッションモード",
   "agent.settings.skills.addMore": "スキルを管理",
   "agent.settings.tooling.mcp.toggle": "{{name}}を切り替え",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Processado",
   "agent.session_delivery.status.delivering": "A entregar",
   "agent.session_delivery.status.failed": "Falhou",
+  "agent.session_turn_origin.background_work": "Continuado após trabalho em segundo plano",
+  "agent.session_turn_origin.goal_round": "Ronda de objetivo {{round}}",
   "agent.settings.permissionMode.title": "Modo de Permissão",
   "agent.settings.skills.addMore": "Gerir Skills",
   "agent.settings.tooling.mcp.toggle": "Alternar {{name}}",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Procesat",
   "agent.session_delivery.status.delivering": "În curs de livrare",
   "agent.session_delivery.status.failed": "Eșuat",
+  "agent.session_turn_origin.background_work": "Continuat după activitate în fundal",
+  "agent.session_turn_origin.goal_round": "Runda obiectivului {{round}}",
   "agent.settings.permissionMode.title": "Mod de permisiune",
   "agent.settings.skills.addMore": "Gestionează abilitățile",
   "agent.settings.tooling.mcp.toggle": "Comută {{name}}",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Обработано",
   "agent.session_delivery.status.delivering": "Доставляется",
   "agent.session_delivery.status.failed": "Ошибка",
+  "agent.session_turn_origin.background_work": "Продолжено после фоновой работы",
+  "agent.session_turn_origin.goal_round": "Раунд цели {{round}}",
   "agent.settings.permissionMode.title": "Режим разрешений",
   "agent.settings.skills.addMore": "Управление навыками",
   "agent.settings.tooling.mcp.toggle": "Переключить {{name}}",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Kullanıldı",
   "agent.session_delivery.status.delivering": "Teslim ediliyor",
   "agent.session_delivery.status.failed": "Başarısız",
+  "agent.session_turn_origin.background_work": "Arka plan çalışması sonrası devam edildi",
+  "agent.session_turn_origin.goal_round": "Hedef turu {{round}}",
   "agent.settings.permissionMode.title": "İzin Modu",
   "agent.settings.skills.addMore": "Becerileri Yönet",
   "agent.settings.tooling.mcp.toggle": "{{name}} durumunu değiştir",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "Đã xử lý",
   "agent.session_delivery.status.delivering": "Đang chuyển",
   "agent.session_delivery.status.failed": "Thất bại",
+  "agent.session_turn_origin.background_work": "Tiếp tục sau công việc nền",
+  "agent.session_turn_origin.goal_round": "Vòng mục tiêu {{round}}",
   "agent.settings.permissionMode.title": "Chế độ quyền truy cập",
   "agent.settings.skills.addMore": "Quản lý kỹ năng",
   "agent.settings.tooling.mcp.toggle": "Chuyển đổi {{name}}",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "已消费",
   "agent.session_delivery.status.delivering": "投递中",
   "agent.session_delivery.status.failed": "失败",
+  "agent.session_turn_origin.background_work": "后台工作完成后继续",
+  "agent.session_turn_origin.goal_round": "目标推进 · 第 {{round}} 轮",
   "agent.settings.permissionMode.title": "权限模式",
   "agent.settings.skills.addMore": "管理技能",
   "agent.settings.tooling.mcp.toggle": "切换 {{name}}",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -252,6 +252,8 @@
   "agent.session_delivery.status.consumed": "已處理",
   "agent.session_delivery.status.delivering": "投遞中",
   "agent.session_delivery.status.failed": "失敗",
+  "agent.session_turn_origin.background_work": "背景工作完成後繼續",
+  "agent.session_turn_origin.goal_round": "目標推進 · 第 {{round}} 輪",
   "agent.settings.permissionMode.title": "權限模式",
   "agent.settings.skills.addMore": "管理技能",
   "agent.settings.tooling.mcp.toggle": "切換 {{name}}",

--- a/src/shared/ai/agentSessionTurnOrigin.ts
+++ b/src/shared/ai/agentSessionTurnOrigin.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod'
+
+/**
+ * Why a runtime opened a turn on its own, with no host-admitted user message. Closed set — each
+ * member has a runtime that produces it today (`goal-round`: dsh's goal-round-driver;
+ * `background-work`: Claude Code waking the main agent).
+ */
+export const AutonomousTurnOriginSchema = z.discriminatedUnion('kind', [
+  z.strictObject({ kind: z.literal('goal-round'), round: z.number().int().positive() }),
+  z.strictObject({ kind: z.literal('background-work') })
+])
+export type AutonomousTurnOrigin = z.infer<typeof AutonomousTurnOriginSchema>
+
+/** Live, per-message explanation for a runtime-started assistant turn. Shared cache, like the
+ *  api-retry status: it rides the session and is gone after a restart — not conversation content. */
+export const AGENT_SESSION_TURN_ORIGIN_CACHE_KEY = (sessionId: string, messageId: string) =>
+  `agent.session.turn_origin.${sessionId}.${messageId}` as const

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -293,6 +293,7 @@ export type SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': CacheValueTypes.CacheAgentSessionBackgroundTasks
   'agent.session.task_events.${sessionId}': CacheValueTypes.CacheAgentSessionTaskEvents
   'agent.session.flow_parts.${sessionId}.${messageId}': CacheValueTypes.CacheAgentSessionFlowParts
+  'agent.session.turn_origin.${sessionId}.${messageId}': CacheValueTypes.CacheAgentSessionTurnOrigin
   'topic.stream.statuses.${topicId}': TopicStatusSnapshotEntry | null
   'topic.stream.last_seen_completion.${topicId}': number | null
   'feature.openclaw.gateway_status': CacheValueTypes.OpenClawGatewayStatus
@@ -347,6 +348,7 @@ export const DefaultSharedCache: SharedCacheSchema = {
   'agent.session.background_tasks.${sessionId}': [],
   'agent.session.task_events.${sessionId}': {},
   'agent.session.flow_parts.${sessionId}.${messageId}': [],
+  'agent.session.turn_origin.${sessionId}.${messageId}': null,
   'topic.stream.statuses.${topicId}': null,
   'topic.stream.last_seen_completion.${topicId}': null,
   'feature.openclaw.gateway_status': 'stopped',

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -8,6 +8,7 @@ import type { AgentSessionCompactionState } from '../../ai/agentSessionCompactio
 import type { AgentSessionContextUsage } from '../../ai/agentSessionContextUsage'
 import type { AgentSessionFlowParts } from '../../ai/agentSessionFlowParts'
 import type { AgentSessionSlashCommand } from '../../ai/agentSessionSlashCommands'
+import type { AutonomousTurnOrigin } from '../../ai/agentSessionTurnOrigin'
 import type { McpServer } from '../types/mcpServer'
 import type { MiniApp } from '../types/miniApp'
 import type { UniqueModelId } from '../types/model'
@@ -189,6 +190,7 @@ export type CacheAgentSessionSlashCommands = AgentSessionSlashCommand[] | null
 export type CacheAgentSessionBackgroundTasks = AgentSessionBackgroundTasks
 export type CacheAgentSessionTaskEvents = AgentSessionTaskEvents
 export type CacheAgentSessionFlowParts = AgentSessionFlowParts
+export type CacheAgentSessionTurnOrigin = AutonomousTurnOrigin | null
 
 /**
  * Persisted window geometry for the WindowManager "remember bounds" capability.

--- a/src/shared/data/types/message.ts
+++ b/src/shared/data/types/message.ts
@@ -1,5 +1,6 @@
 import { CURRENCY, objectValues } from '@cherrystudio/provider-registry'
 import type { AgentSessionDelivery } from '@shared/ai/agentSessionDelivery'
+import type { AutonomousTurnOrigin } from '@shared/ai/agentSessionTurnOrigin'
 import type { CursorPaginationResponse } from '@shared/data/api/types'
 import { type ReasoningEffortOption, ReasoningEffortOptionSchema } from '@shared/types/aiSdk'
 import type {
@@ -215,6 +216,8 @@ export interface CherryUIMessageMetadata {
   stats?: MessageStats
   /** Trusted cross-session sender attribution and durable delivery lifecycle. */
   delivery?: AgentSessionDelivery
+  /** Why a runtime opened this assistant turn with no user message (goal round, background work). */
+  turnOrigin?: AutonomousTurnOrigin
 }
 
 /** Cherry Studio's UIMessage with custom metadata and data part types. */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: after a DSH host turn finished ("Processed"), the `goal-round-driver` could start another round with no user input, and the transcript showed a second assistant message with nothing above it and nothing to say why. Claude Code had the same gap when background work woke the main agent. And if the user replied right after the turn ended while a round was queued, the round's content streamed into the user's response and the user's actual reply was dropped.

After this PR: a runtime-started assistant turn carries a header badge naming why it exists — **Goal round N** (dsh) or **Continued after background work** (Claude Code) — while the session is open. The round itself is shown, not hidden. A user prompt that races a queued round gets its own turn and its own reply.

Fixes #18755

### Why we need it and why it was done in this way

The reporter's complaint was "it started a new answer **without any prompt**" — the surprise, not the visibility. They described exactly what the second bubble did, so hiding it (the earlier revisions of this PR) would have removed real work from the transcript while it kept running in the child: files still written, tokens still spent, and the round still in the model's context on resume. `main`'s behaviour of showing the bubble was closer to right; what it lacked was an explanation.

The explanation is available on both runtimes that open such turns:

- dsh: `turn/start` carries only `{ turn }`, but the entering `user/message` batch that the agent loop appends right after `step/start` (before the model call) is tagged by its producer — `{ kind: 'user' }` by our bridge for a host prompt, `{ kind: 'goal', round }` by `@deepseek-ai/dsh-goal-round-driver` for a continuation.
- Claude Code: parentless content with no open turn is the SDK waking the main agent after background work (`streamAdapter.ts`, already translated to `autonomous-turn-state`).

So the change is made at the runtime-neutral seam, `autonomous-turn-state: started`, which now carries an `AutonomousTurnOrigin`. The state machine keeps it on the `autonomous-turn` execution, `startReceiveOnlyTurn` publishes it to the shared cache per assistant message, and the renderer reads it next to the live flow parts it already reads from the same cache.

**The race** (third commit) was found by running the branch against a live dsh session, not by the unit tests: the user replies ~1 s after a turn ends while a goal round is queued. dsh accepts the prompt, then runs the round first. Two independent defects in `main`:

1. The adapter's `beginTurn()` claimed the round's turn when the round's `turn/start` had already arrived — the round's content streamed into the prompt's response with no badge.
2. `AgentSessionRuntimeService` ignored `autonomous-turn-state: started` whenever the host turn was live *and admitted*. On dsh, admitted means "accepted into the inbox", not "running", so even a correctly classified round streamed into the prompt's turn, and the prompt's own reply — arriving after that turn was closed — was dropped (`Agent SDK usage lost its active turn`, `Ignoring invalid transition runtime-terminal`).

`beginTurn()` now leaves a classified or open runtime turn alone. The service defers an admitted turn the same way it already deferred an unadmitted one, keeping its admission so the relaunch does not re-send the prompt, and buffering content the runtime produces for it before its stream reopens (replayed by `flush-transition`, after the `start` chunk).

The following tradeoffs were made:

- **Not persisted.** The origin is live session status in the shared cache, like the api-retry state, and is gone after a restart — rounds from before a restart show as plain assistant messages again. Persisting it would have cost a column and a migration for an after-the-fact label; the goal state itself (round N of M, "goal in progress", a stop control) is the right durable home and is a follow-up.
- **Closed origin set with two members**, each with a producer today. A new runtime with a new reason adds a member and an i18n key.
- **`@deepseek-ai/dsh-goal` becomes a dependency** purely to load its `MessageSourceMap` merge — the same reason `dsh-compaction-basic` / `dsh-llm-retry` / `dsh-plan-mode` are already declared for this file. Removing the import turns `source.kind === 'goal'` into a compile error.
- **Transcript order follows execution order.** When a prompt is deferred behind a round, its row lands after the round's rows, which is when dsh actually answered it.

The following alternatives were considered:

- **Suppress the round** (this PR's earlier revisions, 500 ms grace window → per-turn latch → turn-id isolation → arrival-time heuristic → event-time comparison). Each revision was reopened by a new interleaving, ending at a tie between two equal millisecond timestamps from two processes — a point with no ordering information. Rejected on both grounds: underdetermined, and it hides real work.
- **Persist the origin on the message** (column + migration). Rejected as disproportionate for a label; see tradeoffs.
- **Infer "unprompted" from transcript adjacency** (assistant after assistant). Gives no reason or round number, pages are newest-first so the previous message may be on another page, and steer continuation rows are also assistant-after-assistant.

Links to places where the discussion took place: review history on this PR; https://github.com/CherryHQ/cherry-studio/pull/18770#issuecomment-5582161992

### Breaking changes

None.

### Special notes for your reviewer

The branch was rebased onto `main` and replaced (force-push): the earlier suppression revisions are superseded, not amended. Three commits: the runtime/main/shared contract, the renderer badge, then the race fix. `pi` and `aiSdk` never emit `autonomous-turn-state`, so they are untouched.

Verified live against a dsh session (`deepseek-v4-flash`) in an isolated profile — the model armed the goal itself via `create_goal`, i.e. the reporter's path:

- three rounds, each badged `目标推进 · 第 N 轮`, content streamed, goal completed;
- a user reply sent ~1 s after the host turn ended, with a round queued: before the third commit the round's content landed under the user's prompt and the user's reply was lost; after it, the rounds are badged and the reply has its own turn.

Tests (state the bug each catches):

- dsh adapter — goal round after a host turn opens as an autonomous turn tagged `{ goal-round, round }` and its content still streams; a round racing a fresh host prompt (either ordering: prompt first, or round's `turn/start` first) opens its own turn and the prompt's content lands in the prompt's turn; non-goal sources are tagged `background-work`; a host batch with injected context ahead of the prompt still classifies as host (`claim()` returns `[injected…, prompt]`); mid-turn input cannot reclassify an open round.
- Claude Code adapter — the wake carries `background-work`.
- State machine — `started(origin)` lands on the execution; an admitted deferred turn stays admitted across the relaunch and its early content is replayed by `flush-transition`.
- `AgentSessionRuntimeService` — publishes the origin under the assistant message's key; an admitted host turn is deferred behind a goal round and resumed without re-sending, with the buffered reply delivered. The old test asserting the guard ("ignores a receive-only signal while an admitted turn is live") pinned the defect and is removed.
- `useAgentSessionParts` — a cache value becomes `metadata.turnOrigin`; `MessageHeader` — renders the badge for a goal round, nothing for a prompted turn.

`src/main/ai` + `src/main/data` full sweep passes. tsgo (node + web), oxlint, biome, eslint, `i18n:check`, `docs:check` clean.

Out of scope, for a follow-up: consume `goal/change` so the session can show "goal in progress · round N/M" with a stop control instead of "Processed", and decide whether a goal the model arms itself via `tool-goal` should require confirmation.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: `docs/references/ai/agent-session-runtime.md` updated; no user-guide change required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Agent sessions now label a reply the agent started on its own — "Goal round N" for a DSH goal continuation, or "Continued after background work" — instead of showing an unexplained new message. A message sent while a DSH goal round is starting no longer has the round's output attributed to it, and its own reply is no longer lost.
```
