### PR TITLE
fix(data-migration): skip irrecoverable Dexie records

### DIFF
--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -10,6 +10,7 @@
  * at its last version, so no Dexie upgrade hooks need to run before export.
  */
 
+import { loggerService } from '@logger'
 import { type MigrationExportFileWriteMode, MigrationIpcChannels } from '@shared/data/migration/v2/types'
 import { clampSurrogateBoundary } from '@shared/utils/text'
 import { Dexie, type IndexableType } from 'dexie'
@@ -18,6 +19,7 @@ import { Dexie, type IndexableType } from 'dexie'
 const DEXIE_DB_NAME = 'CherryStudio'
 const DEXIE_EXPORT_PAGE_SIZE = 100
 const DEXIE_EXPORT_CHUNK_CHAR_LIMIT = 1024 * 1024
+const logger = loggerService.withContext('DexieExporter')
 
 // Required tables that must exist
 const REQUIRED_TABLES = [
@@ -29,6 +31,10 @@ const REQUIRED_TABLES = [
 
 // Optional tables that may not exist in older versions
 const OPTIONAL_TABLES = ['settings', 'translate_history', 'quick_phrases', 'translate_languages']
+
+function isIrrecoverableRecord(error: unknown): error is DOMException {
+  return error instanceof DOMException && error.name === 'NotReadableError'
+}
 
 class JsonExportWriter {
   private pending = ''
@@ -204,7 +210,16 @@ export class DexieExporter {
         const primaryKey = primaryKeys[index]
         // Keep only one complete record in the renderer heap. A page of topics
         // can contain enough embedded messages to exhaust it when bulk-loaded.
-        const record = await table.get(primaryKey)
+        let record: Record<string, unknown> | undefined
+        try {
+          record = await table.get(primaryKey)
+        } catch (error) {
+          if (isIrrecoverableRecord(error)) {
+            logger.warn('Skipping irrecoverable Dexie record', { tableName, primaryKey: String(primaryKey) })
+            continue
+          }
+          throw this.createRecordExportError(tableName, primaryKey, error)
+        }
 
         if (record === undefined) {
           throw this.createRecordExportError(tableName, primaryKey, new Error('Record missing from IndexedDB page'))

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -202,4 +202,28 @@ describe('DexieExporter', () => {
       'Failed to export Dexie table "message_blocks" at primary key "block-1"'
     )
   })
+
+  it('skips an irrecoverable IndexedDB record and exports the remaining records', async () => {
+    const rows = [{ id: 'block-1' }, { id: 'block-2' }, { id: 'block-3' }]
+    const table = createTableMock(rows)
+    table.get.mockRejectedValueOnce(
+      new DOMException(
+        'Data lost due to missing file. Affected record should be considered irrecoverable',
+        'NotReadableError'
+      )
+    )
+    dexieMock.table.mockReturnValue(table)
+
+    await new DexieExporter('/export').exportAll()
+
+    expect(JSON.parse(exportedText())).toEqual(rows.slice(1))
+  })
+
+  it('does not skip other IndexedDB read failures', async () => {
+    const table = createTableMock([{ id: 'block-1' }])
+    table.get.mockRejectedValueOnce(new DOMException('Temporary read failure', 'UnknownError'))
+    dexieMock.table.mockReturnValue(table)
+
+    await expect(new DexieExporter('/export').exportAll()).rejects.toThrow('Temporary read failure')
+  })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: A missing IndexedDB large-value backing file raised `NotReadableError` and aborted the entire v1-to-v2 migration export.

After this PR: The exporter skips only the record Chromium identifies as irrecoverable, logs its table and primary key, and continues exporting all readable records while preserving failure behavior for every other read error.

<img width="1800" height="1240" alt="wecom-temp-83440-8361370641c9532f9dadee9fc188519c" src="https://github.com/user-attachments/assets/661bc8df-93cb-4a1a-aefe-6f07e826c222" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: The already-unreadable record cannot be migrated, but allowing the remaining records through prevents one lost backing file from blocking all recoverable user data.

The following alternatives were considered: Retrying cannot restore a missing file, and matching Chromium's English error text would be less stable than checking the standard `NotReadableError` name.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Focused renderer tests cover both the irrecoverable-record recovery path and the requirement that unrelated IndexedDB errors still abort. `pnpm format`, `pnpm lint`, and `git diff --check` pass; full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed v1-to-v2 migration failing when an IndexedDB record has already lost its backing file.
```
