### PR TITLE
fix(security): close four bypass gaps in existing guards (scheme checks, staging residue, trace perms)

### DIFF
--- a/src/main/ai/observability/storage/TraceStorageService.ts
+++ b/src/main/ai/observability/storage/TraceStorageService.ts
@@ -506,7 +506,9 @@ export class TraceStorageService extends BaseService implements TraceStore, Acti
 
   private async writeTraceFile(spans: SpanEntity[], topicId: string, traceId: string) {
     const dirPath = this.traceTopicDir(topicId)
-    await fs.mkdir(dirPath, { recursive: true })
+    // Owner-only perms: trace JSONL holds raw prompts/API bodies (dev-gated
+    // plaintext by design) and userData can be world-readable on Linux (0755).
+    await fs.mkdir(dirPath, { recursive: true, mode: 0o700 })
     const filePath = this.traceFilePath(topicId, traceId)
     const replacements = new Map(
       spans
@@ -528,7 +530,7 @@ export class TraceStorageService extends BaseService implements TraceStore, Acti
     const tmpPath = `${filePath}.${process.pid}.tmp`
     let output: FileHandle | undefined
     try {
-      output = await fs.open(tmpPath, 'w')
+      output = await fs.open(tmpPath, 'w', 0o600)
       if (historySize !== null) {
         const handle = output
         const seenIds = new Set<string>()

--- a/src/main/ai/observability/storage/__tests__/TraceStorageService.test.ts
+++ b/src/main/ai/observability/storage/__tests__/TraceStorageService.test.ts
@@ -180,6 +180,20 @@ describe('TraceStorageService', () => {
     expect((await service.getSpans('topic-a', 'trace-a')).map((item) => item.id).sort()).toEqual(['first', 'second'])
   })
 
+  // S12: trace JSONL holds raw prompts/API bodies (dev-gated plaintext by design) and
+  // Electron's userData can be world-readable on Linux, so artifacts must be owner-only.
+  it.skipIf(process.platform === 'win32')('writes owner-only trace artifacts (file 0600, topic dir 0700)', async () => {
+    await service._doInit()
+
+    service.saveEntity(span({ id: 'secret-ish', traceId: 'trace-a', topicId: 'topic-a' }))
+    await service.saveSpans('topic-a')
+
+    const fileStats = await fs.stat(path.join(traceDir, 'topic-a', 'trace-a'))
+    expect(fileStats.mode & 0o777).toBe(0o600)
+    const dirStats = await fs.stat(path.join(traceDir, 'topic-a'))
+    expect(dirStats.mode & 0o777).toBe(0o700)
+  })
+
   // The OTel createSpan/endSpan path is the live source of cached spans. If endSpan does not
   // mark the entity ended, TraceSpanStore can never evict the trace and memory grows unbounded
   // while developer_mode is on. Drive a span through the real pipeline and confirm a fully-ended

--- a/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
+++ b/src/main/core/preboot/__tests__/v2MigrationGate.test.ts
@@ -1,3 +1,7 @@
+import { promises as fsp } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -51,7 +55,10 @@ const getBlockMessageMock = vi.fn()
 const defaultMigrationPaths = {
   userData: '/mock/userData',
   versionLogFile: '/mock/version.log',
-  databaseFile: '/mock/userData/Data/cherrystudio.sqlite'
+  databaseFile: '/mock/userData/Data/cherrystudio.sqlite',
+  // The gate's sweep rm's this for real in every skipped-path test, so the default must
+  // point somewhere guaranteed absent and harmless (never a plausible real path).
+  migrationTempDir: path.join(os.tmpdir(), `v2gate-absent-${process.pid}-${Math.random().toString(36).slice(2)}`)
 }
 const defaultResolveResult = {
   paths: defaultMigrationPaths,
@@ -199,6 +206,91 @@ describe('runV2MigrationGate', () => {
       expect(initializeMock).toHaveBeenCalledWith(defaultMigrationPaths, false)
       expect(registerMigratorsMock).toHaveBeenCalledTimes(1)
       expect(registerMigratorsMock).toHaveBeenCalledWith(migrators)
+    })
+  })
+
+  describe('staging sweep (S11)', () => {
+    const fixtureRoots: string[] = []
+
+    /** Real `{userData}/migration_temp` fixture holding a plaintext-looking dump residue. */
+    async function createStagingFixture(): Promise<string> {
+      const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'v2gate-sweep-'))
+      fixtureRoots.push(root)
+      await fsp.mkdir(path.join(root, 'redux_export'), { recursive: true })
+      await fsp.writeFile(path.join(root, 'redux_export', 'provider.json'), '{"apiKeys":["sk-plaintext"]}')
+      return root
+    }
+
+    afterEach(async () => {
+      await Promise.all(fixtureRoots.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })))
+    })
+
+    it('removes leftover migration_temp when no migration is needed (S11: crash residues are never read again)', async () => {
+      const staging = await createStagingFixture()
+      needsMigrationMock.mockResolvedValue(false)
+      resolveMigrationPathsMock.mockReturnValue({
+        ...defaultResolveResult,
+        paths: { ...defaultMigrationPaths, migrationTempDir: staging }
+      })
+      stubMigrationV2()
+      stubElectron()
+      stubApplication()
+
+      const { runV2MigrationGate } = await loadModule()
+      const result = await runV2MigrationGate()
+
+      expect(result).toBe('skipped')
+      await expect(fsp.access(staging)).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
+    it('never touches migration_temp while migration is still pending (PrepareExport owns that cleanup)', async () => {
+      const staging = await createStagingFixture()
+      needsMigrationMock.mockResolvedValue(true)
+      evaluateCandidateVersionMock.mockReturnValue({
+        check: { outcome: 'pass' },
+        previousVersion: '1.9.0',
+        versionLogExists: true
+      })
+      resolveMigrationPathsMock.mockReturnValue({
+        ...defaultResolveResult,
+        paths: { ...defaultMigrationPaths, migrationTempDir: staging }
+      })
+      stubMigrationV2()
+      stubElectron()
+      stubApplication()
+
+      const { runV2MigrationGate } = await loadModule()
+      const result = await runV2MigrationGate()
+
+      expect(result).toBe('handled')
+      await expect(fsp.access(path.join(staging, 'redux_export', 'provider.json'))).resolves.toBeUndefined()
+    })
+
+    it('logs and continues boot when the sweep fails (residue only outlives one launch)', async () => {
+      const staging = await createStagingFixture()
+      const rmSpy = vi
+        .spyOn(fsp, 'rm')
+        .mockRejectedValueOnce(Object.assign(new Error('EACCES: permission denied, unlink'), { code: 'EACCES' }))
+      needsMigrationMock.mockResolvedValue(false)
+      resolveMigrationPathsMock.mockReturnValue({
+        ...defaultResolveResult,
+        paths: { ...defaultMigrationPaths, migrationTempDir: staging }
+      })
+      stubMigrationV2()
+      stubElectron()
+      stubApplication()
+
+      try {
+        const { runV2MigrationGate } = await loadModule()
+        const result = await runV2MigrationGate()
+
+        expect(result).toBe('skipped')
+        expect(rmSpy).toHaveBeenCalledWith(staging, { recursive: true, force: true })
+        expect(showErrorBoxMock).not.toHaveBeenCalled()
+        expect(appQuitMock).not.toHaveBeenCalled()
+      } finally {
+        rmSpy.mockRestore()
+      }
     })
   })
 

