### PR TITLE
perf: eliminate main-process sync IO stalls in file reads and save dialogs

### DIFF
--- a/src/main/services/ExportService.ts
+++ b/src/main/services/ExportService.ts
@@ -359,6 +359,17 @@ export class ExportService {
 
   public exportToWord = async (markdown: string, fileName: string): Promise<void> => {
     try {
+      // Dialog-first is perf-driven: canceling costs zero conversion, and the dialog
+      // opens without waiting on the markdown→docx conversion.
+      const { canceled, filePath } = await dialog.showSaveDialog({
+        title: t('dialog.save_file'),
+        filters: [{ name: t('dialog.word_document'), extensions: ['docx'] }],
+        defaultPath: fileName
+      })
+      if (canceled || !filePath) {
+        return
+      }
+
       const [{ default: MarkdownIt }, docx] = await Promise.all([import('markdown-it'), import('docx')])
       const elements = this.convertMarkdownToDocxElements(markdown, new MarkdownIt(), docx)
 
@@ -385,16 +396,8 @@ export class ExportService {
 
       const buffer = await docx.Packer.toBuffer(doc)
 
-      const filePath = dialog.showSaveDialogSync({
-        title: t('dialog.save_file'),
-        filters: [{ name: t('dialog.word_document'), extensions: ['docx'] }],
-        defaultPath: fileName
-      })
-
-      if (filePath) {
-        await fs.promises.writeFile(filePath, buffer)
-        logger.debug('Document exported successfully')
-      }
+      await fs.promises.writeFile(filePath, buffer)
+      logger.debug('Document exported successfully')
     } catch (error) {
       logger.error('Export to Word failed:', error as Error)
       throw error

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -799,15 +799,15 @@ class FileStorage {
 
   public saveImage = async (_: Electron.IpcMainInvokeEvent, name: string, data: string): Promise<boolean> => {
     try {
-      const filePath = dialog.showSaveDialogSync({
+      const result: SaveDialogReturnValue = await dialog.showSaveDialog({
         defaultPath: `${name}.png`,
         filters: [{ name: t('dialog.png_image'), extensions: ['png'] }]
       })
 
-      if (filePath) {
-        await assertOutsideManagedStorageMutation(filePath)
+      if (!result.canceled && result.filePath) {
+        await assertOutsideManagedStorageMutation(result.filePath)
         const parseResult = parseDataUrl(data)
-        fs.writeFileSync(filePath, parseResult?.data ?? data, 'base64')
+        await fs.promises.writeFile(result.filePath, parseResult?.data ?? data, 'base64')
         return true
       }
     } catch (error) {

--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -441,7 +441,7 @@ class FileStorage {
       if (detectEncoding) {
         return readTextFileWithAutoEncoding(filePath)
       } else {
-        return fs.readFileSync(filePath, 'utf-8')
+        return await fs.promises.readFile(filePath, 'utf-8')
       }
     } catch (error) {
       logger.error('Failed to read text file:', error as Error)

--- a/src/main/services/__tests__/ExportService.test.ts
+++ b/src/main/services/__tests__/ExportService.test.ts
@@ -1,0 +1,74 @@
+import AdmZip from 'adm-zip'
+import { dialog } from 'electron'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `t` pulls in i18n + preference machinery that isn't initialized under test; the
+// dialog title it produces is irrelevant to these contracts, so stub it to the key.
+vi.mock('@main/i18n', () => ({ t: (key: string) => key }))
+
+// Each test re-imports ExportService after vi.resetModules so per-test vi.doMock
+// variants (spied docx for the cancel path, real modules for the product path) apply.
+async function freshService() {
+  vi.resetModules()
+  const { ExportService } = await import('../ExportService')
+  return new ExportService()
+}
+
+describe('ExportService.exportToWord', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.doUnmock('markdown-it')
+    vi.doUnmock('docx')
+    vi.restoreAllMocks()
+  })
+
+  // Catches a regression to convert-before-dialog: any markdown-it / Packer
+  // invocation on the cancel path means the user paid conversion cost for nothing.
+  describe('cancel path (zero conversion cost)', () => {
+    it('does not invoke markdown-it or docx.Packer.toBuffer when the dialog is canceled', async () => {
+      const toBuffer = vi.fn()
+      const markdownItCtor = vi.fn()
+      vi.doMock('docx', () => ({ Document: vi.fn(), Packer: { toBuffer } }))
+      vi.doMock('markdown-it', () => ({ default: markdownItCtor }))
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: undefined } as never)
+
+      const service = await freshService()
+      await expect(service.exportToWord('# Title', 'doc.docx')).resolves.toBeUndefined()
+
+      expect(dialog.showSaveDialog).toHaveBeenCalledTimes(1)
+      expect(markdownItCtor).not.toHaveBeenCalled()
+      expect(toBuffer).not.toHaveBeenCalled()
+    })
+  })
+
+  // Catches the confirm path breaking in the reorder: a wrong canceled/filePath check
+  // or lost write leaves no file; broken conversion leaves document.xml without paragraphs.
+  describe('confirm path (docx product)', () => {
+    let tmpFile: string
+
+    beforeEach(() => {
+      tmpFile = path.join(os.tmpdir(), `export-word-test-${process.pid}-${Math.floor(Math.random() * 1e9)}.docx`)
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpFile, { force: true })
+    })
+
+    it('writes an openable docx whose document.xml contains the converted paragraphs', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+
+      const service = await freshService()
+      await service.exportToWord('# Title\n\nBody paragraph', 'doc.docx')
+
+      const documentXml = new AdmZip(tmpFile).readAsText('word/document.xml')
+      expect(documentXml).toContain('Title')
+      expect(documentXml).toContain('Body paragraph')
+    })
+  })
+})

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -140,6 +140,29 @@ describe('FileStorage', () => {
       expect(shell.trashItem).not.toHaveBeenCalled()
     })
   })
+
+  // Round-trips through the real text branches of readFileCore; catches a
+  // readFileSync → fs.promises.readFile swap regressing content or return type.
+  describe('readExternalFile', () => {
+    let tmpFile: string
+
+    beforeEach(() => {
+      tmpFile = path.join(os.tmpdir(), `filestorage-read-test-${uniqueId()}.md`)
+      fs.writeFileSync(tmpFile, 'Hello 世界\nsecond line')
+    })
+
+    afterEach(() => {
+      fs.rmSync(tmpFile, { force: true })
+    })
+
+    it('returns utf-8 file content verbatim (plain branch)', async () => {
+      await expect(fileStorage.readExternalFile(event, tmpFile)).resolves.toBe('Hello 世界\nsecond line')
+    })
+
+    it('returns utf-8 file content verbatim (auto-encoding branch)', async () => {
+      await expect(fileStorage.readExternalFile(event, tmpFile, true)).resolves.toBe('Hello 世界\nsecond line')
+    })
+  })
 })
 
 function uniqueId(): string {

--- a/src/main/services/__tests__/FileStorage.test.ts
+++ b/src/main/services/__tests__/FileStorage.test.ts
@@ -163,6 +163,29 @@ describe('FileStorage', () => {
       await expect(fileStorage.readExternalFile(event, tmpFile, true)).resolves.toBe('Hello 世界\nsecond line')
     })
   })
