### PR TITLE
fix(pi-runtime): allow trusted reads from enabled skills

### DIFF
--- a/src/main/ai/runtime/pi/PiRuntimeConnection.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.ts
@@ -244,6 +244,7 @@ export class PiRuntimeConnection implements AgentRuntimeConnection {
           application.get('AgentSessionRuntimeService').getInteractionState(this.input.sessionId),
         getPermissionMode: () => this.permissionMode,
         isDisabled: (toolName: string) => this.disabledTools.has(toolName),
+        additionalReadOnlyRoots: additionalSkillPaths,
         // Safe first-party MCP tools may run headlessly; third-party and mutating tools still prompt.
         // disabledTools hard-blocks every class at fire-time.
         autoApprovedTools: PI_AUTO_APPROVED_MCP_TOOLS,

--- a/src/main/ai/runtime/pi/approvalExtension.test.ts
+++ b/src/main/ai/runtime/pi/approvalExtension.test.ts
@@ -23,19 +23,23 @@ let testRoot: string
 let workspace: string
 let agentData: string
 let outside: string
+let skillRoot: string
 
 beforeAll(() => {
   testRoot = mkdtempSync(join(tmpdir(), 'pi-approval-paths-'))
   workspace = join(testRoot, 'workspace')
   agentData = join(testRoot, 'agent-data')
   outside = join(testRoot, 'outside')
+  skillRoot = join(testRoot, 'skills', 'test-skill')
   mkdirSync(workspace)
   mkdirSync(agentData)
   mkdirSync(outside)
+  mkdirSync(skillRoot, { recursive: true })
   writeFileSync(join(workspace, 'inside.txt'), 'inside')
   writeFileSync(join(agentData, 'SOUL.md'), 'soul')
   writeFileSync(join(agentData, 'USER.md'), 'user')
   writeFileSync(join(outside, 'secret.txt'), 'outside')
+  writeFileSync(join(skillRoot, 'SKILL.md'), 'skill')
   symlinkSync(outside, join(workspace, 'escape'), process.platform === 'win32' ? 'junction' : 'dir')
 })
 
@@ -46,6 +50,7 @@ function buildGate(
   overrides: Partial<{
     workspacePath: string
     agentDataPath: string
+    additionalReadOnlyRoots: readonly string[]
     getPermissionMode: () => AgentPermissionMode | undefined
     getInteractionState: () => { userResponse: 'stream' | 'message' | 'unavailable' }
     isDisabled: (toolName: string) => boolean
@@ -60,6 +65,7 @@ function buildGate(
     sessionId: 's1',
     workspacePath: workspace,
     agentDataPath: agentData,
+    additionalReadOnlyRoots: [],
     emit: (event) => emitted.push(event),
     getPermissionMode: () => 'default',
     getInteractionState: () => ({ userResponse: 'stream' }),
@@ -334,6 +340,21 @@ describe('createPiApprovalExtension — policy + approval gate', () => {
       void handler(toolEvent('write', { path: join(outside, 'new.txt'), content: 'x' }), extCtx)
       await flush()
       expect(emitted).toHaveLength(1)
+    })
+
+    it('keeps configured skill roots read-only without asking to read them', async () => {
+      const { handler, emitted } = buildAutoGate({ additionalReadOnlyRoots: [skillRoot] })
+      await expect(handler(toolEvent('read', { path: join(skillRoot, 'SKILL.md') }), extCtx)).resolves.toBeUndefined()
+      expect(emitted).toHaveLength(0)
+
+      const pendingWrite = handler(
+        toolEvent('write', { path: join(skillRoot, 'SKILL.md'), content: 'changed' }),
+        extCtx
+      )
+      await flush()
+      expect(emitted).toHaveLength(1)
+      toolApprovalRegistry.dispatch(emitted[0].request.approvalId, { approved: false })
+      await expect(pendingWrite).resolves.toMatchObject({ block: true })
     })
 
     it('still gates an always-prompt tool', async () => {

--- a/src/main/ai/runtime/pi/approvalExtension.ts
+++ b/src/main/ai/runtime/pi/approvalExtension.ts
@@ -41,7 +41,7 @@ import { PI_TRANSPORT } from './piStreamAdapter'
 const logger = loggerService.withContext('PiApprovalExtension')
 
 /** pi built-in read-only tools — auto-approved in every permission mode when their `path` resolves
- *  inside the session workspace or current agent data directory. */
+ *  inside the session workspace, current agent data directory, or another trusted read-only root. */
 const READ_ONLY_TOOLS = new Set<string>(
   PI_BUILTIN_TOOLS.filter((tool) => tool.permissionClass === 'read').map((tool) => tool.name)
 )
@@ -63,12 +63,14 @@ const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g
 export interface PiApprovalContext {
   /** Agent-session id — keys the neutral registry so close()/abort target the right approvals. */
   sessionId: string
-  /** Session workspace root — the auto-approve fast-path only skips approval when a tool's resolved
-   *  `path` stays inside this directory or the current agent data directory. */
+  /** Session workspace root used to resolve relative tool paths and as a trusted read/write root. */
   workspacePath: string
   /** Current agent's persistent identity and memory directory. It is a trusted file-tool root just
    *  like the workspace; paths under another agent or elsewhere still require approval. */
   agentDataPath: string
+  /** Additional app-owned roots that read tools may access without approval. Mutating file tools do
+   *  not inherit these roots. */
+  additionalReadOnlyRoots: readonly string[]
   /** Push a runtime-neutral event into the connection queue; the host owns presentation. */
   emit: (event: AgentRuntimeEvent) => void
   /** Resolve responder availability at tool fire-time so warm connections follow the current turn. */
@@ -156,7 +158,18 @@ export function createPiToolAuthorizer(ctx: PiApprovalContext): PiToolAuthorizer
     // mode first (unattended heartbeat turns must not block on a renderer prompt). The disabledTools
     // block in (1) already ran, so a disabled soul tool stays hard-blocked — disabled beats auto-allow.
     if (ctx.autoApprovedTools.has(toolName) && !approvalRequired) return
-    if (!(await requiresApproval(mode, toolName, input, ctx.workspacePath, ctx.agentDataPath, approvalRequired))) return
+    if (
+      !(await requiresApproval(
+        mode,
+        toolName,
+        input,
+        ctx.workspacePath,
+        ctx.agentDataPath,
+        ctx.additionalReadOnlyRoots,
+        approvalRequired
+      ))
+    )
+      return
 
     const interactionState = ctx.getInteractionState()
     if (interactionState.userResponse === 'unavailable') {
@@ -219,6 +232,7 @@ async function requiresApproval(
   input: Record<string, unknown>,
   workspacePath: string,
   agentDataPath: string,
+  additionalReadOnlyRoots: readonly string[],
   alwaysPrompt: boolean
 ): Promise<boolean> {
   if (alwaysPrompt) return true
@@ -235,7 +249,10 @@ async function requiresApproval(
       const command = typeof input.command === 'string' ? input.command : ''
       return detectDestructiveCommand(command) !== null
     }
-    if (READ_ONLY_TOOLS.has(toolName) || EDIT_TOOLS.has(toolName)) {
+    if (READ_ONLY_TOOLS.has(toolName)) {
+      return !(await isToolPathInsideAllowedRoots(input, workspacePath, agentDataPath, true, additionalReadOnlyRoots))
+    }
+    if (EDIT_TOOLS.has(toolName)) {
       return !(await isToolPathInsideAllowedRoots(input, workspacePath, agentDataPath, true))
     }
     return false
@@ -244,7 +261,7 @@ async function requiresApproval(
   // inside an allowed root; any other read/write falls through to a normal prompt so a
   // prompt-injected model can't auto-touch ~/.ssh, Cherry's SQLite, ~/.zshrc, LaunchAgents, etc.
   if (READ_ONLY_TOOLS.has(toolName)) {
-    return !(await isToolPathInsideAllowedRoots(input, workspacePath, agentDataPath, false))
+    return !(await isToolPathInsideAllowedRoots(input, workspacePath, agentDataPath, false, additionalReadOnlyRoots))
   }
   if (mode === 'acceptEdits' && EDIT_TOOLS.has(toolName)) {
     return !(await isToolPathInsideAllowedRoots(input, workspacePath, agentDataPath, true))
@@ -267,7 +284,8 @@ async function isToolPathInsideAllowedRoots(
   input: Record<string, unknown>,
   workspacePath: string,
   agentDataPath: string,
-  allowMissingTarget: boolean
+  allowMissingTarget: boolean,
+  additionalAllowedRoots: readonly string[] = []
 ): Promise<boolean> {
   const raw = input.path
   // read defaults a missing/empty path to "." → the workspace root, which is inside.
@@ -283,7 +301,11 @@ async function isToolPathInsideAllowedRoots(
   ])
   if (!canonicalWorkspace || !canonicalAgentData || !canonicalTarget) return false
 
-  return [canonicalWorkspace, canonicalAgentData].some((root) => {
+  const canonicalAdditionalRoots = (
+    await Promise.all(additionalAllowedRoots.map((root) => canonicalizeExistingPath(root)))
+  ).filter((root): root is string => root !== undefined)
+
+  return [canonicalWorkspace, canonicalAgentData, ...canonicalAdditionalRoots].some((root) => {
     const rel = path.relative(root, canonicalTarget)
     return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel))
   })

--- a/src/renderer/components/composer/variants/__tests__/permissionRequestComposerRequest.test.ts
+++ b/src/renderer/components/composer/variants/__tests__/permissionRequestComposerRequest.test.ts
@@ -81,6 +81,14 @@ describe('findNextPendingPermissionRequest', () => {
     expect(result?.title).toBe('Run focused composer tests')
   })
 
+  it('shows the target path for Pi file-tool approvals', () => {
+    const result = findNextPendingPermissionRequest({
+      'message-1': [makePart({ input: { path: '/managed-skills/find-skills/SKILL.md' } })]
+    })
+
+    expect(result?.title).toBe('/managed-skills/find-skills/SKILL.md')
+  })
+
   it('uses Claude Code MCP metadata for the tool preview', () => {
     const result = findNextPendingPermissionRequest({
       'message-1': [

--- a/src/renderer/components/composer/variants/permissionRequestComposerRequest.ts
+++ b/src/renderer/components/composer/variants/permissionRequestComposerRequest.ts
@@ -50,7 +50,7 @@ function getStringField(value: unknown, fields: string[]): string | undefined {
 }
 
 function getPermissionTitle(part: PermissionToolPart, fallback: string): string {
-  return getStringField(part.input, ['question', 'message', 'prompt', 'title', 'description']) ?? fallback
+  return getStringField(part.input, ['question', 'message', 'prompt', 'title', 'description', 'path']) ?? fallback
 }
 
 /** Return the FIFO head from the newest reply that has pending tool permissions. */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Fast (Pi) agents treated enabled Cherry-managed skill directories as outside the trusted file roots. Reading an enabled skill's `SKILL.md` therefore prompted for approval even in "Approve for Me" mode, and the approval composer showed only `Read` without the requested path.

After this PR:

Fast (Pi) agents treat only their enabled skill directories as additional read-only roots. Skill reads proceed without routine approval, while edits and writes to the same directories remain approval-gated. Pi file approval prompts also surface their `path` argument.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Pi's resource loader injects enabled skills from Cherry's managed skill storage, but the approval extension previously knew only about the session workspace and agent data directory. Passing the snapshot's enabled skill paths into the approval context keeps the permission decision in the main-process policy owner and avoids broad trust in the entire global skill library.

The following tradeoffs were made:

- Additional skill roots are canonicalized at authorization time to preserve symlink-escape protection, accepting a small per-read filesystem cost.
- The new roots apply only to read-class tools; workspace and agent data remain the only read/write roots.

The following alternatives were considered:

- Trusting the entire global `Data/Skills` directory was rejected because it would expose disabled skills.
- Copying skills into each workspace was rejected because it would duplicate managed state and risk stale copies.
- Auto-approving files named `SKILL.md` was rejected because filename matching is not a security boundary.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Validation: `pnpm lint` passed, including type checking and i18n validation. ESLint reported 37 pre-existing warnings and no errors.
- Targeted and UI tests were not run under the repository's user-owned verification policy.
- Regression coverage protects both sides of the permission boundary: enabled skill reads are allowed, but writes remain approval-gated.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08/)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fast (Pi) agents in "Approve for Me" mode no longer ask for permission when reading enabled Cherry-managed skills. File approval prompts now show the requested path.
```
