### PR TITLE
fix(wechat): send ciphertext size as image upload filesize

### DIFF
--- a/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
+++ b/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
@@ -294,7 +294,9 @@ async function cdnDownloadFile(item: FileItem): Promise<Buffer | null> {
 // --------------- CDN upload ---------------
 
 const GetUploadUrlRespSchema = z.object({
-  upload_param: z.string()
+  upload_param: z.string().optional(),
+  /** 官方较新的响应字段：服务端直接返回完整上传 URL，存在时优先直接 POST（无需客户端拼接）。 */
+  upload_full_url: z.string().optional()
 })
 
 async function cdnUploadImage(
@@ -307,6 +309,10 @@ async function cdnUploadImage(
   const aeskey = randomBytes(16)
   const filekey = randomBytes(16).toString('hex')
   const md5Hash = await import('node:crypto').then((c) => c.createHash('md5').update(imageData).digest('hex'))
+  // 先加密再请求 getuploadurl：官方（Tencent/openclaw-weixin upload.ts）的 filesize 是
+  // PKCS7 密文大小（Math.ceil((rawsize+1)/16)*16），而非明文大小。直接复用 ciphertext.length
+  // 可保证与实际上传的密文严格一致——filesize 与上传体不一致是「文件已过期/已被清理」的最可疑根因。
+  const ciphertext = aesEcbEncrypt(imageData, aeskey)
 
   // Step 1: get upload URL
   const raw = await apiFetch(
@@ -318,7 +324,7 @@ async function cdnUploadImage(
       to_user_id: toUserId,
       rawsize: imageData.length,
       rawfilemd5: md5Hash,
-      filesize: imageData.length,
+      filesize: ciphertext.length,
       no_need_thumb: true,
       aeskey: aeskey.toString('hex'),
       base_info: buildBaseInfo()
@@ -327,11 +333,18 @@ async function cdnUploadImage(
     uin,
     15_000
   )
-  const { upload_param } = GetUploadUrlRespSchema.parse(raw)
+  const resp = GetUploadUrlRespSchema.parse(raw)
+  const uploadFullUrl = resp.upload_full_url?.trim()
+  const uploadParam = resp.upload_param
+  if (!uploadFullUrl && !uploadParam) {
+    logger.error('getuploadurl response missing both upload_full_url and upload_param')
+    return null
+  }
 
-  // Step 2: encrypt and upload
-  const ciphertext = aesEcbEncrypt(imageData, aeskey)
-  const uploadUrl = `${CDN_BASE_URL}/upload?encrypted_query_param=${encodeURIComponent(upload_param)}&filekey=${encodeURIComponent(filekey)}`
+  // Step 2: upload（官方优先直接 POST upload_full_url，否则回退用 upload_param 拼接）
+  const uploadUrl = uploadFullUrl
+    ? uploadFullUrl
+    : `${CDN_BASE_URL}/upload?encrypted_query_param=${encodeURIComponent(uploadParam!)}&filekey=${encodeURIComponent(filekey)}`
   const uploadResp = await net.fetch(uploadUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/octet-stream' },
@@ -832,7 +845,7 @@ export class WeixinBot {
           image_item: {
             media: {
               encrypt_query_param: uploaded.downloadEncryptedQueryParam,
-              aes_key: Buffer.from(uploaded.aeskey).toString('base64'),
+              aes_key: Buffer.from(uploaded.aeskey.toString('hex')).toString('base64'),
               encrypt_type: 1
             },
             mid_size: uploaded.ciphertextSize


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Sending an image through a WeChat channel looked successful on our side — `getuploadurl`, the CDN upload and `sendMessage` all returned OK — but the receiving client rendered a plain grey image placeholder, and tapping it reported "文件已过期或已被清理" (file expired or cleaned up).

Three details of `cdnUploadImage` in `src/main/ai/channels/adapters/wechat/WeChatProtocol.ts` did not match the official WeChat client:

- `getuploadurl` declared `filesize` as the **plaintext** byte length, while the body actually POSTed to the CDN is the AES-128-ECB PKCS7 **ciphertext** (`Math.ceil((rawsize + 1) / 16) * 16` bytes). The declared size therefore never matched the stored object.
- `image_item.media.aes_key` was base64 of the raw 16 key bytes, not base64 of the 32-character hex string the official client sends.
- Only the `upload_param` response field was accepted, so the newer `upload_full_url` form of the response failed schema validation.

After this PR:

The image data is encrypted before `getuploadurl` is called, and `filesize` is set to `ciphertext.length`, so the declared size is by construction identical to the uploaded body. `aes_key` is sent as base64 of the hex string, and the upload URL prefers `upload_full_url` when the server returns it, falling back to the `upload_param` concatenation. If the response carries neither field the upload fails fast with a log line instead of throwing on a schema mismatch. Images now render normally on the receiving client.

Fixes: None

### Why we need it and why it was done in this way

The size mismatch is the root cause: the CDN indexes and validates the stored object against the `filesize` announced at `getuploadurl` time, so a plaintext-sized declaration against a PKCS7-padded body leaves an object the client cannot fetch and decrypt — surfacing as "expired or cleaned up" rather than an upload error. Encrypting first and reusing `ciphertext.length` makes the two values impossible to drift apart, instead of recomputing the padded size with a formula that has to stay in sync with the cipher.

The reference for all three changes is Tencent's official implementation: `src/cdn/upload.ts` (filesize), `src/cdn/aes-ecb.ts` (key encoding), `src/cdn/cdn-upload.ts` (`upload_full_url`) and `src/messaging/send.ts` in `Tencent/openclaw-weixin`.

The following tradeoffs were made:

- `upload_param` is kept as a fallback rather than being replaced by `upload_full_url`, because the field is optional in the protocol and older responses still only carry `upload_param`.
- Encrypting before `getuploadurl` costs one AES pass even when the URL request fails. For image payloads this is negligible next to the network round trip.

The following alternatives were considered:

- Computing the padded size arithmetically (`Math.ceil((rawsize + 1) / 16) * 16`) and keeping the encrypt step in place. Rejected: it duplicates the padding rule in a second place, and any change to the cipher silently reintroduces the mismatch.
- Changing only `filesize` and leaving `aes_key` and the URL handling alone. Rejected: the key encoding is also observably different from the official client, and a `upload_full_url`-only response currently fails schema parsing.

Links to places where the discussion took place: None

### Breaking changes

None. The change only affects the request Cherry Studio sends when uploading an image to the WeChat CDN.

### Special notes for your reviewer

Verified against a real WeChat account: images that previously rendered grey / "file expired" now display correctly. The upload path has no unit coverage today, and the protocol cannot be exercised without live credentials, so verification is manual.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed images sent through a WeChat channel arriving as a grey placeholder that reports "file expired or cleaned up" on the recipient's client.
```
