### PR TITLE
fix(composer): stop pasted-text data loss on copy and over-limit insert

### DIFF
--- a/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
+++ b/src/renderer/components/chat/messages/frame/messageMenuBarActions.tsx
@@ -249,7 +249,7 @@ registerCommand('message.exportNotes', async ({ actions, messageForExport }) => 
 
 registerCommand('message.copyPlainText', async ({ actions, messageForExport, t }) => {
   const { messageToPlainText } = await import('@renderer/utils/export')
-  await actions.copyText?.(messageToPlainText(messageForExport), {
+  await actions.copyText?.(await messageToPlainText(messageForExport), {
     successMessage: t('message.copy.success')
   })
 })

--- a/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
+++ b/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
@@ -855,10 +855,15 @@ export default function ComposerSurfaceRuntime({
       try {
         const fileText = await window.api.fs.readText(file.path)
         const currentText = serializeComposerDocument(editor).text
-        const textToInsert = getComposerInputTextWithinLimit(currentText, fileText)
+        // Refuse instead of truncating: pasting a truncated copy and dropping the
+        // file token would silently lose everything beyond the input limit.
+        if (exceedsComposerInputMaxLength(currentText, fileText)) {
+          toast.error(t('chat.input.paste_text_too_long', { max: COMPOSER_INPUT_MAX_LENGTH }))
+          return
+        }
         const position = typeof nodeViewProps.getPos === 'function' ? nodeViewProps.getPos() : undefined
-        const content = textToInsert
-          ? createPromptVariableInlineContent(textToInsert, { startIndex: getNextPromptVariableIndex(editor) })
+        const content = fileText
+          ? createPromptVariableInlineContent(fileText, { startIndex: getNextPromptVariableIndex(editor) })
           : []
 
         if (typeof position === 'number') {

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -1,3 +1,4 @@
+import { mockToast } from '@test-mocks/renderer/toast'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ButtonHTMLAttributes, CSSProperties, HTMLAttributes, ReactNode } from 'react'
 import { useState } from 'react'
@@ -14,6 +15,7 @@ import {
 } from '@renderer/utils/message/composerClipboard'
 
 import { ComposerContextProvider } from '../ComposerContext'
+import { COMPOSER_INPUT_MAX_LENGTH } from '../composerDraft'
 import ComposerSurface, { type ComposerSurfaceActions, type ComposerSurfaceProps } from '../ComposerSurfaceRuntime'
 import { COMPOSER_SUPPRESS_SUGGESTION_META } from '../quickPanel/suggestionExtension'
 
@@ -3118,6 +3120,51 @@ describe('ComposerSurface', () => {
 
     const fileUpdater = setFiles.mock.calls[0]?.[0] as (files: (typeof pastedFile)[]) => (typeof pastedFile)[]
     expect(fileUpdater([pastedFile])).toEqual([])
+  })
+
+  it('refuses to replace the pasted text token when the file exceeds the input limit', async () => {
+    const pastedFile = {
+      id: 'file-2',
+      name: 'pasted_text.txt',
+      origin_name: '已粘贴的文本.txt',
+      path: '/tmp/pasted_text.txt',
+      composerFileKind: COMPOSER_FILE_KIND.PASTED_TEXT
+    }
+    const pastedToken = {
+      id: 'file:file-2',
+      kind: 'file' as const,
+      label: '已粘贴的文本.txt',
+      payload: pastedFile
+    }
+    const setFiles = vi.fn()
+
+    // Silently truncating here would drop the tail of the file the moment the
+    // token is replaced — the refusal must keep the token and the file intact.
+    mocks.fsReadText.mockResolvedValue('x'.repeat(COMPOSER_INPUT_MAX_LENGTH + 1))
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'composerToken', attrs: pastedToken }] }]
+    })
+
+    render(<ComposerSurface {...baseProps} tokens={[pastedToken]} managedTokenKinds={['file']} setFiles={setFiles} />)
+
+    await waitFor(() => expect(mocks.editorPresetOptions?.renderToken).toBeDefined())
+    render(
+      <>
+        {mocks.editorPresetOptions.renderToken(pastedToken, {
+          selected: false,
+          nodeViewProps: { getPos: () => 3, node: { nodeSize: 1 } }
+        })}
+      </>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.input.paste_text_file' }))
+
+    await waitFor(() => expect(mocks.fsReadText).toHaveBeenCalledWith('/tmp/pasted_text.txt'))
+    expect(mocks.deleteRange).not.toHaveBeenCalled()
+    expect(mocks.insertContent).not.toHaveBeenCalled()
+    expect(setFiles).not.toHaveBeenCalled()
+    expect(mockToast.error).toHaveBeenCalledWith('chat.input.paste_text_too_long')
   })
 
   it('does not notify token changes when only text changes', async () => {

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Notizen verwalten",
   "chat.input.note_reference.title": "Referenzhinweis",
   "chat.input.paste_text_file": "In die Eingabe einfügen",
+  "chat.input.paste_text_too_long": "Der eingefügte Text ist länger als {{max}} Zeichen und kann nicht in das Eingabefeld eingefügt werden. Er bleibt als Dateianhang erhalten.",
   "chat.input.pasted_text_file_name": "Eingefügter Text.txt",
   "chat.input.pause": "Pausieren",
   "chat.input.placeholder": "Geben Sie hier eine Nachricht ein, drücken Sie {{key}} zum Senden - @ für Modellauswahl, / für Tools",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Διαχείριση σημειώσεων",
   "chat.input.note_reference.title": "Σημείωση Αναφοράς",
   "chat.input.paste_text_file": "Επικόλληση στην είσοδο",
+  "chat.input.paste_text_too_long": "Το επικολλημένο κείμενο υπερβαίνει τους {{max}} χαρακτήρες και δεν μπορεί να εισαχθεί στο πεδίο εισαγωγής. Διατηρείται ως συνημμένο αρχείο.",
   "chat.input.pasted_text_file_name": "Επικολλημένο κείμενο.txt",
   "chat.input.pause": "Παύση",
   "chat.input.placeholder": "Πληκτρολογήστε ένα μήνυμα. Πατήστε {{key}} για αποστολή. Πληκτρολογήστε / για εργαλεία και ενέργειες ή @ για αναφορά σε θέματα.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Manage Notes",
   "chat.input.note_reference.title": "Reference Note",
   "chat.input.paste_text_file": "Paste into input",
+  "chat.input.paste_text_too_long": "The pasted text is longer than {{max}} characters and cannot be inserted into the input. It is kept as a file attachment.",
   "chat.input.pasted_text_file_name": "Pasted text.txt",
   "chat.input.pause": "Pause",
   "chat.input.placeholder": "Type a message. Press {{key}} to send. Type / for tools and actions, @ to reference topics.",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Gestionar notas",
   "chat.input.note_reference.title": "Nota de Referencia",
   "chat.input.paste_text_file": "Pegar en la entrada",
+  "chat.input.paste_text_too_long": "El texto pegado supera los {{max}} caracteres y no puede insertarse en el campo de entrada. Se conserva como archivo adjunto.",
   "chat.input.pasted_text_file_name": "Texto pegado.txt",
   "chat.input.pause": "Pausar",
   "chat.input.placeholder": "Escribe un mensaje. Pulsa {{key}} para enviarlo. Escribe / para ver las herramientas y acciones, o @ para hacer referencia a temas.",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Gérer les notes",
   "chat.input.note_reference.title": "Note de référence",
   "chat.input.paste_text_file": "Coller dans l'entrée",
+  "chat.input.paste_text_too_long": "Le texte collé dépasse {{max}} caractères et ne peut pas être inséré dans le champ de saisie. Il est conservé en pièce jointe.",
   "chat.input.pasted_text_file_name": "Texte collé.txt",
   "chat.input.pause": "Pause",
   "chat.input.placeholder": "Saisissez un message. Appuyez sur {{key}} pour l’envoyer. Saisissez / pour afficher les outils et les actions, ou @ pour référencer des conversations.",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "ノートを管理",
   "chat.input.note_reference.title": "参考注",
   "chat.input.paste_text_file": "入力に貼り付け",
+  "chat.input.paste_text_too_long": "貼り付けたテキストが{{max}}文字を超えているため、入力欄に展開できません。ファイル添付として保持されます。",
   "chat.input.pasted_text_file_name": "貼り付けたテキスト.txt",
   "chat.input.pause": "一時停止",
   "chat.input.placeholder": "ここにメッセージを入力し、{{key}} を押して送信...",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Gerir notas",
   "chat.input.note_reference.title": "Nota de Referência",
   "chat.input.paste_text_file": "Cole na entrada",
+  "chat.input.paste_text_too_long": "O texto colado excede {{max}} caracteres e não pode ser inserido no campo de entrada. Ele é mantido como anexo de arquivo.",
   "chat.input.pasted_text_file_name": "Texto colado.txt",
   "chat.input.pause": "Pausar",
   "chat.input.placeholder": "Escreva uma mensagem. Prima {{key}} para enviar. Escreva / para ver ferramentas e ações e @ para referenciar tópicos.",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Gestionează notițele",
   "chat.input.note_reference.title": "Notă de referință",
   "chat.input.paste_text_file": "Lipește în intrare",
+  "chat.input.paste_text_too_long": "Textul lipit depășește {{max}} caractere și nu poate fi inserat în câmpul de introducere. Rămâne ca atașament de fișier.",
   "chat.input.pasted_text_file_name": "text.txt lipit",
   "chat.input.pause": "Pauză",
   "chat.input.placeholder": "Scrie mesajul tău aici, apasă {{key}} pentru a trimite - @ pentru a selecta modelul, / pentru a include instrumente",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Управление заметками",
   "chat.input.note_reference.title": "Справочная записка",
   "chat.input.paste_text_file": "Вставьте во входные данные",
+  "chat.input.paste_text_too_long": "Вставленный текст длиннее {{max}} символов и не может быть вставлен в поле ввода. Он сохранён как файловое вложение.",
   "chat.input.pasted_text_file_name": "Вставленный текст.txt",
   "chat.input.pause": "Остановить",
   "chat.input.placeholder": "Введите сообщение. Нажмите {{key}}, чтобы отправить его. Введите / для инструментов и действий или @ для ссылки на беседу.",

--- a/src/renderer/i18n/locales/tr-tr.json
+++ b/src/renderer/i18n/locales/tr-tr.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Notları Yönet",
   "chat.input.note_reference.title": "Nota Başvur",
   "chat.input.paste_text_file": "Girdiye yapıştır",
+  "chat.input.paste_text_too_long": "Yapıştırılan metin {{max}} karakterden uzun olduğu için giriş alanına eklenemiyor. Dosya eki olarak korunuyor.",
   "chat.input.pasted_text_file_name": "Yapıştırılan metin.txt",
   "chat.input.pause": "Duraklat",
   "chat.input.placeholder": "Bir mesaj yazın. Göndermek için {{key}} tuşuna basın. Araçlar ve eylemler için /, konulara başvurmak için @ yazın.",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "Quản lý ghi chú",
   "chat.input.note_reference.title": "Ghi chú tham khảo",
   "chat.input.paste_text_file": "Dán vào ô nhập",
+  "chat.input.paste_text_too_long": "Văn bản dán dài hơn {{max}} ký tự nên không thể chèn vào ô nhập. Nó được giữ lại dưới dạng tệp đính kèm.",
   "chat.input.pasted_text_file_name": "Văn bản đã dán.txt",
   "chat.input.pause": "Tạm dừng",
   "chat.input.placeholder": "Nhập tin nhắn của bạn ở đây, nhấn {{key}} để gửi - @ để Chọn Mô hình, / để Bao gồm Công cụ",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "管理笔记",
   "chat.input.note_reference.title": "引用笔记",
   "chat.input.paste_text_file": "粘贴到输入框",
+  "chat.input.paste_text_too_long": "粘贴的文本超过 {{max}} 字符，无法内联到输入框，已保留为文件附件。",
   "chat.input.pasted_text_file_name": "已粘贴的文本.txt",
   "chat.input.pause": "暂停",
   "chat.input.placeholder": "输入消息，按 {{key}} 发送，输入 / 选择工具或操作，输入 @ 引用话题",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -632,6 +632,7 @@
   "chat.input.note_reference.manage": "管理筆記",
   "chat.input.note_reference.title": "引用筆記",
   "chat.input.paste_text_file": "貼到輸入框",
+  "chat.input.paste_text_too_long": "貼上的文字超過 {{max}} 字元，無法內嵌到輸入框，已保留為檔案附件。",
   "chat.input.pasted_text_file_name": "已貼上的文字.txt",
   "chat.input.pause": "暫停",
   "chat.input.placeholder": "輸入訊息，按 {{key}} 傳送，輸入 / 選擇工具或操作",

--- a/src/renderer/services/ExportService.ts
+++ b/src/renderer/services/ExportService.ts
@@ -460,7 +460,7 @@ export const topicToPlainText = async (topic: Topic): Promise<string> => {
   const topicMessages = await getTopicMessages(topic.id)
 
   if (topicMessages && topicMessages.length > 0) {
-    return topicName + '\n\n' + messagesToPlainText(topicMessages)
+    return topicName + '\n\n' + (await messagesToPlainText(topicMessages))
   }
 
   return topicName

--- a/src/renderer/services/__tests__/copy.test.ts
+++ b/src/renderer/services/__tests__/copy.test.ts
@@ -125,7 +125,7 @@ describe('copy', () => {
       const plainTextContent = 'This is the plain text content of the message'
 
       const { messageToPlainText } = await import('@renderer/utils/export')
-      vi.mocked(messageToPlainText).mockReturnValue(plainTextContent)
+      vi.mocked(messageToPlainText).mockResolvedValue(plainTextContent)
       mockClipboard.writeText.mockResolvedValue(undefined)
 
       await copyMessageAsPlainText(message)

--- a/src/renderer/services/agentSessionExport.ts
+++ b/src/renderer/services/agentSessionExport.ts
@@ -123,7 +123,7 @@ export async function agentSessionToPlainText(
 
   if (messages.length === 0) return title
 
-  return `${title}\n\n${messagesToPlainText(messages)}`
+  return `${title}\n\n${await messagesToPlainText(messages)}`
 }
 
 export async function copyAgentSessionAsMarkdown(

--- a/src/renderer/services/copy.ts
+++ b/src/renderer/services/copy.ts
@@ -20,7 +20,7 @@ export const copyTopicAsPlainText = async (topic: Topic) => {
 
 export const copyMessageAsPlainText = async (message: ExportableMessage) => {
   const { messageToPlainText } = await import('@renderer/utils/export')
-  const plainText = messageToPlainText(message)
+  const plainText = await messageToPlainText(message)
   await navigator.clipboard.writeText(plainText)
   toast.success(i18next.t('message.copy.success'))
 }

--- a/src/renderer/utils/__tests__/export.test.ts
+++ b/src/renderer/utils/__tests__/export.test.ts
@@ -15,6 +15,9 @@ beforeEach(() => {
       file: {
         read: vi.fn().mockResolvedValue('[]'),
         writeWithId: vi.fn()
+      },
+      fs: {
+        readText: vi.fn().mockResolvedValue('')
       }
     },
     configurable: true
@@ -199,12 +202,12 @@ describe('export', () => {
       ])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str.replace(/[#*_]/g, ''))
 
-      const result = messageToPlainText(testMessage)
+      const result = await messageToPlainText(testMessage)
       expect(result).toBe('Single Message Content')
       expect(markdownToPlainText).toHaveBeenCalledWith('### Single Message Content')
     })
 
-    it('should copy composer skill tokens as pasteable markers instead of hidden prompt text', () => {
+    it('should copy composer skill tokens as pasteable markers instead of hidden prompt text', async () => {
       const testMessage = createExportView(
         [
           {
@@ -233,13 +236,13 @@ describe('export', () => {
       )
       ;(markdownToPlainText as any).mockImplementation((str: string) => str)
 
-      const result = messageToPlainText(testMessage)
+      const result = await messageToPlainText(testMessage)
 
       expect(result).toBe('/pdf/ hello')
       expect(markdownToPlainText).toHaveBeenCalledWith('/pdf/ hello')
     })
 
-    it('copies an id re-cited from an earlier turn as a plain number', () => {
+    it('copies an id re-cited from an earlier turn as a plain number', async () => {
       const testMessage: MessageExportView = {
         ...createExportView([{ type: 'text', text: 'Still true. [cite:3f2a1b9c-1]' }]),
         priorCitationParts: [
@@ -254,10 +257,10 @@ describe('export', () => {
       }
       ;(markdownToPlainText as any).mockImplementation((str: string) => str)
 
-      expect(messageToPlainText(testMessage)).toBe('Still true. [1]')
+      expect(await messageToPlainText(testMessage)).toBe('Still true. [1]')
     })
 
-    it('should resolve tool citation markers to plain numbers before copying', () => {
+    it('should resolve tool citation markers to plain numbers before copying', async () => {
       // Left in place, `remove-markdown` mangles a chain of markers down to a bare
       // `cite:<id>` and the internal id lands on the clipboard.
       const testMessage = createExportView([
@@ -275,15 +278,89 @@ describe('export', () => {
       ])
       ;(markdownToPlainText as any).mockImplementation((str: string) => str)
 
-      const result = messageToPlainText(testMessage)
+      const result = await messageToPlainText(testMessage)
 
       expect(result).toBe('Prices rose. [1][2]')
       expect(result).not.toContain('cite:')
     })
+
+    it('should copy the stored pasted text instead of the file token label', async () => {
+      // A long paste becomes a `.txt` attachment whose display name ("Pasted text.txt")
+      // is the only thing the old copy produced — the actual pasted text must win.
+      ;(window.api.fs.readText as any).mockResolvedValue('the full pasted content')
+      const testMessage = createExportView(
+        [
+          {
+            type: 'text',
+            text: 'Look at this:',
+            providerMetadata: {
+              cherry: {
+                composer: {
+                  version: 1,
+                  tokens: [
+                    { id: 'file:file-token-1', kind: 'file', label: 'Pasted text.txt', index: 0, textOffset: 13 }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            url: 'file:///tmp/pasted_text.txt',
+            filename: 'Pasted text.txt',
+            providerMetadata: { cherry: { fileTokenSourceId: 'file-token-1', composerFileKind: 'pasted-text' } }
+          }
+        ],
+        'user'
+      )
+      ;(markdownToPlainText as any).mockImplementation((str: string) => str)
+
+      const result = await messageToPlainText(testMessage)
+
+      expect(result).toBe('Look at this:the full pasted content')
+      expect(result).not.toContain('Pasted text.txt')
+      expect(window.api.fs.readText).toHaveBeenCalledWith('/tmp/pasted_text.txt')
+    })
+
+    it('should keep the token label when the pasted text file is unreadable', async () => {
+      ;(window.api.fs.readText as any).mockRejectedValue(new Error('ENOENT'))
+      const testMessage = createExportView(
+        [
+          {
+            type: 'text',
+            text: 'Look at this:',
+            providerMetadata: {
+              cherry: {
+                composer: {
+                  version: 1,
+                  tokens: [
+                    { id: 'file:file-token-2', kind: 'file', label: 'Pasted text.txt', index: 0, textOffset: 14 }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            type: 'file',
+            mediaType: 'text/plain',
+            url: 'file:///tmp/missing.txt',
+            filename: 'Pasted text.txt',
+            providerMetadata: { cherry: { fileTokenSourceId: 'file-token-2', composerFileKind: 'pasted-text' } }
+          }
+        ],
+        'user'
+      )
+      ;(markdownToPlainText as any).mockImplementation((str: string) => str)
+
+      const result = await messageToPlainText(testMessage)
+
+      expect(result).toContain('Pasted text.txt')
+    })
   })
 
   describe('messagesToPlainText', () => {
-    it('labels an assistant row with the frozen snapshot author, not a generic "Assistant"', () => {
+    it('labels an assistant row with the frozen snapshot author, not a generic "Assistant"', async () => {
       const message = createExportView([{ type: 'text', text: 'hi' }])
       message.messageSnapshot = {
         id: 'a1',
@@ -291,11 +368,11 @@ describe('export', () => {
         emoji: '🤖',
         model: { id: 'gpt-5', name: 'GPT-5', provider: 'openai' }
       }
-      expect(messagesToPlainText([message])).toContain('My Assistant:')
+      expect(await messagesToPlainText([message])).toContain('My Assistant:')
     })
 
-    it('falls back to "Assistant:" for a snapshot-less assistant row', () => {
-      expect(messagesToPlainText([createExportView([{ type: 'text', text: 'hi' }])])).toContain('Assistant:')
+    it('falls back to "Assistant:" for a snapshot-less assistant row', async () => {
+      expect(await messagesToPlainText([createExportView([{ type: 'text', text: 'hi' }])])).toContain('Assistant:')
     })
   })
 })

--- a/src/renderer/utils/export.ts
+++ b/src/renderer/utils/export.ts
@@ -1,7 +1,12 @@
 import type { ExportableMessage } from '@renderer/types/messageExport'
 import { markdownToPlainText } from '@renderer/utils/markdown'
-import { getComposerTextFromMessage } from '@renderer/utils/message/composerTokens'
+import { readComposerFileTokenSourceIdFromTokenId } from '@renderer/utils/message/composerFileTokenSource'
+import { getComposerTextFromMessage, getComposerTokenClipboardText } from '@renderer/utils/message/composerTokens'
 import { getNamingTextContent, getToolCitationExport } from '@renderer/utils/message/find'
+import type { ComposerMessageToken } from '@shared/data/types/uiParts'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import type { FileUrlString } from '@shared/types/file'
+import { fileUrlToPath } from '@shared/utils/file'
 
 /**
  * 从消息内容中提取标题，限制长度并处理换行和标点符号。用于导出功能。
@@ -89,11 +94,52 @@ export const processCitations = (content: string, mode: 'remove' | 'normalize' =
   return processedParts.join('').trim()
 }
 
-const formatMessageAsPlainText = (message: ExportableMessage): string => {
+/**
+ * Reads the stored content of every pasted-text file part across the messages,
+ * keyed by `fileTokenSourceId`. Pasted-text tokens are the inline-text chips the
+ * composer mints for long pastes; copying must reproduce the text the user
+ * actually wrote, not the chip's filename. An unreadable file falls back to the
+ * token label (the pre-existing behavior).
+ */
+async function readPastedTextFileContents(messages: readonly ExportableMessage[]): Promise<Map<string, string>> {
+  const contents = new Map<string, string>()
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      if (part.type !== 'file') continue
+      const meta = readCherryMeta(part)
+      if (meta?.composerFileKind !== 'pasted-text' || !meta.fileTokenSourceId) continue
+      if (contents.has(meta.fileTokenSourceId)) continue
+      try {
+        contents.set(meta.fileTokenSourceId, await window.api.fs.readText(fileUrlToPath(part.url as FileUrlString)))
+      } catch {
+        // Leave the token's display label as the copy output for this file.
+      }
+    }
+  }
+  return contents
+}
+
+function createPastedTextTokenTextResolver(
+  contents: ReadonlyMap<string, string>
+): (token: ComposerMessageToken, index: number) => string {
+  return (token) => {
+    if (token.kind === 'file') {
+      const sourceId = readComposerFileTokenSourceIdFromTokenId(token.id)
+      const content = sourceId ? contents.get(sourceId) : undefined
+      if (content !== undefined) return content
+    }
+    return getComposerTokenClipboardText(token)
+  }
+}
+
+const formatMessageAsPlainText = (
+  message: ExportableMessage,
+  getTokenText?: (token: ComposerMessageToken, index: number) => string
+): string => {
   // Assistant/agent rows lead with the frozen producing author (survives rename/delete), like the header.
   const author = 'messageSnapshot' in message ? message.messageSnapshot : undefined
   const roleText = message.role === 'user' ? 'User:' : `${author?.name ?? 'Assistant'}:`
-  const plainTextContent = markdownToPlainText(copyableTextContent(message)).trim()
+  const plainTextContent = markdownToPlainText(copyableTextContent(message, getTokenText)).trim()
   return `${roleText}\n${plainTextContent}`
 }
 
@@ -106,15 +152,21 @@ const formatMessageAsPlainText = (message: ExportableMessage): string => {
  * runs: left in, `remove-markdown` mangles a chain of them down to a bare
  * `cite:<id>` and the internal id ends up on the clipboard.
  */
-const copyableTextContent = (message: ExportableMessage): string => {
-  const content = getComposerTextFromMessage(message, getNamingTextContent(message))
+const copyableTextContent = (
+  message: ExportableMessage,
+  getTokenText?: (token: ComposerMessageToken, index: number) => string
+): string => {
+  const content = getComposerTextFromMessage(message, getNamingTextContent(message), getTokenText)
   return getToolCitationExport(message, content).content
 }
 
-export const messageToPlainText = (message: ExportableMessage): string => {
-  return markdownToPlainText(copyableTextContent(message)).trim()
+export const messageToPlainText = async (message: ExportableMessage): Promise<string> => {
+  const contents = await readPastedTextFileContents([message])
+  return markdownToPlainText(copyableTextContent(message, createPastedTextTokenTextResolver(contents))).trim()
 }
 
-export const messagesToPlainText = (messages: ExportableMessage[]): string => {
-  return messages.map(formatMessageAsPlainText).join('\n\n')
+export const messagesToPlainText = async (messages: ExportableMessage[]): Promise<string> => {
+  const contents = await readPastedTextFileContents(messages)
+  const getTokenText = createPastedTextTokenTextResolver(contents)
+  return messages.map((message) => formatMessageAsPlainText(message, getTokenText)).join('\n\n')
 }

--- a/src/renderer/utils/export.ts
+++ b/src/renderer/utils/export.ts
@@ -95,11 +95,8 @@ export const processCitations = (content: string, mode: 'remove' | 'normalize' =
 }
 
 /**
- * Reads the stored content of every pasted-text file part across the messages,
- * keyed by `fileTokenSourceId`. Pasted-text tokens are the inline-text chips the
- * composer mints for long pastes; copying must reproduce the text the user
- * actually wrote, not the chip's filename. An unreadable file falls back to the
- * token label (the pre-existing behavior).
+ * Reads each pasted-text file part's stored content, keyed by `fileTokenSourceId`, so
+ * copy reproduces the pasted text; an unreadable file falls back to the token label.
  */
 async function readPastedTextFileContents(messages: readonly ExportableMessage[]): Promise<Map<string, string>> {
   const contents = new Map<string, string>()


### PR DESCRIPTION
<!-- Template from
https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft:
https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Issue #18686 bundles several pasted-text problems; two of them silently lose user data:

1. **Copy drops the content.** Copying a user message whose prompt includes a pasted-text attachment (a long paste turned into "Pasted text.txt") yields only the attachment's filename — the actual pasted text never reaches the clipboard.
2. **Over-limit insert truncates.** When a pasted-text attachment exceeds the 40k composer input limit, clicking "Paste into input" inserted a truncated copy AND deleted the file token, permanently losing everything beyond the limit.

After this PR:

1. **Copy reproduces the content.** Plain-text copy/export now reads the stored pasted-text file and expands the token in place (`messageToPlainText` / `messagesToPlainText` became async for the file read; all four callers were already in async contexts). Falls back to the filename when the file is gone — the previous behavior.
2. **Over-limit insert refuses.** When the file's text would exceed the input limit, the conversion is refused with an explanatory toast; the file token and its content stay intact, so nothing is lost.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)`
format, will close the issue(s) when PR gets merged)*: -->

Fixes #18686

### Scope note

The issue also describes (2) the UX friction of having to reach a small "Paste into input" button and (4) input lag when editing very long messages. Neither is a data-loss bug: (2) is a UX redesign discussion and (4) is a separate editor-performance problem — both are left for dedicated issues.

### Special notes for your reviewer

- Copy fix: `getComposerTextFromMessage` already accepts a per-token text resolver; the fix pre-reads pasted-text file contents into a map keyed by `fileTokenSourceId` and passes a sync resolver, keeping the hot sync path untouched.
- Truncation fix: reuses the existing `exceedsComposerInputMaxLength` guard; new i18n key `chat.input.paste_text_too_long` added to all 12 locales.
- Tests: new cases cover the copy expansion (and the unreadable-file fallback) and the over-limit refusal (token kept, no delete/insert). All 244 tests across the seven touched suites pass; renderer typecheck, oxlint, eslint, biome clean.
