### PR TITLE
fix(ai-sdk): handle Gemini MCP array tool schemas

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/toolSchemaCompatibility.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/toolSchemaCompatibility.test.ts
@@ -1,15 +1,20 @@
 import { createAnthropic } from '@ai-sdk/anthropic'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAI } from '@ai-sdk/openai'
 import type { LanguageModelV3CallOptions } from '@ai-sdk/provider'
 import { readFileInputSchema } from '@shared/ai/builtinTools'
+import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
 import type { LanguageModelMiddleware } from 'ai'
 import { generateText, tool, wrapLanguageModel } from 'ai'
 import { describe, expect, it } from 'vitest'
+import * as z from 'zod'
 
 import { toolSchemaCompatibilityFeature } from '../toolSchemaCompatibility'
 
-async function getMiddleware(): Promise<LanguageModelMiddleware> {
-  const [plugin] = toolSchemaCompatibilityFeature.contributeModelAdapters!({} as never)
+async function getMiddleware(
+  scope: { aiSdkProviderId?: string; endpointType?: EndpointType } = {}
+): Promise<LanguageModelMiddleware> {
+  const [plugin] = toolSchemaCompatibilityFeature.contributeModelAdapters!({ ...scope } as never)
   if (!plugin) throw new Error('Tool-schema compatibility plugin was not contributed')
 
   const context = { middlewares: [] as LanguageModelMiddleware[] }
@@ -18,8 +23,11 @@ async function getMiddleware(): Promise<LanguageModelMiddleware> {
   return context.middlewares[0]
 }
 
-async function transform(params: LanguageModelV3CallOptions): Promise<LanguageModelV3CallOptions> {
-  const middleware = await getMiddleware()
+async function transform(
+  params: LanguageModelV3CallOptions,
+  scope: { aiSdkProviderId?: string; endpointType?: EndpointType } = {}
+): Promise<LanguageModelV3CallOptions> {
+  const middleware = await getMiddleware(scope)
   return middleware.transformParams!({ params, type: 'generate', model: {} as never })
 }
 
@@ -129,6 +137,110 @@ describe('toolSchemaCompatibilityFeature', () => {
       ratio: { type: 'number', minimum: 0 },
       ids: { type: 'array', minItems: 1, items: { type: 'string', minLength: 1 } }
     })
+  })
+
+  it('drops only tools with untyped array items on the Gemini endpoint', async () => {
+    const params: LanguageModelV3CallOptions = {
+      prompt: [],
+      tools: [
+        {
+          type: 'function',
+          name: 'calendar_create',
+          inputSchema: {
+            type: 'object',
+            properties: { attendeesToAdd: { type: 'array' } }
+          }
+        },
+        {
+          type: 'function',
+          name: 'calendar_update',
+          inputSchema: {
+            type: 'object',
+            properties: { reminders: { type: 'array', items: {} } }
+          }
+        },
+        {
+          type: 'function',
+          name: 'lookup',
+          inputSchema: {
+            type: 'object',
+            properties: { ids: { type: 'array', items: { type: 'string' } } }
+          }
+        },
+        { type: 'provider', id: 'google.search', name: 'search', args: { mode: 'auto' } }
+      ]
+    }
+
+    const result = await transform(params, {
+      aiSdkProviderId: 'google',
+      endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT
+    })
+
+    expect(result.tools?.map((tool) => tool.name)).toEqual(['lookup', 'search'])
+    expect(params.tools).toHaveLength(4)
+  })
+
+  it('does not drop untyped array tools outside the Gemini endpoint', async () => {
+    const params: LanguageModelV3CallOptions = {
+      prompt: [],
+      tools: [
+        {
+          type: 'function',
+          name: 'calendar_create',
+          inputSchema: { type: 'object', properties: { attendees: { type: 'array' } } }
+        }
+      ]
+    }
+
+    expect(
+      await transform(params, {
+        aiSdkProviderId: 'anthropic',
+        endpointType: ENDPOINT_TYPE.ANTHROPIC_MESSAGES
+      })
+    ).toBe(params)
+  })
+
+  it('prevents an item-less array from reaching Google function declarations', async () => {
+    let capturedBody: unknown
+    const captureFetch: typeof globalThis.fetch = async (_input, init) => {
+      capturedBody = JSON.parse(String(init?.body))
+      return new Response(JSON.stringify({ error: { message: 'captured' } }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      })
+    }
+
+    const model = wrapLanguageModel({
+      model: createGoogleGenerativeAI({ apiKey: 'test-key', fetch: captureFetch })('gemini-3.5-flash'),
+      middleware: await getMiddleware({
+        aiSdkProviderId: 'google',
+        endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT
+      })
+    })
+
+    await expect(
+      generateText({
+        model,
+        prompt: 'hello',
+        tools: {
+          malformed: tool({ inputSchema: z.object({ attendees: z.array(z.unknown()) }) }),
+          valid: tool({ inputSchema: z.object({ ids: z.array(z.string()) }) })
+        }
+      })
+    ).rejects.toBeDefined()
+
+    const declarations = (
+      capturedBody as {
+        tools: Array<{
+          functionDeclarations: Array<{
+            name: string
+            parameters: { properties: Record<string, unknown> }
+          }>
+        }>
+      }
+    ).tools[0].functionDeclarations
+    expect(declarations.map((declaration) => declaration.name)).toEqual(['valid'])
+    expect(declarations[0].parameters.properties.ids).toEqual({ type: 'array', items: { type: 'string' } })
   })
 
   it('is a reference-preserving no-op on already-clean schemas', async () => {

--- a/src/main/ai/runtime/aiSdk/params/features/__tests__/toolSchemaCompatibility.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/__tests__/toolSchemaCompatibility.test.ts
@@ -12,9 +12,12 @@ import * as z from 'zod'
 import { toolSchemaCompatibilityFeature } from '../toolSchemaCompatibility'
 
 async function getMiddleware(
-  scope: { aiSdkProviderId?: string; endpointType?: EndpointType } = {}
+  scope: { aiSdkProviderId?: string; endpointType?: EndpointType; runtimeProviderId?: string } = {}
 ): Promise<LanguageModelMiddleware> {
-  const [plugin] = toolSchemaCompatibilityFeature.contributeModelAdapters!({ ...scope } as never)
+  const [plugin] = toolSchemaCompatibilityFeature.contributeModelAdapters!({
+    ...scope,
+    sdkConfig: { providerId: scope.runtimeProviderId ?? scope.aiSdkProviderId ?? 'openai-compatible' }
+  } as never)
   if (!plugin) throw new Error('Tool-schema compatibility plugin was not contributed')
 
   const context = { middlewares: [] as LanguageModelMiddleware[] }
@@ -25,7 +28,7 @@ async function getMiddleware(
 
 async function transform(
   params: LanguageModelV3CallOptions,
-  scope: { aiSdkProviderId?: string; endpointType?: EndpointType } = {}
+  scope: { aiSdkProviderId?: string; endpointType?: EndpointType; runtimeProviderId?: string } = {}
 ): Promise<LanguageModelV3CallOptions> {
   const middleware = await getMiddleware(scope)
   return middleware.transformParams!({ params, type: 'generate', model: {} as never })
@@ -178,6 +181,90 @@ describe('toolSchemaCompatibilityFeature', () => {
 
     expect(result.tools?.map((tool) => tool.name)).toEqual(['lookup', 'search'])
     expect(params.tools).toHaveLength(4)
+  })
+
+  it('keeps boolean-true array items because the Google SDK serializes them with a type', async () => {
+    const params: LanguageModelV3CallOptions = {
+      prompt: [],
+      tools: [
+        {
+          type: 'function',
+          name: 'accept_any_value',
+          inputSchema: {
+            type: 'object',
+            properties: { values: { type: 'array', items: true } }
+          }
+        }
+      ]
+    }
+
+    expect(
+      await transform(params, {
+        aiSdkProviderId: 'google',
+        endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+        runtimeProviderId: 'google'
+      })
+    ).toBe(params)
+  })
+
+  it('does not apply Gemini array filtering to Vertex MaaS tools', async () => {
+    const params: LanguageModelV3CallOptions = {
+      prompt: [],
+      tools: [
+        {
+          type: 'function',
+          name: 'calendar_create',
+          inputSchema: { type: 'object', properties: { attendees: { type: 'array' } } }
+        }
+      ]
+    }
+
+    expect(
+      await transform(params, {
+        aiSdkProviderId: 'google-vertex',
+        endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+        runtimeProviderId: 'google-vertex-maas'
+      })
+    ).toBe(params)
+  })
+
+  // Keep every schema-bearing traversal route covered, not just properties.
+  it.each([
+    ['patternProperties', { patternProperties: { nested: { type: 'array' } } }],
+    ['$defs', { $defs: { nested: { type: 'array' } } }],
+    ['definitions', { definitions: { nested: { type: 'array' } } }],
+    ['dependentSchemas', { dependentSchemas: { nested: { type: 'array' } } }],
+    ['allOf', { allOf: [{ type: 'array' }] }],
+    ['anyOf', { anyOf: [{ type: 'array' }] }],
+    ['oneOf', { oneOf: [{ type: 'array' }] }],
+    ['prefixItems', { prefixItems: [{ type: 'array' }] }],
+    ['items', { items: { type: 'array' } }],
+    ['additionalItems', { additionalItems: { type: 'array' } }],
+    ['additionalProperties', { additionalProperties: { type: 'array' } }],
+    ['contains', { contains: { type: 'array' } }],
+    ['propertyNames', { propertyNames: { type: 'array' } }],
+    ['not', { not: { type: 'array' } }],
+    ['if', { if: { type: 'array' } }],
+    ['then', { then: { type: 'array' } }],
+    ['else', { else: { type: 'array' } }]
+  ] as const)('drops an incompatible array found through %s', async (branchName, branch) => {
+    const params: LanguageModelV3CallOptions = {
+      prompt: [],
+      tools: [
+        {
+          type: 'function',
+          name: `nested_${branchName}`,
+          inputSchema: { type: 'object', properties: { nested: branch } } as never
+        }
+      ]
+    }
+
+    const result = await transform(params, {
+      aiSdkProviderId: 'google',
+      endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT
+    })
+
+    expect(result.tools).toEqual([])
   })
 
   it('does not drop untyped array tools outside the Gemini endpoint', async () => {

--- a/src/main/ai/runtime/aiSdk/params/features/internalFeatures.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/internalFeatures.ts
@@ -45,7 +45,7 @@ export const INTERNAL_FEATURES: readonly RequestFeature[] = [
   contextBuildFeature,
   anthropicCacheFeature,
   anthropicHeadersFeature,
-  // Provider-agnostic: tool schemas lose the keywords providers reject.
+  // Provider compatibility: strip unsupported schema keywords, then apply Gemini-specific tool filtering.
   toolSchemaCompatibilityFeature,
   openrouterReasoningFeature,
   noThinkFeature,

--- a/src/main/ai/runtime/aiSdk/params/features/toolSchemaCompatibility.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/toolSchemaCompatibility.ts
@@ -121,6 +121,8 @@ function isGeminiArraySchema(schema: JSONSchema7): boolean {
 }
 
 function hasGeminiArrayItems(items: JSONSchema7['items']): boolean {
+  // @ai-sdk/google serializes the `true` schema as a typed boolean schema.
+  if (items === true) return true
   if (typeof items !== 'object' || items === null || Array.isArray(items)) return false
   return typeof items.type === 'string' || (Array.isArray(items.type) && items.type.length > 0)
 }
@@ -162,6 +164,7 @@ function normalizeToolSchemas(params: LanguageModelV3CallOptions, scope: Request
     }
     if (
       scope.endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT &&
+      scope.sdkConfig.providerId !== 'google-vertex-maas' &&
       hasIncompatibleGeminiArray(tool.inputSchema as JSONSchema7Definition)
     ) {
       changed = true
@@ -179,7 +182,7 @@ function normalizeToolSchemas(params: LanguageModelV3CallOptions, scope: Request
 
   if (droppedTools.length > 0) {
     logger.warn('Dropped tools with Gemini-incompatible array schemas', {
-      providerId: scope.aiSdkProviderId,
+      providerId: scope.sdkConfig.providerId,
       toolNames: droppedTools
     })
   }

--- a/src/main/ai/runtime/aiSdk/params/features/toolSchemaCompatibility.ts
+++ b/src/main/ai/runtime/aiSdk/params/features/toolSchemaCompatibility.ts
@@ -11,6 +11,8 @@
  *     the strict subset — Anthropic and OpenAI compile that schema into a
  *     sampling grammar and 400 the whole request otherwise (issue #18037).
  *     Zod emits them freely (`.int()` alone adds safe-integer bounds).
+ *   - a Gemini-only pass drops a function tool when an array has no typed
+ *     `items` schema; there is no safe element type to infer.
  *
  * Local input validation is unaffected: the AI SDK still checks tool calls
  * against the original zod schema.
@@ -18,9 +20,14 @@
 
 import type { JSONSchema7, JSONSchema7Definition, LanguageModelV3CallOptions } from '@ai-sdk/provider'
 import { definePlugin } from '@cherrystudio/ai-core'
+import { loggerService } from '@logger'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { LanguageModelMiddleware } from 'ai'
 
 import type { RequestFeature } from '../feature'
+import type { RequestScope } from '../scope'
+
+const logger = loggerService.withContext('toolSchemaCompatibility')
 
 /** Rejected by Gemini, unenforced everywhere else. */
 const ALWAYS_UNSUPPORTED = ['$schema', 'exclusiveMinimum', 'exclusiveMaximum', 'multipleOf', 'uniqueItems']
@@ -109,42 +116,96 @@ function stripMap(
   return changed ? next : map
 }
 
-function normalizeToolSchemas(params: LanguageModelV3CallOptions): LanguageModelV3CallOptions {
+function isGeminiArraySchema(schema: JSONSchema7): boolean {
+  return schema.type === 'array' || (Array.isArray(schema.type) && schema.type.includes('array'))
+}
+
+function hasGeminiArrayItems(items: JSONSchema7['items']): boolean {
+  if (typeof items !== 'object' || items === null || Array.isArray(items)) return false
+  return typeof items.type === 'string' || (Array.isArray(items.type) && items.type.length > 0)
+}
+
+/** Gemini's Schema requires every array declaration to carry a typed items schema. */
+function hasIncompatibleGeminiArray(schema: JSONSchema7Definition): boolean {
+  if (typeof schema !== 'object' || schema === null || Array.isArray(schema)) return false
+
+  const objectSchema = schema
+  if (isGeminiArraySchema(objectSchema) && !hasGeminiArrayItems(objectSchema.items)) return true
+
+  return Object.entries(objectSchema).some(([key, value]) => {
+    if (SCHEMA_MAPS.has(key) && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      return Object.values(value).some((entry) => hasIncompatibleGeminiArray(entry as JSONSchema7Definition))
+    }
+    if (SCHEMA_LISTS.has(key) && Array.isArray(value)) {
+      return value.some((entry) => hasIncompatibleGeminiArray(entry as JSONSchema7Definition))
+    }
+    if (SCHEMA_VALUES.has(key)) {
+      return Array.isArray(value)
+        ? value.some((entry) => hasIncompatibleGeminiArray(entry as JSONSchema7Definition))
+        : hasIncompatibleGeminiArray(value as JSONSchema7Definition)
+    }
+    return false
+  })
+}
+
+function normalizeToolSchemas(params: LanguageModelV3CallOptions, scope: RequestScope): LanguageModelV3CallOptions {
   const tools = params.tools
   if (!tools) return params
 
   let changed = false
-  const transformedTools = tools.map((tool) => {
-    if (tool.type !== 'function') return tool
+  const droppedTools: string[] = []
+  const transformedTools: NonNullable<LanguageModelV3CallOptions['tools']> = []
+  for (const tool of tools) {
+    if (tool.type !== 'function') {
+      transformedTools.push(tool)
+      continue
+    }
+    if (
+      scope.endpointType === ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT &&
+      hasIncompatibleGeminiArray(tool.inputSchema as JSONSchema7Definition)
+    ) {
+      changed = true
+      droppedTools.push(tool.name)
+      continue
+    }
     const keywords = tool.strict === true ? STRICT_UNSUPPORTED : new Set(ALWAYS_UNSUPPORTED)
     const inputSchema = stripKeywords(tool.inputSchema as JSONSchema7Definition, keywords)
-    if (inputSchema === tool.inputSchema) return tool
-    changed = true
-    return { ...tool, inputSchema: inputSchema as JSONSchema7 }
-  })
+    if (inputSchema === tool.inputSchema) transformedTools.push(tool)
+    else {
+      changed = true
+      transformedTools.push({ ...tool, inputSchema: inputSchema as JSONSchema7 })
+    }
+  }
+
+  if (droppedTools.length > 0) {
+    logger.warn('Dropped tools with Gemini-incompatible array schemas', {
+      providerId: scope.aiSdkProviderId,
+      toolNames: droppedTools
+    })
+  }
 
   return changed ? { ...params, tools: transformedTools } : params
 }
 
-function createToolSchemaCompatibilityMiddleware(): LanguageModelMiddleware {
+function createToolSchemaCompatibilityMiddleware(scope: RequestScope): LanguageModelMiddleware {
   return {
     specificationVersion: 'v3',
-    transformParams: async ({ params }) => normalizeToolSchemas(params)
+    transformParams: async ({ params }) => normalizeToolSchemas(params, scope)
   }
 }
 
-const createToolSchemaCompatibilityPlugin = () =>
+const createToolSchemaCompatibilityPlugin = (scope: RequestScope) =>
   definePlugin({
     name: 'tool-schema-compatibility',
     enforce: 'pre',
     configureContext: (context) => {
       context.middlewares = context.middlewares || []
-      context.middlewares.push(createToolSchemaCompatibilityMiddleware())
+      context.middlewares.push(createToolSchemaCompatibilityMiddleware(scope))
     }
   })
 
-/** Drop JSON Schema keywords providers reject in function-tool schemas. */
+/** Drop provider-rejected JSON Schema keywords and unsafe Gemini array tools. */
 export const toolSchemaCompatibilityFeature: RequestFeature = {
   name: 'tool-schema-compatibility',
-  contributeModelAdapters: () => [createToolSchemaCompatibilityPlugin()]
+  contributeModelAdapters: (scope) => [createToolSchemaCompatibilityPlugin(scope)]
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Claude Agent requests routed to Gemini could include MCP function schemas with array properties that had no typed `items` schema. Gemini rejected the complete `function_declarations` payload with HTTP 400 before generation.

After this PR:

The AI SDK compatibility middleware detects these schemas for Google Generate Content requests and drops only the affected function tools. Valid function tools and provider-defined tools remain available, while non-Gemini providers keep their existing behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18890

### Why we need it and why it was done in this way

The following tradeoffs were made:

- An array without `items` means that the element type is unknown, so inferring `string`, `number`, or `object` could change the MCP tool contract.
- Dropping only the incompatible function tool prevents one malformed declaration from blocking the entire request and logs the affected tool names for diagnosis.

The following alternatives were considered:

- Normalizing every unknown array to a guessed element type was rejected because it could produce incorrect tool arguments.
- Changing the shared Anthropic/MCP schema converter was rejected because the limitation is specific to Gemini's function declaration format.

Links to places where the discussion took place: [Issue #18890](https://github.com/CherryHQ/cherry-studio/issues/18890)

### Breaking changes

None. For Gemini requests only, an MCP function tool with an untyped array schema is omitted from the provider request; other tools and providers are unchanged.

### Special notes for your reviewer

- Added a regression test using the real `@ai-sdk/google` request serialization path.
- Validation completed with the targeted API Gateway/AI SDK tests and `pnpm lint`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this compatibility fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Gemini requests no longer fail when an MCP tool exposes an array without a typed items schema; incompatible tools are skipped so remaining tools can be used.
```
