### PR TITLE
chore(deps): declare @babel/runtime for vite dep optimizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@anthropic-ai/sdk": "^0.81.0",
     "@aws-sdk/client-s3": "^3.998.0",
     "@aws-sdk/lib-storage": "3.998.0",
+    "@babel/runtime": "^7.29.7",
     "@biomejs/biome": "2.2.4",
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@aws-sdk/lib-storage':
         specifier: 3.998.0
         version: 3.998.0(@aws-sdk/client-s3@3.998.0)
+      '@babel/runtime':
+        specifier: ^7.29.7
+        version: 7.29.7
       '@biomejs/biome':
         specifier: 2.2.4
         version: 2.2.4
@@ -2719,10 +2722,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -17054,8 +17053,6 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/runtime@7.28.4': {}
-
   '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.27.2':
@@ -19143,7 +19140,7 @@ snapshots:
 
   '@hello-pangea/dnd@18.0.1(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       css-box-model: 1.2.1
       raf-schd: 4.0.3
       react: 19.2.3
@@ -19708,7 +19705,7 @@ snapshots:
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -22398,7 +22395,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -22417,7 +22414,7 @@ snapshots:
 
   '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -27070,7 +27067,7 @@ snapshots:
 
   i18next@23.16.8:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
 
   i18next@26.3.1(typescript@5.8.3):
     optionalDependencies:
@@ -27387,7 +27384,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -29408,7 +29405,7 @@ snapshots:
 
   rc-input@1.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-util: 5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
@@ -29442,7 +29439,7 @@ snapshots:
 
   rc-select@14.16.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@rc-component/trigger': 2.3.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       classnames: 2.5.1
       rc-motion: 2.9.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -29461,7 +29458,7 @@ snapshots:
 
   rc-virtual-list@3.18.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       classnames: 2.5.1
       rc-resize-observer: 1.4.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rc-util: 5.44.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -29530,7 +29527,7 @@ snapshots:
 
   react-i18next@14.1.3(i18next@23.16.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       html-parse-stringify: 3.0.1
       i18next: 23.16.8
       react: 19.2.3
@@ -29620,7 +29617,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Running `pnpm dev` fails to load the CodeMirror theme bundle. Vite's dev server reports, repeatedly:

```
Internal server error: Failed to resolve import "@babel/runtime/helpers/extends" from "node_modules/.vite/deps/@uiw_codemirror-themes-all.js". Does the file exist?
```

After this PR:

`@babel/runtime` is declared in root `devDependencies`, so it is present in `node_modules/` and resolvable from the dep-optimizer output. Dev starts clean, no Vite internal server errors.

Fixes #

### Why we need it and why it was done in this way

The ESM builds of `@uiw/codemirror-theme-*` import `@babel/runtime/helpers/extends` without declaring `@babel/runtime` as a dependency — an upstream packaging bug.

This stays invisible under normal resolution: from the package's own directory, pnpm's `node_modules/.pnpm/node_modules/` hoist fallback satisfies the import. But Vite's prebundled output is written to `node_modules/.vite/deps/`, and resolution from there only walks up through `node_modules/`, never reaching that fallback. The import therefore fails at dev time.

Verified with `createRequire`:

- from the package itself → resolves via the hoist fallback
- from `node_modules/.vite/deps/` → `MODULE_NOT_FOUND` (before this PR)
- from `node_modules/.vite/deps/` → resolves (after this PR)

The following tradeoffs were made:

- Declaring a dependency the app does not import directly. It compensates for an upstream package that under-declares its own, which is the conventional fix and is inert if upstream ever corrects it.
- The lockfile collapses the duplicate `@babel/runtime@7.28.4` onto `7.29.7`. Both are semver-compatible patch-level runtime helpers, and deduplication is a side benefit.

The following alternatives were considered:

- `public-hoist-pattern[]=@babel/runtime` in `.npmrc` — works, but changes hoisting behavior repo-wide for a single package's bug.
- A `resolve.alias` in `electron.vite.config.ts` pointing into `.pnpm` internals — brittle, depends on pnpm's internal layout.
- Clearing `node_modules/.vite` — does not help; the prebundle is regenerated with the same unresolvable external import.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

No source files changed — only `package.json` and `pnpm-lock.yaml`. The lockfile diff is limited to `@babel/runtime` entries.

Reproducing before the fix requires a dev run that loads the code editor; the error surfaces in the `pnpm dev` output rather than as a build failure, which is likely why it went unnoticed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
