### PR TITLE
docs(claude-md): scope pre-commit checks to the change at hand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ logger.error("message", error);
 
 - All user-visible strings must use `i18next` — never hardcode UI strings
 - Locale catalogs live in `src/renderer/i18n/locales/` and `src/main/i18n/locales/`; both use `en-us.json` as the source of truth
-- Only when you add or change a key: edit `en-us.json`, run `pnpm i18n:sync` (fills the other locales with `[to be translated]:` placeholders), then replace every placeholder with a real translation — `i18n:check` only verifies key structure/sort, so leftover placeholders pass the gate but must never reach a PR. No separate `pnpm i18n:check` run needed; `pnpm lint` already includes it.
+- Only when you add or change a key: edit `en-us.json`, run `pnpm i18n:sync` (fills the other locales with `[to be translated]:` placeholders), then translate every one. No separate `pnpm i18n:check` run needed — `pnpm lint` includes it, and it rejects leftover placeholders as well as empty values, interpolation/tag mismatches, and unsorted keys.
 
 ### UI Design
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Project-specific tools, paths, and conventions.
 - **Build with Tailwind CSS & Shadcn UI**: Use components from `@cherrystudio/ui` (located in `packages/ui`, Shadcn UI + Tailwind CSS) for every new UI component.
 - **Log centrally**: Route all logging through `loggerService` with the right context—no `console.log`.
 - **Access paths centrally**: Use `application.getPath('namespace.key', filename?)` for all main-process filesystem paths—never call `app.getPath()`, `os.homedir()`, or construct paths ad-hoc. Import the singleton via `import { application } from '@application'`.
-- **Lint, test, and format before completion**: Coding tasks are only complete after running `pnpm lint`, `pnpm test`, and `pnpm format` successfully.
+- **Check what you changed, not the whole repo**: for code, run `pnpm lint` (it covers format + typecheck + `i18n:check`) plus the tests covering your change — `pnpm test <path>` for a few files, full `pnpm test` only when the change is broad or you can't name the affected tests. Docs/markdown-only edits need just `pnpm docs:check-links`. CI runs the full gate; your job is to not obviously break it.
 - **Write conventional commits**: Commit small, focused changes using Conventional Commit messages (e.g., `feat(data-api):`, `fix(lifecycle):`, `refactor(quick-assistant):`, `docs(testing):`, `chore(deps):`, `test(window-manager):`). Scope must be a specific kebab-case module, never generic like `main` — when `git log` conflicts with this rule, this rule wins.
 - **Sign commits and sign off**: Every commit must be both cryptographically signed and DCO-signed off. Use `git commit -S --signoff` (not `--signoff` alone), verify the commit object contains a `gpgsig` header with `git cat-file commit HEAD`, and verify the pushed PR commits show `Verified` on GitHub.
 - **Target the right branch**: `main` is the default branch for all active development — submit features, refactors, optimizations, and fixes here.
@@ -68,7 +68,8 @@ Run `pnpm install` first (Node and pnpm versions are pinned in `package.json` �
 - `pnpm lint` — oxlint + eslint fix + typecheck + i18n check + format (writes files)
 - `pnpm test` — run all Vitest tests
 - `pnpm format` — Biome format + lint (write mode)
-- `pnpm build:check` — **REQUIRED before commits**. If it fails on i18n sort, run `pnpm i18n:sync` first; on formatting, run `pnpm format` first; on broken doc links, fix the link.
+- `pnpm docs:check-links` — doc link checker; the only thing `build:check` adds over `lint` + `test`. Run it for docs/markdown edits instead of the full gate.
+- `pnpm build:check` — `lint` + `docs:check-links` + full `test`, i.e. the whole gate in one command. Worth it for broad or risky changes; for anything narrower run the piece that matters. If it fails on i18n sort, run `pnpm i18n:sync` first; on formatting, run `pnpm format` first; on broken doc links, fix the link.
 - `pnpm test:lint` — the CI-equivalent lint gate: it denies oxlint warnings that `pnpm lint` / `pnpm build:check` silently tolerate; run it when CI must pass.
 
 ### Testing
@@ -126,7 +127,7 @@ logger.error("message", error);
 
 - All user-visible strings must use `i18next` — never hardcode UI strings
 - Locale catalogs live in `src/renderer/i18n/locales/` and `src/main/i18n/locales/`; both use `en-us.json` as the source of truth
-- Run `pnpm i18n:sync`, complete every locale, then run `pnpm i18n:check` before submitting
+- Only when you add or change a key: edit `en-us.json`, run `pnpm i18n:sync` (fills the other locales with `[to be translated]:` placeholders), then replace every placeholder with a real translation — `i18n:check` only verifies key structure/sort, so leftover placeholders pass the gate but must never reach a PR. No separate `pnpm i18n:check` run needed; `pnpm lint` already includes it.
 
 ### UI Design
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `CLAUDE.md` told agents that `pnpm build:check` is **REQUIRED before commits** and that a task is only done after `pnpm lint` + `pnpm test` + `pnpm format`. Since `build:check` expands to `pnpm lint && pnpm docs:check-links && pnpm test`, a one-line docs edit had to run the entire Vitest suite, and `pnpm format` / `pnpm i18n:check` were being run separately even though `pnpm lint` already chains both.

After this PR: the completion rule scales with the change — `pnpm lint` plus the tests covering the change for code, just `pnpm docs:check-links` for docs/markdown, full `build:check` only for broad or risky work. The commands list now documents what `build:check` actually composes and surfaces `pnpm docs:check-links` on its own. The i18n rule is scoped to "only when you add or change a key" and drops the separate `pnpm i18n:check` step, since `pnpm lint` already chains it.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The instructions were strict enough that every PR paid the full-gate cost regardless of blast radius, which mostly trains agents to skip the checks wholesale. Scoping by change type keeps the cheap, relevant checks credible while leaving CI as the real gate.

The following tradeoffs were made: contributors can now land a change without having run the full suite locally, so a broken test surfaces in CI instead of before the push — accepted, because CI runs the complete gate on every PR anyway.

The following alternatives were considered: keeping `build:check` mandatory and only exempting docs-only PRs, which still overshoots for the common single-module code change; and adding a per-PR-type decision table, which is more rules than the problem needs.

Links to places where the discussion took place: N/A

### Breaking changes

None. Documentation-only; no CI job, script, or source file changes.

### Special notes for your reviewer

`pnpm build:check` is defined in `package.json` as `pnpm lint && pnpm docs:check-links && pnpm test`, and `pnpm lint` already ends in `pnpm i18n:check && pnpm format` — that redundancy is what the previous wording missed. An earlier revision of the i18n line wrongly claimed `i18n:check` lets `[to be translated]` placeholders through; `scripts/i18n-check.ts` delegates value validation to `scripts/i18n-check-values.ts`, which rejects them. Corrected in c327b85301 after review.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```

