### PR TITLE
fix(model-check): probe image-only models via the image endpoint

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -34,7 +34,7 @@ import type { ImageGenerationMode } from '@shared/data/types/model'
 import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import type { Base64String, CreateInternalEntryIpcParams, UrlString } from '@shared/types/file'
-import { isEmbeddingModel, isFunctionCallingModel, isRerankModel } from '@shared/utils/model'
+import { isEmbeddingModel, isFunctionCallingModel, isGenerateImageModel, isRerankModel } from '@shared/utils/model'
 import { isOllamaProvider } from '@shared/utils/provider'
 import {
   type EmbeddingModelUsage,
@@ -1154,6 +1154,14 @@ export class AiService extends BaseService {
       })
     } else if (isEmbeddingModel(model) && !hasChatPrimaryEndpoint) {
       probe = this.embedMany({ ...probeRequest, values: ['test'] })
+    } else if (isGenerateImageModel(model) && !hasChatPrimaryEndpoint) {
+      // Image-only models reject /chat/completions with a 400 — probe the image endpoint.
+      probe = this.generateImage({
+        ...probeRequest,
+        prompt: 'a red circle',
+        paramValues: {},
+        cleanupPolicy: 'delete_when_unreferenced'
+      })
     } else {
       // Latency is the probe's measured output — thinking tokens would pollute it
       // for reasoning-capable models whose provider default enables reasoning.

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1566,6 +1566,50 @@ describe('AiService tool approval', () => {
     expect(embedSpy).toHaveBeenCalledWith(expect.objectContaining({ values: ['test'] }))
   })
 
+  it('checks image-only models through the image endpoint, not chat', async () => {
+    const service = createService()
+    const imageSpy = vi.spyOn(service, 'generateImage').mockResolvedValue({ files: [] })
+    const generateSpy = vi.spyOn(service, 'generateText').mockResolvedValue({ text: 'ok' })
+    mockModelGetByKey.mockReturnValue({
+      id: 'test-provider::test-image',
+      providerId: 'test-provider',
+      apiModelId: 'test-image',
+      name: 'Test Image',
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_IMAGE_GENERATION],
+      supportsStreaming: false,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    await service.checkModel({ uniqueModelId: 'test-provider::test-image' })
+
+    expect(imageSpy).toHaveBeenCalledWith(expect.objectContaining({ prompt: expect.any(String) }))
+    expect(generateSpy).not.toHaveBeenCalled()
+  })
+
+  it('checks chat models that can also generate images through text generation', async () => {
+    const service = createService()
+    const imageSpy = vi.spyOn(service, 'generateImage').mockResolvedValue({ files: [] })
+    const generateSpy = vi.spyOn(service, 'generateText').mockResolvedValue({ text: 'ok' })
+    mockModelGetByKey.mockReturnValue({
+      id: 'test-provider::test-multimodal',
+      providerId: 'test-provider',
+      apiModelId: 'test-multimodal',
+      name: 'Test Multimodal',
+      capabilities: [MODEL_CAPABILITY.IMAGE_GENERATION],
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    })
+
+    await service.checkModel({ uniqueModelId: 'test-provider::test-multimodal' })
+
+    expect(generateSpy).toHaveBeenCalled()
+    expect(imageSpy).not.toHaveBeenCalled()
+  })
+
   it('fails rerank health checks when the probe returns an empty ranking', async () => {
     const service = createService()
     vi.spyOn(service, 'rerank').mockResolvedValue({ ranking: [] })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: checking an image-only model (a model with the `image_generation` capability whose primary endpoint is not chat) fell through to the text probe in `AiService.checkModel`, sending `{"messages":[...]}` to `/v1/chat/completions` and failing with a 400 like `Model ... is an image model. Use /v1/images/generations.`

After this PR: such models are probed through `generateImage` (the image endpoint) with a throwaway prompt and `delete_when_unreferenced` cleanup, so the probe artifact is garbage-collected. Chat models that can also generate images (chat primary endpoint) keep the text probe.

Fixes #18884

### Why we need it and why it was done in this way

`checkModel` already dispatches rerank and embedding probes by capability; image generation was simply a missing branch, so this adds it in the same shape rather than introducing a new mechanism.

The following tradeoffs were made: the check now actually generates one image, which costs a token/credit on the provider — the alternative is no working check at all for these models. Video / TTS / ASR-only models still fall through to the text probe; each needs its own probe call and no issue reports them yet.

The following alternatives were considered: showing a "cannot check image models" message instead of probing (rejected — the user asked for a real check), and keying off `isTextToImageModel` (rejected — it keys on the absence of reasoning rather than on the endpoint).

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18884

### Breaking changes

None

### Special notes for your reviewer

The new test `checks image-only models through the image endpoint, not chat` fails on `main` and passes here; the companion test pins that multimodal chat models are not diverted to the image endpoint.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix model connectivity check for image-generation models: it now calls the image endpoint instead of failing with a 400 from /v1/chat/completions.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
