### PR TITLE
fix(mcp-oauth): write the token storage file owner-only

### DIFF
--- a/src/main/ai/mcp/oauth/__tests__/storage.test.ts
+++ b/src/main/ai/mcp/oauth/__tests__/storage.test.ts
@@ -100,4 +100,14 @@ describe('JsonFileStorage round-trip', () => {
     const reader = new JsonFileStorage(serverUrlHash, configDir)
     await expect(reader.getTokens()).resolves.toBeUndefined()
   })
+
+  // The file holds access/refresh tokens and the client secret; it must not be
+  // world-readable on multi-user systems (same class as the trace JSONL fix).
+  it.skipIf(process.platform === 'win32')('writes the token file owner-only (0600)', async () => {
+    const storage = new JsonFileStorage(serverUrlHash, configDir)
+    await storage.saveTokens({ access_token: 'tok', token_type: 'Bearer' })
+
+    const stats = await fs.stat(path.join(configDir, `${serverUrlHash}_oauth.json`))
+    expect(stats.mode & 0o777).toBe(0o600)
+  })
 })

--- a/src/main/ai/mcp/oauth/storage.ts
+++ b/src/main/ai/mcp/oauth/storage.ts
@@ -48,15 +48,15 @@ export class JsonFileStorage implements IOAuthStorage {
 
   private async writeStorage(data: OAuthStorageData): Promise<void> {
     try {
-      // Ensure directory exists
-      await fs.mkdir(path.dirname(this.filePath), { recursive: true })
+      // Ensure directory exists; owner-only since it holds OAuth tokens
+      await fs.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 })
 
       // Update timestamp
       data.lastUpdated = Date.now()
 
-      // Write file atomically
+      // Write file atomically, readable only by the owner (tokens + client secret)
       const tempPath = `${this.filePath}.tmp`
-      await fs.writeFile(tempPath, JSON.stringify(data, null, 2))
+      await fs.writeFile(tempPath, JSON.stringify(data, null, 2), { mode: 0o600 })
       await fs.rename(tempPath, this.filePath)
 
       // Update cache


### PR DESCRIPTION
### What this PR does

Before this PR: the MCP OAuth storage (`<configDir>/<hash>_oauth.json`, holding access/refresh tokens and the client secret) was written with default permissions, typically 0644 on Linux, so any local user could read it. The config directory was likewise created with default permissions.

After this PR: the file is written 0600 and the directory is created 0700, the same treatment the trace JSONL artifacts just got.

### Why we need it and why it was done in this way

Token files are the classic thing that should never be world-readable on a multi-user box. The temp-file-then-rename flow already creates a fresh file per write, so setting the mode at creation covers every write.

The following alternatives were considered: chmod after write would leave a readable window between create and rename; setting the mode at creation avoids it.

### How to test

`npx vitest run src/main/ai/mcp/oauth/__tests__/storage.test.ts` passes 9/9, including a new case asserting the written file's mode is 0600 (skipped on Windows, where POSIX modes don't apply).
