### PR TITLE
fix(skills): support valid GitHub SKILL.md links

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/skills.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/skills.test.ts
@@ -173,19 +173,29 @@ describe('SkillsServer', () => {
       expect(result.content[0].text).toContain('No installable skills found')
     })
 
-    it('resolves a GitHub SKILL.md URL to an installable skill the registries never indexed', async () => {
+    it.each([
+      [
+        'repository-root blob link',
+        'https://github.com/Viy1204/recruiting-copilot/blob/master/SKILL.md',
+        'https://github.com/Viy1204/recruiting-copilot/blob/master/SKILL.md'
+      ],
+      [
+        'official raw link',
+        'https://github.com/Viy1204/recruiting-copilot/raw/refs/heads/master/SKILL.md',
+        'https://raw.githubusercontent.com/Viy1204/recruiting-copilot/refs/heads/master/SKILL.md'
+      ]
+    ])('resolves a %s without querying registries', async (_case, url, canonicalUrl) => {
       const server = createServer()
-      installMock.mockResolvedValue({ id: 'skill-1', name: 'resume-review', folderName: 'resume-review' })
+      installMock.mockResolvedValue({ id: 'skill-1', name: 'recruiting-copilot', folderName: 'recruiting-copilot' })
       toggleMock.mockReturnValue({ id: 'skill-1', isEnabled: true })
 
-      const url = 'https://github.com/Viy1204/recruiting-copilot/blob/master/skills/resume-review/SKILL.md'
       const search = await callTool(server, 'search_skills', { query: url })
 
       expect(fetchMock).not.toHaveBeenCalled()
-      expect(search.content[0].text).toContain(`github:${url}`)
+      expect(search.content[0].text).toContain(`github:${canonicalUrl}`)
 
-      const install = await callTool(server, 'install_skill', { install_source: `github:${url}` })
-      expect(installMock).toHaveBeenCalledWith({ installSource: `github:${url}` })
+      const install = await callTool(server, 'install_skill', { install_source: `github:${canonicalUrl}` })
+      expect(installMock).toHaveBeenCalledWith({ installSource: `github:${canonicalUrl}` })
       expect(install.isError).toBeFalsy()
     })
 

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -545,14 +545,14 @@ export class SkillService {
 
     const { owner, repo, refNamespace, refAndPath, descriptorFileName } = location
     const repoUrl = `https://github.com/${owner}/${repo}`
-    const { ref, oid, target } = await this.resolveGithubCommit(repoUrl, refAndPath, refNamespace)
-    logger.info('Installing from GitHub', { owner, repo, ref, oid, target })
+    const { ref, namespace, oid, target } = await this.resolveGithubCommit(repoUrl, refAndPath, refNamespace)
+    logger.info('Installing from GitHub', { owner, repo, ref, namespace, oid, target })
 
-    // Keep the ref, not the commit, as the stored origin: a later install of the same skill has to
-    // match this URL to be treated as an update rather than a foreign folder collision.
+    // Keep the resolved ref and namespace, not the commit, as the stored origin so equivalent URL
+    // forms update the same skill while a same-named branch and tag remain distinct.
     const sourcePath = target.kind === 'root' ? ref : `${ref}/${target.path}`
-    const sourceUrl = refNamespace
-      ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${refNamespace}/${encodeGithubPath(`${sourcePath}/${descriptorFileName}`)}`
+    const sourceUrl = namespace
+      ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${namespace}/${encodeGithubPath(`${sourcePath}/${descriptorFileName}`)}`
       : `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
     const tempDir = await this.createTempDir('github')
 
@@ -581,7 +581,7 @@ export class SkillService {
     repoUrl: string,
     refAndPath: string[],
     refNamespace: 'heads' | 'tags' | null
-  ): Promise<{ ref: string; oid: string; target: GithubSkillTarget }> {
+  ): Promise<{ ref: string; namespace: 'heads' | 'tags' | null; oid: string; target: GithubSkillTarget }> {
     const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
     const output = await this.runGit(gitCommand, ['ls-remote', '--heads', '--tags', '--', repoUrl])
     const refs = output.split('\n').flatMap((line) => {
@@ -596,16 +596,21 @@ export class SkillService {
     const resolution = resolveGithubRef(matchingRefs, refAndPath)
     switch (resolution.kind) {
       case 'resolved':
-        return { ref: resolution.ref.name, oid: resolution.ref.oid, target: resolution.target }
+        return {
+          ref: resolution.ref.name,
+          namespace: resolution.ref.namespace,
+          oid: resolution.ref.oid,
+          target: resolution.target
+        }
       case 'ambiguous':
         throw new Error(`${repoUrl} has both a branch and a tag named "${resolution.name}"; the URL cannot say which.`)
       case 'no-match': {
         const [head, ...rest] = refAndPath
         // A permalink names its commit outright, so no ref has to match for it to be exact.
-        if (/^[0-9a-f]{40}$/i.test(head)) {
+        if (refNamespace === null && /^[0-9a-f]{40}$/i.test(head)) {
           const target: GithubSkillTarget =
             rest.length === 0 ? { kind: 'root' } : { kind: 'directory', path: rest.join('/') }
-          return { ref: head, oid: head.toLowerCase(), target }
+          return { ref: head, namespace: null, oid: head.toLowerCase(), target }
         }
         throw new Error(`No branch or tag in ${repoUrl} matches "${refAndPath.join('/')}"`)
       }

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -27,6 +27,7 @@ import type {
   SystemSkillPlacement
 } from '@shared/types/skill'
 import { ClawhubSkillDetailSchema } from '@shared/types/skill'
+import type { GithubSkillTarget } from '@shared/utils/skillMarketplace'
 import { encodeGithubPath, parseGithubSkillUrl, resolveRefFromSegments } from '@shared/utils/skillMarketplace'
 import { Mutex } from 'async-mutex'
 import { net } from 'electron'
@@ -505,20 +506,26 @@ export class SkillService {
       throw new Error(`Invalid GitHub skill URL: ${identifier}`)
     }
 
-    const { owner, repo, refAndDirectory } = location
+    const { owner, repo, refNamespace, refAndPath, descriptorFileName } = location
     const repoUrl = `https://github.com/${owner}/${repo}`
-    const { ref, oid, directoryPath } = await this.resolveGithubCommit(repoUrl, refAndDirectory)
-    logger.info('Installing from GitHub', { owner, repo, ref, oid, directoryPath })
+    const { ref, oid, target } = await this.resolveGithubCommit(repoUrl, refAndPath, refNamespace)
+    logger.info('Installing from GitHub', { owner, repo, ref, oid, target })
 
     // Keep the ref, not the commit, as the stored origin: a later install of the same skill has to
     // match this URL to be treated as an update rather than a foreign folder collision.
-    const sourceUrl = `${repoUrl}/tree/${encodeGithubPath(`${ref}/${directoryPath}`)}`
+    const sourcePath = target.kind === 'root' ? ref : `${ref}/${target.path}`
+    const sourceUrl = `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
     const tempDir = await this.createTempDir('github')
 
     try {
-      await this.fetchCommit(repoUrl, oid, directoryPath, tempDir)
-      await this.assertUniqueSkillPath(tempDir, directoryPath)
-      const skillDir = await this.resolveSkillDirectory(tempDir, null, directoryPath)
+      const { contentDir, skillDir } = await this.materializeGithubTarget(
+        repoUrl,
+        oid,
+        target,
+        descriptorFileName,
+        tempDir
+      )
+      await this.validateRepositorySkillDirectory(contentDir, skillDir, path.join(skillDir, descriptorFileName))
       await this.assertSkillDirectoryWithinLimits(skillDir)
       return await this.installSkillDir(skillDir, 'marketplace', sourceUrl)
     } finally {
@@ -533,8 +540,9 @@ export class SkillService {
    */
   private async resolveGithubCommit(
     repoUrl: string,
-    refAndDirectory: string[]
-  ): Promise<{ ref: string; oid: string; directoryPath: string }> {
+    refAndPath: string[],
+    refNamespace: 'heads' | 'tags' | null
+  ): Promise<{ ref: string; oid: string; target: GithubSkillTarget }> {
     const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
     const output = await this.runGit(gitCommand, ['ls-remote', '--heads', '--tags', '--', repoUrl])
     const refs = output.split('\n').flatMap((line) => {
@@ -545,45 +553,140 @@ export class SkillService {
       return [{ oid, namespace: match[1] as 'heads' | 'tags', name: match[2] }]
     })
 
-    const resolution = resolveRefFromSegments(refs, refAndDirectory)
+    const matchingRefs = refNamespace ? refs.filter((ref) => ref.namespace === refNamespace) : refs
+    const resolution = resolveRefFromSegments(matchingRefs, refAndPath)
     switch (resolution.kind) {
       case 'resolved':
-        return { ref: resolution.ref.name, oid: resolution.ref.oid, directoryPath: resolution.directoryPath }
-      case 'repo-root':
-        throw new Error(
-          `"${resolution.ref.name}" is a ${resolution.ref.namespace === 'tags' ? 'tag' : 'branch'} in ${repoUrl}, ` +
-            'so this URL points at a SKILL.md in the repository root — install a skill directory instead.'
-        )
+        return { ref: resolution.ref.name, oid: resolution.ref.oid, target: resolution.target }
       case 'ambiguous':
         throw new Error(`${repoUrl} has both a branch and a tag named "${resolution.name}"; the URL cannot say which.`)
       case 'no-match': {
-        const [head, ...rest] = refAndDirectory
+        const [head, ...rest] = refAndPath
         // A permalink names its commit outright, so no ref has to match for it to be exact.
-        if (rest.length > 0 && /^[0-9a-f]{40}$/i.test(head)) {
-          return { ref: head, oid: head.toLowerCase(), directoryPath: rest.join('/') }
+        if (/^[0-9a-f]{40}$/i.test(head)) {
+          const target: GithubSkillTarget =
+            rest.length === 0 ? { kind: 'root' } : { kind: 'directory', path: rest.join('/') }
+          return { ref: head, oid: head.toLowerCase(), target }
         }
-        throw new Error(`No branch or tag in ${repoUrl} matches "${refAndDirectory.join('/')}"`)
+        throw new Error(`No branch or tag in ${repoUrl} matches "${refAndPath.join('/')}"`)
       }
     }
   }
 
   /**
-   * Materialize one commit, and from it only the selected directory. Fetching the OID rather than a
-   * ref name is what makes the install deterministic; the blob filter and sparse pattern keep an
-   * unrelated multi-gigabyte repository from being written to disk on the way to one skill, and the
-   * hardened env keeps it from hanging on a credential prompt or smudging LFS payloads.
+   * Fetch one commit into a bare repository and check out only installable content into a separate
+   * work tree. Keeping the two roots separate prevents a repository-root skill from copying `.git`.
    */
-  private async fetchCommit(repoUrl: string, oid: string, directoryPath: string, destDir: string): Promise<void> {
+  private async materializeGithubTarget(
+    repoUrl: string,
+    oid: string,
+    target: GithubSkillTarget,
+    descriptorFileName: 'SKILL.md' | 'skill.md',
+    tempDir: string
+  ): Promise<{ contentDir: string; skillDir: string }> {
     const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
-    const git = (args: string[]) => this.runGit(gitCommand, ['-C', destDir, ...args])
+    const gitDir = path.join(tempDir, 'repo.git')
+    const contentDir = path.join(tempDir, 'content')
+    const git = (args: string[]) => this.runGit(gitCommand, [`--git-dir=${gitDir}`, ...args])
 
-    await fs.promises.mkdir(destDir, { recursive: true })
-    await git(['init', '--quiet'])
+    await fs.promises.mkdir(contentDir, { recursive: true })
+    await this.runGit(gitCommand, ['init', '--bare', '--quiet', gitDir])
     await git(['fetch', '--quiet', '--depth', '1', '--filter=blob:none', '--no-tags', '--', repoUrl, oid])
-    // Leading `/` anchors the pattern at the repo root and keeps a directory named like an option
-    // from being read as one.
-    await git(['sparse-checkout', 'set', '--no-cone', `/${directoryPath}/`])
-    await git(['checkout', '--quiet', 'FETCH_HEAD'])
+    const pathspec = target.kind === 'root' ? '.' : `:(top,literal)${target.path}`
+    const paths = await git(['ls-tree', '-r', '-z', '--name-only', '--full-tree', 'FETCH_HEAD'])
+    const sizedTree = await git([
+      'ls-tree',
+      '-lr',
+      '-z',
+      '--full-tree',
+      'FETCH_HEAD',
+      ...(target.kind === 'root' ? [] : ['--', pathspec])
+    ])
+    this.assertGithubTargetTree(paths, sizedTree, target, descriptorFileName)
+
+    await this.runGit(gitCommand, [
+      `--git-dir=${gitDir}`,
+      `--work-tree=${contentDir}`,
+      'checkout',
+      '--quiet',
+      'FETCH_HEAD',
+      '--',
+      pathspec
+    ])
+
+    return {
+      contentDir,
+      skillDir: target.kind === 'root' ? contentDir : path.join(contentDir, target.path)
+    }
+  }
+
+  /** Validate the selected Git tree before checkout writes any untrusted content. */
+  private assertGithubTargetTree(
+    paths: string,
+    sizedTree: string,
+    target: GithubSkillTarget,
+    descriptorFileName: 'SKILL.md' | 'skill.md'
+  ): void {
+    const foldKey = (value: string) => value.normalize('NFC').toLowerCase()
+    const targetParts = target.kind === 'root' ? [] : target.path.split('/')
+    const foldedTarget = targetParts.map(foldKey)
+    const selectedPaths: string[] = []
+    const matchingRoots = new Set<string>()
+
+    for (const entryPath of paths.split('\0').filter(Boolean)) {
+      const entryParts = entryPath.split('/')
+      if (target.kind === 'directory') {
+        const rootParts = entryParts.slice(0, targetParts.length)
+        if (!rootParts.every((part, index) => foldKey(part) === foldedTarget[index])) continue
+        matchingRoots.add(rootParts.join('/'))
+        if (rootParts.join('/') !== target.path) continue
+      }
+
+      const relativePath = target.kind === 'root' ? entryPath : entryParts.slice(targetParts.length).join('/')
+      selectedPaths.push(relativePath)
+    }
+
+    if (matchingRoots.size > 1) {
+      throw new Error(
+        `The commit contains directories that collide with "${target.kind === 'directory' ? target.path : '.'}" ` +
+          `once case and Unicode are normalized (${[...matchingRoots].join(', ')}).`
+      )
+    }
+
+    const seenPaths = new Map<string, string>()
+    for (const entryPath of selectedPaths) {
+      const key = foldKey(entryPath)
+      const previous = seenPaths.get(key)
+      if (previous && previous !== entryPath) {
+        throw new Error(
+          `The commit contains paths that collide once case and Unicode are normalized (${previous}, ${entryPath}).`
+        )
+      }
+      seenPaths.set(key, entryPath)
+    }
+
+    const sizedEntries = sizedTree.split('\0').flatMap((record) => {
+      if (!record) return []
+      const tab = record.indexOf('\t')
+      if (tab === -1) return []
+      const [, type, , rawSize] = record.slice(0, tab).trim().split(/\s+/)
+      if (type !== 'blob' || !/^\d+$/.test(rawSize)) return []
+      const entryPath = record.slice(tab + 1)
+      const relativePath = target.kind === 'root' ? entryPath : entryPath.split('/').slice(targetParts.length).join('/')
+      return [{ path: relativePath, size: Number(rawSize) }]
+    })
+
+    if (!sizedEntries.some((entry) => entry.path === descriptorFileName)) {
+      const location = target.kind === 'root' ? descriptorFileName : `${target.path}/${descriptorFileName}`
+      throw new Error(`No ${descriptorFileName} found at the selected GitHub location: ${location}`)
+    }
+    if (sizedEntries.length > MAX_FILES_COUNT) {
+      throw new Error(`Skill directory has too many files: exceeds ${MAX_FILES_COUNT}`)
+    }
+    const totalSize = sizedEntries.reduce((sum, entry) => sum + entry.size, 0)
+    if (totalSize > MAX_EXTRACTED_SIZE) {
+      throw new Error(`Skill directory too large: exceeds ${MAX_EXTRACTED_SIZE} bytes`)
+    }
   }
 
   /** Apply the same ceilings an untrusted ZIP gets — a repository is no more trusted than an archive. */
@@ -632,32 +735,6 @@ export class SkillService {
         GCM_INTERACTIVE: 'never'
       }
     })
-  }
-
-  /**
-   * Refuse a tree whose paths collide once the filesystem folds case or normalizes Unicode. Such a
-   * checkout merges two directories into one, so the containment checks would inspect bytes that are
-   * not the ones the URL selected.
-   */
-  private async assertUniqueSkillPath(repoDir: string, directoryPath: string): Promise<void> {
-    const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
-    const output = await this.runGit(gitCommand, ['-C', repoDir, 'ls-tree', '-r', '--name-only', 'FETCH_HEAD'])
-    const foldKey = (value: string) => value.normalize('NFC').toLowerCase()
-    const wanted = foldKey(`${directoryPath}/`)
-
-    const collisions = new Set<string>()
-    for (const entry of output.split('\n')) {
-      const line = entry.trim()
-      if (!line || !foldKey(line).startsWith(wanted)) continue
-      collisions.add(line.slice(0, line.indexOf('/', directoryPath.length)))
-    }
-
-    if (collisions.size > 1) {
-      throw new Error(
-        `The commit contains directories that collide with "${directoryPath}" once case and Unicode are ` +
-          `normalized (${[...collisions].join(', ')}); refusing to install an ambiguous checkout.`
-      )
-    }
   }
 
   private async installFromSkillsSh(identifier: string): Promise<InstalledSkill> {

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -655,14 +655,18 @@ export class SkillService {
 
     const seenPaths = new Map<string, string>()
     for (const entryPath of selectedPaths) {
-      const key = foldKey(entryPath)
-      const previous = seenPaths.get(key)
-      if (previous && previous !== entryPath) {
-        throw new Error(
-          `The commit contains paths that collide once case and Unicode are normalized (${previous}, ${entryPath}).`
-        )
+      const parts = entryPath.split('/')
+      for (let length = 1; length <= parts.length; length++) {
+        const prefix = parts.slice(0, length).join('/')
+        const key = parts.slice(0, length).map(foldKey).join('/')
+        const previous = seenPaths.get(key)
+        if (previous && previous !== prefix) {
+          throw new Error(
+            `The commit contains paths that collide once case and Unicode are normalized (${previous}, ${prefix}).`
+          )
+        }
+        seenPaths.set(key, prefix)
       }
-      seenPaths.set(key, entryPath)
     }
 
     const sizedEntries = sizedTree.split('\0').flatMap((record) => {

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -27,8 +27,7 @@ import type {
   SystemSkillPlacement
 } from '@shared/types/skill'
 import { ClawhubSkillDetailSchema } from '@shared/types/skill'
-import type { GithubSkillTarget } from '@shared/utils/skillMarketplace'
-import { encodeGithubPath, parseGithubSkillUrl, resolveRefFromSegments } from '@shared/utils/skillMarketplace'
+import { encodeGithubPath, parseGithubSkillUrl } from '@shared/utils/skillMarketplace'
 import { Mutex } from 'async-mutex'
 import { net } from 'electron'
 import StreamZip from 'node-stream-zip'
@@ -47,8 +46,46 @@ const MAX_FILES_COUNT = 2000
 const MAX_FOLDER_NAME_LENGTH = 80
 // A direct-URL install points git at a repository nobody vetted; no single step may hang forever.
 const GIT_COMMAND_TIMEOUT_MS = 2 * 60 * 1000
+const MAX_GIT_TREE_OUTPUT_BYTES = 16 * 1024 * 1024
 const SKILLS_PLUGIN_MANIFEST = `${JSON.stringify({ name: 'cherry-studio-skills' }, null, 2)}\n`
 const BUILTIN_VERSION_FILE = '.version'
+
+type GithubRef = {
+  name: string
+  oid: string
+  namespace: 'heads' | 'tags'
+}
+
+type GithubSkillTarget = { kind: 'root' } | { kind: 'directory'; path: string }
+
+type GithubRefResolution =
+  | { kind: 'resolved'; ref: GithubRef; target: GithubSkillTarget }
+  | { kind: 'ambiguous'; name: string }
+  | { kind: 'no-match' }
+
+function resolveGithubRef(refs: readonly GithubRef[], refAndPath: readonly string[]): GithubRefResolution {
+  const refsByName = new Map<string, GithubRef[]>()
+  for (const ref of refs) {
+    refsByName.set(ref.name, [...(refsByName.get(ref.name) ?? []), ref])
+  }
+
+  for (let length = refAndPath.length; length >= 1; length--) {
+    const name = refAndPath.slice(0, length).join('/')
+    const matches = refsByName.get(name)
+    if (!matches?.length) continue
+    if (matches.length > 1) return { kind: 'ambiguous', name }
+
+    return {
+      kind: 'resolved',
+      ref: matches[0],
+      target:
+        length === refAndPath.length
+          ? { kind: 'root' }
+          : { kind: 'directory', path: refAndPath.slice(length).join('/') }
+    }
+  }
+  return { kind: 'no-match' }
+}
 
 function isOutsidePath(relativePath: string): boolean {
   return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)
@@ -514,7 +551,9 @@ export class SkillService {
     // Keep the ref, not the commit, as the stored origin: a later install of the same skill has to
     // match this URL to be treated as an update rather than a foreign folder collision.
     const sourcePath = target.kind === 'root' ? ref : `${ref}/${target.path}`
-    const sourceUrl = `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
+    const sourceUrl = refNamespace
+      ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${refNamespace}/${encodeGithubPath(`${sourcePath}/${descriptorFileName}`)}`
+      : `${repoUrl}/tree/${encodeGithubPath(sourcePath)}`
     const tempDir = await this.createTempDir('github')
 
     try {
@@ -554,7 +593,7 @@ export class SkillService {
     })
 
     const matchingRefs = refNamespace ? refs.filter((ref) => ref.namespace === refNamespace) : refs
-    const resolution = resolveRefFromSegments(matchingRefs, refAndPath)
+    const resolution = resolveGithubRef(matchingRefs, refAndPath)
     switch (resolution.kind) {
       case 'resolved':
         return { ref: resolution.ref.name, oid: resolution.ref.oid, target: resolution.target }
@@ -587,22 +626,18 @@ export class SkillService {
     const gitCommand = (await findExecutableInEnv('git')) ?? 'git'
     const gitDir = path.join(tempDir, 'repo.git')
     const contentDir = path.join(tempDir, 'content')
-    const git = (args: string[]) => this.runGit(gitCommand, [`--git-dir=${gitDir}`, ...args])
+    const git = (args: string[], options?: { maxOutputBytes?: number }) =>
+      this.runGit(gitCommand, [`--git-dir=${gitDir}`, ...args], options)
 
     await fs.promises.mkdir(contentDir, { recursive: true })
     await this.runGit(gitCommand, ['init', '--bare', '--quiet', gitDir])
     await git(['fetch', '--quiet', '--depth', '1', '--filter=blob:none', '--no-tags', '--', repoUrl, oid])
     const pathspec = target.kind === 'root' ? '.' : `:(top,literal)${target.path}`
-    const paths = await git(['ls-tree', '-r', '-z', '--name-only', '--full-tree', 'FETCH_HEAD'])
-    const sizedTree = await git([
-      'ls-tree',
-      '-lr',
-      '-z',
-      '--full-tree',
-      'FETCH_HEAD',
-      ...(target.kind === 'root' ? [] : ['--', pathspec])
-    ])
-    this.assertGithubTargetTree(paths, sizedTree, target, descriptorFileName)
+    const sizedTree = await git(
+      ['ls-tree', '-lr', '-z', '--full-tree', 'FETCH_HEAD', ...(target.kind === 'root' ? [] : ['--', pathspec])],
+      { maxOutputBytes: MAX_GIT_TREE_OUTPUT_BYTES }
+    )
+    this.assertGithubTargetTree(sizedTree, target, descriptorFileName)
 
     await this.runGit(gitCommand, [
       `--git-dir=${gitDir}`,
@@ -622,40 +657,27 @@ export class SkillService {
 
   /** Validate the selected Git tree before checkout writes any untrusted content. */
   private assertGithubTargetTree(
-    paths: string,
     sizedTree: string,
     target: GithubSkillTarget,
     descriptorFileName: 'SKILL.md' | 'skill.md'
   ): void {
     const foldKey = (value: string) => value.normalize('NFC').toLowerCase()
     const targetParts = target.kind === 'root' ? [] : target.path.split('/')
-    const foldedTarget = targetParts.map(foldKey)
-    const selectedPaths: string[] = []
-    const matchingRoots = new Set<string>()
 
-    for (const entryPath of paths.split('\0').filter(Boolean)) {
-      const entryParts = entryPath.split('/')
-      if (target.kind === 'directory') {
-        const rootParts = entryParts.slice(0, targetParts.length)
-        if (!rootParts.every((part, index) => foldKey(part) === foldedTarget[index])) continue
-        matchingRoots.add(rootParts.join('/'))
-        if (rootParts.join('/') !== target.path) continue
-      }
-
-      const relativePath = target.kind === 'root' ? entryPath : entryParts.slice(targetParts.length).join('/')
-      selectedPaths.push(relativePath)
-    }
-
-    if (matchingRoots.size > 1) {
-      throw new Error(
-        `The commit contains directories that collide with "${target.kind === 'directory' ? target.path : '.'}" ` +
-          `once case and Unicode are normalized (${[...matchingRoots].join(', ')}).`
-      )
-    }
+    const sizedEntries = sizedTree.split('\0').flatMap((record) => {
+      if (!record) return []
+      const tab = record.indexOf('\t')
+      if (tab === -1) return []
+      const [, type, , rawSize] = record.slice(0, tab).trim().split(/\s+/)
+      if (type !== 'blob' || !/^\d+$/.test(rawSize)) return []
+      const entryPath = record.slice(tab + 1)
+      const relativePath = target.kind === 'root' ? entryPath : entryPath.split('/').slice(targetParts.length).join('/')
+      return [{ path: relativePath, size: Number(rawSize) }]
+    })
 
     const seenPaths = new Map<string, string>()
-    for (const entryPath of selectedPaths) {
-      const parts = entryPath.split('/')
+    for (const entry of sizedEntries) {
+      const parts = entry.path.split('/')
       for (let length = 1; length <= parts.length; length++) {
         const prefix = parts.slice(0, length).join('/')
         const key = parts.slice(0, length).map(foldKey).join('/')
@@ -668,17 +690,6 @@ export class SkillService {
         seenPaths.set(key, prefix)
       }
     }
-
-    const sizedEntries = sizedTree.split('\0').flatMap((record) => {
-      if (!record) return []
-      const tab = record.indexOf('\t')
-      if (tab === -1) return []
-      const [, type, , rawSize] = record.slice(0, tab).trim().split(/\s+/)
-      if (type !== 'blob' || !/^\d+$/.test(rawSize)) return []
-      const entryPath = record.slice(tab + 1)
-      const relativePath = target.kind === 'root' ? entryPath : entryPath.split('/').slice(targetParts.length).join('/')
-      return [{ path: relativePath, size: Number(rawSize) }]
-    })
 
     if (!sizedEntries.some((entry) => entry.path === descriptorFileName)) {
       const location = target.kind === 'root' ? descriptorFileName : `${target.path}/${descriptorFileName}`
@@ -725,10 +736,11 @@ export class SkillService {
    * The single entry point for every git subprocess an install spawns: bounded, non-interactive, and
    * routed through Cherry's proxy — which lives in the main process env, not in the captured login shell.
    */
-  private async runGit(gitCommand: string, args: string[]): Promise<string> {
+  private async runGit(gitCommand: string, args: string[], options?: { maxOutputBytes?: number }): Promise<string> {
     const env = await getShellEnv()
     return executeCommand(gitCommand, args, {
       capture: true,
+      maxOutputBytes: options?.maxOutputBytes,
       timeout: GIT_COMMAND_TIMEOUT_MS,
       env: {
         ...env,

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -650,8 +650,13 @@ describe('SkillService', () => {
             .join('\n')
         }
         if (args.includes('ls-tree')) {
-          if (args.includes('--name-only')) return tree.map((entry) => `${entry.path}\0`).join('')
-          return tree.map((entry) => `100644 blob ${'d'.repeat(40)} ${entry.size}\t${entry.path}\0`).join('')
+          const separator = args.lastIndexOf('--')
+          const pathspec = separator === -1 ? null : args[separator + 1]
+          const selectedPath = pathspec?.replace(/^:\(top,literal\)/, '')
+          const selectedTree = tree.filter(
+            (entry) => !selectedPath || entry.path === selectedPath || entry.path.startsWith(`${selectedPath}/`)
+          )
+          return selectedTree.map((entry) => `100644 blob ${'d'.repeat(40)} ${entry.size}\t${entry.path}\0`).join('')
         }
         if (args.includes('checkout')) {
           const separator = args.lastIndexOf('--')
@@ -758,7 +763,7 @@ describe('SkillService', () => {
 
     it('uses an explicit tag namespace when a branch has the same name', async () => {
       const tagOid = 'b'.repeat(40)
-      const { skillService, gitCalls } = await setupGithubInstall({
+      const { skillService, installSpy, gitCalls } = await setupGithubInstall({
         refs: [
           { name: 'v1', oid: 'a'.repeat(40) },
           { name: 'v1', oid: tagOid, namespace: 'tags' }
@@ -770,6 +775,11 @@ describe('SkillService', () => {
       })
 
       expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining([tagOid]))
+      expect(installSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        'marketplace',
+        'https://raw.githubusercontent.com/owner/repo/refs/tags/v1/skills/demo/SKILL.md'
+      )
     })
 
     it('installs the exact lowercase descriptor selected by the URL', async () => {
@@ -847,9 +857,7 @@ describe('SkillService', () => {
       expect(gitFetchArgs(gitCalls)).toBeUndefined()
     })
 
-    it('refuses a tree whose directories collide once case is folded', async () => {
-      // A case-insensitive filesystem merges these two into one checkout, so containment checks would
-      // inspect bytes other than the ones the URL selected.
+    it('does not inspect a case-variant sibling outside the selected directory', async () => {
       const { skillService } = await setupGithubInstall({
         refs: [{ name: 'main', oid: 'a'.repeat(40) }],
         tree: ['skills/demo/SKILL.md', 'skills/Demo/SKILL.md']
@@ -857,7 +865,7 @@ describe('SkillService', () => {
 
       await expect(
         skillService.install({ installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md' })
-      ).rejects.toThrow('collide')
+      ).resolves.toBeDefined()
     })
 
     it('refuses case-folded directory collisions inside the selected skill', async () => {
@@ -882,6 +890,11 @@ describe('SkillService', () => {
       expect(gitCalls.find((args) => args.includes('checkout'))).toEqual(
         expect.arrayContaining(['--', ':(top,literal)skills/demo'])
       )
+      expect(gitCalls.filter((args) => args.includes('ls-tree'))).toEqual([
+        expect.arrayContaining(['--', ':(top,literal)skills/demo'])
+      ])
+      const treeCall = executeCommandMock.mock.calls.find(([, args]) => args.includes('ls-tree'))
+      expect(treeCall?.[2]).toMatchObject({ maxOutputBytes: expect.any(Number) })
     })
 
     it('never lets an untrusted repository prompt for credentials or pull LFS payloads', async () => {

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -631,12 +631,15 @@ describe('SkillService', () => {
      */
     async function setupGithubInstall(options: {
       refs?: Array<{ name: string; oid: string; namespace?: 'heads' | 'tags' }>
-      tree?: string[]
+      tree?: Array<string | { path: string; size: number }>
     }) {
       const skillService = new SkillService()
       const workDir = await createTempDir('github-install-')
       vi.spyOn(skillService as never, 'createTempDir').mockResolvedValue(workDir as never)
-      const tree = options.tree ?? ['skills/demo/SKILL.md']
+      vi.spyOn(skillService as never, 'safeRemoveDirectory').mockResolvedValue(undefined as never)
+      const tree = (options.tree ?? ['skills/demo/SKILL.md']).map((entry) =>
+        typeof entry === 'string' ? { path: entry, size: 8 } : entry
+      )
       const gitCalls: string[][] = []
 
       executeCommandMock.mockImplementation(async (_command: string, args: string[]) => {
@@ -646,11 +649,20 @@ describe('SkillService', () => {
             .map((ref) => `${ref.oid}\trefs/${ref.namespace ?? 'heads'}/${ref.name}`)
             .join('\n')
         }
-        if (args.includes('ls-tree')) return tree.join('\n')
+        if (args.includes('ls-tree')) {
+          if (args.includes('--name-only')) return tree.map((entry) => `${entry.path}\0`).join('')
+          return tree.map((entry) => `100644 blob ${'d'.repeat(40)} ${entry.size}\t${entry.path}\0`).join('')
+        }
         if (args.includes('checkout')) {
-          for (const entry of tree) {
-            await fs.promises.mkdir(path.join(workDir, path.dirname(entry)), { recursive: true })
-            await fs.promises.writeFile(path.join(workDir, entry), '# skill')
+          const separator = args.lastIndexOf('--')
+          const pathspec = args[separator + 1]
+          const selectedPath = pathspec === '.' ? null : pathspec.replace(/^:\(top,literal\)/, '')
+          for (const entry of tree.filter(
+            (entry) => !selectedPath || entry.path === selectedPath || entry.path.startsWith(`${selectedPath}/`)
+          )) {
+            const contentPath = path.join(workDir, 'content', entry.path)
+            await fs.promises.mkdir(path.dirname(contentPath), { recursive: true })
+            await fs.promises.writeFile(contentPath, '# skill')
           }
         }
         return ''
@@ -700,18 +712,106 @@ describe('SkillService', () => {
       expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining([wanted]))
     })
 
-    it('refuses a URL that names a repo-root SKILL.md instead of falling back to a shorter ref', async () => {
+    it('installs a repository-root SKILL.md without exposing Git metadata as skill content', async () => {
+      const oid = 'a'.repeat(40)
+      const { skillService, installSpy } = await setupGithubInstall({
+        refs: [{ name: 'main', oid }],
+        tree: ['SKILL.md', 'scripts/run.ts']
+      })
+
+      await skillService.install({
+        installSource: 'github:https://github.com/owner/repo/blob/main/SKILL.md'
+      })
+
+      const installedDirectory = installSpy.mock.calls[0][0] as string
+      await expect(fs.promises.access(path.join(installedDirectory, 'SKILL.md'))).resolves.toBeUndefined()
+      await expect(fs.promises.access(path.join(installedDirectory, '.git'))).rejects.toMatchObject({ code: 'ENOENT' })
+    })
+
+    it('uses the longest slash-bearing ref for a repository-root SKILL.md', async () => {
       const { skillService, gitCalls } = await setupGithubInstall({
         refs: [
           { name: 'feature', oid: 'a'.repeat(40) },
           { name: 'feature/foo', oid: 'b'.repeat(40) }
+        ],
+        tree: ['SKILL.md']
+      })
+
+      await skillService.install({ installSource: 'github:https://github.com/owner/repo/blob/feature/foo/SKILL.md' })
+
+      expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining(['b'.repeat(40)]))
+    })
+
+    it('installs a repository-root Skill from a full commit permalink', async () => {
+      const oid = 'c'.repeat(40)
+      const { skillService, installSpy, gitCalls } = await setupGithubInstall({ tree: ['SKILL.md'] })
+
+      await skillService.install({ installSource: `github:https://github.com/owner/repo/blob/${oid}/SKILL.md` })
+
+      expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining([oid]))
+      expect(installSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`${path.sep}content`),
+        'marketplace',
+        `https://github.com/owner/repo/tree/${oid}`
+      )
+    })
+
+    it('uses an explicit tag namespace when a branch has the same name', async () => {
+      const tagOid = 'b'.repeat(40)
+      const { skillService, gitCalls } = await setupGithubInstall({
+        refs: [
+          { name: 'v1', oid: 'a'.repeat(40) },
+          { name: 'v1', oid: tagOid, namespace: 'tags' }
         ]
       })
 
+      await skillService.install({
+        installSource: 'github:https://github.com/owner/repo/raw/refs/tags/v1/skills/demo/SKILL.md'
+      })
+
+      expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining([tagOid]))
+    })
+
+    it('installs the exact lowercase descriptor selected by the URL', async () => {
+      const { skillService, installSpy } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }],
+        tree: ['skills/demo/skill.md']
+      })
+
+      await skillService.install({
+        installSource: 'github:https://raw.githubusercontent.com/owner/repo/main/skills/demo/skill.md'
+      })
+
+      const installedDirectory = installSpy.mock.calls[0][0] as string
+      await expect(fs.promises.access(path.join(installedDirectory, 'skill.md'))).resolves.toBeUndefined()
+    })
+
+    it('rejects a missing exact descriptor before checkout', async () => {
+      const { skillService, gitCalls } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }],
+        tree: ['skills/demo/skill.md']
+      })
+
       await expect(
-        skillService.install({ installSource: 'github:https://github.com/owner/repo/blob/feature/foo/SKILL.md' })
-      ).rejects.toThrow('repository root')
-      expect(gitFetchArgs(gitCalls)).toBeUndefined()
+        skillService.install({
+          installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md'
+        })
+      ).rejects.toThrow('No SKILL.md found')
+      expect(gitCalls.some((args) => args.includes('checkout'))).toBe(false)
+    })
+
+    it('rejects an oversized selected target before checkout', async () => {
+      const { skillService, gitCalls } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }],
+        tree: ['skills/demo/SKILL.md', { path: 'skills/demo/model.bin', size: 100 * 1024 * 1024 }]
+      })
+
+      await expect(
+        skillService.install({
+          installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md'
+        })
+      ).rejects.toThrow('too large')
+      expect(gitCalls.some((args) => args.includes('checkout'))).toBe(false)
     })
 
     it('refuses a ref name carried by both a branch and a tag', async () => {
@@ -768,8 +868,8 @@ describe('SkillService', () => {
       })
 
       expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining(['--filter=blob:none']))
-      expect(gitCalls.find((args) => args.includes('sparse-checkout'))).toEqual(
-        expect.arrayContaining(['/skills/demo/'])
+      expect(gitCalls.find((args) => args.includes('checkout'))).toEqual(
+        expect.arrayContaining(['--', ':(top,literal)skills/demo'])
       )
     })
 

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -632,6 +632,7 @@ describe('SkillService', () => {
     async function setupGithubInstall(options: {
       refs?: Array<{ name: string; oid: string; namespace?: 'heads' | 'tags' }>
       tree?: Array<string | { path: string; size: number }>
+      realInstall?: boolean
     }) {
       const skillService = new SkillService()
       const workDir = await createTempDir('github-install-')
@@ -673,7 +674,13 @@ describe('SkillService', () => {
         return ''
       })
 
-      const installSpy = vi.spyOn(skillService as never, 'installSkillDir').mockResolvedValue({} as never)
+      const installSkillDir = skillService['installSkillDir'].bind(skillService)
+      const installSpy = vi.spyOn(skillService as never, 'installSkillDir')
+      if (options.realInstall) {
+        installSpy.mockImplementation(installSkillDir as never)
+      } else {
+        installSpy.mockResolvedValue({} as never)
+      }
       vi.mocked(findSkillMdPath).mockImplementation(async (dir: string) => path.join(dir, 'SKILL.md'))
       return { skillService, installSpy, gitCalls, workDir }
     }
@@ -697,8 +704,51 @@ describe('SkillService', () => {
       expect(installSpy).toHaveBeenCalledWith(
         expect.stringContaining(path.join('skills', 'recruit-init')),
         'marketplace',
-        'https://github.com/owner/repo/tree/dev/skills/recruit-init'
+        'https://raw.githubusercontent.com/owner/repo/refs/heads/dev/skills/recruit-init/SKILL.md'
       )
+    })
+
+    it('updates the same skill when switching between blob and explicit raw branch URLs', async () => {
+      const root = await createTempDir('github-reinstall-')
+      const dataSkillsRoot = path.join(root, 'Data', 'Skills')
+      const mirrorRoot = path.join(root, '.claude', 'skills')
+      const getPathSpy = vi.spyOn(application, 'getPath').mockImplementation((key: string, filename?: string) => {
+        const base = key === 'feature.agents.skills' ? dataSkillsRoot : mirrorRoot
+        return filename ? path.join(base, filename) : base
+      })
+      vi.mocked(parseSkillMetadata).mockResolvedValue({
+        sourcePath: 'demo',
+        filename: 'demo',
+        name: 'Demo',
+        description: 'Demo skill',
+        category: 'skills',
+        type: 'skill',
+        version: '1.0.0',
+        size: 0,
+        contentHash: 'demo-hash'
+      })
+      const { skillService } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }],
+        realInstall: true
+      })
+
+      try {
+        const installed = await skillService.install({
+          installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md'
+        })
+        const updatedFromRaw = await skillService.install({
+          installSource: 'github:https://raw.githubusercontent.com/owner/repo/refs/heads/main/skills/demo/SKILL.md'
+        })
+        const updatedFromBlob = await skillService.install({
+          installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md'
+        })
+
+        expect(updatedFromRaw).toMatchObject({ id: installed.id, sourceUrl: installed.sourceUrl })
+        expect(updatedFromBlob).toMatchObject({ id: installed.id, sourceUrl: installed.sourceUrl })
+      } finally {
+        getPathSpy.mockRestore()
+        vi.mocked(parseSkillMetadata).mockReset()
+      }
     })
 
     it('resolves a slash-bearing branch against the remote instead of splitting at the first segment', async () => {
@@ -846,6 +896,20 @@ describe('SkillService', () => {
       })
 
       expect(gitFetchArgs(gitCalls)).toEqual(expect.arrayContaining([oid]))
+    })
+
+    it.each(['heads', 'tags'] as const)('does not treat a missing explicit %s ref as a commit', async (namespace) => {
+      const oid = 'c'.repeat(40)
+      const { skillService, gitCalls } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }]
+      })
+
+      await expect(
+        skillService.install({
+          installSource: `github:https://raw.githubusercontent.com/owner/repo/refs/${namespace}/${oid}/skills/demo/SKILL.md`
+        })
+      ).rejects.toThrow('No branch or tag')
+      expect(gitFetchArgs(gitCalls)).toBeUndefined()
     })
 
     it('fails a github URL whose ref matches no branch, tag or commit', async () => {

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -860,6 +860,17 @@ describe('SkillService', () => {
       ).rejects.toThrow('collide')
     })
 
+    it('refuses case-folded directory collisions inside the selected skill', async () => {
+      const { skillService } = await setupGithubInstall({
+        refs: [{ name: 'main', oid: 'a'.repeat(40) }],
+        tree: ['skills/demo/SKILL.md', 'skills/demo/Docs/a.md', 'skills/demo/docs/b.md']
+      })
+
+      await expect(
+        skillService.install({ installSource: 'github:https://github.com/owner/repo/blob/main/skills/demo/SKILL.md' })
+      ).rejects.toThrow('collide')
+    })
+
     it('materializes only the selected directory instead of the whole repository', async () => {
       const { skillService, gitCalls } = await setupGithubInstall({ refs: [{ name: 'main', oid: 'a'.repeat(40) }] })
 

--- a/src/main/utils/__tests__/processRunner.test.ts
+++ b/src/main/utils/__tests__/processRunner.test.ts
@@ -1,13 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@application', () => ({ application: { getPath: vi.fn() } }))
-
-vi.mock('@logger', () => ({
-  loggerService: {
-    withContext: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() })
-  }
-}))
-
 vi.mock('@main/utils/shellEnv', () => ({ getShellEnv: vi.fn() }))
 
 import { executeCommand } from '../processRunner'

--- a/src/main/utils/__tests__/processRunner.test.ts
+++ b/src/main/utils/__tests__/processRunner.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@application', () => ({ application: { getPath: vi.fn() } }))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() })
+  }
+}))
+
+vi.mock('@main/utils/shellEnv', () => ({ getShellEnv: vi.fn() }))
+
+import { executeCommand } from '../processRunner'
+
+describe('executeCommand', () => {
+  it('terminates a command whose captured stdout exceeds the configured limit', async () => {
+    await expect(
+      executeCommand(process.execPath, ['-e', "process.stdout.write('x'.repeat(64))"], {
+        capture: true,
+        env: process.env,
+        maxOutputBytes: 16
+      })
+    ).rejects.toThrow('output exceeded 16 bytes')
+  })
+})

