### PR TITLE
fix(api-gateway): disable Responses storage for Claude Code

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -788,7 +788,50 @@ describe('buildAgentParams assistant-less reasoning', () => {
     await expect(sdkModel.doGenerate({ prompt, providerOptions: result.options.providerOptions })).rejects.toThrow(
       'request captured'
     )
-    expect(requestBody).toMatchObject({ reasoning: { effort: 'none' } })
+    expect(requestBody).toMatchObject({ store: false, reasoning: { effort: 'none' } })
+  })
+
+  it('serializes gateway reasoning overrides with Responses storage disabled', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'newapi', providerSettings: {} },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'new-api',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      endpointConfigs: { [ENDPOINT_TYPE.OPENAI_RESPONSES]: { adapterFamily: 'newapi' } }
+    })
+    const model = makeModel({
+      id: 'new-api::gpt-5.6-sol',
+      providerId: 'new-api',
+      apiModelId: 'gpt-5.6-sol',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES],
+      capabilities: [MODEL_CAPABILITY.REASONING]
+    })
+
+    const result = await buildAgentParams({
+      request: { callOverrides: { providerOptions: { openai: { reasoningEffort: 'none', forceReasoning: true } } } },
+      signal: undefined,
+      provider,
+      model
+    })
+    let requestBody: Record<string, unknown> | undefined
+    const sdkModel = createOpenAI({
+      apiKey: 'sk-test',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body))
+        throw new Error('request captured')
+      }
+    }).responses('gpt-5.6-sol')
+
+    await expect(
+      sdkModel.doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Run the task.' }] }],
+        providerOptions: result.options.providerOptions
+      })
+    ).rejects.toThrow('request captured')
+    expect(requestBody).toMatchObject({ store: false, reasoning: { effort: 'none' } })
   })
 
   const makeOffCapableSetup = () => {

--- a/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/buildAgentParams.test.ts
@@ -591,6 +591,29 @@ describe('buildAgentParams web-tool routing', () => {
     }
   )
 
+  it('disables Responses storage for assistant-backed calls too', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'openai', providerSettings: {} },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'openai',
+      presetProviderId: 'openai',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_RESPONSES,
+      endpointConfigs: { [ENDPOINT_TYPE.OPENAI_RESPONSES]: { adapterFamily: 'openai' } }
+    })
+    const model = makeModel({
+      id: 'openai::gpt-5.6',
+      providerId: 'openai',
+      apiModelId: 'gpt-5.6',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_RESPONSES]
+    })
+
+    const result = await buildAgentParams({ request: {}, signal: undefined, provider, model, assistant })
+
+    expect(result.options.providerOptions?.openai).toMatchObject({ store: false })
+  })
+
   it.each([
     { endpointType: ENDPOINT_TYPE.OPENAI_RESPONSES, runtimeProviderId: 'openai', expectedRoute: 'server' },
     {
@@ -862,6 +885,29 @@ describe('buildAgentParams assistant-less reasoning', () => {
     return { provider, model }
   }
 
+  it('applies the Ollama context-window default without an assistant', async () => {
+    resolveProviderAiSdkConfigMock.mockResolvedValue({
+      config: { providerId: 'ollama', providerSettings: {} },
+      credentialReceipt: { attribution: 'unknown' }
+    })
+    const provider = makeProvider({
+      id: 'ollama',
+      presetProviderId: 'ollama',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: { [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { adapterFamily: 'ollama' } }
+    })
+    const model = makeModel({
+      id: 'ollama::qwen3',
+      providerId: 'ollama',
+      apiModelId: 'qwen3',
+      contextWindow: 131072
+    })
+
+    const result = await buildAgentParams({ request: {}, signal: undefined, provider, model })
+
+    expect(result.options.providerOptions?.ollama).toMatchObject({ options: { num_ctx: 131072 } })
+  })
+
   it("encodes an explicit 'none' selection into the off wire mode without an assistant (translate)", async () => {
     const { provider, model } = makeOffCapableSetup()
 
@@ -937,9 +983,10 @@ describe('buildAgentParams assistant-less reasoning', () => {
     // turning reasoning off must send `thinkingBudget: 0`. This row is exactly
     // the shape that used to leak the Gemini 3 field: a catalog-backed custom
     // row (resolvable apiModelId, no presetModelId) on a gateway with no pin.
-    expect(result.options.providerOptions).toEqual({
-      google: { thinkingConfig: { includeThoughts: false, thinkingBudget: 0 } }
+    expect(result.options.providerOptions?.google).toMatchObject({
+      thinkingConfig: { includeThoughts: false, thinkingBudget: 0 }
     })
+    expect(Object.keys(result.options.providerOptions ?? {})).toEqual(['google'])
   })
 
   it('leaves assistant-less requests without an explicit selection un-emitted (gateway regression guard)', async () => {

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -569,8 +569,7 @@ function buildAgentOptions(
           }
         )
       : // Assistant-less callers (translate, prompt streams) opt into reasoning by setting
-        // `request.reasoningEffort` explicitly; without it the invocation stays un-emitted so
-        // gateway/topic-naming requests are unchanged.
+        // `request.reasoningEffort` explicitly; without it only protocol defaults below are emitted.
         request.reasoningEffort !== undefined
         ? (buildResolvedReasoningProviderOptions({
             aiSdkProviderId: sdkConfig.providerId,
@@ -579,6 +578,10 @@ function buildAgentOptions(
             reasoning
           }) as Record<string, Record<string, JSONValue>>)
         : {}
+
+  if (!assistant && endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES && sdkConfig.providerOptionsKey === 'openai') {
+    providerOptions.openai = { ...providerOptions.openai, store: false }
+  }
   let standardParams: Partial<Record<string, unknown>> = {}
   if (assistant) {
     const temperature = getTemperature(assistant, model, reasoning)

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -26,7 +26,7 @@ import { ENDPOINT_TYPE, type EndpointType, type Model } from '@shared/data/types
 import type { Provider } from '@shared/data/types/provider'
 import { isFunctionCallingModel } from '@shared/utils/model'
 import { finalizeWebToolRoutes, resolveWebToolRoutes, type WebToolRoutes } from '@shared/utils/provider'
-import { type JSONValue, stepCountIs, type StopCondition, type ToolSet, type UIMessage } from 'ai'
+import { stepCountIs, type StopCondition, type ToolSet, type UIMessage } from 'ai'
 
 import { resolveRequestContextSettings } from '../../../contextBuild/resolveRequestContextSettings'
 import type { FileAttachmentRef } from '../../../messages/attachmentTypes'
@@ -62,7 +62,6 @@ import {
 import {
   applyFastModeToProviderOptions,
   buildCapabilityProviderOptions,
-  buildResolvedReasoningProviderOptions,
   extractAiSdkStandardParams,
   mergeCustomProviderParameters
 } from '../../../utils/options'
@@ -550,38 +549,25 @@ function buildAgentOptions(
     reasoning
   } = scope
 
-  let providerOptions =
-    assistant && capabilities
-      ? buildCapabilityProviderOptions(
-          model,
-          provider,
-          {
-            enableReasoning: capabilities.enableReasoning,
-            enableGenerateImage: capabilities.enableGenerateImage,
-            enableWebSearch: scope.webToolRoutes?.webSearch === 'server'
-          },
-          {
-            aiSdkProviderId,
-            runtimeProviderId: sdkConfig.providerId,
-            providerOptionsKey: sdkConfig.providerOptionsKey,
-            endpointType,
-            reasoning
-          }
-        )
-      : // Assistant-less callers (translate, prompt streams) opt into reasoning by setting
-        // `request.reasoningEffort` explicitly; without it only protocol defaults below are emitted.
-        request.reasoningEffort !== undefined
-        ? (buildResolvedReasoningProviderOptions({
-            aiSdkProviderId: sdkConfig.providerId,
-            providerOptionsKey: sdkConfig.providerOptionsKey,
-            endpointType,
-            reasoning
-          }) as Record<string, Record<string, JSONValue>>)
-        : {}
-
-  if (!assistant && endpointType === ENDPOINT_TYPE.OPENAI_RESPONSES && sdkConfig.providerOptionsKey === 'openai') {
-    providerOptions.openai = { ...providerOptions.openai, store: false }
-  }
+  // One path for both callers, so protocol/model defaults (store, safetySettings, num_ctx…)
+  // can't diverge. Assistant-less callers (translate, prompt streams) carry no capabilities;
+  // they opt into reasoning by setting `request.reasoningEffort` explicitly.
+  let providerOptions = buildCapabilityProviderOptions(
+    model,
+    provider,
+    {
+      enableReasoning: capabilities ? capabilities.enableReasoning : request.reasoningEffort !== undefined,
+      enableGenerateImage: capabilities?.enableGenerateImage ?? false,
+      enableWebSearch: capabilities ? scope.webToolRoutes?.webSearch === 'server' : false
+    },
+    {
+      aiSdkProviderId,
+      runtimeProviderId: sdkConfig.providerId,
+      providerOptionsKey: sdkConfig.providerOptionsKey,
+      endpointType,
+      reasoning
+    }
+  )
   let standardParams: Partial<Record<string, unknown>> = {}
   if (assistant) {
     const temperature = getTemperature(assistant, model, reasoning)
@@ -619,6 +605,9 @@ function buildAgentOptions(
     overridden.providerOptions,
     request.fastMode === true
   )
+  // A namespace that ended up empty carries nothing; emitting it would ship a bare
+  // `providerOptions` for callers that opted into nothing.
+  const hasProviderOptions = Object.values(effectiveProviderOptions).some((ns) => Object.keys(ns ?? {}).length > 0)
   const effectiveBudgetTokens = resolveEffectiveThinkingBudget(
     effectiveProviderOptions,
     sdkConfig.providerOptionsKey,
@@ -645,7 +634,7 @@ function buildAgentOptions(
     ...(stopWhen && { stopWhen }),
     ...(headers && { headers }),
     ...(callOverrides?.toolChoice && { toolChoice: callOverrides.toolChoice }),
-    ...(Object.keys(effectiveProviderOptions).length > 0 && { providerOptions: effectiveProviderOptions }),
+    ...(hasProviderOptions && { providerOptions: effectiveProviderOptions }),
     ...(telemetry && { telemetry }),
     ...standardParams,
     context: requestContext,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Assistant-less OpenAI Responses requests, including Claude Code Agent traffic routed through Cherry's API Gateway, omitted `store`, causing compatible upstreams that require an explicit `store: false` to reject the request with HTTP 400.

After this PR: Assistant-less Responses requests using the OpenAI provider-options namespace explicitly disable storage while preserving gateway reasoning overrides, with wire-level regression coverage for NewAPI and the existing Bailian path.

```
错误名称: ClaudeCodeResultError
错误信息: API Error: 400 Store must be set to false
堆栈信息: ClaudeCodeResultError: API Error: 400 Store must be set to false
    at createClaudeCodeResultError (/opt/Cherry Studio/resources/app.asar/out/main/ClaudeCodeRuntimeDriver-Ch0rQSNZ.js:23:9)
    at ClaudeCodeStreamAdapter.handleResultMessage (/opt/Cherry Studio/resources/app.asar/out/main/ClaudeCodeRuntimeDriver-Ch0rQSNZ.js:938:23)
    at ClaudeCodeStreamAdapter.handleMessage (/opt/Cherry Studio/resources/app.asar/out/main/ClaudeCodeRuntimeDriver-Ch0rQSNZ.js:445:10)
    at ClaudeCodeRuntimeConnection.runQueryLoop (/opt/Cherry Studio/resources/app.asar/out/main/ClaudeCodeRuntimeDriver-Ch0rQSNZ.js:1919:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) what happen
```

### Why we need it and why it was done in this way

The following tradeoffs were made: the default is applied in the shared parameter builder so every assistant-less Responses caller follows the same privacy and compatibility contract as assistant-backed chat.

The following alternatives were considered: special-casing only Claude Code or NewAPI was rejected because the omission belongs to the shared Responses request path.

Links to places where the discussion took place: None.

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

The regression test serializes the final Responses wire body and asserts both `store: false` and the existing reasoning payload; focused main-process tests passed 64/64, `pnpm lint` passed with no errors, and `git diff --check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-everywhere/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Claude Code Agent sessions using OpenAI Responses-compatible providers no longer fail when the upstream requires storage to be explicitly disabled.
```
