### PR TITLE
fix(ai-params): serialize disabled reasoning for Responses models

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -1,5 +1,7 @@
 import path from 'node:path'
 
+import { createOpenAI } from '@ai-sdk/openai'
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
 import type { ProviderOptions } from '@ai-sdk/provider-utils'
 import { generateText as aiCoreGenerateText } from '@cherrystudio/ai-core'
 import { FS_READ_TOOL_NAME } from '@shared/ai/builtinTools'
@@ -736,6 +738,59 @@ describe('buildAgentParams web-tool routing', () => {
 })
 
 describe('buildAgentParams assistant-less reasoning', () => {
+  it('disables Bailian qwen3.7-max reasoning in the serialized Responses request', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: {
+        providerId: 'openai',
+        providerSettings: {}
+      },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'dashscope',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { adapterFamily: 'openai-compatible' },
+        [ENDPOINT_TYPE.OPENAI_RESPONSES]: { adapterFamily: 'openai' }
+      }
+    })
+    const model = makeModel({
+      id: 'dashscope::qwen3-7-max',
+      providerId: 'dashscope',
+      apiModelId: 'qwen3.7-max',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS],
+      capabilities: [MODEL_CAPABILITY.REASONING],
+      reasoning: {
+        controls: [{ kind: 'toggle' }],
+        selectableEfforts: ['none', 'auto']
+      }
+    })
+
+    const result = await buildAgentParams({
+      request: { reasoningEffort: 'none' },
+      signal: undefined,
+      provider,
+      model
+    })
+    const prompt: LanguageModelV3CallOptions['prompt'] = [
+      { role: 'user', content: [{ type: 'text', text: 'Translate this.' }] }
+    ]
+    let requestBody: Record<string, unknown> | undefined
+    const sdkModel = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body))
+        throw new Error('request captured')
+      }
+    }).responses('qwen3.7-max')
+
+    await expect(sdkModel.doGenerate({ prompt, providerOptions: result.options.providerOptions })).rejects.toThrow(
+      'request captured'
+    )
+    expect(requestBody).toMatchObject({ reasoning: { effort: 'none' } })
+  })
+
   const makeOffCapableSetup = () => {
     resolveProviderAiSdkConfigMock.mockResolvedValue({
       config: {

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -274,7 +274,15 @@ export function buildResolvedReasoningProviderOptions(context: {
   const options = shouldNormalizeOpenAICompatibleReasoning(context.aiSdkProviderId, context.endpointType)
     ? normalizeOpenAICompatibleParams(encoded.options)
     : encoded.options
-  return Object.keys(options).length > 0 ? { [encoded.providerId]: options } : {}
+  if (Object.keys(options).length === 0) return {}
+
+  return {
+    [encoded.providerId]: {
+      ...options,
+      ...(context.endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES &&
+        encoded.providerId === 'openai' && { forceReasoning: true })
+    }
+  }
 }
 
 /** Whether a custom parameter key names a providerOptions namespace rather than a body field. */

--- a/src/main/features/apiGateway/adapters/__tests__/providerOptionsMapper.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/providerOptionsMapper.test.ts
@@ -166,9 +166,9 @@ describe('cross-dialect descriptor translation', () => {
 
     expect(
       mapAnthropicThinkingToProviderOptions(target, openAIModel, { type: 'enabled', budget_tokens: 6000 })
-    ).toEqual({ openai: { reasoningEffort: 'medium' } })
+    ).toEqual({ openai: { reasoningEffort: 'medium', forceReasoning: true } })
     expect(mapAnthropicThinkingToProviderOptions(target, openAIModel, { type: 'disabled' })).toEqual({
-      openai: { reasoningEffort: 'none' }
+      openai: { reasoningEffort: 'none', forceReasoning: true }
     })
   })
 
@@ -184,23 +184,23 @@ describe('cross-dialect descriptor translation', () => {
         type: 'enabled',
         budget_tokens: 1500
       })
-    ).toEqual({ openai: { reasoningEffort: 'high' } })
+    ).toEqual({ openai: { reasoningEffort: 'high', forceReasoning: true } })
   })
 
   it('normalizes Gemini sentinels, levels, and positive budgets before target dispatch', () => {
     const target = provider('openai', ENDPOINT_TYPE.OPENAI_RESPONSES)
 
     expect(mapGeminiThinkingToProviderOptions(target, openAIModel, { thinkingBudget: -1 })).toEqual({
-      openai: { reasoningEffort: 'medium' }
+      openai: { reasoningEffort: 'medium', forceReasoning: true }
     })
     expect(mapGeminiThinkingToProviderOptions(target, openAIModel, { thinkingBudget: 0 })).toEqual({
-      openai: { reasoningEffort: 'none' }
+      openai: { reasoningEffort: 'none', forceReasoning: true }
     })
     expect(mapGeminiThinkingToProviderOptions(target, openAIModel, { thinkingLevel: 'high' })).toEqual({
-      openai: { reasoningEffort: 'high' }
+      openai: { reasoningEffort: 'high', forceReasoning: true }
     })
     expect(mapGeminiThinkingToProviderOptions(target, openAIModel, { thinkingBudget: 6000 })).toEqual({
-      openai: { reasoningEffort: 'medium' }
+      openai: { reasoningEffort: 'medium', forceReasoning: true }
     })
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Assistant-less translation and language detection requested `reasoningEffort: none`, but the OpenAI Responses adapter silently omitted it for Bailian Qwen model IDs that the SDK did not recognize as reasoning models. Bailian then used its default reasoning mode, causing long waits and sometimes blank or extra output.

After this PR:

Resolved OpenAI Responses reasoning options explicitly force reasoning-model serialization, so disabled reasoning reaches Bailian as `reasoning: { effort: "none" }`. Other endpoint families and requests without an explicit reasoning selection remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The shared reasoning-to-provider-options boundary now opts into the AI SDK's supported `forceReasoning` behavior only when a resolved reasoning payload targets the OpenAI Responses namespace. This fixes translation, language detection, and API Gateway consumers consistently without provider- or model-ID heuristics.

The following tradeoffs were made:

- `forceReasoning` also enables the SDK's reasoning-model compatibility rules, matching the existing assistant-backed OpenAI Responses path.
- The behavior applies to every resolved OpenAI Responses reasoning payload, not only DashScope, so compatible third-party Responses providers receive the same serialization contract.

The following alternatives were considered:

- Special-case DashScope or `qwen3.7-max`; rejected because endpoint adapter metadata already owns this decision and other third-party reasoning model IDs have the same SDK behavior.
- Inject the raw `reasoning` field through a fetch wrapper; rejected because it would bypass the AI SDK provider-options contract and duplicate serialization logic.
- Force translation back to Chat Completions; rejected because it would override the model's configured endpoint and could regress Responses-only capabilities.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- The regression test builds the real DashScope `qwen3.7-max` assistant-less parameters and captures the final `@ai-sdk/openai` Responses request body.
- Focused validation passed: 126 main-process tests, 21 renderer language-detection tests, TypeScript typecheck, Oxlint, and ESLint.
- The full local test suite was not run; CI should provide the full repository validation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed slow or blank selection translation results with Bailian Qwen Responses models by ensuring disabled reasoning is sent to the provider.
```
