### PR TITLE
fix(dsh-runtime): preserve tool approval cards during event races

### DIFF
--- a/packages/dsh-bridge/__tests__/plugin.test.ts
+++ b/packages/dsh-bridge/__tests__/plugin.test.ts
@@ -5,7 +5,9 @@ import os from 'node:os'
 import path from 'node:path'
 
 import type { Context } from '@deepseek-ai/cordis'
+import type { Agent } from '@deepseek-ai/dsh-agent'
 import { JsonRpcLineTransport } from '@deepseek-ai/dsh-sdk-protocol'
+import type { UserQuestionProvider } from '@deepseek-ai/dsh-user-questions'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { apply } from '../src/plugin'
@@ -144,6 +146,66 @@ describe('cherry bridge plugin', () => {
 
     const toolCall = host.requests.find((entry) => entry.method === 'tool/call')
     expect(toolCall?.params).toMatchObject({ sessionId: 'session-1', name: 'echo', args: { value: 1 } })
+  })
+
+  it('correlates a plan review with the newest matching exit_plan_mode call', async () => {
+    const host = await startHost()
+    const plan = '# Revised plan'
+    const agent = {
+      id: 'session-1',
+      session: {
+        events: [
+          {
+            type: 'tool/call',
+            data: { callId: 'exit-plan-call-1', name: 'exit_plan_mode', arguments: JSON.stringify({ plan }) }
+          },
+          {
+            type: 'tool/call',
+            data: { callId: 'exit-plan-call-2', name: 'exit_plan_mode', arguments: JSON.stringify({ plan }) }
+          }
+        ]
+      }
+    } as unknown as Agent
+    let provider: UserQuestionProvider | undefined
+    const registerProvider = vi.fn((candidate: UserQuestionProvider) => {
+      provider = candidate
+      return () => undefined
+    })
+    const effect = vi.fn((factory: () => unknown) => {
+      const disposer = factory()
+      if (typeof disposer === 'function') cleanup.push(disposer as () => void)
+      return () => undefined
+    })
+    const ctx = makeContext({
+      agents: { resume: vi.fn(), create: vi.fn(), get: vi.fn(() => agent) },
+      userQuestions: { registerProvider },
+      effect
+    })
+    process.env[BRIDGE_SOCKET_ENV] = host.socketPath
+    process.env[BRIDGE_TOKEN_ENV] = 'one-time-token'
+
+    apply(ctx)
+    await expect.poll(() => host.requests[0]?.method).toBe('ready')
+    if (!provider) throw new Error('user-questions provider was not registered')
+
+    const answer = provider.ask({
+      agent,
+      questions: [
+        {
+          id: 'plan-review',
+          question: 'Approve?',
+          detail: plan,
+          options: [{ label: 'Approve' }],
+          intent: { kind: 'plan-review', approve: 'Approve' }
+        }
+      ]
+    })
+    await expect
+      .poll(() => host.requests.find((request) => request.method === 'question/ask'))
+      .toMatchObject({
+        params: { sessionId: 'session-1', callId: 'exit-plan-call-2' }
+      })
+    await expect(answer).resolves.toEqual({})
   })
 
   it('rejects an unknown method instead of answering it', async () => {

--- a/packages/dsh-bridge/src/plugin.ts
+++ b/packages/dsh-bridge/src/plugin.ts
@@ -16,7 +16,7 @@ import type {} from '@deepseek-ai/dsh-subagent'
 import type {} from '@deepseek-ai/dsh-token-meter'
 import type { ToolDefinition } from '@deepseek-ai/dsh-tools'
 import type { ApprovalRequest } from '@deepseek-ai/dsh-user-approval'
-import { UserQuestionError } from '@deepseek-ai/dsh-user-questions'
+import { type AskUserQuestionRequest, UserQuestionError } from '@deepseek-ai/dsh-user-questions'
 
 import { type BridgeLink, connectBridgeLink } from './link'
 import { decideDelegatedToolCall, decideToolCall, detectGlobalInstall } from './policy'
@@ -299,7 +299,11 @@ export function apply(ctx: Context): void {
           try {
             return await link.request(
               'question/ask',
-              { sessionId: request.agent?.id ?? '', questions: request.questions },
+              {
+                sessionId: request.agent?.id ?? '',
+                callId: correlatePlanReviewCallId(request),
+                questions: request.questions
+              },
               request.signal
             )
           } catch (error) {
@@ -430,4 +434,26 @@ function correlateCallArguments(req: ApprovalRequest): unknown {
     }
   }
   return undefined
+}
+
+/** Correlate the plan-review question with the newest matching durable tool call. */
+function correlatePlanReviewCallId(request: AskUserQuestionRequest): string {
+  const review = request.questions.length === 1 ? request.questions[0] : undefined
+  const plan = review?.intent?.kind === 'plan-review' ? review.detail : undefined
+  if (!request.agent || typeof plan !== 'string') {
+    throw new UserQuestionError('only an agent plan review can cross the Cherry bridge', 'UNSUPPORTED_QUESTION')
+  }
+
+  const events = request.agent.session.events
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+    if (event.type !== 'tool/call' || event.data.name !== 'exit_plan_mode') continue
+    try {
+      const args = JSON.parse(event.data.arguments) as { plan?: unknown } | null
+      if (args?.plan === plan) return String(event.data.callId)
+    } catch {
+      continue
+    }
+  }
+  throw new UserQuestionError('the current exit_plan_mode call could not be correlated', 'CALL_NOT_FOUND')
 }

--- a/packages/dsh-bridge/src/protocol.ts
+++ b/packages/dsh-bridge/src/protocol.ts
@@ -139,7 +139,12 @@ export interface BridgePluginRequestMap {
   }
   /** One `ctx.userQuestions` ask (today only plan review reaches it) relayed to the host UI. */
   'question/ask': {
-    params: { sessionId: string; questions: AskUserQuestionItem[] }
+    params: {
+      sessionId: string
+      /** Exact `exit_plan_mode` call correlated from the plugin's authoritative session log. */
+      callId: string
+      questions: AskUserQuestionItem[]
+    }
     result: AskUserQuestionAnswer
   }
 }

