### PR TITLE
fix(topic-list): allow spaces in conversation names

### DIFF
--- a/src/renderer/components/EditNameDialog.tsx
+++ b/src/renderer/components/EditNameDialog.tsx
@@ -83,6 +83,10 @@ const EditNameDialog = ({
     // buffer instead of the composed text. `keyCode === 229` is the legacy fallback.
     // oxlint-disable-next-line no-deprecated
     if (event.nativeEvent.isComposing || event.keyCode === 229) return
+    if (event.key === ' ' || event.key === 'Spacebar') {
+      event.stopPropagation()
+      return
+    }
     if (event.key !== 'Enter') return
 
     event.preventDefault()

--- a/src/renderer/components/__tests__/EditNameDialog.test.tsx
+++ b/src/renderer/components/__tests__/EditNameDialog.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import EditNameDialog from '../EditNameDialog'
@@ -115,5 +116,24 @@ describe('EditNameDialog', () => {
     fireEvent.keyDown(input, { key: 'Enter' })
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledWith('对比'))
+  })
+
+  it('keeps spaces when nested under a keyboard-activatable parent', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <div
+        onKeyDown={(event) => {
+          if (event.key === ' ' || event.key === 'Spacebar') event.preventDefault()
+        }}>
+        <EditNameDialog open title="Edit name" initialName="Alpha" onSubmit={onSubmit} onOpenChange={onOpenChange} />
+      </div>
+    )
+
+    const input = within(screen.getByRole('dialog')).getByLabelText('Name')
+    await user.clear(input)
+    await user.type(input, 'Alpha Beta')
+
+    expect(input).toHaveValue('Alpha Beta')
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Editing an unpinned assistant conversation name could not insert spaces because the sortable row's keyboard sensor consumed the Space key event.

After this PR:

The shared rename dialog stops Space key propagation, allowing spaces in conversation names without disabling keyboard dragging on the conversation row itself.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18866

### Why we need it and why it was done in this way

The rename input is the correct event boundary because Space is text input while the field is active. This also matches the existing inline rename behavior.

The following tradeoffs were made:

- Space no longer reaches keyboard handlers above `EditNameDialog` while its input is active, which is the expected behavior for text entry.

The following alternatives were considered:

- Restricting sortable keyboard activators to dedicated row nodes was considered, but it would broaden the change across the virtualized sortable list and could alter existing keyboard accessibility behavior.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18866

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

- Reproduced before the fix in the development Electron app on an unpinned, draggable assistant conversation.
- Verified after the fix that the name becomes `Alpha Beta`, no drag starts while editing, and Space still starts keyboard dragging when the conversation row itself is focused.
- User-guide documentation is not required because this restores the intended text-input behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed editing conversation names so spaces can be entered for unpinned assistant conversations.
```
