### PR TITLE
fix(xlsx-preview): terminate parse worker on terminal states

### DIFF
--- a/src/renderer/components/FilePreview/plugins/spreadsheet/__tests__/useXlsxWorkbook.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/spreadsheet/__tests__/useXlsxWorkbook.test.tsx
@@ -101,6 +101,31 @@ describe('useXlsxWorkbook', () => {
     expect(result.current).toEqual({ status: 'ready', model })
   })
 
+  it('terminates the worker after a successful parse and not again on unmount', async () => {
+    const model = createMockWorkbookModel()
+    const { result, unmount } = renderHook(() => useXlsxWorkbook('/tmp/book.xlsx', 0))
+
+    await waitFor(() => expect(mocks.requests).toHaveLength(1))
+    const worker = lastWorker()
+    act(() => worker.respond({ id: mocks.requests[0].id, ok: true, model }))
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    expect(worker.terminate).toHaveBeenCalledTimes(1)
+    unmount()
+    expect(worker.terminate).toHaveBeenCalledTimes(1)
+  })
+
+  it('maps a worker crash to the error state and terminates the worker', async () => {
+    const { result } = renderHook(() => useXlsxWorkbook('/tmp/book.xlsx', 0))
+
+    await waitFor(() => expect(mocks.requests).toHaveLength(1))
+    const worker = lastWorker()
+    act(() => worker.onerror?.({ message: 'worker exploded' }))
+
+    await waitFor(() => expect(result.current).toEqual({ status: 'error', message: 'worker exploded' }))
+    expect(worker.terminate).toHaveBeenCalledTimes(1)
+  })
+
   it('terminates the worker and reports a synchronous postMessage failure', async () => {
     const error = new Error('structured clone failed')
     mocks.postMessageError = error
@@ -185,6 +210,7 @@ describe('useXlsxWorkbook', () => {
     act(() => lastWorker().respond({ id: mocks.requests[0].id, ok: false, message: 'not an xlsx' }))
 
     await waitFor(() => expect(result.current).toEqual({ status: 'error', message: 'not an xlsx' }))
+    expect(lastWorker().terminate).toHaveBeenCalledTimes(1)
     // The raw technical message is logged at the failure site so the UI can show a generic translated description.
     expect(mocks.logger.error).toHaveBeenCalledWith('Failed to parse xlsx file: not an xlsx')
   })

--- a/src/renderer/components/FilePreview/plugins/spreadsheet/useXlsxWorkbook.ts
+++ b/src/renderer/components/FilePreview/plugins/spreadsheet/useXlsxWorkbook.ts
@@ -29,8 +29,8 @@ type XlsxWorker = Pick<Worker, 'postMessage' | 'terminate'> & {
 /**
  * Reads file bytes with window.api.fs.read, parses them in a Worker, and exposes a state machine.
  * Handles size limits, request ids for stale-response discards, and refreshKey reparsing. Each request owns a
- * dedicated worker that is terminated when the request is superseded or the component unmounts, so a slow parse
- * can't pin a shared worker (queuing the next file behind it) or leak its crash onto the next request.
+ * dedicated worker that is terminated as soon as it reaches a terminal state (response, crash, supersession, or
+ * unmount), so a slow parse can't pin a shared worker and an idle preview doesn't hold a parser isolate alive.
  */
 export function useXlsxWorkbook(filePath: string, refreshKey: number, sourceSize?: number): XlsxWorkbookState {
   const [state, setState] = useState<XlsxWorkbookState>({ status: 'idle' })
@@ -89,6 +89,9 @@ export function useXlsxWorkbook(filePath: string, refreshKey: number, sourceSize
 
       worker.onmessage = (event: MessageEvent<XlsxParseResponse>) => {
         if (cancelled || event.data.id !== requestIdRef.current) return
+        // The response is this worker's only job — free the isolate now instead of holding it until cleanup.
+        worker.terminate()
+        if (workerRef.current === worker) workerRef.current = null
         if (event.data.ok) {
           for (const warning of event.data.model.warnings) {
             if (loggedWarningsRef.current.has(warning)) continue
@@ -103,6 +106,8 @@ export function useXlsxWorkbook(filePath: string, refreshKey: number, sourceSize
       }
       worker.onerror = (event: ErrorEvent) => {
         if (cancelled || requestId !== requestIdRef.current) return
+        worker.terminate()
+        if (workerRef.current === worker) workerRef.current = null
         logger.error(
           'xlsx parser worker crashed',
           event.error instanceof Error ? event.error : new Error(event.message)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the xlsx preview's per-request parse worker was only terminated on effect cleanup (file switch, refresh, or unmount). All three terminal outcomes — successful parse, parse-error response, and worker crash (`onerror`) — merely updated hook state, so every open spreadsheet preview kept an idle worker isolate (with the full parser module loaded) alive until the user navigated away.

After this PR: the worker is terminated and `workerRef` is cleared (identity-safe) the moment it reaches a terminal state. Effect cleanup still covers in-flight parses. Three regression tests pin the contract: terminate after success (and no double-terminate on unmount), after a parse-error response, and after a crash — each fails on the old code with zero `terminate` calls.

Fixes: N/A

### Why we need it and why it was done in this way

Each request owns a dedicated worker whose protocol is one request → one response, so `onmessage`/`onerror` are the earliest points where the worker is provably done; releasing it there frees a few MB to tens of MB per open preview instead of holding the isolate until unmount.

The following tradeoffs were made: terminate runs after the existing `cancelled`/request-id guards, not before — a guard failure means the handler belongs to a superseded request whose worker was already terminated by cleanup, and keeping the guard first preserves the "stale responses are simply discarded" semantics the existing tests pin.

The following alternatives were considered: having the worker call `self.close()` after posting its response. Rejected because it cannot cover the crash path (a crashed worker never reaches `close()`), so the renderer-side `onerror` terminate is needed anyway; keeping all lifecycle ownership in the hook covers all three terminal states uniformly.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

`Worker.terminate()` is idempotent, and the identity-safe ref clear means effect cleanup skips workers already released by a terminal state, so no path double-terminates. The existing supersession and stale-id tests pass unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
