### PR TITLE
fix(markdown-parser): skip hidden directories in skill directory scanner

### DIFF
--- a/src/main/utils/__tests__/markdownParser.directories.test.ts
+++ b/src/main/utils/__tests__/markdownParser.directories.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import { findAllSkillDirectories } from '../markdownParser'
 
+/** Normalize path separators to forward slash for cross-platform assertions. */
+const fwd = (p: string): string => p.replaceAll('\\', '/')
+
 describe('findAllSkillDirectories', () => {
   const tempDirs: string[] = []
 
@@ -26,6 +29,31 @@ describe('findAllSkillDirectories', () => {
 
     const result = await findAllSkillDirectories(root, root)
 
-    expect(result.map((candidate) => candidate.sourcePath).sort()).toEqual(['first/shared-name', 'second/shared-name'])
+    expect(result.map((candidate) => fwd(candidate.sourcePath)).sort()).toEqual([
+      'first/shared-name',
+      'second/shared-name'
+    ])
+  })
+
+  it('skips hidden directories and node_modules', async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'skill-directories-'))
+    tempDirs.push(root)
+    const visible = path.join(root, 'skills', 'my-skill')
+    const hidden = path.join(root, '.openclaw', 'skills', 'my-skill')
+    const nodeModules = path.join(root, 'node_modules', 'my-skill')
+    await Promise.all([
+      fs.promises.mkdir(visible, { recursive: true }),
+      fs.promises.mkdir(hidden, { recursive: true }),
+      fs.promises.mkdir(nodeModules, { recursive: true })
+    ])
+    await Promise.all([
+      fs.promises.writeFile(path.join(visible, 'SKILL.md'), '# visible'),
+      fs.promises.writeFile(path.join(hidden, 'SKILL.md'), '# hidden'),
+      fs.promises.writeFile(path.join(nodeModules, 'SKILL.md'), '# node_modules')
+    ])
+
+    const result = await findAllSkillDirectories(root, root)
+
+    expect(result.map((candidate) => fwd(candidate.sourcePath))).toEqual(['skills/my-skill'])
   })
 })

--- a/src/main/utils/markdownParser.ts
+++ b/src/main/utils/markdownParser.ts
@@ -272,6 +272,8 @@ export async function findAllSkillDirectories(
     const entries = await fs.promises.readdir(dirPath, { withFileTypes: true })
 
     for (const entry of entries) {
+      // Skip hidden directories and node_modules
+      if (entry.name.startsWith('.') || entry.name === 'node_modules') continue
       // Support both directories and symlinks pointing to directories
       if (await isDirectoryOrSymlinkToDirectory(entry, dirPath)) {
         const subDirPath = path.join(dirPath, entry.name)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`findAllSkillDirectories()` in `markdownParser.ts` recursed into **all** subdirectories when scanning for SKILL.md files — including hidden directories (`.openclaw/`, `.cursor/`, `.git/`, etc.) and `node_modules/`.

Repos that store platform-specific plugin copies in hidden directories (e.g. the popular `dietrichgebert/ponytail` repo has identical SKILL.md files in both `skills/ponytail/` and `.openclaw/skills/ponytail/`) produced **duplicate candidates with the same skill name**, causing `resolveSkillDirectory()` to throw:

```
Multiple SKILL.md files declare the specified skill: ponytail
```

After this PR:

Hidden directories (those starting with `.`) and `node_modules` are skipped during the recursive scan. Only visible, non-`node_modules` directories are traversed.

Fixes #18790

### Why we need it and why it was done in this way

The fix follows an existing pattern: `SkillService.buildFileTree()` (line 1596) already applies the same `!e.name.startsWith('.') && e.name !== 'node_modules'` filter. Hidden directories in cloned repos are config/plugin directories (`.openclaw/`, `.cursor/`, `.claude/`, etc.), not user-authored skills — they should never be scanned.

The following tradeoffs were made:

- A skill literally stored inside a hidden directory would no longer be discovered by the scanner. This is acceptable: hidden directories are platform tool configuration, not skill authoring locations.

The following alternatives were considered:

- Deduplicating candidates by name after the scan. Rejected: it would silently pick an arbitrary copy instead of the correct one.

### Breaking changes

None.

### Special notes for your reviewer

The ponytail repo (`dietrichgebert/ponytail`) has 37,800+ installs on skills.sh. You can verify the fix by cloning that repo and confirming `findAllSkillDirectories` no longer returns `.openclaw/skills/ponytail/` as a candidate.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required — this restores the documented install behavior rather than changing it.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed skill marketplace installs failing for repos that contain duplicate SKILL.md files in hidden directories (e.g. `.openclaw/`): the skill directory scanner now skips hidden directories and `node_modules`.
```
