### PR TITLE
docs: point reference docs at the paths the June refactors moved them to

### DIFF
--- a/docs/references/ai/chat-attachments.md
+++ b/docs/references/ai/chat-attachments.md
@@ -70,7 +70,7 @@ Default cap ≈ 8k chars/file (tunable).
 
 ## `read_file` — text-only overflow tool
 
-`src/main/ai/tools/fileLookup.ts` + `tools/adapters/aiSdk/builtin/ReadFileTool.ts`.
+`src/main/ai/tools/adapters/aiSdk/builtin/ReadFileTool.ts`.
 
 - Input `{ filename, offset?, limit? }`. The `filename` is the model-facing
   **handle** (unique, normalized — see `collectFileAttachments`), resolved to an

--- a/docs/references/ai/ipc-transport.md
+++ b/docs/references/ai/ipc-transport.md
@@ -48,7 +48,7 @@ explicit `Ai_ToolApproval_Respond` IPC handled by
 
 ## Dispatch coordinator
 
-`streamDispatchCoordinator` (`src/renderer/services/aiTransport/streamDispatchCoordinator.ts`)
+`streamDispatchService` (`src/renderer/services/aiTransport/StreamDispatchService.ts`)
 sits between the transport and the IPC call so the `Ai_Stream_Open` ack
 (`reservedMessages`, `activeExecutions`, and `preserveActiveNode`) is
 observable to callers that need to seed optimistic UI bubbles, rather than

--- a/docs/references/ai/tool-approval.md
+++ b/docs/references/ai/tool-approval.md
@@ -48,7 +48,7 @@ persists, and resumes the stream.
 
 ## Persistent decisions
 
-`useToolApproval` (`src/renderer/pages/home/Messages/Tools/hooks/useToolApproval.ts`)
+`useToolApproval` (`src/renderer/components/chat/messages/tools/hooks/useToolApproval.ts`)
 exposes an `autoApprove` action **only for MCP tools** — when an `mcpTool`
 descriptor is passed. It persists the opt-out by PATCHing the server's
 `disabledAutoApproveTools`, so the MCP settings page reflects it and
@@ -71,5 +71,5 @@ per-tool default for non-MCP (e.g. Claude-Agent) tools.
 
 - Main IPC handler: `src/main/ai/AiService.ts` (`Ai_ToolApproval_Respond`)
 - Renderer bridge: `src/renderer/hooks/useToolApprovalBridge.ts`
-- Persistent decisions: `src/renderer/pages/home/Messages/Tools/hooks/useToolApproval.ts`
+- Persistent decisions: `src/renderer/components/chat/messages/tools/hooks/useToolApproval.ts`
 - Status broadcast: [Stream Manager](./stream-manager.md)

--- a/docs/references/command/README.md
+++ b/docs/references/command/README.md
@@ -44,7 +44,7 @@ Two consequences fall out of this split:
 
 | Concept | Where it lives | Example for `topic.create` |
 | --- | --- | --- |
-| Command definition | `COMMAND_DEFINITIONS` (`src/shared/command/definitions.ts`) | `{ id: 'topic.create', scope: 'renderer', keybinding: { defaultBinding: ['CommandOrControl','N'] } }` |
+| Command definition | `COMMAND_DEFINITIONS` (`src/shared/utils/command/definitions.ts`) | `{ id: 'topic.create', scope: 'renderer', keybinding: { defaultBinding: ['CommandOrControl','N'] } }` |
 | Default key binding | the command's `keybinding.defaultBinding` | `Cmd/Ctrl + N` |
 | **User override** | the preference `shortcut.<commandId>` | `shortcut.topic.create` → `{ binding, enabled }` |
 | Handler | a surface via `useCommandHandler` (renderer) or a built‑in (main) | `useCommandHandler('topic.create', addNewTopic)` |
@@ -81,7 +81,7 @@ Pure data and pure functions, no Electron or React.
 | `types.ts` | all command/keybinding/menu/context types |
 
 Token formatting (typed shortcut vocabulary, normalization, display/accelerator
-formatting) lives in `src/shared/shortcuts/tokens.ts`; `src/shared/shortcuts/types.ts`
+formatting) lives in `src/shared/utils/shortcut.ts`; `src/shared/types/shortcut.ts`
 keeps only `ShortcutPreferenceKey` + `ResolvedShortcut`.
 
 ### 2. Main runtime — `src/main/services/`

