### PR TITLE
docs(agent-notes): propose docs governance and spec-driven workflow

### DIFF
--- a/.agents/notes/README.md
+++ b/.agents/notes/README.md
@@ -1,0 +1,14 @@
+# Agent Notes
+
+English | [中文](README.zh.md)
+
+An **Agent Note** records a decision that affects this codebase — the *why* and *what we gave up*, the parts code and docs can't carry.
+
+Notes live at `{lifecycle}/{class}/yyyy-mm-dd-topic.md`:
+
+- **Lifecycle**: `proposed/` (reviewed before implementation) · `implemented/` (shipped, kept current) · `rejected/` (declined, kept while the rationale prevents a mistake)
+- **Class**: `feature` · `bug-fix` · `simplification` · `architecture` · `process` · `testing`
+
+Every note opens with `# Agent Note: <title>` and a `Status:` line, states its `## Problem`, and carries a mandatory `## Alternatives considered`. Each note has a `.zh.md` counterpart mirroring its structure.
+
+This system is being adopted per [the docs-governance proposal](proposed/process/2026-08-18-docs-governance-and-spec-workflow.md), which defines the format, the note-worthiness threshold, and the rollout. The full ruleset and format gate land with that proposal's Phase 1.

--- a/.agents/notes/README.zh.md
+++ b/.agents/notes/README.zh.md
@@ -1,0 +1,14 @@
+# Agent Notes
+
+[English](README.md) | 中文
+
+**Agent Note** 记录影响本代码库的决策——*为什么*以及*放弃了什么*,这些是代码和文档承载不了的部分。
+
+Note 位于 `{lifecycle}/{class}/yyyy-mm-dd-topic.md`:
+
+- **生命周期**:`proposed/`(实现前先评审)· `implemented/`(已落地,保持同步)· `rejected/`(被否决,理由还能防错就保留)
+- **类别**:`feature` · `bug-fix` · `simplification` · `architecture` · `process` · `testing`
+
+每条 note 以 `# Agent Note: <title>` 和 `Status:` 行开头,先陈述 `## Problem`,并强制携带 `## Alternatives considered`。每条 note 都有结构镜像的 `.zh.md` 对照。
+
+本系统正依照[文档治理方案](proposed/process/2026-08-18-docs-governance-and-spec-workflow.zh.md)引入,该方案定义了格式、什么决策值得记录的门槛以及推进计划。完整规则集与格式门禁随该方案的 Phase 1 落地。

