### PR TITLE
fix(agent): preselect compatible default model for every runtime

### DIFF
--- a/src/renderer/components/ModelSelector/index.ts
+++ b/src/renderer/components/ModelSelector/index.ts
@@ -9,6 +9,7 @@ export {
 export type {
   FlatListItem,
   ModelSelectorAlign,
+  ModelSelectorFilter,
   ModelSelectorGroupItem,
   ModelSelectorModelItem,
   ModelSelectorMultiIdProps,

--- a/src/renderer/components/resourceCatalog/dialogs/create/ResourceCreateWizard.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/create/ResourceCreateWizard.tsx
@@ -1,9 +1,11 @@
 import { Button, Dialog, DialogContent, DialogTitle, Form, Scrollbar } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
+import type { ModelSelectorFilter } from '@renderer/components/ModelSelector'
 import { useAgentModelFilter } from '@renderer/hooks/agent/useAgentModelFilter'
 import { useDefaultModel } from '@renderer/hooks/useModel'
+import { useProviderById } from '@renderer/hooks/useProvider'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
-import type { Model, UniqueModelId } from '@shared/data/types/model'
+import type { UniqueModelId } from '@shared/data/types/model'
 import { Check } from 'lucide-react'
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import { useForm, type UseFormReturn, useFormState, useWatch } from 'react-hook-form'
@@ -27,7 +29,7 @@ type ResourceCreateWizardProps = {
   open: boolean
   onOpenChange: (open: boolean) => void
   onSubmit: (values: ResourceCreateWizardValues) => Promise<void> | void
-  modelFilter?: (model: Model) => boolean
+  modelFilter?: ModelSelectorFilter
   isSubmitting?: boolean
   /** Seeds the name field when the caller already knows it (e.g. the picker's search query). */
   initialName?: string
@@ -136,8 +138,14 @@ export function ResourceCreateWizard({
   const agentModelFilter = useAgentModelFilter(kind === 'agent' ? agentType : undefined)
   const activeModelFilter = kind === 'agent' ? agentModelFilter : modelFilter
   const { defaultModel } = useDefaultModel({ enabled: open })
+  const { provider: defaultModelProvider } = useProviderById(open ? defaultModel?.providerId : undefined)
   const selectableDefaultModelId =
-    open && defaultModel && (!activeModelFilter || activeModelFilter(defaultModel)) ? defaultModel.id : null
+    open &&
+    defaultModel?.isEnabled &&
+    defaultModelProvider?.isEnabled &&
+    (!activeModelFilter || activeModelFilter(defaultModel, defaultModelProvider))
+      ? defaultModel.id
+      : null
   const autoSelectedDefaultModelIdRef = useRef<UniqueModelId | null>(null)
   const [stepIndex, setStepIndex] = useState(0)
   const [dialogContentElement, setDialogContentElement] = useState<HTMLDivElement | null>(null)
@@ -183,7 +191,7 @@ export function ResourceCreateWizard({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads the latest initialName; this effect is keyed by the open transition.
   }, [kind, open])
 
-  // Preference/model hydration may finish after the dialog opens. Seed only an
+  // Preference/model/provider hydration may finish after the dialog opens. Seed only an
   // empty field, and retract only a value that this effect auto-selected if it
   // later falls outside the active model filter.
   useEffect(() => {
@@ -213,7 +221,7 @@ export function ResourceCreateWizard({
 
     autoSelectedDefaultModelIdRef.current = selectableDefaultModelId
     form.setValue('modelId', selectableDefaultModelId, { shouldDirty: false, shouldTouch: false })
-  }, [form, kind, open, selectableDefaultModelId])
+  }, [agentType, form, kind, open, selectableDefaultModelId])
 
   const isLast = stepIndex === steps.length - 1
 

--- a/src/renderer/components/resourceCatalog/dialogs/create/__tests__/ResourceCreateWizard.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/create/__tests__/ResourceCreateWizard.test.tsx
@@ -1,13 +1,16 @@
+import type { AgentType } from '@shared/data/types/agent'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
-import { cleanup, render, screen } from '@testing-library/react'
+import type { Provider } from '@shared/data/types/provider'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type * as ReactHookForm from 'react-hook-form'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const modelHook = vi.hoisted(() => ({
   defaultModel: undefined as Model | undefined,
+  defaultProvider: { id: 'provider', name: 'Provider', isEnabled: true } as Provider | undefined,
   useDefaultModel: vi.fn(),
-  agentModelFilter: vi.fn<(model: Model) => boolean>(() => true)
+  agentModelFilter: vi.fn<(agentType: AgentType | undefined, model: Model, provider?: Provider) => boolean>(() => true)
 }))
 
 function makeModel(id: UniqueModelId = 'provider::default'): Model {
@@ -34,8 +37,13 @@ vi.mock('@renderer/hooks/useModel', () => ({
   }
 }))
 
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviderById: () => ({ provider: modelHook.defaultProvider })
+}))
+
 vi.mock('@renderer/hooks/agent/useAgentModelFilter', () => ({
-  useAgentModelFilter: () => modelHook.agentModelFilter
+  useAgentModelFilter: (agentType: AgentType | undefined) => (model: Model, provider?: Provider) =>
+    modelHook.agentModelFilter(agentType, model, provider)
 }))
 
 // Mock the step bodies so the wizard shell (navigation, validation gate, submit
@@ -80,6 +88,22 @@ vi.mock('../steps/BasicInfoStep', async () => {
             }}>
             fill pi basic
           </button>
+          <button
+            type="button"
+            onClick={() => {
+              form.setValue('agentType', 'pi')
+              form.setValue('modelId', null)
+            }}>
+            switch to pi
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              form.setValue('agentType', 'dsh')
+              form.setValue('modelId', null)
+            }}>
+            switch to dsh
+          </button>
         </>
       )
     }
