### PR TITLE
fix(chat): keep top-selected model for the next turn

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -177,6 +177,8 @@ interface SavedComposerDraft {
   draftTokens: ComposerSerializedToken[]
   files: ComposerAttachment[]
   mentionedModels: Model[]
+  mentionedModelSelectorValue: Model[]
+  mentionedModelMultiSelectMode: boolean
   selectedKnowledgeBases: KnowledgeBase[]
   knowledgeBaseIds: string[]
 }
@@ -746,7 +748,8 @@ const ChatComposerInner = ({
     handleMentionedModelsSelect: selectMentionedModels,
     handleMentionedModelMultiSelectModeChange: changeMentionedModelMultiSelectMode,
     handleMentionedModelSelectorRestore: restoreMentionedModelSelector,
-    restoreMentionedModelDraft
+    restoreMentionedModelDraft,
+    restoreMentionedModelSelection
   } = useChatMentionedModels({
     enabled: useMentionedModelSelector,
     runtimeModel,
@@ -758,6 +761,8 @@ const ChatComposerInner = ({
     preserveExplicitSelectionOnRuntimeChange: !assistant && !assistantId,
     onModelSelect: handleModelSelect
   })
+  const mentionedModelSelectorValueRef = useLatest(mentionedModelSelectorValue)
+  const mentionedModelMultiSelectModeRef = useLatest(mentionedModelMultiSelectMode)
 
   useEffect(() => {
     if (isMentionedModelDraftHydrated || !useMentionedModelSelector) return
@@ -1095,7 +1100,8 @@ const ChatComposerInner = ({
       knowledgeBaseIds: savedDraft?.knowledgeBaseIds ?? knowledgeBaseIdsRef.current,
       mentionedModelIds:
         savedDraft?.mentionedModels.map((model) => model.id) ?? mentionedModelDraftRef.current.mentionedModelIds,
-      modelMultiSelectMode: mentionedModelDraftRef.current.modelMultiSelectMode
+      modelMultiSelectMode:
+        savedDraft?.mentionedModelMultiSelectMode ?? mentionedModelDraftRef.current.modelMultiSelectMode
     })
   })
   // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads the latest draft; cleanup is keyed only by topic.
@@ -1112,9 +1118,13 @@ const ChatComposerInner = ({
     setText(savedDraft.text)
     setDraftTokens(savedDraft.draftTokens)
     setFiles(savedDraft.files)
-    setMentionedModels(savedDraft.mentionedModels)
+    restoreMentionedModelSelection(
+      savedDraft.mentionedModelSelectorValue,
+      savedDraft.mentionedModels,
+      savedDraft.mentionedModelMultiSelectMode
+    )
     setSelectedKnowledgeBases(savedDraft.selectedKnowledgeBases)
-  }, [actionsRef, exitInputHistoryPreview, setFiles, setMentionedModels, setSelectedKnowledgeBases])
+  }, [actionsRef, exitInputHistoryPreview, restoreMentionedModelSelection, setFiles, setSelectedKnowledgeBases])
 
   const handleCancelEditing = useCallback(() => {
     restoreSavedDraft()
@@ -1162,6 +1172,8 @@ const ChatComposerInner = ({
         draftTokens: currentDraft.tokens,
         files: currentTools?.files ?? filesRef.current,
         mentionedModels: currentTools?.mentionedModels ?? mentionedModelsRef.current,
+        mentionedModelSelectorValue: mentionedModelSelectorValueRef.current,
+        mentionedModelMultiSelectMode: mentionedModelMultiSelectModeRef.current,
         selectedKnowledgeBases: currentTools?.selectedKnowledgeBases ?? selectedKnowledgeBasesRef.current,
         knowledgeBaseIds: [...knowledgeBaseIdsRef.current]
       }

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -179,6 +179,7 @@ interface SavedComposerDraft {
   mentionedModels: Model[]
   mentionedModelSelectorValue: Model[]
   mentionedModelMultiSelectMode: boolean
+  mentionedModelSelectionWasPending: boolean
   selectedKnowledgeBases: KnowledgeBase[]
   knowledgeBaseIds: string[]
 }
@@ -763,6 +764,7 @@ const ChatComposerInner = ({
   })
   const mentionedModelSelectorValueRef = useLatest(mentionedModelSelectorValue)
   const mentionedModelMultiSelectModeRef = useLatest(mentionedModelMultiSelectMode)
+  const runtimeModelRef = useLatest(runtimeModel)
 
   useEffect(() => {
     if (isMentionedModelDraftHydrated || !useMentionedModelSelector) return
@@ -1118,13 +1120,26 @@ const ChatComposerInner = ({
     setText(savedDraft.text)
     setDraftTokens(savedDraft.draftTokens)
     setFiles(savedDraft.files)
+    const restoredSelectorModels =
+      savedDraft.mentionedModelSelectionWasPending && savedDraft.mentionedModelSelectorValue.length === 0
+        ? runtimeModelRef.current
+          ? [runtimeModelRef.current]
+          : []
+        : savedDraft.mentionedModelSelectorValue
     restoreMentionedModelSelection(
-      savedDraft.mentionedModelSelectorValue,
+      restoredSelectorModels,
       savedDraft.mentionedModels,
       savedDraft.mentionedModelMultiSelectMode
     )
     setSelectedKnowledgeBases(savedDraft.selectedKnowledgeBases)
-  }, [actionsRef, exitInputHistoryPreview, restoreMentionedModelSelection, setFiles, setSelectedKnowledgeBases])
+  }, [
+    actionsRef,
+    exitInputHistoryPreview,
+    restoreMentionedModelSelection,
+    runtimeModelRef,
+    setFiles,
+    setSelectedKnowledgeBases
+  ])
 
   const handleCancelEditing = useCallback(() => {
     restoreSavedDraft()
@@ -1174,6 +1189,7 @@ const ChatComposerInner = ({
         mentionedModels: currentTools?.mentionedModels ?? mentionedModelsRef.current,
         mentionedModelSelectorValue: mentionedModelSelectorValueRef.current,
         mentionedModelMultiSelectMode: mentionedModelMultiSelectModeRef.current,
+        mentionedModelSelectionWasPending: runtimeModelPending && mentionedModelSelectorValueRef.current.length === 0,
         selectedKnowledgeBases: currentTools?.selectedKnowledgeBases ?? selectedKnowledgeBasesRef.current,
         knowledgeBaseIds: [...knowledgeBaseIdsRef.current]
       }

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -857,6 +857,10 @@ const ChatComposerInner = ({
             ? [runtimeModel]
             : EMPTY_MODELS
   const effectiveSubmittedModel = effectiveSubmittedModels.length === 1 ? effectiveSubmittedModels[0] : undefined
+  // Persisted assistant refreshes may clear transient mentions; submit the visible selector
+  // snapshot so the next turn cannot fall back to stale assistant state.
+  const submittedMentionedModels =
+    assistant && useMentionedModelSelector ? mentionedModelSelectorValue : mentionedModels
   // Without an assistant, persistent request controls have no owner. Keep per-turn Fast available.
   const speedControlModel = useMemo(
     () =>
@@ -1369,7 +1373,9 @@ const ChatComposerInner = ({
         // Allow attachment-only sends (matches v1 Inputbar + the send-enabled condition above).
         requireText: false,
         extra: () => ({
-          mentionedModels: mentionedModels.length ? mentionedModels.map((currentModel) => currentModel.id) : undefined,
+          mentionedModels: submittedMentionedModels.length
+            ? submittedMentionedModels.map((currentModel) => currentModel.id)
+            : undefined,
           reasoningEffort:
             assistantId && speedControlModel
               ? resolveComposerReasoningEffort(speedControlModel, reasoningEffort)
@@ -1402,11 +1408,11 @@ const ChatComposerInner = ({
       chatTarget,
       fastMode,
       files,
-      mentionedModels,
       reasoningEffort,
       serviceTier,
       selectedKnowledgeBasesInScope,
-      speedControlModel
+      speedControlModel,
+      submittedMentionedModels
     ]
   )
 

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -3443,6 +3443,7 @@ describe('ChatComposer', () => {
   })
 
   it('does not carry models selected during an edit into the next normal send', async () => {
+    const user = userEvent.setup()
     const onSend = vi.fn().mockResolvedValue(undefined)
     const forkAndResend = vi.fn().mockResolvedValue(undefined)
     mocks.chatWrite = { pause: vi.fn(), editMessage: vi.fn(), resend: vi.fn(), forkAndResend }
@@ -3462,15 +3463,59 @@ describe('ChatComposer', () => {
       </MessageEditingProvider>
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await user.click(screen.getByRole('button', { name: 'start editing' }))
     await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
-    fireEvent.click(screen.getByText('toggle model multi select'))
-    fireEvent.click(screen.getByText('select models 1 and 2'))
+    await user.click(screen.getByText('toggle model multi select'))
+    await user.click(screen.getByText('select models 1 and 2'))
 
     await mocks.surfaceProps?.onSendDraft({ text: 'edited prompt', tokens: [] })
 
     await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'next prompt', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith('next prompt', expect.objectContaining({ mentionedModels: [model.id] }))
+  })
+
+  it('restores the resolved runtime model when editing started while model loading was pending', async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage: vi.fn(), resend: vi.fn(), forkAndResend }
+    mocks.model = undefined
+    mocks.modelPending = true
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old prompt' }] as any[]
+    const view = render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={onSend} useMentionedModelSelector />
+      </MessageEditingProvider>
+    )
+
+    await user.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+
+    mocks.model = model
+    mocks.modelPending = false
+    view.rerender(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={onSend} useMentionedModelSelector />
+      </MessageEditingProvider>
+    )
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'edited prompt', tokens: [] })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
 
     await mocks.surfaceProps?.onSendDraft({ text: 'next prompt', tokens: [] })

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -7,6 +7,7 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type ReactNode, useEffect } from 'react'
 import type * as ReactI18nextModule from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -3293,6 +3294,27 @@ describe('ChatComposer', () => {
       expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
       expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
     })
+  })
+
+  it('keeps the selected model in the next send after the assistant model refresh completes', async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const view = render(<ChatHomeComposer topic={topic} onSend={onSend} />)
+
+    await user.click(screen.getByText('select model 2'))
+
+    mocks.assistant = { ...mocks.assistant, modelId: modelB.id }
+    mocks.model = modelB
+    view.rerender(<ChatHomeComposer topic={topic} onSend={onSend} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Model B')
+      expect(mocks.mentionedModels).toEqual([])
+    })
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'use the new model', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith('use the new model', expect.objectContaining({ mentionedModels: [modelB.id] }))
   })
 
   it('does not hydrate draft home model selection from mentioned-model cache', () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -3442,6 +3442,42 @@ describe('ChatComposer', () => {
     expect(screen.getByTestId('selected-models-trigger')).toHaveAttribute('data-disabled', 'false')
   })
 
+  it('does not carry models selected during an edit into the next normal send', async () => {
+    const onSend = vi.fn().mockResolvedValue(undefined)
+    const forkAndResend = vi.fn().mockResolvedValue(undefined)
+    mocks.chatWrite = { pause: vi.fn(), editMessage: vi.fn(), resend: vi.fn(), forkAndResend }
+    const message = {
+      id: 'message-1',
+      role: 'user',
+      topicId: topic.id,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      status: 'success'
+    } as const
+    const parts = [{ type: 'text', text: 'old prompt' }] as any[]
+
+    render(
+      <MessageEditingProvider>
+        <StartEditingButton message={message as any} parts={parts} />
+        <ChatComposer topic={topic} onSend={onSend} useMentionedModelSelector />
+      </MessageEditingProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'start editing' }))
+    await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe('message-1'))
+    fireEvent.click(screen.getByText('toggle model multi select'))
+    fireEvent.click(screen.getByText('select models 1 and 2'))
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'edited prompt', tokens: [] })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-multi-select-mode', 'false')
+    expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
+
+    await mocks.surfaceProps?.onSendDraft({ text: 'next prompt', tokens: [] })
+
+    expect(onSend).toHaveBeenCalledWith('next prompt', expect.objectContaining({ mentionedModels: [model.id] }))
+  })
+
   it('hydrates Composer from an edited message and restores the previous draft on cancel', async () => {
     const message = {
       id: 'message-1',

--- a/src/renderer/components/composer/variants/chat/useChatMentionedModels.ts
+++ b/src/renderer/components/composer/variants/chat/useChatMentionedModels.ts
@@ -22,6 +22,7 @@ interface UseMentionedModelSelectorResult {
   handleMentionedModelMultiSelectModeChange: (enabled: boolean) => void
   handleMentionedModelSelectorRestore: () => void
   restoreMentionedModelDraft: (models: Model[], multiSelectMode: boolean) => void
+  restoreMentionedModelSelection: (selectorModels: Model[], mentionedModels: Model[], multiSelectMode: boolean) => void
 }
 
 /**
@@ -144,16 +145,23 @@ export function useChatMentionedModels({
     setMentionedModels([])
   }, [runtimeModel, setMentionedModels])
 
-  const restoreMentionedModelDraft = useCallback(
-    (models: Model[], multiSelectMode: boolean) => {
-      mentionedModelsRef.current = models
-      mentionedModelSelectorValueRef.current = models
+  const restoreMentionedModelSelection = useCallback(
+    (selectorModels: Model[], restoredMentionedModels: Model[], multiSelectMode: boolean) => {
+      mentionedModelsRef.current = restoredMentionedModels
+      mentionedModelSelectorValueRef.current = selectorModels
       mentionedModelMultiSelectModeRef.current = multiSelectMode
-      setMentionedModels(models)
-      setMentionedModelSelectorValue(models)
+      setMentionedModels(restoredMentionedModels)
+      setMentionedModelSelectorValue(selectorModels)
       setMentionedModelMultiSelectMode(multiSelectMode)
     },
     [setMentionedModels]
+  )
+
+  const restoreMentionedModelDraft = useCallback(
+    (models: Model[], multiSelectMode: boolean) => {
+      restoreMentionedModelSelection(models, models, multiSelectMode)
+    },
+    [restoreMentionedModelSelection]
   )
 
   return {
@@ -162,6 +170,7 @@ export function useChatMentionedModels({
     handleMentionedModelsSelect,
     handleMentionedModelMultiSelectModeChange,
     handleMentionedModelSelectorRestore,
-    restoreMentionedModelDraft
+    restoreMentionedModelDraft,
+    restoreMentionedModelSelection
   }
 }


### PR DESCRIPTION
## Summary

Fixes a race where switching the model from the conversation header could leave the next message routed to the previously selected model.

The header selector and the outgoing payload previously read from different model states. Once the assistant refresh completed, the transient mentioned-model state was cleared while the selector still displayed the new model. The next request could therefore omit the selected model id and fall back to the stale assistant default.

## Changes

- Use the visible model selector snapshot when sending messages in persisted assistant conversations.
- Preserve the existing default-model fallback for assistant-less topics.
- Preserve existing multi-model behavior.
- Add a deterministic regression test covering model selection, assistant refresh, and the subsequent send.

## Testing

- ChatComposer.test.tsx: 144/144 passed
- Web TypeScript check passed
- Repository basic checks passed
- Full renderer suite: 9,556 tests passed
- Environment-sensitive tests rechecked with the repository-supported Node.js version: 28/28 passed

## Release note

Switching the model from the conversation header now reliably uses the newly selected model for the next message.

Fixes #18872