### PR TITLE
fix(openclaw): strip proxy env from gateway spawn

### DIFF
--- a/src/main/services/OpenClawService.ts
+++ b/src/main/services/OpenClawService.ts
@@ -13,7 +13,7 @@ import { isWin } from '@main/core/platform'
 import type { Model, Provider, ProviderType, VertexProvider } from '@main/data/migration/legacyTypes'
 import { t } from '@main/i18n'
 import { atomicWriteFile, remove } from '@main/utils/file'
-import { crossPlatformSpawn } from '@main/utils/processRunner'
+import { crossPlatformSpawn, removeEnvProxy } from '@main/utils/processRunner'
 import { getRawShellEnv, refreshShellEnv } from '@main/utils/shellEnv'
 import type { EndpointType, Model as DataModel, UniqueModelId } from '@shared/data/types/model'
 import {
@@ -728,12 +728,16 @@ export class OpenClawService extends BaseService {
     // On Windows, avoid detached: true as it creates a visible console window.
     // Instead, use windowsHide: true without detached - proc.unref() ensures
     // the parent can exit independently.
+    // Copy before stripping: removeEnvProxy mutates in place, and shellEnv is reused
+    // for other OpenClaw commands. OpenClaw's undici EnvHttpProxyAgent rejects socks5://.
+    const env = { ...shellEnv }
+    removeEnvProxy(env)
     const proc = crossPlatformSpawn(openclawPath, args, {
       // OpenClaw's own auto-updater would swap the binary underneath us, desyncing the
       // version BinaryManager installed and reports. This is OpenClaw's documented kill
       // switch, scoped to the gateway process we spawn.
       env: {
-        ...shellEnv,
+        ...env,
         OPENCLAW_CONFIG_PATH: openclawConfigPath(),
         OPENCLAW_NO_AUTO_UPDATE: '1'
       },

--- a/src/main/services/__tests__/OpenClawService.test.ts
+++ b/src/main/services/__tests__/OpenClawService.test.ts
@@ -138,9 +138,13 @@ vi.mock('@main/core/platform', () => ({
   }
 }))
 
-vi.mock('@main/utils/processRunner', () => ({
-  crossPlatformSpawn: crossPlatformSpawnMock
-}))
+vi.mock('@main/utils/processRunner', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...actual,
+    crossPlatformSpawn: crossPlatformSpawnMock
+  }
+})
 
 vi.mock('@shared/utils', () => ({
   hasApiVersion: vi.fn(() => false),
@@ -881,6 +885,46 @@ describe('OpenClawService gateway status state machine', () => {
         })
       )
       expect(child.unref).toHaveBeenCalledOnce()
+    })
+
+    it('strips proxy variables from the gateway spawn env without mutating the source shellEnv', async () => {
+      const child = createSpawnChild()
+      startAndWaitSpy.mockRestore()
+      crossPlatformSpawnMock.mockReturnValue(child)
+      vi.spyOn(service as any, 'checkGatewayHealthWithError').mockResolvedValue({
+        status: 'healthy',
+        gatewayPort: 18790
+      })
+      vi.useFakeTimers()
+
+      const shellEnv = {
+        PATH: '/usr/local/bin:/usr/bin',
+        HTTP_PROXY: 'socks5://127.0.0.1:1080',
+        HTTPS_PROXY: 'http://127.0.0.1:7897',
+        http_proxy: 'socks5://127.0.0.1:1080',
+        ALL_PROXY: 'socks5://127.0.0.1:1080',
+        SOCKS_PROXY: 'socks5://127.0.0.1:1080',
+        NO_PROXY: 'localhost',
+        GRPC_PROXY: 'http://proxy.example',
+        CHERRY_STUDIO_NODE_PROXY_RULES: 'socks5://127.0.0.1:1080',
+        CHERRY_STUDIO_NODE_PROXY_BYPASS_RULES: 'localhost',
+        USER_DEFINED_TOKEN: 'keep-me',
+        MISE_DATA_DIR: '/user/mise'
+      }
+      const sourceSnapshot = { ...shellEnv }
+
+      const started = (service as any).startAndWaitForGateway('/usr/local/bin/openclaw', shellEnv)
+      await vi.advanceTimersByTimeAsync(1000)
+      await expect(started).resolves.toBeUndefined()
+
+      expect(crossPlatformSpawnMock.mock.calls[0][2].env).toEqual({
+        PATH: '/usr/local/bin:/usr/bin',
+        USER_DEFINED_TOKEN: 'keep-me',
+        MISE_DATA_DIR: '/user/mise',
+        OPENCLAW_CONFIG_PATH: '/mock/openclaw/openclaw.json',
+        OPENCLAW_NO_AUTO_UPDATE: '1'
+      })
+      expect(shellEnv).toEqual(sourceSnapshot)
     })
 
     it('stops stale gateway and restarts when port is in use by our gateway', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The OpenClaw gateway inherited Cherry Studio's proxy environment. When a configured proxy used `socks5://`, OpenClaw's undici `EnvHttpProxyAgent` rejected the URL protocol and the gateway exited during startup.

After this PR:

The gateway spawn copies the resolved shell environment and applies the existing `removeEnvProxy` policy before adding the required `OPENCLAW_*` variables. Other OpenClaw commands keep their original environment, and the shared shell environment object is not mutated.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

Related to #13140. Supersedes the stale implementation in #13380.

### Why we need it and why it was done in this way

The following tradeoffs were made:

This deliberately strips all variables covered by the repository's existing `removeEnvProxy` helper for the gateway process. OpenClaw therefore does not inherit Cherry Studio's HTTP(S), socks, bypass, gRPC, or internal Node proxy settings, while unrelated environment variables remain available.

The following alternatives were considered:

Porting #13380 directly was rejected because its branch predates the current OpenClaw lifecycle and spawn implementation. Mutating `shellEnv` was rejected because that object is reused by other OpenClaw commands. Adding a gateway-specific proxy-variable list was rejected in favor of the established central helper.

Links to places where the discussion took place: #13140 and #13380

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm lint` passed.
- Focused OpenClaw and process-runner tests passed: 93 tests.
- Independent review accepted commit `9488694e89816199a8504b40d8eb39eceea4663d`.
- Windows socks5 cold-start validation is still outstanding, so this PR intentionally does not auto-close #13140.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: N/A - this is a focused spawn-environment bug fix
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this startup fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Prevent the OpenClaw gateway from failing to start when Cherry Studio uses a socks5 proxy.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenClaw gateway process environment; uses an established helper and is covered by a focused unit test. No auth or data-path changes.
> 
> **Overview**
> Fixes **OpenClaw gateway startup** when Cherry Studio uses a **socks5** proxy: inherited proxy variables caused OpenClaw’s undici `EnvHttpProxyAgent` to reject the URL and exit early.
> 
> In `startAndWaitForGateway`, the spawn environment is now a **copy** of the resolved shell env with the existing **`removeEnvProxy`** helper applied before adding `OPENCLAW_*` variables. The shared `shellEnv` object is **not mutated**, so other OpenClaw CLI commands keep the original environment.
> 
> Tests partially mock `processRunner` to preserve the real `removeEnvProxy` and add coverage that proxy-related keys are removed from the gateway spawn env while unrelated variables remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9488694e89816199a8504b40d8eb39eceea4663d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->