### PR TITLE
fix(ovms): list all configured OVMS models regardless of loading state

### DIFF
--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -1008,9 +1008,9 @@ describe('listModels — ovmsFetcher config endpoint', () => {
     expect(models.map((m) => m.apiModelId)).toEqual(['Qwen3-4B-int4-ov'])
   })
 
-  // A servable that is registered in config.json but failed to load must not be offered
-  // as a usable model.
-  it('lists only servables reporting an AVAILABLE version', async () => {
+  // All models registered in OVMS config are listed regardless of their server-side
+  // loading state, so users see every downloaded model in the model manager.
+  it('lists all configured servables regardless of loading state', async () => {
     aiSdkGetFromApiMock.mockResolvedValue({
       value: {
         'Qwen3-4B-int4-ov': { model_version_status: [{ state: 'AVAILABLE' }] },
@@ -1023,7 +1023,11 @@ describe('listModels — ovmsFetcher config endpoint', () => {
 
     const models = await listModels(makeOvmsProvider('http://localhost:8000/v3/'))
 
-    expect(models.map((m) => m.apiModelId)).toEqual(['Qwen3-4B-int4-ov'])
+    expect(models.map((m) => m.apiModelId)).toEqual([
+      'Qwen3-4B-int4-ov',
+      'FLUX.1-schnell-int4-ov',
+      'bge-base-en-v1.5-fp16-ov'
+    ])
   })
 })
 

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -395,10 +395,13 @@ const ovmsFetcher: ModelFetcher = {
       responseSchema: OVMSConfigResponseSchema,
       abortSignal: signal
     })
-    const entries = Object.entries(response).filter(([, info]) =>
-      info?.model_version_status?.some((v) => v?.state === 'AVAILABLE')
+    // List every model registered in OVMS config regardless of its server-side
+    // loading state (AVAILABLE, LOADING, FAILED_PRECONDITION, etc.).  Users
+    // expect downloaded models to appear in the model manager even when OVMS
+    // fails to load them server-side — the UI communicates readiness, not OVMS.
+    return dedup(Object.entries(response), ([name]) => name).map(([name]) =>
+      toModel(name, provider, { ownedBy: 'ovms' })
     )
-    return dedup(entries, ([name]) => name).map(([name]) => toModel(name, provider, { ownedBy: 'ovms' }))
   }
 }
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: The `ovmsFetcher` in `listModels.ts` filtered OVMS models to only those with `state === 'AVAILABLE'` in the `/v1/config` response. Models that failed to load server-side (due to unsupported VLM types, corrupted weights, missing graph files, etc.) never reached `AVAILABLE` state and were hidden from the model manager.

After this PR: All models registered in OVMS's `config.json` are listed in Cherry Studio regardless of their server-side loading state (AVAILABLE, LOADING, FAILED_PRECONDITION, etc.). Users see every downloaded model in the model manager, matching the expectation that downloaded models should appear.

Fixes #18588

### Why we need it and why it was done in this way

Users downloading models through the built-in OVMS download feature expected all downloaded models to appear in the model manager and "Get Models" interface. However, the `AVAILABLE` state filter silently excluded models that OVMS failed to load server-side — leaving users confused about why only some models appeared.

The fix removes the server-side state filter entirely. Cherry Studio's role is to surface configured models; OVMS's server-side validation errors are a separate concern that should not prevent models from being listed.

The following alternatives were considered:

- Showing models with a status indicator (AVAILABLE/FAILED/LOADING) — more informative but requires UI changes beyond the scope of this bug fix.
- Only filtering out models with empty `model_version_status` (never registered) — still hides failed models.

### Breaking changes

None.

### Special notes for your reviewer

The existing test `lists only servables reporting an AVAILABLE version` was updated to reflect the new behavior: it now asserts all configured models are listed regardless of state.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix OVMS downloaded models not appearing in model manager when server-side loading fails
```