### PR TITLE
fix(cherryin): refresh balance when returning from top-up

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/CherryInOauth.tsx
@@ -11,7 +11,7 @@ import { cn } from '@renderer/utils/style'
 import type { CherryInBalance } from '@shared/ipc/schemas/cherryin'
 import { hasApiKeys } from '@shared/utils/provider'
 import type { FC } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('CherryInOauth')
@@ -42,6 +42,7 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
   // `oauth.has_token` returns only a boolean — the access/refresh tokens stay in
   // the main process and never reach the renderer (null = status not loaded yet).
   const [remoteHasOAuthToken, setRemoteHasOAuthToken] = useState<boolean | null>(null)
+  const topupInProgressRef = useRef(false)
 
   const refreshHasToken = useCallback(async () => {
     try {
@@ -86,6 +87,19 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
       setOauthTokenOverride(null)
     }
   }, [oauthTokenOverride, remoteHasOAuthToken])
+
+  // Top-up happens in the system browser (see WindowManager.setWindowOpenHandler),
+  // so the balance refresh must wait for the user to come back.
+  useEffect(() => {
+    const handleWindowFocus = () => {
+      if (topupInProgressRef.current) {
+        topupInProgressRef.current = false
+        void fetchData()
+      }
+    }
+    window.addEventListener('focus', handleWindowFocus)
+    return () => window.removeEventListener('focus', handleWindowFocus)
+  }, [fetchData])
 
   const handleOAuthLogin = useCallback(async () => {
     try {
@@ -149,6 +163,7 @@ const CherryInOauth: FC<CherryInOauthProps> = ({ providerId }) => {
   }, [deleteApiKey, provider?.apiKeys, refreshHasToken, t])
 
   const handleTopup = useCallback(() => {
+    topupInProgressRef.current = true
     window.open(CHERRYIN_TOPUP_URL, '_blank')
   }, [])
 

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/__tests__/CherryInOauth.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSpecific/__tests__/CherryInOauth.test.tsx
@@ -1,0 +1,112 @@
+import { MockUseDataApiUtils } from '@test-mocks/renderer/useDataApi'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import CherryInOauth from '../CherryInOauth'
+
+const { requestMock, tMock, useProviderMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+  tMock: (key: string) => key,
+  useProviderMock: vi.fn()
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: tMock }),
+  Trans: ({ children }: { children?: ReactNode }) => <>{children}</>
+}))
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: (...args: unknown[]) => requestMock(...args) }
+}))
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProvider: (...args: unknown[]) => useProviderMock(...args)
+}))
+vi.mock('@renderer/services/oauth', () => ({
+  oauthWithCherryIn: vi.fn()
+}))
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, onClick, disabled }: { children: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  Skeleton: ({ className }: { className?: string }) => <div className={className} data-testid="skeleton" />
+}))
+vi.mock('@cherrystudio/ui/icons/providers', () => ({
+  Cherryin: { Avatar: () => <div data-testid="cherryin-avatar" /> }
+}))
+
+const LOGGED_IN_PROVIDER = {
+  id: 'cherryin',
+  name: 'CherryIN',
+  apiKeys: [{ id: 'key-1', label: 'OAuth', isEnabled: true }]
+}
+
+const ZERO_BALANCE = { balance: 0, profile: null }
+const TOPPED_UP_BALANCE = { balance: 12.5, profile: null }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  MockUseDataApiUtils.resetMocks()
+  useProviderMock.mockReturnValue({
+    provider: LOGGED_IN_PROVIDER,
+    updateProvider: vi.fn().mockResolvedValue(undefined),
+    addApiKey: vi.fn().mockResolvedValue(undefined),
+    deleteApiKey: vi.fn().mockResolvedValue(undefined)
+  })
+})
+
+async function renderLoggedIn(): Promise<void> {
+  requestMock.mockImplementation((channel: string) => {
+    if (channel === 'oauth.has_token') return Promise.resolve(true)
+    if (channel === 'cherryin.get_balance') return Promise.resolve(ZERO_BALANCE)
+    throw new Error(`unexpected channel: ${channel}`)
+  })
+  render(<CherryInOauth providerId="cherryin" />)
+  await screen.findByText('settings.provider.oauth.topup')
+}
+
+describe('CherryInOauth', () => {
+  it('re-fetches the balance when the window regains focus after a top-up', async () => {
+    await renderLoggedIn()
+    expect(requestMock).toHaveBeenCalledWith('cherryin.get_balance', expect.anything())
+    await screen.findByText('$0.00')
+
+    // The recharge happens on the CherryIN console in the system browser; the
+    // renderer learns the new balance only when it asks again.
+    let callCount = 0
+    requestMock.mockImplementation((channel: string) => {
+      if (channel === 'oauth.has_token') return Promise.resolve(true)
+      if (channel === 'cherryin.get_balance') {
+        callCount += 1
+        return Promise.resolve(TOPPED_UP_BALANCE)
+      }
+      throw new Error(`unexpected channel: ${channel}`)
+    })
+
+    const user = userEvent.setup()
+    await user.click(screen.getByText('settings.provider.oauth.topup'))
+    fireEvent.focus(window)
+
+    await waitFor(() => expect(callCount).toBe(1))
+    await screen.findByText('$12.50')
+  })
+
+  it('does not re-fetch the balance on focus when no top-up was initiated', async () => {
+    await renderLoggedIn()
+
+    requestMock.mockClear()
+    requestMock.mockImplementation((channel: string) => {
+      if (channel === 'cherryin.get_balance') return Promise.resolve(TOPPED_UP_BALANCE)
+      if (channel === 'oauth.has_token') return Promise.resolve(true)
+      throw new Error(`unexpected channel: ${channel}`)
+    })
+
+    fireEvent.focus(window)
+
+    // Give any stray listener a chance to fire before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(requestMock).not.toHaveBeenCalledWith('cherryin.get_balance', expect.anything())
+  })
+})


### PR DESCRIPTION
<!-- Template from
https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft:
https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

CherryIN recharge happens on the CherryIN console opened in the system
browser (`window.open` → `shell.openExternal`). After the recharge
succeeds, the balance in the provider settings keeps showing the stale
pre-top-up amount (`$0.00` for a fresh account) until the user logs
out / re-enters or otherwise remounts the card — see #15022.

After this PR:

Clicking Top Up marks a top-up in progress; when the window regains
focus (i.e. the user comes back from the browser), the balance is
re-fetched once and the new amount is shown. No extra network traffic
is generated while no top-up was initiated.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)`
format, will close the issue(s) when PR gets merged)*: -->

Fixes #15022

### Special notes for your reviewer

- `fetchData` already shows a skeleton only when there is no cached
  balance, so the refresh stays unobtrusive.
- Added a component test asserting the focus-triggered re-fetch and a
  guard test asserting no re-fetch on focus when no top-up happened.
