### PR TITLE
fix(pi-runtime): honor Cherry proxy environment

### DIFF
--- a/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
@@ -2,7 +2,7 @@ import type * as NodeFs from 'node:fs'
 
 import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AgentRuntimeConnectInput, AgentRuntimeEvent, AgentRuntimeUserInput } from '../types'
 
@@ -386,6 +386,10 @@ beforeEach(() => {
   })
 })
 
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('PiRuntimeConnection', () => {
   it('forces Cherry-owned pi dirs and creates a fresh session (no resume)', async () => {
     await new PiRuntimeConnection(input).start()
@@ -413,6 +417,29 @@ describe('PiRuntimeConnection', () => {
     expect(appendedSystemPrompt()).toContain('<agent_instructions>\nBe helpful.\n</agent_instructions>')
     expect(appendedSystemPrompt()).toContain(REPORT_ARTIFACTS_PROMPT)
     expect(appendedSystemPrompt()).toContain('IMPORTANT: You must respond in English.')
+  })
+
+  it('forwards the active Cherry proxy environment to Pi provider requests', async () => {
+    const injection = mocks.resolveInjection()
+    mocks.resolveInjection.mockReturnValue({
+      ...injection,
+      requestEnvironment: { AZURE_OPENAI_API_VERSION: '2025-04-01-preview' }
+    })
+
+    await new PiRuntimeConnection(input).start()
+    vi.stubEnv('HTTP_PROXY', 'http://127.0.0.1:7890')
+    vi.stubEnv('HTTPS_PROXY', 'http://127.0.0.1:7890')
+    vi.stubEnv('NO_PROXY', 'localhost,127.0.0.1')
+    const providerConfig = mocks.registerProvider.mock.calls[0][1]
+    providerConfig.streamSimple({}, [], { env: { REQUEST_SCOPED: 'preserved' } })
+
+    expect(mocks.providerStreamSimple.mock.calls[0][2].env).toMatchObject({
+      REQUEST_SCOPED: 'preserved',
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NO_PROXY: 'localhost,127.0.0.1',
+      AZURE_OPENAI_API_VERSION: '2025-04-01-preview'
+    })
   })
 
   it('uses a generation-scoped api namespace so same-session replacements cannot overwrite each other', async () => {

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.ts
@@ -28,6 +28,7 @@ import {
 } from '@main/ai/runtime/toolApproval/cherryBuiltinApproval'
 import { wrapSteerReminder } from '@main/ai/steerReminder'
 import { resolveKnowledgeBaseScope } from '@main/ai/utils/knowledgeScope'
+import { getProxyEnvironment } from '@main/services/proxy/proxyEnv'
 import { type Span, SpanKind, SpanStatusCode } from '@opentelemetry/api'
 import type { AgentSessionCompactionAnchorData, AgentSessionCompactionTrigger } from '@shared/ai/agentSessionCompaction'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
@@ -807,11 +808,13 @@ interface PiProviderSpanObserver {
 
 function withPiRequestEnvironment(
   streamSimple: NonNullable<ProviderConfig['streamSimple']>,
-  environment: Record<string, string> | undefined
+  providerEnvironment: Record<string, string> | undefined
 ): NonNullable<ProviderConfig['streamSimple']> {
-  if (!environment) return streamSimple
   return (model, context, options) =>
-    streamSimple(model, context, { ...options, env: { ...options?.env, ...environment } })
+    streamSimple(model, context, {
+      ...options,
+      env: { ...options?.env, ...getProxyEnvironment(process.env), ...providerEnvironment }
+    })
 }
 
 function finiteTokenCount(value: number | undefined): number {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Pi Agent provider requests only received provider-specific environment variables. Cherry Studio's active proxy environment was omitted, so endpoints that required the configured proxy could fail while the same endpoint worked through Claude Code.

After this PR:

Pi Agent provider requests merge the active Cherry Studio proxy environment with request-scoped and provider-specific variables. The proxy environment is resolved for each request so proxy changes also apply to existing Pi sessions without mutating `process.env`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18763, fixes #18587

### Why we need it and why it was done in this way

Cherry Studio already materializes its proxy settings into a bounded set of proxy environment variables, and the Pi provider API accepts an `env` map per request. Forwarding those variables at that boundary keeps the behavior aligned with the Claude Code runtime while remaining request-scoped.

The following tradeoffs were made:

- The small proxy key set is read on every provider request so a session does not retain stale proxy settings.
- Provider-specific variables take precedence over generic proxy variables if a key ever overlaps.

The following alternatives were considered:

- Mutating `process.env` globally was rejected because it would leak configuration across unrelated requests.
- Capturing proxy values only when a Pi session starts was rejected because later proxy changes would require rebuilding the session.

Links to places where the discussion took place: #18763, #18587

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Added a regression test proving that HTTP, HTTPS, and bypass proxy variables reach the Pi provider while request-scoped and Azure provider variables are preserved.
- `pnpm format`, lint, type checks, documentation link checks, all 12,029 main tests, the focused 63 Pi runtime tests, and 3,014 AI Core/UI/shared/provider-registry/scripts tests pass.
- All 9,313 renderer assertions pass, but the current renderer suite exits with an unrelated pre-existing unhandled rejection after `ExecutionStreamOverlayService.test.ts`: `Invalid state: Controller is already closed`. The same 19-test file reproduces the rejection in isolation and no renderer files are changed by this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Pi Agent requests now honor Cherry Studio's configured proxy environment.
```
