### PR TITLE
fix(ollama): extract inline reasoning from streamed text

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/internalFeatures.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/internalFeatures.test.ts
@@ -88,7 +88,7 @@ describe('INTERNAL_FEATURES — decision matrix', () => {
     ])
   })
 
-  it('reasoning-extraction activates only for the openai-chat wire', () => {
+  it('reasoning-extraction activates for inline-reasoning wires', () => {
     expect(
       activeNames(
         makeScope({
@@ -96,6 +96,16 @@ describe('INTERNAL_FEATURES — decision matrix', () => {
           model: {},
           aiSdkProviderId: 'openai-chat',
           endpointType: 'openai-chat-completions'
+        })
+      )
+    ).toContain('reasoning-extraction')
+    expect(
+      activeNames(
+        makeScope({
+          provider: { id: 'ollama' },
+          model: {},
+          aiSdkProviderId: 'ollama',
+          endpointType: 'ollama-chat'
         })
       )
     ).toContain('reasoning-extraction')

--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/reasoningExtraction.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/reasoningExtraction.test.ts
@@ -1,0 +1,102 @@
+import type { LanguageModelV3CallOptions, LanguageModelV3StreamPart } from '@ai-sdk/provider'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import type { LanguageModelMiddleware } from 'ai'
+import { wrapLanguageModel } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { createOllamaWithImageModel } from '../../../../../provider/custom/ollama/ollamaProvider'
+import { reasoningExtractionFeature } from '../reasoningExtraction'
+
+const PROMPT: LanguageModelV3CallOptions['prompt'] = [
+  { role: 'user', content: [{ type: 'text', text: 'Explain the answer' }] }
+]
+
+interface OllamaMessageDelta {
+  content: string
+  thinking?: string
+}
+
+function ollamaChunk(message: OllamaMessageDelta, done = false): string {
+  return JSON.stringify({
+    model: 'qwen3.6:27b-mtp-q8_0',
+    created_at: '2026-08-19T00:00:00Z',
+    done,
+    message: { role: 'assistant', ...message },
+    ...(done ? { done_reason: 'stop', prompt_eval_count: 1, eval_count: 2 } : {})
+  })
+}
+
+async function getOllamaReasoningMiddleware(): Promise<LanguageModelMiddleware[]> {
+  const scope = {
+    endpointType: ENDPOINT_TYPE.OLLAMA_CHAT,
+    model: { id: 'ollama::qwen3.6:27b-mtp-q8_0' }
+  } as never
+
+  if (reasoningExtractionFeature.applies?.(scope) === false) return []
+
+  const middlewares: LanguageModelMiddleware[] = []
+  for (const plugin of reasoningExtractionFeature.contributeModelAdapters?.(scope) ?? []) {
+    await plugin.configureContext?.({ middlewares } as never)
+  }
+  return middlewares
+}
+
+async function streamOllama(chunks: string[]): Promise<LanguageModelV3StreamPart[]> {
+  const fetch = () =>
+    Promise.resolve(
+      new Response(`${chunks.join('\n')}\n`, {
+        status: 200,
+        headers: { 'content-type': 'application/x-ndjson' }
+      })
+    )
+  const baseModel = createOllamaWithImageModel({ baseURL: 'https://ollama.example/api', fetch }).languageModel(
+    'qwen3.6:27b-mtp-q8_0'
+  )
+  const middlewares = await getOllamaReasoningMiddleware()
+  const model = middlewares.length > 0 ? wrapLanguageModel({ model: baseModel, middleware: middlewares }) : baseModel
+  const result = await model.doStream({ prompt: PROMPT } as LanguageModelV3CallOptions)
+
+  const parts: LanguageModelV3StreamPart[] = []
+  for await (const part of result.stream) parts.push(part)
+  return parts
+}
+
+function joinedDelta(parts: LanguageModelV3StreamPart[], type: 'reasoning-delta' | 'text-delta'): string {
+  return parts
+    .filter((part): part is Extract<LanguageModelV3StreamPart, { type: typeof type }> => part.type === type)
+    .map((part) => part.delta)
+    .join('')
+}
+
+describe('reasoningExtractionFeature', () => {
+  it('extracts inline Ollama reasoning when think tags are split across stream chunks', async () => {
+    const parts = await streamOllama([
+      ollamaChunk({ content: '<thi' }),
+      ollamaChunk({ content: 'nk>first step' }),
+      ollamaChunk({ content: ' and second step</th' }),
+      ollamaChunk({ content: 'ink>The answer is 42.' }),
+      ollamaChunk({ content: '' }, true)
+    ])
+
+    expect(joinedDelta(parts, 'reasoning-delta')).toBe('first step and second step')
+    expect(joinedDelta(parts, 'text-delta')).toBe('The answer is 42.')
+  })
+
+  it('preserves Ollama native thinking without duplicating it', async () => {
+    const parts = await streamOllama([
+      ollamaChunk({ content: '', thinking: 'native thought' }),
+      ollamaChunk({ content: 'Native answer.' }),
+      ollamaChunk({ content: '' }, true)
+    ])
+
+    expect(joinedDelta(parts, 'reasoning-delta')).toBe('native thought')
+    expect(joinedDelta(parts, 'text-delta')).toBe('Native answer.')
+  })
+
+  it('leaves ordinary Ollama text unchanged', async () => {
+    const parts = await streamOllama([ollamaChunk({ content: 'Plain answer.' }), ollamaChunk({ content: '' }, true)])
+
+    expect(joinedDelta(parts, 'reasoning-delta')).toBe('')
+    expect(joinedDelta(parts, 'text-delta')).toBe('Plain answer.')
+  })
+})

--- a/src/main/ai/runtime/aiSdk/params/features/reasoningExtraction.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/reasoningExtraction.ts
@@ -31,17 +31,15 @@ const createReasoningExtractionPlugin = (options: { tagName?: string } = {}) =>
  * reverses the middleware chain, extractReasoning wraps simulateStreaming
  * and resolves unclosed `<think>` tags produced by the simulated stream.
  *
- * Applies only on the `openai-chat-completions` wire. That wire has no native reasoning field, so a
- * reasoning model served over it emits its chain inline as `<tag>…</tag>` in the
- * text channel — this covers third-party models behind a bespoke-family gateway
- * (e.g. AiHubMix's compat route) and native chat-completions providers
- * (groq, mistral, …) alike. Endpoints with a native
- * reasoning channel (anthropic-messages / google / openai-responses) are left
- * untouched, so a literal `<tag>` there stays real content.
+ * Applies to `openai-chat-completions` and Ollama. Chat-completions has no native reasoning field;
+ * Ollama supports one, but custom model templates can still emit inline `<tag>…</tag>` text. Native
+ * Ollama reasoning remains separate and passes through untouched. Other native-reasoning endpoints
+ * (anthropic-messages / google / openai-responses) are left untouched, so literal tags stay content.
  */
 export const reasoningExtractionFeature: RequestFeature = {
   name: 'reasoning-extraction',
-  applies: (scope) => scope.endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  applies: (scope) =>
+    scope.endpointType === ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS || scope.endpointType === ENDPOINT_TYPE.OLLAMA_CHAT,
   contributeModelAdapters: (scope) => [
     createReasoningExtractionPlugin({ tagName: getReasoningTagName(scope.model.id.toLowerCase()) })
   ]


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Ollama models that returned reasoning inline as `<think>...</think>` in `message.content` displayed no dedicated reasoning block. The Ollama provider supports structured `message.thinking`, but custom Qwen templates can still emit reasoning through the text channel.

After this PR:

Cherry Studio applies its existing reasoning-extraction middleware to Ollama chat streams. Inline reasoning is converted into reasoning events, including when tags are split across NDJSON chunks. Native structured Ollama thinking remains unchanged, and ordinary text continues to render normally.

Fixes #18795

### Why we need it and why it was done in this way

The existing AI SDK middleware already handles incremental reasoning-tag extraction correctly. Extending its endpoint gate to Ollama keeps the behavior aligned with the OpenAI-compatible fallback and avoids introducing a second stream parser.

The following tradeoffs were made:

- Ollama text streams now pass through the existing reasoning-tag extractor.
- Content enclosed by the configured reasoning tag is treated as reasoning, matching the convention already used for OpenAI-compatible reasoning models.
- Native `message.thinking` events remain separate and are not duplicated.

The following alternatives were considered:

- Adding an Ollama-specific parser was rejected because it would duplicate the existing incremental tag parser.
- Patching the provider dependency was rejected because it already exposes both structured thinking and normal text correctly; selecting the inline fallback is an application-level concern.
- Requiring every custom model template to emit `message.thinking` was rejected because existing Qwen templates emit `<think>` through `message.content`.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18795

### Breaking changes

None.

### Special notes for your reviewer

The regression uses the real `ollama-ai-provider-v2` NDJSON parser with a deterministic network response and covers:

- `<think>` tags split across multiple stream chunks.
- Native `message.thinking` without duplication.
- Ordinary untagged Ollama text.
- The feature activation decision for the Ollama chat endpoint.

Validation completed:

- AI SDK feature and Ollama reasoning tests: 131/131 passed.
- `pnpm lint`
- `pnpm test:lint`
- Biome checks for all changed files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every-programmer/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present or not required.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix Ollama Qwen models not displaying inline `<think>` reasoning in the collapsible reasoning block.
```
