### PR TITLE
fix(cherry-autonomy-tools): drop root anyOf from notify input schema

### DIFF
--- a/src/main/ai/mcp/servers/cherryAutonomyTools.ts
+++ b/src/main/ai/mcp/servers/cherryAutonomyTools.ts
@@ -150,10 +150,9 @@ const NOTIFY_TOOL: Tool = {
         type: 'string',
         description: 'Optional: send to a specific channel only (omit to send to all notify-enabled channels)'
       }
-    },
-    // Enforce "message or file_path" so MCP clients can pre-validate; the handler re-checks
-    // the trimmed values (empty strings must still be rejected).
-    anyOf: [{ required: ['message'] }, { required: ['file_path'] }]
+    }
+    // ponytail: no root anyOf — some providers (xAI) reject union root schemas; the handler
+    // enforces "message or file_path" on the trimmed values anyway.
   }
 }
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: the built-in `notify` tool's `inputSchema` had a root-level `anyOf: [{required:['message']}, {required:['file_path']}]`, so xAI (via OpenRouter) rejected every request with `tool parameter root must be an object type`.

After this PR: the root schema is a plain object; the "message or file_path" rule stays enforced by the tool handler on trimmed values.

Fixes #18880

### Why we need it and why it was done in this way

The following tradeoffs were made: the `anyOf` only added client-side pre-validation that the handler already duplicates, so dropping it costs nothing and unblocks providers that refuse union root schemas.

The following alternatives were considered: normalizing root unions for all MCP tool schemas in a shared sanitizer — deferred until a second built-in tool needs it.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18880

### Breaking changes

None.

### Special notes for your reviewer

Existing `cherryAutonomyTools` tests (76) pass unchanged — the invalid-args cases are handler-level, not schema-level.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed agents failing with "tool parameter root must be an object type" when using xAI/Grok models with the built-in notify tool.
```
