### PR TITLE
fix(agent-runtime): surface ExitPlanMode plans

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -817,6 +817,18 @@ class ClaudeCodeRuntimeConnection implements AgentRuntimeConnection {
   private bindApprovalEmitter(): void {
     if (!this.approvalEmitter) return
     this.approvalEmitter.emit = (request) => this.eventQueue.push({ type: 'tool-approval-request', request })
+    this.approvalEmitter.emitInput = (request) =>
+      this.eventQueue.push({
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: request.toolCallId,
+          toolName: request.toolName,
+          input: request.input,
+          providerExecuted: true,
+          dynamic: true
+        }
+      })
   }
 
   /**

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -3320,6 +3320,25 @@ describe('ClaudeCodeRuntimeDriver', () => {
         }
       }
     })
+
+    approvalEmitter.emitInput({
+      toolCallId: 'tool-plan-1',
+      toolName: 'ExitPlanMode',
+      input: { plan: '# Plan' }
+    })
+    await expect(events.next()).resolves.toMatchObject({
+      value: {
+        type: 'chunk',
+        chunk: {
+          type: 'tool-input-available',
+          toolCallId: 'tool-plan-1',
+          toolName: 'ExitPlanMode',
+          input: { plan: '# Plan' },
+          dynamic: true,
+          providerExecuted: true
+        }
+      }
+    })
     void connection.close()
     expect(dispose).toHaveBeenCalled()
   })

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -1509,6 +1509,73 @@ describe('buildClaudeCodeSessionSettings', () => {
     expect(getInteractionState).toHaveBeenCalledWith('session-1')
   })
 
+  it('surfaces the normalized ExitPlanMode plan before denying a headless turn', async () => {
+    mocks.applicationGet.mockImplementation((name: string) => {
+      if (name === 'PreferenceService') return { get: vi.fn(() => undefined) }
+      if (name === 'McpCatalogService') return { listTools: vi.fn(async () => []) }
+      if (name === 'AgentSessionRuntimeService') {
+        return { getInteractionState: () => ({ currentTurn: 'headless', userResponse: 'unavailable' }) }
+      }
+      throw new Error(`Unexpected application.get(${name})`)
+    })
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+    const emitInput = vi.fn()
+    ;(settings.approvalEmitter as { emitInput?: typeof emitInput }).emitInput = emitInput
+    const input = { plan: '# Release plan\n\n1. Add the regression test' }
+
+    const result = await settings.canUseTool?.('ExitPlanMode', input, {
+      signal: { aborted: false },
+      toolUseID: 'exit-plan-1'
+    } as never)
+
+    expect(emitInput).toHaveBeenCalledWith({
+      toolCallId: 'exit-plan-1',
+      toolName: 'ExitPlanMode',
+      input
+    })
+    expect(result).toEqual({
+      behavior: 'deny',
+      message:
+        'This channel or scheduled turn has no interactive responder, so proceed without asking the user and state your assumptions instead.'
+    })
+  })
+
+  it('surfaces the normalized ExitPlanMode plan before requesting interactive approval', async () => {
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+    const emitInput = vi.fn()
+    const emit = vi.fn()
+    ;(settings.approvalEmitter as { emit?: typeof emit; emitInput?: typeof emitInput }).emitInput = emitInput
+    settings.approvalEmitter!.emit = emit
+    const input = { plan: '# Release plan\n\n1. Add the regression test' }
+
+    void settings.canUseTool?.('ExitPlanMode', input, {
+      signal: { aborted: false },
+      toolUseID: 'exit-plan-1'
+    } as never)
+
+    expect(emitInput).toHaveBeenCalledWith({
+      toolCallId: 'exit-plan-1',
+      toolName: 'ExitPlanMode',
+      input
+    })
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({ toolCallId: 'exit-plan-1', input }))
+    expect(emitInput.mock.invocationCallOrder[0]).toBeLessThan(emit.mock.invocationCallOrder[0])
+  })
+
   it('denies interactive no-responder tools via PreToolUse so the gate fires under bypassPermissions', async () => {
     // The SDK skips `canUseTool` for auto-approved paths (bypassPermissions / acceptEdits), so the
     // per-turn denial must also run as a PreToolUse hook (which fires in every permission mode) or a
@@ -1559,6 +1626,44 @@ describe('buildClaudeCodeSessionSettings', () => {
       )
     }
     expect(getInteractionState).toHaveBeenCalledWith('session-1')
+  })
+
+  it('surfaces a headless ExitPlanMode plan from PreToolUse before bypassPermissions denies it', async () => {
+    mocks.applicationGet.mockImplementation((name: string) => {
+      if (name === 'PreferenceService') return { get: vi.fn(() => undefined) }
+      if (name === 'McpCatalogService') return { listTools: vi.fn(async () => []) }
+      if (name === 'AgentSessionRuntimeService') {
+        return { getInteractionState: () => ({ currentTurn: 'headless', userResponse: 'unavailable' }) }
+      }
+      throw new Error(`Unexpected application.get(${name})`)
+    })
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+    const emitInput = vi.fn()
+    ;(settings.approvalEmitter as { emitInput?: typeof emitInput }).emitInput = emitInput
+    const input = { plan: '# Headless plan' }
+
+    await Promise.all(
+      (settings.hooks?.PreToolUse?.[0]?.hooks ?? []).map((hook) =>
+        hook(
+          { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode', tool_input: input } as never,
+          'exit-plan-hook-1',
+          {} as never
+        )
+      )
+    )
+
+    expect(emitInput).toHaveBeenCalledWith({
+      toolCallId: 'exit-plan-hook-1',
+      toolName: 'ExitPlanMode',
+      input
+    })
   })
 
   it('forces AskUserQuestion through approval without denying other interactive tools', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -1666,6 +1666,57 @@ describe('buildClaudeCodeSessionSettings', () => {
     })
   })
 
+  it.each(['bypassPermissions', 'acceptEdits'] as const)(
+    'surfaces an interactive ExitPlanMode plan from PreToolUse under %s',
+    async (permissionMode) => {
+      mocks.getAgent.mockReturnValue({
+        id: 'agent-1',
+        type: 'claude-code',
+        instructions: 'Follow instructions.',
+        model: 'anthropic::claude-sonnet',
+        planModel: 'anthropic::claude-sonnet',
+        smallModel: 'anthropic::claude-haiku',
+        mcps: [],
+        allowedTools: [],
+        configuration: { permission_mode: permissionMode }
+      })
+      const settings = await buildClaudeCodeSessionSettings(
+        {
+          id: 'session-1',
+          agentId: 'agent-1',
+          workspace: { type: 'user', path: '/workspace/project' }
+        } as never,
+        {} as never
+      )
+      const emitInput = vi.fn()
+      ;(settings.approvalEmitter as { emitInput?: typeof emitInput }).emitInput = emitInput
+      const input = { plan: '# Interactive plan' }
+
+      const results = await Promise.all(
+        (settings.hooks?.PreToolUse?.[0]?.hooks ?? []).map((hook) =>
+          hook(
+            { hook_event_name: 'PreToolUse', tool_name: 'ExitPlanMode', tool_input: input } as never,
+            'exit-plan-hook-1',
+            {} as never
+          )
+        )
+      )
+
+      expect(settings.permissionMode).toBe(permissionMode)
+      expect(results).not.toContainEqual(
+        expect.objectContaining({
+          hookSpecificOutput: expect.objectContaining({ permissionDecision: expect.stringMatching(/ask|deny/) })
+        })
+      )
+      expect(emitInput).toHaveBeenCalledTimes(1)
+      expect(emitInput).toHaveBeenCalledWith({
+        toolCallId: 'exit-plan-hook-1',
+        toolName: 'ExitPlanMode',
+        input
+      })
+    }
+  )
+
   it('forces AskUserQuestion through approval without denying other interactive tools', async () => {
     const getInteractionState = vi.fn(() => ({ currentTurn: 'interactive', userResponse: 'stream' }))
     mocks.applicationGet.mockImplementation((name: string) => {

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -1098,12 +1098,14 @@ async function buildToolPermissions(
     const toolName = String((input as Record<string, unknown>).tool_name ?? '')
     if (!HEADLESS_INTERACTIVE_TOOLS.includes(toolName as (typeof HEADLESS_INTERACTIVE_TOOLS)[number])) return {}
 
+    const toolInput = (input as Record<string, unknown>).tool_input
+    if (toolUseId && toolInput && typeof toolInput === 'object' && !Array.isArray(toolInput)) {
+      // `canUseTool` is skipped for auto-approved paths (bypassPermissions / acceptEdits), so
+      // surface the normalized plan from the hook that runs under every permission mode.
+      surfaceExitPlanModeInput(session.id, toolName, toolInput as Record<string, unknown>, toolUseId)
+    }
+
     if (application.get('AgentSessionRuntimeService').getInteractionState(session.id).userResponse === 'unavailable') {
-      const toolInput = (input as Record<string, unknown>).tool_input
-      if (toolUseId && toolInput && typeof toolInput === 'object' && !Array.isArray(toolInput)) {
-        // A deny hook short-circuits `canUseTool`, so surface the normalized plan here as well.
-        surfaceExitPlanModeInput(session.id, toolName, toolInput as Record<string, unknown>, toolUseId)
-      }
       return {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -180,6 +180,7 @@ function resolveRequestedOutputTokens(
 }
 
 const ASK_USER_QUESTION_TOOL_NAME = 'AskUserQuestion'
+const EXIT_PLAN_MODE_TOOL_NAME = 'ExitPlanMode'
 const HEADLESS_INTERACTIVE_TOOLS = [
   ASK_USER_QUESTION_TOOL_NAME,
   'EnterPlanMode',
@@ -228,6 +229,7 @@ function getToolApprovalEmitterHolder(sessionId: string): ToolApprovalEmitterHol
     const nextHolder: ToolApprovalEmitterHolder = {
       dispose: () => {
         nextHolder.emit = undefined
+        nextHolder.emitInput = undefined
         toolApprovalRegistry.abort(sessionId, 'stream-ended')
         // Evict so the module-level Map doesn't grow unbounded across sessions;
         // the holder is rebuilt lazily on the next settings build.
@@ -247,6 +249,16 @@ function getToolApprovalEmitterHolder(sessionId: string): ToolApprovalEmitterHol
 // means no live stream is bound, so the approval is denied.
 function peekToolApprovalEmitter(sessionId: string): ToolApprovalEmitterHolder | undefined {
   return toolApprovalEmitters.get(sessionId)
+}
+
+function surfaceExitPlanModeInput(
+  sessionId: string,
+  toolName: string,
+  input: Record<string, unknown>,
+  toolCallId: string
+): void {
+  if (toolName !== EXIT_PLAN_MODE_TOOL_NAME || typeof input.plan !== 'string' || !input.plan.trim()) return
+  peekToolApprovalEmitter(sessionId)?.emitInput?.({ toolCallId, toolName, input })
 }
 
 // Session-keyed so a warm-pooled query's PreToolUse steer hook and the live connection's
@@ -945,6 +957,10 @@ async function buildToolPermissions(
     // no-responder denial at fire time for interactive and approval-required tools. PreToolUse
     // mirrors both groups for bypassPermissions/acceptEdits, where the SDK skips `canUseTool`.
     const interactionState = application.get('AgentSessionRuntimeService').getInteractionState(session.id)
+    // Claude Code streams ExitPlanMode's model-authored `{}` before normalizing the plan file into
+    // the permission input. Replace that raw input while the tool row is still live so the approval
+    // preview — and a later headless denial — retain the plan the SDK actually reviewed.
+    surfaceExitPlanModeInput(session.id, toolName, input, opts.toolUseID)
     const requiresInteractiveResponder =
       HEADLESS_INTERACTIVE_TOOLS.includes(toolName as (typeof HEADLESS_INTERACTIVE_TOOLS)[number]) ||
       approvalRequiredTools.includes(toolName)
@@ -1077,12 +1093,17 @@ async function buildToolPermissions(
   // Headless turns deny tools that need a responder. Interactive AskUserQuestion calls explicitly ask
   // so bypassPermissions cannot skip `canUseTool` and execute without a user-authored answer.
   // Resolve headless state by session id at fire-time so warm connections are judged per turn.
-  const interactiveToolPermissionHook: HookCallback = async (input): Promise<HookJSONOutput> => {
+  const interactiveToolPermissionHook: HookCallback = async (input, toolUseId): Promise<HookJSONOutput> => {
     if (!input || input.hook_event_name !== 'PreToolUse') return {}
     const toolName = String((input as Record<string, unknown>).tool_name ?? '')
     if (!HEADLESS_INTERACTIVE_TOOLS.includes(toolName as (typeof HEADLESS_INTERACTIVE_TOOLS)[number])) return {}
 
     if (application.get('AgentSessionRuntimeService').getInteractionState(session.id).userResponse === 'unavailable') {
+      const toolInput = (input as Record<string, unknown>).tool_input
+      if (toolUseId && toolInput && typeof toolInput === 'object' && !Array.isArray(toolInput)) {
+        // A deny hook short-circuits `canUseTool`, so surface the normalized plan here as well.
+        surfaceExitPlanModeInput(session.id, toolName, toolInput as Record<string, unknown>, toolUseId)
+      }
       return {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',

--- a/src/main/ai/runtime/claudeCode/types.ts
+++ b/src/main/ai/runtime/claudeCode/types.ts
@@ -67,6 +67,8 @@ export type ClaudeCodeSettings = Omit<Options, 'model' | 'abortController' | 'pr
 export type ToolApprovalEmitterHolder = {
   /** Bound for the connection lifetime; the host decides whether to stream or persist the request. */
   emit?: (request: AgentRuntimeToolApprovalRequest) => void
