### PR TITLE
perf(resource-list): reduce scroll timer churn

### DIFF
--- a/src/renderer/components/chat/resourceList/base/ResourceListVirtual.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceListVirtual.tsx
@@ -133,23 +133,51 @@ function isSectionVirtualGroup(group: ResourceListVirtualGroupData) {
 
 function useAutoHideScrollbar(delay = SCROLLBAR_AUTO_HIDE_DELAY) {
   const [stage, setStage] = useState<ScrollbarStage>('idle')
-  const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])
+  const stageRef = useRef<ScrollbarStage>('idle')
+  const fadeStartAtRef = useRef(0)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const clearScrollingTimeout = useCallback(() => {
-    timeoutRefs.current.forEach(clearTimeout)
-    timeoutRefs.current = []
+    if (timeoutRef.current === null) return
+
+    clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
   }, [])
 
+  const updateStage = useCallback((nextStage: ScrollbarStage) => {
+    if (stageRef.current === nextStage) return
+
+    stageRef.current = nextStage
+    setStage(nextStage)
+  }, [])
+
+  const scheduleNextStage = useCallback(
+    function scheduleNextStage(timeout: number) {
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null
+        const remainingDelay = fadeStartAtRef.current - Date.now()
+        if (remainingDelay > 0) {
+          scheduleNextStage(remainingDelay)
+          return
+        }
+
+        if (stageRef.current === 'active') updateStage('fade-1')
+        else if (stageRef.current === 'fade-1') updateStage('fade-2')
+        else if (stageRef.current === 'fade-2') updateStage('fade-3')
+        else if (stageRef.current === 'fade-3') updateStage('idle')
+
+        if (stageRef.current !== 'idle') scheduleNextStage(SCROLLBAR_FADE_STEP)
+      }, timeout)
+    },
+    [updateStage]
+  )
+
   const handleScroll = useCallback(() => {
-    clearScrollingTimeout()
-    setStage('active')
-    timeoutRefs.current = [
-      setTimeout(() => setStage('fade-1'), delay),
-      setTimeout(() => setStage('fade-2'), delay + SCROLLBAR_FADE_STEP),
-      setTimeout(() => setStage('fade-3'), delay + SCROLLBAR_FADE_STEP * 2),
-      setTimeout(() => setStage('idle'), delay + SCROLLBAR_FADE_STEP * 3)
-    ]
-  }, [clearScrollingTimeout, delay])
+    fadeStartAtRef.current = Date.now() + delay
+    updateStage('active')
+    // Keep one deadline-driven timer alive so a scroll burst only updates the deadline.
+    if (timeoutRef.current === null) scheduleNextStage(delay)
+  }, [delay, scheduleNextStage, updateStage])
 
   useEffect(() => clearScrollingTimeout, [clearScrollingTimeout])
 