--- a/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.md
+++ b/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.md
@@ -1,0 +1,151 @@
+# Agent Note: Docs governance and spec-driven workflow
+
+Status: proposed
+
+English | [中文](2026-08-18-docs-governance-and-spec-workflow.zh.md)
+
+## Problem
+
+The repository's developer documentation has four connected defects, and no mechanism catches any of them.
+
+**Docs rot silently.** `docs/guides/middleware.md` teaches the deleted v1 `AiProviderMiddlewareTypes` middleware system (zero hits in `src/`). `docs/references/messaging/message-system.md` documents a Redux + IndexedDB message store that no longer exists: the repo has no `@reduxjs/toolkit` dependency, no `messageThunk.ts`, no `src/renderer/store/`. Both read as current authority to contributors and agents. The only doc gate, `docs:check-links`, validates that link targets exist — nothing more — and CI never runs it: `ci:basic-check` covers lint, format, typecheck, i18n, and skills, not docs.
+
+**The hierarchy misleads.** The `guides/` vs `references/` split does not hold: `guides/` mostly holds process policy (contributing, branching-strategy, test-plan) and usage references (logging, i18n, diagnostics), not tutorials. The `references/` top level is an open set mixing 17 domain directories with 10 loose files. The docs split one domain into `chat/` and `messaging/` where the code has only chat. `docs/README.md` is a hand-maintained index that has already drifted: `main-process-architecture.md`, `renderer-architecture.md`, `shared-layer-architecture.md`, and `naming-conventions.md` are not listed at all, and `chat/message-tree.md` is listed under the Messaging section. Root `CONTRIBUTING.md` has a drifted near-copy at `docs/guides/contributing.md` whose "中文" language switcher links to itself — the Chinese version does not exist.
+
+**Decisions evaporate.** Rationale and rejected alternatives live only in PR threads and chat. With multiple agents working in parallel, the same declined idea gets re-proposed and re-litigated because nothing records that it lost, or why.
+
+**Docs are a product with a missing half.** A large share of Cherry Studio's users and contributors read Chinese, yet the corpus is ~110 English markdown files with one Chinese pair (`.agents/skills/README.zh.md`).
+
+## Proposal
+
+Adopt the deepseek-harness (dsh) documentation and decision-record process, adapted where explicitly stated. Six parts, then a rollout plan.
+
+### P1 — Target tree
+
+```
+docs/
+  README.md            # thin index generated from frontmatter descriptions; never hand-edited
+  contrib/             # process & repo engineering: contributing pointers, branching-strategy,
+                       # development, linux-packaging, test-plan, feishu-notify, app-upgrade
+  references/
+    architecture/      # architecture-overview, main-process-architecture,
+                       # renderer-architecture, shared-layer-architecture, naming-conventions
+    <domain>/          # closed set; every domain directory has README.md as the domain home
+.agents/notes/         # Agent Notes (decision records) — see P4
+```
+
+Rules:
+
+- The `references/` top level is a **closed set** of domain directories — no loose files (gate-enforced, mirroring the closed-set rule the code tree already has in naming-conventions §4.8).
+- Every domain directory has a `README.md` that owns the domain: full detail about its own subject, children summarized with links. One fact, one home.
+- Files inside a domain directory do not repeat the domain prefix (`window-manager-usage.md` → `usage.md`); existing prefixed files are renamed during their domain's Phase 0b move, when inbound links are being rewritten anyway.
+- Division of labor with code-adjacent READMEs (`src/main/core/paths/README.md`, `tests/__mocks__/README.md`, …): cross-cutting or multi-module material lives in `docs/`; module-private facts live next to the module.
+- `docs/README.md` becomes a generated thin index; the hand-maintained table is retired.
+
+Disposition of current files (decided here; executed in Phase 0b):
+
+| File | Disposition |
+|---|---|
+| `references/messaging/message-system.md` | **Delete** — documents a deleted system. |
+| `guides/middleware.md` | **Delete** — documents a deleted system; current middleware facts belong to the `src/main/ai` domain docs. |
+| `guides/contributing.md` | **Delete** — drifted copy of root `CONTRIBUTING.md`, which becomes the single home (GitHub-special file); its stale "Branch Strategy 🚨" residue is cleaned there. Chinese arrives in Phase 2 as root `CONTRIBUTING.zh.md`. |
+| `references/messaging/composer-rich-clipboard.md` | Move → `references/chat/` (its cited code lives entirely under `components/chat/**` and `components/composer/**`). |
+| `references/fuzzy-search.md` | Move → `references/file/`. |
+| `references/ui-semantic-contract.md` | Move → `references/components/`. |
+| `references/lan-transfer-protocol.md` | Move → `references/lan-transfer/` (a protocol spec is its own domain). |
+| `references/{architecture-overview,main-process-architecture,renderer-architecture,shared-layer-architecture,naming-conventions}.md` | Move → `references/architecture/`. |
+| `guides/{logging,i18n}.md` | Move → their subject domains under `references/`. |
+| `guides/diagnostics.md` | Placement (contrib vs reference) decided during its Phase 0b audit. |
+| `references/chat/{adapters,conventions}.md` | **Keep in place** — explicitly marked target-architecture design docs; their home is re-decided when the adapters code lands. Out of Phase 0b scope. |
+| `references/file/architecture.md` + `file-manager-architecture.md` | **Keep both** — deliberately layered with mutual SoT-scope declarations, not rot. |
+
+### P2 — Frontmatter
+
+Every doc under `docs/references/**` carries:
+
+```yaml
+---
+description: One-line summary (feeds the generated index and agent doc catalogs)
+sources: # code paths this document describes; directories preferred
+  - src/main/services/file/tree/
+---
+```
+
+`docs/contrib/**` requires only `description`. Agent Notes carry **no frontmatter** — their path and header block already encode their metadata, as in dsh.
+
+The admission criterion for any future field: it must carry something the path, the H1, or git cannot, **and** name the script that consumes it. Rejected now, each because an owner already exists: `domain`/`category` (the path), `title` (the H1), `updated`/`author` (git), `status: deprecated` (deletion — current-state prose or nothing), `tags` (no consumer), `sidebar_position` (site navigation belongs in one mapping file, dsh-style), and the translation-pairing hash (writing a file's hash into the file changes the hash — it must live in a sidecar).
+
+### P3 — Gates
+
+Three new scripts, all `tsx scripts/*.ts` following the repo's newer script convention (exported functions plus tests under `scripts/__tests__/`, like `i18n-check-values.ts`):
+
+- `verify-doc-structure` — closed set at the `references/` root; every domain directory has a `README.md`.
+- `verify-doc-frontmatter` — required fields present; every `sources` path exists. This is the gate that catches the `middleware.md` class of rot the day the code moves.
+- `gen-doc-index` (with `--check`) — regenerates `docs/README.md` from frontmatter; drift fails.
+
+Wiring: a new aggregate `pnpm docs:check` = `docs:check-links` + the three above. It joins `ci:basic-check` (closing the gap where CI checks docs not at all) and replaces the bare `docs:check-links` inside `build:check`.
+
+A follow-up consumer of `sources`: intersecting a PR's diff paths with all `sources` lists mechanically yields "docs this PR should have updated", wired into the `gh-pr-review` skill (Phase 4). That turns the "docs accompany every code change" rule from an honor system into a checkable one.
+
+### P4 — Agent Notes
+
+Decision records live in `.agents/notes/{lifecycle}/{class}/yyyy-mm-dd-topic.md`:
+
+- **Lifecycle**: `proposed/` (reviewed before implementation) → `implemented/` (shipped, kept current with reality) or `rejected/` (declined; kept while the rationale prevents a tempting mistake). The dsh `archived/` tier is deferred until volume warrants it.
+- **Class**: `feature`, `bug-fix`, `simplification`, `architecture`, `process`, `testing`. There is deliberately no `refactor` class — `simplification` covers it, discriminated by "does observable behavior change?".
+- **Format**: header block (`# Agent Note: <title>`, `Status: <lifecycle>`), then `## Problem`, `## Proposal` (proposed) or `## Decision` (implemented, present tense), bespoke sections, a **mandatory `## Alternatives considered`**, then `## Acceptance criteria` + `## Risks` (proposed) or `## Consequences` (implemented). A decision recorded without what it beat invites re-litigation.
+- A decision is never edited into a different decision: supersede with a new note and cross-link.
+- **Threshold** (deliberate deviation from dsh, which requires a note for every non-trivial PR): a note is required only for **decisions a maintainer may reasonably revisit** — architectural choices, cross-module contracts, data/on-disk/wire formats, process changes, and declined approaches. Cherry Studio's routine-fix volume makes a per-PR mandate a tax, not a record.
+- Spec-first features: substantial feature work starts as a `proposed/` note, reviewed before implementation, verified against its own acceptance criteria, then rewritten into `implemented/` when it ships. This note is the first instance of that loop.
+
+The format gate (a port of dsh's `verify-agent-note-format`) lands in Phase 1 alongside the full `.agents/notes/README.md` ruleset.
+
+### P5 — Bilingual pairing
+
+Every in-scope document is an English/Chinese pair plus a consistency sidecar: `foo.md` + `foo.zh.md` + `foo.i18n.yaml` recording the git blob hash of each side as of the last confirmed-consistent state (a port of dsh's `verify-translation-pairing`). Either language may be authored first; an out-of-sync pair is repaired by patching the counterpart against the edited side's diff, never by re-translating whole files.
+
+Scope rolls out by discovery root — a deliberate deviation from dsh's no-rollout-list stance: `.agents/notes/**` and root `CONTRIBUTING.md` first (new corpora are born bilingual), extending to `docs/**` only after the Phase 3 backfill. `docs/i18n/terminology.md` becomes the doc-translation terminology source, seeded from `scripts/i18n-glossary.json` (whose `terms` block is currently five entries and unenforced — it needs growth, but the vocabulary choices it records, e.g. Provider=提供商, Agent=智能体, carry over).
+
+### P6 — Skills
+
+Cherry versions of the dsh process skills, adapted to this repo's domains: a find-simplifications skill (turns "clean this up" into evidence-backed proposed notes; survey domains become renderer hooks, the four data layers, IPC, lifecycle services, v1-migration residue), a doc-standards/prose-standard skill (hierarchy detail rules, tutorial/reference classification, slop checklist), and the `gh-pr-review` reverse-lookup integration from P3.
+
+### Rollout
+
+| Phase | Work | Verification |
+|---|---|---|
+| 0a (this PR) | This proposal; `.agents/notes/` skeleton with stub README | Review of this note is the decision |
+| 0b | Per-domain move + audit PRs: relocate, rename, add frontmatter, fact-check every claim against code, rewrite or delete; gates land with the first moved domain | `pnpm docs:check` green; moved docs' claims verified against `src/` |
+| 1 | Full `.agents/notes/README.md` ruleset + format gate + backfilled seed notes (bilingual) | Format gate green on all notes |
+| 2 | Pairing gate port; discovery roots `.agents/notes` + `CONTRIBUTING.md`; `CONTRIBUTING.zh.md` | `verify-translation-pairing` green |
+| 3 | Translation backfill of audited-current docs only; extend pairing scope to `docs/**` | Corpus-wide pairing green |
+| 4 | Process skills + `gh-pr-review` sources integration | Skill review |
+
+Quality precedes translation throughout: a doc is audited current before it is paired, because translating rot bakes it into two languages at double the correction cost.
+
+## Alternatives considered
+
+- **Frontmatter-free, path-only metadata (the dsh design).** dsh encodes everything in paths and headers and its docs carry no frontmatter. Rejected here because our two acute needs — a rot gate (`sources`) and a drift-proof generated index (`description`) — both need per-file machine-readable fields; dsh instead covers these with word budgets, `verify-doc-refs`, and hand-curated hierarchy, machinery we are not porting wholesale.
+- **Marking stale docs `status: deprecated`.** Rejected: current-state prose or deletion. A deprecation marker is a license to keep rot.
+- **Translate first, audit later.** Rejected: every later correction costs two languages plus a pairing re-record.
+- **Keeping the `guides/` vs `references/` split.** Rejected: the classification is already fiction; use-based classification (tutorial = ordered steps to an observable outcome) shows almost everything here is reference or process material.
+- **Porting dsh's full translation machinery now** (merge driver, `gen-translation-brief`, doc budgets). Deferred: dsh itself marks the heavy paths as explicit-invocation-only; routine one-pass counterpart updates suffice until sync conflicts become a real cost.
+- **dsh's per-PR note mandate.** Amended to the decision threshold in P4; the fix volume here would turn the mandate into ritual.
+- **Building the website projection now.** Deferred: docs.cherry-ai.com lives in a separate repository; projection is a separate decision after the corpus is governed.
+
+## Acceptance criteria
+
+- `references/` top level is a closed set of domain directories, each with a README home; `verify-doc-structure` green.
+- The three dead/duplicate docs are deleted; every surviving reference doc's claims verified against current code.
+- Every `references/**` doc carries `description` + existing `sources`; `verify-doc-frontmatter` green.
+- `docs/README.md` is generated; `gen-doc-index --check` green.
+- CI runs `pnpm docs:check` in `ci:basic-check`.
+- `.agents/notes/` holds this note plus backfilled seeds, bilingual, format-gate green.
+- `.agents/notes/**` and `CONTRIBUTING.md` pass the pairing gate; after Phase 3, `docs/**` does too.
+
+## Risks
+
+- **Inbound-link churn.** `CLAUDE.md` links many docs, and TypeScript comments reference `docs/*.md` paths that `docs:check-links` does not scan; every Phase 0b move must grep `src/` for the old path. Mitigation: moves are atomic per domain (relocate + fix all inbound links in one PR).
+- **Collision with in-flight PRs.** Tree moves conflict with open work touching the same docs. Mitigation: Phase 0b proceeds domain by domain in small windows, not as one big-bang move.
+- **Bilingual maintenance cost.** Every paired-doc edit obligates the counterpart and a re-record; churn-heavy docs pay the most. Accepted deliberately — docs are a product here — and bounded by pairing only audited-current material.
+- **Translation review burden.** The pairing gate checks structure, not faithfulness; zh quality still needs reviewer attention, and terminology starts thin.

--- a/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.md
+++ b/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.md
@@ -56,6 +56,7 @@ Disposition of current files (decided here; executed in Phase 0b):
 | `references/{architecture-overview,main-process-architecture,renderer-architecture,shared-layer-architecture,naming-conventions}.md` | Move → `references/architecture/`. |
 | `guides/{logging,i18n}.md` | Move → their subject domains under `references/`. |
 | `guides/diagnostics.md` | Placement (contrib vs reference) decided during its Phase 0b audit. |
+| `docs/sponsor.md` | **Stays at the `docs/` root** — a user-facing page linked from the root README, not a developer doc; outside the reference tree, the gates, and bilingual pairing. |
 | `references/chat/{adapters,conventions}.md` | **Keep in place** — explicitly marked target-architecture design docs; their home is re-decided when the adapters code lands. Out of Phase 0b scope. |
 | `references/file/architecture.md` + `file-manager-architecture.md` | **Keep both** — deliberately layered with mutual SoT-scope declarations, not rot. |
 
@@ -71,7 +72,9 @@ sources: # code paths this document describes; directories preferred
 ---
 ```
 
-`docs/contrib/**` requires only `description`. Agent Notes carry **no frontmatter** — their path and header block already encode their metadata, as in dsh.
+`docs/contrib/**` requires only `description`. Agent Notes carry **no frontmatter** — their path and header block already encode their metadata, as in dsh. `docs/sponsor.md` is a user-facing page linked from the root README, not a developer doc: it stays at the `docs/` root and is outside every gate's scan scope (which covers `references/` and `contrib/` only) and outside bilingual pairing.
+
+A `sources` entry is a **path prefix**: a diff path is attributed to a doc when it equals the entry or lies beneath it, so a directory entry covers all its descendants. That is what makes the Phase 4 reverse lookup work on subtree changes; it is also why a broad entry weakens the signal, and why an entry names the narrowest directory that still holds the doc's whole subject.
 
 The admission criterion for any future field: it must carry something the path, the H1, or git cannot, **and** name the script that consumes it. Rejected now, each because an owner already exists: `domain`/`category` (the path), `title` (the H1), `updated`/`author` (git), `status: deprecated` (deletion — current-state prose or nothing), `tags` (no consumer), `sidebar_position` (site navigation belongs in one mapping file, dsh-style), and the translation-pairing hash (writing a file's hash into the file changes the hash — it must live in a sidecar).
 
@@ -80,10 +83,10 @@ The admission criterion for any future field: it must carry something the path, 
 Three new scripts, all `tsx scripts/*.ts` following the repo's newer script convention (exported functions plus tests under `scripts/__tests__/`, like `i18n-check-values.ts`):
 
 - `verify-doc-structure` — closed set at the `references/` root; every domain directory has a `README.md`.
-- `verify-doc-frontmatter` — required fields present; every `sources` path exists. This is the gate that catches the `middleware.md` class of rot the day the code moves.
+- `verify-doc-frontmatter` — required fields present; every `sources` path exists. This catches one specific class of rot — the doc whose subject was deleted or moved away, which is exactly what `middleware.md` and `message-system.md` were — on the day the code moves. **It is an existence test, not a freshness test**: a doc that goes stale while its paths survive (behavior changed in place, or a file moved within a broad directory entry) stays green. Semantic staleness is caught by the Phase 4 reverse lookup and by review, not here.
 - `gen-doc-index` (with `--check`) — regenerates `docs/README.md` from frontmatter; drift fails.
 
-Wiring: a new aggregate `pnpm docs:check` = `docs:check-links` + the three above. It joins `ci:basic-check` (closing the gap where CI checks docs not at all) and replaces the bare `docs:check-links` inside `build:check`.
+Wiring: a new aggregate `pnpm docs:check` = `docs:check-links` + the three above; it replaces the bare `docs:check-links` inside `build:check`. Closing the CI gap takes a **workflow** edit, not only a script edit: `.github/workflows/ci.yml` does not invoke `pnpm ci:basic-check` — its `basic-checks` job inlines the individual commands through `concurrently`, so `docs:check` must be added to that step to run in CI at all. The `ci:basic-check` script is updated alongside it to keep the local equivalent honest.
 
 A follow-up consumer of `sources`: intersecting a PR's diff paths with all `sources` lists mechanically yields "docs this PR should have updated", wired into the `gh-pr-review` skill (Phase 4). That turns the "docs accompany every code change" rule from an honor system into a checkable one.
 
@@ -115,7 +118,7 @@ Cherry versions of the dsh process skills, adapted to this repo's domains: a fin
 | Phase | Work | Verification |
 |---|---|---|
 | 0a (this PR) | This proposal; `.agents/notes/` skeleton with stub README | Review of this note is the decision |
-| 0b | Per-domain move + audit PRs: relocate, rename, add frontmatter, fact-check every claim against code, rewrite or delete; gates land with the first moved domain | `pnpm docs:check` green; moved docs' claims verified against `src/` |
+| 0b | Per-domain move + audit PRs: relocate, rename, fact-check every claim against code, rewrite or delete. **The gates land last, after the final move**, together with the frontmatter for the whole corpus — `verify-doc-structure` reads the entire `references/` root and `verify-doc-frontmatter` every reference doc, so neither can be green while the tree is half-migrated, and a staged-enforcement allowlist would be more machinery than the short migration is worth | `docs:check-links` green per move PR; full `pnpm docs:check` green once the gates land; moved docs' claims verified against `src/` |
 | 1 | Full `.agents/notes/README.md` ruleset + format gate + backfilled seed notes (bilingual) | Format gate green on all notes |
 | 2 | Pairing gate port; discovery roots `.agents/notes` + `CONTRIBUTING.md`; `CONTRIBUTING.zh.md` | `verify-translation-pairing` green |
 | 3 | Translation backfill of audited-current docs only; extend pairing scope to `docs/**` | Corpus-wide pairing green |
@@ -139,13 +142,13 @@ Quality precedes translation throughout: a doc is audited current before it is p
 - The three dead/duplicate docs are deleted; every surviving reference doc's claims verified against current code.
 - Every `references/**` doc carries `description` + existing `sources`; `verify-doc-frontmatter` green.
 - `docs/README.md` is generated; `gen-doc-index --check` green.
-- CI runs `pnpm docs:check` in `ci:basic-check`.
+- CI runs `pnpm docs:check` — verified by the `basic-checks` job in `.github/workflows/ci.yml` invoking it, not merely by the `ci:basic-check` script listing it.
 - `.agents/notes/` holds this note plus backfilled seeds, bilingual, format-gate green.
 - `.agents/notes/**` and `CONTRIBUTING.md` pass the pairing gate; after Phase 3, `docs/**` does too.
 
 ## Risks
 
-- **Inbound-link churn.** `CLAUDE.md` links many docs, and TypeScript comments reference `docs/*.md` paths that `docs:check-links` does not scan; every Phase 0b move must grep `src/` for the old path. Mitigation: moves are atomic per domain (relocate + fix all inbound links in one PR).
+- **Inbound-link churn.** `docs:check-links` only resolves Markdown links, so it sees none of the other consumers: `CLAUDE.md` prose, lint rule messages in `eslint.config.mjs`, TypeScript comments, and code that *reads a doc by path* — `scripts/uiContract/__tests__/maintainedAnchors.test.ts` opens `ui-semantic-contract.md`, and a missed rename there breaks a test, not a link. Every Phase 0b move therefore greps the **whole repository** for the old path (`src/`, `scripts/`, `packages/`, `tests/`, `.github/`, root config), never just `src/`. Mitigation: moves are atomic per domain (relocate + fix every inbound reference in one PR).
 - **Collision with in-flight PRs.** Tree moves conflict with open work touching the same docs. Mitigation: Phase 0b proceeds domain by domain in small windows, not as one big-bang move.
 - **Bilingual maintenance cost.** Every paired-doc edit obligates the counterpart and a re-record; churn-heavy docs pay the most. Accepted deliberately — docs are a product here — and bounded by pairing only audited-current material.
 - **Translation review burden.** The pairing gate checks structure, not faithfulness; zh quality still needs reviewer attention, and terminology starts thin.

--- a/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.zh.md
+++ b/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.zh.md
@@ -1,0 +1,151 @@
+# Agent Note: Docs governance and spec-driven workflow
+
+Status: proposed
+
+[English](2026-08-18-docs-governance-and-spec-workflow.md) | 中文
+
+## Problem
+
+本仓库的开发者文档有四个相互关联的缺陷,而且没有任何机制能发现它们。
+
+**文档在无声地腐烂。** `docs/guides/middleware.md` 在教已删除的 v1 `AiProviderMiddlewareTypes` 中间件系统(`src/` 中零命中)。`docs/references/messaging/message-system.md` 描述的 Redux + IndexedDB 消息存储早已不存在:仓库没有 `@reduxjs/toolkit` 依赖,没有 `messageThunk.ts`,没有 `src/renderer/store/`。这两篇在贡献者和 agent 眼里都是现行权威。唯一的文档门禁 `docs:check-links` 只校验链接目标存在——仅此而已——而且 CI 根本不跑它:`ci:basic-check` 覆盖 lint、format、typecheck、i18n 和 skills,不含文档。
+
+**层级在误导读者。** `guides/` 与 `references/` 的二分并不成立:`guides/` 里大多是流程规范(contributing、branching-strategy、test-plan)和用法参考(logging、i18n、diagnostics),不是教程。`references/` 顶层是开放集,17 个域目录与 10 个散文件混住。代码里只有 chat 一个域,文档却拆成 `chat/` 和 `messaging/`。`docs/README.md` 是手工维护的索引,且已经漂移:`main-process-architecture.md`、`renderer-architecture.md`、`shared-layer-architecture.md`、`naming-conventions.md` 完全未列入,`chat/message-tree.md` 被列在 Messaging 章节下。根 `CONTRIBUTING.md` 在 `docs/guides/contributing.md` 有一份已经措辞分叉的近似副本,后者的"中文"语言切换链指向它自己——中文版并不存在。
+
+**决策在蒸发。** 理由和被否决的替代方案只存在于 PR 讨论串和聊天里。多个 agent 并行工作时,同一个被否过的主意会被反复提出、反复争论,因为没有任何记录说它输过、为什么输。
+
+**文档是产品,却缺了一半。** Cherry Studio 的用户和贡献者中有很大比例读中文,而语料是约 110 篇英文 markdown,中文对照仅一对(`.agents/skills/README.zh.md`)。
+
+## Proposal
+
+移植 deepseek-harness(dsh)的文档与决策记录流程,并在明确标注处做适配。共六部分,外加推进计划。
+
+### P1 — Target tree
+
+```
+docs/
+  README.md            # thin index generated from frontmatter descriptions; never hand-edited
+  contrib/             # process & repo engineering: contributing pointers, branching-strategy,
+                       # development, linux-packaging, test-plan, feishu-notify, app-upgrade
+  references/
+    architecture/      # architecture-overview, main-process-architecture,
+                       # renderer-architecture, shared-layer-architecture, naming-conventions
+    <domain>/          # closed set; every domain directory has README.md as the domain home
+.agents/notes/         # Agent Notes (decision records) — see P4
+```
+
+规则:
+
+- `references/` 顶层是**封闭集**,只允许域目录——不许散文件(门禁校验,与代码树在 naming-conventions §4.8 中已有的封闭集规则呼应)。
+- 每个域目录必须有 `README.md` 作为域之家:本域主题写全细节,子级只概括并链接。一个事实,一个家。
+- 域目录内的文件名不重复域前缀(`window-manager-usage.md` → `usage.md`);存量带前缀的文件在其所属域的 Phase 0b 搬家窗口一并改名,反正入链当时就要重写。
+- 与代码旁 README(`src/main/core/paths/README.md`、`tests/__mocks__/README.md`……)的分工:跨切面或多模块的内容归 `docs/`;模块私有事实住在模块旁边。
+- `docs/README.md` 改为生成式薄索引,退役手工维护的表格。
+
+现有文件的处置(在此决定;Phase 0b 执行):
+
+| 文件 | 处置 |
+|---|---|
+| `references/messaging/message-system.md` | **删除**——描述的系统已被删除。 |
+| `guides/middleware.md` | **删除**——描述的系统已被删除;现行中间件事实归 `src/main/ai` 域文档负责。 |
+| `guides/contributing.md` | **删除**——根 `CONTRIBUTING.md` 的漂移副本,后者定为唯一的家(GitHub 特殊文件);其中旧双分支时代的"Branch Strategy 🚨"残骸一并清理。中文版在 Phase 2 以根 `CONTRIBUTING.zh.md` 落地。 |
+| `references/messaging/composer-rich-clipboard.md` | 移动 → `references/chat/`(它引用的代码全部位于 `components/chat/**` 与 `components/composer/**` 之下)。 |
+| `references/fuzzy-search.md` | 移动 → `references/file/`。 |
+| `references/ui-semantic-contract.md` | 移动 → `references/components/`。 |
+| `references/lan-transfer-protocol.md` | 移动 → `references/lan-transfer/`(协议规范自成一域)。 |
+| `references/{architecture-overview,main-process-architecture,renderer-architecture,shared-layer-architecture,naming-conventions}.md` | 移动 → `references/architecture/`。 |
+| `guides/{logging,i18n}.md` | 移动 → `references/` 下各自的主题域。 |
+| `guides/diagnostics.md` | 归属(contrib 还是 reference)在其 Phase 0b 审计时决定。 |
+| `references/chat/{adapters,conventions}.md` | **保持原位**——明确标注为 target-architecture 设计文档;adapters 代码落地时重新决定其归宿。不在 Phase 0b 范围内。 |
+| `references/file/architecture.md` + `file-manager-architecture.md` | **两篇都保留**——刻意分层且互相声明 SoT 边界,不是腐烂。 |
+
+### P2 — Frontmatter
+
+`docs/references/**` 下每篇文档携带:
+
+```yaml
+---
+description: One-line summary (feeds the generated index and agent doc catalogs)
+sources: # code paths this document describes; directories preferred
+  - src/main/services/file/tree/
+---
+```
+
+`docs/contrib/**` 只要求 `description`。Agent Notes **不用 frontmatter**——路径与 header block 已经编码了它们的元数据,与 dsh 一致。
+
+未来任何字段的准入标准:它必须承载路径、H1、git 都承载不了的信息,**并且**说得出消费它的脚本。现在即拒绝的字段,每个都已有归属:`domain`/`category`(路径)、`title`(H1)、`updated`/`author`(git)、`status: deprecated`(删除——要么是现行事实要么不存在)、`tags`(无消费者)、`sidebar_position`(站点导航集中在一个映射文件,dsh 式),以及翻译配对 hash(把文件的 hash 写进文件本身会改变 hash——它必须住在 sidecar 里)。
+
+### P3 — Gates
+
+三个新脚本,全部是 `tsx scripts/*.ts`,遵循仓库较新的脚本惯例(导出函数 + `scripts/__tests__/` 下的测试,同 `i18n-check-values.ts`):
+
+- `verify-doc-structure`——`references/` 根的封闭集;每个域目录有 `README.md`。
+- `verify-doc-frontmatter`——必填字段齐全;每个 `sources` 路径存在。代码一搬走,`middleware.md` 那类腐烂当天就被这道门禁抓住。
+- `gen-doc-index`(带 `--check`)——从 frontmatter 重新生成 `docs/README.md`;漂移即失败。
+
+接线:新聚合命令 `pnpm docs:check` = `docs:check-links` + 上述三个。它加入 `ci:basic-check`(补上 CI 完全不查文档的缺口),并替换 `build:check` 里的裸 `docs:check-links`。
+
+`sources` 的后续消费者:把 PR 的 diff 路径与全部 `sources` 清单求交集,即可机械得出"这个 PR 本应更新的文档",接进 `gh-pr-review` skill(Phase 4)。这把"改代码必须带文档"从自觉守则变成可校验的规则。
+
+### P4 — Agent Notes
+
+决策记录住在 `.agents/notes/{lifecycle}/{class}/yyyy-mm-dd-topic.md`:
+
+- **生命周期**:`proposed/`(实现前先评审)→ `implemented/`(已落地,与现实保持同步)或 `rejected/`(被否决;只要其理由还能防住一个诱人的错误就保留)。dsh 的 `archived/` 层缓行,等数量需要时再引入。
+- **类别**:`feature`、`bug-fix`、`simplification`、`architecture`、`process`、`testing`。刻意不设 `refactor` 类——`simplification` 已覆盖它,判据是"可观察行为是否变化?"。
+- **格式**:header block(`# Agent Note: <title>`、`Status: <lifecycle>`),然后 `## Problem`、`## Proposal`(proposed)或 `## Decision`(implemented,现在时),自由的技术小节,**强制的 `## Alternatives considered`**,再然后 `## Acceptance criteria` + `## Risks`(proposed)或 `## Consequences`(implemented)。不记录赢过谁的决策,就是在邀请重新争论。
+- 决策永不被原地改写成另一个决策:用新 note 取代并互相链接。
+- **门槛**(对 dsh 的有意偏离,dsh 要求每个非平凡 PR 必带 note):只对**维护者可能合理地重新质疑的决策**要求 note——架构选择、跨模块契约、数据/磁盘/线上格式、流程变更、被否决的方案。Cherry Studio 的日常修复流量会让逐 PR 强制变成一种税,而不是记录。
+- Spec-first 的 feature 流程:大型 feature 从一条 `proposed/` note 开始,实现前先评审,按其自身的 acceptance criteria 验收,落地后改写为 `implemented/`。本 note 就是这个闭环的第一个实例。
+
+格式门禁(移植 dsh 的 `verify-agent-note-format`)与完整的 `.agents/notes/README.md` 规则集一起在 Phase 1 落地。
+
+### P5 — Bilingual pairing
+
+范围内的每篇文档都是英文/中文对照加一个一致性 sidecar:`foo.md` + `foo.zh.md` + `foo.i18n.yaml`,后者记录两侧在最近一次确认一致时的 git blob hash(移植 dsh 的 `verify-translation-pairing`)。任一语言都可以先写;失同步的配对用被改一侧的 diff 去最小化修补另一侧,永不整篇重翻。
+
+范围按发现根逐步扩——这是对 dsh"不设灰度清单"立场的有意偏离:`.agents/notes/**` 和根 `CONTRIBUTING.md` 先行(新语料生而双语),`docs/**` 等 Phase 3 回填完成后再纳入。`docs/i18n/terminology.md` 成为文档翻译的术语源,以 `scripts/i18n-glossary.json` 为种子(其 `terms` 块目前只有五条且不被强制——需要扩充,但它记录的词汇选择,如 Provider=提供商、Agent=智能体,直接沿用)。
+
+### P6 — Skills
+
+把 dsh 的流程 skills 做成 cherry 版本,适配本仓库的领域:find-simplifications skill(把"清理一下"变成有证据支撑的 proposed notes;调查领域换成 renderer hooks、四个数据层、IPC、lifecycle services、v1 迁移残留)、doc-standards/prose-standard skill(层级详略规则、tutorial/reference 分类、slop 检查单),以及 P3 里的 `gh-pr-review` 反向查询集成。
+
+### Rollout
+
+| Phase | 工作 | 验证 |
+|---|---|---|
+| 0a(本 PR) | 本方案;带 stub README 的 `.agents/notes/` 骨架 | 对本 note 的评审即是决策 |
+| 0b | 逐域搬家 + 审计 PR:移动、改名、补 frontmatter、逐条对照代码验证、重写或删除;门禁随第一个搬家的域落地 | `pnpm docs:check` 绿;搬过的文档所有断言对照 `src/` 验证过 |
+| 1 | 完整 `.agents/notes/README.md` 规则集 + 格式门禁 + 回填种子 notes(双语) | 格式门禁对全部 notes 绿 |
+| 2 | 配对门禁移植;发现根 `.agents/notes` + `CONTRIBUTING.md`;`CONTRIBUTING.zh.md` | `verify-translation-pairing` 绿 |
+| 3 | 只对审定为现行的文档做翻译回填;配对范围扩到 `docs/**` | 全语料配对绿 |
+| 4 | 流程 skills + `gh-pr-review` 的 sources 集成 | Skill 评审 |
+
+全程质量先于翻译:一篇文档先审定为现行,再进入配对——翻译腐烂内容等于把它固化成两种语言,纠错成本翻倍。
+
+## Alternatives considered
+
+- **零 frontmatter、纯路径编码元数据(dsh 的设计)。** dsh 把一切编码进路径和 header,其文档不带 frontmatter。此处拒绝,因为我们两个最迫切的需求——腐烂门禁(`sources`)和防漂移的生成式索引(`description`)——都需要逐文件的机器可读字段;dsh 用字数预算、`verify-doc-refs` 和手工层级维护覆盖这些,而那套机械我们并不整体移植。
+- **给过时文档打 `status: deprecated` 标记。** 拒绝:要么是现行事实,要么删除。弃用标记是给腐烂发的留存许可证。
+- **先翻译,后审计。** 拒绝:此后每次纠错都要付两种语言的成本外加一次配对重录。
+- **保留 `guides/` 与 `references/` 的二分。** 拒绝:这个分类已经名存实亡;按用途分类(tutorial = 有序步骤走到可观察结果)一照,这里几乎全是 reference 或流程材料。
+- **现在就整体移植 dsh 的翻译机械**(merge driver、`gen-translation-brief`、doc budgets)。缓行:dsh 自己也把重型路径标为仅显式调用;在失同步冲突成为真实成本之前,常规的单遍对照更新就够了。
+- **dsh 的逐 PR note 强制令。** 修订为 P4 的决策门槛;以这里的修复流量,强制令会沦为仪式。
+- **现在就做网站投影。** 缓行:docs.cherry-ai.com 在独立仓库;等语料被治理之后,投影是另一个独立决策。
+
+## Acceptance criteria
+
+- `references/` 顶层是封闭的域目录集,每域有 README 之家;`verify-doc-structure` 绿。
+- 三篇死/重复文档已删除;每篇存活的 reference 文档的断言都对照现行代码验证过。
+- 每篇 `references/**` 文档带 `description` + 存在的 `sources`;`verify-doc-frontmatter` 绿。
+- `docs/README.md` 是生成的;`gen-doc-index --check` 绿。
+- CI 在 `ci:basic-check` 里跑 `pnpm docs:check`。
+- `.agents/notes/` 持有本 note 加回填的种子,双语,格式门禁绿。
+- `.agents/notes/**` 与 `CONTRIBUTING.md` 通过配对门禁;Phase 3 之后 `docs/**` 也通过。
+
+## Risks
+
+- **入链翻新。** `CLAUDE.md` 链接大量文档,而 TypeScript 注释里引用的 `docs/*.md` 路径 `docs:check-links` 并不扫描;Phase 0b 的每次移动都必须对旧路径 grep `src/`。缓解:按域原子化移动(搬家 + 修复全部入链在同一个 PR)。
+- **与进行中 PR 的冲突。** 目录树移动会与触及相同文档的在途工作冲突。缓解:Phase 0b 逐域小步推进,不搞一次性大搬家。
+- **双语维护成本。** 每次编辑配对文档都要同步另一侧并重录;高频变动的文档付出最多。有意接受——文档在这里是产品——并通过只配对审定为现行的材料来控制上限。
+- **翻译评审负担。** 配对门禁校验的是结构而非忠实度;中文质量仍需评审者投入,而术语表起点很薄。

--- a/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.zh.md
+++ b/.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.zh.md
@@ -56,6 +56,7 @@ docs/
 | `references/{architecture-overview,main-process-architecture,renderer-architecture,shared-layer-architecture,naming-conventions}.md` | 移动 → `references/architecture/`。 |
 | `guides/{logging,i18n}.md` | 移动 → `references/` 下各自的主题域。 |
 | `guides/diagnostics.md` | 归属(contrib 还是 reference)在其 Phase 0b 审计时决定。 |
+| `docs/sponsor.md` | **留在 `docs/` 根目录**——根 README 链接的面向用户页面,不是开发者文档;不进参考树、不进门禁、不进双语配对。 |
 | `references/chat/{adapters,conventions}.md` | **保持原位**——明确标注为 target-architecture 设计文档;adapters 代码落地时重新决定其归宿。不在 Phase 0b 范围内。 |
 | `references/file/architecture.md` + `file-manager-architecture.md` | **两篇都保留**——刻意分层且互相声明 SoT 边界,不是腐烂。 |
 
@@ -71,7 +72,9 @@ sources: # code paths this document describes; directories preferred
 ---
 ```
 
-`docs/contrib/**` 只要求 `description`。Agent Notes **不用 frontmatter**——路径与 header block 已经编码了它们的元数据,与 dsh 一致。
+`docs/contrib/**` 只要求 `description`。Agent Notes **不用 frontmatter**——路径与 header block 已经编码了它们的元数据,与 dsh 一致。`docs/sponsor.md` 是根 README 链接的面向用户页面,不是开发者文档:它留在 `docs/` 根目录,不在任何门禁的扫描范围内(门禁只覆盖 `references/` 与 `contrib/`),也不进双语配对。
+
+`sources` 的每一条是一个**路径前缀**:diff 路径等于该条或位于其下时即归属该文档,因此目录条目覆盖其全部子孙。这正是 Phase 4 反向查询能对子树改动生效的原因;也正因如此,过宽的条目会稀释信号——每条应写仍能覆盖该文档全部主题的最窄目录。
 
 未来任何字段的准入标准:它必须承载路径、H1、git 都承载不了的信息,**并且**说得出消费它的脚本。现在即拒绝的字段,每个都已有归属:`domain`/`category`(路径)、`title`(H1)、`updated`/`author`(git)、`status: deprecated`(删除——要么是现行事实要么不存在)、`tags`(无消费者)、`sidebar_position`(站点导航集中在一个映射文件,dsh 式),以及翻译配对 hash(把文件的 hash 写进文件本身会改变 hash——它必须住在 sidecar 里)。
 
@@ -80,10 +83,10 @@ sources: # code paths this document describes; directories preferred
 三个新脚本,全部是 `tsx scripts/*.ts`,遵循仓库较新的脚本惯例(导出函数 + `scripts/__tests__/` 下的测试,同 `i18n-check-values.ts`):
 
 - `verify-doc-structure`——`references/` 根的封闭集;每个域目录有 `README.md`。
-- `verify-doc-frontmatter`——必填字段齐全;每个 `sources` 路径存在。代码一搬走,`middleware.md` 那类腐烂当天就被这道门禁抓住。
+- `verify-doc-frontmatter`——必填字段齐全;每个 `sources` 路径存在。它抓住的是特定一类腐烂:主题已被删除或搬走的文档——`middleware.md` 与 `message-system.md` 正是此类——在代码移动当天即被抓住。**它是存在性检查,不是新鲜度检查**:主题原地变化、或文件在某个宽目录条目内部移动而导致的过时,门禁仍是绿的。语义过时由 Phase 4 的反向查询和评审负责,不在这里。
 - `gen-doc-index`(带 `--check`)——从 frontmatter 重新生成 `docs/README.md`;漂移即失败。
 
-接线:新聚合命令 `pnpm docs:check` = `docs:check-links` + 上述三个。它加入 `ci:basic-check`(补上 CI 完全不查文档的缺口),并替换 `build:check` 里的裸 `docs:check-links`。
+接线:新聚合命令 `pnpm docs:check` = `docs:check-links` + 上述三个,并替换 `build:check` 里的裸 `docs:check-links`。补上 CI 缺口需要改**工作流**,而不只是改 script:`.github/workflows/ci.yml` 并不调用 `pnpm ci:basic-check`——它的 `basic-checks` job 通过 `concurrently` 内联各条命令,因此 `docs:check` 必须加进那个步骤才会在 CI 里真正运行。`ci:basic-check` script 同步更新,以保持本地等价物诚实。
 
 `sources` 的后续消费者:把 PR 的 diff 路径与全部 `sources` 清单求交集,即可机械得出"这个 PR 本应更新的文档",接进 `gh-pr-review` skill(Phase 4)。这把"改代码必须带文档"从自觉守则变成可校验的规则。
 
@@ -115,7 +118,7 @@ sources: # code paths this document describes; directories preferred
 | Phase | 工作 | 验证 |
 |---|---|---|
 | 0a(本 PR) | 本方案;带 stub README 的 `.agents/notes/` 骨架 | 对本 note 的评审即是决策 |
-| 0b | 逐域搬家 + 审计 PR:移动、改名、补 frontmatter、逐条对照代码验证、重写或删除;门禁随第一个搬家的域落地 | `pnpm docs:check` 绿;搬过的文档所有断言对照 `src/` 验证过 |
+| 0b | 逐域搬家 + 审计 PR:移动、改名、逐条对照代码验证、重写或删除。**门禁最后落地,在最后一次搬家之后**,与全语料的 frontmatter 一起 —— `verify-doc-structure` 读整个 `references/` 根、`verify-doc-frontmatter` 读每篇参考文档,树迁移到一半时两者都不可能绿;而为这段短暂的迁移期做一套分级放行白名单,机械成本大于收益 | 每个搬家 PR `docs:check-links` 绿;门禁落地后完整 `pnpm docs:check` 绿;搬过的文档所有断言对照 `src/` 验证过 |
 | 1 | 完整 `.agents/notes/README.md` 规则集 + 格式门禁 + 回填种子 notes(双语) | 格式门禁对全部 notes 绿 |
 | 2 | 配对门禁移植;发现根 `.agents/notes` + `CONTRIBUTING.md`;`CONTRIBUTING.zh.md` | `verify-translation-pairing` 绿 |
 | 3 | 只对审定为现行的文档做翻译回填;配对范围扩到 `docs/**` | 全语料配对绿 |
@@ -139,13 +142,13 @@ sources: # code paths this document describes; directories preferred
 - 三篇死/重复文档已删除;每篇存活的 reference 文档的断言都对照现行代码验证过。
 - 每篇 `references/**` 文档带 `description` + 存在的 `sources`;`verify-doc-frontmatter` 绿。
 - `docs/README.md` 是生成的;`gen-doc-index --check` 绿。
-- CI 在 `ci:basic-check` 里跑 `pnpm docs:check`。
+- CI 跑 `pnpm docs:check` —— 以 `.github/workflows/ci.yml` 的 `basic-checks` job 确实调用它为准,而不是以 `ci:basic-check` script 列出它为准。
 - `.agents/notes/` 持有本 note 加回填的种子,双语,格式门禁绿。
 - `.agents/notes/**` 与 `CONTRIBUTING.md` 通过配对门禁;Phase 3 之后 `docs/**` 也通过。
 
 ## Risks
 
-- **入链翻新。** `CLAUDE.md` 链接大量文档,而 TypeScript 注释里引用的 `docs/*.md` 路径 `docs:check-links` 并不扫描;Phase 0b 的每次移动都必须对旧路径 grep `src/`。缓解:按域原子化移动(搬家 + 修复全部入链在同一个 PR)。
+- **入链翻新。** `docs:check-links` 只解析 Markdown 链接,因此看不到其余任何消费者:`CLAUDE.md` 正文、`eslint.config.mjs` 里的 lint 规则消息、TypeScript 注释,以及*按路径读取文档*的代码——`scripts/uiContract/__tests__/maintainedAnchors.test.ts` 会打开 `ui-semantic-contract.md`,那里漏改会挂掉一个测试而不是一条链接。因此 Phase 0b 的每次移动都要对旧路径 grep **整个仓库**(`src/`、`scripts/`、`packages/`、`tests/`、`.github/`、根配置),而不只是 `src/`。缓解:按域原子化移动(搬家 + 修复全部入链引用在同一个 PR)。
 - **与进行中 PR 的冲突。** 目录树移动会与触及相同文档的在途工作冲突。缓解:Phase 0b 逐域小步推进,不搞一次性大搬家。
 - **双语维护成本。** 每次编辑配对文档都要同步另一侧并重录;高频变动的文档付出最多。有意接受——文档在这里是产品——并通过只配对审定为现行的材料来控制上限。
 - **翻译评审负担。** 配对门禁校验的是结构而非忠实度;中文质量仍需评审者投入,而术语表起点很薄。


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: repository decisions (architecture choices, rejected alternatives, process changes) live only in PR threads and chat; developer docs rot silently (`docs/guides/middleware.md` and `docs/references/messaging/message-system.md` document deleted systems), the docs hierarchy misleads (open-set `references/` root, chat/messaging split-brain, drifted hand-maintained index), and no doc gate runs in CI.

After this PR: the `.agents/notes/` decision-record skeleton exists, holding its first proposed Agent Note — a full adoption plan for dsh-style docs governance: target doc tree with per-file dispositions, a two-field frontmatter spec (`description` + `sources`), three doc gates wired into CI, the Agent Notes system (lifecycle × class, mandatory Alternatives considered, decision-level threshold), bilingual en/zh pairing with staged rollout, and process skills. This PR adds four markdown files only; no code, no doc moves, no gates yet — review of the proposal is the decision that unlocks the later phases.

Fixes: N/A

### Why we need it and why it was done in this way

With multiple agents and contributors working in parallel, undocumented decisions get re-proposed and re-litigated, and stale docs are read as current authority. The proposal ports the deepseek-harness documentation/decision-record process, which solves exactly this, adapted where our context differs.

The following tradeoffs were made:

- Note threshold is "decisions a maintainer may revisit", not dsh's every-non-trivial-PR mandate — Cherry Studio's routine-fix volume would turn the mandate into ritual.
- Bilingual pairing rolls out by discovery root (notes + CONTRIBUTING first, `docs/**` after audit/backfill) instead of dsh's all-at-once scope.
- Quality remediation precedes translation backfill, so rot is never baked into two languages.

The following alternatives were considered: frontmatter-free path-only metadata, `status: deprecated` markers, translate-first, keeping the guides/references split, porting dsh's full translation machinery now, and building the website projection now — each is recorded with its rejection rationale in the note's "Alternatives considered" section.

Links to places where the discussion took place: N/A (Conductor session)

### Breaking changes

None.

### Special notes for your reviewer

The deliverable under review is the proposal note itself: `.agents/notes/proposed/process/2026-08-18-docs-governance-and-spec-workflow.md` (with a section-mirrored `.zh.md` counterpart). The stub `.agents/notes/README.md` intentionally defers the full ruleset and format gate to the proposal's Phase 1. `pnpm docs:check-links` passes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
