### PR TITLE
fix(provider-settings): use granular api-key mutations in key list drawer

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderApiKeyListDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderApiKeyListDrawer.tsx
@@ -24,7 +24,6 @@ interface DraftState {
   id: string
   key: string
   label: string
-  isEnabled: boolean
   isNew: boolean
 }
 
@@ -32,7 +31,6 @@ const createEmptyDraft = (): DraftState => ({
   id: uuidv4(),
   key: '',
   label: '',
-  isEnabled: true,
   isNew: true
 })
 
@@ -47,24 +45,14 @@ function toDraft(entry: ApiKeyEntry): DraftState {
     id: entry.id,
     key: entry.key,
     label: entry.label ?? '',
-    isEnabled: entry.isEnabled,
     isNew: false
-  }
-}
-
-function toEntry(draft: DraftState): ApiKeyEntry {
-  return {
-    id: draft.id,
-    key: normalizeApiKeyValue(draft.key),
-    label: draft.label.trim() || undefined,
-    isEnabled: draft.isEnabled
   }
 }
 
 export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: ProviderApiKeyListDrawerProps) {
   const { t } = useTranslation()
   const { data: apiKeysData } = useProviderApiKeys(providerId)
-  const { updateApiKeys } = useProviderMutations(providerId)
+  const { addApiKey, updateApiKey, deleteApiKey } = useProviderMutations(providerId)
   const apiKeys = useMemo(() => apiKeysData?.keys ?? [], [apiKeysData?.keys])
   const [editingId, setEditingId] = useState<string | null>(null)
   const [draft, setDraft] = useState<DraftState | null>(null)
@@ -81,7 +69,7 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
   const enabledCount = apiKeys.filter((item) => item.isEnabled).length
 
   const persist = useCallback(
-    async (nextKeys: ApiKeyEntry[]) => {
+    async (mutation: () => Promise<void>) => {
       if (savingRef.current) {
         return false
       }
@@ -89,7 +77,7 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
       savingRef.current = true
       setSaving(true)
       try {
-        await updateApiKeys(nextKeys)
+        await mutation()
         return true
       } catch (error) {
         logger.error('Failed to persist provider API keys', { providerId, error })
@@ -100,7 +88,7 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
         setSaving(false)
       }
     },
-    [providerId, t, updateApiKeys]
+    [providerId, t]
   )
 
   const validateDraft = useCallback(
@@ -117,7 +105,7 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
         return null
       }
 
-      return toEntry(nextDraft)
+      return key
     },
     [apiKeys, t]
   )
@@ -144,31 +132,34 @@ export default function ProviderApiKeyListDrawer({ providerId, open, onClose }: 
       return
     }
 