@@ -108,6 +132,7 @@ const CANCEL = 'common.cancel'
 afterEach(() => {
   cleanup()
   modelHook.defaultModel = undefined
+  modelHook.defaultProvider = { id: 'provider', name: 'Provider', isEnabled: true } as Provider
   modelHook.useDefaultModel.mockReset()
   modelHook.agentModelFilter.mockReset()
   modelHook.agentModelFilter.mockReturnValue(true)
@@ -133,6 +158,14 @@ describe('ResourceCreateWizard', () => {
     render(<ResourceCreateWizard kind="assistant" open onOpenChange={vi.fn()} onSubmit={vi.fn()} />)
 
     expect(await screen.findByTestId('model-id')).toHaveTextContent('provider::default')
+  })
+
+  it('does not prefill a disabled default model', async () => {
+    modelHook.defaultModel = { ...makeModel(), isEnabled: false }
+
+    render(<ResourceCreateWizard kind="assistant" open onOpenChange={vi.fn()} onSubmit={vi.fn()} />)
+
+    expect(await screen.findByTestId('model-id')).toHaveTextContent('empty')
   })
 
   it('submits the default model when the user does not choose another model', async () => {
@@ -333,4 +366,32 @@ describe('ResourceCreateWizard', () => {
 
     expect(await screen.findByTestId('model-id')).toHaveTextContent('provider::default')
   })
+
+  it('does not prefill a default model when its provider is disabled', async () => {
+    modelHook.defaultModel = makeModel()
+    modelHook.defaultProvider = { id: 'provider', name: 'Provider', isEnabled: false } as Provider
+
+    render(<ResourceCreateWizard kind="agent" open onOpenChange={vi.fn()} onSubmit={vi.fn()} />)
+
+    expect(await screen.findByTestId('model-id')).toHaveTextContent('empty')
+  })
+
+  it.each(['pi', 'dsh'] as const)(
+    'reselects a compatible default model after switching an agent to the %s runtime',
+    async (agentType) => {
+      const user = userEvent.setup()
+      modelHook.defaultModel = makeModel()
+      modelHook.defaultProvider = { id: 'provider', name: 'Provider', isEnabled: true } as Provider
+      modelHook.agentModelFilter.mockImplementation(
+        (agentType, _model, provider) => agentType === 'claude-code' || Boolean(provider)
+      )
+
+      render(<ResourceCreateWizard kind="agent" open onOpenChange={vi.fn()} onSubmit={vi.fn()} />)
+
+      expect(await screen.findByTestId('model-id')).toHaveTextContent('provider::default')
+      await user.click(screen.getByRole('button', { name: `switch to ${agentType}` }))
+
+      await waitFor(() => expect(screen.getByTestId('model-id')).toHaveTextContent('provider::default'))
+    }
+  )
 })

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -106,6 +106,7 @@ vi.mock('@renderer/hooks/useCodeStyle', () => ({
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviderById: () => ({ provider: undefined }),
   useProviderDisplayName: () => (providerId: string) => providerId,
   useProviders: useProvidersMock
 }))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The Agent creation wizard preselected the configured default model for the Claude Agent runtime, but switching to Pi or DeepSeek Harness could leave the model field empty even when that default model was compatible.

After this PR:

The wizard reselects the configured default model for every compatible Agent runtime and only seeds it when both the model and its provider are enabled.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

Pi and DeepSeek Harness compatibility checks require provider context, but the wizard previously passed only the model to the active filter. In addition, changing the runtime cleared the model field without retriggering default-model selection because the runtime was not part of the effect dependencies.

The fix reuses the Model Selector filter contract, resolves the default model's provider, validates that both records are enabled, and reruns default selection when the Agent runtime changes.

The following tradeoffs were made:

- The wizard performs one cached provider lookup for the configured default model so it can use the same compatibility contract as the model selector.
- Automatic selection remains conservative: an unavailable, disabled, or incompatible default model leaves the field empty.

The following alternatives were considered:

- Duplicating runtime-specific compatibility checks inside the wizard was rejected because the model selector already owns those rules and duplicated checks could drift.
- Keeping the previous model-only filter signature was rejected because provider capabilities are required to evaluate Pi and DeepSeek Harness compatibility correctly.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation completed:

- Vitest: 4 affected renderer test files, 44 tests passed.
- `pnpm typecheck:web` passed.
- Biome, ESLint, and `git diff --check` passed for the changed files.
- Manual Electron verification used real runtime selections for Claude Agent, Pi, and DeepSeek Harness; the compatible default model remained selected in each mode.

Documentation was considered; no user-guide update is required because this restores the intended default-selection behavior without adding a new setting or workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent creation so the configured default model is automatically selected for Pi and DeepSeek Harness when it is enabled and compatible.
```