--- a/docs/references/command/command-usage.md
+++ b/docs/references/command/command-usage.md
@@ -95,7 +95,7 @@ Use these instead of assembling labels/shortcuts in feature components:
 
 ## Adding a command
 
-1. **Declare it** in `src/shared/command/definitions.ts` — add an entry to
+1. **Declare it** in `src/shared/utils/command/definitions.ts` — add an entry to
    `COMMAND_DEFINITIONS` (`id`, `titleKey`, `categoryKey`, `scope`, optional
    `keybinding` with a `defaultBinding`, optional `enablement`).
 2. **Add its shortcut preference key** `shortcut.<commandId>` through the

--- a/docs/references/components/code-execution.md
+++ b/docs/references/components/code-execution.md
@@ -36,7 +36,7 @@ The user-facing code execution component is [CodeBlockView][codeblock-view-link]
 - **State Management and Output Display**: Uses `executionResult` to manage all execution output; whenever there's any result (text or image), the [StatusBar][statusbar-link] component is rendered for unified display.
 
 ```typescript
-// src/renderer/components/CodeBlockView/view.tsx
+// src/renderer/components/CodeBlockView/CodeBlockView.tsx
 const [executionResult, setExecutionResult] = useState<{ text: string; image?: string } | null>(null)
 
 const handleRunScript = useCallback(() => {
@@ -119,7 +119,7 @@ The core Python execution happens inside the Web Worker defined in [pyodide.work
 <!-- Link Definitions -->
 
 [pyodide-link]: https://pyodide.org/
-[codeblock-view-link]: /src/renderer/components/CodeBlockView/view.tsx
+[codeblock-view-link]: /src/renderer/components/CodeBlockView/CodeBlockView.tsx
 [pyodide-service-link]: /src/renderer/services/PyodideService.ts
 [pyodide-worker-link]: /src/renderer/workers/pyodide.worker.ts
 [statusbar-link]: /src/renderer/components/CodeBlockView/StatusBar.tsx

--- a/docs/references/data/data-api-in-main.md
+++ b/docs/references/data/data-api-in-main.md
@@ -269,7 +269,7 @@ Some `rowToEntity` functions do too much to benefit from spread. Keep them hand-
 - **Field renaming**: `row.parameters → domain parameterSupport` (ModelService)
 - **Computed / merged fields**: `authType` derivation, `apiFeatures` merging from defaults (ProviderService)
 - **Sensitive data sanitization**: `apiKeys` stripping — `...clean` would leak unsanitized values
-- **Discriminator-driven field stripping with brand validation**: branded discriminated union where each variant declares only its own fields — `nullsToUndefined + spread` would emit absent fields as `undefined` and break the BO shape. Dispatch on the discriminator and call `schema.parse` per variant. Example: `FileEntryService.rowToFileEntry` for `FileEntry` (variants on `origin`); see `src/shared/data/types/file/fileEntry.ts` header (§"DB row vs Business Object") for the full DB-CHECK / BO-narrow rationale.
+- **Discriminator-driven field stripping with brand validation**: branded discriminated union where each variant declares only its own fields — `nullsToUndefined + spread` would emit absent fields as `undefined` and break the BO shape. Dispatch on the discriminator and call `schema.parse` per variant. Example: `FileEntryService.rowToFileEntry` for `FileEntry` (variants on `origin`); see `src/shared/data/types/file.ts` header (§"DB row vs Business Object") for the full DB-CHECK / BO-narrow rationale.
 
 **Anti-pattern — `??` fallbacks for fabricated defaults:**
 

--- a/docs/references/file/architecture.md
+++ b/docs/references/file/architecture.md
@@ -870,8 +870,8 @@ To avoid the governance pitfall of "added a sourceType but forgot to wire up som
 
 | Step | Location | Action | Enforcement |
 |---|---|---|---|
-| 1 | `src/shared/data/types/file/ref/<name>.ts` | Create the variant file: declare `xxxSourceType` / `xxxRoles` / `xxxRefFields` + `xxxFileRefSchema = createRefSchema(...)` | Code review |
-| 2 | `src/shared/data/types/file/ref/index.ts` | Add the variant to `allSourceTypes` (type aggregation) + `FileRefSchema` discriminated union | Type system narrow failure |
+| 1 | `src/shared/data/types/file.ts` | Create the variant file: declare `xxxSourceType` / `xxxRoles` / `xxxRefFields` + `xxxFileRefSchema = createRefSchema(...)` | Code review |
+| 2 | `src/shared/data/types/file.ts` | Add the variant to `allSourceTypes` (type aggregation) + `FileRefSchema` discriminated union | Type system narrow failure |
 | 3 | `src/main/data/db/schemas/*` | Add the dedicated FK-constrained association table | Migration + schema tests |
 | 4 | Owning business service/migrator | Write/copy/delete relationship rows directly; use FK cascade for source and `file_entry` deletion | Unit/integration tests |
 | 5 | `FileRefService` | Add the table to read/ref-count aggregation only — the registry-driven cleanup anti-join (`persistentRefAbsenceConditions`) picks it up automatically; a missing `persistentFileRefTablesBySourceType` entry fails compilation (`satisfies Record<PersistentFileRefSourceType, …>` in `fileRelations.ts`), and the vitest coverage test additionally pins that `persistentRefAbsenceConditions()` stays registry-derived rather than hand-enumerated | DataApi + sweep tests |

--- a/docs/references/file/directory-tree.md
+++ b/docs/references/file/directory-tree.md
@@ -72,7 +72,7 @@ src/main/services/file/tree/   ← parallel to internal/ and watcher/
 └── __tests__/            ← builder.test.ts / registry.test.ts /
                             TreeNode.test.ts / search.test.ts
 
-src/shared/file/types/tree.ts   ← shared with renderer
+src/shared/utils/file/tree.ts   ← shared with renderer
 ├── DirectoryTreeOptionsSchema (Zod) — IPC validation source of truth
 ├── DirectoryTreeOptions = z.infer<...> — derived type
 ├── SerializedTreeNode — wire DTO (parentless, plain object)
@@ -399,4 +399,4 @@ Renderer-side: `src/renderer/hooks/__tests__/useDirectoryTree.test.tsx` covers m
 
 - [`architecture.md`](./architecture.md) — module-level positioning (where this primitive sits relative to FileManager).
 - [`file-manager-architecture.md`](./file-manager-architecture.md) — sister FileEntry / FileRef primitive. Specifically: §8 ("DirectoryWatcher") for the watcher contract this primitive consumes, including the `WatcherEvent` shape (`ready` / `add` / `addDir` / `unlink` / `unlinkDir` / `change` / `error`).
-- `src/shared/file/types/tree.ts` — the wire types and class hierarchy this primitive emits.
+- `src/shared/utils/file/tree.ts` — the wire types and class hierarchy this primitive emits.

--- a/docs/references/file/file-manager-architecture.md
+++ b/docs/references/file/file-manager-architecture.md
@@ -827,7 +827,7 @@ Grouping a stateful class with pure-function primitives would break the primitiv
 
 ### 8.2 API
 
-Shipped surface mirrors `src/main/services/file/watcher/index.ts` —
+Shipped surface mirrors `src/main/services/file/watcher.ts` —
 a single `onEvent(listener)` subscriber over a normalized event union.
 Earlier drafts proposed seven separate event channels (`onAdd` /
 `onAddDir` / `onUnlink` / `onUnlinkDir` / `onRename` / `onReady` /
@@ -1432,7 +1432,7 @@ This checklist is the canonical addition procedure. A PR introducing a new origi
 
 | Location | Change required |
 |---|---|
-| `src/shared/data/types/file/fileEntry.ts` → `FileEntryOriginSchema` | Add the new enum value |
+| `src/shared/data/types/file.ts` → `FileEntryOriginSchema` | Add the new enum value |
 | Same file → new `XxxEntrySchema` | Define the row shape for the new variant (which columns are nullable / required / branded) |
 | Same file → `FileEntrySchema` discriminated union | Add the new schema as a union member |
 | Same file → any type guard helpers (`isInternalEntry`, etc.) | Add `isXxxEntry` helper if code needs to narrow |

--- a/docs/references/renderer-architecture.md
+++ b/docs/references/renderer-architecture.md
@@ -118,7 +118,7 @@ A **headless** capability (no UI) that outgrows one file grows **in place** into
 | Satellites skip shape routing | a topic-**specific** helper lives here even though its shape says `utils/` — the §3 shape tests bind **shared** modules only; a **generic** helper (reads naturally with no topic context) still goes to `utils/` |
 | Single consumer, or out | a satellite stays only while this topic is its sole consumer; a second consumer moves it to `utils/` (generic) or promotes it into the barrel (topic public API) |
 | No UI, ever | no JSX and no React hooks inside; UI parts route into the shared buckets by shape (§3 / §6), and the domain promotes to `features/<domain>/` only once the §4.1 trigger holds |
-| Plain internal names | files drop the topic prefix (the directory carries it) — `aiTransport/streamDispatchCoordinator.ts`, not `aiTransportStreamDispatchCoordinator.ts`; the `Service` / `Manager` suffix still marks only stateful singleton classes ([Naming §5.2](./naming-conventions.md)) |
+| Plain internal names | files drop the topic prefix (the directory carries it) — `aiTransport/StreamDispatchService.ts`, not `aiTransportStreamDispatchService.ts`; the `Service` / `Manager` suffix still marks only stateful singleton classes ([Naming §5.2](./naming-conventions.md)) |
 
 ## 4. `features/` Definition
 


### PR DESCRIPTION
`docs/references/` names files that four refactors moved in June and July. Each
change below was checked against `git ls-tree -r HEAD` in both directions - the old
path is absent, the new one is present - and the symbol or section the sentence
actually refers to was confirmed to have moved with the file, not just the filename.

| document | says | is |
|---|---|---|
| `command/README.md` | `src/shared/command/definitions.ts` | `src/shared/utils/command/definitions.ts` |
| `command/README.md` | `src/shared/shortcuts/tokens.ts` | `src/shared/utils/shortcut.ts` |
| `command/README.md` | `src/shared/shortcuts/types.ts` | `src/shared/types/shortcut.ts` |
| `command/command-usage.md` | `src/shared/command/definitions.ts` | `src/shared/utils/command/definitions.ts` |
| `components/code-execution.md` | `.../CodeBlockView/view.tsx` | `.../CodeBlockView/CodeBlockView.tsx` |
| `data/data-api-in-main.md` | `src/shared/data/types/file/fileEntry.ts` | `src/shared/data/types/file.ts` |
| `file/directory-tree.md` | `src/shared/file/types/tree.ts` | `src/shared/utils/file/tree.ts` |
| `file/file-manager-architecture.md` | `src/main/services/file/watcher/index.ts` | `src/main/services/file/watcher.ts` |
| `file/file-manager-architecture.md` | `src/shared/data/types/file/fileEntry.ts` | `src/shared/data/types/file.ts` |

Moved by `ff6de394f6` (*dissolve command/file/shortcuts/externalApp*), `f952e6c7fb`
(*consolidate file types*) and `8f60b56cca` (*align type-bucket placement and file
naming*).

## Content checked, not just the filename

A path fix is only right if what the sentence describes moved too:

- `COMMAND_DEFINITIONS` is in `src/shared/utils/command/definitions.ts`
- `FileEntryOriginSchema` and the `## DB row vs Business Object` section are both in
  `src/shared/data/types/file.ts`, which is what `data-api-in-main.md` points a reader at
- `src/shared/utils/file/tree.ts` opens *"Directory-tree primitive - wire types + shared
  class hierarchy"*, which is exactly what `directory-tree.md` says that file holds

## What is deliberately NOT in this PR

**Fourteen further stale paths are deletions with no replacement** - `fileLookup.ts`,
`streamDispatchCoordinator.ts`, `useToolApproval.ts`, `src/shared/command/menus.ts`,
`useProviders.ts` and others. I cannot tell from the tree whether each should be
removed from the docs or repointed at whatever took over, and guessing would be
worse than leaving them, so they are untouched.

`src/renderer/features/` is the largest of those and is
[#18815](https://github.com/CherryHQ/cherry-studio/issues/18815) rather than a patch,
because `renderer-architecture.md` builds its whole two-axis model on it.

One reported path is a **false positive** and is correctly left alone:
`knowledge/knowledge-service.md` names `src/main/knowledge` in order to exclude it -
*"It does not describe the legacy `src/main/knowledge` service"*.

Found with [docproof](https://github.com/melbinjp/docproof).
