### PR TITLE
docs(mobile-migration): staged monorepo migration runbook

### DIFF
--- a/mobile-migration-temp/README.md
+++ b/mobile-migration-temp/README.md
@@ -20,7 +20,7 @@ preserve the following invariants:
 | I2 | Desktop import specifiers never change en masse | Strangler-fig re-export shims at original module paths; measured blast radius: 1,989 desktop files import `@shared/*` — all remain valid |
 | I3 | Package name collisions are resolved on the mobile side only | Desktop retains canonical names (`@cherrystudio/ai-core`, …); mobile adopts prefixed names, then converges back when unified |
 | I4 | Every stage lands on `main` as a conventional PR passing the full desktop gate | No long-lived migration branch; merge gate = `pnpm build:check && pnpm test && pnpm test:lint` |
-| M5 | The whole landing is atomically revertible | Stage 1 is one subtree merge commit (`git revert -m 1`) plus one wiring commit |
+| I5 | The whole landing is atomically revertible | Stage 1 is one subtree-landing merge PR (`git revert -m 1`) plus one wiring PR |
 | I6 | Desktop root relocation (`src/` → `apps/desktop/`) is explicitly deferred | Trigger-based (Stage 6), not scheduled; symmetry is an aesthetic property, not a functional dependency |
 
 ## Target Topology
@@ -61,11 +61,16 @@ cherry-studio/
 ## Stage Graph
 
 ```
-stage-0 (hygiene, guards) ──┐
-stage-1 (landing) ──────────┼──► stage-2 (design-tokens/icons, ai-sdk-provider, ai-core)
-                            │        ├──► stage-3 (provider-registry, src/shared strangler extraction)
-                            │        └──► stage-4 (lifecycle-kernel, db-schema) ──► stage-5 (4 parallel tracks)
-                            └──────────────────────────────────────────────────► stage-6 (trigger-based)
+stage-0 (hygiene, guards) ──► stage-1 (landing)
+                                  ├──► stage-2 (design-tokens/icons, ai-sdk-provider, ai-core)
+                                  ├──► stage-3 (provider-registry, src/shared extraction)
+                                  ├──► stage-4 (lifecycle-kernel, db-schema)
+                                  └──► stage-5 Track B (service decomposition)
+
+stage-2b/2c (+ stage-4a for Wave 2) ──► stage-5 Track A
+stage-4a/4b ──► stage-5 Track C
+stage-2a ──► stage-5 Track D
+all migration tracks ──► stage-6 (trigger-based)
 ```
 
 | Document | Scope | Independently pausable |
