### PR TITLE
fix(ai-service): use lightweight probe for Ollama health check (#18705)

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -55,7 +55,7 @@ import { deleteImageInputEntries, imageGenerationJobHandler } from './provider/c
 import type { ImageGenerationJobOutput, ImageGenerationJobPayload } from './provider/custom/tasks/jobTypes'
 import { buildVendorProviderOptions } from './provider/custom/wire/buildImageRequest'
 import { DEFAULT_DIFFUSION_REGISTRATION, WIRE_REGISTRY } from './provider/custom/wire/wireProfile'
-import { listModels as listModelsFromProvider } from './provider/listModels'
+import { listModels as listModelsFromProvider, probeOllamaModel } from './provider/listModels'
 import type { AgentLoopHooks, NativeFileSupport, RequestFeature } from './runtime/aiSdk'
 import { Agent, buildAgentParams, buildFallbackModels, createRetryableWrap, readRetryPolicy } from './runtime/aiSdk'
 import { skillService } from './skills/SkillService'
@@ -72,7 +72,6 @@ import type {
 } from './types'
 import { installProviderUserAgentInterceptor } from './utils/customFetch'
 import { type SplitImageParams, splitParamValues } from './utils/imageOptions'
-import { defaultHeaders, getBaseUrl } from './utils/provider'
 import { createAiUsageCaptureContext } from './utils/usageCapture'
 
 const logger = loggerService.withContext('AiService')
@@ -1118,24 +1117,13 @@ export class AiService extends BaseService {
     const start = performance.now()
     const timeout = request.timeout ?? 15000
 
-    // Ollama: lightweight /api/tags probe — avoids loading the model into memory.
     if (isOllamaProvider(provider)) {
-      const baseUrl = getBaseUrl(provider)
-      if (baseUrl) {
-        const controller = new AbortController()
-        const timeoutHandle = setTimeout(() => controller.abort(), timeout)
-        try {
-          const response = await fetch(`${baseUrl}/tags`, {
-            signal: controller.signal,
-            headers: defaultHeaders(provider)
-          })
-          if (!response.ok) {
-            throw new Error(`Ollama server returned ${response.status}`)
-          }
-          return { latency: performance.now() - start }
-        } finally {
-          clearTimeout(timeoutHandle)
-        }
+      const controller = new AbortController()
+      const timeoutHandle = setTimeout(() => controller.abort(), timeout)
+      try {
+        return await probeOllamaModel(provider, model.apiModelId, controller.signal)
+      } finally {
+        clearTimeout(timeoutHandle)
       }
     }
 

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -1121,7 +1121,7 @@ export class AiService extends BaseService {
       const controller = new AbortController()
       const timeoutHandle = setTimeout(() => controller.abort(), timeout)
       try {
-        return await probeOllamaModel(provider, model.apiModelId, controller.signal)
+        return await probeOllamaModel(provider, model.apiModelId, controller.signal, request.apiKeyOverride)
       } finally {
         clearTimeout(timeoutHandle)
       }

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -35,6 +35,7 @@ import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import type { Base64String, CreateInternalEntryIpcParams, UrlString } from '@shared/types/file'
 import { isEmbeddingModel, isFunctionCallingModel, isRerankModel } from '@shared/utils/model'
+import { isOllamaProvider } from '@shared/utils/provider'
 import {
   type EmbeddingModelUsage,
   isToolUIPart,
@@ -71,6 +72,7 @@ import type {
 } from './types'
 import { installProviderUserAgentInterceptor } from './utils/customFetch'
 import { type SplitImageParams, splitParamValues } from './utils/imageOptions'
+import { defaultHeaders, getBaseUrl } from './utils/provider'
 import { createAiUsageCaptureContext } from './utils/usageCapture'
 
 const logger = loggerService.withContext('AiService')
@@ -1112,9 +1114,31 @@ export class AiService extends BaseService {
 
   /** Dispatches rerank first, then prefers text for chat-primary models over embedding. */
   async checkModel(request: AiBaseRequest & { timeout?: number }): Promise<{ latency: number }> {
-    const { model } = this.getProviderAndModel(request)
+    const { provider, model } = this.getProviderAndModel(request)
     const start = performance.now()
     const timeout = request.timeout ?? 15000
+
+    // Ollama: lightweight /api/tags probe — avoids loading the model into memory.
+    if (isOllamaProvider(provider)) {
+      const baseUrl = getBaseUrl(provider)
+      if (baseUrl) {
+        const controller = new AbortController()
+        const timeoutHandle = setTimeout(() => controller.abort(), timeout)
+        try {
+          const response = await fetch(`${baseUrl}/tags`, {
+            signal: controller.signal,
+            headers: defaultHeaders(provider)
+          })
+          if (!response.ok) {
+            throw new Error(`Ollama server returned ${response.status}`)
+          }
+          return { latency: performance.now() - start }
+        } finally {
+          clearTimeout(timeoutHandle)
+        }
+      }
+    }
+
     const primaryEndpoint = model.endpointTypes?.[0]
     const hasChatPrimaryEndpoint = primaryEndpoint != null && endpointImpliedCapability(primaryEndpoint) === undefined
 

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1577,6 +1577,52 @@ describe('AiService tool approval', () => {
       })
     ).rejects.toThrow('Rerank health check returned empty ranking')
   })
+
+  it('uses lightweight /api/tags probe for Ollama providers', async () => {
+    const service = createService()
+    const generateSpy = vi.spyOn(service, 'generateText')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+
+    mockProviderGetByProviderId.mockReturnValue({
+      id: 'ollama',
+      presetProviderId: 'ollama',
+      name: 'Ollama',
+      apiKeys: [],
+      authType: 'api-key',
+      apiFeatures: {
+        arrayContent: true,
+        streamOptions: true,
+        developerRole: false,
+        serviceTier: false,
+        verbosity: false
+      },
+      settings: {},
+      isEnabled: true,
+      endpointConfigs: {
+        'ollama-chat': { baseUrl: 'http://127.0.0.1:11434/api' }
+      },
+      defaultChatEndpoint: 'ollama-chat'
+    })
+    mockModelGetByKey.mockReturnValue({
+      id: 'ollama::llama3',
+      providerId: 'ollama',
+      apiModelId: 'llama3',
+      name: 'Llama 3',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    const result = await service.checkModel({ uniqueModelId: 'ollama::llama3' })
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:11434/api/tags',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    expect(generateSpy).not.toHaveBeenCalled()
+    expect(result.latency).toBeGreaterThanOrEqual(0)
+  })
 })
 
 describe('imageInputEntryParams', () => {

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -102,7 +102,7 @@ vi.mock('@data/services/ProviderRegistryService', () => ({
 }))
 
 vi.mock('../provider/listModels', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../provider/listModels')>()
+  const actual = await importOriginal<typeof ListModelsModule>()
   return {
     ...actual,
     listModels: (...args: unknown[]) => mockListModelsFromProvider(...args)

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -19,6 +19,7 @@ const mockMessageUpdate = vi.fn()
 const mockMessageApplyApproval = vi.fn()
 const mockProviderGetByProviderId = vi.fn()
 const mockProviderGetRotatedApiKey = vi.fn()
+const mockProviderResolveApiKey = vi.fn()
 const mockModelGetByKey = vi.fn()
 const mockCreateRetryableWrap = vi.fn((options?: unknown): ((model: unknown) => unknown) | undefined => {
   void options
@@ -84,7 +85,8 @@ vi.mock('../utils/customFetch', () => ({
 vi.mock('@main/data/services/ProviderService', () => ({
   providerService: {
     getByProviderId: (...args: unknown[]) => mockProviderGetByProviderId(...args),
-    getRotatedApiKey: (...args: unknown[]) => mockProviderGetRotatedApiKey(...args)
+    getRotatedApiKey: (...args: unknown[]) => mockProviderGetRotatedApiKey(...args),
+    resolveApiKey: (...args: unknown[]) => mockProviderResolveApiKey(...args)
   }
 }))
 
@@ -220,6 +222,10 @@ describe('AiService', () => {
     })
     mockCreateAgent.mockResolvedValue({ generate: mockAgentGenerate })
     mockProviderGetRotatedApiKey.mockReturnValue('test-key')
+    mockProviderResolveApiKey.mockImplementation((_id: string, override?: string) => ({
+      value: override ?? 'test-key',
+      apiKeySelection: { attribution: override ? ('matched' as const) : ('unknown' as const) }
+    }))
     mockProviderGetByProviderId.mockReturnValue({
       id: 'test-provider',
       name: 'Test Provider',
@@ -1630,6 +1636,97 @@ describe('AiService tool approval', () => {
     )
     expect(generateSpy).not.toHaveBeenCalled()
     expect(result.latency).toBeGreaterThanOrEqual(0)
+  })
+
+  it('passes apiKeyOverride into the Ollama probe', async () => {
+    const service = createService()
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
+
+    mockProviderGetByProviderId.mockReturnValue({
+      id: 'ollama',
+      presetProviderId: 'ollama',
+      name: 'Ollama',
+      apiKeys: [],
+      authType: 'api-key',
+      apiFeatures: {
+        arrayContent: true,
+        streamOptions: true,
+        developerRole: false,
+        serviceTier: false,
+        verbosity: false
+      },
+      settings: {},
+      isEnabled: true,
+      endpointConfigs: {
+        'ollama-chat': { baseUrl: 'http://localhost:11434' }
+      },
+      defaultChatEndpoint: 'ollama-chat'
+    })
+    mockModelGetByKey.mockReturnValue({
+      id: 'ollama::llama3',
+      providerId: 'ollama',
+      apiModelId: 'llama3',
+      name: 'Llama 3',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    await service.checkModel({
+      uniqueModelId: 'ollama::llama3',
+      apiKeyOverride: 'sk-selected'
+    })
+
+    expect(mockProviderResolveApiKey).toHaveBeenCalledWith('ollama', 'sk-selected')
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/show'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Api-Key': 'sk-selected'
+        })
+      })
+    )
+  })
+
+  it('surfaces Ollama string error from /api/show', async () => {
+    const service = createService()
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'model "nope" not found' }), { status: 404 })
+    )
+
+    mockProviderGetByProviderId.mockReturnValue({
+      id: 'ollama',
+      presetProviderId: 'ollama',
+      name: 'Ollama',
+      apiKeys: [],
+      authType: 'api-key',
+      apiFeatures: {
+        arrayContent: true,
+        streamOptions: true,
+        developerRole: false,
+        serviceTier: false,
+        verbosity: false
+      },
+      settings: {},
+      isEnabled: true,
+      endpointConfigs: {
+        'ollama-chat': { baseUrl: 'http://localhost:11434' }
+      },
+      defaultChatEndpoint: 'ollama-chat'
+    })
+    mockModelGetByKey.mockReturnValue({
+      id: 'ollama::nope',
+      providerId: 'ollama',
+      apiModelId: 'nope',
+      name: 'Nope',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    await expect(service.checkModel({ uniqueModelId: 'ollama::nope' })).rejects.toThrow('model "nope" not found')
   })
 })
 

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -101,9 +101,13 @@ vi.mock('@data/services/ProviderRegistryService', () => ({
   }
 }))
 
-vi.mock('../provider/listModels', () => ({
-  listModels: (...args: unknown[]) => mockListModelsFromProvider(...args)
-}))
+vi.mock('../provider/listModels', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../provider/listModels')>()
+  return {
+    ...actual,
+    listModels: (...args: unknown[]) => mockListModelsFromProvider(...args)
+  }
+})
 vi.mock('@main/utils/downloadAsBase64', () => ({
   downloadImageAsBase64: (...args: unknown[]) => mockDownloadImageAsBase64(...args)
 }))
@@ -1578,7 +1582,7 @@ describe('AiService tool approval', () => {
     ).rejects.toThrow('Rerank health check returned empty ranking')
   })
 
-  it('uses lightweight /api/tags probe for Ollama providers', async () => {
+  it('uses lightweight /api/show probe for Ollama providers', async () => {
     const service = createService()
     const generateSpy = vi.spyOn(service, 'generateText')
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }))
@@ -1599,7 +1603,7 @@ describe('AiService tool approval', () => {
       settings: {},
       isEnabled: true,
       endpointConfigs: {
-        'ollama-chat': { baseUrl: 'http://127.0.0.1:11434/api' }
+        'ollama-chat': { baseUrl: 'http://localhost:11434' }
       },
       defaultChatEndpoint: 'ollama-chat'
     })
@@ -1617,8 +1621,12 @@ describe('AiService tool approval', () => {
     const result = await service.checkModel({ uniqueModelId: 'ollama::llama3' })
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      'http://127.0.0.1:11434/api/tags',
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
+      'http://localhost:11434/api/show',
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+        body: JSON.stringify({ model: 'llama3' })
+      })
     )
     expect(generateSpy).not.toHaveBeenCalled()
     expect(result.latency).toBeGreaterThanOrEqual(0)

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -23,7 +23,7 @@ import {
   MODEL_CAPABILITY
 } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { formatApiHost, withoutTrailingApiVersion, withoutTrailingSlash } from '@shared/utils/api'
+import { formatApiHost, formatOllamaApiHost, withoutTrailingApiVersion, withoutTrailingSlash } from '@shared/utils/api'
 import { deriveModelGroupName } from '@shared/utils/model'
 import {
   isAIGatewayProvider,
@@ -35,7 +35,7 @@ import {
 import { SystemProviderIds } from '@shared/utils/systemProviderId'
 import * as z from 'zod'
 
-import { defaultHeaders, getBaseUrl } from '../utils/provider'
+import { defaultHeaders, getBaseUrl, getExtraHeaders } from '../utils/provider'
 import { COPILOT_DEFAULT_HEADERS } from './constants'
 import {
   createVertexModelListRequest,
@@ -742,21 +742,30 @@ const openAICompatibleFetcher: ModelFetcher = {
 export async function probeOllamaModel(
   provider: Provider,
   modelApiId: string | undefined,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  apiKeyOverride?: string
 ): Promise<{ latency: number }> {
   const start = performance.now()
-  const baseUrl = withoutTrailingSlash(getBaseUrl(provider))
-    .replace(/\/v1$/, '')
-    .replace(/\/api$/, '')
-  const response = await fetch(`${baseUrl}/api/show`, {
+  const baseUrl = formatOllamaApiHost(getBaseUrl(provider))
+  const resolved = providerService.resolveApiKey(provider.id, apiKeyOverride)
+  const headers: Record<string, string> = {
+    ...defaultAppHeaders(),
+    ...getExtraHeaders(provider),
+    'Content-Type': 'application/json'
+  }
+  if (resolved.value) {
+    headers.Authorization = `Bearer ${resolved.value}`
+    headers['X-Api-Key'] = resolved.value
+  }
+  const response = await fetch(`${baseUrl}/show`, {
     method: 'POST',
-    headers: { ...defaultHeaders(provider), 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify({ model: modelApiId ?? '' }),
     signal
   })
   if (!response.ok) {
-    const body = (await response.json().catch(() => undefined)) as ApiError | undefined
-    throw new Error(body?.error?.message ?? body?.message ?? `Ollama /api/show returned ${response.status}`)
+    const body = (await response.json().catch(() => undefined)) as { error?: string; message?: string } | undefined
+    throw new Error(body?.error ?? body?.message ?? `Ollama /api/show returned ${response.status}`)
   }
   return { latency: performance.now() - start }
 }

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -736,6 +736,31 @@ const openAICompatibleFetcher: ModelFetcher = {
   }
 }
 
+// ── Ollama probe ──
+
+/** Lightweight model-existence check for Ollama — avoids loading the model into memory. */
+export async function probeOllamaModel(
+  provider: Provider,
+  modelApiId: string | undefined,
+  signal?: AbortSignal
+): Promise<{ latency: number }> {
+  const start = performance.now()
+  const baseUrl = withoutTrailingSlash(getBaseUrl(provider))
+    .replace(/\/v1$/, '')
+    .replace(/\/api$/, '')
+  const response = await fetch(`${baseUrl}/api/show`, {
+    method: 'POST',
+    headers: { ...defaultHeaders(provider), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: modelApiId ?? '' }),
+    signal
+  })
+  if (!response.ok) {
+    const body = (await response.json().catch(() => undefined)) as ApiError | undefined
+    throw new Error(body?.error?.message ?? body?.message ?? `Ollama /api/show returned ${response.status}`)
+  }
+  return { latency: performance.now() - start }
+}
+
 // ── Registry (order matters: first match wins) ──
 
 const fetchers: ModelFetcher[] = [


### PR DESCRIPTION
### What this PR does

Before this PR:
The Ollama health check (⚡️ button) uses `AiService.checkModel()` which calls `generateText()` — the full AI SDK agent pipeline including tool resolution, parameter building, and a chat completion request. For large Ollama models (e.g., `qwen3.6:27b`), this triggers model loading + inference, causing the UI to freeze for ~30 seconds.

After this PR:
Ollama providers use a lightweight `POST /api/show` HTTP request for the health check instead of the full `generateText` pipeline. This validates that the selected model exists on the Ollama server without loading it into memory, completing in <1 second.

Fixes #18705

### Why we need it and why it was done in this way

The following tradeoffs were made:
- The `/api/show` probe validates the specific model exists rather than only checking server reachability — this matches user expectations for a per-model health check while remaining lightweight (reads manifest metadata, no weight loading).
- The existing `generateText` path is preserved as a fallback for providers that don't match `isOllamaProvider()`.

The following alternatives were considered:
- Reducing the `generateText` timeout: rejected — the underlying issue is unnecessary model loading, not timeout tuning.
- Adding a configurable health-check endpoint per provider: rejected — over-engineered for this specific case.
- Using `GET /api/tags`: rejected — only verifies server reachability, not model existence.

### Breaking changes

None.

### Special notes for your reviewer

- Reuses existing `isOllamaProvider()`, `formatOllamaApiHost()`, and `providerService.resolveApiKey()` utilities.
- The Ollama branch early-returns before the existing rerank/embedding/chat probe logic.
- Tests cover apiKeyOverride passthrough, Ollama error response handling, and model existence verification.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikiquote.org/wiki/KISS-principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed Ollama health check causing UI to freeze for ~30 seconds by using a lightweight `POST /api/show` probe to validate model existence instead of the full text generation pipeline.
```
