### PR TITLE
fix(provider-error): extract nested detail.error.message and wrap long tokens

### DIFF
--- a/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/ErrorBlock.tsx
@@ -239,7 +239,7 @@ const MessageErrorInfo: React.FC<{
 
       {/* Description */}
       <div
-        className="wrap-break-word ml-5.75 line-clamp-3 text-xs leading-normal [&_a]:text-link"
+        className="[overflow-wrap:anywhere] ml-5.75 line-clamp-3 text-xs leading-normal [&_a]:text-link"
         style={{ color: ERROR_DESCRIPTION_COLOR }}>
         <ErrorMessage error={error} />
       </div>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelCheckDialog.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelCheckDialog.tsx
@@ -415,7 +415,7 @@ export default function ModelCheckDialog() {
                   <div className="pr-5 text-[13px] leading-[1.4]">{t('message.api.connection.failed')}</div>
                 </div>
                 <div
-                  className="wrap-break-word ml-5.75 line-clamp-3 text-xs leading-normal"
+                  className="[overflow-wrap:anywhere] ml-5.75 line-clamp-3 text-xs leading-normal"
                   style={{ color: CONNECTION_ERROR_DESCRIPTION_COLOR }}>
                   {singleErrorText}
                 </div>

--- a/src/renderer/utils/__tests__/error.test.ts
+++ b/src/renderer/utils/__tests__/error.test.ts
@@ -283,6 +283,30 @@ describe('error', () => {
       ).toBe('model access denied')
     })
 
+    it('reads a message nested under detail.error.message', () => {
+      expect(
+        providerErrorText({
+          name: 'AI_APICallError',
+          message: '429 Too Many Requests',
+          stack: null,
+          statusCode: 429,
+          responseBody:
+            '{"detail":{"error":{"message":"Model API rate limit exceeded; please retry later","type":"rate_limit_error","code":"global_concurrency_rate_limit_exceeded"}}}'
+        })
+      ).toBe('Model API rate limit exceeded; please retry later')
+    })
+
+    it('reads a message nested under detail.message', () => {
+      expect(
+        providerErrorText({
+          name: 'AI_APICallError',
+          message: 'Bad Request',
+          stack: null,
+          responseBody: '{"detail":{"message":"invalid model id"}}'
+        })
+      ).toBe('invalid model id')
+    })
+
     it('falls back to the raw body for an unrecognised shape', () => {
       expect(
         providerErrorText({

--- a/src/renderer/utils/error.ts
+++ b/src/renderer/utils/error.ts
@@ -334,7 +334,17 @@ export function providerErrorText(error: SerializedError | undefined): string {
 
   const parsed = parseJSON(body)
   // Probe the common shapes one level deep; an unknown shape falls through to the raw body.
-  const picked = parsed && (parsed.error?.message ?? parsed.message ?? parsed.detail ?? parsed.msg ?? parsed.error)
+  // Some providers (e.g. AMD) nest the message under `detail.error.message`; probe one
+  // more level there so users see the message, not the raw JSON body.
+  const picked =
+    parsed &&
+    (parsed.error?.message ??
+      parsed.message ??
+      parsed.detail?.error?.message ??
+      parsed.detail?.message ??
+      parsed.detail ??
+      parsed.msg ??
+      parsed.error)
   const text = typeof picked === 'string' && picked.trim() ? picked.trim() : body
   return text.length > PROVIDER_ERROR_TEXT_MAX ? `${text.slice(0, PROVIDER_ERROR_TEXT_MAX)}…` : text
 }


### PR DESCRIPTION
### What this PR does

Before this PR:

When a provider returns an error whose response body is JSON-nested under `detail.error.message` (e.g. AMD's rate-limit response `{"detail":{"error":{"message":"Model API rate limit exceeded; please retry later","type":"rate_limit_error","code":"global_concurrency_rate_limit_exceeded"}}}`), the connection-check popup and chat error block showed the **raw JSON body** instead of the human-readable message, and the long unbroken token (`...later","type":"rate_limit_error","code":"global_concurrency_rate_limit_exceeded"}}}`) overflowed the popup width.

After this PR:

- The popup shows only `Model API rate limit exceeded; please retry later`.
- Long unbroken tokens wrap inside the popup via `overflow-wrap: anywhere`.

### Why we need it and why it was done in this way

Two defects surfaced together in the same user-visible scenario (provider connection check / chat error popup):

1. **Logic layer** — `providerErrorText` probed only one level deep (`parsed.detail`), so `{\"detail\":{\"error\":{\"message\":...}}}` fell through to the raw body because `parsed.detail` is an object, not a string.
2. **Display layer** — the error-text container used `overflow-wrap: break-word`, which does not reliably break a long unbroken token; the trailing JSON fragment with no spaces overflowed the drawer.

The following tradeoffs were made:

- Both fixes ship in one PR because they share the same trigger scenario and only together restore the correct UX: the logic fix ensures the right text is shown, the display fix guarantees any remaining long token still wraps. Splitting them would leave one layer broken in isolation.

The following alternatives were considered:

- Only fix the logic layer (skip CSS): rejected — if another provider returns a genuinely long unbroken string, the overflow would recur.
- Only fix the display layer (skip logic): rejected — users would still see raw JSON instead of the friendly message.
- Unify all `wrap-break-word` occurrences repo-wide: rejected per the surgical-changes principle; only the two error-display containers in scope were changed. `data-table` already uses `[overflow-wrap:anywhere]` as precedent.

### Breaking changes

None.

### Special notes for your reviewer

- `providerErrorText` gains two probe candidates (`detail.error.message`, `detail.message`) before the existing `detail` fallback; existing probe paths are unchanged, so previously-recognised shapes still resolve identically.
- The CSS change swaps `wrap-break-word` → `[overflow-wrap:anywhere]` in two error-display containers (`ProviderConnectionCheckDrawer`, `ErrorBlock`). `data-table` already uses the same pattern.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than I found it
- [ ] Upgrade: N/A
- [ ] Documentation: N/A
- [x] Self-review: reviewed via `gh pr diff`

### Release note

```release-note
Fix: provider connection-check error popup no longer shows raw JSON for `detail.error.message`-nested errors, and long unbroken tokens no longer overflow the popup width.
```