@@ -78,7 +83,7 @@ stage-1 (landing) ──────────┼──► stage-2 (design-tok
 | [stage-5-track-a-ai-runtime.md](stage-5-track-a-ai-runtime.md) | AI runtime unification, 3 waves over 215 semantically-ported files | Yes, per wave |
 | [stage-5-track-b-services.md](stage-5-track-b-services.md) | `src/main/services` decomposition via ports-and-adapters | Yes, per service |
 | [stage-5-track-c-data-services.md](stage-5-track-c-data-services.md) | 30 same-name data services: business-rule layer extraction | Yes, per service |
-| [stage-5-track-d-ui.md](stage-5-track-d-ui.md) | Universal UI package with platform-forked implementations | Yes, per component |
+| [stage-5-track-d-ui.md](stage-5-track-d-ui.md) | Cross-platform UI primitives with platform-forked implementations | Yes, per component |
 | [stage-6-finish.md](stage-6-finish.md) | Desktop relocation, exit criteria, decommissioning ledger | Trigger-based |
 
 **Stability invariant between stages:** at any pause point, the repository satisfies
@@ -101,14 +106,3 @@ execution time. Key aggregate measurements:
 | `src/main/data/services` ↔ `backend/data/services` | n/a | 30 of 33 services re-implemented under identical class names |
 | `src/main/core/lifecycle` ↔ `backend/core/lifecycle` | near-total textual rewrite, ~90% API-congruent | **Not covered by any sync-manifest domain** (untracked drift) |
 | `src/main/ai` ↔ `ai-runtime` + `backend/ai` | 608-entry file-level map | 215 `semantic-port` / 317 `blocked` / 76 `explicit-exclusion` |
-
-## Current Workspace State (read before executing Stage 1)
-
-This worktree (`bogota-v1`) carries residue from a landing feasibility spike:
-
-- Commit `9ac573a245` — a subtree merge of mobile v0.2 (mechanism validated: 1,978 commits
-  preserved, merge parents verifiable).
-- 281 uncommitted working-tree modifications (package rename rehearsal inside `apps/mobile/`).
-- 138 mobile `v0.x`/`v1.x` tags erroneously fetched into the local tag namespace.
-
-Stage 1 §1a prescribes the exact cleanup sequence before the production landing.

--- a/mobile-migration-temp/README.md
+++ b/mobile-migration-temp/README.md
@@ -1,0 +1,114 @@
+# Mobile → Monorepo Incremental Migration Playbook
+
+Absorb the `cherry-studio-app` repository (mobile client, ref `origin/v0.2`, 1,978 commits) into this
+repository as a fully co-located application, then incrementally eliminate the duplicated business
+logic currently tracked by `desktop-sync-manifest.json` (13 sync domains: 7 `unbaselined`,
+1 `blocked`, 5 `aligned`-but-manually-synchronized).
+
+This directory is the execution runbook. Every document is file-precise and independently
+executable. The directory is deleted when the exit criteria in
+[stage-6-finish.md](stage-6-finish.md) are met.
+
+## Prime Directive: Zero Disruption to Desktop Development
+
+The desktop repository has ~110 active worktrees/branches at time of writing. Every stage MUST
+preserve the following invariants:
+
+| # | Invariant | Mechanism |
+|---|---|---|
+| I1 | Desktop source tree (`src/`) is not relocated or renamed before Stage 6 | Asymmetric layout: mobile lands under `apps/mobile/`; desktop remains at repository root |
+| I2 | Desktop import specifiers never change en masse | Strangler-fig re-export shims at original module paths; measured blast radius: 1,989 desktop files import `@shared/*` — all remain valid |
+| I3 | Package name collisions are resolved on the mobile side only | Desktop retains canonical names (`@cherrystudio/ai-core`, …); mobile adopts prefixed names, then converges back when unified |
+| I4 | Every stage lands on `main` as a conventional PR passing the full desktop gate | No long-lived migration branch; merge gate = `pnpm build:check && pnpm test && pnpm test:lint` |
+| M5 | The whole landing is atomically revertible | Stage 1 is one subtree merge commit (`git revert -m 1`) plus one wiring commit |
+| I6 | Desktop root relocation (`src/` → `apps/desktop/`) is explicitly deferred | Trigger-based (Stage 6), not scheduled; symmetry is an aesthetic property, not a functional dependency |
+
+## Target Topology
+
+```
+cherry-studio/
+├── apps/
+│   └── mobile/                  # Entire mobile application (Expo/React Native)
+│       ├── src/                 # {app, backend, bootstrap, frontend, shared}
+│       ├── packages/            # Mobile-only workspace packages (ui-native, ui-nitro, mobile-*)
+│       ├── modules/             # Expo native modules (pdf-text-extractor)
+│       ├── migrations/          # Mobile SQLite migration chain (disjoint from desktop's; never merged)
+│       ├── metro.config.js, app.json, eas.json, babel.config.js
+│       └── package.json         # Expo application manifest
+├── packages/                    # Shared tier + legacy desktop-only packages (transitional co-location)
+├── src/, migrations/, electron.vite.config.ts, …   # Desktop, untouched until Stage 6
+├── pnpm-workspace.yaml          # Single workspace definition
+└── pnpm-lock.yaml               # Single lockfile
+```
+
+### Directory Position Encodes Sharing Tier (lint-enforced, see Stage 0)
+
+| Location | Semantics | Banned imports |
+|---|---|---|
+| `packages/*` (shared-tier members) | Consumed by both applications; platform-pure | `electron`, `expo-*`, `react-native*`, `node:*`, bare Node builtins |
+| `apps/mobile/packages/*` | Mobile-only | `electron`, `node:*` |
+| Desktop-only packages (transitional, co-located in `packages/`) | Desktop-only | `expo-*`, `react-native*` |
+
+### Package Naming Policy
+
+- Package names describe **content domain** (`url-safety`, `data-contract`, `lifecycle-kernel`),
+  never the consumer set. Banned name tokens: `universal`, `shared`, `common`, `core`, `utils`.
+- A `mobile-` name prefix is a **unification debt marker**, removed when the corresponding
+  package pair is reconciled. Progress metric:
+  `grep -r "@cherrystudio/mobile-" --include='*.ts*' apps/ | wc -l` → must reach 0.
+- `ui-native` is a **permanent** name (genuine platform fork; see stage-5-track-d), not debt.
+
+## Stage Graph
+
+```
+stage-0 (hygiene, guards) ──┐
+stage-1 (landing) ──────────┼──► stage-2 (design-tokens/icons, ai-sdk-provider, ai-core)
+                            │        ├──► stage-3 (provider-registry, src/shared strangler extraction)
+                            │        └──► stage-4 (lifecycle-kernel, db-schema) ──► stage-5 (4 parallel tracks)
+                            └──────────────────────────────────────────────────► stage-6 (trigger-based)
+```
+
+| Document | Scope | Independently pausable |
+|---|---|---|
+| [stage-0-hygiene.md](stage-0-hygiene.md) | Pre-existing violations, purity lint guards, shared-package conventions | Yes |
+| [stage-1-landing.md](stage-1-landing.md) | Subtree merge, workspace wiring, patch reconciliation, CI split, dual green gates | Yes (atomically revertible) |
+| [stage-2-quick-unify.md](stage-2-quick-unify.md) | design-tokens promotion, icon single-sourcing, `ai-sdk-provider` (14-line drift), `ai-core` (321-line drift) | Yes, per package |
+| [stage-3-shared-extraction.md](stage-3-shared-extraction.md) | `provider-registry` reconciliation (11,107-line drift), `src/shared` domain-by-domain extraction | Yes, per domain |
+| [stage-4-enablers.md](stage-4-enablers.md) | `lifecycle-kernel` extraction, shared DB schema definitions | Yes |
+| [stage-5-track-a-ai-runtime.md](stage-5-track-a-ai-runtime.md) | AI runtime unification, 3 waves over 215 semantically-ported files | Yes, per wave |
+| [stage-5-track-b-services.md](stage-5-track-b-services.md) | `src/main/services` decomposition via ports-and-adapters | Yes, per service |
+| [stage-5-track-c-data-services.md](stage-5-track-c-data-services.md) | 30 same-name data services: business-rule layer extraction | Yes, per service |
+| [stage-5-track-d-ui.md](stage-5-track-d-ui.md) | Universal UI package with platform-forked implementations | Yes, per component |
+| [stage-6-finish.md](stage-6-finish.md) | Desktop relocation, exit criteria, decommissioning ledger | Trigger-based |
+
+**Stability invariant between stages:** at any pause point, the repository satisfies
+*desktop unimpaired + mobile buildable + no regression of already-unified surfaces*.
+
+## Measurement Provenance
+
+All quantitative claims (diff line counts, coupling histograms, file inventories) were measured on
+2026-08-18 against desktop `9754c9267e` (branch base of `mono-repo-full-migration`) × mobile
+`3707410b` (`origin/v0.2` HEAD). Items marked ⟳ are staleness-sensitive and MUST be re-measured at
+execution time. Key aggregate measurements:
+
+| Domain pair | Divergence (lines) | Notes |
+|---|---|---|
+| `packages/ai-sdk-provider` (both) | 14 | 1 of 4 files differs; same published version `0.1.6` on both sides |
+| `packages/aiCore` ↔ `packages/ai-core` | 321 | 13 of 75 files differ; same published version `2.0.1` |
+| `packages/provider-registry` (both) | 11,107 | 161 of 167 files differ under identical version `0.0.1-alpha.1` |
+| `src/shared/ai` ↔ `universal/src/ai` | 2,721 | 22 common-modified, 20 desktop-only, 5 mobile-only |
+| `src/shared/data` ↔ `universal/src/data` | 13,867 | 80 common-modified, 43 desktop-only, 13 mobile-only (bidirectional fork) |
+| `src/main/data/services` ↔ `backend/data/services` | n/a | 30 of 33 services re-implemented under identical class names |
+| `src/main/core/lifecycle` ↔ `backend/core/lifecycle` | near-total textual rewrite, ~90% API-congruent | **Not covered by any sync-manifest domain** (untracked drift) |
+| `src/main/ai` ↔ `ai-runtime` + `backend/ai` | 608-entry file-level map | 215 `semantic-port` / 317 `blocked` / 76 `explicit-exclusion` |
+
+## Current Workspace State (read before executing Stage 1)
+
+This worktree (`bogota-v1`) carries residue from a landing feasibility spike:
+
+- Commit `9ac573a245` — a subtree merge of mobile v0.2 (mechanism validated: 1,978 commits
+  preserved, merge parents verifiable).
+- 281 uncommitted working-tree modifications (package rename rehearsal inside `apps/mobile/`).
+- 138 mobile `v0.x`/`v1.x` tags erroneously fetched into the local tag namespace.
+
+Stage 1 §1a prescribes the exact cleanup sequence before the production landing.

--- a/mobile-migration-temp/stage-0-hygiene.md
+++ b/mobile-migration-temp/stage-0-hygiene.md
@@ -28,26 +28,24 @@ makes them invisible to `pnpm --filter`, changesets, and dependency auditing.
    guard allowlist (0d).
 3. Bundler aliases remain untouched — desktop consumption is unchanged; desktop diff is zero.
 
-## 0b. `packages/provider-catalog`: orphaned directory
+## 0b. `packages/provider-catalog`: developer-local notice (no repository change)
 
-**Current state.** The directory contains a single gitignored `.env` (≈40 provider API-key
-placeholders), no manifest, no sources.
+**Current state.** The path is absent from git. Some developer worktrees contain only a gitignored
+`.env` (≈40 provider API-key placeholders), with no manifest or sources.
 
-**Procedure.**
-1. Locate the consumer:
-   `grep -rn "provider-catalog" scripts/ packages/ src/ --include='*.ts' --include='*.json'`.
-2. If a consumer exists, relocate the `.env` convention to the consumer's own directory and update
-   its dotenv path. If none exists, delete the directory and notify developers to retain local
-   `.env` copies out-of-tree.
+There is nothing for a Stage 0 PR to remove. Do not automate deletion of this path because the
+ignored file may contain developer-owned secrets. Developers may inspect their own worktree and
+relocate or remove their local copy after confirming it has no consumer.
 
 ## 0c. `packages/ui`: undeclared dependencies + defective export condition
 
 **Current state.** `@cherrystudio/ui@1.0.0-alpha.1` is a **published** package whose sources import
 12 packages not declared in its manifest (they currently resolve only via pnpm root hoisting; an
 external consumer gets `ERR_MODULE_NOT_FOUND` while CI stays green). Additionally, its
-`exports["."]` map contains `"react-native": "./dist/index.js"` — a tsup scaffold artifact pointing
-the React Native resolution condition at the **web CJS build**; if Metro ever resolved this package
-it would bundle `react-dom` code paths into a native bundle.
+conditional export map repeats `"react-native": "./dist/…/index.js"` at the root and every JS
+subpath (`.`, `./components`, `./hooks`, `./utils`, `./icons`, `./icons/providers`) — tsup scaffold
+artifacts pointing the React Native condition at **web CJS builds**. If Metro ever resolved one of
+these entries it would bundle DOM code paths into a native bundle.
 
 **Procedure.**
 1. Add to `packages/ui/package.json` `dependencies` (versions pinned to the root lockfile's
@@ -57,9 +55,11 @@ it would bundle `react-dom` code paths into a native bundle.
    `@radix-ui/react-switch`.
 2. Add to `devDependencies`: `@testing-library/react`, `@testing-library/user-event`,
    `@types/hast` (the `hast` import is type-only).
-3. Delete the `"react-native"` key from `exports["."]`.
-4. Audit `packages/aiCore/package.json` and `packages/ai-sdk-provider/package.json` for the same
-   scaffold artifact; delete if present and equally unbacked by a native build.
+3. Delete the `"react-native"` condition from every entry in the `exports` map; checking only the
+   root entry leaves subpath imports broken under Metro.
+4. Audit every export entry in `packages/aiCore/package.json` and
+   `packages/ai-sdk-provider/package.json` for the same scaffold artifact; delete any condition
+   equally unbacked by a native build.
 
 ## 0d. Import-purity lint guard
 
@@ -129,6 +129,6 @@ cd packages/ui && pnpm build        # proves the package builds against its own 
 
 | PR | Scope | Conventional commit |
 |---|---|---|
-| 1 | 0a + 0b | `chore(packages): add mcp-trace manifests, remove provider-catalog stub` |
-| 2 | 0c | `fix(ui): declare phantom dependencies, drop bogus react-native export condition` |
+| 1 | 0a | `chore(mcp-trace): add workspace manifests` |
+| 2 | 0c | `fix(ui): declare phantom dependencies, drop bogus react-native export conditions` |
 | 3 | 0d + 0e | `chore(lint): shared-package purity guard` + `docs(shared-packages): conventions` |

--- a/mobile-migration-temp/stage-0-hygiene.md
+++ b/mobile-migration-temp/stage-0-hygiene.md
@@ -1,0 +1,134 @@
+# Stage 0 — Repository Hygiene & Purity Guards
+
+## Objective
+
+Fix pre-existing violations of the workspace-package invariant, and install the import-purity lint
+guards and shared-package conventions **before** any shared code lands. The guard must predate the
+code it guards.
+
+## Preconditions
+
+None. Independent of all other stages. Zero changes under desktop `src/`.
+
+---
+
+## 0a. `packages/mcp-trace`: missing manifests
+
+**Current state.** `packages/mcp-trace/trace-core/` and `packages/mcp-trace/trace-node/` are bare
+source directories with no `package.json`. They are resolvable only through bundler aliases
+(`electron.vite.config.ts:73-74` for the main process, `:120` for preload, `:167` for the
+renderer), which violates the invariant *every child of `packages/` is a workspace package* and
+makes them invisible to `pnpm --filter`, changesets, and dependency auditing.
+
+**Procedure.**
+1. Create `packages/mcp-trace/trace-core/package.json`:
+   `{ "name": "@mcp-trace/trace-core", "private": true, "main": "<actual entry>.ts" }`.
+   Repeat for `trace-node`.
+2. `trace-node` is a Node-side implementation by design; it is **excluded** from the shared-purity
+   guard allowlist (0d).
+3. Bundler aliases remain untouched — desktop consumption is unchanged; desktop diff is zero.
+
+## 0b. `packages/provider-catalog`: orphaned directory
+
+**Current state.** The directory contains a single gitignored `.env` (≈40 provider API-key
+placeholders), no manifest, no sources.
+
+**Procedure.**
+1. Locate the consumer:
+   `grep -rn "provider-catalog" scripts/ packages/ src/ --include='*.ts' --include='*.json'`.
+2. If a consumer exists, relocate the `.env` convention to the consumer's own directory and update
+   its dotenv path. If none exists, delete the directory and notify developers to retain local
+   `.env` copies out-of-tree.
+
+## 0c. `packages/ui`: undeclared dependencies + defective export condition
+
+**Current state.** `@cherrystudio/ui@1.0.0-alpha.1` is a **published** package whose sources import
+12 packages not declared in its manifest (they currently resolve only via pnpm root hoisting; an
+external consumer gets `ERR_MODULE_NOT_FOUND` while CI stays green). Additionally, its
+`exports["."]` map contains `"react-native": "./dist/index.js"` — a tsup scaffold artifact pointing
+the React Native resolution condition at the **web CJS build**; if Metro ever resolved this package
+it would bundle `react-dom` code paths into a native bundle.
+
+**Procedure.**
+1. Add to `packages/ui/package.json` `dependencies` (versions pinned to the root lockfile's
+   currently-resolved versions):
+   `@codemirror/lint`, `@codemirror/view`, `fast-diff`, `@hello-pangea/dnd`,
+   `@tanstack/react-virtual`, `rehype-parse`, `rehype-stringify`, `react-error-boundary`,
+   `@radix-ui/react-switch`.
+2. Add to `devDependencies`: `@testing-library/react`, `@testing-library/user-event`,
+   `@types/hast` (the `hast` import is type-only).
+3. Delete the `"react-native"` key from `exports["."]`.
+4. Audit `packages/aiCore/package.json` and `packages/ai-sdk-provider/package.json` for the same
+   scaffold artifact; delete if present and equally unbacked by a native build.
+
+## 0d. Import-purity lint guard
+
+**Design.** Purity is enforced per-package via an explicit allowlist, not a blanket
+`packages/**` rule — the root `packages/` tree transitionally co-locates desktop-only packages
+(`dsh-bridge`, `extension-table-plus`, `mcp-trace/trace-node`, `ui`) that legitimately import Node
+or DOM APIs.
+
+**Procedure.** In `eslint.config.mjs`, adjacent to the existing import-ban constants (≈L76,
+`BAN_RENDERER_FROM_MAIN` et al.):
+
+```
+const SHARED_PURE_PACKAGES = [
+  'packages/aiCore/src/**',
+  'packages/ai-sdk-provider/src/**',
+  'packages/provider-registry/src/**',   // EXCEPT the Node loader:
+]
+// ignores: ['packages/provider-registry/src/registry-loader/**']
+//   (aliased as `@cherrystudio/provider-registry/node`; Node-side by contract)
+```
+
+Rule block: `@typescript-eslint/no-restricted-imports` with `patterns` banning
+`electron`, `electron/*`, `expo-*`, `react-native`, `react-native-*`, `@react-native*`,
+`node:*`, and bare Node builtins (`fs`, `path`, `os`, `crypto`, `child_process`, `stream`,
+`http`, `https`, `net`, `zlib`, `util`, `buffer`).
+
+**Growth protocol:** every shared package born in Stages 2–5 appends its glob to
+`SHARED_PURE_PACKAGES` in the same PR that creates the package.
+
+Additionally enable `import/no-extraneous-dependencies` over `packages/*/src/**`
+(`eslint-plugin-import` is already a devDependency) to prevent recurrence of the 0c phantom-dependency
+class.
+
+## 0e. Shared-package conventions document
+
+Create `docs/references/shared-packages.md`. Referenced normatively by all later stages. Contents:
+
+1. **Package birth criteria** (all three required; otherwise code stays application-local):
+   (a) name describes a content domain; (b) both applications consume it — evidenced by an existing
+   mobile re-implementation, not by speculation; (c) coherent change cadence.
+2. **Narrow-port injection (ports-and-adapters).** A shared package requiring I/O declares the
+   minimal port interface *in its own module* (e.g. `readFile: (path: string) => Promise<Uint8Array>`);
+   each application supplies the adapter at its composition root. No global `Platform` service, no
+   service locator. A port is promoted to a standalone types package only when a **second**
+   consumer package needs the identical capability.
+3. **Shared-service lifecycle contract** (the intersection of both platforms' lifecycle semantics):
+   - **No ordered-shutdown assumption.** Mobile processes are OS-killed without notice; `onStop`
+     may never fire. Persistence must be write-through; flush-on-stop is forbidden.
+   - **Host-replacement tolerance.** Mobile's `ApplicationHost` is rebuilt in place on Fast
+     Refresh / test generations. No module-level mutable state; `start`/`stop` idempotent.
+   - **No IPC surface.** Shared services expose plain methods; the desktop shell binds IpcApi
+     endpoints externally.
+   - **Foreground/background awareness via injected policy callbacks**, never by importing
+     React Native `AppState`.
+4. **Phase assignment at registration site.** Shared services do not carry `@ServicePhase`;
+   each application assigns the phase where it registers the service (desktop `serviceRegistry.ts`,
+   mobile composition root). Application-local services keep using the decorator.
+
+## Verification
+
+```
+pnpm build:check && pnpm test && pnpm test:lint
+cd packages/ui && pnpm build        # proves the package builds against its own declared deps
+```
+
+## PR Partitioning
+
+| PR | Scope | Conventional commit |
+|---|---|---|
+| 1 | 0a + 0b | `chore(packages): add mcp-trace manifests, remove provider-catalog stub` |
+| 2 | 0c | `fix(ui): declare phantom dependencies, drop bogus react-native export condition` |
+| 3 | 0d + 0e | `chore(lint): shared-package purity guard` + `docs(shared-packages): conventions` |

--- a/mobile-migration-temp/stage-1-landing.md
+++ b/mobile-migration-temp/stage-1-landing.md
@@ -14,8 +14,9 @@ both applications.
 ## Blast-Radius Contract
 
 Desktop-side diff is confined to: `pnpm-workspace.yaml`, `pnpm-lock.yaml`,
-`.github/workflows/*`. Nothing under desktop `src/` is touched. The stage is two commits:
-one subtree merge (revertible via `git revert -m 1`) and one wiring commit.
+`.github/workflows/*`. Nothing under desktop `src/` is touched. The stage is two PRs: the landing
+branch contains one subtree merge and lands through a GitHub merge commit; the second PR contains
+the workspace wiring. The landed GitHub merge is the atomic `git revert -m 1` target.
 
 ## Design Decisions (ADR summary)
 
@@ -24,32 +25,29 @@ one subtree merge (revertible via `git revert -m 1`) and one wiring commit.
   merge commit whose second parent is the mobile HEAD — full history reachable
   (`git log --follow` works), no rewrite of either history, trivially revertible.
   Mechanism empirically validated: 1,978 commits preserved; repository went 8,369 → 10,347 commits.
-- **`--no-tags` on fetch.** Mobile carries 138 `v0.x`/`v1.x` release tags that would pollute the
-  desktop tag namespace (desktop releases are `v2.x`). Historical mobile tags remain resolvable in
-  the archived origin repository.
+- **`--no-tags` on fetch.** Both repositories already own release tags in the `0.x`/`1.x`
+  namespaces; identical names such as `0.1.0` and `0.1.1` exist on both sides. Importing tags would
+  therefore be ambiguous: existing desktop refs win silently on collisions, while non-colliding
+  mobile refs add a second project's release namespace. The commit history does not require tags,
+  and historical mobile tags remain resolvable in the archived origin repository. Never bulk-delete
+  desktop `v0.*`/`v1.*` tags as landing cleanup.
 - **Collision renames applied on the mobile side only** (Invariant I3), scoped strictly to the
   `apps/mobile/` subtree.
 
 ---
 
-## 1a. Cleanup of spike residue, then production landing
+## 1a. Production landing from a clean branch
 
-This worktree carries a feasibility-spike state (see README). Reset it first:
-
-```bash
-git reset --hard 9754c9267e            # drop the spike subtree merge
-git clean -fd apps                     # drop 281 uncommitted rename rehearsal edits
-# Delete only tags belonging to mobile history (guards against deleting any desktop-owned v0/v1 tag):
-for t in $(git tag -l 'v0.*' 'v1.*'); do
-  git merge-base --is-ancestor "$t" refs/remotes/mobile/v0.2 2>/dev/null && git tag -d "$t"
-done
-```
-
-Production landing:
+Create a dedicated branch at the then-current `origin/main`. Do not reuse a feasibility-spike
+worktree and do not put hard resets or broad clean commands in the landing procedure.
 
 ```bash
+git fetch origin main
+git switch -c feat/mobile-subtree-landing origin/main
+test -z "$(git status --porcelain)"
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
 git remote add mobile https://github.com/CherryHQ/cherry-studio-app.git   # skip if present
-git fetch --no-tags mobile refs/remotes/origin/v0.2:refs/remotes/mobile/v0.2
+git fetch --no-tags mobile v0.2:refs/remotes/mobile/v0.2
 git subtree add --prefix=apps/mobile refs/remotes/mobile/v0.2
 ```
 
@@ -59,6 +57,32 @@ Post-conditions (assert before proceeding):
 git merge-base --is-ancestor 3707410b9191e6a8ab5ff1e1271f10c4626f5958 HEAD   # exit 0
 git cat-file -p HEAD | grep -c ^parent                                        # == 2
 ```
+
+### 1a-1. Landing merge strategy (history-preservation blocker)
+
+PR 1 must be merged with **Create a merge commit**. Squash or rebase flattens the subtree commit,
+disconnects the imported 1,978-commit history from `main`, and invalidates the documented
+`git revert -m 1` rollback.
+
+The `main` ruleset measured on 2026-08-18 requires linear history and allows only squash merges, so
+PR 1 cannot land correctly under the normal policy. Immediately before merge, a repository admin
+must make a time-bounded exception: suspend `required_linear_history` and add `merge` to the PR
+rule's allowed merge methods, without weakening review, signature, or status-check requirements.
+Merge this PR only, then restore both settings immediately after the assertions below pass. Do not
+substitute squash, rebase, or a silent history rewrite.
+
+After GitHub merges PR 1, fetch `main` and assert the landed commit, not merely the pre-PR branch:
+
+```bash
+git fetch origin main
+git cat-file -p origin/main | grep -c ^parent                                  # == 2
+git cat-file -p <subtree-merge-sha> | grep -c ^parent                          # == 2
+git merge-base --is-ancestor <subtree-merge-sha> origin/main
+git merge-base --is-ancestor 3707410b9191e6a8ab5ff1e1271f10c4626f5958 origin/main
+```
+
+Record both the subtree merge SHA before opening PR 1 and the landed GitHub merge SHA afterward.
+The latter is the `-m 1` rollback target used below.
 
 **Origin-repository cutover.** After 1c gates pass and the PR merges: freeze
 `cherry-studio-app` (README banner, close PR intake). If `v0.2` advances during the landing window,
@@ -79,8 +103,14 @@ packages:
   - 'apps/mobile/packages/*'
 ```
 
-Merge the following keys from `apps/mobile/pnpm-workspace.yaml` into the root file (pnpm ignores
-nested workspace manifests; leaving the nested file is inert but misleading):
+Prefix and carry over **every** mobile `packages:` glob, not only the known package directory. At
+measurement time mobile declares `packages/*`, which becomes `apps/mobile/packages/*` above. At
+execution time, diff the discovered workspace member set before and after the merge; if mobile has
+added another glob (for example `modules/*`), add its `apps/mobile/…` equivalent before deleting the
+nested manifest.
+
+Merge the following non-member keys from `apps/mobile/pnpm-workspace.yaml` into the root file (pnpm
+ignores nested workspace manifests; leaving the nested file is inert but misleading):
 
 | Key | Action |
 |---|---|
@@ -88,6 +118,11 @@ nested workspace manifests; leaving the nested file is inert but misleading):
 | `trustPolicy: no-downgrade` + `trustPolicyExclude` (5 entries: `eslint-import-resolver-typescript@3.10.1`, `react-native-chart-kit@7.0.2`, `semver@6.3.1`, `tinyexec@1.2.2`, `ua-parser-js@0.7.41\|\|1.0.41`) | Adopt verbatim |
 | `packageExtensions` (`@bottom-tabs/react-navigation@1.4.0` block et al.) | Merge verbatim |
 | `patchedDependencies` | See 1b-2 |
+
+`apps/mobile/package.json` currently declares `"packageManager": "pnpm@11.8.0"`. Remove that leaf
+declaration after verifying compatibility with the root's pinned pnpm version; the root becomes the
+single Corepack authority. Audit `engines` on both manifests and reconcile any incompatible Node or
+pnpm range before install (mobile has no `engines` field at measurement time).
 
 Then delete `apps/mobile/pnpm-workspace.yaml` and `apps/mobile/pnpm-lock.yaml`.
 
@@ -183,8 +218,13 @@ Actions does not read nested workflow directories; all four are dead on arrival.
 | `android-release.yml`, `ios-release.yml` | Relocate as `mobile-android-release.yml` / `mobile-ios-release.yml`; EAS credentials must be provisioned into `CherryHQ/cherry-studio` org secrets (requires org admin; can lag — see Risks) |
 | `port-bot.yml` | **Decommission** (cross-repository sync automation; purpose voided by the monorepo) |
 
-Desktop `ci.yml`: add `paths-ignore: ['apps/mobile/**', 'mobile-migration-temp/**']`.
-Delete the now-inert `apps/mobile/.github/` tree.
+Do **not** add workflow-level `paths-ignore` to desktop `ci.yml`. The `main` ruleset currently
+requires the `basic-checks`, `general-test`, and `render-test` contexts; if the workflow never
+starts, a mobile-only PR remains blocked at "Expected — Waiting for status to be reported."
+Instead, add a change-detection job and keep every required job name present on every PR. On a
+mobile-only diff, those jobs run an explicit no-op step; on desktop or shared-package diffs, they run
+the existing desktop gate. Re-query the active ruleset at execution time and prove the design with a
+mobile-only draft PR before merging Stage 1. Delete the now-inert `apps/mobile/.github/` tree.
 
 ---
 
@@ -203,14 +243,14 @@ pnpm --filter cherry-studio-app dev    # Metro boots; smoke test on simulator/de
 
 ## Rollback
 
-`git revert -m 1 <subtree-merge-sha>` + revert of the wiring commit restores the pre-landing state
+`git revert -m 1 <landing-pr-merge-sha>` + revert of the wiring PR restores the pre-landing state
 exactly (single-lockfile revert included).
 
 ## Risks
 
 | Risk | Mitigation |
 |---|---|
-| Lockfile conflicts against ~110 in-flight branches | Land 1b within one day of 1a; broadcast beforehand. Conflict resolution recipe for branch owners: `git checkout --theirs pnpm-lock.yaml && pnpm install` |
+| Lockfile conflicts against ~110 in-flight branches | Land 1b within one day of 1a; broadcast beforehand. Direction-independent conflict recipe: delete only the conflicted root `pnpm-lock.yaml`, then run `pnpm install` to regenerate it from the reconciled manifests |
 | Faulty reconciliation of the 4 divergent patches | Per-patch gate: desktop `pnpm test:main` + mobile `pnpm --filter cherry-studio-app test:ai-runtime` |
 | Hoisting shift breaks packaging | `build:unpack` is a hard gate; on failure inspect the app-builder-lib collector patch |
 | EAS secrets not yet provisioned | `mobile-ci.yml` (typecheck/test) lands first; release workflows may trail without blocking the landing |
@@ -219,5 +259,5 @@ exactly (single-lockfile revert included).
 
 | PR | Content |
 |---|---|
-| 1 | `feat(monorepo): land mobile application as apps/mobile subtree` — the merge commit only |
+| 1 | `feat(monorepo): land mobile application as apps/mobile subtree` — subtree merge only; repository-admin policy exception + GitHub **Create a merge commit** required; never squash/rebase |
 | 2 | `chore(workspace): integrate apps/mobile into the root workspace` — all of 1b + 1c evidence. 1b-1…3 and 1b-4 are inseparable (the workspace cannot install with duplicate package names); keep them in one PR |

--- a/mobile-migration-temp/stage-1-landing.md
+++ b/mobile-migration-temp/stage-1-landing.md
@@ -1,0 +1,223 @@
+# Stage 1 — Landing (Subtree Merge + Workspace Integration)
+
+## Objective
+
+Land the entire mobile repository under `apps/mobile/` with full history, integrate it into a single
+pnpm workspace with a single lockfile, resolve all package-name collisions, and re-establish CI for
+both applications.
+
+## Preconditions
+
+- Stage 0 merged (purity guard exists before shared code arrives).
+- Announcement to all active branch owners: a lockfile-touching change is landing (see Risks).
+
+## Blast-Radius Contract
+
+Desktop-side diff is confined to: `pnpm-workspace.yaml`, `pnpm-lock.yaml`,
+`.github/workflows/*`. Nothing under desktop `src/` is touched. The stage is two commits:
+one subtree merge (revertible via `git revert -m 1`) and one wiring commit.
+
+## Design Decisions (ADR summary)
+
+- **`git subtree` over submodule/monorepo-import tooling.** Submodules would preserve the
+  two-repository boundary this migration exists to remove. `git subtree add` produces a single
+  merge commit whose second parent is the mobile HEAD — full history reachable
+  (`git log --follow` works), no rewrite of either history, trivially revertible.
+  Mechanism empirically validated: 1,978 commits preserved; repository went 8,369 → 10,347 commits.
+- **`--no-tags` on fetch.** Mobile carries 138 `v0.x`/`v1.x` release tags that would pollute the
+  desktop tag namespace (desktop releases are `v2.x`). Historical mobile tags remain resolvable in
+  the archived origin repository.
+- **Collision renames applied on the mobile side only** (Invariant I3), scoped strictly to the
+  `apps/mobile/` subtree.
+
+---
+
+## 1a. Cleanup of spike residue, then production landing
+
+This worktree carries a feasibility-spike state (see README). Reset it first:
+
+```bash
+git reset --hard 9754c9267e            # drop the spike subtree merge
+git clean -fd apps                     # drop 281 uncommitted rename rehearsal edits
+# Delete only tags belonging to mobile history (guards against deleting any desktop-owned v0/v1 tag):
+for t in $(git tag -l 'v0.*' 'v1.*'); do
+  git merge-base --is-ancestor "$t" refs/remotes/mobile/v0.2 2>/dev/null && git tag -d "$t"
+done
+```
+
+Production landing:
+
+```bash
+git remote add mobile https://github.com/CherryHQ/cherry-studio-app.git   # skip if present
+git fetch --no-tags mobile refs/remotes/origin/v0.2:refs/remotes/mobile/v0.2
+git subtree add --prefix=apps/mobile refs/remotes/mobile/v0.2
+```
+
+Post-conditions (assert before proceeding):
+
+```bash
+git merge-base --is-ancestor 3707410b9191e6a8ab5ff1e1271f10c4626f5958 HEAD   # exit 0
+git cat-file -p HEAD | grep -c ^parent                                        # == 2
+```
+
+**Origin-repository cutover.** After 1c gates pass and the PR merges: freeze
+`cherry-studio-app` (README banner, close PR intake). If `v0.2` advances during the landing window,
+absorb increments with `git subtree pull --prefix=apps/mobile mobile <ref>`.
+
+---
+
+## 1b. Workspace Integration
+
+### 1b-1. Workspace topology (desktop diff site ①)
+
+Root `pnpm-workspace.yaml`:
+
+```yaml
+packages:
+  - 'packages/*'
+  - 'apps/mobile'
+  - 'apps/mobile/packages/*'
+```
+
+Merge the following keys from `apps/mobile/pnpm-workspace.yaml` into the root file (pnpm ignores
+nested workspace manifests; leaving the nested file is inert but misleading):
+
+| Key | Action |
+|---|---|
+| `minimumReleaseAge: 1440` | Adopt (absent at root; root's existing `minimumReleaseAgeExclude` retained) |
+| `trustPolicy: no-downgrade` + `trustPolicyExclude` (5 entries: `eslint-import-resolver-typescript@3.10.1`, `react-native-chart-kit@7.0.2`, `semver@6.3.1`, `tinyexec@1.2.2`, `ua-parser-js@0.7.41\|\|1.0.41`) | Adopt verbatim |
+| `packageExtensions` (`@bottom-tabs/react-navigation@1.4.0` block et al.) | Merge verbatim |
+| `patchedDependencies` | See 1b-2 |
+
+Then delete `apps/mobile/pnpm-workspace.yaml` and `apps/mobile/pnpm-lock.yaml`.
+
+### 1b-2. Patch reconciliation (measured collision inventory)
+
+pnpm resolves `patchedDependencies` paths relative to the workspace root; all mobile patches must
+relocate to root `patches/`.
+
+**Byte-identical on both sides (6)** — delete the mobile copy; the root `patchedDependencies` entry
+already exists with the same key:
+`@ai-sdk__anthropic.patch`, `@ai-sdk__deepseek@2.0.30.patch`, `@ai-sdk__google@3.0.64.patch`,
+`@ai-sdk__xai@3.0.111.patch`, `@openrouter__ai-sdk-provider@2.10.0.patch`,
+`@opeoginni__github-copilot-openai-compatible@1.0.0.patch`.
+
+**Content-divergent (4)** — hunk-level reconciliation required (⟳ re-diff at execution):
+
+| Patch | Divergence | Resolution |
+|---|---|---|
+| `@ai-sdk__openai@3.0.53.patch` | 176 diff lines | Desktop version is the baseline; graft mobile-only hunks; run both sides' provider test suites |
+| `@ai-sdk__openai-compatible@2.0.62.patch` | 72 diff lines | Same procedure |
+| `ollama-ai-provider-v2@3.3.1.patch` | 163 diff lines | Same procedure |
+| `ai@6.0.183.patch` (mobile) vs `ai@6.0.185.patch` (desktop) | Version fork | Root `overrides` pins `ai: 6.0.185` workspace-wide, so mobile's resolution converges on 6.0.185. Verify the 6.0.183 patch's hunks are subsumed by the 6.0.185 patch (reasoning-retention class), then delete the 6.0.183 patch and its manifest entry |
+
+**Mobile-only (11)** — `git mv apps/mobile/patches/* patches/` and merge their
+`patchedDependencies` entries into the root manifest:
+`@bottom-tabs__react-navigation@1.4.0`, `@magrinj__expo-quick-look@0.3.1`, `expo-widgets@57.0.8`,
+`metro@0.84.4`, `metro-runtime@0.84.4`, `react-native-bottom-tabs@1.4.0`,
+`react-native-keyboard-controller@1.21.13`, `react-native-nitro-healthkit@1.0.0`,
+`react-native-reanimated@4.5.0`, `uniwind@1.6.5`. Delete the emptied `apps/mobile/patches/`.
+
+### 1b-3. Override propagation audit
+
+Root `overrides` apply workspace-wide and therefore now constrain mobile. Measured to be benign —
+every desktop pin satisfies the corresponding mobile range:
+`ai@6.0.185 ∈ ^6.0.143`, `@ai-sdk/anthropic@3.0.103 ∈ ^3.0.79`,
+`@ai-sdk/provider-utils@4.0.40 = 4.0.40`.
+
+Ordinary (non-override) dependencies coexist per-package and are **deliberately not unified** —
+pnpm resolves each `package.json` independently. The 32 measured version divergences
+(`drizzle-orm` `^0.44.5`/`^0.45.2`, `i18next` 23/26, `react-i18next` 14/17, `uuid` 13/14, `katex`,
+`tailwind-merge`, …) remain as-is; unification of any of them is a per-domain decision made when
+that domain is unified, not a landing precondition.
+
+Post-`pnpm install` spot-check:
+`pnpm ls --filter cherry-studio-app ai drizzle-orm i18next` — assert no unexpected downgrades.
+
+### 1b-4. Collision renames (288 files, `apps/mobile/` subtree only)
+
+Workspace package names must be unique. Four collisions, resolved per naming policy (README):
+
+| Original | New name | Category |
+|---|---|---|
+| `@cherrystudio/ui` | `@cherrystudio/ui-native` | Permanent (genuine platform fork: Radix/DOM vs RN/Skia/Nitro) |
+| `@cherrystudio/ai-core` | `@cherrystudio/mobile-ai-core` | Debt marker → removed in Stage 2c |
+| `@cherrystudio/ai-sdk-provider` | `@cherrystudio/mobile-ai-sdk-provider` | Debt marker → removed in Stage 2b |
+| `@cherrystudio/provider-registry` | `@cherrystudio/mobile-provider-registry` | Debt marker → removed in Stage 3a |
+
+Batch rewrite (validated: does not touch the external npm packages `@cherrystudio/openai` and
+`@cherrystudio/pdf-text-extractor`; negative lookahead on `ui` prevents double application):
+
+```bash
+find apps/mobile -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.mjs' \
+  -o -name '*.cjs' -o -name '*.json' -o -name '*.md' \) ! -path '*/node_modules/*' -print0 |
+xargs -0 perl -pi -e '
+  s{\@cherrystudio/ai-sdk-provider}{\@cherrystudio/mobile-ai-sdk-provider}g;
+  s{\@cherrystudio/ai-core}{\@cherrystudio/mobile-ai-core}g;
+  s{\@cherrystudio/provider-registry}{\@cherrystudio/mobile-provider-registry}g;
+  s{\@cherrystudio/ui(?![a-zA-Z0-9-])}{\@cherrystudio/ui-native}g;
+'
+```
+
+Coverage includes each package's `package.json#name`. Post-rewrite assertion — the specifier
+histogram over `apps/mobile` must contain exactly:
+`ui-native`, `mobile-provider-registry`, `mobile-ai-core`, `mobile-ai-sdk-provider`,
+`universal`, `ai-runtime`, `app-icons`, `design-tokens`, plus external `openai` and
+`pdf-text-extractor`.
+
+### 1b-5. Metro resolution scope
+
+`apps/mobile/metro.config.js`: `projectRoot` stays `apps/mobile`; add the repository root to
+`watchFolders` and `<repo-root>/node_modules` to `resolver.nodeModulesPaths` (required for
+resolving root `node_modules` and, later, promoted root `packages/*`). Mobile was already a
+workspace-shaped project; this is a parameter change, not an architectural one.
+
+### 1b-6. CI split (desktop diff site ②)
+
+After the subtree merge, mobile workflows live at `apps/mobile/.github/workflows/` — **GitHub
+Actions does not read nested workflow directories; all four are dead on arrival.** Disposition:
+
+| Mobile workflow | Disposition |
+|---|---|
+| `pr-ci.yml` | Rewrite as root `.github/workflows/mobile-ci.yml`: `on.pull_request.paths: ['apps/mobile/**', 'packages/**']`, `defaults.run.working-directory: apps/mobile` |
+| `android-release.yml`, `ios-release.yml` | Relocate as `mobile-android-release.yml` / `mobile-ios-release.yml`; EAS credentials must be provisioned into `CherryHQ/cherry-studio` org secrets (requires org admin; can lag — see Risks) |
+| `port-bot.yml` | **Decommission** (cross-repository sync automation; purpose voided by the monorepo) |
+
+Desktop `ci.yml`: add `paths-ignore: ['apps/mobile/**', 'mobile-migration-temp/**']`.
+Delete the now-inert `apps/mobile/.github/` tree.
+
+---
+
+## 1c. Dual Green Gates (merge blockers)
+
+```bash
+# Desktop non-regression:
+pnpm install && pnpm build:check && pnpm test && pnpm test:lint
+pnpm build:unpack     # MANDATORY: electron-builder's pnpm file collector is hoisting-sensitive
+                      # (see patches/app-builder-lib@26.15.6.patch); must be exercised against the merged lockfile
+# Mobile viability:
+pnpm --filter cherry-studio-app typecheck
+pnpm --filter cherry-studio-app test
+pnpm --filter cherry-studio-app dev    # Metro boots; smoke test on simulator/device
+```
+
+## Rollback
+
+`git revert -m 1 <subtree-merge-sha>` + revert of the wiring commit restores the pre-landing state
+exactly (single-lockfile revert included).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Lockfile conflicts against ~110 in-flight branches | Land 1b within one day of 1a; broadcast beforehand. Conflict resolution recipe for branch owners: `git checkout --theirs pnpm-lock.yaml && pnpm install` |
+| Faulty reconciliation of the 4 divergent patches | Per-patch gate: desktop `pnpm test:main` + mobile `pnpm --filter cherry-studio-app test:ai-runtime` |
+| Hoisting shift breaks packaging | `build:unpack` is a hard gate; on failure inspect the app-builder-lib collector patch |
+| EAS secrets not yet provisioned | `mobile-ci.yml` (typecheck/test) lands first; release workflows may trail without blocking the landing |
+
+## PR Partitioning
+
+| PR | Content |
+|---|---|
+| 1 | `feat(monorepo): land mobile application as apps/mobile subtree` — the merge commit only |
+| 2 | `chore(workspace): integrate apps/mobile into the root workspace` — all of 1b + 1c evidence. 1b-1…3 and 1b-4 are inseparable (the workspace cannot install with duplicate package names); keep them in one PR |

--- a/mobile-migration-temp/stage-1-landing.md
+++ b/mobile-migration-temp/stage-1-landing.md
@@ -226,6 +226,33 @@ mobile-only diff, those jobs run an explicit no-op step; on desktop or shared-pa
 the existing desktop gate. Re-query the active ruleset at execution time and prove the design with a
 mobile-only draft PR before merging Stage 1. Delete the now-inert `apps/mobile/.github/` tree.
 
+### 1b-7. Path-aware review policy (non-blocking governance follow-up)
+
+**Goal:** after landing, a PR whose entire diff is under `apps/mobile/**` needs one valid approval so
+the mobile team can iterate quickly. A PR touching desktop code, root configuration, workflows, or
+shared `packages/**` keeps the existing two-approval policy. Required signatures, status checks,
+linear-history policy, and CODEOWNERS review remain unchanged for both classes.
+
+GitHub's built-in `required_approving_review_count` applies to the `main` ref as a whole; it cannot
+express a path-specific count. The current ruleset requires two approvals, so lowering it directly
+would unintentionally relax every desktop PR. Implement the mobile exception as a separate
+repository-governance change, not as a Stage 1 merge blocker:
+
+1. Add `/apps/mobile/` ownership for the nominated mobile maintainer team in `.github/CODEOWNERS`.
+2. Add a trusted required check (organization-required workflow or GitHub App, not a workflow that
+   the evaluated PR can weaken) that reads the changed-file set and latest non-dismissed reviews:
+   - every changed path matches `apps/mobile/**` → require at least 1 approval;
+   - any other path → require at least 2 approvals.
+3. Trigger/recompute the check on PR open/reopen/synchronize and review submit/dismiss events so a
+   new push or dismissed review cannot retain a stale pass.
+4. Only after the path-aware check is required on `main`, lower the built-in approval count from 2
+   to 1. Never reverse this order.
+5. Prove the policy with three draft PRs: mobile-only + 1 approval passes; desktop/shared + 1 remains
+   blocked; desktop/shared + 2 passes.
+
+This follow-up is outside the two landing PRs below and may land after Stage 1. Until it does,
+mobile-only PRs retain the repository-wide two-approval requirement.
+
 ---
 
 ## 1c. Dual Green Gates (merge blockers)

--- a/mobile-migration-temp/stage-2-quick-unify.md
+++ b/mobile-migration-temp/stage-2-quick-unify.md
@@ -1,0 +1,122 @@
+# Stage 2 — High-Pain / Low-Surface Unifications
+
+## Objective
+
+Eliminate the three smallest live forks (highest drift-pain-to-effort ratio) and single-source the
+design layer. Each substage is an independent PR; all three may proceed in parallel.
+
+## Preconditions
+
+Stage 1 merged.
+
+## The Canonical Unification Procedure ("three-step")
+
+Used by 2b, 2c, and Stage 3a. Preserves Invariant I3 (desktop import specifiers unchanged):
+
+1. **Reconcile.** Diff the desktop package against its mobile counterpart; graft mobile-only
+   changes into the root (desktop-named) package. Both test suites green against the reconciled
+   source.
+2. **Repoint the mobile consumer.**
+   - `apps/mobile/package.json`: replace the `@cherrystudio/mobile-<name>` dependency with
+     `@cherrystudio/<name>: workspace:*`.
+   - Revert the Stage 1b-4 rename within the mobile subtree:
+     ```bash
+     find apps/mobile -type f \( -name '*.ts*' -o -name '*.json' \) ! -path '*/node_modules/*' -print0 |
+     xargs -0 perl -pi -e 's{\@cherrystudio/mobile-<name>}{\@cherrystudio/<name>}g'
+     ```
+   - Audit `apps/mobile/tsconfig.json#paths`, Babel config, and Metro `resolver` for aliases
+     pointing at the local package directory; repoint to the root package.
+3. **Delete the mobile copy.** `git rm -r apps/mobile/packages/<name>`. The root package's glob
+   joins `SHARED_PURE_PACKAGES` (Stage 0d) if not already present.
+
+---
+
+## 2a. Design layer single-sourcing
+
+### design-tokens promotion
+
+**Current state.** `apps/mobile/packages/design-tokens/` (1,010 lines) maintains a token set
+synchronized *manually* against desktop's `DESIGN.md`/theme sources via
+`scripts/sync-desktop.ts` + `src/sync-manifest.json`. Both applications speak Tailwind v4
+(desktop: `tailwindcss`; mobile: `uniwind`), so a single token source is consumable by both.
+
+**Procedure.**
+1. `git mv apps/mobile/packages/design-tokens packages/design-tokens`.
+   No workspace-manifest change needed (`packages/*` glob covers it); the package name
+   `@cherrystudio/design-tokens` is collision-free, so mobile consumers are untouched.
+2. Append the package glob to `SHARED_PURE_PACKAGES`.
+3. **Desktop adoption (separate follow-up PR).** Locate the desktop theme source of truth
+   (`pnpm styles:canonical`, `DESIGN.md`), replace literal token values with imports from
+   `@cherrystudio/design-tokens`.
+4. On completion of (3): delete `packages/design-tokens/scripts/sync-desktop.ts` and
+   `src/sync-manifest.json`; the `design-catalog` sync-manifest domain transitions to
+   "shared package" status.
+
+### Icon single-sourcing
+
+Coordinate with the pre-existing `icons-static-webp-export` branch to avoid duplicated effort.
+
+**Current state** (sync-manifest domain `design-catalog`, status `aligned` — i.e., manually kept
+in lockstep):
+- Desktop source of truth: `packages/ui/icons/`,
+  `packages/ui/src/components/icons/{registry.ts,models/,providers/}`.
+- Mobile mirrors: `apps/mobile/packages/ui/icons/`, `.../src/icons/`, `.../src/icons-webp/`,
+  plus `apps/mobile/packages/app-icons/` (1,322 lines).
+
+**Procedure.** Create `packages/icon-source/` holding SVG sources + registry data with a build
+emitting two artifact sets: TSX components (web, consumed by `@cherrystudio/ui`) and WebP
+(React Native, consumed by `ui-native`/`app-icons`). Repoint mobile's `ui:icons:generate*` scripts
+(`apps/mobile/package.json`) at icon-source artifacts. `app-icons` either becomes a thin RN
+wrapper or is absorbed into icon-source's artifact tree (decide against its actual contents at
+execution time).
+
+---
+
+## 2b. `ai-sdk-provider` unification
+
+**Measured divergence:** 1 of 4 source files, 14 lines, under the identical published version
+`0.1.6` — i.e., npm identity `@cherrystudio/ai-sdk-provider@0.1.6` currently denotes two different
+artifacts depending on which repository built it. Unification resolves this integrity defect.
+
+Apply the three-step procedure with `<name> = ai-sdk-provider`. Reconciliation step: ⟳ re-diff to
+confirm direction of the 14-line delta before grafting.
+
+**Verification.**
+```
+pnpm --filter @cherrystudio/ai-sdk-provider build && pnpm --filter @cherrystudio/ai-sdk-provider test
+pnpm test:aicore                                # desktop downstream consumer
+pnpm --filter cherry-studio-app typecheck && pnpm --filter cherry-studio-app test
+```
+Mobile's `test:ai-sdk-provider` script: repoint at the root package or delete.
+Changeset: patch bump (dual-artifact ambiguity eliminated).
+
+---
+
+## 2c. `ai-core` unification
+
+**Measured divergence:** 13 of 75 files, 321 lines, plus structural asymmetries — under identical
+published version `2.0.1`.
+
+Apply the three-step procedure with `<name> = ai-core`. Reconciliation inventory (⟳):
+
+| Divergence | Resolution |
+|---|---|
+| 13 content-divergent files: `core/agents/createAgent.ts`, `core/providers/core/ProviderExtension.ts`, `core/providers/core/initialization.ts`, `core/providers/types/index.ts`, `core/plugins/built-in/index.ts`, `core/runtime/{executor,index,pluginEngine}.ts`, `src/index.ts`, + 4 test files | File-by-file merge; desktop is the baseline; graft mobile-only capabilities |
+| Mobile-only: `core/plugins/built-in/webSearchPlugin/` | Absorb into the root package (platform-pure plugin) |
+| Desktop-only: `core/context/`, `core/plugins/built-in/__tests__/`, `core/runtime/__tests__/resolveLanguageModel.test.ts` | Retain |
+
+Note: the desktop root `typecheck` script already invokes
+`pnpm --filter @cherrystudio/ai-core typecheck`; the package name is unchanged, so root scripts
+need no modification. Repoint mobile's `test:ai-core` script.
+
+**Verification.** `pnpm test:aicore && pnpm build:check`; mobile `typecheck` + `test`.
+Changeset: minor bump (webSearchPlugin is additive capability).
+
+---
+
+## Exit Criterion
+
+```
+grep -r "@cherrystudio/mobile-ai" apps/mobile --include='*.ts*' | wc -l   # → 0
+```
+(Only `mobile-provider-registry` remains, owned by Stage 3a.)

--- a/mobile-migration-temp/stage-3-shared-extraction.md
+++ b/mobile-migration-temp/stage-3-shared-extraction.md
@@ -55,6 +55,9 @@ the lint guard turns any violation into a CI failure rather than a runtime crash
      edits to the *moved* file surface as regular content conflicts on the package file, not as
      tree conflicts).
    - Type identity is preserved (re-export, not re-declaration).
+   - `export *` does not forward a default export. Audit every moved module and add
+     `export { default } from '@cherrystudio/<package>'` to its shim when the original module has a
+     default export.
 3. Mirror on mobile: the corresponding `apps/mobile/packages/universal/src/` module becomes a shim
    (or is repointed directly — mobile branch pressure is low).
 4. Append the new package glob to `SHARED_PURE_PACKAGES`.
@@ -87,17 +90,23 @@ Adjacent files `model.ts`, `provider.ts`, `providerTopology.ts`, `systemProvider
 `shortcut.ts`: **merge into `provider-registry`** (their content domain) or defer — do not mint
 packages for them.
 
-**Wave 2 — `packages/ai-protocol`**
+**Wave 2 — `packages/ai-primitives`**
 
 Desktop `src/shared/ai/` (24 entries) vs mobile `universal/src/ai/` (9 entries); measured drift
 2,721 lines. Extract the intersection only (⟳ re-verify): `agentSessionCompaction.ts`,
 `anthropicCache.ts`, `builtinTools.ts`, `generateImageTool.ts`, `paintingGenerateError.ts`,
 `prompts.ts`, `reasoning.ts`, `tools/`, `transport/`.
 
+This package is only the measured intersection of platform-pure AI primitives; the name describes
+that content rather than claiming a broader protocol boundary. The Agent protocol tracked by
+[#18802](https://github.com/CherryHQ/cherry-studio/issues/18802) is a separate architecture
+initiative, not a deliverable or prerequisite of this migration, and may proceed independently at
+any stage.
+
 Desktop-only remainder stays in `src/shared/ai/` (`agentSession*` ×5, `claudecode/`, `dsh*`,
-`pi*`, `builtinAgent.ts`, `compaction.ts`, `slashCommands.ts`, …) — predominantly bound to the
-desktop-only agents platform; individual files graduate when mobile ships the corresponding
-feature.
+`pi*`, `builtinAgent.ts`, `compaction.ts`, `slashCommands.ts`, …). Individual files graduate when
+mobile ships the corresponding feature; this extraction does not wait for #18802, and #18802 does
+not wait for this extraction.
 
 **Wave 3 — `packages/data-contract`** (largest: desktop `src/shared/data/` ≈20k lines; measured
 drift 13,867 lines)

--- a/mobile-migration-temp/stage-3-shared-extraction.md
+++ b/mobile-migration-temp/stage-3-shared-extraction.md
@@ -1,0 +1,136 @@
+# Stage 3 — provider-registry Reconciliation + `src/shared` Strangler Extraction
+
+## Objective
+
+3a: reconcile the largest package-level fork (`provider-registry`, 11,107-line divergence).
+3b: dissolve the `src/shared` ↔ `packages/universal` duplication into domain-named shared packages
+using the strangler-fig pattern, preserving all 1,989 desktop `@shared/*` import sites unmodified.
+
+## Preconditions
+
+Stage 1. 3a and 3b are independent; within 3b, each domain is an independent PR, ordered
+smallest-first.
+
+---
+
+## 3a. `provider-registry` unification
+
+**Measured divergence:** 161 of 167 files, 11,107 lines, under the identical published version
+`0.0.1-alpha.1` — the most drifted mirror pair in the repository.
+
+**Timebox policy:** this reconciliation is the largest in the playbook. If it stalls, retain the
+`mobile-provider-registry` fork and proceed; **no later stage depends on 3a** (Stage 5 Track A
+consumes whichever registry the mobile side declares).
+
+**Reconciliation strategy** (the package is data-driven: model/provider catalog data + pattern
+matchers + generators; desktop additionally participates in a remote-override update pipeline):
+
+1. **Generators and schemas first** (`src/` excluding catalog data): the code-level divergence is
+   the small fraction; unify it before touching data.
+2. **Catalog data second** (models/providers): the bulk of the 11k lines. Reconcile per-provider;
+   desktop is the baseline (its data feeds the remote-override + CI update pipeline); graft
+   mobile-only providers/models.
+3. Adjudicate the 6 desktop-only and 3 mobile-only files (⟳
+   `diff -rq packages/provider-registry/src apps/mobile/packages/provider-registry/src`).
+4. Finish with the three-step procedure (Stage 2), `<name> = provider-registry`.
+
+**Purity note:** the `@cherrystudio/provider-registry/node` subpath (`src/registry-loader/`) is
+Node-side by contract and excluded from the purity allowlist (Stage 0d). Mobile must not import it;
+the lint guard turns any violation into a CI failure rather than a runtime crash.
+
+**Verification.** `pnpm test:provider-registry`,
+`pnpm --filter @cherrystudio/provider-registry generate:check`, mobile `typecheck` + `test`.
+
+---
+
+## 3b. `src/shared` domain-by-domain extraction
+
+### Mechanism (identical for every domain)
+
+1. `git mv` the desktop files into the new package: `packages/<domain>/src/`.
+2. **Leave a re-export shim at every original module path**, e.g. `src/shared/utils/url.ts`
+   becomes the single line `export * from '@cherrystudio/url-safety'`. Consequences:
+   - All desktop `@shared/*` import sites (1,989 files) remain valid — zero desktop churn,
+     zero merge conflicts against in-flight branches (a shim is an ordinary TS file; concurrent
+     edits to the *moved* file surface as regular content conflicts on the package file, not as
+     tree conflicts).
+   - Type identity is preserved (re-export, not re-declaration).
+3. Mirror on mobile: the corresponding `apps/mobile/packages/universal/src/` module becomes a shim
+   (or is repointed directly — mobile branch pressure is low).
+4. Append the new package glob to `SHARED_PURE_PACKAGES`.
+5. The new `package.json` declares its actual npm dependencies — a subset of `src/shared`'s
+   measured dependency surface: `zod`, `es-toolkit`, `semver`, `ai`, `@modelcontextprotocol/sdk`,
+   `@anthropic-ai/claude-agent-sdk`, `@cherrystudio/openai`, `@mcp-trace/trace-core`,
+   `builder-util-runtime`, `selection-hook` (take per-domain what is actually imported).
+6. Test placement: extend the `shared` vitest project's `include` globs to the new package, or
+   give the package its own vitest project — follow whichever the first extraction PR establishes.
+
+**Shim amortization policy:** shims are not removed by dedicated PRs. Feature branches touching a
+shimmed module inline the direct import opportunistically. Progress metric:
+`grep -rl "export \* from '@cherrystudio/" src/shared | wc -l` → 0, then delete emptied
+directories.
+
+### Domain inventory and order (smallest first; proven intersection first)
+
+The proven intersection is mobile's `universal/src/utils/` — 7 files that the mobile team already
+re-implemented. Extraction starts there, not from the desktop superset.
+
+**Wave 1 — micro-domains**
+
+| New package | Desktop sources (`src/shared/utils/`) | Mobile sources (`universal/src/utils/`) |
+|---|---|---|
+| `packages/url-safety` | `url.ts`, `dataUrl.ts` (+ `__tests__`) | `url.ts` |
+| `packages/text-processing` | `text.ts`, `keywordSearch.ts`, `conversationTitle.ts` | same three + `fnv1a.ts` (mobile-only; absorb) |
+| `packages/serialization` | `serializable.ts`, `serialize.ts`, `redaction.ts` | `types/serializable.ts` |
+
+Adjacent files `model.ts`, `provider.ts`, `providerTopology.ts`, `systemProviderId.ts`,
+`shortcut.ts`: **merge into `provider-registry`** (their content domain) or defer — do not mint
+packages for them.
+
+**Wave 2 — `packages/ai-protocol`**
+
+Desktop `src/shared/ai/` (24 entries) vs mobile `universal/src/ai/` (9 entries); measured drift
+2,721 lines. Extract the intersection only (⟳ re-verify): `agentSessionCompaction.ts`,
+`anthropicCache.ts`, `builtinTools.ts`, `generateImageTool.ts`, `paintingGenerateError.ts`,
+`prompts.ts`, `reasoning.ts`, `tools/`, `transport/`.
+
+Desktop-only remainder stays in `src/shared/ai/` (`agentSession*` ×5, `claudecode/`, `dsh*`,
+`pi*`, `builtinAgent.ts`, `compaction.ts`, `slashCommands.ts`, …) — predominantly bound to the
+desktop-only agents platform; individual files graduate when mobile ships the corresponding
+feature.
+
+**Wave 3 — `packages/data-contract`** (largest: desktop `src/shared/data/` ≈20k lines; measured
+drift 13,867 lines)
+
+**Mandatory pre-measurement:** the divergence is a *bidirectional* fork — 43 desktop-only and 13
+mobile-only files. Classify each as (a) lag (one side trails; absorb directly) or (b) design fork
+(requires a jointly designed API before extraction). The classification outcome determines whether
+Wave 3 is a two-week or a one-quarter effort; do not begin moving files before it exists.
+
+Extraction scope: `src/shared/data/{api,cache,preference,presets,types}` ∩
+`universal/src/data/{api,cache,preference,presets,types}`.
+
+Explicitly **excluded** from extraction:
+- `src/shared/data/bootConfig/` — desktop BootConfig subsystem only.
+- `src/shared/data/migration/` — v1→v2 migrator types, desktop-only.
+- Codegen caveat: `src/shared/data/preference/preferenceSchemas.ts` is a **generated artifact**
+  (data-classify toolchain; never hand-edited). Moving it requires updating the generator output
+  path in `v2-refactor-temp/tools/data-classify` within the same PR. Mobile's
+  `mobilePreferenceSchemas.ts` remains application-local.
+
+**Permanently excluded from all waves:** `src/shared/ipc/` (3,083 lines), `src/shared/IpcChannel.ts`,
+`utils/window.ts`, `utils/command/` — desktop main↔renderer IPC contracts; mobile has no IPC.
+`src/shared` is not coextensive with "shareable".
+
+### `universal` dissolution endpoint
+
+After Waves 1–3, `apps/mobile/packages/universal/` consists of shims plus mobile-only residue.
+Relocate residue into the mobile app tree, delete the husk, retire the name
+`@cherrystudio/universal`.
+
+## Verification (per-domain PR)
+
+```
+pnpm build:check && pnpm test:shared && pnpm test        # desktop: shims keep everything green
+pnpm --filter cherry-studio-app typecheck && pnpm --filter cherry-studio-app test
+```

--- a/mobile-migration-temp/stage-4-enablers.md
+++ b/mobile-migration-temp/stage-4-enablers.md
@@ -1,0 +1,103 @@
+# Stage 4 — Structural Enablers (Prerequisites for Stage 5)
+
+## Objective
+
+Extract the two pieces of infrastructure that Stage 5 tracks depend on: a shared service-lifecycle
+kernel (4a → required by Track A Wave 2 and Track C) and shared database table definitions
+(4b → required by Track C). Neither directly removes business-logic duplication; both unblock the
+tracks that do.
+
+## Preconditions
+
+Stage 1. 4a and 4b are mutually independent.
+
+---
+
+## 4a. `lifecycle-kernel` extraction
+
+### Background (measured)
+
+The mobile codebase is a **port of the desktop lifecycle framework** (mobile's own README:
+"Mobile now runs Desktop's lifecycle framework — container, dependency graph, and phases"). The two
+copies are ~90% API-congruent but textually rewritten almost in full, and — critically —
+`src/main/core` is **not covered by any `desktop-sync-manifest.json` domain**: this fork drifts
+untracked.
+
+| Aspect | Desktop `src/main/core/lifecycle/` | Mobile `apps/mobile/src/backend/core/lifecycle/` |
+|---|---|---|
+| Congruent modules | `ServiceContainer`, `DependencyResolver`, `LifecycleManager`, `BaseService`, `decorators`, `event`, `signal`, `types` | Same module set, same names |
+| Decorator deltas | `@Conditional` (desktop-only) | `@AppStatePolicy` (mobile-only; foreground/background policy metadata) |
+| BaseService deltas | `ipcHandle`/`ipcOn` (Electron IPC binding) | IPC hooks removed (documented in-source: "There is no ipcMain here") |
+| Phase topology | `BeforeReady` / `WhenReady`, anchored to Electron `app` events | `Gate` / `PostReady`, anchored to React mount + startup cover |
+| Host model | `Application` process-lifetime singleton | `ApplicationHost`, replaceable in place (Fast Refresh, per-test generations) |
+
+**Consequent design:** unify the kernel; keep the anchors per-application. The platform-bound
+surface is exactly four things — phase topology, host model, platform hook mixins, and shutdown
+guarantees — none of which live in the container/resolver/scheduler core.
+
+### Procedure
+
+1. **API-level design review (standalone deliverable, one-page decision record committed to this
+   directory).** Compare both implementations module-by-module and fix the convergence direction.
+   Working hypothesis: desktop migrates onto the mobile variant (replaceable host + generation
+   support is a strict superset), but this is to be confirmed by review, not assumed.
+2. Create `packages/lifecycle-kernel/src/` containing the platform-independent core:
+   - `ServiceContainer.ts`, `DependencyResolver.ts`, `event.ts`, `signal.ts`, `types.ts`
+   - `decorators.ts` — `@Injectable`, `@DependsOn`, `@ServicePhase`, `@Priority`,
+     `@ErrorHandling` (excluding `@Conditional` and `@AppStatePolicy`)
+   - `BaseService.ts` — `registerDisposable`, `registerInterval`, `onActivate`/`onDeactivate`,
+     `onStop` only
+   - `LifecycleManager.ts` — **phase list parameterized** (generic/constructor argument; no
+     hard-coded phase enum)
+3. Desktop side thins out (`src/main/core/lifecycle/` becomes shims + extensions):
+   - Retained: `constants.ts` (phase enum), `conditions.ts` (`@Conditional`)
+   - New `DesktopBaseService.ts` extends the kernel BaseService with `ipcHandle`/`ipcOn`
+   - Original module paths re-export kernel + extensions — **all 55 registered services and
+     `serviceRegistry.ts` compile unchanged** (strangler shims; Invariant I2)
+4. Mobile side symmetrically: retains `Gate`/`PostReady`, `@AppStatePolicy`, `ApplicationHost`;
+   original paths shim the kernel.
+5. The shared-service contract (Stage 0e §3–4) becomes operative: four behavioral rules + phase
+   assignment at registration site.
+
+### Verification
+
+Desktop: `pnpm test:main` (lifecycle has its own `__tests__`) + full `pnpm test` + `pnpm dev`
+boot smoke. Mobile: `pnpm --filter cherry-studio-app test` (bootstrap/composition suites cover
+host replacement) + dev-client boot smoke.
+
+---
+
+## 4b. `db-schema`: shared table definitions, per-application migration chains
+
+### Principle
+
+Drizzle table definitions are pure declarations (zero platform dependencies) and can be shared;
+`drizzle-kit generate` derives each application's incremental migrations by diffing the shared
+definitions against that application's own migration snapshot. **Sharing schema definitions and
+keeping migration chains separate are compatible.** The chains are permanently disjoint (measured:
+desktop `0000_orange_jasper_sitwell…` ×9 vs mobile `0000_release_baseline…` ×8, zero shared
+filenames, generated under different drizzle-orm majors) and are never merged.
+
+### Procedure
+
+1. **Convergence survey:**
+   `diff -rq src/main/data/db/schemas/ apps/mobile/src/backend/data/db/schemas/` — classify every
+   table as shape-identical / shape-divergent / single-sided. (The sync-manifest `schema` domain is
+   currently `unbaselined`; this survey is its baseline.)
+2. **Shape convergence:** for divergent tables, each application appends its own forward migration
+   to reach the agreed shape. Repository law applies unchanged on both sides: shipped migrations
+   are never rewritten; conflicts are resolved by regenerate-never-rename.
+3. Create `packages/db-schema/src/`; `git mv` the converged table definitions in. Repoint both
+   drizzle configs — desktop `migrations/sqlite-drizzle.config.ts`, mobile
+   `apps/mobile/drizzle.config.ts` — at the package path. Original schema directories keep shims.
+4. Single-sided tables (desktop v1-migration auxiliaries, mobile-only tables) remain in per-app
+   supplementary schema files; each drizzle config lists package + supplement as multiple schema
+   paths.
+5. CI: both applications' migration checks gate the package — desktop `db:migrations:check`,
+   mobile `db:generate` idempotence (no pending diff). A table-definition change therefore fails
+   CI unless both chains have been regenerated.
+
+### Verification
+
+Both sides: migrate-forward against a populated database copy (already mandated desktop policy);
+`pnpm db:migrations:check`; mobile `db:generate` produces an empty diff.

--- a/mobile-migration-temp/stage-4-enablers.md
+++ b/mobile-migration-temp/stage-4-enablers.md
@@ -9,7 +9,8 @@ tracks that do.
 
 ## Preconditions
 
-Stage 1. 4a and 4b are mutually independent.
+Stage 1. 4a and 4b are mutually independent. Before 4b, both applications must converge on one
+resolved `drizzle-orm` version (see 4b); this is a hard dependency, not an optional cleanup.
 
 ---
 
@@ -76,24 +77,29 @@ Drizzle table definitions are pure declarations (zero platform dependencies) and
 definitions against that application's own migration snapshot. **Sharing schema definitions and
 keeping migration chains separate are compatible.** The chains are permanently disjoint (measured:
 desktop `0000_orange_jasper_sitwell…` ×9 vs mobile `0000_release_baseline…` ×8, zero shared
-filenames, generated under different drizzle-orm majors) and are never merged.
+filenames, generated under different `drizzle-orm` versions) and are never merged.
 
 ### Procedure
 
-1. **Convergence survey:**
+1. **Dependency convergence (hard prerequisite):** desktop currently declares `drizzle-orm`
+   `^0.44.5` while mobile declares `^0.45.2`. A shared schema package cannot expose one set of
+   Drizzle table/query types to consumers resolved against incompatible copies. Align both apps and
+   `packages/db-schema` on one tested version before moving a schema; verify both migration
+   toolchains and populated-database migrate-forward gates after the upgrade.
+2. **Convergence survey:**
    `diff -rq src/main/data/db/schemas/ apps/mobile/src/backend/data/db/schemas/` — classify every
    table as shape-identical / shape-divergent / single-sided. (The sync-manifest `schema` domain is
    currently `unbaselined`; this survey is its baseline.)
-2. **Shape convergence:** for divergent tables, each application appends its own forward migration
+3. **Shape convergence:** for divergent tables, each application appends its own forward migration
    to reach the agreed shape. Repository law applies unchanged on both sides: shipped migrations
    are never rewritten; conflicts are resolved by regenerate-never-rename.
-3. Create `packages/db-schema/src/`; `git mv` the converged table definitions in. Repoint both
+4. Create `packages/db-schema/src/`; `git mv` the converged table definitions in. Repoint both
    drizzle configs — desktop `migrations/sqlite-drizzle.config.ts`, mobile
    `apps/mobile/drizzle.config.ts` — at the package path. Original schema directories keep shims.
-4. Single-sided tables (desktop v1-migration auxiliaries, mobile-only tables) remain in per-app
+5. Single-sided tables (desktop v1-migration auxiliaries, mobile-only tables) remain in per-app
    supplementary schema files; each drizzle config lists package + supplement as multiple schema
    paths.
-5. CI: both applications' migration checks gate the package — desktop `db:migrations:check`,
+6. CI: both applications' migration checks gate the package — desktop `db:migrations:check`,
    mobile `db:generate` idempotence (no pending diff). A table-definition change therefore fails
    CI unless both chains have been regenerated.
 

--- a/mobile-migration-temp/stage-5-track-a-ai-runtime.md
+++ b/mobile-migration-temp/stage-5-track-a-ai-runtime.md
@@ -1,0 +1,104 @@
+# Stage 5 / Track A — AI Runtime Unification (Three Waves)
+
+## Objective
+
+Converge desktop `src/main/ai` (683 files, 162,842 lines) and mobile
+`apps/mobile/packages/ai-runtime` (+ `apps/mobile/src/backend/ai` shell) onto a single shared
+`packages/ai-runtime`. This is the largest unification prize in the repository: 215 files are
+currently maintained as live semantic duplicates (≈35–40k lines).
+
+The cut line already exists: `apps/mobile/packages/ai-runtime/desktop-sync-map.json` is a
+608-entry, file-granular classification produced by the mobile team during their port. This track
+executes along that map rather than re-deriving a decomposition.
+
+## Preconditions
+
+Stage 2b/2c (package dependency chain). Wave 2 additionally requires Stage 4a
+(`lifecycle-kernel`). Stage 3a (`provider-registry`) is *not* a hard prerequisite (Track A consumes
+whichever registry package mobile declares).
+
+## Prerequisite Task: Re-baseline the sync map
+
+The map is pinned to desktop commit `12498d68` and is **stale** — measured: desktop
+`src/main/ai/tokens/` (6 files) has no entries. Before Wave 1:
+
+1. Regenerate/extend the map against the current desktop HEAD (reuse the audit logic in
+   `apps/mobile/scripts/desktopSyncAudit.ts`).
+2. Reinterpret the map as the **package membership registry**:
+   `semantic-port` → shared package; `blocked` → desktop shell (graduates when mobile ships the
+   feature); `explicit-exclusion` → desktop shell permanently.
+
+## Measured Profile (drives the wave partition)
+
+| Directory | Lines | electron / `@application` files | Map (port / blocked / excluded) | Wave |
+|---|---|---|---|---|
+| `provider` | 8,661 | 0 / 4 | **118 / 2 / 0** (98% already ported) | W1 |
+| `types`, `utils`, `tokens`, `messages`, `hooks`, `steerReminder.ts`, `constants.ts` | ≈4,100 | ≈0 | predominantly port | W1 |
+| `streamManager` | 6,242 | 0 / 7 | 4 / 45 / 2 | W2 |
+| `runtime` | 22,639 | 0 / 28 | 30 / 39 / 34 — **three classes interleaved in one directory** | W2 (file-level surgery) |
+| `tools` | 5,250 | 1 / 9 | 22 / 45 / 5 | W2 |
+| `mcp` | 13,105 | 7 / 14 | 2 / 72 / 0 | W3 (catalog/process split) |
+| `channels`, `inference`, `contextBuild`, `observability`, `skills` | ≈15,000 | low | blocked wholesale | W3 (product-driven graduation) |
+| `agents`, `agentSession` | 6,037 | low | explicit-exclusion | **Never** (desktop agents platform) |
+
+Of the 317 `blocked` entries, **315 carry the reason "No mobile implementation or approved semantic
+equivalence mapping exists"** — product lag, not a platform wall. Genuine platform blocks: 2 files
+(Node-native local inference).
+
+## Coupling Disposition (measured `application.get()` histogram over `src/main/ai`)
+
+| Cluster | Members (call counts) | Disposition |
+|---|---|---|
+| 1 — intra-domain DI (~60 calls) | `AiStreamManager`×29, `AgentSessionRuntimeService`×18, `ChannelManager`×7, `AiService`×4 | The AI domain uses the DI container as its own module system. Becomes package-internal imports / kernel registrations (Wave 2; depends on 4a). Not a port surface. |
+| 2 — cross-domain ports (~100 calls) | `CacheService`×28, `McpCatalogService`×21, `PreferenceService`×18, `FileManager`×18, `JobManager`×10, `DbService`×7, `KnowledgeService`×7 | The true injection surface: 7–8 narrow port interfaces, declared in-package per Stage 0e §2; both applications have counterparts. |
+| 3 — desktop-only leaves (~25 calls) | `IpcApiService`×9, `ClaudeCode*`×7, `WindowManager`×2, `BinaryManager`, `PythonService`, `AnalyticsService`, … | All located in `blocked`/`excluded` files. Remain in the desktop shell; no work required. |
+
+Electron symbol surface across the domain: `net`×15 (→ the `fetch` port), plus scattered
+single-digit usages (`app`, `shell`, `session`, `BrowserWindow`) confined to shell-destined files.
+Direct DB access ≈0 (3 files) — the AI domain reads/writes through data services.
+
+## Wave 1 — `provider` + pure modules (≈13k lines, lowest risk)
+
+1. **Convergence direction: desktop adopts the package boundary.** Promote
+   `apps/mobile/packages/ai-runtime` → `packages/ai-runtime` (`git mv` + purity glob), then
+   reconcile desktop `src/main/ai/provider/` against `packages/ai-runtime/src/provider/`
+   file-by-file (118 port entries).
+2. Same wave absorbs: `types/`, `utils/` (23 port files), `tokens/` (6 files; added to the map
+   during re-baseline), `messages/` (5 port files), `hooks/` (2), `steerReminder.ts`,
+   `constants.ts`.
+3. Desktop original paths receive strangler shims (`src/main/ai/provider/… → package re-export`);
+   desktop import sites unchanged (Invariant I2).
+4. Ports: Wave 1 files need only `fetch`, `cache`, `preference` — declared in-package, adapters
+   injected at each application's composition root.
+5. **Boundary discipline takes effect at Wave 1 merge:** new desktop AI code lands either in the
+   package (pure) or in the shell (impure); PR review enforces.
+
+## Wave 2 — `streamManager` / `runtime` / `tools` (file-level surgery)
+
+- Move the `semantic-port` file set **per file, not per directory** (the three classes interleave
+  inside `runtime/`); `blocked`/`excluded` files stay at their desktop paths.
+- Cluster-1 refactor happens here: `AiStreamManager` et al. register with `lifecycle-kernel`; each
+  application assigns phases at its registration site (desktop `WhenReady`, mobile `Gate`).
+- Mobile shell (`apps/mobile/src/backend/ai/{streamManager,runtime,tools}` counterparts) repoints
+  to the package.
+- Largest work item of the track; partition into 3 PRs (`streamManager` → `tools` → `runtime`),
+  each passing both applications' full gates.
+
+## Wave 3 — `mcp` split + long-tail graduation
+
+- `mcp/`: split **catalog** (data/protocol; shareable) from **process runtime** (stdio spawn —
+  a genuine platform wall: iOS cannot spawn subprocesses). Remote/SSE transports enter the
+  package; stdio stays in the desktop shell. Mobile currently has 2 ported files; the split hands
+  it catalog + remote capability wholesale.
+- `channels`, `inference`, `contextBuild`, `observability`, `skills`: graduate directory-by-
+  directory when the mobile roadmap schedules the corresponding feature. **Unscheduled in this
+  playbook.**
+- The 2 Node-native local-inference files remain desktop-shell permanently.
+
+## Verification (every PR)
+
+```
+pnpm test:main && pnpm build:check
+pnpm --filter cherry-studio-app test:ai-runtime && pnpm --filter cherry-studio-app typecheck
+```
+End-to-end smoke on both applications: send a chat message (desktop `pnpm dev`; mobile simulator).

--- a/mobile-migration-temp/stage-5-track-a-ai-runtime.md
+++ b/mobile-migration-temp/stage-5-track-a-ai-runtime.md
@@ -26,7 +26,8 @@ The map is pinned to desktop commit `12498d68` and is **stale** — measured: de
    `apps/mobile/scripts/desktopSyncAudit.ts`).
 2. Reinterpret the map as the **package membership registry**:
    `semantic-port` → shared package; `blocked` → desktop shell (graduates when mobile ships the
-   feature); `explicit-exclusion` → desktop shell permanently.
+   feature); `explicit-exclusion` → excluded from the current package cut and reclassified only by
+   an explicit architecture decision.
 
 ## Measured Profile (drives the wave partition)
 
@@ -39,11 +40,22 @@ The map is pinned to desktop commit `12498d68` and is **stale** — measured: de
 | `tools` | 5,250 | 1 / 9 | 22 / 45 / 5 | W2 |
 | `mcp` | 13,105 | 7 / 14 | 2 / 72 / 0 | W3 (catalog/process split) |
 | `channels`, `inference`, `contextBuild`, `observability`, `skills` | ≈15,000 | low | blocked wholesale | W3 (product-driven graduation) |
-| `agents`, `agentSession` | 6,037 | low | explicit-exclusion | **Never** (desktop agents platform) |
+| `agents`, `agentSession` | 6,037 | low | explicit-exclusion | **Separate scope** (no dependency on #18802) |
 
 Of the 317 `blocked` entries, **315 carry the reason "No mobile implementation or approved semantic
 equivalence mapping exists"** — product lag, not a platform wall. Genuine platform blocks: 2 files
 (Node-native local inference).
+
+### Non-dependency with the Agent protocol
+
+[#18802](https://github.com/CherryHQ/cherry-studio/issues/18802) is an independent architecture
+initiative, not a migration stage, prerequisite, or residual item. It may proceed before, during, or
+after this track; Track A must not postpone protocol work, and protocol work does not block the
+measured runtime-package moves here.
+
+Independently of that schedule, keep `src/main/ai/runtime/pi` platform-pure: no Electron or Node-only
+API may enter the runtime core. Filesystem, process, network, and secret access stay behind injected
+ports so mobile Pi support does not require a later rewrite.
 
 ## Coupling Disposition (measured `application.get()` histogram over `src/main/ai`)
 

--- a/mobile-migration-temp/stage-5-track-b-services.md
+++ b/mobile-migration-temp/stage-5-track-b-services.md
@@ -3,14 +3,14 @@
 ## Objective
 
 Split the business logic out of desktop's `src/main/services` where a mobile counterpart proves
-demand, using the measured Electron symbol imports as the port inventory. Governing rule:
+demand, using the measured Electron **and Node-builtin** imports as the port inventory. Governing rule:
 **decompose a service only when unifying it** — no speculative pre-splitting.
 
 ## Preconditions
 
 Stage 1. Independent of Stages 3–4 (oauth and webSearch can start immediately after landing).
 
-## Classification (measured: 40 top-level files + 20 subdirectories; per-file Electron symbol extraction)
+## Classification (measured: 40 top-level files + 20 subdirectories; per-file platform-import extraction)
 
 ### Bucket A — platform-intrinsic; never split; desktop-permanent
 
@@ -25,15 +25,15 @@ native), `protocol/`, `mediaProtocol/`, `menu/`.
 
 Priority-ordered by proven mobile demand:
 
-| # | Service | Size | Electron surface (= port inventory) | Mobile counterpart (evidence) |
+| # | Service | Size | Platform surface (= port inventory) | Mobile counterpart (evidence) |
 |---|---|---|---|---|
-| 1 | `oauth/` | 1,670 lines / 5 electron files | `net` (+ `safeStorage` via Copilot) | **Delegated sync map exists** (`apps/mobile/src/backend/services/oauth/desktop-sync-map.json`) — manual synchronization is ongoing; decomposition stops active bleeding |
+| 1 | `oauth/` | 1,670 lines / 5 Electron files | Electron `net`; Node `crypto`, `http` (+ `safeStorage` via Copilot) | **Delegated sync map exists** (`apps/mobile/src/backend/services/oauth/desktop-sync-map.json`) — manual synchronization is ongoing; decomposition stops active bleeding |
 | 2 | `webSearch/` | 2,739 lines / 9 electron files | predominantly `net` | Mobile rewrite: 37 files (`apps/mobile/src/backend/services/webSearch/`) |
-| 3 | `CopilotService.ts` | 328 lines | `net`, `safeStorage` | Ported (`CopilotOAuthAdapter`: "adapted to Expo fetch and SQLite-backed auth config") |
-| 4 | `FileStorage.ts` | 1,119 lines | `dialog`, `net`, `shell` | Mobile `services/file/` (549 lines) |
-| 5 | `ExportService.ts` | 403 lines | `dialog` only (one save dialog) | — |
+| 3 | `CopilotService.ts` | 328 lines | Electron `net`, `safeStorage`; Node `fs`, `path` | Ported (`CopilotOAuthAdapter`: "adapted to Expo fetch and SQLite-backed auth config") |
+| 4 | `FileStorage.ts` | 1,119 lines | Electron `dialog`, `net`, `shell`; Node `crypto`, `fs`, `path` | Mobile `services/file/` (549 lines) |
+| 5 | `ExportService.ts` | 403 lines | Electron `dialog`; Node `fs` | — |
 | 6 | `TopicNamingService.ts` | 460 lines | none | Equivalent logic in mobile streamManager |
-| 7+ | `translate/` (183), `readableContent/` (290), `S3Storage` (201), `WebDav` (157), `ObsidianVaultService` (224), `VertexAiService` (173), `RegionService` (93), `CitationPreviewService` (255), `codeCli/` (1,214) | zero Electron imports or `net` only | partial mobile counterparts |
+| 7+ | `translate/` (183), `readableContent/` (290), `S3Storage` (201), `WebDav` (157), `ObsidianVaultService` (224), `VertexAiService` (173), `RegionService` (93), `CitationPreviewService` (255), `codeCli/` (1,214) | Electron usage is low, but Node surfaces remain: `net`/`stream` (S3), `https`/`path`/`stream` (WebDAV), `fs`/`path` (Obsidian), `fs`/`path`/`child_process`/`util` (codeCli) | partial mobile counterparts |
 
 ### Bucket C — desktop-only business; untouched
 
@@ -44,15 +44,22 @@ Priority-ordered by proven mobile demand:
 Note: `lanTransfer/` (1,492 lines) is the **desktop half of phone-to-desktop transfer**; its
 protocol layer becomes a sharing candidate if that feature is reworked — ledger entry, unscheduled.
 
-## Decomposition Rule: Electron Symbol → Port Mapping
+An Electron-only histogram is therefore a lower bound, not a portability estimate. Re-run both the
+Electron import scan and the Stage 0d Node-builtin scan before sizing each service.
 
-| Electron symbol | Disposition | Desktop adapter | Mobile adapter |
+## Decomposition Rule: Platform API → Port Mapping
+
+| Platform API | Disposition | Desktop adapter | Mobile adapter |
 |---|---|---|---|
 | `net` (fetch) | Port: injected `fetch` | `net.fetch` (proxy-wired) | Expo fetch |
 | `safeStorage` | Port: `SecretStore` | safeStorage | expo SecureStore |
 | `app.getPath` | Injected paths (desktop already centralizes via `application.getPath`) | paths subsystem | expo-file-system directories |
 | `shell.openExternal` | Port: `openUrl` | shell | RN Linking |
 | `dialog` | **Not a port — stays in the shell.** The core returns data; asking the user where to put it is shell responsibility | dialog | RN share sheet / picker |
+| `fs`, `path` | File operations stay behind a narrow file/path port; do not pass Node path semantics into the core | Node fs + paths subsystem | expo-file-system |
+| `crypto` | Prefer platform Web Crypto where the required primitive exists; otherwise inject the exact random/hash operation | Node crypto | Expo/Web Crypto adapter |
+| `http`, `https`, `net`, `stream` | Use the injected fetch/transport contract when semantically HTTP; raw sockets and Node streams stay in a platform shell | Node/Electron transport | fetch/native transport when supported |
+| `child_process`, `os` | Process execution stays desktop-only; expose only a capability-specific port when mobile has a real counterpart | Node process/OS adapter | no adapter unless the capability exists |
 
 Decomposition artifact shape: core logic → `packages/<domain>/` (content-domain name per Stage 0e,
 e.g. `packages/oauth-flows/`); desktop shell remains in `src/main/services/` (IpcApi binding,
@@ -64,8 +71,9 @@ dialogs, lifecycle registration); mobile shell remains in `apps/mobile/src/backe
    classifications are the cut list (the mobile team already performed the analysis:
    `PkceSessionOAuthAdapter`, `CopilotOAuthAdapter`, `PpioOAuthAdapter`,
    `WebviewApiKeyOAuthAdapter`, `BlockedOAuthAdapter`).
-2. For each of the 5 Electron-importing files in desktop `src/main/services/oauth/`, apply the
-   symbol→port mapping to separate shell from core.
+2. Inventory every Electron and Node-builtin import in desktop `src/main/services/oauth/` (starting
+   with the 5 Electron-importing files plus the `crypto`/`http` users), then apply the platform-port
+   mapping to separate shell from core.
 3. Core into `packages/oauth-flows/src/`: device-code flow, PKCE session management, token
    exchange, account lookup — pure protocol logic over two ports (`fetch`, `SecretStore`).
 4. Each application's shell injects its adapters. Decommission mobile's

--- a/mobile-migration-temp/stage-5-track-b-services.md
+++ b/mobile-migration-temp/stage-5-track-b-services.md
@@ -1,0 +1,82 @@
+# Stage 5 / Track B — `src/main/services` Decomposition (Ports-and-Adapters)
+
+## Objective
+
+Split the business logic out of desktop's `src/main/services` where a mobile counterpart proves
+demand, using the measured Electron symbol imports as the port inventory. Governing rule:
+**decompose a service only when unifying it** — no speculative pre-splitting.
+
+## Preconditions
+
+Stage 1. Independent of Stages 3–4 (oauth and webSearch can start immediately after landing).
+
+## Classification (measured: 40 top-level files + 20 subdirectories; per-file Electron symbol extraction)
+
+### Bucket A — platform-intrinsic; never split; desktop-permanent
+
+Electron *is* the service; removing it leaves no residue:
+`TrayService` (Tray/Menu/nativeImage), `AppMenuService`, `ContextMenu`, `nativePopupMenu`,
+`ShortcutService` (globalShortcut), `MainWindowService`, `SubWindowService`,
+`QuickAssistantService` (BrowserWindow/screen), `PrintService`, `WebviewService`, `ThemeService`
+(nativeTheme), `NotificationService` (23-line shim), `screenshot/`, `selection/` (selection-hook
+native), `protocol/`, `mediaProtocol/`, `menu/`.
+
+### Bucket B — business skeleton with a thin Electron shell; the decomposition targets
+
+Priority-ordered by proven mobile demand:
+
+| # | Service | Size | Electron surface (= port inventory) | Mobile counterpart (evidence) |
+|---|---|---|---|---|
+| 1 | `oauth/` | 1,670 lines / 5 electron files | `net` (+ `safeStorage` via Copilot) | **Delegated sync map exists** (`apps/mobile/src/backend/services/oauth/desktop-sync-map.json`) — manual synchronization is ongoing; decomposition stops active bleeding |
+| 2 | `webSearch/` | 2,739 lines / 9 electron files | predominantly `net` | Mobile rewrite: 37 files (`apps/mobile/src/backend/services/webSearch/`) |
+| 3 | `CopilotService.ts` | 328 lines | `net`, `safeStorage` | Ported (`CopilotOAuthAdapter`: "adapted to Expo fetch and SQLite-backed auth config") |
+| 4 | `FileStorage.ts` | 1,119 lines | `dialog`, `net`, `shell` | Mobile `services/file/` (549 lines) |
+| 5 | `ExportService.ts` | 403 lines | `dialog` only (one save dialog) | — |
+| 6 | `TopicNamingService.ts` | 460 lines | none | Equivalent logic in mobile streamManager |
+| 7+ | `translate/` (183), `readableContent/` (290), `S3Storage` (201), `WebDav` (157), `ObsidianVaultService` (224), `VertexAiService` (173), `RegionService` (93), `CitationPreviewService` (255), `codeCli/` (1,214) | zero Electron imports or `net` only | partial mobile counterparts |
+
+### Bucket C — desktop-only business; untouched
+
+`BinaryManager` (2,030), `LegacyBackupManager` (2,125), `OvmsManager`, `PythonService`,
+`localModel/`, `cacheCleanup/`, `diagnostics/`, `userDataRelocation/`, `proxy/`, `nutstore/`,
+`mainNetworkDevtools/`, `deepSeekHarness/`, `AutoBackupService`, `AppUpdaterService`,
+`VersionService`, `AnalyticsService`, `dataReset`.
+Note: `lanTransfer/` (1,492 lines) is the **desktop half of phone-to-desktop transfer**; its
+protocol layer becomes a sharing candidate if that feature is reworked — ledger entry, unscheduled.
+
+## Decomposition Rule: Electron Symbol → Port Mapping
+
+| Electron symbol | Disposition | Desktop adapter | Mobile adapter |
+|---|---|---|---|
+| `net` (fetch) | Port: injected `fetch` | `net.fetch` (proxy-wired) | Expo fetch |
+| `safeStorage` | Port: `SecretStore` | safeStorage | expo SecureStore |
+| `app.getPath` | Injected paths (desktop already centralizes via `application.getPath`) | paths subsystem | expo-file-system directories |
+| `shell.openExternal` | Port: `openUrl` | shell | RN Linking |
+| `dialog` | **Not a port — stays in the shell.** The core returns data; asking the user where to put it is shell responsibility | dialog | RN share sheet / picker |
+
+Decomposition artifact shape: core logic → `packages/<domain>/` (content-domain name per Stage 0e,
+e.g. `packages/oauth-flows/`); desktop shell remains in `src/main/services/` (IpcApi binding,
+dialogs, lifecycle registration); mobile shell remains in `apps/mobile/src/backend/services/`.
+
+## First Cut: oauth (execution template; subsequent services replicate)
+
+1. Read `apps/mobile/src/backend/services/oauth/desktop-sync-map.json`; its per-file
+   classifications are the cut list (the mobile team already performed the analysis:
+   `PkceSessionOAuthAdapter`, `CopilotOAuthAdapter`, `PpioOAuthAdapter`,
+   `WebviewApiKeyOAuthAdapter`, `BlockedOAuthAdapter`).
+2. For each of the 5 Electron-importing files in desktop `src/main/services/oauth/`, apply the
+   symbol→port mapping to separate shell from core.
+3. Core into `packages/oauth-flows/src/`: device-code flow, PKCE session management, token
+   exchange, account lookup — pure protocol logic over two ports (`fetch`, `SecretStore`).
+4. Each application's shell injects its adapters. Decommission mobile's
+   `oauth:desktop-sync:check` script and the oauth `desktop-sync-map.json`.
+5. End-to-end smoke: complete the GitHub Copilot device-code flow on both applications.
+
+## Verification (per-service PR)
+
+```
+pnpm test:main && pnpm build:check
+pnpm --filter cherry-studio-app test && pnpm --filter cherry-studio-app typecheck
+```
+Plus a functional smoke of the decomposed capability on both applications (one OAuth login / one
+web search / one export, as applicable).

--- a/mobile-migration-temp/stage-5-track-c-data-services.md
+++ b/mobile-migration-temp/stage-5-track-c-data-services.md
@@ -1,0 +1,80 @@
+# Stage 5 / Track C — Data Services: Business-Rule Layer Extraction
+
+## Objective
+
+Deduplicate the 30 same-name data services by extracting their platform-independent business rules
+into shared pure modules, while retaining per-application execution shells that own the
+synchronous/asynchronous divide.
+
+## Preconditions
+
+**Stage 4b (`db-schema`) is a hard prerequisite** — service-layer sharing presupposes shared table
+definitions. Stage 4a (`lifecycle-kernel`) provides the registration host.
+
+## Measured State
+
+- Desktop `src/main/data/services/`: 35 files (33 services + `dataServiceRegistry.ts` + `utils/`),
+  **all with zero Electron imports** — coupling is exclusively `@application` (DI) and Drizzle.
+- Mobile `apps/mobile/src/backend/data/services/`: **30 services re-implemented under identical
+  class names** (`AgentChannel`, `AgentGlobalSkill`, `Agent`, `AgentSessionMessage`,
+  `AgentSession`, `AgentTask`, `AgentWorkspace`, `AiUsageRecord`, `Assistant`, `ContentSearch`,
+  `EntitySearch`, `FileEntry`, `FileRef`, `Group`, `Job`, `KnowledgeBase`, `KnowledgeItem`,
+  `McpServer`, `Message`, `MiniApp`, `Model`, `Note`, `Painting`, `Pin`, `Prompt`,
+  `ProviderRegistry`, `Provider`, `Tag`, `TemporaryChat`, `Topic`, `TranslateHistory`,
+  `TranslateLanguage`).
+- Desktop-only: `AgentChannelWorkflowService`, `JobScheduleService`.
+- **The structural wall (sampled on `TagService`):** desktop 480 lines / `async` count 0
+  (better-sqlite3 is synchronous; `withWriteTx` requires a synchronous callback holding
+  `BEGIN IMMEDIATE`); mobile 365 lines / `async` count 39 (expo-sqlite is asynchronous). Textual
+  diff 611 lines, dominated by the sync/async transform plus schema drift.
+
+**Conclusion:** whole-service unification is not directly achievable — the synchronous/asynchronous
+execution models cannot be papered over by an interface. The shareable stratum is the business-rule
+layer.
+
+## Target Shape
+
+```
+packages/<domain>-rules/            # or folded into data-contract; decide by volume at execution
+  Pure functions: validation, default resolution, ordering rules, query shapes
+  (Drizzle query-builder fragments), entity state machines (e.g. message status
+  transitions), error taxonomy.
+  Dependencies: packages/db-schema (table definitions), data-contract (types). Zero I/O.
+
+Per-application thin execution shells:
+  desktop  src/main/data/services/XxxService.ts        — synchronous shell, withWriteTx
+  mobile   apps/mobile/src/backend/data/services/…     — asynchronous shell, await tx
+```
+
+Rule modules return Drizzle expressions/query shapes; execution (sync vs async) belongs to the
+shells.
+
+## Execution Order
+
+1. **Shape validation on the smallest pair:** `TagService` (480↔365) or `PromptService`
+   (desktop coupling: el=0 / app=2 / db=2; measured diff 209 lines). Deliver the first `-rules`
+   module + both rewritten shells; both applications' suites green → shape confirmed before
+   batching.
+2. **Batch order by ascending desktop coupling** (`@application` / db reference counts):
+   `PinService` (2/2) → `TemporaryChatService` (2/2) → `GroupService` (2/2) → `NoteService` (2/5)
+   → … → the heavyweights last: `MessageService` (26/28), `AgentSessionService` (18/18),
+   `ProviderService` (18/17), `TopicService` (17/18).
+3. One service per PR. Gate: CRUD contract tests on both shells against real databases (desktop:
+   `setupTestDatabase()` from `@test-helpers/db`; mobile: its existing DB test rig). Repository
+   testing law applies: assert contracts, no behavior-pinning tests.
+4. Untouched: the two desktop-only services and both `dataServiceRegistry` implementations.
+
+## On Further Unifying the Execution Shells
+
+**Deliberately undecided.** After the rule layer lands across the batch, re-evaluate: if the shells
+have become mechanical boilerplate, a desktop transaction-model redesign (heavy, separately
+chartered) could merge them; if shell maintenance cost is negligible, dual shells are the terminal
+state.
+
+## Verification (per-service PR)
+
+```
+pnpm test:main                                   # desktop data-service suites (setupTestDatabase)
+pnpm --filter cherry-studio-app test
+```
+Sync-manifest domains `data-main` / `data-renderer` shed entries as the batch progresses.

--- a/mobile-migration-temp/stage-5-track-d-ui.md
+++ b/mobile-migration-temp/stage-5-track-d-ui.md
@@ -1,0 +1,89 @@
+# Stage 5 / Track D — Universal UI Package (Narrowed Dual-Implementation Strategy)
+
+## Objective
+
+Establish a single UI package exposing one component API with platform-forked implementations
+(web: Radix/Base UI; native: rn-primitives), seeded from the measured component intersection,
+under an explicit dual-birth discipline for new design-system primitives. Existing single-platform
+components are not migrated.
+
+## Preconditions
+
+Stage 2a (design-tokens promoted — the shared token source both implementations consume).
+Fully independent of Tracks A–C.
+
+## Measured Constraints (design rationale)
+
+- **Component vocabulary overlap: 6 of 91.** Desktop `packages/ui`: 76 components
+  (pointer-idiom vocabulary — `dialog`, `context-menu`, `hover-card`, `combobox`, `data-table`,
+  `resizable`, …). Mobile `ui-native`: 21 components (touch-idiom vocabulary — `bottom-sheet`,
+  `composer`, `scroll-shadow`, `shimmer-text`, …). Intersection: `alert`, `button`, `input`,
+  `slider`, `switch`, `tabs`. Merging the two existing packages wholesale would therefore unify
+  nothing for 85 components while coupling two design systems.
+- **`ui-native` is not a pure-JS package.** It vendors native build artifacts:
+  `CherryStudioUI.podspec`, `ios/HybridCherryMenuView.swift`, `android/.../cpp-adapter.cpp` +
+  Kotlin sources, `nitrogen/generated/` (Nitro codegen). These require pod/gradle toolchains and
+  Expo autolinking.
+- **Resolution isolation is sound** (validated): Metro honors the `"react-native"` export
+  condition and `.native.tsx` platform extensions; Vite resolves `default`/`import`; under a
+  single lockfile the install surface is workspace-wide regardless of package layout;
+  electron-builder packages the Vite bundle output and never touches podspecs. Cross-bundler
+  leakage is not a blocker.
+- **Radix/Base UI are DOM libraries.** Their "mobile support" means mobile *browsers* (touch
+  events, responsive layout over `document`/`HTMLElement`), not React Native. The mobile app
+  renders natively (Fabric/Nitro, Skia, Reanimated worklets) with no DOM. API-shape parity on RN
+  is obtained through the `rn-primitives` ecosystem, which mirrors Radix component APIs over RN
+  primitives — one contract, two implementations remains the irreducible cost.
+
+## Package Topology
+
+```
+packages/ui-universal/                    # new dual-implementation package
+  src/button/
+    button.tsx                            # web implementation (Radix / Base UI)
+    button.native.tsx                     # RN implementation (rn-primitives)
+    button.shared.ts                      # platform-free: props contract, variants (cva), token mapping
+    __tests__/                            # contract tests, executed per platform
+  src/index.ts / src/index.native.ts
+  package.json:
+    exports: { ".": { "types": …, "react-native": "./src/index.native.ts", "default": "./src/index.ts" } }
+
+apps/mobile/packages/ui-nitro/            # native-module stratum extracted from ui-native
+  CherryStudioUI.podspec, ios/, android/, nitrogen/, TS bindings
+  (hybrid native views have no web counterpart; excluded from the universal package by construction)
+```
+
+- `apps/mobile/tsconfig.json`: set `"customConditions": ["react-native"]` so the mobile type
+  graph resolves RN typings instead of DOM typings.
+- Lint (extends Stage 0d): within `ui-universal`, `.tsx` files may not import RN modules;
+  `.native.tsx` files may not import DOM/Radix modules; `.shared.ts` may import neither.
+
+## Procedure
+
+1. **Extract `ui-nitro`.** Move `apps/mobile/packages/ui/{ios,android,nitrogen,CherryStudioUI.podspec}`
+   plus their TS bindings into `apps/mobile/packages/ui-nitro/`; `ui-native` depends on it.
+   Verify Expo autolinking discovers the relocated module (pod install + android build).
+2. **Seed migration — 6 components, one PR each:**
+   `alert` → `button` → `input` → `switch` → `tabs` → `slider`.
+   - Web implementation lifted from `packages/ui/src/components/primitives/<name>.tsx`,
+     preserving the desktop-facing props contract.
+   - Native implementation lifted from `apps/mobile/packages/ui/src/components/<name>/`, API
+     aligned to the shared contract (web contract is the baseline; touch-specific divergence is
+     encapsulated inside `.native.tsx`).
+   - Original locations re-export from `ui-universal` (both `packages/ui` and `ui-native`) —
+     **zero import churn for either application's consumers** (Invariant I2 applied to UI).
+3. **Dual-birth discipline (effective at first seed merge):** every new **design-system-level
+   primitive** ships `.tsx` + `.native.tsx` + `.shared.ts` in the same PR. Page-level composites
+   are exempt. The 85 existing single-platform components are not migrated.
+4. **Quarterly review:** after one quarter, evaluate the sustained cost of the dual-birth
+   discipline (velocity coupling to the slower platform is its real price — an organizational
+   commitment, not a build-system property). Decide expansion, steady-state, or rollback of scope.
+
+## Verification (per-component PR)
+
+```
+pnpm test:pkg:ui                                  # desktop ui project (green through re-exports)
+pnpm --filter cherry-studio-app test              # mobile (Jest, RN rendering)
+```
+Storybook on both sides (desktop `packages/ui` Storybook; mobile `.rnstorybook`) renders the
+component; visual token parity verified against the shared `design-tokens` source.

--- a/mobile-migration-temp/stage-5-track-d-ui.md
+++ b/mobile-migration-temp/stage-5-track-d-ui.md
@@ -1,4 +1,4 @@
-# Stage 5 / Track D — Universal UI Package (Narrowed Dual-Implementation Strategy)
+# Stage 5 / Track D — Cross-Platform UI Primitives (Narrowed Dual-Implementation Strategy)
 
 ## Objective
 
@@ -38,7 +38,7 @@ Fully independent of Tracks A–C.
 ## Package Topology
 
 ```
-packages/ui-universal/                    # new dual-implementation package
+packages/ui-primitives/                   # new dual-implementation package
   src/button/
     button.tsx                            # web implementation (Radix / Base UI)
     button.native.tsx                     # RN implementation (rn-primitives)
@@ -55,7 +55,7 @@ apps/mobile/packages/ui-nitro/            # native-module stratum extracted from
 
 - `apps/mobile/tsconfig.json`: set `"customConditions": ["react-native"]` so the mobile type
   graph resolves RN typings instead of DOM typings.
-- Lint (extends Stage 0d): within `ui-universal`, `.tsx` files may not import RN modules;
+- Lint (extends Stage 0d): within `ui-primitives`, `.tsx` files may not import RN modules;
   `.native.tsx` files may not import DOM/Radix modules; `.shared.ts` may import neither.
 
 ## Procedure
@@ -70,7 +70,7 @@ apps/mobile/packages/ui-nitro/            # native-module stratum extracted from
    - Native implementation lifted from `apps/mobile/packages/ui/src/components/<name>/`, API
      aligned to the shared contract (web contract is the baseline; touch-specific divergence is
      encapsulated inside `.native.tsx`).
-   - Original locations re-export from `ui-universal` (both `packages/ui` and `ui-native`) —
+   - Original locations re-export from `ui-primitives` (both `packages/ui` and `ui-native`) —
      **zero import churn for either application's consumers** (Invariant I2 applied to UI).
 3. **Dual-birth discipline (effective at first seed merge):** every new **design-system-level
    primitive** ships `.tsx` + `.native.tsx` + `.shared.ts` in the same PR. Page-level composites

--- a/mobile-migration-temp/stage-6-finish.md
+++ b/mobile-migration-temp/stage-6-finish.md
@@ -1,0 +1,55 @@
+# Stage 6 — Completion (Trigger-Based; Unscheduled)
+
+## Desktop Relocation: root → `apps/desktop/`
+
+**Trigger condition** (maintainer judgment; either suffices): active branch/worktree count drops to
+a coordinable window, or a post-release lull. Symmetry is deferred deliberately — it is an
+aesthetic property with real migration cost against ~110 in-flight branches (Invariant I6).
+
+Executed as a single mechanical commit:
+
+- `git mv` desktop-owned root entries → `apps/desktop/`: `src/`, `migrations/`,
+  `electron.vite.config.ts`, `tsconfig*.json`, desktop build/packaging config.
+- Root `package.json` becomes a pure workspace orchestrator (script forwarding); the desktop
+  application manifest moves to `apps/desktop/package.json`.
+- Desktop-only packages (`ui`, `dsh-bridge`, `extension-table-plus`, `mcp-trace`) →
+  `apps/desktop/packages/`; from this point root `packages/` contains shared-tier packages only,
+  and the transitional co-location noted in the README ends.
+- Git rename detection resolves most rebases of in-flight branches automatically; execution still
+  requires an all-hands announcement and a low-activity window.
+
+## Exit Criteria (all must hold — monorepo migration is complete)
+
+```bash
+grep -r "@cherrystudio/mobile-" --include='*.ts*' apps/ | wc -l        # == 0  (debt prefixes cleared)
+grep -rl "export \* from '@cherrystudio/" src/shared | wc -l           # == 0  (strangler shims amortized)
+test ! -f apps/mobile/desktop-sync-manifest.json                       # manifest retired
+```
+
+## Decommissioning Ledger (items retire as stages progress; consolidated here for final audit)
+
+| Artifact / mechanism | Retirement point |
+|---|---|
+| `apps/mobile/desktop-sync-manifest.json` | Domain entries cleared per unification; file deleted when empty |
+| `apps/mobile/scripts/desktopSyncAudit.ts` + `desktop:sync:audit` script | With manifest deletion |
+| `apps/mobile/scripts/oauthDesktopSyncAudit.ts` + oauth `desktop-sync-map.json` | Track B first cut (oauth) completion |
+| `packages/design-tokens/scripts/sync-desktop.ts` + `src/sync-manifest.json` | Stage 2a desktop adoption completion |
+| `apps/mobile/packages/ai-runtime/desktop-sync-map.json` | After Track A Wave 3 (retained meanwhile as the package membership registry) |
+| Mobile `port-bot.yml` workflow | Stage 1b-6 (already decommissioned at landing) |
+| `sync-cherry-desktop` agent skill (mobile `.agents`) | With manifest deletion |
+| Origin repository `cherry-studio-app` | Frozen and archived at Stage 1 cutover (not deleted; historical `v0.x` tags remain resolvable there) |
+| This directory (`mobile-migration-temp/`) | When all exit criteria hold |
+
+## Residual Ledger (recorded, deliberately unscheduled)
+
+- AI directories `channels`, `inference`, `contextBuild`, `observability`, `skills`: graduate via
+  Track A Wave 3 procedure when the mobile roadmap schedules each feature.
+- `lanTransfer/` protocol-layer sharing (Track B, Bucket C note).
+- Data-service execution-shell unification (Track C terminal evaluation).
+- Disposition of the 85 single-platform UI components (Track D quarterly review).
+- Desktop `packages/aiCore` directory rename → `ai-core` (kebab-case conformance; piggyback on the
+  Stage 6 relocation commit).
+- File-processing orchestration sharing: cloud processors (`doc2x`, `mineru`, `openMineru`,
+  `mistral`, paddleocr-API, `ovocr`) are pure HTTP and directly shareable; local leaves stay
+  per-platform (desktop Node libraries vs mobile `modules/pdf-text-extractor` native module);
+  measured port surface: 2 methods (`extractText`, file read).


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: The mobile client lives in a separate repository (`cherry-studio-app`) and duplicated business logic is kept in sync manually via `desktop-sync-manifest.json` (13 sync domains; measured live duplication includes an 11,107-line drift in `provider-registry`, 13,867 lines in the shared data layer, 30 data services re-implemented under identical class names, and 215 AI-runtime files maintained as semantic ports). There is no written plan for absorbing the mobile repository.

After this PR: `mobile-migration-temp/` contains an 11-document, file-precise execution runbook for the staged monorepo migration: subtree landing under `apps/mobile/`, single-workspace integration (lockfile, patch reconciliation, collision renames, CI split), and incremental unification tracks (packages, `src/shared` strangler extraction, lifecycle kernel, DB schema, AI runtime, services, data services, UI). Documentation only — no code, configuration, or build behavior changes.

Fixes #

### Why we need it and why it was done in this way

The migration must not disrupt desktop development (~110 active worktrees/branches at time of writing), so the runbook is built around explicit non-disruption invariants: mobile lands under `apps/mobile/` while the desktop tree stays at the repository root; desktop import specifiers are preserved via strangler-fig re-export shims; package-name collisions are resolved on the mobile side only; every stage is an independently mergeable, revertible PR gated on the full desktop CI.

The following tradeoffs were made:

- Asymmetric layout (desktop at root, mobile under `apps/`) over an immediate symmetric `apps/desktop` + `apps/mobile` restructure — symmetry would conflict with every in-flight branch; it is deferred to a trigger-based final stage.
- `git subtree` over submodules or history rewriting — preserves the full 1,978-commit mobile history in one revertible merge commit while removing the cross-repository boundary.
- Per-domain incremental unification over a big-bang merge — each stage is independently pausable; at any pause point the repository remains "desktop unimpaired + mobile buildable".

The following alternatives were considered:

- Keeping two repositories with improved sync tooling — rejected: the sync manifest already shows 7 `unbaselined` and 1 `blocked` domain; manual synchronization does not converge.
- A single universal `Platform` service abstraction — rejected in favor of consumer-defined narrow ports (documented in the runbook's shared-package conventions).

Links to places where the discussion took place: N/A

### Breaking changes

None. Documentation only.

### Special notes for your reviewer

- All quantitative claims in the runbook (diff line counts, coupling histograms, file inventories) were measured on 2026-08-18 against desktop `9754c9267e` × mobile `3707410b` (`origin/v0.2` HEAD); staleness-sensitive figures are marked ⟳ for re-measurement at execution time.
- The directory is intentionally named `mobile-migration-temp/` (mirroring `v2-refactor-temp/`) and is deleted when the exit criteria in `stage-6-finish.md` hold.
- Draft on purpose: this PR is the review vehicle for the migration plan itself; stage execution PRs will follow separately.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