--- a/src/main/core/preboot/v2MigrationGate.ts
+++ b/src/main/core/preboot/v2MigrationGate.ts
@@ -9,6 +9,8 @@
  * keeps no domain files (see core/preboot/README.md, Membership criteria).
  */
 
+import { promises as fs } from 'node:fs'
+
 import { application } from '@application'
 import {
   evaluateCandidateVersion,
@@ -280,6 +282,16 @@ export async function runV2MigrationGate(): Promise<V2MigrationGateResult> {
   // Normal path: no migration needed. Release the bare DB handle so the
   // lifecycle DbService can open its own connection when bootstrap runs.
   migrationEngine.close()
+
+  // Migration is no longer pending: sweep the renderer-export staging tree
+  // (plaintext v1 dumps) that the engine's own cleanup paths can miss.
+  try {
+    await fs.rm(paths.migrationTempDir, { recursive: true, force: true })
+  } catch (error) {
+    logger.warn('Failed to sweep legacy migration export staging', error as Error, {
+      path: paths.migrationTempDir
+    })
+  }
 
   // Edge case: userData was redirected from legacy config but migration is
   // not needed (e.g. boot-config.json was manually deleted after a

--- a/src/main/core/window/WindowManager.ts
+++ b/src/main/core/window/WindowManager.ts
@@ -1375,6 +1375,11 @@ export class WindowManager extends BaseService {
           event.preventDefault()
           void shell.openExternal(url)
         }
+      } else {
+        // Non-web schemes (file:, custom protocols) have no legitimate in-window
+        // navigation path; deny like the window-open handler denies non-http(s) popups.
+        event.preventDefault()
+        logger.warn(`Blocked navigation to untrusted URL scheme: ${url}`)
       }
     })
 