--- a/src/renderer/components/chat/resourceList/base/ResourceListVirtual.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceListVirtual.tsx
@@ -155,7 +155,7 @@ function useAutoHideScrollbar(delay = SCROLLBAR_AUTO_HIDE_DELAY) {
     function scheduleNextStage(timeout: number) {
       timeoutRef.current = setTimeout(() => {
         timeoutRef.current = null
-        const remainingDelay = fadeStartAtRef.current - Date.now()
+        const remainingDelay = fadeStartAtRef.current - performance.now()
         if (remainingDelay > 0) {
           scheduleNextStage(remainingDelay)
           return
@@ -173,7 +173,7 @@ function useAutoHideScrollbar(delay = SCROLLBAR_AUTO_HIDE_DELAY) {
   )
 
   const handleScroll = useCallback(() => {
-    fadeStartAtRef.current = Date.now() + delay
+    fadeStartAtRef.current = performance.now() + delay
     updateStage('active')
     // Keep one deadline-driven timer alive so a scroll burst only updates the deadline.
     if (timeoutRef.current === null) scheduleNextStage(delay)

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -2040,6 +2040,37 @@ describe('ResourceList', () => {
     expect(viewport).toHaveStyle({ scrollbarColor: 'transparent transparent' })
   })
 
+  it('keeps the shared list viewport fade deadline when the system clock moves backward', () => {
+    vi.useFakeTimers()
+    const Provider = ResourceList.Provider<TestItem>
+
+    render(
+      <Provider items={ITEMS}>
+        <ResourceList.Frame>
+          <ResourceList.VirtualItems<TestItem>
+            renderItem={(item) => (
+              <ResourceList.Item item={item}>
+                <span>{item.name}</span>
+              </ResourceList.Item>
+            )}
+          />
+        </ResourceList.Frame>
+      </Provider>
+    )
+
+    const viewport = screen.getByRole('listbox')
+    fireEvent.scroll(viewport)
+    vi.setSystemTime(Date.now() - 60_000)
+
+    act(() => {
+      vi.advanceTimersByTime(1200)
+    })
+
+    expect(viewport).toHaveStyle({
+      scrollbarColor: 'color-mix(in srgb, var(--scrollbar-thumb) 70%, transparent) transparent'
+    })
+  })
+
   it('limits each group to the default visible count and expands the group independently', () => {
     const Provider = ResourceList.Provider<TestItem>
     const items = Array.from({ length: 12 }, (_, index) => ({

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -1987,7 +1987,7 @@ describe('ResourceList', () => {
     await waitFor(() => expect(onAction).toHaveBeenCalledWith('topic'))
   })
 
-  it('auto-hides the shared list viewport scrollbar after scrolling stops', () => {
+  it('restarts the shared list viewport scrollbar fade after continued scrolling', () => {
     vi.useFakeTimers()
     const Provider = ResourceList.Provider<TestItem>
 
@@ -2007,21 +2007,37 @@ describe('ResourceList', () => {
 
     const viewport = screen.getByRole('listbox')
     expect(viewport).toHaveAttribute('data-scrolling', 'false')
+    // scrollbarColor is part of the shared viewport's documented fade behavior.
+    expect(viewport).toHaveStyle({ scrollbarColor: 'transparent transparent' })
 
     fireEvent.scroll(viewport)
     expect(viewport).toHaveAttribute('data-scrolling', 'true')
+    expect(viewport).toHaveStyle({ scrollbarColor: 'var(--scrollbar-thumb) transparent' })
 
     act(() => {
-      vi.advanceTimersByTime(1200)
+      vi.advanceTimersByTime(1000)
     })
+    fireEvent.scroll(viewport)
 
+    act(() => {
+      vi.advanceTimersByTime(1199)
+    })
     expect(viewport).toHaveAttribute('data-scrolling', 'true')
+    expect(viewport).toHaveStyle({ scrollbarColor: 'var(--scrollbar-thumb) transparent' })
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(viewport).toHaveAttribute('data-scrolling', 'true')
+    expect(viewport).toHaveStyle({
+      scrollbarColor: 'color-mix(in srgb, var(--scrollbar-thumb) 70%, transparent) transparent'
+    })
 
     act(() => {
       vi.advanceTimersByTime(420)
     })
-
     expect(viewport).toHaveAttribute('data-scrolling', 'false')
+    expect(viewport).toHaveStyle({ scrollbarColor: 'transparent transparent' })
   })
 
   it('limits each group to the default visible count and expands the group independently', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

`useAutoHideScrollbar` cleared and recreated four fade timers for every scroll event. Even after reducing that to one restarted timer, rapid bidirectional scrolling still performed timeout churn and repeatedly requested the already-active React state.

After this PR:

The shared ResourceList scrollbar uses one deadline-driven timer. Scroll events only move the fade deadline and enter `active` when the stage actually changes. The timer advances through `fade-1`, `fade-2`, `fade-3`, and `idle` at the existing 1200/140/140/140 ms cadence, while new scroll input immediately returns to `active`.

Fixes # N/A

### Why we need it and why it was done in this way

The root cause was per-scroll work in the shared scrollbar handler, not row sizing, drag-and-drop, pagination, or the virtual-list data model. Expanded lists generate a dense stream of scroll events, especially when users repeatedly reverse direction.

The implementation keeps the change inside the shared ResourceList hook. At most one timeout exists, a scroll burst updates only a deadline ref, and React state changes only for observable stage transitions.

Pre-change performance baseline (five-run median, identical two-second oscillating scroll scenario):

- Script duration: 1611.54 ms
- Frames over 33 ms: 13
- React commits: 116

Post-change runtime medians were not collected after the development instance exited because relaunching it was explicitly declined. No post-change numbers are inferred or fabricated. The profiling artifacts remain local under `.context/cherry-electron-dev/` and are not committed.

The following tradeoffs were made:

A long scroll burst can wake the single timer to reschedule itself against the latest deadline, but scroll events do not clear or create timers.

The following alternatives were considered:

Changing virtual row heights, dnd-kit wrappers, pagination, and ResourceList data structures were excluded because prior isolation did not identify them as the cause and they are outside this focused fix.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Please focus review on rapid bidirectional scrolling and the preserved scrollbar stages. The fake-timer test covers immediate activation, deadline reset after continued scrolling, fade start, and return to idle through user-observable attributes and `scrollbarColor`.

Validation:

- `pnpm exec vitest run --silent --project renderer src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx` — 57 passed
- `pnpm lint` — passed (37 pre-existing unrelated warnings)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Improved scrolling smoothness for expanded conversation resource lists.
```
