### PR TITLE
feat(ui): render ECharts diagrams in markdown code blocks

### DIFF
--- a/src/renderer/components/CodeBlockView/CodeBlockView.tsx
+++ b/src/renderer/components/CodeBlockView/CodeBlockView.tsx
@@ -364,12 +364,12 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
 
     return (
       <Suspense fallback={null}>
-        <SpecialView ref={specialViewRef} enableToolbar={codeImageTools}>
+        <SpecialView ref={specialViewRef} enableToolbar={codeImageTools} isStreaming={isStreaming}>
           {children}
         </SpecialView>
       </Suspense>
     )
-  }, [children, codeImageTools, language])
+  }, [children, codeImageTools, isStreaming, language])
 
   const renderHeader = useMemo(() => {
     if (isInSpecialView) {

--- a/src/renderer/components/CodeBlockView/CodeBlockView.tsx
+++ b/src/renderer/components/CodeBlockView/CodeBlockView.tsx
@@ -395,7 +395,7 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
     return (
       <div
         className={cn(
-          'split-view-wrapper flex *:w-full *:flex-[1_1_auto]',
+          'split-view-wrapper flex *:min-w-0 *:flex-1',
           !hasStatusBar && (showSpecialView && !showSourceView ? 'rounded-lg' : 'rounded-b-lg'),
           !hasStatusBar && '[&_.code-viewer]:rounded-[inherit]',
           showSpecialView &&

--- a/src/renderer/components/CodeBlockView/constants.ts
+++ b/src/renderer/components/CodeBlockView/constants.ts
@@ -4,7 +4,7 @@ import { type ComponentType, lazy, type RefObject } from 'react'
 /**
  * 特殊视图语言列表
  */
-export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg', 'dot', 'graphviz']
+export const SPECIAL_VIEWS = ['mermaid', 'plantuml', 'svg', 'dot', 'graphviz', 'echarts']
 
 type SpecialViewProps = BasicPreviewProps & { ref?: RefObject<BasicPreviewHandles | null> }
 
@@ -26,6 +26,9 @@ export const SPECIAL_VIEW_COMPONENTS = {
   ),
   graphviz: lazy<ComponentType<SpecialViewProps>>(() =>
     import('@renderer/components/Preview/GraphvizPreview').then((module) => ({ default: module.default }))
+  ),
+  echarts: lazy<ComponentType<SpecialViewProps>>(() =>
+    import('@renderer/components/Preview/EChartsPreview').then((module) => ({ default: module.default }))
   )
 } as const
 

--- a/src/renderer/components/Preview/EChartsPreview.tsx
+++ b/src/renderer/components/Preview/EChartsPreview.tsx
@@ -1,3 +1,4 @@
+import { loggerService } from '@logger'
 import { useTheme } from '@renderer/hooks/useTheme'
 import type { EChartsCoreOption } from 'echarts'
 import * as echarts from 'echarts'
@@ -8,6 +9,8 @@ import { useDebouncedRender } from './hooks/useDebouncedRender'
 import ImagePreviewLayout from './ImagePreviewLayout'
 import type { BasicPreviewHandles, BasicPreviewProps } from './types'
 
+const logger = loggerService.withContext('EChartsPreview')
+
 const EChartsPreview = ({
   children,
   enableToolbar = false,
@@ -17,11 +20,24 @@ const EChartsPreview = ({
   const { theme } = useTheme()
   const { t } = useTranslation()
   const chartRef = useRef<ReturnType<typeof echarts.init> | null>(null)
+  const optionRef = useRef<EChartsCoreOption | null>(null)
   const wasStreamingRef = useRef(isStreaming)
+
+  const renderChartOption = useCallback(
+    (container: HTMLDivElement, option: EChartsCoreOption) => {
+      if (!chartRef.current) {
+        chartRef.current = echarts.init(container, theme === 'dark' ? 'dark' : undefined, { renderer: 'svg' })
+      }
+
+      chartRef.current.setOption(option, true)
+    },
+    [theme]
+  )
 
   const renderChart = useCallback(
     async (content: string, container: HTMLDivElement) => {
       if (!content) {
+        optionRef.current = null
         return
       }
 
@@ -36,16 +52,20 @@ const EChartsPreview = ({
       try {
         option = JSON.parse(content) as EChartsCoreOption
       } catch {
+        optionRef.current = null
         throw new Error(t('code_block.preview.invalid_json'))
       }
 
-      if (!chartRef.current) {
-        chartRef.current = echarts.init(container, theme === 'dark' ? 'dark' : undefined, { renderer: 'svg' })
+      optionRef.current = option
+
+      const { width, height } = container.getBoundingClientRect()
+      if (!chartRef.current && (width === 0 || height === 0)) {
+        return
       }
 
-      chartRef.current.setOption(option, true)
+      renderChartOption(container, option)
     },
-    [isStreaming, t, theme]
+    [isStreaming, t, renderChartOption]
   )
 
   const { containerRef, error, isLoading, triggerImmediateRender } = useDebouncedRender(children, renderChart, {
@@ -68,21 +88,66 @@ const EChartsPreview = ({
     }
   }, [theme])
 
+  // Resize the chart when the container size changes.
+  // because ECharts does not automatically detect container size changes.
   useEffect(() => {
-    if (!containerRef.current) {
+    const container = containerRef.current
+    if (!container) {
       return
+    }
+
+    const initChartIfReady = (width: number, height: number) => {
+      if (width === 0 || height === 0) {
+        return
+      }
+
+      const option = optionRef.current
+      if (!option || chartRef.current) {
+        return
+      }
+
+      try {
+        renderChartOption(container, option)
+      } catch (error) {
+        logger.error(
+          'Failed to initialize chart on container resize',
+          error instanceof Error ? error : new Error(String(error))
+        )
+      }
     }
 
     let resizeObserver: ResizeObserver | null = null
     if (typeof ResizeObserver !== 'undefined') {
-      resizeObserver = new ResizeObserver(() => chartRef.current?.resize())
-      resizeObserver.observe(containerRef.current)
+      const { width, height } = container.getBoundingClientRect()
+      initChartIfReady(width, height)
+
+      resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (!entry) {
+          return
+        }
+
+        const { width, height } = entry.contentRect
+        if (width === 0 || height === 0) {
+          return
+        }
+
+        if (!chartRef.current) {
+          initChartIfReady(width, height)
+        } else {
+          // Resize the chart when the container size changes.
+          // because ECharts does not automatically detect container size changes.
+          chartRef.current.resize()
+        }
+      })
+
+      resizeObserver.observe(container)
     }
 
     return () => {
       resizeObserver?.disconnect()
     }
-  }, [containerRef])
+  }, [containerRef, renderChartOption])
 
   return (
     <ImagePreviewLayout

--- a/src/renderer/components/Preview/EChartsPreview.tsx
+++ b/src/renderer/components/Preview/EChartsPreview.tsx
@@ -1,0 +1,73 @@
+import { useTheme } from '@renderer/hooks/useTheme'
+import type { EChartsCoreOption } from 'echarts'
+import * as echarts from 'echarts'
+import { memo, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import ImagePreviewLayout from './ImagePreviewLayout'
+import type { BasicPreviewHandles, BasicPreviewProps } from './types'
+
+const EChartsPreview = ({
+  children,
+  enableToolbar = false,
+  ref
+}: BasicPreviewProps & { ref?: React.RefObject<BasicPreviewHandles | null> }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [error, setError] = useState<string | null>(null)
+  const { theme } = useTheme()
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    let chart: ReturnType<typeof echarts.init> | null = null
+    let resizeObserver: ResizeObserver | null = null
+    let handleWindowResize: (() => void) | null = null
+    let parsedOption: EChartsCoreOption | undefined
+
+    try {
+      parsedOption = JSON.parse(children) as EChartsCoreOption
+    } catch {
+      setError(t('code_block.preview.invalid_json'))
+      return
+    }
+
+    try {
+      if (!containerRef.current) {
+        return
+      }
+
+      const chartTheme = theme === 'dark' ? 'dark' : undefined
+      chart = echarts.init(containerRef.current, chartTheme, { renderer: 'svg' })
+      chart.setOption(parsedOption)
+      setError(null)
+
+      if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(() => chart?.resize())
+        resizeObserver.observe(containerRef.current)
+      }
+
+      handleWindowResize = () => chart?.resize()
+      window.addEventListener('resize', handleWindowResize)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(message)
+    }
+
+    return () => {
+      if (handleWindowResize) {
+        window.removeEventListener('resize', handleWindowResize)
+      }
+      if (resizeObserver) {
+        resizeObserver.disconnect()
+      }
+      chart?.dispose()
+    }
+  }, [children, theme, t])
+
+  return (
+    <ImagePreviewLayout error={error} enableToolbar={enableToolbar} ref={ref} imageRef={containerRef} source="echarts">
+      <div ref={containerRef} className="echarts special-preview h-64 w-full" />
+    </ImagePreviewLayout>
+  )
+}
+
+export default memo(EChartsPreview)

--- a/src/renderer/components/Preview/EChartsPreview.tsx
+++ b/src/renderer/components/Preview/EChartsPreview.tsx
@@ -1,9 +1,10 @@
 import { useTheme } from '@renderer/hooks/useTheme'
 import type { EChartsCoreOption } from 'echarts'
 import * as echarts from 'echarts'
-import { memo, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { useDebouncedRender } from './hooks/useDebouncedRender'
 import ImagePreviewLayout from './ImagePreviewLayout'
 import type { BasicPreviewHandles, BasicPreviewProps } from './types'
 
@@ -12,59 +13,65 @@ const EChartsPreview = ({
   enableToolbar = false,
   ref
 }: BasicPreviewProps & { ref?: React.RefObject<BasicPreviewHandles | null> }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const [error, setError] = useState<string | null>(null)
   const { theme } = useTheme()
   const { t } = useTranslation()
+  const chartRef = useRef<ReturnType<typeof echarts.init> | null>(null)
 
-  useEffect(() => {
-    let chart: ReturnType<typeof echarts.init> | null = null
-    let resizeObserver: ResizeObserver | null = null
-    let handleWindowResize: (() => void) | null = null
-    let parsedOption: EChartsCoreOption | undefined
-
-    try {
-      parsedOption = JSON.parse(children) as EChartsCoreOption
-    } catch {
-      setError(t('code_block.preview.invalid_json'))
-      return
-    }
-
-    try {
-      if (!containerRef.current) {
+  const renderChart = useCallback(
+    async (content: string, container: HTMLDivElement) => {
+      if (!content) {
         return
       }
 
-      const chartTheme = theme === 'dark' ? 'dark' : undefined
-      chart = echarts.init(containerRef.current, chartTheme, { renderer: 'svg' })
-      chart.setOption(parsedOption)
-      setError(null)
-
-      if (typeof ResizeObserver !== 'undefined') {
-        resizeObserver = new ResizeObserver(() => chart?.resize())
-        resizeObserver.observe(containerRef.current)
+      let option: EChartsCoreOption
+      try {
+        option = JSON.parse(content) as EChartsCoreOption
+      } catch {
+        throw new Error(t('code_block.preview.invalid_json'))
       }
 
-      handleWindowResize = () => chart?.resize()
-      window.addEventListener('resize', handleWindowResize)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      setError(message)
+      if (!chartRef.current) {
+        chartRef.current = echarts.init(container, theme === 'dark' ? 'dark' : undefined, { renderer: 'svg' })
+      }
+
+      chartRef.current.setOption(option, true)
+    },
+    [t, theme]
+  )
+
+  const { containerRef, error, isLoading } = useDebouncedRender(children, renderChart, { debounceDelay: 300 })
+
+  useEffect(() => {
+    return () => {
+      chartRef.current?.dispose()
+      chartRef.current = null
+    }
+  }, [theme])
+
+  useEffect(() => {
+    if (!containerRef.current) {
+      return
+    }
+
+    let resizeObserver: ResizeObserver | null = null
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => chartRef.current?.resize())
+      resizeObserver.observe(containerRef.current)
     }
 
     return () => {
-      if (handleWindowResize) {
-        window.removeEventListener('resize', handleWindowResize)
-      }
-      if (resizeObserver) {
-        resizeObserver.disconnect()
-      }
-      chart?.dispose()
+      resizeObserver?.disconnect()
     }
-  }, [children, theme, t])
+  }, [containerRef])
 
   return (
-    <ImagePreviewLayout error={error} enableToolbar={enableToolbar} ref={ref} imageRef={containerRef} source="echarts">
+    <ImagePreviewLayout
+      loading={isLoading}
+      error={error}
+      enableToolbar={enableToolbar}
+      ref={ref}
+      imageRef={containerRef}
+      source="echarts">
       <div ref={containerRef} className="echarts special-preview h-64 w-full" />
     </ImagePreviewLayout>
   )

--- a/src/renderer/components/Preview/EChartsPreview.tsx
+++ b/src/renderer/components/Preview/EChartsPreview.tsx
@@ -11,15 +11,24 @@ import type { BasicPreviewHandles, BasicPreviewProps } from './types'
 const EChartsPreview = ({
   children,
   enableToolbar = false,
+  isStreaming = false,
   ref
 }: BasicPreviewProps & { ref?: React.RefObject<BasicPreviewHandles | null> }) => {
   const { theme } = useTheme()
   const { t } = useTranslation()
   const chartRef = useRef<ReturnType<typeof echarts.init> | null>(null)
+  const wasStreamingRef = useRef(isStreaming)
 
   const renderChart = useCallback(
     async (content: string, container: HTMLDivElement) => {
       if (!content) {
+        return
+      }
+
+      // While the source is still streaming, never surface temporary parse errors
+      // or commit a partially-generated option. The caller will trigger an immediate
+      // render once streaming completes.
+      if (isStreaming) {
         return
       }
 
@@ -36,10 +45,21 @@ const EChartsPreview = ({
 
       chartRef.current.setOption(option, true)
     },
-    [t, theme]
+    [isStreaming, t, theme]
   )
 
-  const { containerRef, error, isLoading } = useDebouncedRender(children, renderChart, { debounceDelay: 300 })
+  const { containerRef, error, isLoading, triggerImmediateRender } = useDebouncedRender(children, renderChart, {
+    debounceDelay: 300
+  })
+
+  // Render the exact final option immediately when streaming completes. After that,
+  // ordinary children changes continue to be debounced by useDebouncedRender.
+  useEffect(() => {
+    if (wasStreamingRef.current && !isStreaming) {
+      triggerImmediateRender(children)
+    }
+    wasStreamingRef.current = isStreaming
+  }, [children, isStreaming, triggerImmediateRender])
 
   useEffect(() => {
     return () => {
@@ -66,7 +86,7 @@ const EChartsPreview = ({
 
   return (
     <ImagePreviewLayout
-      loading={isLoading}
+      loading={isLoading || isStreaming}
       error={error}
       enableToolbar={enableToolbar}
       ref={ref}

--- a/src/renderer/components/Preview/EChartsPreview.tsx
+++ b/src/renderer/components/Preview/EChartsPreview.tsx
@@ -89,6 +89,9 @@ const EChartsPreview = ({
       loading={isLoading || isStreaming}
       error={error}
       enableToolbar={enableToolbar}
+      // ECharts owns interactions inside the chart; generic image pan/zoom would break its coordinate model.
+      enableDrag={false}
+      enableWheelZoom={false}
       ref={ref}
       imageRef={containerRef}
       source="echarts">

--- a/src/renderer/components/Preview/ImagePreviewLayout.tsx
+++ b/src/renderer/components/Preview/ImagePreviewLayout.tsx
@@ -14,6 +14,8 @@ interface ImagePreviewLayoutProps {
   loading?: boolean
   error?: string | null
   enableToolbar?: boolean
+  enableDrag?: boolean
+  enableWheelZoom?: boolean
   className?: string
 }
 
@@ -27,14 +29,16 @@ const ImagePreviewLayout = ({
   loading,
   error,
   enableToolbar,
+  enableDrag = true,
+  enableWheelZoom = true,
   className
 }: ImagePreviewLayoutProps) => {
   // 使用通用图像工具
   const { pan, zoom, copy, download, dialog } = useImageTools(imageRef, {
     imgSelector: 'svg',
     prefix: source ?? 'svg',
-    enableDrag: true,
-    enableWheelZoom: true
+    enableDrag,
+    enableWheelZoom
   })
 
   useImperativeHandle(ref, () => {
@@ -47,6 +51,8 @@ const ImagePreviewLayout = ({
     }
   })
 
+  const enablePanZoom = enableDrag || enableWheelZoom
+
   return (
     <PreviewContainer className={`image-preview-layout flex-col ${className ?? ''}`}>
       {loading && (
@@ -56,7 +62,7 @@ const ImagePreviewLayout = ({
       )}
       {error && <PreviewError>{error}</PreviewError>}
       {children}
-      {!error && enableToolbar && <ImageToolbar pan={pan} zoom={zoom} dialog={dialog} />}
+      {!error && enableToolbar && <ImageToolbar pan={pan} zoom={zoom} dialog={dialog} enablePanZoom={enablePanZoom} />}
     </PreviewContainer>
   )
 }

--- a/src/renderer/components/Preview/ImageToolbar.tsx
+++ b/src/renderer/components/Preview/ImageToolbar.tsx
@@ -10,10 +10,11 @@ interface ImageToolbarProps {
   pan: (dx: number, dy: number, absolute?: boolean) => void
   zoom: (delta: number, absolute?: boolean) => void
   dialog: () => void
+  enablePanZoom?: boolean
   className?: string
 }
 
-const ImageToolbar = ({ pan, zoom, dialog, className }: ImageToolbarProps) => {
+const ImageToolbar = ({ pan, zoom, dialog, enablePanZoom = true, className }: ImageToolbarProps) => {
   const { t } = useTranslation()
 
   // 定义平移距离
@@ -35,50 +36,58 @@ const ImageToolbar = ({ pan, zoom, dialog, className }: ImageToolbarProps) => {
       )}
       role="toolbar"
       aria-label={t('preview.label')}>
-      {/* Up */}
-      <div className="flex w-full justify-center gap-1">
-        <div className="flex-1" />
-        <ImageToolButton
-          tooltip={t('preview.pan_up')}
-          icon={<ChevronUp size={'1rem'} />}
-          onClick={() => pan(0, -panDistance)}
-        />
-        <ImageToolButton tooltip={t('preview.dialog')} icon={<Scan size={'1rem'} />} onClick={dialog} />
-      </div>
+      {enablePanZoom ? (
+        <>
+          {/* Up */}
+          <div className="flex w-full justify-center gap-1">
+            <div className="flex-1" />
+            <ImageToolButton
+              tooltip={t('preview.pan_up')}
+              icon={<ChevronUp size={'1rem'} />}
+              onClick={() => pan(0, -panDistance)}
+            />
+            <ImageToolButton tooltip={t('preview.dialog')} icon={<Scan size={'1rem'} />} onClick={dialog} />
+          </div>
 
-      {/* Left, Reset, Right */}
-      <div className="flex w-full justify-center gap-1">
-        <ImageToolButton
-          tooltip={t('preview.pan_left')}
-          icon={<ChevronLeft size={'1rem'} />}
-          onClick={() => pan(-panDistance, 0)}
-        />
-        <ImageToolButton tooltip={t('preview.reset')} icon={<ResetIcon size={'1rem'} />} onClick={handleReset} />
-        <ImageToolButton
-          tooltip={t('preview.pan_right')}
-          icon={<ChevronRight size={'1rem'} />}
-          onClick={() => pan(panDistance, 0)}
-        />
-      </div>
+          {/* Left, Reset, Right */}
+          <div className="flex w-full justify-center gap-1">
+            <ImageToolButton
+              tooltip={t('preview.pan_left')}
+              icon={<ChevronLeft size={'1rem'} />}
+              onClick={() => pan(-panDistance, 0)}
+            />
+            <ImageToolButton tooltip={t('preview.reset')} icon={<ResetIcon size={'1rem'} />} onClick={handleReset} />
+            <ImageToolButton
+              tooltip={t('preview.pan_right')}
+              icon={<ChevronRight size={'1rem'} />}
+              onClick={() => pan(panDistance, 0)}
+            />
+          </div>
 
-      {/* Down, Zoom */}
-      <div className="flex w-full justify-center gap-1">
-        <ImageToolButton
-          tooltip={t('preview.zoom_out')}
-          icon={<ZoomOut size={'1rem'} />}
-          onClick={() => zoom(-zoomDelta)}
-        />
-        <ImageToolButton
-          tooltip={t('preview.pan_down')}
-          icon={<ChevronDown size={'1rem'} />}
-          onClick={() => pan(0, panDistance)}
-        />
-        <ImageToolButton
-          tooltip={t('preview.zoom_in')}
-          icon={<ZoomIn size={'1rem'} />}
-          onClick={() => zoom(zoomDelta)}
-        />
-      </div>
+          {/* Down, Zoom */}
+          <div className="flex w-full justify-center gap-1">
+            <ImageToolButton
+              tooltip={t('preview.zoom_out')}
+              icon={<ZoomOut size={'1rem'} />}
+              onClick={() => zoom(-zoomDelta)}
+            />
+            <ImageToolButton
+              tooltip={t('preview.pan_down')}
+              icon={<ChevronDown size={'1rem'} />}
+              onClick={() => pan(0, panDistance)}
+            />
+            <ImageToolButton
+              tooltip={t('preview.zoom_in')}
+              icon={<ZoomIn size={'1rem'} />}
+              onClick={() => zoom(zoomDelta)}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="flex w-full justify-center gap-1">
+          <ImageToolButton tooltip={t('preview.dialog')} icon={<Scan size={'1rem'} />} onClick={dialog} />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
+++ b/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
@@ -72,6 +72,7 @@ describe('EChartsPreview', () => {
     })
     mocks.theme.theme = 'light'
     resizeCallback = undefined
+    vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({ width: 640, height: 256 } as DOMRect)
     vi.stubGlobal(
       'ResizeObserver',
       vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
@@ -84,11 +85,30 @@ describe('EChartsPreview', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   const advanceDebounce = async () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(300)
+    })
+  }
+
+  const getChartContainer = () => document.querySelector('.echarts') as HTMLElement
+
+  const stubContainerSize = (width: number, height: number) => {
+    const container = getChartContainer()
+    if (container) {
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({ width, height } as DOMRect)
+    }
+  }
+
+  const fireResize = (width: number, height: number) => {
+    act(() => {
+      resizeCallback?.(
+        [{ contentRect: { width, height } } as unknown as ResizeObserverEntry],
+        mocks.resizeObserver as unknown as ResizeObserver
+      )
     })
   }
 
@@ -172,15 +192,89 @@ describe('EChartsPreview', () => {
     expect(mocks.chart.dispose).toHaveBeenCalledTimes(1)
   })
 
-  it('calls chart.resize when ResizeObserver fires', async () => {
+  it('calls chart.resize when ResizeObserver reports positive dimensions', async () => {
     render(<EChartsPreview>{validOption}</EChartsPreview>)
     await advanceDebounce()
 
-    act(() => {
-      resizeCallback?.([], mocks.resizeObserver as unknown as ResizeObserver)
-    })
+    fireResize(640, 256)
 
     expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not initialize the chart in a zero-sized container', async () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    stubContainerSize(0, 0)
+    await advanceDebounce()
+
+    expect(mocks.init).not.toHaveBeenCalled()
+    expect(mocks.chart.setOption).not.toHaveBeenCalled()
+  })
+
+  it('initializes the chart with the latest ready option when the container transitions from zero to positive size', async () => {
+    const { rerender } = render(<EChartsPreview>{validOption}</EChartsPreview>)
+    stubContainerSize(0, 0)
+    await advanceDebounce()
+
+    expect(mocks.init).not.toHaveBeenCalled()
+
+    const updatedOption = JSON.stringify({ series: [{ data: [5, 6], type: 'line' }] })
+    rerender(<EChartsPreview>{updatedOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    expect(mocks.init).not.toHaveBeenCalled()
+
+    fireResize(640, 256)
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(updatedOption), true)
+  })
+
+  it('calls resize on subsequent positive-size ResizeObserver notifications without re-initializing', async () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    fireResize(640, 256)
+    fireResize(800, 400)
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.chart.resize).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not initialize the chart when ResizeObserver reports zero dimensions', async () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    stubContainerSize(0, 0)
+    await advanceDebounce()
+
+    fireResize(0, 0)
+
+    expect(mocks.init).not.toHaveBeenCalled()
+    expect(mocks.chart.resize).not.toHaveBeenCalled()
+  })
+
+  it('does not re-initialize with a stale option after invalid JSON follows a valid render', async () => {
+    const { rerender } = render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+
+    // Simulate the container becoming hidden and dispose the instance via a theme change.
+    stubContainerSize(0, 0)
+    mocks.theme.theme = 'dark'
+    rerender(<EChartsPreview enableToolbar>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    // The disposed chart should not be re-initialized while the container has no size.
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+
+    // Now replace the valid option with invalid JSON while still hidden.
+    rerender(<EChartsPreview enableToolbar>{'{invalid'}</EChartsPreview>)
+    await advanceDebounce()
+
+    expect(screen.getByText('Invalid JSON configuration')).toBeInTheDocument()
+
+    // Becoming visible again must not resurrect the previous valid option.
+    fireResize(640, 256)
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
   })
 
   it('does not surface JSON parse errors while streaming', async () => {

--- a/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
+++ b/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
@@ -181,4 +181,87 @@ describe('EChartsPreview', () => {
 
     expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
   })
+
+  it('does not surface JSON parse errors while streaming', async () => {
+    render(<EChartsPreview isStreaming>{'{invalid'}</EChartsPreview>)
+
+    await advanceDebounce()
+
+    expect(screen.queryByText('Invalid JSON configuration')).not.toBeInTheDocument()
+    expect(mocks.init).not.toHaveBeenCalled()
+  })
+
+  it('does not commit a partial option even if it parses as valid JSON while streaming', async () => {
+    const partial = JSON.stringify({ xAxis: { type: 'category' } })
+    render(<EChartsPreview isStreaming>{partial}</EChartsPreview>)
+
+    await advanceDebounce()
+
+    expect(mocks.init).not.toHaveBeenCalled()
+    expect(mocks.chart.setOption).not.toHaveBeenCalled()
+  })
+
+  it('keeps suppressing errors and partial renders through a streaming pause longer than the debounce delay', async () => {
+    const { rerender } = render(<EChartsPreview isStreaming>{'{invalid'}</EChartsPreview>)
+
+    // Pause longer than the 300 ms debounce while still streaming.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+
+    expect(screen.queryByText('Invalid JSON configuration')).not.toBeInTheDocument()
+    expect(mocks.init).not.toHaveBeenCalled()
+
+    rerender(<EChartsPreview>{validOption}</EChartsPreview>)
+
+    // Should render immediately without waiting for the debounce interval.
+    await act(async () => {})
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(validOption), true)
+  })
+
+  it('renders the final option immediately when streaming completes', async () => {
+    const { rerender } = render(<EChartsPreview isStreaming>{'{invalid'}</EChartsPreview>)
+    await advanceDebounce()
+
+    rerender(<EChartsPreview>{validOption}</EChartsPreview>)
+
+    // Should render immediately without waiting for the debounce interval.
+    await act(async () => {})
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(validOption), true)
+  })
+
+  it('surfaces invalid JSON after streaming completes', async () => {
+    const { rerender } = render(<EChartsPreview isStreaming>{'{invalid'}</EChartsPreview>)
+    await advanceDebounce()
+
+    rerender(<EChartsPreview>{'{invalid'}</EChartsPreview>)
+
+    await act(async () => {})
+
+    expect(screen.getByText('Invalid JSON configuration')).toBeInTheDocument()
+    expect(mocks.init).not.toHaveBeenCalled()
+  })
+
+  it('debounces updates after streaming completes', async () => {
+    const { rerender } = render(<EChartsPreview isStreaming>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    rerender(<EChartsPreview>{validOption}</EChartsPreview>)
+    await act(async () => {})
+    expect(mocks.chart.setOption).toHaveBeenCalledTimes(1)
+
+    const updatedOption = JSON.stringify({ series: [{ data: [3, 4], type: 'line' }] })
+    rerender(<EChartsPreview>{updatedOption}</EChartsPreview>)
+
+    expect(mocks.chart.setOption).toHaveBeenCalledTimes(1)
+
+    await advanceDebounce()
+
+    expect(mocks.chart.setOption).toHaveBeenCalledTimes(2)
+    expect(mocks.chart.setOption).toHaveBeenLastCalledWith(JSON.parse(updatedOption), true)
+  })
 })

--- a/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
+++ b/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
@@ -1,3 +1,4 @@
+import { useImageTools } from '@renderer/components/ActionTools'
 import { act, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -42,7 +43,7 @@ vi.mock('@renderer/hooks/useTheme', () => ({
 }))
 
 vi.mock('@renderer/components/ActionTools', () => ({
-  useImageTools: () => mocks.imageActions
+  useImageTools: vi.fn(() => mocks.imageActions)
 }))
 
 vi.mock('@renderer/components/icons/LoadingIcon', () => ({
@@ -263,5 +264,18 @@ describe('EChartsPreview', () => {
 
     expect(mocks.chart.setOption).toHaveBeenCalledTimes(2)
     expect(mocks.chart.setOption).toHaveBeenLastCalledWith(JSON.parse(updatedOption), true)
+  })
+
+  it('disables generic image drag and wheel zoom so ECharts owns chart interactions', async () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    expect(useImageTools).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        enableDrag: false,
+        enableWheelZoom: false
+      })
+    )
   })
 })

--- a/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
+++ b/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
@@ -1,0 +1,131 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import EChartsPreview from '../EChartsPreview'
+
+const mocks = vi.hoisted(() => ({
+  chart: {
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn()
+  },
+  init: vi.fn(),
+  theme: { theme: 'light' },
+  imageActions: {
+    pan: vi.fn(),
+    zoom: vi.fn(),
+    copy: vi.fn(),
+    download: vi.fn(),
+    dialog: vi.fn()
+  },
+  resizeObserver: {
+    observe: vi.fn(),
+    disconnect: vi.fn(),
+    unobserve: vi.fn()
+  }
+}))
+
+vi.mock('echarts', () => ({
+  init: mocks.init
+}))
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => mocks.theme
+}))
+
+vi.mock('@renderer/components/ActionTools', () => ({
+  useImageTools: () => mocks.imageActions
+}))
+
+vi.mock('@renderer/components/icons/LoadingIcon', () => ({
+  default: () => <div data-testid="loading-indicator" />
+}))
+
+describe('EChartsPreview', () => {
+  const validOption = JSON.stringify({
+    xAxis: { type: 'category', data: ['A', 'B'] },
+    yAxis: { type: 'value' },
+    series: [{ data: [1, 2], type: 'bar' }]
+  })
+  let resizeCallback: ResizeObserverCallback | undefined
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.chart.setOption.mockReset()
+    mocks.chart.resize.mockReset()
+    mocks.chart.dispose.mockReset()
+    mocks.init.mockReset()
+    mocks.init.mockImplementation((container: HTMLElement) => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      container.appendChild(svg)
+      return mocks.chart
+    })
+    mocks.theme.theme = 'light'
+    resizeCallback = undefined
+    vi.stubGlobal(
+      'ResizeObserver',
+      vi.fn().mockImplementation((callback: ResizeObserverCallback) => {
+        resizeCallback = callback
+        return mocks.resizeObserver
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('parses and renders a valid JSON option into an svg container', () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    const container = mocks.init.mock.calls[0][0] as HTMLElement
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.init).toHaveBeenCalledWith(expect.any(HTMLElement), undefined, { renderer: 'svg' })
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(validOption))
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('uses dark theme when the app theme is dark', () => {
+    mocks.theme.theme = 'dark'
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    expect(mocks.init).toHaveBeenCalledWith(expect.any(HTMLElement), 'dark', { renderer: 'svg' })
+  })
+
+  it('surfaces JSON parse errors in PreviewError', () => {
+    render(<EChartsPreview>{'{invalid'}</EChartsPreview>)
+    expect(screen.getByText('配置 JSON 格式错误')).toBeInTheDocument()
+    expect(mocks.init).not.toHaveBeenCalled()
+  })
+
+  it('surfaces ECharts setOption errors', () => {
+    mocks.chart.setOption.mockImplementation(() => {
+      throw new Error('Invalid option')
+    })
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    expect(screen.getByText('Invalid option')).toBeInTheDocument()
+  })
+
+  it('disposes the previous instance when children changes', () => {
+    const { rerender } = render(<EChartsPreview>{validOption}</EChartsPreview>)
+    expect(mocks.chart.dispose).not.toHaveBeenCalled()
+
+    rerender(<EChartsPreview>{JSON.stringify({ series: [] })}</EChartsPreview>)
+    expect(mocks.chart.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls chart.resize when ResizeObserver fires', () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    act(() => {
+      resizeCallback?.([], mocks.resizeObserver as unknown as ResizeObserver)
+    })
+    expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls chart.resize on window resize', () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+    })
+    expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
+++ b/src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx
@@ -26,7 +26,15 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('echarts', () => ({
-  init: mocks.init
+  __esModule: true,
+  init: mocks.init,
+  default: { init: mocks.init }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'code_block.preview.invalid_json' ? 'Invalid JSON configuration' : key)
+  })
 }))
 
 vi.mock('@renderer/hooks/useTheme', () => ({
@@ -50,6 +58,7 @@ describe('EChartsPreview', () => {
   let resizeCallback: ResizeObserverCallback | undefined
 
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     mocks.chart.setOption.mockReset()
     mocks.chart.resize.mockReset()
@@ -72,60 +81,104 @@ describe('EChartsPreview', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
-  it('parses and renders a valid JSON option into an svg container', () => {
+  const advanceDebounce = async () => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300)
+    })
+  }
+
+  it('shows a loading indicator while the chart is debounced', async () => {
     render(<EChartsPreview>{validOption}</EChartsPreview>)
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument()
+  })
+
+  it('parses and renders a valid JSON option into an svg container', async () => {
+    render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
     const container = mocks.init.mock.calls[0][0] as HTMLElement
 
     expect(mocks.init).toHaveBeenCalledTimes(1)
     expect(mocks.init).toHaveBeenCalledWith(expect.any(HTMLElement), undefined, { renderer: 'svg' })
-    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(validOption))
+    expect(mocks.chart.setOption).toHaveBeenCalledWith(JSON.parse(validOption), true)
     expect(container.querySelector('svg')).toBeInTheDocument()
   })
 
-  it('uses dark theme when the app theme is dark', () => {
+  it('uses dark theme when the app theme is dark', async () => {
     mocks.theme.theme = 'dark'
     render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
     expect(mocks.init).toHaveBeenCalledWith(expect.any(HTMLElement), 'dark', { renderer: 'svg' })
   })
 
-  it('surfaces JSON parse errors in PreviewError', () => {
+  it('surfaces JSON parse errors in PreviewError', async () => {
     render(<EChartsPreview>{'{invalid'}</EChartsPreview>)
-    expect(screen.getByText('配置 JSON 格式错误')).toBeInTheDocument()
+    await advanceDebounce()
+
+    expect(screen.getByText('Invalid JSON configuration')).toBeInTheDocument()
     expect(mocks.init).not.toHaveBeenCalled()
   })
 
-  it('surfaces ECharts setOption errors', () => {
+  it('surfaces ECharts setOption errors', async () => {
     mocks.chart.setOption.mockImplementation(() => {
       throw new Error('Invalid option')
     })
     render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
     expect(screen.getByText('Invalid option')).toBeInTheDocument()
   })
 
-  it('disposes the previous instance when children changes', () => {
+  it('reuses the existing instance when children changes', async () => {
     const { rerender } = render(<EChartsPreview>{validOption}</EChartsPreview>)
-    expect(mocks.chart.dispose).not.toHaveBeenCalled()
+    await advanceDebounce()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
 
-    rerender(<EChartsPreview>{JSON.stringify({ series: [] })}</EChartsPreview>)
+    const updatedOption = JSON.stringify({ series: [{ data: [3, 4], type: 'line' }] })
+    rerender(<EChartsPreview>{updatedOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.chart.setOption).toHaveBeenCalledTimes(2)
+    expect(mocks.chart.setOption).toHaveBeenLastCalledWith(JSON.parse(updatedOption), true)
+  })
+
+  it('re-initializes the chart when the theme changes', async () => {
+    const { rerender } = render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+
+    mocks.theme.theme = 'dark'
+    rerender(<EChartsPreview enableToolbar>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    expect(mocks.chart.dispose).toHaveBeenCalledTimes(1)
+    expect(mocks.init).toHaveBeenCalledTimes(2)
+    expect(mocks.init).toHaveBeenLastCalledWith(expect.any(HTMLElement), 'dark', { renderer: 'svg' })
+  })
+
+  it('disposes the chart when the component unmounts', async () => {
+    const { unmount } = render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
+    unmount()
     expect(mocks.chart.dispose).toHaveBeenCalledTimes(1)
   })
 
-  it('calls chart.resize when ResizeObserver fires', () => {
+  it('calls chart.resize when ResizeObserver fires', async () => {
     render(<EChartsPreview>{validOption}</EChartsPreview>)
+    await advanceDebounce()
+
     act(() => {
       resizeCallback?.([], mocks.resizeObserver as unknown as ResizeObserver)
     })
-    expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
-  })
 
-  it('calls chart.resize on window resize', () => {
-    render(<EChartsPreview>{validOption}</EChartsPreview>)
-    act(() => {
-      window.dispatchEvent(new Event('resize'))
-    })
     expect(mocks.chart.resize).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/components/Preview/__tests__/ImagePreviewLayout.test.tsx
+++ b/src/renderer/components/Preview/__tests__/ImagePreviewLayout.test.tsx
@@ -1,3 +1,4 @@
+import { useImageTools } from '@renderer/components/ActionTools'
 import { render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -13,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/components/ActionTools', () => ({
-  useImageTools: () => mocks
+  useImageTools: vi.fn(() => mocks)
 }))
 
 vi.mock('@renderer/components/icons/LoadingIcon', () => ({
@@ -69,5 +70,29 @@ describe('ImagePreviewLayout', () => {
       copy: mocks.copy,
       download: mocks.download
     })
+  })
+
+  it('enables drag and wheel zoom by default', () => {
+    render(<ImagePreviewLayout {...defaultProps} />)
+
+    expect(useImageTools).toHaveBeenCalledWith(
+      defaultProps.imageRef,
+      expect.objectContaining({
+        enableDrag: true,
+        enableWheelZoom: true
+      })
+    )
+  })
+
+  it('forwards explicit drag and wheel zoom settings to useImageTools', () => {
+    render(<ImagePreviewLayout {...defaultProps} enableDrag={false} enableWheelZoom={false} />)
+
+    expect(useImageTools).toHaveBeenCalledWith(
+      defaultProps.imageRef,
+      expect.objectContaining({
+        enableDrag: false,
+        enableWheelZoom: false
+      })
+    )
   })
 })

--- a/src/renderer/components/Preview/__tests__/ImageToolbar.test.tsx
+++ b/src/renderer/components/Preview/__tests__/ImageToolbar.test.tsx
@@ -66,4 +66,19 @@ describe('ImageToolbar', () => {
 
     expect(openDialog).toHaveBeenCalledOnce()
   })
+
+  it('hides pan/zoom controls but keeps the dialog control when pan/zoom is disabled', async () => {
+    const user = userEvent.setup()
+    render(<ImageToolbar pan={pan} zoom={zoom} dialog={openDialog} enablePanZoom={false} />)
+
+    expect(screen.queryByRole('button', { name: 'preview.pan_up' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'preview.zoom_in' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'preview.reset' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'preview.dialog' }))
+
+    expect(openDialog).toHaveBeenCalledOnce()
+    expect(pan).not.toHaveBeenCalled()
+    expect(zoom).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/components/Preview/__tests__/useDebouncedRender.test.ts
+++ b/src/renderer/components/Preview/__tests__/useDebouncedRender.test.ts
@@ -77,4 +77,28 @@ describe('useDebouncedRender', () => {
     expect(renderFunction).not.toHaveBeenCalled()
     expect(result.current.isLoading).toBe(false)
   })
+
+  it('renders immediately with triggerImmediateRender and cancels pending debounced renders', async () => {
+    const renderFunction = vi.fn(async () => {})
+    const { result } = renderHook(() => useDebouncedRender('', renderFunction, { debounceDelay: 100 }))
+    const container = document.createElement('div')
+    result.current.containerRef.current = container
+
+    act(() => {
+      result.current.triggerRender('first')
+    })
+
+    act(() => {
+      result.current.triggerImmediateRender('second')
+    })
+
+    expect(renderFunction).toHaveBeenCalledOnce()
+    expect(renderFunction).toHaveBeenCalledWith('second', container)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(renderFunction).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/components/Preview/hooks/useDebouncedRender.ts
+++ b/src/renderer/components/Preview/hooks/useDebouncedRender.ts
@@ -26,6 +26,8 @@ export interface DebouncedRenderResult {
   isLoading: boolean
   /** 手动触发渲染 */
   triggerRender: (content: string) => void
+  /** 立即触发渲染（跳过防抖） */
+  triggerImmediateRender: (content: string) => void
   /** 取消渲染 */
   cancelRender: () => void
   /** 清除错误状态 */
@@ -120,6 +122,22 @@ export const useDebouncedRender = (
     [debouncedRender]
   )
 
+  // 立即触发渲染（跳过防抖），用于流式完成时立即渲染最终内容
+  const triggerImmediateRender = useCallback(
+    (content: string) => {
+      if (content) {
+        setIsLoading(true)
+        debouncedRender.cancel()
+        void wrappedRenderFunction(content)
+      } else {
+        debouncedRender.cancel()
+        setIsLoading(false)
+        setError(null)
+      }
+    },
+    [debouncedRender, wrappedRenderFunction]
+  )
+
   const cancelRender = useCallback(() => {
     debouncedRender.cancel()
     setIsLoading(false)
@@ -160,6 +178,7 @@ export const useDebouncedRender = (
     error,
     isLoading,
     triggerRender,
+    triggerImmediateRender,
     cancelRender,
     clearError,
     setLoading: setLoadingState

--- a/src/renderer/components/Preview/types.ts
+++ b/src/renderer/components/Preview/types.ts
@@ -4,6 +4,8 @@
 export interface BasicPreviewProps {
   children: string
   enableToolbar?: boolean
+  /** True while the source is still being streamed / generated. */
+  isStreaming?: boolean
 }
 
 /**

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Gespeichert",
   "code_block.expand": "Ausklappen",
   "code_block.more": "Mehr",
+  "code_block.preview.invalid_json": "Ungültige JSON-Konfiguration",
   "code_block.run": "Code ausführen",
   "code_block.split.label": "Ansicht teilen",
   "code_block.split.restore": "Ansichtsteilung aufheben",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Αποθηκεύτηκε",
   "code_block.expand": "επιλογή",
   "code_block.more": "Περισσότερα",
+  "code_block.preview.invalid_json": "Μη έγκυρη διαμόρφωση JSON",
   "code_block.run": "Εκτέλεση κώδικα",
   "code_block.split.label": "Διαχωρισμός προβολής",
   "code_block.split.restore": "Ακύρωση διαχωρισμού προβολής",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Saved",
   "code_block.expand": "Expand",
   "code_block.more": "More",
+  "code_block.preview.invalid_json": "Invalid JSON configuration",
   "code_block.run": "Run",
   "code_block.split.label": "Split View",
   "code_block.split.restore": "Restore Split View",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Guardado",
   "code_block.expand": "Expandir",
   "code_block.more": "Más",
+  "code_block.preview.invalid_json": "Configuración JSON no válida",
   "code_block.run": "Ejecutar código",
   "code_block.split.label": "Dividir vista",
   "code_block.split.restore": "Cancelar vista dividida",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Enregistré",
   "code_block.expand": "Développer",
   "code_block.more": "Plus",
+  "code_block.preview.invalid_json": "Configuration JSON invalide",
   "code_block.run": "Exécuter le code",
   "code_block.split.label": "Fractionner la vue",
   "code_block.split.restore": "Annuler la vue fractionnée",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "保存しました",
   "code_block.expand": "展開する",
   "code_block.more": "もっと",
+  "code_block.preview.invalid_json": "JSON 設定の形式が無効です",
   "code_block.run": "コードを実行",
   "code_block.split.label": "分割視圖",
   "code_block.split.restore": "分割視圖を解除",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Guardado",
   "code_block.expand": "Expandir",
   "code_block.more": "Mais",
+  "code_block.preview.invalid_json": "Configuração JSON inválida",
   "code_block.run": "Executar código",
   "code_block.split.label": "Dividir visualização",
   "code_block.split.restore": "Cancelar divisão de visualização",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Salvat",
   "code_block.expand": "Extinde",
   "code_block.more": "Mai mult",
+  "code_block.preview.invalid_json": "Configurație JSON invalidă",
   "code_block.run": "Rulează",
   "code_block.split.label": "Vizualizare divizată",
   "code_block.split.restore": "Restaurează vizualizarea divizată",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Изменения сохранены",
   "code_block.expand": "Развернуть",
   "code_block.more": "Ещё",
+  "code_block.preview.invalid_json": "Некорректная конфигурация JSON",
   "code_block.run": "Выполнить код",
   "code_block.split.label": "Разделить на два окна",
   "code_block.split.restore": "Вернуться к одному окну",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "Đã lưu",
   "code_block.expand": "Mở rộng",
   "code_block.more": "Thêm",
+  "code_block.preview.invalid_json": "Cấu hình JSON không hợp lệ",
   "code_block.run": "Chạy",
   "code_block.split.label": "Chia đôi màn hình",
   "code_block.split.restore": "Khôi phục Chế độ chia đôi",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "已保存",
   "code_block.expand": "展开",
   "code_block.more": "更多",
+  "code_block.preview.invalid_json": "配置 JSON 格式错误",
   "code_block.run": "运行代码",
   "code_block.split.label": "分割视图",
   "code_block.split.restore": "取消分割视图",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1034,6 +1034,7 @@
   "code_block.edit.save.success": "已儲存",
   "code_block.expand": "展開",
   "code_block.more": "更多",
+  "code_block.preview.invalid_json": "配置 JSON 格式錯誤",
   "code_block.run": "執行",
   "code_block.split.label": "分割檢視",
   "code_block.split.restore": "還原分割檢視",

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -517,10 +517,13 @@ export const captureScrollableIframeAsBlob = async (
  */
 export const svgToCanvas = (svgElement: SVGElement, scale = 3): Promise<HTMLCanvasElement> => {
   // 获取 SVG 尺寸信息
+  // 优先使用 viewBox；ECharts 等 SVG 渲染器可能直接设置 width/height 属性且没有 viewBox
   const viewBox = svgElement.getAttribute('viewBox')?.split(' ').map(Number) || []
+  const attrWidth = parseFloat(svgElement.getAttribute('width') || '')
+  const attrHeight = parseFloat(svgElement.getAttribute('height') || '')
   const rect = svgElement.getBoundingClientRect()
-  const width = viewBox[2] || svgElement.clientWidth || rect.width
-  const height = viewBox[3] || svgElement.clientHeight || rect.height
+  const width = viewBox[2] || svgElement.clientWidth || rect.width || attrWidth
+  const height = viewBox[3] || svgElement.clientHeight || rect.height || attrHeight
 
   // 序列化 SVG 内容
   const svgData = new XMLSerializer().serializeToString(svgElement)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Markdown code blocks tagged as `echarts` were rendered as plain JSON source code, so users could not see the chart directly inside the conversation.

After this PR:

Code blocks with language `echarts` are rendered as interactive ECharts diagrams using the existing special-view infrastructure. Users can switch between the chart preview, the source JSON, and a split view, and reuse the existing image toolbar actions (copy as image / download image / view source).

#### echarts example
```echarts
{
"title": {
"left": "center",
"text": "各季度工单数量分布"
},
"tooltip": {
"trigger": "axis",
"axisPointer": {
"type": "cross"
}
},
"xAxis": {
"type": "category",
"data": [
"1 季度",
"2 季度",
"3 季度",
"4 季度"
]
},
"yAxis": {
"type": "value"
},
"series": [
{
"data": [
93,
77,
90,
55
],
"type": "bar",
"smooth": true
}
]
}
```

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes  #4581 

### Why we need it and why it was done in this way

The implementation follows the same pattern already used for `MermaidPreview`, `PlantUmlPreview`, `SvgPreview`, and `GraphvizPreview`:

- Added `EChartsPreview.tsx` under `@renderer/components/Preview/`. It parses the code-block content as JSON and feeds it to `echarts.init(..., { renderer: 'svg' })`, with theme switching, resize observer, and error handling.
- Registered `echarts` in `SPECIAL_VIEWS` / `SPECIAL_VIEW_COMPONENTS` in `@renderer/components/CodeBlockView/constants.ts`, so `CodeBlockView` picks it up like the other diagram languages and automatically provides copy/download/view-source actions through `ImagePreviewLayout`.
- Added i18n key `code_block.preview.invalid_json` in all supported locales.
- Added unit tests in `src/renderer/components/Preview/__tests__/EChartsPreview.test.tsx` covering valid JSON, dark theme, JSON parse errors, `setOption` errors, disposal on prop changes, ResizeObserver resize, and window resize.

The following tradeoffs were made:

- ECharts is rendered with the SVG renderer so it integrates cleanly with the existing image-export utilities; PNG/SVG export reuse the same path as other special views.
- The preview height is fixed via Tailwind's `h-64`; charts with very large intrinsic widths are expected to fit within the responsive container.

The following alternatives were considered:

- Creating a standalone non-special-view component for ECharts. This was rejected because it would duplicate the toolbar, source/split toggles, and image actions that `CodeBlockView` already provides.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

The split-view layout in `CodeBlockView` changed from:

```tsx
className="split-view-wrapper flex *:w-full *:flex-[1_1_auto]"
```

to:

```tsx
className="split-view-wrapper flex *:min-w-0 *:flex-1"
```

This fixes a layout issue where the ECharts SVG container has a large intrinsic width and the source-code pane was collapsed to nearly zero in split view. The new classes make both panes start from `0%` and grow equally, while allowing each child to shrink below its content width.

This is a visual/layout change for all special views that support split mode, but the previous behavior was effectively broken for wide SVG charts; after the change, source and preview each take roughly 50% of the width as intended.

### Special notes for your reviewer

<!-- optional -->

- Screenshot / effect GIF placeholder — please attach here before submitting.
<img width="2669" height="1713" alt="20260819120814" src="https://github.com/user-attachments/assets/dc4de3b1-b082-4a2b-93b1-5d661f6e0340" />

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added support for rendering ECharts charts inside `echarts` code blocks in markdown messages. The preview integrates with the existing special-view toolbar, supporting theme-aware rendering, split view, copy image, and download image.
```
