### PR TITLE
fix(obsidian-export): prevent duplicate export on double click

### DIFF
--- a/src/renderer/components/ObsidianExportDialog.tsx
+++ b/src/renderer/components/ObsidianExportDialog.tsx
@@ -192,6 +192,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
   const [fileTreeData, setFileTreeData] = useState<TreeSelectOption[]>([])
   const [selectedVault, setSelectedVault] = useState<string>('')
   const [loading, setLoading] = useState<boolean>(false)
+  const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [exportReasoning, setExportReasoning] = useState(false)
 
@@ -261,39 +262,44 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
       setError(i18n.t('chat.topics.export.obsidian_no_vault_selected'))
       return
     }
-    let markdown = ''
-    if (rawContent) {
-      markdown = rawContent
-    } else if (topic) {
-      markdown = await topicToMarkdown(topic, exportReasoning)
-    } else if (messages && messages.length > 0) {
-      markdown = await messagesToMarkdown(messages, exportReasoning)
-    } else if (message) {
-      markdown = exportReasoning ? await messageToMarkdownWithReasoning(message) : await messageToMarkdown(message)
-    } else {
-      markdown = ''
+    setSubmitting(true)
+    try {
+      let markdown = ''
+      if (rawContent) {
+        markdown = rawContent
+      } else if (topic) {
+        markdown = await topicToMarkdown(topic, exportReasoning)
+      } else if (messages && messages.length > 0) {
+        markdown = await messagesToMarkdown(messages, exportReasoning)
+      } else if (message) {
+        markdown = exportReasoning ? await messageToMarkdownWithReasoning(message) : await messageToMarkdown(message)
+      } else {
+        markdown = ''
+      }
+      let content = ''
+      if (state.processingMethod !== ObsidianProcessingMethod.NEW_OR_OVERWRITE) {
+        content = `\n---\n${markdown}`
+      } else {
+        content = `---\ntitle: ${state.title}\ncreated: ${state.createdAt}\nsource: ${state.source}\ntags: ${state.tags}\n---\n${markdown}`
+      }
+      if (content === '') {
+        toast.error(i18n.t('chat.topics.export.obsidian_export_failed'))
+        return
+      }
+      await navigator.clipboard.writeText(content)
+      const success = await exportMarkdownToObsidian({
+        ...state,
+        folder: state.folder,
+        vault: selectedVault
+      })
+      if (!success) {
+        return
+      }
+      setOpen(false)
+      resolve(true)
+    } finally {
+      setSubmitting(false)
     }
-    let content = ''
-    if (state.processingMethod !== ObsidianProcessingMethod.NEW_OR_OVERWRITE) {
-      content = `\n---\n${markdown}`
-    } else {
-      content = `---\ntitle: ${state.title}\ncreated: ${state.createdAt}\nsource: ${state.source}\ntags: ${state.tags}\n---\n${markdown}`
-    }
-    if (content === '') {
-      toast.error(i18n.t('chat.topics.export.obsidian_export_failed'))
-      return
-    }
-    await navigator.clipboard.writeText(content)
-    const success = await exportMarkdownToObsidian({
-      ...state,
-      folder: state.folder,
-      vault: selectedVault
-    })
-    if (!success) {
-      return
-    }
-    setOpen(false)
-    resolve(true)
   }
 
   const [openState, setOpen] = useState(open)
@@ -498,6 +504,7 @@ const PopupContainer: React.FC<PopupContainerProps> = ({
           </Button>
           <Button
             type="button"
+            loading={submitting}
             disabled={vaults.length === 0 || loading || !!error || !state.title.trim()}
             onClick={handleOk}>
             {i18n.t('chat.topics.export.obsidian_btn')}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Double-clicking the confirm button in the Obsidian export dialog runs `handleOk` twice. The shared export lock in `ExportService` cannot stop this: `exportMarkdownToObsidian` acquires and releases it synchronously in the same tick, while the real race window is the `await`s inside `handleOk` (markdown conversion, clipboard write). Both clicks reach `window.open`, so the `obsidian://new` protocol link opens twice and the same content is appended (or prepended) twice.

After this PR:

The confirm button switches to a loading state for the whole submit flow (`loading` prop of the UI `Button` primitive disables it and shows a spinner), so a second click never fires. The protocol link opens exactly once per submit. The button is restored in `finally`, so validation failures and failed exports leave the dialog usable.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- A new `submitting` state was added instead of reusing the existing `loading` state, which drives the vault/file fetch spinners and would swap form fields into a loading UI during export.
- The button-level `loading` state relies on React 18 flushing discrete-event updates synchronously before the next click is dispatched; a disabled DOM button cannot re-fire `onClick`, so no extra ref guard is needed.

The following alternatives were considered:

- Extending the shared `exportState` lock in `ExportService` to span the async work — rejected: the race lives in the dialog's `handleOk`, so the dialog is the right scope for the guard.
- A `useRef`-only synchronous guard — rejected: same protection but no user feedback while the export is in flight.

Links to places where the discussion took place:

### Breaking changes

None

### Special notes for your reviewer

The diff looks larger than it is: most changed lines are the existing `handleOk` body re-indented by the new `try/finally`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Obsidian export appending the same content twice when the export button is double-clicked.
```
