### PR TITLE
fix(image-export): unclip tables and wait for webfonts before capture

### DIFF
--- a/src/renderer/assets/styles/markdown.css
+++ b/src/renderer/assets/styles/markdown.css
@@ -460,6 +460,23 @@
   border-radius: 0;
 }
 
+/*
+ * Image export (utils/image.ts `captureScrollable`) rasterizes a DOM clone via
+ * html-to-image: computed box sizes are frozen and `overflow` keeps clipping in
+ * the static image, where the user can no longer scroll. Unclip table scroll
+ * viewports (and the table's own corner-clipping) while the capture root marker
+ * is set so wide tables render in full instead of being cut off. `!important`
+ * is required to override the table's inline `overflow: hidden`.
+ */
+[data-image-capturing] .table-scroll-viewport,
+[data-image-capturing] [data-streamdown='table-wrapper'] > div:last-child {
+  overflow: visible !important;
+}
+
+[data-image-capturing] .table-scroll-viewport > table {
+  overflow: visible !important;
+}
+
 .markdown img {
   display: block;
   max-width: 100%;

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -14,6 +14,7 @@ import {
   checkEntityImageSize,
   convertToBase64,
   getImageBlobFromSource,
+  IMAGE_CAPTURE_ATTRIBUTE,
   makeSvgSizeAdaptive,
   MAX_ENTITY_IMAGE_UPLOAD_BYTES,
   prepareEntityImageBytes,
@@ -280,6 +281,34 @@ describe('utils/image', () => {
       const result = await captureScrollable(ref)
 
       expect(result).toBe(finalCanvas)
+    })
+
+    it('marks the capture root during capture and removes the marker afterward', async () => {
+      const finalCanvas = { toDataURL: vi.fn(() => 'final') } as unknown as HTMLCanvasElement
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+
+      vi.mocked(htmlToImage.toCanvas).mockImplementation(async (node) => {
+        expect(node.hasAttribute(IMAGE_CAPTURE_ATTRIBUTE)).toBe(true)
+        return finalCanvas
+      })
+
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
+      await expect(captureScrollable(ref)).resolves.toBe(finalCanvas)
+      expect(div.hasAttribute(IMAGE_CAPTURE_ATTRIBUTE)).toBe(false)
+    })
+
+    it('removes the capture marker when capture fails', async () => {
+      vi.mocked(htmlToImage.toCanvas).mockRejectedValue(new Error('capture failed'))
+
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'scrollWidth', { value: 100, configurable: true })
+      Object.defineProperty(div, 'scrollHeight', { value: 100, configurable: true })
+      const ref = { current: div } as React.RefObject<HTMLDivElement>
+
+      await expect(captureScrollable(ref)).rejects.toThrow('capture failed')
+      expect(div.hasAttribute(IMAGE_CAPTURE_ATTRIBUTE)).toBe(false)
     })
 
     it('should exclude HTML artifacts from image capture', async () => {

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -9,6 +9,13 @@ import { Base64 } from 'js-base64'
 
 const logger = loggerService.withContext('Utils:image')
 const TRANSPARENT_IMAGE_PLACEHOLDER = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
+/**
+ * Marker applied to the capture root while html-to-image clones it. Capture-only
+ * CSS (see markdown.css) keys off this attribute, e.g. to unclip inner scroll
+ * containers such as table viewports that would otherwise cut off overflowing
+ * content in the rasterized image.
+ */
+export const IMAGE_CAPTURE_ATTRIBUTE = 'data-image-capturing'
 
 let htmlToImagePromise: Promise<typeof HtmlToImage> | undefined
 
@@ -175,6 +182,20 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
     let restoreLocalImageSources: (() => void) | undefined
 
     try {
+      // Mark the subtree before measuring: capture-only CSS keyed off this
+      // attribute (e.g. unclipped table viewports) can change the scroll size,
+      // and html-to-image freezes computed styles at clone time.
+      el.setAttribute(IMAGE_CAPTURE_ATTRIBUTE, '')
+
+      // Wait for webfonts before cloning. The clone pins every element's
+      // computed width/height, so text re-laid-out with fallback font metrics
+      // would overflow those frozen boxes and get clipped by overflow
+      // containers (table cells are the common victim).
+      await Promise.race([
+        document.fonts?.ready ?? Promise.resolve(),
+        new Promise((resolve) => setTimeout(resolve, 1000))
+      ])
+
       // calculate the size of the element
       const totalWidth = el.scrollWidth
       const totalHeight = el.scrollHeight
@@ -236,6 +257,7 @@ export const captureScrollable = async (elRef: React.RefObject<HTMLElement | nul
       logger.error('Error capturing scrollable element:', error as Error)
       throw error
     } finally {
+      el.removeAttribute(IMAGE_CAPTURE_ATTRIBUTE)
       restoreLocalImageSources?.()
     }
   }


### PR DESCRIPTION
### What this PR does

Fixes table truncation in "export topic/message as image":

- **Outer clipping** — wide tables were cut off at the `.table-scroll-viewport` boundary. Image export rasterizes a DOM clone via html-to-image (`<svg><foreignObject>`), where inner `overflow-x: auto` containers keep clipping at `scrollLeft = 0` and the user can no longer scroll to see the rest.
- **Inner clipping** — html-to-image freezes every element's computed width/height into the clone. If text is re-laid-out with fallback font metrics (webfonts not yet settled / not embeddable), content overflows its frozen row box and is hard-clipped by the table's own `overflow: hidden`.

### Changes

- `captureScrollable` now marks the capture root with a `data-image-capturing` attribute for the duration of the capture (removed in `finally`), and capture-only CSS in `markdown.css` sets `overflow: visible !important` on table scroll viewports (chat tables and streamdown's default wrapper) and on the table element itself, so overflowing content renders in full instead of being cut off.
- `captureScrollable` now awaits `document.fonts.ready` (1s budget, matching the existing iframe capture path) before measuring/cloning, so webfont metrics are settled before box sizes are frozen.

### Trade-off note

Unclipping the table's `overflow: hidden` means header-cell backgrounds are no longer rounded-corner-clipped during capture; correctness (no lost content) was preferred over pixel-perfect corners.

### Tests

- Added unit tests: capture marker is present on the root during capture, removed afterward, and removed on failure.
- `pnpm vitest run src/renderer/utils/__tests__/image.test.ts` — 41 passed.
- `tsgo --noEmit -p tsconfig.web.json`, oxlint, eslint, biome — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)