+  /** Replaces a streamed tool call's raw input with the SDK-normalized input before approval. */
+  emitInput?: (request: Pick<AgentRuntimeToolApprovalRequest, 'toolCallId' | 'toolName' | 'input'>) => void
   /** Session-scoped cleanup (e.g. `toolApprovalRegistry.abort(sessionId)`). */
   dispose?: () => void
 }

--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -341,6 +341,22 @@ describe('AgentToolRenderer', () => {
   })
 
   describe('completed tool rendering', () => {
+    it('does not duplicate an ExitPlanMode plan repeated in the tool result', () => {
+      const plan = '# Release plan\n\n1. Run the focused tests'
+      const toolResponse = createToolResponse({
+        tool: { id: 'ExitPlanMode', name: 'ExitPlanMode', description: 'Exit plan mode', type: 'provider' },
+        status: 'done',
+        arguments: { plan },
+        response: { plan, isAgent: false }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getAllByText('Release plan')).toHaveLength(1)
+      expect(screen.getAllByText('Run the focused tests')).toHaveLength(1)
+    })
+
     it('should render newly supported structured agent tools', () => {
       const toolResponse = createToolResponse({
         tool: { id: 'TaskCreate', name: 'TaskCreate', description: 'Create task', type: 'provider' },

--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -357,6 +357,22 @@ describe('AgentToolRenderer', () => {
       expect(screen.getAllByText('Run the focused tests')).toHaveLength(1)
     })
 
+    it('does not duplicate an ExitPlanMode plan that differs only by surrounding whitespace', () => {
+      const plan = '# Release plan\n\n1. Run the focused tests'
+      const toolResponse = createToolResponse({
+        tool: { id: 'ExitPlanMode', name: 'ExitPlanMode', description: 'Exit plan mode', type: 'provider' },
+        status: 'done',
+        arguments: { plan: `${plan}   ` },
+        response: { plan: `  ${plan}\n`, isAgent: false }
+      })
+
+      render(<AgentToolRenderer toolResponse={toolResponse} />)
+      fireEvent.click(screen.getByRole('button'))
+
+      expect(screen.getAllByText('Release plan')).toHaveLength(1)
+      expect(screen.getAllByText('Run the focused tests')).toHaveLength(1)
+    })
+
     it('should render newly supported structured agent tools', () => {
       const toolResponse = createToolResponse({
         tool: { id: 'TaskCreate', name: 'TaskCreate', description: 'Create task', type: 'provider' },

--- a/src/renderer/components/chat/messages/tools/agent/ExitPlanModeTool.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/ExitPlanModeTool.tsx
@@ -19,7 +19,9 @@ export function ExitPlanModeTool({
   const outputContent = typeof output === 'string' ? output : (output?.plan ?? '')
   // The SDK returns the same normalized plan after approval. Keep distinct result text, but do not
   // render an identical plan twice once both the permission input and tool output are available.
-  const combinedContent = Array.from(new Set([plan, outputContent].filter((content) => content.trim()))).join('\n\n')
+  const combinedContent = Array.from(
+    new Set([plan, outputContent].map((content) => content.trim()).filter(Boolean))
+  ).join('\n\n')
   const { data: truncatedContent, isTruncated, originalLength } = truncateOutput(combinedContent)
   const planCount = combinedContent ? 1 : 0
 

--- a/src/renderer/components/chat/messages/tools/agent/ExitPlanModeTool.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/ExitPlanModeTool.tsx
@@ -17,9 +17,11 @@ export function ExitPlanModeTool({
   const { t } = useTranslation()
   const plan = input?.plan ?? ''
   const outputContent = typeof output === 'string' ? output : (output?.plan ?? '')
-  const combinedContent = plan + '\n\n' + outputContent
+  // The SDK returns the same normalized plan after approval. Keep distinct result text, but do not
+  // render an identical plan twice once both the permission input and tool output are available.
+  const combinedContent = Array.from(new Set([plan, outputContent].filter((content) => content.trim()))).join('\n\n')
   const { data: truncatedContent, isTruncated, originalLength } = truncateOutput(combinedContent)
-  const planCount = plan.split('\n\n').length
+  const planCount = combinedContent ? 1 : 0
 
   return {
     key: AgentToolsType.ExitPlanMode,

--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -166,6 +166,27 @@ describe('PermissionRequestComposer', () => {
     expect(screen.getByTestId('permission-builtin-body-scroll')).toHaveClass('max-h-60', 'overflow-y-auto')
   })
 
+  it('renders the ExitPlanMode plan in the approval preview', () => {
+    render(
+      <PermissionRequestComposer
+        request={makeRequest({
+          title: 'ExitPlanMode',
+          toolResponse: {
+            id: 'exit-plan-call-1',
+            toolCallId: 'exit-plan-call-1',
+            status: 'pending',
+            arguments: { plan: '# Release plan\n\n1. Run the focused tests' },
+            tool: { id: 'ExitPlanMode', name: 'ExitPlanMode', type: 'builtin' }
+          }
+        })}
+        onRespond={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Release plan')).toBeInTheDocument()
+    expect(screen.getByText('Run the focused tests')).toBeInTheDocument()
+  })
+
   it('does not add a fallback body scroller when the tool content owns scrolling', () => {
     render(
       <PermissionRequestComposer


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Claude Code initially streamed `ExitPlanMode` with an empty tool input. Although the SDK later normalized the saved plan into the permission request, the live approval bridge forwarded only the approval ID. As a result, the composer showed a generic empty tool preview, and headless denials discarded the normalized plan.

After this PR:

The Claude Code runtime refreshes the streamed `ExitPlanMode` input with the SDK-normalized plan before interactive approval or headless denial. The existing plan renderer then shows the plan in the permission composer and transcript, while identical input and output plans are rendered only once.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18601

### Why we need it and why it was done in this way

The SDK already owns plan-file lookup and input normalization, so this change forwards that normalized input through the existing runtime stream instead of reading Claude's plan files independently. This preserves the current approval flow and fail-closed headless behavior.

The following tradeoffs were made:

The input refresh is scoped to non-empty `ExitPlanMode.plan` values. Headless turns still deny interactive plan exit; they now retain the plan in the tool record instead of silently dropping it.

The following alternatives were considered:

A dedicated plan-dialog protocol and direct plan-file reads were considered, but both would duplicate SDK behavior and broaden the change. Auto-approving `ExitPlanMode` in headless turns was rejected because it would change permission semantics.

Links to places where the discussion took place: #18601

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

The current Claude Agent SDK emits the raw tool call before `normalizeToolInput` injects `plan`. Regression tests cover interactive approval, headless denial, the `PreToolUse` short-circuit path, the runtime input-refresh chunk, approval preview rendering, and duplicate output suppression.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent Plan Mode so ExitPlanMode approval and denied headless tool records show the generated plan instead of an empty tool preview.
```
