### PR TITLE
fix(skills): discover nested system skills

### DIFF
--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -327,30 +327,11 @@ export class SkillService {
     for (const source of sources) {
       if (path.resolve(source.directoryPath) === mirrorRoot) continue
 
-      let entries: fs.Dirent[]
-      try {
-        entries = await fs.promises.readdir(source.directoryPath, { withFileTypes: true })
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          logger.warn('Failed to enumerate system skill source', {
-            sourceId: source.id,
-            directoryPath: source.directoryPath,
-            error: error instanceof Error ? error.message : String(error)
-          })
-        }
-        continue
-      }
-
-      for (const entry of entries) {
-        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
-
-        const entryPath = path.join(source.directoryPath, entry.name)
+      const skillDirectories = await findAllSkillDirectories(source.directoryPath, source.directoryPath)
+      for (const skillDirectory of skillDirectories) {
+        const entryPath = skillDirectory.folderPath
         try {
-          const [stats, canonicalPath] = await Promise.all([
-            fs.promises.stat(entryPath),
-            fs.promises.realpath(entryPath)
-          ])
-          if (!stats.isDirectory()) continue
+          const canonicalPath = await fs.promises.realpath(entryPath)
           if (canonicalPath === managedRoot || canonicalPath.startsWith(managedRoot + path.sep)) continue
 
           const placement: SystemSkillPlacement = {
@@ -364,7 +345,9 @@ export class SkillService {
             continue
           }
 
-          const metadata = await parseSkillMetadata(canonicalPath, entry.name, 'skills', { calculateSize: false })
+          const metadata = await parseSkillMetadata(canonicalPath, skillDirectory.sourcePath, 'skills', {
+            calculateSize: false
+          })
           const folderName = this.sanitizeFolderName(metadata.filename)
           const registered = installedByPath.get(canonicalPath)
           const folderConflict = installedByFolder.get(this.normalizeFolderKey(folderName))

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -411,12 +411,19 @@ describe('SkillService', () => {
         size: 0,
         contentHash: 'system-hash'
       })
+      vi.mocked(findAllSkillDirectories).mockImplementation(async (directoryPath) =>
+        directoryPath === path.join(home, '.codex', 'skills')
+          ? [{ folderPath: sourceSkillDir, sourcePath: 'large-skill' }]
+          : []
+      )
       vi.mocked(findSkillMdPath).mockImplementation(async (directoryPath) => path.join(directoryPath, 'SKILL.md'))
     })
 
     afterEach(() => {
       restoreGetPath()
       vi.mocked(parseSkillMetadata).mockReset()
+      vi.mocked(findAllSkillDirectories).mockReset()
+      vi.mocked(findAllSkillDirectories).mockResolvedValue([])
       vi.mocked(findSkillMdPath).mockReset()
     })
 
@@ -435,6 +442,47 @@ describe('SkillService', () => {
       expect(parseSkillMetadata).toHaveBeenCalledWith(
         await fs.promises.realpath(sourceSkillDir),
         'large-skill',
+        'skills',
+        { calculateSize: false }
+      )
+    })
+
+    it('discovers skills recursively under known system roots', async () => {
+      const agentsSkillsRoot = path.join(home, '.agents', 'skills')
+      const nestedSkillDir = path.join(agentsSkillsRoot, 'github', 'github-pr-workflow')
+      await fs.promises.mkdir(nestedSkillDir, { recursive: true })
+      await fs.promises.writeFile(path.join(nestedSkillDir, 'SKILL.md'), '# GitHub PR workflow')
+      vi.mocked(findAllSkillDirectories).mockImplementation(async (directoryPath) =>
+        directoryPath === agentsSkillsRoot
+          ? [{ folderPath: nestedSkillDir, sourcePath: path.join('github', 'github-pr-workflow') }]
+          : []
+      )
+      vi.mocked(parseSkillMetadata).mockResolvedValue({
+        sourcePath: path.join('github', 'github-pr-workflow'),
+        filename: 'github-pr-workflow',
+        name: 'GitHub PR Workflow',
+        description: 'Nested system skill',
+        category: 'skills',
+        type: 'skill',
+        version: '1.0.0',
+        size: 0,
+        contentHash: 'nested-system-hash'
+      })
+
+      const result = await skillService.discoverSystem()
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          name: 'GitHub PR Workflow',
+          filename: 'github-pr-workflow',
+          directoryPath: await fs.promises.realpath(nestedSkillDir),
+          status: 'available',
+          placements: [expect.objectContaining({ sourceId: 'agents', sourceName: 'Agent Skills' })]
+        })
+      ])
+      expect(parseSkillMetadata).toHaveBeenCalledWith(
+        await fs.promises.realpath(nestedSkillDir),
+        path.join('github', 'github-pr-workflow'),
         'skills',
         { calculateSize: false }
       )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!-- Thanks for sending a pull request! -->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

System skill discovery only inspected direct children of each known CLI skill root. Skills organized into categories, such as `~/.agents/skills/github/github-pr-workflow`, were not shown and could not be imported.

After this PR:

System skill discovery reuses the existing recursive skill-directory scanner. Nested skills are discovered from known roots while retaining their relative source path and leaf directory name.

Fixes #18287

### Why we need it and why it was done in this way

`SkillService.discoverSystem()` implemented its own one-level `readdir` loop even though `findAllSkillDirectories()` already provides the repository's recursive SKILL.md discovery behavior. Reusing that helper keeps system discovery consistent with repository skill discovery, including hidden-directory and `node_modules` filtering, symlink handling, and the existing depth bound.

The following tradeoffs were made:

- Discovery keeps the helper's existing maximum depth of 10.
- Once a directory contains a SKILL.md, it is treated as the skill root and its descendants are not scanned as separate skills.
- Canonical-path deduplication and managed-library exclusion remain unchanged.

The following alternatives were considered:

- Adding a second recursive walker inside `SkillService` was rejected because it would duplicate path traversal and filtering rules.
- Changing the shared scanner API was unnecessary for this fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18287

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- Recursive system discovery tests: 2 passed.
- Shared recursive directory scanner tests: 2 passed.
- Biome and ESLint checks for the changed files passed.
- Pre-commit Biome and ESLint hooks passed.
- Full local typecheck remains blocked by unrelated existing DSH bridge build/type errors.
- The full SkillService suite contains Windows symlink tests that require Developer Mode or elevated symlink privileges; the affected discovery tests pass independently.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The change reuses the existing recursive scanner and keeps the implementation focused
- [x] Refactor: The duplicated one-level traversal was removed
- [x] Upgrade: Existing flat system skill layouts remain supported
- [x] Documentation: No user-guide update is required
- [x] Self-review: The final diff and commit signature were verified

### Release note

```release-note
System skills organized in nested directories are now discovered and can be imported.
```
