### PR TITLE
fix(tabs): prevent pinning transient mini-apps

### DIFF
--- a/src/renderer/components/layout/AppShellTabBar.tsx
+++ b/src/renderer/components/layout/AppShellTabBar.tsx
@@ -410,16 +410,18 @@ interface TabCapabilities {
 
 /**
  * Single source of truth for what a tab can do, derived from its zone and the
- * tab counts. Normal tabs can always be closed/pinned/detached; if the last tab
- * closes, TabsProvider opens Launchpad as the empty-state fallback. Pinned tabs
- * can be closed via the context menu (no inline X), and the batch close actions
- * only ever clear the normal zone — pinned tabs are exempt as close *targets*,
- * matching browser convention. Reordering is per-zone. `normalIndex` is the
- * tab's position within the normal zone — required to offer "close tabs to the
- * right"; for a pinned tab every normal tab counts as being to its right.
+ * tab counts. Normal tabs can always be closed/detached; restorable tabs can also
+ * be pinned. Transient mini-app tabs cannot be restored from the persistent pinned
+ * store, so pinning is deliberately unavailable for them. If the last tab closes,
+ * TabsProvider opens Launchpad as the empty-state fallback. Pinned tabs can be
+ * closed via the context menu (no inline X), and the batch close actions only ever
+ * clear the normal zone — pinned tabs are exempt as close *targets*, matching
+ * browser convention. Reordering is per-zone. `normalIndex` is the tab's position
+ * within the normal zone — required to offer "close tabs to the right"; for a
+ * pinned tab every normal tab counts as being to its right.
  */
 export function getTabCapabilities(
-  tab: Pick<Tab, 'id' | 'isPinned'>,
+  tab: Pick<Tab, 'id' | 'isPinned' | 'metadata'>,
   ctx: { pinnedCount: number; normalCount: number; canDetach: boolean; normalIndex?: number }
 ): TabCapabilities {
   const detach = ctx.canDetach
@@ -439,7 +441,7 @@ export function getTabCapabilities(
   return {
     menu: true,
     reorder: hasSiblings,
-    togglePin: true,
+    togglePin: tab.metadata?.transientMiniApp !== true,
     detach,
     close: true,
     closeOthers: hasSiblings,

--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -522,7 +522,7 @@ export function TabsProvider({
   const pinTab = useCallback(
     (id: string) => {
       const tab = tabs.find((t) => t.id === id)
-      if (!tab || tab.isPinned) return
+      if (!tab || tab.isPinned || isTransientMiniAppTab(tab)) return
 
       // Remove from normalTabs
       setNormalTabs((prev) => prev.filter((t) => t.id !== id))

--- a/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
+++ b/src/renderer/components/layout/__tests__/AppShellTabBar.test.tsx
@@ -533,6 +533,19 @@ describe('AppShellTabBar', () => {
     expect(screen.queryAllByTestId('menu-tab.close')).toHaveLength(1)
   })
 
+  it('does not offer pinning for transient mini-app tabs', () => {
+    const transientMiniAppTab = createTab('mini-app', {
+      url: '/app/mini-app/deepseek-harness',
+      metadata: { transientMiniApp: true }
+    })
+
+    renderTabBar({ tabs: [transientMiniAppTab], activeTabId: transientMiniAppTab.id, detachTab: vi.fn() })
+
+    expect(screen.queryByTestId('menu-tab.pin')).not.toBeInTheDocument()
+    expect(screen.getByTestId('menu-tab.open-in-new-window')).toBeInTheDocument()
+    expect(screen.getByTestId('menu-tab.close')).toBeInTheDocument()
+  })
+
   it('allows both the last normal tab and pinned tabs to close from the menu', () => {
     const tabs = [createTab('home'), createTab('p', { isPinned: true })]
 
@@ -1293,5 +1306,11 @@ describe('getTabCapabilities', () => {
     expect(getTabCapabilities({ id: 'a', isPinned: false }, ctx({ normalCount: 2, canDetach: false })).detach).toBe(
       false
     )
+  })
+
+  it('disables pinning for transient mini-app tabs', () => {
+    const transientMiniAppTab = createTab('mini-app', { metadata: { transientMiniApp: true } })
+
+    expect(getTabCapabilities(transientMiniAppTab, ctx({ normalIndex: 0 })).togglePin).toBe(false)
   })
 })

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -317,6 +317,31 @@ function PinnedOverflowSeeder() {
   )
 }
 
+function TransientMiniAppPinner() {
+  const { openTab, pinTab, tabs } = useTabsContext()
+  const didOpenRef = useRef(false)
+  const didPinRef = useRef(false)
+
+  useEffect(() => {
+    if (didOpenRef.current) return
+    didOpenRef.current = true
+    openTab('/app/mini-app/deepseek-harness', {
+      id: 'transient-mini-app',
+      title: 'DeepSeek Harness',
+      metadata: { transientMiniApp: true },
+      forceNew: true
+    })
+  }, [openTab])
+
+  useEffect(() => {
+    if (didPinRef.current || !tabs.some((tab) => tab.id === 'transient-mini-app')) return
+    didPinRef.current = true
+    pinTab('transient-mini-app')
+  }, [pinTab, tabs])
+
+  return <div data-testid="transient-tab-ids">{tabs.map((tab) => tab.id).join(',')}</div>
+}
+
 beforeEach(() => {
   currentLanguage = 'en'
   pinnedTabsValue = [PINNED_FILES_TAB]
@@ -390,6 +415,17 @@ describe('TabsProvider', () => {
     )
 
     await waitFor(() => expect(setPinnedTabsMock).toHaveBeenCalled())
+  })
+
+  it('keeps a transient mini-app tab visible when pinning is requested programmatically', async () => {
+    render(
+      <TabsProvider initialDefaultTab={HOME_TAB}>
+        <TransientMiniAppPinner />
+      </TabsProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('transient-tab-ids')).toHaveTextContent('transient-mini-app'))
+    expect(setPinnedTabsMock.mock.calls.some(([arg]) => typeof arg === 'function')).toBe(false)
   })
 
   it('removes a menu-closed pinned tab from the persistent pinned list', async () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

Transient mini-app tabs, such as DeepSeek Harness, exposed the Pin Tab action. Pinning moved the tab into the persistent pinned store, whose reconciliation intentionally removes transient mini-app tabs because they cannot be restored after restart. The tab therefore disappeared immediately.

After this PR:

Transient mini-app tabs no longer expose the unsupported Pin Tab action. The tab provider also rejects programmatic attempts to pin them, preventing the tab from disappearing while preserving its existing open, detach, and close behavior.

Fixes #18892

### Why we need it and why it was done in this way

The pinned-tab zone is backed by persistent storage, while transient mini-app tabs depend on runtime state that cannot be restored across application restarts. Allowing them into that store creates an invalid state.

The following tradeoffs were made:

Pinning is disabled for transient mini-app tabs instead of introducing a second session-only pinned store. This keeps the current pinned-tab persistence contract intact and avoids making visually identical pinned tabs follow different lifecycle rules.

The following alternatives were considered:

Supporting session-only pinning was considered, but it would require separating persistent and ephemeral pinned state throughout restoration, reordering, detaching, closing, and LRU management.

Links to places where the discussion took place: #18892

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage verifies that:

- Transient mini-app tabs do not expose the Pin Tab action.
- Detach and close actions remain available.
- Programmatic pin requests leave the tab visible.
- No persistent pinned-store update is produced for the rejected request.

Validation completed with Node.js 24.11.1:

- `pnpm test:lint`
- `pnpm build:check`
- 83 focused tab-bar and tab-provider tests

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this focused context-menu correction
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Transient mini-app tabs no longer offer the unsupported Pin Tab action, preventing them from disappearing from the tab bar.
```
