### PR TITLE
fix(pyodide): inject context variables into python execution scope

### DIFF
--- a/src/renderer/workers/pyodide.worker.ts
+++ b/src/renderer/workers/pyodide.worker.ts
@@ -143,8 +143,9 @@ pyodidePromise
   })
 
 // 处理消息
+// 串行化由 PyodideService 的队列负责：stdout/stderr 回调闭包引用模块级 output，并发处理请求会互相串扰
 self.onmessage = async (event) => {
-  const { id, python } = event.data
+  const { id, python, context } = event.data
 
   // 重置输出变量
   output = {
@@ -159,6 +160,16 @@ self.onmessage = async (event) => {
     const pyodide = await pyodidePromise
     // 创建一个新的全局作用域
     globals = pyodide.globals.get('dict')()
+
+    if (context && Object.keys(context).length > 0) {
+      // 经 JSON 往返注入而非 toPy：Pyodide 0.28 把 JS null 转成 jsnull 而非 None，json.loads 保证全是 Python 原生类型
+      // 单表达式且先 pop 临时键再 update：不绑定任何名字，用户 context 的同名键不会被误删
+      globals.set('__cherry_studio_context_json__', JSON.stringify(context))
+      await pyodide.runPythonAsync(
+        "globals().update(__import__('json').loads(globals().pop('__cherry_studio_context_json__')))",
+        { globals }
+      )
+    }
 
     // 载入需要的包
     try {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

> **Companion to #18878** — that PR's service-level queue owns serialization, timeout, and cancellation, which is why this one deliberately adds no worker-side queue. The two PRs share no files and merge independently in either order.

Before this PR:

- The built-in `python` MCP tool advertises a `context` parameter ("Optional context variables to pass to the Python execution environment"), and the whole chain (MCP server → `PythonService` → IPC → `PyodideService`) forwards it to the worker — but the worker's message handler never reads it. Any script referencing a context variable fails with `NameError`, silently contradicting the tool schema shown to models.

After this PR:

- The worker injects `context` into the script's global scope via a JSON round-trip: `JSON.stringify` on the JS side, then a single Python expression `globals().update(__import__('json').loads(globals().pop('__cherry_studio_context_json__')))`. Objects, arrays, and `null` arrive as native `dict`, `list`, and `None`; the temp key is popped before the update so user context keys with the same name survive; no helper names leak into the user's namespace.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- JSON round-trip instead of `pyodide.toPy`: Pyodide 0.28 converts JS `null` to `pyodide.ffi.jsnull` rather than `None` (at every nesting level), so `value is None` checks would silently fail. `json.loads` guarantees Python-native types and removes all PyProxy lifecycle handling.
- The injection is a single expression binding no names: `pop` runs before `update`, so even a user context key literally named `__cherry_studio_context_json__` ends up with the user's value.

The following alternatives were considered:

- `toPy` + per-key `globals.set`: rejected due to the `jsnull` conversion and JS-side proxy destroy bookkeeping.
- `convertNullToNone: true` at `loadPyodide`: the flag exists in 0.28 but is a deprecated global compat switch (`setCompatNullToNone`); a local, version-independent fix was preferred.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

The worker module cannot be unit-tested (module-level CDN import; the repo convention is to mock workers entirely). Verification was empirical, pinned to the same Pyodide 0.28.0: nested/array/top-level `null` all arrive as `None`, colliding user keys keep their values, and the namespace afterwards contains exactly `__builtins__` plus the context keys — plus a CDP probe against the real dev app confirming end-to-end context flow (`print(x + y)` with `{x: 1, y: 2}` prints `3`).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix: context variables passed to the built-in Python tool are now injected into the script's execution scope
```
