### PR TITLE
fix(resource-list): unify drag overlay styling

### DIFF
--- a/src/renderer/components/VirtualList/GroupedSortableVirtualList.tsx
+++ b/src/renderer/components/VirtualList/GroupedSortableVirtualList.tsx
@@ -1278,7 +1278,7 @@ function GroupedSortableVirtualList<TGroup, TItem, THeader = TGroup, TFooter = u
     <DragOverlay dropAnimation={null}>
       {dragOverlayContent ? (
         <div
-          className="pointer-events-none"
+          className="pointer-events-none rounded-lg bg-background"
           style={{
             height: activeDragState?.overlaySize?.height,
             width: activeDragState?.overlaySize?.width

--- a/src/renderer/components/chat/resourceList/base/ResourceListContext.ts
+++ b/src/renderer/components/chat/resourceList/base/ResourceListContext.ts
@@ -145,7 +145,6 @@ export type ResourceListMeta<T extends ResourceListItemBase> = {
   getGroupHeaderLeadingAction?: (group: ResourceListGroup, context: ResourceListGroupHeaderIconContext) => ReactNode
   getGroupHeaderIcon?: (group: ResourceListGroup, context: ResourceListGroupHeaderIconContext) => ReactNode
   isGroupHeaderIconVisible?: (group: ResourceListGroup, context: ResourceListGroupHeaderIconContext) => boolean
-  getGroupHeaderClassName?: (group: ResourceListGroup) => string | undefined
   getGroupHeaderTooltip?: (group: ResourceListGroup) => string | undefined
   getGroupHeaderClickBehavior: (group: ResourceListGroup) => ResourceListGroupHeaderClickBehavior
   getGroupHeaderKind?: (group: ResourceListGroup) => ResourceListGroupHeaderKind

--- a/src/renderer/components/chat/resourceList/base/ResourceListGroups.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceListGroups.tsx
@@ -167,7 +167,6 @@ export function GroupHeader({ group, className, ref, style, onContextMenu, ...pr
   const groupHeaderContextMenu = meta.getGroupHeaderContextMenu?.(group)
   const groupHeaderLeadingAction = meta.getGroupHeaderLeadingAction?.(group, groupHeaderContext)
   const customGroupHeaderIcon = meta.getGroupHeaderIcon?.(group, groupHeaderContext)
-  const groupHeaderClassName = meta.getGroupHeaderClassName?.(group)
   const groupHeaderTooltip = meta.getGroupHeaderTooltip?.(group)
   const groupHeaderIcon = customGroupHeaderIcon ?? null
   // Default to `entity` explicitly: a list that declares no kinds at all reads as all-entity.
@@ -250,8 +249,7 @@ export function GroupHeader({ group, className, ref, style, onContextMenu, ...pr
         !showsSelectedSurface && RESOURCE_LIST_DESCENDANT_FOCUS_ROW_CLASS,
         showsSelectedSurface && 'has-[:focus-visible]:bg-resource-list-row-selected',
         isBucketHeader && 'text-muted-foreground',
-        showsSelectedSurface && RESOURCE_LIST_SELECTED_ROW_CLASS,
-        groupHeaderClassName
+        showsSelectedSurface && RESOURCE_LIST_SELECTED_ROW_CLASS
       )}>
       {groupHeaderLeadingAction && (
         <div

--- a/src/renderer/components/chat/resourceList/base/ResourceListProvider.tsx
+++ b/src/renderer/components/chat/resourceList/base/ResourceListProvider.tsx
@@ -325,7 +325,6 @@ export type ResourceListProviderProps<T extends ResourceListItemBase> = {
   getGroupHeaderLeadingAction?: ResourceListMeta<T>['getGroupHeaderLeadingAction']
   getGroupHeaderIcon?: ResourceListMeta<T>['getGroupHeaderIcon']
   isGroupHeaderIconVisible?: ResourceListMeta<T>['isGroupHeaderIconVisible']
-  getGroupHeaderClassName?: ResourceListMeta<T>['getGroupHeaderClassName']
   getGroupHeaderTooltip?: ResourceListMeta<T>['getGroupHeaderTooltip']
   groupHeaderClickBehavior?: ResourceListGroupHeaderClickBehaviorResolver
   getGroupHeaderKind?: (group: ResourceListGroup) => ResourceListGroupHeaderKind
@@ -533,7 +532,6 @@ export function ResourceListProvider<T extends ResourceListItemBase>({
   getGroupHeaderLeadingAction,
   getGroupHeaderIcon,
   isGroupHeaderIconVisible,
-  getGroupHeaderClassName,
   getGroupHeaderTooltip,
   groupHeaderClickBehavior = 'toggle',
   getGroupHeaderKind,
@@ -901,7 +899,6 @@ export function ResourceListProvider<T extends ResourceListItemBase>({
       getGroupHeaderLeadingAction,
       getGroupHeaderIcon,
       isGroupHeaderIconVisible,
-      getGroupHeaderClassName,
       getGroupHeaderTooltip,
       getGroupHeaderClickBehavior,
       getGroupHeaderKind,
@@ -937,7 +934,6 @@ export function ResourceListProvider<T extends ResourceListItemBase>({
       filterOptions,
       getSectionHeaderAction,
       getGroupHeaderAction,
-      getGroupHeaderClassName,
       getGroupHeaderClickBehavior,
       getGroupHeaderKind,
       getGroupHeaderContextMenu,

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1800,18 +1800,6 @@ const Sessions = ({
     [assistantIconType, displayMode]
   )
 
-  const getGroupHeaderClassName = useCallback(
-    (group: ResourceListGroup) => {
-      if (displayMode !== 'agent' || group.id === SESSION_PINNED_GROUP_ID) return undefined
-
-      const agentId = getAgentIdFromSessionGroupId(group.id)
-      if (!agentId || !agentById.has(agentId)) return undefined
-
-      return 'rounded-lg border border-transparent'
-    },
-    [agentById, displayMode]
-  )
-
   // Only the pseudo-group gets a tooltip: it needs explaining. Real agent rows don't — a hint about
   // dragging fired on every hover, covering the row next to it to say something you find by trying.
   const getGroupHeaderTooltip = useCallback(
@@ -1975,7 +1963,6 @@ const Sessions = ({
       groupLoadStep={DEFAULT_SESSION_GROUP_VISIBLE_COUNT}
       getSectionHeaderAction={getSectionHeaderAction}
       getGroupHeaderAction={getGroupHeaderAction}
-      getGroupHeaderClassName={getGroupHeaderClassName}
       getGroupHeaderContextMenu={getGroupHeaderContextMenu}
       getGroupHeaderIcon={getGroupHeaderIcon}
       isGroupHeaderIconVisible={isGroupHeaderIconVisible}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Drag previews in the assistant and agent conversation sidebars used different surfaces. Agent group previews could appear transparent, and the agent list supplied a page-specific transparent border style.

After this PR:

All resource-list drag previews use the same shared background and radius. The agent-only group-header style hook and override are removed so both sidebars share one styling path.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Drag feedback is a shared resource-list concern, so the shared drag overlay now owns its surface. Removing the page-specific customization prevents the assistant and agent sidebars from drifting apart again.

The following tradeoffs were made:

Every consumer of the shared grouped sortable list now receives the same semantic background and radius during dragging.

The following alternatives were considered:

Adding an agent-only background or retaining the page-specific class hook was rejected because either option would preserve separate styling paths.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

`pnpm lint` passed with 37 pre-existing ESLint warnings and no errors. `git diff --check` also passed. Per workspace verification policy, no targeted tests or manual UI verification were run, and the app was not launched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Use consistent drag-preview backgrounds in assistant and agent conversation lists.
```