+
+  // Catches an inverted canceled/filePath check (cancel writing a file, confirm
+  // returning false) and a lost 'base64' encoding (literal base64 text on disk).
+  describe('saveImage', () => {
+    it('returns false and writes nothing when the save dialog is canceled', async () => {
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: undefined } as never)
+
+      await expect(fileStorage.saveImage(event, 'pic', 'data:image/png;base64,AAAA')).resolves.toBe(false)
+    })
+
+    it('decodes the base64 payload to disk and returns true on confirm', async () => {
+      const tmpFile = path.join(os.tmpdir(), `filestorage-image-test-${uniqueId()}.png`)
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: tmpFile } as never)
+      const payload = Buffer.from('fake-png-bytes').toString('base64')
+
+      try {
+        await expect(fileStorage.saveImage(event, 'pic', `data:image/png;base64,${payload}`)).resolves.toBe(true)
+        expect(fs.readFileSync(tmpFile).equals(Buffer.from('fake-png-bytes'))).toBe(true)
+      } finally {
+        fs.rmSync(tmpFile, { force: true })
+      }
+    })
+  })
 })
 
 function uniqueId(): string {


### PR DESCRIPTION
### What this PR does

Before this PR:

Three main-process paths performed synchronous IO that could stall the event loop:

- Word export (`ExportService.exportToWord`) ran the markdown→docx conversion and `Packer.toBuffer` **before** showing a modal `showSaveDialogSync` — canceling still paid the full conversion cost, and the dialog only appeared after conversion finished.
- `FileStorage.readFileCore`'s plain utf-8 branch used `fs.readFileSync` — Notes full-text search (`File_ReadExternal`) blocked the main process while reading large note files.
- `FileStorage.saveImage` used the same `showSaveDialogSync` + `fs.writeFileSync` pattern.

After this PR:

- `exportToWord` awaits `dialog.showSaveDialog` first; conversion, packing and writing only run after the user confirms a path — canceling costs zero conversion work and the dialog opens without waiting on conversion.
- The `readFileCore` text branch awaits `fs.promises.readFile`; both callers (`readFile`, `readExternalFile`) keep their async string contract unchanged.
- `saveImage` awaits `dialog.showSaveDialog` and `fs.promises.writeFile`; the boolean return semantics (false on cancel or error) are unchanged.

Fixes # N/A (internal perf review quick-wins batch)

### Why we need it and why it was done this way

The following tradeoffs were made:

- The markdown→docx conversion CPU block stays on the main process: offloading to a utilityProcess/worker adds a serialization boundary for a transient ~100ms block, while the dialog-related costs were the dominant, user-visible ones.
- Large-file reads still consume IPC bandwidth and are re-read on every search burst — the structural fix (FTS indexing in the main process) is deliberately out of scope; this batch only removes event-loop stalls.
- Word-export conversion errors now surface **after** path selection instead of before the dialog opens (accepted timing-only behavior change; markdown-it is robust and conversion errors are rare in practice).

The following alternatives were considered:

- Renderer-side mtime-based content cache for Notes search — rejected for this batch: external-editor invalidation logic adds correctness risk for marginal benefit once reads are async.
- Keeping the sync dialog but spawning work early — meaningless: the stall is the dialog itself.
- Full utilityProcess offload of docx conversion — deferred as a future option.

Links to places where the discussion took place: internal perf review (2026-08-17 full-repo audit, quick-wins batch planning).

### Breaking changes

None. One timing-only behavior change: Word-export conversion errors surface after path selection (see tradeoffs).

### Special notes for your reviewer

- **Stacked after #18751** (`fix/legacy-ipc-zipslip-guards`, **merged 2026-08-18**): `FileStorage.ts` is shared, but the hunks are disjoint (ours: `readFileCore` ~:444 and `saveImage` ~:800; theirs: `openPath` ~:690) — GitHub reports this PR MERGEABLE against current `main`, so no rebase is required.
- `saveImage` (commit 3) is the same-pattern fix for the `showSaveDialogSync` + `writeFileSync` twin found during review of the Word-export path.
- CDP verification (macOS dev instance, isolated profile):
  - **P2**: `preference.get` latency during 9×21MB concurrent `readExternal` bursts: first probe 1.2ms, steady-state 6.6–8.9ms — well under the 50ms acceptance threshold. The steady-state tail is IPC return-channel queuing from the 21MB payloads (the known out-of-scope structural cost), not event-loop blocking.
  - **P8**: with the save dialog open and the export promise pending (dialog provably up), concurrent `preference.get` answered in 0–0.4ms.
  - Honest finding: on macOS, `showSaveDialogSync` runs in a Cocoa nested modal loop that still pumps IPC — the pre-fix binary also answered `preference.get` during the dialog (~0–1ms). The dialog-freeze argument therefore matters mainly for other platforms; the reorder benefits that hold everywhere are zero cancel cost and dialog latency no longer waiting on conversion.
  - Independently re-verified by a second session (isolated profile, real dev instance): P2 probes 0.1–0.8ms during a 9×21MB concurrent `readExternal` burst; P8 probes 0.1–1.4ms with the native save dialog provably up (export promise pending); a 4MB-markdown export also enters the dialog immediately.
- Unit tests: `ExportService.test.ts` asserts the order contract (cancel → markdown-it constructor and `Packer.toBuffer` never called; confirm → real docx unzipped, `document.xml` contains the converted paragraphs); `FileStorage.test.ts` round-trips real temp files through both utf-8 and auto-encoding branches and covers `saveImage` cancel/confirm paths (decoded base64 bytes verified on disk).
- Verification: scoped biome/oxlint/eslint + `typecheck:node` + full vitest suite (225 files, 3046 tests) all green; commits are SSH-signed and DCO-signed-off.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: N/A — pure synchronous→asynchronous swaps, no restructuring
- [ ] Upgrade: N/A — no schema/persistence changes
- [ ] Documentation: not required — no user-facing feature or UI change
- [x] Self-review: reviewed via subagent review (verdict PASS; one comment-length nit fixed and amended)

### Release note

```release-note
Reduced main-process stalls: file reads (Notes search), Word export and image save no longer block the whole app while reading files or showing save dialogs; canceling the Word export dialog no longer runs the conversion.
```
