### PR TITLE
test(permission-composer): stabilize ExitPlanMode preview assertion

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/PermissionRequestComposer.test.tsx
@@ -183,8 +183,9 @@ describe('PermissionRequestComposer', () => {
       />
     )
 
-    expect(screen.getByText('Release plan')).toBeInTheDocument()
-    expect(screen.getByText('Run the focused tests')).toBeInTheDocument()
+    const preview = screen.getByTestId('permission-preview')
+    expect(preview).toHaveTextContent('Release plan')
+    expect(preview).toHaveTextContent('Run the focused tests')
   })
 
   it('does not add a fallback body scroller when the tool content owns scrolling', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The ExitPlanMode approval-preview regression test failed after the renderer's lightweight Markdown stand-in began preserving the entire plan as one raw text node; exact `getByText` queries could not find its individual lines.

After this PR:

The test scopes its assertions to the permission preview and verifies both plan lines through text content, preserving coverage while remaining independent of Markdown's internal DOM.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

This keeps the regression at the component-contract level: omitting the plan still fails the test, while behavior-preserving Markdown markup changes do not.

The following tradeoffs were made:

The renderer test no longer asserts heading/list element boundaries; Markdown parsing stays covered by `@cherrystudio/ui` tests.

The following alternatives were considered:

Using the real Markdown component or expanding the global mock was rejected because either would broaden this focused CI repair.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/32248043288

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

- Focused renderer test: 14/14 passed.
- `pnpm lint` passed; the repository still reports 37 unrelated pre-existing warnings.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