--- a/src/main/core/window/__tests__/WindowManager.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.test.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { shell } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BaseService } from '../../lifecycle/BaseService'
@@ -430,6 +431,62 @@ describe('WindowManager', () => {
       expect(win).toBeDefined()
       expect(win.loadFile).not.toHaveBeenCalled()
       expect(win.loadURL).not.toHaveBeenCalled()
+    })
+  })
+
+  // ─── will-navigate guard (S13) ──────────────────────────
+
+  describe('will-navigate guard', () => {
+    beforeEach(() => {
+      vi.mocked(shell.openExternal).mockClear()
+    })
+
+    /** The guard WindowManager registers via webContents.on('will-navigate', …). */
+    function getWillNavigateHandler(
+      win: MockBrowserWindow
+    ): (event: { preventDefault: () => void }, url: string) => void {
+      const call = win.webContents.on.mock.calls.find(([event]) => event === 'will-navigate')
+      if (!call) throw new Error('will-navigate handler was not registered')
+      return call[1] as never
+    }
+
+    it('blocks navigation to non-http(s) URLs instead of letting it pass', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      const handler = getWillNavigateHandler(win)
+
+      for (const url of ['file:///etc/passwd', 'cherry://settings', 'about:blank']) {
+        const preventDefault = vi.fn()
+        handler({ preventDefault }, url)
+        expect(preventDefault, `expected navigation to ${url} to be blocked`).toHaveBeenCalledTimes(1)
+      }
+      expect(shell.openExternal).not.toHaveBeenCalled()
+    })
+
+    it('allows same-origin http(s) navigation unchanged', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      win.webContents.getURL.mockReturnValue('https://app.local/index.html')
+      const handler = getWillNavigateHandler(win)
+
+      const preventDefault = vi.fn()
+      handler({ preventDefault }, 'https://app.local/other.html')
+
+      expect(preventDefault).not.toHaveBeenCalled()
+      expect(shell.openExternal).not.toHaveBeenCalled()
+    })
+
+    it('still blocks cross-origin http(s) and routes it to the system browser', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      win.webContents.getURL.mockReturnValue('https://app.local/index.html')
+      const handler = getWillNavigateHandler(win)
+
+      const preventDefault = vi.fn()
+      handler({ preventDefault }, 'https://evil.example.com')
+
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+      expect(shell.openExternal).toHaveBeenCalledWith('https://evil.example.com')
     })
   })
 

--- a/src/main/services/WebviewService.ts
+++ b/src/main/services/WebviewService.ts
@@ -47,7 +47,13 @@ export function setOpenLinkExternal(webviewId: number, isExternal: boolean) {
       }
       return { action: 'deny' }
     } else {
-      return { action: 'allow' }
+      // In-app popups must stay on web origins; isSafeExternalUrl is not reused here
+      // because its allowlist (mailto:, editor deep-links) targets shell.openExternal.
+      if (url.startsWith('http:') || url.startsWith('https:')) {
+        return { action: 'allow' }
+      }
+      logger.warn(`Blocked in-app popup for untrusted URL scheme: ${url}`)
+      return { action: 'deny' }
     }
   })
 }