--- a/src/main/ai/runtime/dsh/DshBridgeServer.ts
+++ b/src/main/ai/runtime/dsh/DshBridgeServer.ts
@@ -43,8 +43,6 @@ export interface DshBridgeServerOptions {
   onToolCall: (name: string, args: unknown, signal: AbortSignal) => Promise<BridgeToolCallResult>
   /** One subagent residency-epoch edge from the plugin's lifecycle listeners. */
   onSubagentLifecycle?: (edge: BridgeNotificationMap['subagent/lifecycle']) => void
-  /** The streamed `exit_plan_mode` call id, so the plan-review card anchors to its tool row. */
-  getPlanReviewAnchor?: () => string | undefined
   /** Deadline for an accepted socket to authenticate; also bounds `whenReady()`. */
   readyTimeoutMs?: number
 }
@@ -330,12 +328,13 @@ export class DshBridgeServer {
     if (!review || intent?.kind !== 'plan-review' || typeof review.detail !== 'string') {
       return Promise.reject(new Error('only plan-review questions are bridged to the host'))
     }
+    if (!ask.callId) return Promise.reject(new Error('dsh bridge plan review is missing its tool call id'))
     const interactionState = this.options.getInteractionState()
     if (interactionState.userResponse === 'unavailable') {
       return Promise.reject(new Error('no user is available to review the plan'))
     }
     const approvalId = randomUUID()
-    const toolCallId = this.options.getPlanReviewAnchor?.() ?? approvalId
+    const toolCallId = ask.callId
     const presentation = interactionState.userResponse === 'stream' ? 'stream' : 'message'
     const input = { plan: review.detail }
     return new Promise((resolve) => {

--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -29,7 +29,6 @@ import {
 } from '@shared/ai/builtinTools'
 import { type DshBuiltinToolDescriptor, getDshRuntimeBuiltinTools } from '@shared/ai/dshBuiltinTools'
 import type { AgentPermissionMode } from '@shared/data/api/schemas/agents'
-import type { CherryUIMessageChunk } from '@shared/data/types/message'
 import type { UniqueModelId } from '@shared/data/types/model'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
 
@@ -87,7 +86,7 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
   private readonly committedInvocationIds = new Set<string>()
   private readonly adapter = new DshStreamAdapter({
     enqueue: (chunk) => {
-      this.observeMainChunk(chunk)
+      this.subagents.noteMainChunk(chunk)
       this.eventQueue.push({ type: 'chunk', chunk })
     },
     onAssistantUsage: (info) => this.recordProviderInvocation(info),
@@ -128,8 +127,6 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
    * comparisons keep using the stored mode alone.
    */
   private runtimePlanActive?: boolean
-  /** Latest streamed `exit_plan_mode` call — anchors the plan-review approval card. */
-  private planReviewAnchor?: string
   private disabledTools = new Set<string>()
   /** Spawn-frozen agent/model facts, excluding the live permission gate. */
   private connectionSignature?: string
@@ -149,14 +146,6 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
     // Constructor-body creation: parameter properties are not yet assigned while
     // field initializers run, so `input.sessionId` is unavailable up there.
     this.subagents = new DshSubagentCoordinator(input.sessionId, this.buildSubagentSink())
-  }
-
-  /** Main-stream taps: subagent binding anchors and the plan-review card anchor. */
-  private observeMainChunk(chunk: CherryUIMessageChunk): void {
-    this.subagents.noteMainChunk(chunk)
-    if (chunk.type === 'tool-input-start' && chunk.toolName === 'exit_plan_mode') {
-      this.planReviewAnchor = chunk.toolCallId
-    }
   }
 
   /** Bridge-socket events. A stream-presented approval whose `tool/call` has not landed yet would
@@ -351,8 +340,7 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
         getInteractionState: () =>
           application.get('AgentSessionRuntimeService').getInteractionState(this.input.sessionId),
         onToolCall: (name, args, signal) => toolBridge.callTool(name, args, signal),
-        onSubagentLifecycle: (edge) => this.subagents.handleLifecycle(edge),
-        getPlanReviewAnchor: () => this.planReviewAnchor
+        onSubagentLifecycle: (edge) => this.subagents.handleLifecycle(edge)
       })
       await this.bridge.listen()
 

--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -159,6 +159,15 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
     }
   }
 
+  /** Bridge-socket events. A stream-presented approval whose `tool/call` has not landed yet would
+   *  truncate the turn accumulator instead of showing a card, so materialize its tool part first. */
+  private emitBridgeEvent(event: AgentRuntimeEvent): void {
+    if (event.type === 'tool-approval-request' && event.request.presentation === 'stream') {
+      this.adapter.ensureToolCall(event.request.toolCallId, event.request.toolName, event.request.input)
+    }
+    this.eventQueue.push(event)
+  }
+
   /** Flip the live-turn flag; a false→true edge opens a NEW host turn identity. */
   private markTurnActive(): void {
     if (!this.turnActive) this.turnEpoch += 1
@@ -338,7 +347,7 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
 
       this.bridge = new DshBridgeServer({
         sessionId: this.input.sessionId,
-        emit: (event) => this.eventQueue.push(event),
+        emit: (event) => this.emitBridgeEvent(event),
         getInteractionState: () =>
           application.get('AgentSessionRuntimeService').getInteractionState(this.input.sessionId),
         onToolCall: (name, args, signal) => toolBridge.callTool(name, args, signal),

--- a/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
@@ -43,7 +43,6 @@ function makeServer(
     getInteractionState: () => ({ userResponse }),
     onToolCall,
     onSubagentLifecycle: (edge) => lifecycleEdges.push(edge),
-    getPlanReviewAnchor: () => 'exit-plan-call-1',
     ...(readyTimeoutMs === undefined ? {} : { readyTimeoutMs })
   })
   return { server, events, lifecycleEdges }
@@ -369,6 +368,7 @@ describe('DshBridgeServer', () => {
     const harness = await makeHarness()
     const ask = harness.transport.request('question/ask', {
       sessionId: SESSION_ID,
+      callId: 'exit-plan-call-1',
       questions: [
         {
           id: 'plan-review',
@@ -396,10 +396,11 @@ describe('DshBridgeServer', () => {
     await expect(ask).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
   })
 
-  it('answers a denied plan review as keep-planning, carrying the reason as feedback', async () => {
+  it('anchors a rejected plan review retry to its new call id and carries the rejection feedback', async () => {
     const harness = await makeHarness()
     const ask = harness.transport.request('question/ask', {
       sessionId: SESSION_ID,
+      callId: 'exit-plan-call-1',
       questions: [
         {
           id: 'plan-review',
@@ -418,6 +419,30 @@ describe('DshBridgeServer', () => {
     await expect(ask).resolves.toEqual({
       answers: [{ id: 'plan-review', selected: [], custom: 'missing tests' }]
     })
+
+    const retry = harness.transport.request('question/ask', {
+      sessionId: SESSION_ID,
+      callId: 'exit-plan-call-2',
+      questions: [
+        {
+          id: 'plan-review',
+          question: 'Approve this revised plan and leave plan mode?',
+          detail: '# Revised',
+          options: [{ label: 'Approve' }, { label: 'Keep planning' }],
+          intent: { kind: 'plan-review', approve: 'Approve' }
+        }
+      ]
+    })
+    await vi.waitFor(() => expect(harness.events).toHaveLength(2))
+    const retryEvent = harness.events[1]
+    if (retryEvent.type !== 'tool-approval-request') throw new Error('unreachable')
+    expect(retryEvent.request).toMatchObject({
+      toolCallId: 'exit-plan-call-2',
+      input: { plan: '# Revised' }
+    })
+
+    toolApprovalRegistry.dispatch(retryEvent.request.approvalId, { approved: true })
+    await expect(retry).resolves.toEqual({ answers: [{ id: 'plan-review', selected: ['Approve'] }] })
   })
 
   it('rejects non-plan-review questions and asks without a responder', async () => {
@@ -425,14 +450,32 @@ describe('DshBridgeServer', () => {
     await expect(
       harness.transport.request('question/ask', {
         sessionId: SESSION_ID,
+        callId: 'question-call-1',
         questions: [{ id: 'q1', question: 'Pick one', options: [{ label: 'A' }] }]
       })
     ).rejects.toThrow('plan-review')
+
+    await expect(
+      harness.transport.request('question/ask', {
+        sessionId: SESSION_ID,
+        callId: '',
+        questions: [
+          {
+            id: 'plan-review',
+            question: 'Approve?',
+            detail: '# P',
+            options: [{ label: 'Approve' }],
+            intent: { kind: 'plan-review', approve: 'Approve' }
+          }
+        ]
+      })
+    ).rejects.toThrow('tool call id')
 
     const unattended = await makeHarness('unavailable')
     await expect(
       unattended.transport.request('question/ask', {
         sessionId: SESSION_ID,
+        callId: 'exit-plan-call-1',
         questions: [
           {
             id: 'plan-review',

--- a/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
@@ -251,7 +251,7 @@ describe('DshRuntimeConnection tracing', () => {
     }
   )
 
-  it('opens the tool part before a stream-presented approval that outran its tool/call event', async () => {
+  it('opens the plan-review tool part before its raced tool/call event', async () => {
     const connection = await new DshRuntimeConnection(connectInput).start()
     const events = connection.events[Symbol.asyncIterator]()
     await expect(events.next()).resolves.toMatchObject({ value: { type: 'resume-token' } })
@@ -263,8 +263,8 @@ describe('DshRuntimeConnection tracing', () => {
       request: {
         approvalId: 'approval-1',
         toolCallId: 'call-1',
-        toolName: 'bash',
-        input: { command: 'rm -rf build' },
+        toolName: 'exit_plan_mode',
+        input: { plan: '# Ship it' },
         presentation: 'stream'
       }
     })
@@ -275,7 +275,7 @@ describe('DshRuntimeConnection tracing', () => {
     await expect(events.next()).resolves.toMatchObject({
       value: {
         type: 'chunk',
-        chunk: { type: 'tool-input-available', toolCallId: 'call-1', input: { command: 'rm -rf build' } }
+        chunk: { type: 'tool-input-available', toolCallId: 'call-1', input: { plan: '# Ship it' } }
       }
     })
     await expect(events.next()).resolves.toMatchObject({

--- a/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
@@ -145,6 +145,7 @@ vi.mock('@main/ai/runtime/agentMcpServers', () => ({ buildAgentMcpServers: vi.fn
 vi.mock('@main/ai/runtime/citationsGuidance', () => ({ buildCitationsGuidance: vi.fn(() => '') }))
 vi.mock('@main/ai/steerReminder', () => ({ wrapSteerReminder: vi.fn((text: string) => text) }))
 
+const { DshBridgeServer } = await import('../DshBridgeServer')
 const { DshRuntimeConnection } = await import('../DshRuntimeConnection')
 
 const traceContext: AgentRuntimeTraceContext = {
@@ -168,6 +169,7 @@ const drain = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 beforeEach(() => {
   runtimeMocks.snapshot = baseSnapshot()
   runtimeMocks.bridgeRequest.mockReset().mockResolvedValue(undefined)
+  vi.mocked(DshBridgeServer).mockClear()
   spans.length = 0
   startSpan.mockClear()
 })
@@ -248,6 +250,40 @@ describe('DshRuntimeConnection tracing', () => {
       await connection.close()
     }
   )
+
+  it('opens the tool part before a stream-presented approval that outran its tool/call event', async () => {
+    const connection = await new DshRuntimeConnection(connectInput).start()
+    const events = connection.events[Symbol.asyncIterator]()
+    await expect(events.next()).resolves.toMatchObject({ value: { type: 'resume-token' } })
+    await connection.send({ message: {} } as never)
+
+    const { emit } = vi.mocked(DshBridgeServer).mock.calls[0][0]
+    emit({
+      type: 'tool-approval-request',
+      request: {
+        approvalId: 'approval-1',
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        input: { command: 'rm -rf build' },
+        presentation: 'stream'
+      }
+    })
+
+    await expect(events.next()).resolves.toMatchObject({
+      value: { type: 'chunk', chunk: { type: 'tool-input-start', toolCallId: 'call-1' } }
+    })
+    await expect(events.next()).resolves.toMatchObject({
+      value: {
+        type: 'chunk',
+        chunk: { type: 'tool-input-available', toolCallId: 'call-1', input: { command: 'rm -rf build' } }
+      }
+    })
+    await expect(events.next()).resolves.toMatchObject({
+      value: { type: 'tool-approval-request', request: { approvalId: 'approval-1' } }
+    })
+
+    await connection.close()
+  })
 
   it('sends cross-Session provenance and forged instructions inside the untrusted delivery boundary', async () => {
     const connection = await new DshRuntimeConnection(connectInput).start()

--- a/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/dshStreamAdapter.test.ts
@@ -180,6 +180,36 @@ describe('DshStreamAdapter', () => {
     expect(chunks[2]).toMatchObject({ toolCallId: 'c1', output: 'file.txt' })
   })
 
+  it('materializes an approval tool part ahead of its tool/call event, without duplicating it', () => {
+    const { adapter, chunks } = makeAdapter()
+    adapter.beginTurn()
+    adapter.ensureToolCall('c1', 'bash', { command: 'rm -rf build' })
+    adapter.handleEvent(envelope('turn/start', { turn: 1 }))
+    // The late session event for the same call must not re-open the part (it would reset an
+    // already-rendered approval back to input-streaming).
+    adapter.handleEvent(
+      envelope('tool/call', { turn: 1, step: 1, callId: callId('c1'), name: 'bash', arguments: '{"command":"ls"}' })
+    )
+    adapter.handleEvent(
+      envelope('tool/result', {
+        turn: 1,
+        step: 1,
+        message: toolResultMessage('c1', [{ type: 'text', text: 'done' }])
+      })
+    )
+
+    expect(chunks.map((chunk) => chunk.type)).toEqual([
+      'tool-input-start',
+      'tool-input-available',
+      'tool-output-available'
+    ])
+    expect(chunks[1]).toMatchObject({ toolCallId: 'c1', toolName: 'bash', input: { command: 'rm -rf build' } })
+    expect(chunks[2]).toMatchObject({
+      toolCallId: 'c1',
+      providerMetadata: { cherry: { tool: { type: 'builtin', name: 'bash' } } }
+    })
+  })
+
   it('unwraps an all-text tool result into its structured payload', () => {
     const { adapter, chunks } = makeAdapter()
     const results = [{ id: 'dsh-1', url: 'https://a.com/x', title: 'A', content: 'a' }]

--- a/src/main/ai/runtime/dsh/dshStreamAdapter.ts
+++ b/src/main/ai/runtime/dsh/dshStreamAdapter.ts
@@ -20,7 +20,7 @@
  */
 // The dsh-compaction-basic / dsh-llm-retry / dsh-plan-mode imports load their SessionEventMap merges.
 import type {} from '@deepseek-ai/dsh-compaction-basic'
-import type { ContentBlock, TokenUsage } from '@deepseek-ai/dsh-llm'
+import type { CallId, ContentBlock, TokenUsage } from '@deepseek-ai/dsh-llm'
 import type {} from '@deepseek-ai/dsh-llm-retry'
 import type {} from '@deepseek-ai/dsh-plan-mode'
 import type { SessionEvent, SessionEventMap, TurnEndReason } from '@deepseek-ai/dsh-session'
@@ -131,6 +131,7 @@ export class DshStreamAdapter {
 
   /** Mark the next turn as host-prompted; called by the connection before each bridge prompt. */
   beginTurn(): void {
+    this.startedTools.clear()
     this.turnActive = true
     this.autonomousTurn = false
   }
@@ -139,6 +140,17 @@ export class DshStreamAdapter {
   abortTurn(): void {
     this.turnActive = false
     this.autonomousTurn = false
+  }
+
+  /**
+   * Emit a call's input parts now, as if its `tool/call` event had already arrived. The bridge
+   * socket can outrun the session-event stream, and an approval chunk with no tool part truncates
+   * the turn accumulator. The real `tool/call` then no-ops on `startedTools`.
+   */
+  ensureToolCall(callId: string, toolName: string, input: Record<string, unknown>): void {
+    if (this.startedTools.has(callId)) return
+    this.ensureTurnOpen()
+    this.handleToolCall({ callId: callId as CallId, name: toolName, arguments: JSON.stringify(input) })
   }
 
   /** Content with no host-opened turn = the runtime started its own (goal-round) turn. */
@@ -154,7 +166,9 @@ export class DshStreamAdapter {
       case 'turn/start':
         this.flushPendingProviderUsage()
         this.turnUsage = emptyTurnUsage()
-        this.startedTools.clear()
+        // Host turns clear in beginTurn, before cross-channel events can race. Preserve a bridge-first
+        // synthetic call here; an ordinary autonomous turn is still inactive and clears normally.
+        if (!this.turnActive) this.startedTools.clear()
         this.resetStepTiming()
         return
       case 'step/start':


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: A stream-presented DSH approval could arrive before its `tool/call` event, causing the AI SDK accumulator to drop the approval card.

After this PR: DSH materializes the tool input before forwarding the approval and deduplicates delayed session events, keeping the approval card visible.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Synthetic tool-input emission from bridge approval data, with the durable session `tool/call` treated as a duplicate

The following alternatives were considered: Generic AI SDK accumulator changes, rejected because the race is specific to DSH's independent bridge and session-event channels

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None

### Special notes for your reviewer

The regression covers approvals outrunning both `tool/call` and `turn/start`; 33 focused tests and `pnpm typecheck:node` pass. Live Electron validation in `acceptEdits` mode showed a persistent Bash `pwd` approval card with both actions available.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix DSH tool approval cards that could disappear when bridge and session events arrived out of order.
```
