### PR TITLE
fix(agent-sessions): keep empty agent groups visible

### DIFF
--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -8,6 +8,7 @@ import {
   ResourceList,
   type ResourceListGroup,
   type ResourceListGroupHeaderKind,
+  type ResourceListGroupSeed,
   type ResourceListItemReorderPayload,
   type ResourceListPresentation,
   type ResourceListReorderPayload,
@@ -56,6 +57,7 @@ import {
   createSessionDisplayGroupResolver,
   createSessionWorkdirDisplayMaps,
   getAgentIdFromSessionGroupId,
+  getSessionAgentGroupId,
   getWorkdirPathFromSessionGroupId,
   isSystemWorkspaceSession,
   moveSessionAgentGroupAfterDrop,
@@ -690,6 +692,19 @@ const Sessions = ({
       }
     }
   }, [displayMode, t])
+  const agentGroupSeeds = useMemo<readonly ResourceListGroupSeed[]>(() => {
+    if (displayMode !== 'agent') return []
+
+    const section = {
+      id: SESSION_AGENT_SECTION_ID,
+      label: t(SESSION_DISPLAY_LABEL_KEYS.agent)
+    }
+    return agentsForDisplay.map((agent) => ({
+      id: getSessionAgentGroupId(agent.id),
+      label: agent.name,
+      section
+    }))
+  }, [agentsForDisplay, displayMode, t])
 
   const collapsedSessionState = useMemo(() => {
     const resolvedSessionExpansion = resolveDefaultCollapsedGroupIds({
@@ -722,12 +737,6 @@ const Sessions = ({
     [displayMode, isRightPanel, setSessionExpansionAgent, setSessionExpansionTime, setSessionExpansionWorkdir]
   )
 
-  // Silent creation for a stranded agent: when the deleted (non-active) session was that agent's
-  // only one, open a fresh empty session for it without activating it or switching the user's view.
-  const { trigger: createSessionSilently } = useMutation('POST', '/agent-sessions', {
-    refresh: ['/agent-sessions']
-  })
-
   const handleDeleteSession = useCallback(
     async (id: string) => {
       // Capture the deleted session before removal so selection can be scoped to its agent even
@@ -756,41 +765,9 @@ const Sessions = ({
           return
         }
 
-        // Deleting a non-active session must not move the active selection (the switch above only
-        // fires when wasActive). But if the removed session was its agent's only one, silently open
-        // a fresh empty session for that agent so it stays in the list instead of vanishing.
-        if (!wasActive) {
-          const deletedAgentHasSessionsLeft = deletedSession
-            ? filteredGroupedSessions.some((session) => session.agentId === deletedSession.agentId && session.id !== id)
-            : true
-          if (!deletedAgentHasSessionsLeft) {
-            const seed = deletedSession
-              ? buildCreateSessionSeed({
-                  agentId: deletedSession.agentId,
-                  workspace: deletedSession.workspace,
-                  workspaceId: deletedSession.workspaceId
-                })
-              : null
-            if (seed?.agentId) {
-              try {
-                await createSessionSilently({
-                  body: {
-                    agentId: seed.agentId,
-                    name: '',
-                    workspace: seed.workspace ?? { type: AGENT_WORKSPACE_TYPE.SYSTEM }
-                  }
-                })
-              } catch (err) {
-                logger.error('Failed to create session after deleting last session of an agent', {
-                  err,
-                  sessionId: id
-                })
-                toast.error(formatErrorMessageWithPrefix(err, t('agent.session.create.error.failed')))
-              }
-            }
-          }
-          return
-        }
+        // Agent groups are seeded from the agent entities, so deleting a non-active agent's last
+        // session no longer needs to manufacture a replacement to keep that agent visible.
+        if (!wasActive) return
 
         // The deleted session was the active one. We already switched to the neighbour above; if
         // there was none, its agent had no other session left — open a fresh empty one for it
@@ -862,7 +839,6 @@ const Sessions = ({
     },
     [
       agentIdFilter,
-      createSessionSilently,
       deleteSession,
       filteredGroupedSessions,
       onCreateSession,
@@ -1456,6 +1432,18 @@ const Sessions = ({
       displayMode === 'agent' && group.id !== SESSION_PINNED_GROUP_ID ? 'select-first-then-toggle' : 'toggle',
     [displayMode]
   )
+  const handleEmptyGroupHeaderClick = useCallback(
+    (group: ResourceListGroup) => {
+      if (displayMode !== 'agent') return false
+
+      const agentId = getAgentIdFromSessionGroupId(group.id)
+      if (!agentId || !agentById.has(agentId)) return false
+
+      requestCreateSessionFromSeed({ agentId, workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM } })
+      return true
+    },
+    [agentById, displayMode, requestCreateSessionFromSeed]
+  )
   const canDragSessionItem = useCallback(
     ({ item }: { item: SessionListItem }) => itemDragReady && !item.pinned,
     [itemDragReady]
@@ -1646,7 +1634,11 @@ const Sessions = ({
         displayMode === 'workdir'
           ? (workdirDisplay.pathByGroupId.get(group.id) ?? getWorkdirPathFromSessionGroupId(group.id))
           : undefined
-      const createSessionSeed = createSessionSeedIndex.byGroupId.get(group.id) ?? null
+      const createSessionSeed =
+        createSessionSeedIndex.byGroupId.get(group.id) ??
+        (agentGroupId && agentById.has(agentGroupId)
+          ? { agentId: agentGroupId, workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM } }
+          : null)
       const canCreateSession = createSessionSeed !== null && agentById.has(createSessionSeed.agentId)
       const canManageAgentGroup = !!agentGroupId && agentById.has(agentGroupId)
 
@@ -1944,11 +1936,12 @@ const Sessions = ({
     () => (metadataLoading ? [] : filteredGroupedSessions),
     [filteredGroupedSessions, metadataLoading]
   )
+  const visibleAgentGroupSeeds = metadataLoading ? [] : agentGroupSeeds
   const listStatus = listError
     ? 'error'
     : listLoading && visibleGroupedSessions.length === 0
       ? 'loading'
-      : visibleGroupedSessions.length === 0
+      : visibleGroupedSessions.length === 0 && visibleAgentGroupSeeds.length === 0
         ? 'empty'
         : 'idle'
   const hasActiveCenterSurface = manageAgentsActive || historyRecordsActive
@@ -1968,6 +1961,7 @@ const Sessions = ({
       status={listStatus}
       selectedId={hasActiveCenterSurface ? null : activeSessionId}
       groupBy={sessionGroupByForDisplay}
+      groupSeeds={visibleAgentGroupSeeds}
       sectionBy={sessionSectionBy}
       collapsedState={collapsedSessionState}
       revealRequest={revealRequest}
@@ -1982,6 +1976,7 @@ const Sessions = ({
       getGroupHeaderTooltip={getGroupHeaderTooltip}
       getGroupHeaderKind={getGroupHeaderKind}
       groupHeaderClickBehavior={getGroupHeaderClickBehavior}
+      onEmptyGroupHeaderClick={handleEmptyGroupHeaderClick}
       dragCapabilities={{
         groups: displayMode === 'agent' ? agentDragReady : workdirDragReady,
         items: itemDragReady,

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -279,7 +279,6 @@ const tabsContextMocks = vi.hoisted(() => ({
 const windowFrameMocks = vi.hoisted(() => ({ mode: 'embedded' as 'embedded' | 'window' }))
 
 const dataApiMocks = vi.hoisted(() => ({
-  createSessionSilently: vi.fn().mockResolvedValue({ id: 'created-session' }),
   deleteAgent: vi.fn().mockResolvedValue(undefined),
   deleteAgentSessions: vi.fn().mockResolvedValue({ deletedIds: [] as string[] }),
   deleteWorkspace: vi.fn().mockResolvedValue({ deletedIds: [] as string[] }),
@@ -495,21 +494,19 @@ vi.mock('@renderer/data/hooks/useDataApi', () => ({
     dataApiMocks.mutationOptions.set(`${method} ${path}`, options ?? {})
     return {
       trigger:
-        method === 'POST' && path === '/agent-sessions'
-          ? dataApiMocks.createSessionSilently
-          : method === 'PATCH' && path === '/agent-workspaces/:id/order'
-            ? dataApiMocks.reorderWorkspace
-            : method === 'PATCH' && path === '/agents/:id/order'
-              ? dataApiMocks.reorderAgent
-              : method === 'PATCH' && path === '/agent-workspaces/:workspaceId'
-                ? dataApiMocks.updateWorkspace
-                : method === 'DELETE' && path === '/agent-workspaces/:workspaceId'
-                  ? dataApiMocks.deleteWorkspace
-                  : method === 'DELETE' && path === '/agents/:agentId'
-                    ? dataApiMocks.deleteAgent
-                    : method === 'DELETE' && path === '/agents/:agentId/sessions'
-                      ? dataApiMocks.deleteAgentSessions
-                      : dataApiMocks.findOrCreateWorkspace,
+        method === 'PATCH' && path === '/agent-workspaces/:id/order'
+          ? dataApiMocks.reorderWorkspace
+          : method === 'PATCH' && path === '/agents/:id/order'
+            ? dataApiMocks.reorderAgent
+            : method === 'PATCH' && path === '/agent-workspaces/:workspaceId'
+              ? dataApiMocks.updateWorkspace
+              : method === 'DELETE' && path === '/agent-workspaces/:workspaceId'
+                ? dataApiMocks.deleteWorkspace
+                : method === 'DELETE' && path === '/agents/:agentId'
+                  ? dataApiMocks.deleteAgent
+                  : method === 'DELETE' && path === '/agents/:agentId/sessions'
+                    ? dataApiMocks.deleteAgentSessions
+                    : dataApiMocks.findOrCreateWorkspace,
       isLoading: false,
       error: undefined
     }
@@ -849,7 +846,6 @@ describe('Sessions', () => {
     dataApiMocks.refetchAgents.mockResolvedValue(undefined)
     dataApiMocks.reorderAgent.mockResolvedValue(undefined)
     dataApiMocks.updateWorkspace.mockResolvedValue(undefined)
-    dataApiMocks.createSessionSilently.mockResolvedValue({ id: 'created-session' })
     dataApiMocks.mutationOptions.clear()
     sessionDataMocks.deleteSession.mockResolvedValue(true)
     sessionDataMocks.deleteSessions.mockResolvedValue({ deletedIds: [] })
@@ -1320,6 +1316,36 @@ describe('Sessions', () => {
     expect(getSessionGroupExpansionCache().agent).not.toContain('session:agent:agent-b')
   })
 
+  it('keeps agents without tasks visible and creates their first task from the empty group', async () => {
+    const onCreateSession = vi.fn()
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    agentDataMocks.useAgents.mockReturnValue({
+      agents: [
+        { id: 'agent-a', model: 'model-a', name: 'Alpha agent', configuration: { avatar: 'A' } },
+        { id: 'agent-b', model: 'model-b', name: 'Beta agent', configuration: { avatar: 'B' } }
+      ],
+      isLoading: false,
+      error: undefined
+    })
+    setupSessions({ sessions: [] })
+
+    render(<SessionsForTest onCreateSession={onCreateSession} />)
+
+    expect(screen.queryByText('No tasks')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Alpha agent' })).toBeInTheDocument()
+    const betaGroup = screen.getByRole('button', { name: 'Beta agent' })
+    expect(within(betaGroup.parentElement as HTMLElement).getByRole('button', { name: 'New task' })).toBeInTheDocument()
+
+    fireEvent.click(betaGroup)
+
+    await vi.waitFor(() =>
+      expect(onCreateSession).toHaveBeenCalledWith({
+        agentId: 'agent-b',
+        workspace: { type: 'system' }
+      })
+    )
+  })
+
   it('renders orphan sessions under the unlinked agent group without a virtual agent icon', () => {
     preferenceMocks.values.set('agent.session.display_mode', 'agent')
     setupSessions({
@@ -1605,7 +1631,7 @@ describe('Sessions', () => {
       })
     )
 
-    expect(screen.queryByRole('button', { name: 'Gamma agent' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Gamma agent' })).toBeInTheDocument()
   })
 
   it('guards creation of a new system session because it receives a distinct file workspace', async () => {
@@ -2563,11 +2589,7 @@ describe('Sessions', () => {
     expect(setActiveSessionId).not.toHaveBeenCalledWith('session-b-first', expect.anything())
   })
 
-  it('silently recreates a session for an agent after deleting its only non-active session, without switching the view', async () => {
-    // Regression: deleting a session that is NOT the active one used to early-return before the
-    // "agent has no session left → create one" branch. When the deleted session was that agent's
-    // only one, the agent vanished from the list. The fix silently creates a replacement session
-    // for the stranded agent without activating it or moving the current selection.
+  it('keeps an agent visible without recreating a task after deleting its only non-active task', async () => {
     preferenceMocks.values.set('agent.session.display_mode', 'agent')
     agentDataMocks.useAgents.mockReturnValue({
       agents: [
@@ -2587,7 +2609,7 @@ describe('Sessions', () => {
     const setActiveSessionId = vi.fn()
 
     // Active session belongs to agent-b; the deleted session is agent-a's only one.
-    render(
+    const view = render(
       <SessionsForTest
         activeSessionId="session-b-first"
         onCreateSession={onCreateSession}
@@ -2605,19 +2627,22 @@ describe('Sessions', () => {
     })
 
     await vi.waitFor(() => expect(sessionDataMocks.deleteSession).toHaveBeenCalledWith('session-a-only'))
-    // A replacement session is silently created for the stranded agent-a (not via the activate path).
-    await vi.waitFor(() =>
-      expect(dataApiMocks.createSessionSilently).toHaveBeenCalledWith({
-        body: {
-          agentId: 'agent-a',
-          name: '',
-          workspace: { type: 'user', workspaceId: 'ws-a' }
-        }
-      })
-    )
-    // The current view is undisturbed: the active selection is never moved or cleared.
     expect(setActiveSessionId).not.toHaveBeenCalled()
     expect(onCreateSession).not.toHaveBeenCalled()
+
+    setupSessions({
+      sessions: [createSession({ id: 'session-b-first', name: 'B First session', agentId: 'agent-b', orderKey: 'b' })]
+    })
+    view.rerender(
+      <SessionsForTest
+        activeSessionId="session-b-first"
+        onCreateSession={onCreateSession}
+        setActiveSessionId={setActiveSessionId}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Alpha agent' })).toBeInTheDocument()
+    expect(screen.queryByText('A Only session')).not.toBeInTheDocument()
   })
 
   it('clears the active session and toasts when the post-delete session create fails in the right panel', async () => {

--- a/src/renderer/utils/chat/sessionListHelpers.ts
+++ b/src/renderer/utils/chat/sessionListHelpers.ts
@@ -97,7 +97,7 @@ function withSessionGroupIdPrefix<T>(resolver: ResourceListGroupResolver<T>): Re
   return withResourceListGroupIdPrefix('session:', resolver)
 }
 
-function getSessionAgentGroupId(agentId: string) {
+export function getSessionAgentGroupId(agentId: string) {
   return `${SESSION_AGENT_GROUP_ID_PREFIX}${agentId}`
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The by-agent task list inferred group existence from sessions. Deleting an agent's last non-active task therefore required silently creating a replacement task to keep the agent visible.

After this PR:

The by-agent task list seeds groups from `/agents`, so agents remain visible with zero tasks. Empty agent groups expose the existing new-task action and create a system-workspace task when their header is selected. The non-active deletion path no longer creates a ghost replacement task.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18606

### Why we need it and why it was done in this way

Agent existence is owned by `/agents`, not `/agent-sessions`. Seeding list groups from the entity source fixes the derivation direction while reusing the existing ResourceList empty-group API and task creation path.

The following tradeoffs were made:

- Only by-agent grouping is changed; workdir grouping remains unchanged.
- Active-session deletion and AgentPage entry/deleted-agent safeguards remain intact.
- A first task created from an empty agent group uses the system workspace because no previous task exists to provide workspace context.

The following alternatives were considered:

- Removing all automatic creation paths would break first entry on an empty database.
- Keeping the silent replacement would continue manufacturing tasks solely for presentation.
- Adding only a hidden creation entry point would leave agent visibility session-derived.

Links to places where the discussion took place: #18606 <!-- optional: slack, other GH issue, mailinglist, ... -->

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Validation:

- `pnpm lint`
- `pnpm test:lint`
- Focused Sessions suite: 90/90 tests passed.
- Full renderer suite: 9,497/9,497 assertions passed; Vitest still exits non-zero because the unrelated `ExecutionStreamOverlayService` test leaves an existing `ReadableStream` double-close rejection, reproducible when that file runs alone.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this task-list behavior fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agents now remain visible in the by-agent task list after their last task is deleted, with an action to create a new task.
```