--- a/src/main/services/__tests__/WebviewService.test.ts
+++ b/src/main/services/__tests__/WebviewService.test.ts
@@ -1,0 +1,70 @@
+import { shell, webContents } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setOpenLinkExternal } from '../WebviewService'
+
+type OpenHandler = (details: { url: string }) => { action: 'allow' | 'deny' }
+
+/**
+ * Contract tests for the miniapp webview popup policy (S14):
+ * the in-app (`allow`) branch must only let web origins open popups —
+ * non-http(s) schemes have no legitimate target inside a webview popup.
+ */
+
+describe('setOpenLinkExternal', () => {
+  let handler: OpenHandler
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const setWindowOpenHandler = vi.fn((cb: OpenHandler) => {
+      handler = cb
+    })
+    vi.mocked(webContents.fromId).mockReturnValue({ setWindowOpenHandler } as never)
+  })
+
+  describe('in-app mode (isExternal=false)', () => {
+    beforeEach(() => {
+      setOpenLinkExternal(1, false)
+    })
+
+    it('allows http and https popups', () => {
+      expect(handler({ url: 'https://cherrystudio.com/page' })).toEqual({ action: 'allow' })
+      expect(handler({ url: 'http://cherrystudio.com/page' })).toEqual({ action: 'allow' })
+    })
+
+    it.each([
+      ['file scheme', 'file:///etc/passwd'],
+      ['javascript scheme', 'javascript:alert(1)'],
+      ['mailto scheme (in isSafeExternalUrl but not an in-app target)', 'mailto:support@example.com'],
+      ['editor deep-link (in isSafeExternalUrl but not an in-app target)', 'vscode://file/src/index.ts'],
+      ['custom scheme', 'cherry://whatever']
+    ])('denies a non-web popup URL (%s)', (_label, url) => {
+      expect(handler({ url })).toEqual({ action: 'deny' })
+      expect(shell.openExternal).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('external mode (isExternal=true)', () => {
+    beforeEach(() => {
+      setOpenLinkExternal(1, true)
+    })
+
+    it('still routes safe web URLs to the system browser and denies everything else', () => {
+      expect(handler({ url: 'https://cherrystudio.com/page' })).toEqual({ action: 'deny' })
+      expect(shell.openExternal).toHaveBeenCalledWith('https://cherrystudio.com/page')
+
+      expect(handler({ url: 'file:///etc/passwd' })).toEqual({ action: 'deny' })
+      expect(shell.openExternal).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps isSafeExternalUrl semantics for external routing (mailto allowed via shell)', () => {
+      expect(handler({ url: 'mailto:support@example.com' })).toEqual({ action: 'deny' })
+      expect(shell.openExternal).toHaveBeenCalledWith('mailto:support@example.com')
+    })
+  })
+
+  it('is a no-op when the webview id is unknown', () => {
+    vi.mocked(webContents.fromId).mockReturnValue(undefined as never)
+    expect(() => setOpenLinkExternal(404, false)).not.toThrow()
+  })
+})

--- a/tests/main.setup.ts
+++ b/tests/main.setup.ts
@@ -108,7 +108,8 @@ vi.mock('electron', () => {
       }
     },
     webContents: {
-      getAllWebContents: vi.fn(() => [])
+      getAllWebContents: vi.fn(() => []),
+      fromId: vi.fn(() => undefined)
     },
     systemPreferences: {
       getMediaAccessStatus: vi.fn(),


### PR DESCRIPTION
### What this PR does

Before this PR:

Four audited bypass gaps in already-hardened surfaces (2026-08-17 full-repo security audit, items S11–S14; follow-up to #18751 / #18764 / #18793 from the same effort):

- **S13**: the generic `will-navigate` guard registered by `WindowManager` for every window only handled cross-origin http(s); any other scheme (`file:`, custom protocols) navigated unchecked. SubWindow and Selection windows rely on this guard alone (the main window and quick assistant have their own stricter fail-closed handlers).
- **S14**: the miniapp webview popup policy's in-app branch returned an unconditional `allow`, so a webview page could `window.open` a `file:` / `mailto:` / custom-scheme URL into an in-app popup.
- **S11**: the v1→v2 renderer export stages plaintext redux dumps (including provider apiKeys) under `{userData}/migration_temp`; the engine's own cleanup misses three windows (kill between `markCompleted` and the `run()` finally, a swallowed `cleanupTempFiles` failure, `skipMigration` not clearing staging) after which the residue is never read again but also never removed.
- **S12**: developer-mode trace JSONL intentionally stores raw prompts / API bodies in plaintext (documented threat-model tradeoff, see `docs/references/ai/observability.md`) but was written world-readable; on Linux Electron's userData commonly lands 0755, exposing the artifacts to other local accounts.

After this PR:

- **S13**: non-http(s) targets are `preventDefault`'ed with a warning — matching what the adjacent window-open handler already denies for non-http(s) popups. Same-origin http(s) behavior unchanged.
- **S14**: the allow branch only permits http(s) origins. `isSafeExternalUrl` is deliberately not reused: its allowlist (`mailto:`, editor deep-links) encodes `shell.openExternal` semantics, wrong for in-webview popups.
- **S11**: the migration gate best-effort removes the staging tree on the `needsMigration=false` path only — completed migrations have zero remaining readers; pending migrations keep going through `PrepareExport`'s own cleanup; the single-instance lock rules out concurrent processes. Sweep failure logs a warning and lets boot continue (residue only outlives one launch).
- **S12**: trace topic directories are created 0700 and the flush temp file 0600; the atomic rename carries the mode onto the final file, so existing 0644 files tighten on their next flush. Redaction stays out of scope per the documented decision.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **S13 minimal patch over full unification**: the else-branch deny deliberately does not adopt the main window's preventDefault-first shape (`MainWindowService` / `QuickAssistantService` allow app-renderer `file:` URLs via `isAppRendererUrl`; both listeners fire and the generic guard's new deny would now outrank that allow). Verified no current flow relies on it: `loadFile`/`loadURL` don't fire `will-navigate`, SPA routing uses pushState, the migration window and MCP browser build their own `BrowserWindow`s. Unifying the three handler shapes is a recorded follow-up.
- **S14 http(s)-only narrow allowlist** instead of reusing `isSafeExternalUrl` (semantics mismatch, see above).
- **S11 gate-branch placement** instead of an unconditional boot sweep: pending migrations must not have their staging disturbed mid-flow — `PrepareExport` owns that case; the gate's skipped branch is the only place where "migration will never run again" is proven.
- **S12 permissions only**: redaction of trace content remains the documented, deferred threat-model decision; this PR does not reopen it.

The following alternatives were considered:

- Whitelisting `about:`/`blob:` in S13 (rejected: fail-closed until a real need appears).
- Reusing `isSafeExternalUrl` for S14 (rejected: wrong semantics).
- Retrying the S11 sweep once on failure (rejected: EACCES/EBUSY retries rarely succeed; the residue's readers need local filesystem access anyway).
- An S12 startup banner about plaintext recording (rejected: dev mode is opt-in by the developer, already documented).

Links to places where the discussion took place: audit trail and Decision Register in `.trellis/tasks/08-18-security-small-hardening/prd.md` (local, gitignored) — summarized above; sibling PRs #18751 / #18764 / #18793.

### Breaking changes

None expected. Edge behaviors that changed by design: renderer-initiated navigation to non-http(s) URLs in SubWindow/Selection-class windows is now denied (none existed in the codebase); in-app webview popups to non-web origins are now denied; leftover `migration_temp` trees are removed on boot once migration is permanently done.

### Special notes for your reviewer

- Two review rounds (subagent): R1 verdict CLEAN (2 MINOR fixed: test fixture path made guaranteed-absent; comment trimmed), R2 CONFIRMED-CLEAN.
- Verification: 16 new tests (S13 3, S14 9, S11 3, S12 1) — all contract-style; full suite green locally (main 12349 / renderer 9561 / small projects 3046). Live smoke on a dev instance (isolated profile): injected `file:///etc/passwd` and `cherry://settings` navigations into a pooled SubWindow stayed on origin while same-origin navigation proceeded (S13); a seeded `migration_temp/redux_export/provider.json` was swept on the next real boot with the gate logging `needsMigration=false` (S11). S14/S12 are covered by unit contract tests (driving a real miniapp webview / dev-mode trace in an isolated profile was out of smoke budget).
- Adjacent pre-existing surfaces noted during review (not addressed here): `DiagnosticBundleService` copies trace plaintext into user-chosen bundles with default perms; the webview popup handler has a milliseconds-long attach gap before `webview.set_open_link_external` lands while `allowpopups` is already effective.
- Known unrelated local-lint pollution (markdown-image-export worktree, #18632) keeps repo-wide `pnpm lint` red locally; scoped lint/typecheck for every touched file is clean and CI runs on the pushed tree.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Tests: Unit and integration tests included (16 new; full suite green)
- [x] Changelog: not user-facing behavior requiring release notes beyond security hardening summary below

```release-note
Security hardening: window navigation to non-http(s) URLs and in-app webview popups to non-web origins are now denied; leftover v1 migration staging files (which contain plaintext credentials) are removed once migration is permanently complete; developer-mode trace files are written owner-only.
```