### PR TITLE
fix(window-manager): follow native window focus

### DIFF
--- a/src/main/core/window/__tests__/windowRegistry.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.test.ts
@@ -277,3 +277,12 @@ describe('WINDOW_TYPE_REGISTRY SubWindow — must not keep the Dock icon alive',
     expect(metadata?.behavior?.macShowInDock).toBe(false)
   })
 })
+
+// 'active' keeps sidebar vibrancy bright after the window loses key focus;
+// Electron flattens native material only when this is 'followWindow'.
+describe('WINDOW_TYPE_REGISTRY Main and SubWindow — visualEffectState contract', () => {
+  it('follows the window key state so macOS vibrancy flattens when unfocused', () => {
+    expect(WINDOW_TYPE_REGISTRY[WindowType.Main]?.windowOptions.visualEffectState).toBe('followWindow')
+    expect(WINDOW_TYPE_REGISTRY[WindowType.SubWindow]?.windowOptions.visualEffectState).toBe('followWindow')
+  })
+})

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -65,7 +65,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       autoHideMenuBar: true,
       transparent: false,
       vibrancy: 'sidebar',
-      visualEffectState: 'active',
+      visualEffectState: 'followWindow',
       platformOverrides: {
         mac: {
           titleBarStyle: 'hidden',
@@ -214,7 +214,7 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
       // flash on reuse and the never-fires ready-to-show stuck-hidden failure mode).
       paintWhenInitiallyHidden: true,
       vibrancy: 'sidebar',
-      visualEffectState: 'active',
+      visualEffectState: 'followWindow',
       platformOverrides: {
         mac: {
           titleBarStyle: 'hidden',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The main window and detached sub-windows forced macOS vibrancy to remain visually active after the native window lost key focus.

After this PR:

Main and SubWindow use Electron's `followWindow` visual-effect state, so native sidebar vibrancy follows the BrowserWindow key state and flattens when the window is inactive.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

Related to the surviving window-focus demand from #16505; this current-main recut does not port that PR's superseded UI stack.

### Why we need it and why it was done in this way

The following tradeoffs were made:

This uses the BrowserWindow constructor contract that owns native vibrancy. The current `sidebar` material and all other window options remain unchanged.

The following alternatives were considered:

Adding IpcApi focus routes, WindowManager focus events, a renderer hook, or AppShell glass CSS was rejected because no current renderer surface consumes native focus state. Those additions would create unused shared surface area without improving the native outcome.

Links to places where the discussion took place: #16505

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Current head: `8225c1a2fceba16c5e020b9cce3fec391af4d89c`; the commit is GitHub Verified and includes the required DCO sign-off.
- Architecture scope: only the Main/SubWindow registry `visualEffectState` changes from `active` to `followWindow`; this adds no IPC route, renderer focus state, or other cross-process surface.
- Verification: focused main tests passed 17/17, `pnpm lint` passed, exact-head CI product checks are green, and Cherry Review approved this exact head with no findings.
- UI screenshots are unavailable. Before launch, safety validation showed that the empty suffixed development profile would enter MigrationPaths B fuzzy recovery and select the real `/Users/siin/Documents/Cherry Studio`, which contains V1 evidence and a non-empty SQLite database. The test was terminated before launch to avoid redirecting, pinning, or relaunching Electron into real user data. No trustworthy Before/After screenshot was produced.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this native focus-state correction.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Transparent macOS windows now dim their native sidebar material when the window becomes inactive.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two registry default changes plus a test; macOS-only visual behavior with no security, data, or cross-platform logic changes.
> 
> **Overview**
> **Main** and **SubWindow** registry entries now set Electron `visualEffectState` to **`followWindow`** instead of **`active`**, so macOS `sidebar` vibrancy dims when the window loses key focus instead of staying bright.
> 
> A regression test in `windowRegistry.test.ts` locks the contract for both window types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8225c1a2fceba16c5e020b9cce3fec391af4d89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->