### PR TITLE
fix(knowledge-base): steer attached bases through search

### DIFF
--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeListTool.test.ts
@@ -200,6 +200,11 @@ describe('kb_list', () => {
     expect(entry.tool.needsApproval).toBeFalsy()
   })
 
+  it('tells the model that browse results are not retrieved evidence', () => {
+    expect(entry.tool.description).toMatch(/metadata.*structure.*not.*retrieved evidence/i)
+    expect(entry.tool.description).toMatch(/content questions.*kb_search.*kb_read/i)
+  })
+
   it('passes the assistant scope into the paged service query', async () => {
     knowledgeServiceListBasesForDiscovery.mockReturnValue(listPage([makeBase({ id: 'kb-1', name: 'Allowed' })]))
     knowledgeServiceListRootItems.mockReturnValue([])

--- a/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/builtin/__tests__/KnowledgeSearchTool.test.ts
@@ -71,6 +71,11 @@ describe('kb_search', () => {
     expect(entry.codec).toBeDefined()
   })
 
+  it('searches directly when a relevant base id is already known', () => {
+    expect(entry.tool.description).toMatch(/base id.*already.*kb_search directly/i)
+    expect(entry.tool.description).toMatch(/kb_list.*only.*no relevant base id/i)
+  })
+
   it('returns [] and does not search when every requested baseId is outside the assistant scope', async () => {
     const result = await callExecute({ query: 'foo', baseIds: ['kb-other'] }, { knowledgeBaseIds: ['kb-1'] })
     expect(result).toEqual([])

--- a/src/main/ai/tools/knowledgeLookup.ts
+++ b/src/main/ai/tools/knowledgeLookup.ts
@@ -80,13 +80,15 @@ Use this when:
 - The question references topics likely covered in stored documents
 - Specific factual lookup that isn't general knowledge
 
-Workflow: call kb_list first to discover available bases and their contents, then call this tool with the chosen baseIds. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.`
+Workflow: when a relevant base ID is already known (for example, from an attached knowledge base), call kb_search directly with that ID in baseIds. Call kb_list first only when no relevant base ID is known. You may call this multiple times with refined queries or different baseIds if the first results are insufficient. Cite: append [cite:id] immediately after each statement a result supports, using the result's exact \`id\` field.`
 
 export const KNOWLEDGE_LIST_DESCRIPTION = `Browse the user's knowledge bases and their structure.
 
 Two modes, selected by \`baseId\`:
 - Omit \`baseId\` to list one page of available bases — each with its name, group, item count, and a few sample sources (filenames, URLs, note titles) so you can judge what it covers. Use \`query\` to filter by base name or source. If \`nextCursor\` is returned, pass it as \`cursor\` to continue. Call this first when the user asks about their materials and you don't already know which base is relevant, then call kb_search with the chosen baseIds. If a base comes back with \`itemsUnavailable: true\` its contents could not be read this call (not that it is empty) — do not tell the user it holds nothing; retry or use kb_search.
-- Pass a \`baseId\` to outline that base instead: a flat top-down list of its folders and documents, each with a \`depth\`, title, type, \`status\`, and — for a readable document — a \`conceptId\` you can pass to kb_read. A node only carries a \`conceptId\` once its \`status\` is "completed"; a still-indexing or failed document has none. Use this to see how a base is organized, or to find a document's conceptId, without searching.`
+- Pass a \`baseId\` to outline that base instead: a flat top-down list of its folders and documents, each with a \`depth\`, title, type, \`status\`, and — for a readable document — a \`conceptId\` you can pass to kb_read. A node only carries a \`conceptId\` once its \`status\` is "completed"; a still-indexing or failed document has none. Use this to see how a base is organized, or to find a document's conceptId, without searching.
+
+This tool returns metadata and structure, not retrieved evidence. Do not answer content questions from names or sampleSources; use kb_search for relevant passages or kb_read for a known document.`
 
 export const KNOWLEDGE_READ_DESCRIPTION = `Read a single knowledge base document by its Concept ID — or grep inside it.
 

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3562,7 +3562,8 @@ describe('AgentComposer', () => {
   it('restores a cached knowledge chip and its prompt text', async () => {
     mocks.knowledgeBases = [knowledgeBaseOne]
     const cachedToken = knowledgeBaseToken(knowledgeBaseOne)
-    const promptText = 'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
+    const promptText =
+      'The user attached knowledge base "Knowledge One" (id: kb-1). Include "kb-1" in kb_search baseIds before answering questions that may depend on this knowledge base, and cite relevant kb_search or kb_read results. Use kb_list only to browse its structure; kb_list output is not retrieved evidence.'
     vi.mocked(cacheService.get).mockReturnValue({
       text: promptText,
       tokens: [
@@ -3738,7 +3739,8 @@ describe('AgentComposer', () => {
       />
     )
 
-    const promptText = 'The user attached knowledge base "Knowledge One" (id: kb-1) — use that id with the kb_* tools.'
+    const promptText =
+      'The user attached knowledge base "Knowledge One" (id: kb-1). Include "kb-1" in kb_search baseIds before answering questions that may depend on this knowledge base, and cite relevant kb_search or kb_read results. Use kb_list only to browse its structure; kb_list output is not retrieved evidence.'
     const cachedToken = { ...knowledgeBaseToken(knowledgeBaseOne), promptText }
     mocks.selectedKnowledgeBases = [knowledgeBaseOne]
     act(() => {

--- a/src/renderer/components/composer/variants/__tests__/chatComposerTokens.test.ts
+++ b/src/renderer/components/composer/variants/__tests__/chatComposerTokens.test.ts
@@ -33,7 +33,7 @@ describe('chat composer token mapping', () => {
     })
   })
 
-  it('gives a knowledge base a promptText carrying its name and id, and a file none', () => {
+  it('steers attached knowledge base questions through semantic search, and gives a file no promptText', () => {
     // The pick reaches the model only as this sentence — the `data-knowledge-scope` part is dropped
     // before the model sees the message. The id has to be in it: every kb_* tool addresses a base by
     // id, so without it the model must spend a kb_list call to discover one.
@@ -41,10 +41,9 @@ describe('chat composer token mapping', () => {
 
     expect(promptText).toContain('Docs')
     expect(promptText).toContain('kb-1')
-    expect(promptText).toContain('kb_*')
-    // Only the tool family, never one tool: which of kb_search / kb_read / kb_list comes next is the
-    // (separately tuned) tool descriptions' call, and pinning one here would narrow it for no gain.
-    expect(promptText).not.toMatch(/kb_(search|list|read|manage)\b/)
+    expect(promptText).toContain('kb_search')
+    expect(promptText).toContain('baseIds')
+    expect(promptText).toMatch(/kb_list.*not.*evidence/i)
 
     // Files stay zero-width: they travel as real file parts, so a sentence would only duplicate them.
     expect(

--- a/src/renderer/components/composer/variants/shared/composerTokens.ts
+++ b/src/renderer/components/composer/variants/shared/composerTokens.ts
@@ -27,33 +27,13 @@ export function fileToComposerToken(file: ComposerAttachment): ComposerDraftToke
   }
 }
 
-/**
- * The pick has to reach the model as text, because nothing else tells it a base was attached: the
- * `data-knowledge-scope` part only gates which bases the kb_* tools accept, and it is dropped before
- * the model ever sees the message. Left unsaid, the model falls back to the kb_* tools' own
- * descriptions, which are deliberately conservative ("use this when the user references *my
- * notes*") — so it skips retrieval until the user says the words out loud.
- *
- * It states the fact and points at the tool family, but names no individual tool and gives no
- * timing. Two reasons. "The user attached knowledge base X" IS the user referencing their own
- * materials, so it *satisfies* that conservative condition rather than arguing with it — the tool
- * descriptions (tuned against EnterpriseRAG-Bench) stay the single place deciding when to retrieve.
- * And which tool comes next is genuinely open: `kb_read` and `kb_list` are as often right as
- * `kb_search`, so pinning one here would narrow the model for no gain.
- *
- * The id is load-bearing, not decoration — every kb_* tool addresses a base by id, and `kb_search`
- * requires a non-empty `baseIds` documented as "picked from the result of kb_list", so carrying it
- * here saves an otherwise mandatory kb_list round-trip.
- *
- * Each picked base contributes its own sentence (chips serialize independently, separated by the
- * space the editor inserts after each one), so this must stay short and self-contained.
- */
+/** Model-visible instruction: the scope part is dropped, while the attached base ID already identifies the search target. */
 export function knowledgeBaseToComposerToken(base: KnowledgeBase): ComposerDraftToken {
   return {
     id: composerKnowledgeBaseTokenId(base),
     kind: 'knowledge',
     label: base.name,
-    promptText: `The user attached knowledge base "${base.name}" (id: ${base.id}) — use that id with the kb_* tools.`,
+    promptText: `The user attached knowledge base "${base.name}" (id: ${base.id}). Include "${base.id}" in kb_search baseIds before answering questions that may depend on this knowledge base, and cite relevant kb_search or kb_read results. Use kb_list only to browse its structure; kb_list output is not retrieved evidence.`,
     payload: base
   }
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Attaching a knowledge base only gave the model a generic `kb_*` hint, while `kb_search` instructed it to call `kb_list` first. Models could stop after browsing metadata, bypass semantic retrieval, and answer without stable citations.

After this PR:

Attached knowledge bases direct the model to call `kb_search` with the already-known base ID before answering relevant questions and to cite retrieved results. `kb_list` is explicitly limited to metadata and structure browsing, and only precedes `kb_search` when no relevant base ID is known.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The configured embedding model is used by `kb_search`, but tool selection remains model-driven. The previous prompt made `kb_list` a likely first and final call even though an attached base already supplied its ID. Strengthening the attachment prompt and aligning the tool descriptions fixes that orchestration gap at the narrowest existing seam.

The following tradeoffs were made:

This remains best-effort model guidance rather than deterministic retrieval. It improves behavior without adding unconditional latency or injecting retrieved context into every attached-base request.

The following alternatives were considered:

A system-owned pre-retrieval step would guarantee retrieval across models, but it is a larger behavioral and architectural change with query-selection, latency, and context-budget implications.

Links to places where the discussion took place: https://mcnnox2fhjfq.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&view=vewBsY1QzA

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Targeted local checks passed:

- Renderer Vitest: 133 tests
- Main Vitest: 83 tests
- Biome and ESLint on all six changed files
- `git diff --check`

The same 216 targeted tests passed on a remote macOS 26.2 arm64 host using Node 24.15.0. An isolated Electron profile reached a healthy main window and CDP target; no model-backed end-to-end query was run because the isolated profile intentionally contained no user provider or knowledge-base data. Full repository checks are deferred to PR CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improve retrieval and citations when using an attached knowledge base.
```