-    const entry = validateDraft(draft)
-    if (!entry) {
+    const key = validateDraft(draft)
+    if (!key) {
       return
     }
 
-    const nextKeys = draft.isNew ? [...apiKeys, entry] : apiKeys.map((item) => (item.id === entry.id ? entry : item))
-    if (await persist(nextKeys)) {
+    const label = draft.label.trim()
+    const saved = await persist(() =>
+      draft.isNew ? addApiKey(key, label || undefined) : updateApiKey(draft.id, { key, label })
+    )
+    if (saved) {
       cancelEdit()
     }
-  }, [apiKeys, cancelEdit, draft, persist, validateDraft])
+  }, [addApiKey, cancelEdit, draft, persist, updateApiKey, validateDraft])
 
   const removeKey = useCallback(
     async (id: string) => {
-      if ((await persist(apiKeys.filter((item) => item.id !== id))) && editingId === id) {
+      if ((await persist(() => deleteApiKey(id))) && editingId === id) {
         cancelEdit()
       }
     },
-    [apiKeys, cancelEdit, editingId, persist]
+    [cancelEdit, deleteApiKey, editingId, persist]
   )
 
   const toggleEnabled = useCallback(
     async (entry: ApiKeyEntry, isEnabled: boolean) => {
-      await persist(apiKeys.map((item) => (item.id === entry.id ? { ...item, isEnabled } : item)))
+      await persist(() => updateApiKey(entry.id, { isEnabled }))
     },
-    [apiKeys, persist]
+    [persist, updateApiKey]
   )
 
   return (

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderApiKeyListDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderApiKeyListDrawer.test.tsx
@@ -1,8 +1,13 @@
 import ProviderApiKeyListDrawer from '@renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderApiKeyListDrawer'
+import type { ApiKeyEntry } from '@shared/data/types/provider'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const updateApiKeysMock = vi.fn()
+const addApiKeyMock = vi.fn()
+const updateApiKeyMock = vi.fn()
+const deleteApiKeyMock = vi.fn()
+
+let mockKeys: ApiKeyEntry[] = []
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<object>()
@@ -25,10 +30,12 @@ vi.mock('@logger', () => ({
 
 vi.mock('@renderer/hooks/useProvider', () => ({
   useProviderApiKeys: () => ({
-    data: { keys: [] }
+    data: { keys: mockKeys }
   }),
   useProviderMutations: () => ({
-    updateApiKeys: updateApiKeysMock
+    addApiKey: addApiKeyMock,
+    updateApiKey: updateApiKeyMock,
+    deleteApiKey: deleteApiKeyMock
   })
 }))
 
@@ -45,14 +52,17 @@ vi.mock('../../primitives/ProviderSettingsDrawer', () => ({
 describe('ProviderApiKeyListDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    updateApiKeysMock.mockResolvedValue(undefined)
+    mockKeys = []
+    addApiKeyMock.mockResolvedValue(undefined)
+    updateApiKeyMock.mockResolvedValue(undefined)
+    deleteApiKeyMock.mockResolvedValue(undefined)
     ;(window as any).toast = {
       error: vi.fn(),
       warning: vi.fn()
     }
   })
 
-  it('saves new API key drafts as enabled by default', async () => {
+  it('creates new drafts via addApiKey with the trimmed key value', async () => {
     render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'common.add' }))
@@ -62,12 +72,49 @@ describe('ProviderApiKeyListDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
 
     await waitFor(() => {
-      expect(updateApiKeysMock).toHaveBeenCalledWith([
-        expect.objectContaining({
-          key: 'sk-new',
-          isEnabled: true
-        })
-      ])
+      expect(addApiKeyMock).toHaveBeenCalledWith('sk-new', undefined)
+    })
+  })
+
+  it('saves edits to an existing key via updateApiKey without touching other entries', async () => {
+    mockKeys = [
+      { id: 'key-1', key: 'sk-old', label: 'Main', isEnabled: true },
+      { id: 'key-2', key: 'sk-other', isEnabled: true }
+    ]
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'common.edit' })[0])
+    fireEvent.change(screen.getByPlaceholderText('settings.provider.api.key.new_key.placeholder'), {
+      target: { value: 'sk-rotated' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(updateApiKeyMock).toHaveBeenCalledWith('key-1', { key: 'sk-rotated', label: 'Main' })
+    })
+    expect(addApiKeyMock).not.toHaveBeenCalled()
+    expect(deleteApiKeyMock).not.toHaveBeenCalled()
+  })
+
+  it('toggles enablement via updateApiKey with only the isEnabled change', async () => {
+    mockKeys = [{ id: 'key-1', key: 'sk-a', isEnabled: true }]
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('switch'))
+
+    await waitFor(() => {
+      expect(updateApiKeyMock).toHaveBeenCalledWith('key-1', { isEnabled: false })
+    })
+  })
+
+  it('removes a key via deleteApiKey by id', async () => {
+    mockKeys = [{ id: 'key-1', key: 'sk-a', isEnabled: true }]
+    render(<ProviderApiKeyListDrawer providerId="openai" open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.delete' }))
+
+    await waitFor(() => {
+      expect(deleteApiKeyMock).toHaveBeenCalledWith('key-1')
     })
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Every operation in the provider API key list drawer (add, edit, enable/disable toggle, remove) rebuilt the **entire** key array from the renderer-side DataApi cache and replaced it wholesale via `PUT /providers/:providerId/api-keys`. A write based on a stale snapshot therefore had the whole list as its blast radius: it could silently resurrect a just-deleted key or drop a key added concurrently by another writer (e.g. an OAuth-provisioned key), with no error surfaced.

After this PR:

Each drawer operation calls the existing granular per-key endpoints, which perform their read-modify-write inside a main-process transaction on fresh DB rows:

- add → `addApiKey(key, label?)` (`POST /providers/:providerId/api-keys`)
- edit → `updateApiKey(id, { key, label })` (`PATCH /providers/:providerId/api-keys/:keyId`)
- toggle → `updateApiKey(id, { isEnabled })`
- remove → `deleteApiKey(id)` (`DELETE /providers/:providerId/api-keys/:keyId`)

Concurrent modifications of different keys can no longer clobber each other. UI behavior is unchanged (same saving guard, same failure toast). The now-orphaned `toEntry` helper and unused `DraftState.isEnabled` field were removed; "enabled by default" for new keys is guaranteed server-side by `addApiKey`.

### Why we need it and why it was done in this way

The drawer was the last renderer surface still using the cache-based full-replace pattern; OAuth login and onboarding already write through the granular endpoints. This change makes the write primitive match the operation's intent: a per-entry UI sends per-entry mutations, moving the read-modify-write from the renderer (based on a possibly stale cache) into the main process (transactional, on current data).

The following tradeoffs were made:

The scalar comma-separated key input intentionally keeps the full-replace `PUT`: its UI semantics are "this string is the complete enabled set", so a whole-set write is the honest expression there. After this PR it is the sole caller of that endpoint.

The following alternatives were considered:

Adding optimistic-concurrency (version/CAS) checks to the full-replace `PUT` was considered and rejected: it would keep the stale-cache read-modify-write pattern and add conflict-handling UX, while the correct granular endpoints already exist and are tested.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

- Clearing a label on edit sends `label: ''`; `ProviderService.updateApiKey` deletes the label field for falsy values, and `UpdateApiKeySchema` accepts the empty string.
- The component test was rewritten to pin the new contract (each UI operation maps to its granular mutation), replacing the previous single full-array assertion. This guards against regressing to wholesale replacement.
- Scoped verification run locally: the drawer Vitest file (4/4 pass), `tsgo --noEmit -p tsconfig.web.json`, `oxlint --deny-warnings`, `biome check`, and `eslint` on the two changed files. Full gate left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
