### PR TITLE
fix(ipc-security): trust renderer path aliases

### DIFF
--- a/src/main/core/security/__tests__/validateSender.test.ts
+++ b/src/main/core/security/__tests__/validateSender.test.ts
@@ -38,6 +38,26 @@ describe('isAppRendererUrl', () => {
     }
   })
 
+  it('trusts a packaged app page when the renderer path reaches the app through a directory link', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'cherry-sender-renderer-link-'))
+    const realProgramsDir = join(fixtureRoot, 'real-programs')
+    const linkedProgramsDir = join(fixtureRoot, 'linked-programs')
+    const realAppRoot = join(realProgramsDir, 'Cherry Studio', 'resources', 'app.asar')
+    const appRootFromRendererPath = join(linkedProgramsDir, 'Cherry Studio', 'resources', 'app.asar')
+
+    try {
+      mkdirSync(dirname(realAppRoot), { recursive: true })
+      writeFileSync(realAppRoot, '')
+      symlinkSync(realProgramsDir, linkedProgramsDir, process.platform === 'win32' ? 'junction' : 'dir')
+
+      const rendererPath = join(appRootFromRendererPath, 'out', 'renderer', 'windows', 'main', 'index.html')
+
+      expect(isAppRendererUrl(pathToFileURL(rendererPath).href, null, realpathSync.native(realAppRoot))).toBe(true)
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
   it('rejects a file:// page outside the app root (downloaded/exported HTML)', () => {
     expect(isAppRendererUrl(pathToFileURL(resolve('/Users/victim/Downloads/evil.html')).href, null, APP_ROOT)).toBe(
       false

--- a/src/main/core/security/validateSender.ts
+++ b/src/main/core/security/validateSender.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from 'node:fs'
-import { isAbsolute, relative } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { application } from '@application'
@@ -26,6 +26,27 @@ function resolveAppRoot(appRootDir: string): string {
   }
 }
 
+/** Resolve aliases in the existing portion of a path while preserving an ASAR virtual suffix. */
+function resolveRendererPath(filePath: string): string | undefined {
+  let candidate = filePath
+  const missingSegments: string[] = []
+
+  while (true) {
+    try {
+      return join(realpathSync.native(candidate), ...missingSegments)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') return undefined
+
+      const parent = dirname(candidate)
+      if (parent === candidate) return undefined
+
+      missingSegments.unshift(basename(candidate))
+      candidate = parent
+    }
+  }
+}
+
 /**
  * Whether a URL belongs to the app's own renderer.
  *
@@ -40,8 +61,8 @@ function resolveAppRoot(appRootDir: string): string {
  * that origin.
  *
  * A `file:` URL is trusted only when its path is **inside `appRootDir`** — not any
- * `file:` wholesale. The app root is resolved to its real path first because Chromium
- * canonicalizes renderer URLs while Electron may report a symlinked launch path.
+ * `file:` wholesale. Filesystem aliases may appear on either side, so existing path
+ * portions are compared canonically while preserving the virtual path below `app.asar`.
  * Reaching IpcApi does not require the app preload (a
  * `nodeIntegration` window can call `ipcRenderer.invoke` directly), so a
  * downloaded/exported HTML opened in such a window would otherwise be trusted, and
@@ -72,7 +93,11 @@ export function isAppRendererUrl(
     } catch {
       return false
     }
-    return isPathInside(filePath, resolveAppRoot(appRootDir))
+    const appRoot = resolveAppRoot(appRootDir)
+    if (isPathInside(filePath, appRoot)) return true
+
+    const resolvedFilePath = resolveRendererPath(filePath)
+    return resolvedFilePath !== undefined && isPathInside(resolvedFilePath, appRoot)
   }
 
   if (devServerUrl) {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: A packaged renderer could be rejected as untrusted when its path used an equivalent filesystem alias, such as a Windows 8.3 short name.

After this PR: Renderer path aliases are canonicalized before the existing app-root containment check.

Fixes #18846

### Why we need it and why it was done in this way

The existing lexical fast path remains unchanged. Only failed comparisons resolve the renderer's nearest existing ancestor, preserve the virtual ASAR suffix, and fail closed on unexpected filesystem errors. Results are not cached.

Resolving the complete renderer path is not viable because entries below `app.asar` are virtual. A Windows-only API was avoided because the same mismatch can occur with symlinks and junctions.

Links to places where the discussion took place: #18846, #17766

### Breaking changes

None.

### Special notes for your reviewer

The focused sender-validation suite passes (18/18), including external-file, traversal, iframe, webview, and remote-origin rejection cases. A patched Windows portable build was also verified under the original 8.3 short-path condition.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixes startup and IPC access in Windows portable builds when the renderer path uses a filesystem alias such as a Windows 8.3 short name.
```