--- a/src/main/utils/processRunner.ts
+++ b/src/main/utils/processRunner.ts
@@ -130,6 +130,8 @@ export async function executeCommand(
     capture?: boolean
     /** Environment variables (defaults to getShellEnv()) */
     env?: NodeJS.ProcessEnv
+    /** Maximum combined stdout/stderr bytes before the command is terminated */
+    maxOutputBytes?: number
     /** Timeout in milliseconds */
     timeout?: number
   }
@@ -140,16 +142,33 @@ export async function executeCommand(
     const child = crossPlatformSpawn(command, args, { env })
     let stdout = ''
     let stderr = ''
+    let outputBytes = 0
+    let outputLimitError: Error | undefined
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+    const collectOutput = (chunk: unknown): string | null => {
+      if (outputLimitError) return null
+      const text = String(chunk)
+      const chunkBytes = Buffer.isBuffer(chunk) ? chunk.byteLength : Buffer.byteLength(text)
+      const nextOutputBytes = outputBytes + chunkBytes
+      if (options?.maxOutputBytes !== undefined && nextOutputBytes > options.maxOutputBytes) {
+        outputLimitError = new Error(`Command output exceeded ${options.maxOutputBytes} bytes`)
+        if (timeoutId) clearTimeout(timeoutId)
+        child.kill('SIGKILL')
+        return null
+      }
+      outputBytes = nextOutputBytes
+      return text
+    }
 
     child.stdout?.on('data', (chunk) => {
-      stdout += chunk.toString()
+      stdout += collectOutput(chunk) ?? ''
     })
 
     child.stderr?.on('data', (chunk) => {
-      stderr += chunk.toString()
+      stderr += collectOutput(chunk) ?? ''
     })
 
-    let timeoutId: ReturnType<typeof setTimeout> | undefined
     if (options?.timeout) {
       timeoutId = setTimeout(() => {
         child.kill('SIGKILL')
@@ -159,12 +178,14 @@ export async function executeCommand(
 
     child.on('error', (err) => {
       if (timeoutId) clearTimeout(timeoutId)
-      reject(err)
+      reject(outputLimitError ?? err)
     })
 
     child.on('close', (code) => {
       if (timeoutId) clearTimeout(timeoutId)
-      if (code === 0) {
+      if (outputLimitError) {
+        reject(outputLimitError)
+      } else if (code === 0) {
         resolve(options?.capture ? stdout : '')
       } else {
         reject(new Error(stderr || `Command failed with code ${code}`))

--- a/src/renderer/components/resourceCatalog/dialogs/skill/__tests__/SkillMarketplaceDialog.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/skill/__tests__/SkillMarketplaceDialog.test.tsx
@@ -319,26 +319,35 @@ describe('SkillMarketplaceDialog', () => {
       }
     }
 
-    it('installs the skill a SKILL.md URL points at without querying the registries', async () => {
+    it.each([
+      [
+        'repository-root blob link',
+        'https://github.com/owner/repo/blob/main/SKILL.md',
+        'github:https://github.com/owner/repo/blob/main/SKILL.md'
+      ],
+      [
+        'official raw link',
+        'https://github.com/owner/repo/raw/refs/heads/main/SKILL.md',
+        'github:https://raw.githubusercontent.com/owner/repo/refs/heads/main/SKILL.md'
+      ]
+    ])('installs a %s without querying the registries', async (_case, url, installSource) => {
       const user = userEvent.setup()
       renderDialog()
 
-      await selectGithubAndType('https://github.com/owner/repo/blob/main/skills/resume-review/SKILL.md')
+      await selectGithubAndType(url)
 
       expect(searchMock).not.toHaveBeenCalled()
-      expect(screen.getByText('resume-review')).toBeInTheDocument()
+      expect(screen.getByText('repo')).toBeInTheDocument()
       // The dropdown counts what each source currently offers, and GitHub's one row is not in
       // `results` — reading only the registry list would leave it blank.
       expect(within(sourceSelect()).getByRole('option', { name: 'GitHub1' })).toBeInTheDocument()
       await user.click(screen.getByRole('button', { name: /settings.skills.install/ }))
       await waitFor(() => {
-        expect(installMock).toHaveBeenCalledWith(
-          'github:https://github.com/owner/repo/blob/main/skills/resume-review/SKILL.md'
-        )
+        expect(installMock).toHaveBeenCalledWith(installSource)
       })
     })
 
-    it('reports a URL that does not end with SKILL.md instead of offering an install', async () => {
+    it('reports an unsupported GitHub URL format instead of offering an install', async () => {
       renderDialog()
 
       await selectGithubAndType('https://github.com/owner/repo')

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Nach Fähigkeiten suchen",
       "github_empty_description": "Fügen Sie einen Link zu einer SKILL.md-Datei einer Fähigkeit ein, z. B. github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Von GitHub installieren",
-      "github_url_invalid": "Fügen Sie einen GitHub-Link ein, der mit SKILL.md endet",
+      "github_url_invalid": "Fügen Sie einen unterstützten GitHub-Link ein, der direkt auf eine SKILL.md-Datei verweist",
       "github_url_label": "GitHub-SKILL.md-URL",
       "github_url_placeholder": "GitHub-Link, endend mit /SKILL.md",
       "no_results_description": "Versuchen Sie ein anderes Stichwort oder importieren Sie eine lokale ZIP-Datei oder ein Verzeichnis.",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Αναζήτηση δεξιοτήτων",
       "github_empty_description": "Επικολλήστε έναν σύνδεσμο προς ένα αρχείο SKILL.md μιας ικανότητας, π.χ. github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Εγκατάσταση από GitHub",
-      "github_url_invalid": "Επικολλήστε έναν σύνδεσμο GitHub που τελειώνει με SKILL.md",
+      "github_url_invalid": "Επικολλήστε έναν υποστηριζόμενο σύνδεσμο GitHub που οδηγεί απευθείας σε αρχείο SKILL.md",
       "github_url_label": "URL SKILL.md GitHub",
       "github_url_placeholder": "Σύνδεσμος GitHub που λήγει σε /SKILL.md",
       "no_results_description": "Δοκιμάστε μια άλλη λέξη-κλειδί ή εισαγάγετε ένα τοπικό αρχείο ZIP ή φάκελο.",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Search for skills",
       "github_empty_description": "Paste a link to a skill's SKILL.md file, for example github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Install from GitHub",
-      "github_url_invalid": "Paste a GitHub link that ends with SKILL.md",
+      "github_url_invalid": "Paste a supported GitHub link directly to a SKILL.md file",
       "github_url_label": "GitHub SKILL.md URL",
       "github_url_placeholder": "GitHub link ending in /SKILL.md",
       "no_results_description": "Try another keyword or import a local ZIP or directory.",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Buscar habilidades",
       "github_empty_description": "Pega un enlace al archivo SKILL.md de una habilidad, por ejemplo github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Instalar desde GitHub",
-      "github_url_invalid": "Pega un enlace de GitHub que termine con SKILL.md",
+      "github_url_invalid": "Pega un enlace de GitHub compatible que apunte directamente a un archivo SKILL.md",
       "github_url_label": "URL del SKILL.md en GitHub",
       "github_url_placeholder": "Enlace de GitHub que termina en /SKILL.md",
       "no_results_description": "Prueba otra palabra clave o importa un archivo ZIP local o una carpeta.",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Rechercher des compétences",
       "github_empty_description": "Collez un lien vers le fichier SKILL.md d'une compétence, par exemple github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Installer depuis GitHub",
-      "github_url_invalid": "Collez un lien GitHub qui se termine par SKILL.md",
+      "github_url_invalid": "Collez un lien GitHub pris en charge qui pointe directement vers un fichier SKILL.md",
       "github_url_label": "URL SKILL.md GitHub",
       "github_url_placeholder": "Lien GitHub se terminant par /SKILL.md",
       "no_results_description": "Essayez un autre mot-clé ou importez un fichier ZIP local ou un répertoire.",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -3001,7 +3001,7 @@
       "empty_title": "スキルを検索",
       "github_empty_description": "SKILL.mdファイルへのリンクを貼り付けてください。例: github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "GitHubからインストール",
-      "github_url_invalid": "SKILL.mdで終わるGitHubリンクを貼り付けてください",
+      "github_url_invalid": "SKILL.md ファイルを直接指す対応済みの GitHub リンクを貼り付けてください",
       "github_url_label": "GitHub SKILL.md URL",
       "github_url_placeholder": "/SKILL.mdで終わるGitHubリンク",
       "no_results_description": "別のキーワードを試すか、ローカルのZIPファイルまたはフォルダーをインポートしてください。",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Pesquisar competências",
       "github_empty_description": "Cole a ligação para um ficheiro SKILL.md de uma skill, por exemplo github.com/proprietário/repositório/blob/main/skills/minha-skill/SKILL.md",
       "github_empty_title": "Instalar do GitHub",
-      "github_url_invalid": "Cole uma ligação do GitHub que termine com SKILL.md",
+      "github_url_invalid": "Cole uma ligação do GitHub suportada que aponte diretamente para um ficheiro SKILL.md",
       "github_url_label": "URL GitHub SKILL.md",
       "github_url_placeholder": "Ligação GitHub que termina em /SKILL.md",
       "no_results_description": "Experimente outra palavra-chave ou importe um ficheiro ZIP local ou uma pasta.",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Caută abilități",
       "github_empty_description": "Lipește un link către fișierul SKILL.md al unei abilități, de exemplu github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Instalează de pe GitHub",
-      "github_url_invalid": "Lipește un link GitHub care se termină cu SKILL.md",
+      "github_url_invalid": "Lipește un link GitHub acceptat care indică direct către un fișier SKILL.md",
       "github_url_label": "URL SKILL.md GitHub",
       "github_url_placeholder": "Link GitHub care se termină cu /SKILL.md",
       "no_results_description": "Încearcă un alt cuvânt cheie sau importă un fișier ZIP sau director local.",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Поиск навыков",
       "github_empty_description": "Вставьте ссылку на файл SKILL.md навыка, например github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Установить из GitHub",
-      "github_url_invalid": "Вставьте ссылку GitHub, оканчивающуюся на SKILL.md",
+      "github_url_invalid": "Вставьте поддерживаемую ссылку GitHub, ведущую непосредственно к файлу SKILL.md",
       "github_url_label": "Ссылка GitHub на SKILL.md",
       "github_url_placeholder": "Ссылка GitHub, оканчивающаяся на /SKILL.md",
       "no_results_description": "Попробуйте другое ключевое слово или импортируйте локальный ZIP-архив или папку.",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -3001,7 +3001,7 @@
       "empty_title": "Tìm kiếm kỹ năng",
       "github_empty_description": "Dán liên kết đến tập tin SKILL.md của một kỹ năng, ví dụ github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "Cài đặt từ GitHub",
-      "github_url_invalid": "Hãy dán liên kết GitHub có kết thúc bằng SKILL.md",
+      "github_url_invalid": "Dán liên kết GitHub được hỗ trợ trỏ trực tiếp đến tệp SKILL.md",
       "github_url_label": "URL SKILL.md trên GitHub",
       "github_url_placeholder": "Liên kết GitHub, kết thúc bằng /SKILL.md",
       "no_results_description": "Thử một từ khóa khác hoặc nhập tệp ZIP hoặc thư mục cục bộ.",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3001,7 +3001,7 @@
       "empty_title": "搜索技能",
       "github_empty_description": "粘贴某个技能 SKILL.md 文件的链接，例如 github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "从 GitHub 安装",
-      "github_url_invalid": "请粘贴直接指向 SKILL.md 文件的受支持 GitHub 链接",
+      "github_url_invalid": "请粘贴受支持且直接指向 SKILL.md 文件的 GitHub 链接",
       "github_url_label": "GitHub SKILL.md 链接",
       "github_url_placeholder": "GitHub 链接，以 /SKILL.md 结尾",
       "no_results_description": "请尝试其他关键词,或本地导入 ZIP 文件/目录。",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3001,7 +3001,7 @@
       "empty_title": "搜索技能",
       "github_empty_description": "粘贴某个技能 SKILL.md 文件的链接，例如 github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "从 GitHub 安装",
-      "github_url_invalid": "请粘贴以 SKILL.md 结尾的 GitHub 链接",
+      "github_url_invalid": "请粘贴直接指向 SKILL.md 文件的受支持 GitHub 链接",
       "github_url_label": "GitHub SKILL.md 链接",
       "github_url_placeholder": "GitHub 链接，以 /SKILL.md 结尾",
       "no_results_description": "请尝试其他关键词,或本地导入 ZIP 文件/目录。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -3001,7 +3001,7 @@
       "empty_title": "搜尋技能",
       "github_empty_description": "請貼上技能的 SKILL.md 檔案連結，例如 github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "從 GitHub 安裝",
-      "github_url_invalid": "請貼上以 SKILL.md 結尾的 GitHub 連結",
+      "github_url_invalid": "請貼上直接指向 SKILL.md 檔案的受支援 GitHub 連結",
       "github_url_label": "GitHub SKILL.md 連結",
       "github_url_placeholder": "GitHub 連結，以 /SKILL.md 結尾",
       "no_results_description": "請嘗試其他關鍵字，或從本機匯入 ZIP 檔或資料夾。",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -3001,7 +3001,7 @@
       "empty_title": "搜尋技能",
       "github_empty_description": "請貼上技能的 SKILL.md 檔案連結，例如 github.com/owner/repo/blob/main/skills/my-skill/SKILL.md",
       "github_empty_title": "從 GitHub 安裝",
-      "github_url_invalid": "請貼上直接指向 SKILL.md 檔案的受支援 GitHub 連結",
+      "github_url_invalid": "請貼上受支援且直接指向 SKILL.md 檔案的 GitHub 連結",
       "github_url_label": "GitHub SKILL.md 連結",
       "github_url_placeholder": "GitHub 連結，以 /SKILL.md 結尾",
       "no_results_description": "請嘗試其他關鍵字，或從本機匯入 ZIP 檔或資料夾。",

--- a/src/shared/utils/__tests__/skillMarketplace.test.ts
+++ b/src/shared/utils/__tests__/skillMarketplace.test.ts
@@ -119,15 +119,20 @@ describe('resolveRefFromSegments', () => {
         [head('feature'), head('feature/foo', 'b'.repeat(40))],
         ['feature', 'foo', 'skills', 'demo']
       )
-    ).toEqual({ kind: 'resolved', ref: head('feature/foo', 'b'.repeat(40)), directoryPath: 'skills/demo' })
+    ).toEqual({
+      kind: 'resolved',
+      ref: head('feature/foo', 'b'.repeat(40)),
+      target: { kind: 'directory', path: 'skills/demo' }
+    })
   })
 
-  it('reports a repo-root descriptor instead of falling back to a shorter ref', () => {
+  it('resolves a repo-root descriptor instead of falling back to a shorter ref', () => {
     // `feature/foo` consumes every segment, so the URL names SKILL.md at that branch's root. Falling
     // through to `feature` would install `foo/SKILL.md` from an unrelated revision.
     expect(resolveRefFromSegments([head('feature'), head('feature/foo')], ['feature', 'foo'])).toEqual({
-      kind: 'repo-root',
-      ref: head('feature/foo')
+      kind: 'resolved',
+      ref: head('feature/foo'),
+      target: { kind: 'root' }
     })
   })
 
@@ -142,7 +147,11 @@ describe('resolveRefFromSegments', () => {
 
   it('carries the observed commit so the install cannot follow a moved branch', () => {
     const resolution = resolveRefFromSegments([head('main', 'f'.repeat(40))], ['main', 'skills', 'demo'])
-    expect(resolution).toMatchObject({ kind: 'resolved', ref: { oid: 'f'.repeat(40) } })
+    expect(resolution).toMatchObject({
+      kind: 'resolved',
+      ref: { oid: 'f'.repeat(40) },
+      target: { kind: 'directory', path: 'skills/demo' }
+    })
   })
 
   it('reports no match rather than guessing a boundary', () => {

--- a/src/shared/utils/__tests__/skillMarketplace.test.ts
+++ b/src/shared/utils/__tests__/skillMarketplace.test.ts
@@ -8,8 +8,9 @@ describe('parseGithubSkillUrl', () => {
     ).toEqual({
       owner: 'Viy1204',
       repo: 'recruiting-copilot',
-      refAndDirectory: ['main', 'skills', 'resume-review'],
-      name: 'resume-review'
+      refNamespace: null,
+      refAndPath: ['main', 'skills', 'resume-review'],
+      descriptorFileName: 'SKILL.md'
     })
   })
 
@@ -17,8 +18,26 @@ describe('parseGithubSkillUrl', () => {
     expect(parseGithubSkillUrl('https://raw.githubusercontent.com/owner/repo/v2.1/plugins/a/b/skill.md')).toEqual({
       owner: 'owner',
       repo: 'repo',
-      refAndDirectory: ['v2.1', 'plugins', 'a', 'b'],
-      name: 'b'
+      refNamespace: null,
+      refAndPath: ['v2.1', 'plugins', 'a', 'b'],
+      descriptorFileName: 'skill.md'
+    })
+  })
+
+  it('accepts a SKILL.md at the repository root', () => {
+    expect(parseGithubSkillUrl('https://github.com/owner/repo/blob/main/SKILL.md')).not.toBeNull()
+  })
+
+  it.each([
+    'https://github.com/owner/repo/raw/refs/heads/main/SKILL.md',
+    'https://raw.githubusercontent.com/owner/repo/refs/heads/main/SKILL.md'
+  ])('normalizes an official raw URL (%s)', (url) => {
+    expect(parseGithubSkillUrl(url)).toEqual({
+      owner: 'owner',
+      repo: 'repo',
+      refNamespace: 'heads',
+      refAndPath: ['main'],
+      descriptorFileName: 'SKILL.md'
     })
   })
 
@@ -28,7 +47,6 @@ describe('parseGithubSkillUrl', () => {
     ['a tree URL, which denotes a directory', 'https://github.com/owner/repo/tree/main/skills/foo/SKILL.md'],
     ['a filename the installer does not look for', 'https://github.com/owner/repo/blob/main/skills/foo/SKILL.MD'],
     ['a different file in the skill directory', 'https://github.com/owner/repo/blob/main/skills/foo/README.md'],
-    ['a SKILL.md at the repo root', 'https://github.com/owner/repo/blob/main/SKILL.md'],
     ['a non-github host', 'https://gitlab.com/owner/repo/blob/main/skills/foo/SKILL.md'],
     ['a path that escapes the repo', 'https://github.com/owner/repo/blob/main/skills/../../etc/SKILL.md'],
     ['a segment hiding a separator', 'https://github.com/owner/repo/blob/main/skills/foo%2F../SKILL.md'],
@@ -47,7 +65,7 @@ describe('parseGithubSkillUrl', () => {
   })
 
   it('decodes escaped directory names', () => {
-    expect(parseGithubSkillUrl('https://github.com/o/r/blob/main/skills/foo%23bar/SKILL.md')?.refAndDirectory).toEqual([
+    expect(parseGithubSkillUrl('https://github.com/o/r/blob/main/skills/foo%23bar/SKILL.md')?.refAndPath).toEqual([
       'main',
       'skills',
       'foo#bar'
@@ -62,8 +80,14 @@ describe('buildGithubSkillResult', () => {
 
     expect(fromRaw?.installSource).toBe('github:https://github.com/owner/repo/blob/main/skills/foo/SKILL.md')
     expect(fromRaw).toEqual(fromBlob)
-    expect(fromRaw?.name).toBe('foo')
+    expect(fromRaw?.name).toBe('repo')
     expect(fromRaw?.sourceRegistry).toBe('github')
+  })
+
+  it('preserves a lowercase descriptor filename in the canonical install source', () => {
+    expect(
+      buildGithubSkillResult('https://raw.githubusercontent.com/owner/repo/main/skills/foo/skill.md')?.installSource
+    ).toBe('github:https://github.com/owner/repo/blob/main/skills/foo/skill.md')
   })
 
   it('returns null for input the installer could not resolve', () => {

--- a/src/shared/utils/__tests__/skillMarketplace.test.ts
+++ b/src/shared/utils/__tests__/skillMarketplace.test.ts
@@ -1,4 +1,4 @@
-import { buildGithubSkillResult, parseGithubSkillUrl, resolveRefFromSegments } from '@shared/utils/skillMarketplace'
+import { buildGithubSkillResult, parseGithubSkillUrl } from '@shared/utils/skillMarketplace'
 import { describe, expect, it } from 'vitest'
 
 describe('parseGithubSkillUrl', () => {
@@ -106,55 +106,4 @@ describe('buildGithubSkillResult', () => {
       expect(parseGithubSkillUrl(result!.installSource.slice('github:'.length))).toEqual(parseGithubSkillUrl(url))
     }
   )
-})
-
-describe('resolveRefFromSegments', () => {
-  const head = (name: string, oid = 'a'.repeat(40)) => ({ name, oid, namespace: 'heads' as const })
-
-  it('prefers the longest ref the remote actually has', () => {
-    // Both refs exist; splitting at the first segment would fetch `feature` and look for
-    // `foo/skills/demo` there.
-    expect(
-      resolveRefFromSegments(
-        [head('feature'), head('feature/foo', 'b'.repeat(40))],
-        ['feature', 'foo', 'skills', 'demo']
-      )
-    ).toEqual({
-      kind: 'resolved',
-      ref: head('feature/foo', 'b'.repeat(40)),
-      target: { kind: 'directory', path: 'skills/demo' }
-    })
-  })
-
-  it('resolves a repo-root descriptor instead of falling back to a shorter ref', () => {
-    // `feature/foo` consumes every segment, so the URL names SKILL.md at that branch's root. Falling
-    // through to `feature` would install `foo/SKILL.md` from an unrelated revision.
-    expect(resolveRefFromSegments([head('feature'), head('feature/foo')], ['feature', 'foo'])).toEqual({
-      kind: 'resolved',
-      ref: head('feature/foo'),
-      target: { kind: 'root' }
-    })
-  })
-
-  it('refuses a name carried by both a branch and a tag', () => {
-    expect(
-      resolveRefFromSegments(
-        [head('v1'), { name: 'v1', oid: 'c'.repeat(40), namespace: 'tags' }],
-        ['v1', 'skills', 'demo']
-      )
-    ).toEqual({ kind: 'ambiguous', name: 'v1' })
-  })
-
-  it('carries the observed commit so the install cannot follow a moved branch', () => {
-    const resolution = resolveRefFromSegments([head('main', 'f'.repeat(40))], ['main', 'skills', 'demo'])
-    expect(resolution).toMatchObject({
-      kind: 'resolved',
-      ref: { oid: 'f'.repeat(40) },
-      target: { kind: 'directory', path: 'skills/demo' }
-    })
-  })
-
-  it('reports no match rather than guessing a boundary', () => {
-    expect(resolveRefFromSegments([head('main')], ['a1b2c3', 'skills', 'demo'])).toEqual({ kind: 'no-match' })
-  })
 })

--- a/src/shared/utils/skillMarketplace.ts
+++ b/src/shared/utils/skillMarketplace.ts
@@ -96,14 +96,10 @@ export function normalizeClaudePlugins(raw: unknown): SkillSearchResult[] {
 export type GithubSkillLocation = {
   owner: string
   repo: string
-  /**
-   * Decoded segments between the repo and SKILL.md. A GitHub URL gives no delimiter between the ref
-   * and the path, and a branch may contain `/`, so where the ref ends is only knowable from the
-   * repo's actual refs — see `resolveRefFromSegments`.
-   */
-  refAndDirectory: string[]
-  /** Directory holding SKILL.md — the display name, wherever the ref turns out to end. */
-  name: string
+  refNamespace: 'heads' | 'tags' | null
+  /** Decoded ref and path segments. Their boundary is resolved from the repository's actual refs. */
+  refAndPath: string[]
+  descriptorFileName: 'SKILL.md' | 'skill.md'
 }
 
 const GITHUB_REPO_PART = /^[a-zA-Z0-9_.-]+$/
@@ -191,7 +187,14 @@ export function parseGithubSkillUrl(rawUrl: string): GithubSkillLocation | null 
   let url: URL
   let segments: string[]
   try {
-    url = new URL(rawUrl.trim())
+    const trimmedUrl = rawUrl.trim()
+    url = new URL(trimmedUrl)
+    const authorityEnd = trimmedUrl.indexOf('/', trimmedUrl.indexOf('://') + 3)
+    const rawPath = authorityEnd === -1 ? '' : trimmedUrl.slice(authorityEnd).split(/[?#]/, 1)[0]
+    const rawSegments = rawPath.split('/').filter(Boolean).map(decodeURIComponent)
+    // WHATWG URL parsing removes literal dot segments before exposing `pathname`; inspect the raw
+    // path first so accepting a repository-root descriptor does not turn traversal into a valid ref.
+    if (rawSegments.some(invalidPathPart)) return null
     // Decoding belongs inside the guard: `new URL` accepts a lone `%`, but decoding one throws, and
     // callers rely on invalid input returning null rather than raising mid-render.
     segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent)
@@ -201,24 +204,33 @@ export function parseGithubSkillUrl(rawUrl: string): GithubSkillLocation | null 
 
   const host = url.hostname.toLowerCase().replace(/^www\./, '')
   const [owner, rawRepo, ...tail] = segments
-  // `tree` denotes a directory on GitHub, so only `blob` (and the raw host) can name a file.
-  const refAndPath =
-    host === 'github.com' && tail[0] === 'blob' ? tail.slice(1) : host === 'raw.githubusercontent.com' ? tail : null
-  if (!refAndPath) return null
+  // `tree` denotes a directory. GitHub's Raw action uses `/raw/refs/heads/...` and redirects to the
+  // raw-content host, so both file routes belong to the same syntax contract.
+  const rawRefAndPath =
+    host === 'github.com' && (tail[0] === 'blob' || tail[0] === 'raw')
+      ? tail.slice(1)
+      : host === 'raw.githubusercontent.com'
+        ? tail
+        : null
+  if (!rawRefAndPath) return null
 
   const repo = rawRepo?.replace(/\.git$/i, '')
-  const fileName = refAndPath.at(-1)
-  const refAndDirectory = refAndPath.slice(0, -1)
-  const name = refAndDirectory.at(-1)
+  const fileName = rawRefAndPath.at(-1)
+  const descriptorFileName = fileName === 'SKILL.md' || fileName === 'skill.md' ? fileName : null
+  let refAndPath = rawRefAndPath.slice(0, -1)
+  let refNamespace: GithubSkillLocation['refNamespace'] = null
 
-  // Only the two spellings `findSkillMdPath` looks for: accepting `SKILL.MD` here would validate in
-  // the UI and then fail after the user approved the install.
-  if (!owner || !repo || !name || (fileName !== 'SKILL.md' && fileName !== 'skill.md')) return null
+  if (refAndPath[0] === 'refs' && (refAndPath[1] === 'heads' || refAndPath[1] === 'tags')) {
+    refNamespace = refAndPath[1]
+    refAndPath = refAndPath.slice(2)
+  }
+
+  if (!owner || !repo || !descriptorFileName) return null
   if (![owner, repo].every((part) => GITHUB_REPO_PART.test(part))) return null
-  // The shortest resolvable URL is one ref segment plus one directory segment.
-  if (refAndDirectory.length < 2 || refAndDirectory.some(invalidPathPart)) return null
+  // A single segment can be a ref selecting a descriptor at the repository root.
+  if (refAndPath.length < 1 || refAndPath.some(invalidPathPart)) return null
 
-  return { owner, repo, refAndDirectory, name }
+  return { owner, repo, refNamespace, refAndPath, descriptorFileName }
 }
 
 /** Present a validated GitHub SKILL.md URL as an installable search result. */
@@ -226,12 +238,14 @@ export function buildGithubSkillResult(rawUrl: string): SkillSearchResult | null
   const location = parseGithubSkillUrl(rawUrl)
   if (!location) return null
 
-  const { owner, repo, refAndDirectory, name } = location
-  const path = encodeGithubPath(refAndDirectory.join('/'))
-  const canonicalUrl = `https://github.com/${owner}/${repo}/blob/${path}/SKILL.md`
+  const { owner, repo, refNamespace, refAndPath, descriptorFileName } = location
+  const path = encodeGithubPath(refAndPath.join('/'))
+  const canonicalUrl = refNamespace
+    ? `https://raw.githubusercontent.com/${owner}/${repo}/refs/${refNamespace}/${path}/${descriptorFileName}`
+    : `https://github.com/${owner}/${repo}/blob/${path}/${descriptorFileName}`
   return {
-    slug: `${owner}/${repo}/${refAndDirectory.join('/')}`,
-    name,
+    slug: `${owner}/${repo}/${refNamespace ? `refs/${refNamespace}/` : ''}${refAndPath.join('/')}`,
+    name: repo,
     description: null,
     author: owner,
     stars: 0,

--- a/src/shared/utils/skillMarketplace.ts
+++ b/src/shared/utils/skillMarketplace.ts
@@ -125,10 +125,10 @@ export type GithubRef = {
   namespace: 'heads' | 'tags'
 }
 
+export type GithubSkillTarget = { kind: 'root' } | { kind: 'directory'; path: string }
+
 export type GithubRefResolution =
-  | { kind: 'resolved'; ref: GithubRef; directoryPath: string }
-  /** Every segment is the ref, so the URL names a SKILL.md at the repo root — no directory to install. */
-  | { kind: 'repo-root'; ref: GithubRef }
+  | { kind: 'resolved'; ref: GithubRef; target: GithubSkillTarget }
   /** A branch and a tag share the name, so the URL does not say which revision was meant. */
   | { kind: 'ambiguous'; name: string }
   | { kind: 'no-match' }
@@ -158,9 +158,11 @@ export function resolveRefFromSegments(
     if (matches.length > 1) return { kind: 'ambiguous', name }
 
     const ref = matches[0]
-    return length === refAndDirectory.length
-      ? { kind: 'repo-root', ref }
-      : { kind: 'resolved', ref, directoryPath: refAndDirectory.slice(length).join('/') }
+    const target: GithubSkillTarget =
+      length === refAndDirectory.length
+        ? { kind: 'root' }
+        : { kind: 'directory', path: refAndDirectory.slice(length).join('/') }
+    return { kind: 'resolved', ref, target }
   }
   return { kind: 'no-match' }
 }

--- a/src/shared/utils/skillMarketplace.ts
+++ b/src/shared/utils/skillMarketplace.ts
@@ -118,57 +118,8 @@ function invalidPathPart(part: string): boolean {
   )
 }
 
-/** A branch or tag as the remote reports it, carrying the commit it pointed at when observed. */
-export type GithubRef = {
-  name: string
-  oid: string
-  namespace: 'heads' | 'tags'
-}
-
-export type GithubSkillTarget = { kind: 'root' } | { kind: 'directory'; path: string }
-
-export type GithubRefResolution =
-  | { kind: 'resolved'; ref: GithubRef; target: GithubSkillTarget }
-  /** A branch and a tag share the name, so the URL does not say which revision was meant. */
-  | { kind: 'ambiguous'; name: string }
-  | { kind: 'no-match' }
-
 /**
- * Split `refAndDirectory` at the boundary the repo's own refs prove, longest first: with both a
- * `feature` branch and a `feature/foo` branch, `blob/feature/foo/skills/demo/SKILL.md` must resolve
- * to the latter rather than silently installing a different revision's `foo/skills/demo`.
- *
- * The full-length match is tested before any shorter one. `blob/feature/foo/SKILL.md` on branch
- * `feature/foo` is a repo-root descriptor, and reporting that is the only safe answer — skipping it
- * to keep a directory segment would install `foo/SKILL.md` from the unrelated `feature` branch.
- */
-export function resolveRefFromSegments(
-  refs: readonly GithubRef[],
-  refAndDirectory: readonly string[]
-): GithubRefResolution {
-  const byName = new Map<string, GithubRef[]>()
-  for (const ref of refs) {
-    byName.set(ref.name, [...(byName.get(ref.name) ?? []), ref])
-  }
-
-  for (let length = refAndDirectory.length; length >= 1; length--) {
-    const name = refAndDirectory.slice(0, length).join('/')
-    const matches = byName.get(name)
-    if (!matches?.length) continue
-    if (matches.length > 1) return { kind: 'ambiguous', name }
-
-    const ref = matches[0]
-    const target: GithubSkillTarget =
-      length === refAndDirectory.length
-        ? { kind: 'root' }
-        : { kind: 'directory', path: refAndDirectory.slice(length).join('/') }
-    return { kind: 'resolved', ref, target }
-  }
-  return { kind: 'no-match' }
-}
-
-/**
- * Re-encode a decoded repo path for use in a URL. `GithubSkillLocation.directoryPath` is decoded so
+ * Re-encode a decoded repo path for use in a URL. `GithubSkillLocation.refAndPath` is decoded so
  * the installer can resolve it on disk; concatenating it raw would break the round-trip back through
  * `parseGithubSkillUrl` (a `#` in a directory name turns the rest of the URL into a fragment).
  */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

GitHub skill installation rejected some valid direct file links, including repository-root descriptors and explicit raw branch/tag URLs. It could also lose the branch/tag namespace in provenance and inspect an unbounded repository tree while installing a nested skill.

After this PR:

GitHub `SKILL.md` links are normalized consistently across the renderer and main process. The installer supports nested or repository-root `SKILL.md`/`skill.md` files, resolves slash-bearing refs and explicit branch/tag namespaces against remote refs, fetches the observed commit, validates the selected tree, and checks out only the requested skill content with bounded command output.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The UI and installer need one URL contract so every link accepted by validation can be installed. Remote refs are used to find the ref/path boundary because branch and tag names may contain `/`. Installation is pinned to the observed commit to avoid ref movement between lookup and fetch, and Git metadata is kept outside the checked-out skill content so repository-root skills remain safe.

The following tradeoffs were made:

- Unqualified URLs remain rejected when a branch and tag share the same name; explicit `refs/heads` or `refs/tags` links disambiguate them.
- Git tree output is capped at 16 MiB, so pathologically large repository-root trees fail closed instead of consuming unbounded memory.
- Direct URL results use the repository name as their display name because repository-root skills do not have a containing directory name.

The following alternatives were considered:

- Guessing the ref/path boundary from URL segments was rejected because slash-bearing refs make the result ambiguous.
- Cloning or scanning the entire repository was rejected because it writes unrelated content and leaves tree output unbounded.
- Keeping remote-ref resolution in the shared layer was rejected because it is used only by the main-process installer.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- Supported direct links include GitHub blob URLs, GitHub/raw-content URLs, repository-root descriptors, lowercase `skill.md`, and explicit branch/tag namespaces.
- Invalid directory links, non-GitHub hosts, unsupported filenames, traversal segments, ambiguous refs, oversized trees, and normalized path collisions fail closed.
- Focused Vitest coverage passed: 153 tests across the shared URL parser, renderer dialog, main MCP server, skill installer, and process runner.
- `pnpm lint` passed. The full `pnpm test` suite was intentionally not run; validation was limited to the affected suites.
- A standalone user-guide update is not required; the dialog guidance and all locale catalogs were updated with the supported-link wording.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed GitHub skill installation for valid raw links, repository-root descriptors, lowercase `skill.md` files, and explicit branch/tag references.
```
