### PR TITLE
fix(code-mate): filter DSH-incompatible providers from Code Mate UI

### DIFF
--- a/src/renderer/pages/code/__tests__/cliTools.test.ts
+++ b/src/renderer/pages/code/__tests__/cliTools.test.ts
@@ -55,6 +55,7 @@ describe('DeepSeek Harness provider support', () => {
       provider({
         id: 'api-key',
         apiKeys: [{ id: 'key', isEnabled: true }],
+        apiFeatures: { developerRole: true },
         endpointConfigs: { 'openai-responses': { baseUrl: 'https://api.example/v1' } }
       }),
       provider({
@@ -88,5 +89,36 @@ describe('DeepSeek Harness provider support', () => {
     ])
 
     expect(supported.map((item) => item.id)).toEqual(['api-key', 'keyless', 'oauth-with-api-key'])
+  })
+
+  it('excludes providers without developer role and without an Anthropic fallback', () => {
+    const supported = CLI_TOOL_PROVIDER_MAP[CodeCli.DEEPSEEK_HARNESS]([
+      provider({
+        id: 'openai-only-no-developer-role',
+        apiKeys: [{ id: 'key', isEnabled: true }],
+        apiFeatures: { developerRole: false },
+        endpointConfigs: { 'openai-chat-completions': { baseUrl: 'https://api.example/v1' } }
+      }),
+      provider({
+        id: 'openai-only-with-developer-role',
+        apiKeys: [{ id: 'key', isEnabled: true }],
+        apiFeatures: { developerRole: true },
+        endpointConfigs: { 'openai-chat-completions': { baseUrl: 'https://api.example/v1' } }
+      }),
+      provider({
+        id: 'no-developer-role-but-has-anthropic-fallback',
+        apiKeys: [{ id: 'key', isEnabled: true }],
+        apiFeatures: { developerRole: false },
+        endpointConfigs: {
+          'openai-chat-completions': { baseUrl: 'https://api.example/v1' },
+          'anthropic-messages': { baseUrl: 'https://api.example/anthropic' }
+        }
+      })
+    ])
+
+    expect(supported.map((item) => item.id)).toEqual([
+      'openai-only-with-developer-role',
+      'no-developer-role-but-has-anthropic-fallback'
+    ])
   })
 })

--- a/src/renderer/pages/code/constants/cliTools.ts
+++ b/src/renderer/pages/code/constants/cliTools.ts
@@ -14,7 +14,7 @@ import { Deepseek, Openclaw } from '@cherrystudio/ui/icons/providers'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { CodeCli } from '@shared/types/codeCli'
-import { isGeminiProvider, isLoginBasedProvider } from '@shared/utils/provider'
+import { isGeminiProvider, isLoginBasedProvider, isSupportDeveloperRoleProvider } from '@shared/utils/provider'
 
 /** `label` is an i18n key (under `code.cli_tools`), not display text — resolve it with `t()` before rendering. */
 export const CLI_TOOLS = [
@@ -79,7 +79,8 @@ export const CLI_TOOL_PROVIDER_MAP: Record<string, (providers: Provider[]) => Pr
       (p) =>
         !isLoginBasedProvider(p) &&
         (p.authOptional || p.apiKeys.some((key) => key.isEnabled)) &&
-        (hasAnthropic(p) || hasOpenAILike(p))
+        (hasAnthropic(p) || hasOpenAILike(p)) &&
+        (isSupportDeveloperRoleProvider(p) || hasAnthropic(p))
     ),
   [CodeCli.GEMINI_CLI]: (providers) =>
     providers.filter((p) => isGeminiProvider(p) || hasGemini(p) || GEMINI_AGGREGATOR_PROVIDERS.has(p.id)),


### PR DESCRIPTION
## Summary

Fixes #18756

The DSH provider filter in `CLI_TOOL_PROVIDER_MAP` only checked endpoints, API keys, and auth mode — but not whether the provider supports the `developerRole` required by DSH for reasoning models on OpenAI-compatible endpoints. This let providers like cherryin Enterprise (which lack `developerRole` and have no Anthropic fallback) appear in the selectable list, only to fail at launch with an opaque UUID-containing error.

## Changes

- **`src/renderer/pages/code/constants/cliTools.ts`**: Added `isSupportDeveloperRoleProvider(p) || hasAnthropic(p)` condition to the `DEEPSEEK_HARNESS` provider filter. This mirrors the backend's constraints in `resolveDeepSeekHarnessEndpoint()`:
  - Providers with `developerRole: true` → included (they support the developer role needed for reasoning models)
  - Providers with `developerRole: false` but an Anthropic endpoint → included (Anthropic endpoint serves as fallback)
  - Providers with `developerRole: false` and no Anthropic endpoint → **excluded** (would fail at launch)

- **`src/renderer/pages/code/__tests__/cliTools.test.ts`**: Updated existing test to add `developerRole: true` to the OpenAI-only provider (realistic representation), and added new test case covering the developer role filter logic.

## Testing

- ✅ `cliTools.test.ts` — 5/5 tests pass
- ✅ `deepSeekHarness/config.test.ts` — all DSH config tests pass (unchanged)
- ✅ `deepSeekHarness/DeepSeekHarnessService.test.ts` — all service tests pass (unchanged)