### PR TITLE
fix(agents): disable ToolSearch for models that reject dynamically-loaded tools

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -308,6 +308,46 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     })
   })
 
+  it('strips ENABLE_TOOL_SEARCH when the connection model rejects dynamically-loaded tools', async () => {
+    // The settings builder force-enables ToolSearch for every agent; the route must undo that for
+    // models whose provider rejects dynamic tool declarations (Kimi non-K3 → tokenization failed).
+    mocks.buildSessionSettings.mockResolvedValue({ env: { ENABLE_TOOL_SEARCH: 'auto' } })
+    mocks.getModelByKey.mockReturnValue({ id: 'model-1', apiModelId: 'kimi-for-coding', contextWindow: 262_144 })
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.settings.env).not.toHaveProperty('ENABLE_TOOL_SEARCH')
+  })
+
+  it('keeps ENABLE_TOOL_SEARCH for models that accept dynamically-loaded tools', async () => {
+    mocks.buildSessionSettings.mockResolvedValue({ env: { ENABLE_TOOL_SEARCH: 'auto' } })
+    mocks.getModelByKey.mockReturnValue({ id: 'model-1', apiModelId: 'kimi-k3', contextWindow: 262_144 })
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(request?.settings.env).toMatchObject({ ENABLE_TOOL_SEARCH: 'auto' })
+  })
+
+  it('gates ToolSearch on the per-turn connection model, not the agent model', async () => {
+    // agent.model is Claude, but this turn's connection was captured on kimi-for-coding — the
+    // toggle must follow the connection model (the one that actually receives the declarations).
+    mocks.buildSessionSettings.mockResolvedValue({ env: { ENABLE_TOOL_SEARCH: 'auto' } })
+    mocks.getModelByKey.mockImplementation((_providerId: string, modelId: string) => ({
+      id: modelId,
+      apiModelId: modelId === 'model-2' ? 'kimi-for-coding' : 'claude-sonnet',
+      contextWindow: 262_144
+    }))
+
+    const request = await buildClaudeCodeQueryRequestForAgentSession(
+      'session-1',
+      undefined,
+      'provider-1::model-2' as any
+    )
+
+    expect(request?.settings.env).toMatchObject({ ANTHROPIC_MODEL: 'kimi-for-coding' })
+    expect(request?.settings.env).not.toHaveProperty('ENABLE_TOOL_SEARCH')
+  })
+
   it('captures the baseline from the same agent snapshot that materializes the request', async () => {
     const materializedAgent = {
       id: 'agent-1',

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -28,6 +28,7 @@ import type { Provider } from '@shared/data/types/provider'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
 import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
 import { formatGatewayModelId } from '@shared/utils/apiGateway'
+import { supportsDynamicallyLoadedTools } from '@shared/utils/model'
 import {
   isExternalCliProvider,
   isOllamaProvider,
@@ -84,6 +85,15 @@ interface ClaudeCodeRouteFacts {
     sonnet: string
     haiku: string
   }
+  /**
+   * Whether the primary model accepts dynamically-loaded tool declarations — the mechanism behind
+   * the SDK's ToolSearch, which Cherry force-enables via `ENABLE_TOOL_SEARCH=auto`
+   * (settingsBuilder). False means `mergeRuntimeSettings` must strip that env var, or providers
+   * that reject the injected blocks (Moonshot's Anthropic endpoint on non-K3 models) fail every
+   * turn with `400 Invalid request: tokenization failed`. Computed from the effective connection
+   * model in `deriveRouteFacts`, not `agent.model` — a per-turn connection can override it.
+   */
+  toolSearchCompatible: boolean
   /** Configured model identities keyed by every SDK alias that can appear in `result.modelUsage`. */
   usageModels: Extract<AgentSessionUsageCapture, { owner: 'agent-sdk' }>['frozenModels']
 }
@@ -630,6 +640,13 @@ function deriveRouteFacts(
   const haikuRef = resolveRuntimeModelRef(smallModel, primaryRef)
   const modelRefs = [primaryRef, opusRef, sonnetRef, haikuRef]
 
+  // ToolSearch is gated on the *primary* model only: it is the only one that can emit ToolSearch
+  // calls, and every dynamically-loaded tool declaration lands in the shared conversation the
+  // primary model must parse. Sub-models are pinned to the primary whenever they differ from
+  // `agent.model` (see `pinSubModelsToPrimary`), so keying on the primary never misses a
+  // per-turn model override.
+  const toolSearchCompatible = supportsDynamicallyLoadedTools(primaryRef.apiModelId)
+
   // External-cli (e.g. claude-code) authenticates only through the SDK's
   // subscription login, which can serve *only* this provider's own models. A
   // plan/small model pointing at another provider can't run on that login — and
@@ -654,6 +671,7 @@ function deriveRouteFacts(
     return {
       branch: 'external-cli',
       credentialsFingerprint: 'external-cli',
+      toolSearchCompatible,
       modelIds,
       usageModels: buildUsageModels([
         { sdkModelId: modelIds.primary, ref: externalRefs.primary },
@@ -684,6 +702,7 @@ function deriveRouteFacts(
         typeof gatewayKey === 'string' ? gatewayKey : '',
         gatewayStateTag(config.enabled, apiGatewayService.isRunning())
       ]),
+      toolSearchCompatible,
       modelIds: {
         primary: toGatewayModelId(primaryRef),
         opus: toGatewayModelId(opusRef),
@@ -717,6 +736,7 @@ function deriveRouteFacts(
       ...enabledKeys.map((key) => `api-key:${key}`),
       ...(customHeaders ? [`custom-headers:${customHeaders}`] : [])
     ]),
+    toolSearchCompatible,
     modelIds,
     usageModels: buildUsageModels([
       { sdkModelId: modelIds.primary, ref: primaryRef },
@@ -792,6 +812,7 @@ function toConnectionRouteFacts(route: ClaudeCodeRuntimeRoute): ClaudeCodeRouteF
     branch: route.branch,
     baseUrl: route.baseUrl,
     credentialsFingerprint: route.credentialsFingerprint,
+    toolSearchCompatible: route.toolSearchCompatible,
     modelIds: route.modelIds,
     usageModels: route.usageModels
   }
@@ -885,6 +906,14 @@ function mergeRuntimeSettings(
     },
     { additionalBypassRule: gatewayBypassRule(route) }
   )
+  // `buildEnvironment` force-enables the SDK's ToolSearch via `ENABLE_TOOL_SEARCH=auto` before the
+  // per-turn model is known, and the var is in the blocked list so agents cannot override it. When
+  // the effective connection model rejects dynamically-loaded tool declarations (e.g. Kimi models
+  // other than K3 on Moonshot's Anthropic endpoint → `400 Invalid request: tokenization failed`),
+  // drop it here so the SDK falls back to loading every tool upfront.
+  if (!route.toolSearchCompatible) {
+    delete env.ENABLE_TOOL_SEARCH
+  }
   return {
     ...settings,
     env

--- a/src/shared/utils/__tests__/model.test.ts
+++ b/src/shared/utils/__tests__/model.test.ts
@@ -13,7 +13,8 @@ import {
   isSpeechToTextModel,
   isTextToSpeechModel,
   isVideoModel,
-  isVisionModel
+  isVisionModel,
+  supportsDynamicallyLoadedTools
 } from '@shared/utils/model'
 import { describe, expect, it } from 'vitest'
 
@@ -156,6 +157,32 @@ describe('shared model capability helpers', () => {
         providerId: 'corp:west'
       }
       expect(isGatewayRoutableModel(colonProvider)).toBe(false)
+    })
+  })
+
+  describe('supportsDynamicallyLoadedTools', () => {
+    it.each([
+      ['claude-sonnet-4-5', true],
+      ['gpt-5.1', true],
+      ['deepseek-v4-flash', true],
+      ['qwen3.7-plus', true],
+      // Kimi K3 is the only model in the family that accepts dynamically-loaded tool declarations.
+      ['k3', true],
+      ['kimi-k3', true],
+      ['kimi-k3-0905-preview', true],
+      // Everything else in the Kimi family rejects them with `tokenization failed`.
+      ['kimi-for-coding', false],
+      ['kimi-k2.5', false],
+      ['kimi-k2-0711-preview', false],
+      ['kimi-latest', false],
+      ['moonshot-v1-128k', false],
+      // Namespace prefixes and Claude Code's [1m] suffix must not break matching.
+      ['provider:kimi-for-coding', false],
+      ['provider:k3', true],
+      ['kimi-for-coding[1m]', false],
+      ['k3[1m]', true]
+    ])('classifies %s as %s', (modelId, expected) => {
+      expect(supportsDynamicallyLoadedTools(modelId)).toBe(expected)
     })
   })
 })

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -164,6 +164,34 @@ export const isMaxTemperatureOneModel = (model: Model): boolean => {
 // Model family checks (lightweight ID-based, safe for runtime)
 // ---------------------------------------------------------------------------
 
+/**
+ * Whether the model accepts dynamically-loaded tool declarations (the mechanism behind
+ * Claude Code's ToolSearch: `tool_reference` blocks / `system` messages carrying a `tools`
+ * array injected mid-conversation).
+ *
+ * Claude Code forces ToolSearch on for every non-first-party host when Cherry sets
+ * `ENABLE_TOOL_SEARCH=auto` (see settingsBuilder). Most Anthropic-compatible providers
+ * simply ignore unknown content blocks, but Moonshot's Anthropic endpoint rejects them on
+ * every model except Kimi K3 with `400 Invalid request: tokenization failed`
+ * (https://platform.kimi.com/docs/guide/use-dynamic-tool-loading). Kimi K3 ids resolve to
+ * `k3`/`kimi-k3*`/... — everything else in the Kimi family is excluded.
+ *
+ * Input is a raw API model id (e.g. `kimi-for-coding`); namespace prefixes (`provider:id`)
+ * and Claude Code's `[1m]` suffix are stripped before matching.
+ */
+export const supportsDynamicallyLoadedTools = (apiModelId: string): boolean => {
+  // Strip the gateway namespace prefix (`providerId:apiModelId`) and Claude Code's `[1m]`
+  // context suffix before matching — both wrap the raw API model id this check targets.
+  const bareId =
+    apiModelId
+      .replace(/\[1m\]$/i, '')
+      .split(':')
+      .pop() ?? ''
+  const id = getLowerBaseModelName(bareId)
+  if (!VENDOR_PATTERNS.kimi.test(id)) return true
+  return /^(?:k3|kimi-k3)(?:[-_.]|$)/i.test(id)
+}
+
 // Vendor identity checks all delegate to `VENDOR_PATTERNS` in
 // `@cherrystudio/provider-registry`. Do NOT inline new regex here —
 // add the vendor to the registry's pattern map instead of duplicating


### PR DESCRIPTION
### What this PR does

Before this PR:
- Cherry force-enables the Claude Code SDK's ToolSearch for every agent session via `ENABLE_TOOL_SEARCH=auto` (`settingsBuilder`), and the variable sits in the blocked env list so agents cannot override it.
- ToolSearch defers MCP tools and re-injects them mid-conversation as dynamic tool declarations (`tool_reference` blocks / system messages carrying a `tools` array).
- Moonshot's Anthropic endpoint only accepts dynamically-loaded tools on Kimi K3. Any other Kimi model (`kimi-for-coding`, `kimi-k2.x`, …) fails the entire turn with `400 Invalid request: tokenization failed` the moment ToolSearch activates — i.e. as soon as the agent has enough MCP tools for deferral to kick in. Reproduced locally: 4/4 turns on `kimi-for-coding` failed while `k3` on the same provider completed 216/216.

After this PR:
- The effective connection model is checked before spawning the CLI. Models that reject dynamically-loaded tools get `ENABLE_TOOL_SEARCH` removed from the subprocess env, so the SDK falls back to loading every tool upfront and the session works.
- Compatible models (Anthropic, Kimi K3, everything else) are completely unaffected — the env var passes through untouched.

### Why we need it and why it was done in this way

The following tradeoffs were made:
- **Gated on the primary model only.** Only the primary model can emit ToolSearch calls, and every injected declaration lands in the shared conversation the primary model must parse. Sub-models are already pinned to the primary on per-turn overrides (`pinSubModelsToPrimary`), so keying on the primary never misses a connection-scoped model switch — which matters because `buildEnvironment` runs against `agent.model` while the actual turn may run on a different captured model.
- **Deny-list by model-id pattern** (`supportsDynamicallyLoadedTools` in `@shared/utils/model`), matching the repo's existing vendor/family classification idiom (`VENDOR_PATTERNS`, `isMaxTemperatureOneModel`, …). The check strips the gateway `provider:id` prefix and Claude Code's `[1m]` suffix before matching.
- **`delete env.ENABLE_TOOL_SEARCH` in `mergeRuntimeSettings`**, the single point where the final route (and therefore the final model) is known. The settings builder keeps its current unconditional default, so any future caller that bypasses the route still gets the old behavior.

The following alternatives were considered:
- **A per-model capability flag in the Model schema + preset data** — more principled, but requires schema changes and backfilling every vendor's preset data for one known-incompatible family. Can be layered on later if more providers show up with the same restriction.
- **Not setting `ENABLE_TOOL_SEARCH` at all for non-first-party hosts** — that would silently regress PR #13690 for every third-party-host user whose provider tolerates the declarations fine.

Upstream reference: https://platform.kimi.com/docs/guide/use-dynamic-tool-loading ("动态加载工具目前仅 kimi-k3 支持，在其他模型（如 kimi-k2.6）上请求会返回 tokenization failed 错误").

### Breaking changes

None. Sessions that previously worked are byte-identical (env passes through); only previously-broken sessions change behavior (they start working).

### Special notes for your reviewer

- `pre-commit` hooks were skipped on this commit because the worktree used for development symlinks `node_modules`, which pnpm refuses to touch without a TTY. Biome format, ESLint, `tsgo --noEmit -p tsconfig.node.json` (0 errors), and the full `claudeCode` runtime suite (508 tests) plus shared model tests (35) were all run manually and pass.
- New tests cover: the pattern classifier (K3 allow, non-K3 Kimi deny, namespace/`[1m]` stripping), env stripping for incompatible models, env preservation for compatible ones, and gating on the per-turn connection model rather than `agent.model`.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required — this only restores expected behavior for broken configurations; no user-facing setting changes.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix(agents): agent sessions on Kimi models other than K3 (e.g. kimi-for-coding) no longer fail with "400 Invalid request: tokenization failed" when ToolSearch activates
```
