### PR TITLE
perf(html-artifacts): skip full-element height sweeps for scrollable previews

### DIFF
--- a/src/renderer/components/chat/HtmlArtifactView.tsx
+++ b/src/renderer/components/chat/HtmlArtifactView.tsx
@@ -98,6 +98,18 @@ function getIframeContentHeight(iframe: HTMLIFrameElement): number | null {
     const frameWindow = iframe.contentWindow
     if (!frameDocument || !body || !documentElement || !frameWindow) return null
 
+    const documentScrollHeight = Math.max(
+      body.scrollHeight,
+      documentElement.scrollHeight,
+      frameDocument.scrollingElement?.scrollHeight ?? 0
+    )
+
+    // Scrollable: scrollHeight is authoritative (scrollbar-bounded); the sweep
+    // exists only for collapsed bottom margins in non-scrolling documents.
+    if (documentScrollHeight > iframe.clientHeight + 1) {
+      return documentScrollHeight
+    }
+
     const bodyStyle = frameWindow.getComputedStyle(body)
     const bodyEndSpacing =
       (Number.parseFloat(bodyStyle.paddingBottom) || 0) + (Number.parseFloat(bodyStyle.borderBottomWidth) || 0)
@@ -105,9 +117,6 @@ function getIframeContentHeight(iframe: HTMLIFrameElement): number | null {
     const scrollTop = frameWindow.scrollY || documentElement.scrollTop || body.scrollTop
     let renderedContentBottom = 0
 
-    // A last descendant's margin can collapse through otherwise margin-less wrappers. Measuring
-    // only body.children then underestimates the natural document height and can make this preview
-    // alternate forever between that smaller value and documentScrollHeight.
     for (const element of body.querySelectorAll('*')) {
       const bounds = element.getBoundingClientRect()
       if (bounds.width === 0 && bounds.height === 0) continue
@@ -133,17 +142,7 @@ function getIframeContentHeight(iframe: HTMLIFrameElement): number | null {
       }
     }
 
-    const documentScrollHeight = Math.max(
-      body.scrollHeight,
-      documentElement.scrollHeight,
-      frameDocument.scrollingElement?.scrollHeight ?? 0
-    )
     const renderedContentHeight = Math.ceil(renderedContentBottom)
-
-    if (documentScrollHeight > iframe.clientHeight + 1) {
-      return Math.max(documentScrollHeight, renderedContentHeight)
-    }
-
     return renderedContentHeight > 0 ? renderedContentHeight : documentScrollHeight || null
   } catch {
     return null
@@ -297,13 +296,16 @@ const AdaptiveHtmlPreview = memo(function AdaptiveHtmlPreview({
 
       if (typeof ResizeObserver !== 'undefined') {
         documentResizeObserver = new ResizeObserver(syncHeight)
+        // In-flow child changes propagate to body size (per-child observe is
+        // quadratic); out-of-flow self-resizes trade on other triggers.
         documentResizeObserver.observe(body)
         documentResizeObserver.observe(frameDocument.documentElement)
-        for (const child of body.children) documentResizeObserver.observe(child)
       }
 
       if (typeof MutationObserver !== 'undefined') {
-        documentMutationObserver = new MutationObserver(observeDocument)
+        // Re-measure only; observers stay attached because body itself is what
+        // they watch, and document replacement is covered by the load listener.
+        documentMutationObserver = new MutationObserver(() => syncHeight())
         documentMutationObserver.observe(body, { childList: true, subtree: true, characterData: true })
       }
 

--- a/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
+++ b/src/renderer/components/chat/__tests__/HtmlArtifactView.test.tsx
@@ -618,6 +618,71 @@ describe('HtmlArtifactView', () => {
     }
   })
 
+  it('uses the scroll height directly for scrollable content without sweeping every element', () => {
+    render(<HtmlArtifactView html="<main>Page</main>" title="Preview" />)
+
+    const surface = screen.getByTestId('html-artifact-surface')
+    const setPreviewContentHeight = createPreviewContentHeightController()
+    const iframe = screen.getByTestId<HTMLIFrameElement>('html-preview-frame')
+    const body = iframe.contentDocument?.body
+    if (!body) throw new Error('Expected iframe body')
+
+    const sweepSpy = vi.spyOn(body, 'querySelectorAll')
+
+    setPreviewContentHeight(1200)
+
+    expect(surface).toHaveStyle({ height: '576px' })
+    expect(sweepSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-measures on DOM mutations without rebuilding observers', async () => {
+    render(<HtmlArtifactView html="<main>Page</main>" title="Preview" />)
+
+    const surface = screen.getByTestId('html-artifact-surface')
+    const iframe = screen.getByTestId<HTMLIFrameElement>('html-preview-frame')
+    const frameDocument = iframe.contentDocument
+    const body = frameDocument?.body
+    if (!frameDocument || !body) throw new Error('Expected iframe document')
+
+    const content = frameDocument.createElement('main')
+    body.replaceChildren(content)
+    body.style.margin = '0'
+    Object.defineProperty(iframe, 'clientHeight', {
+      configurable: true,
+      get: () => Number.parseFloat(surface.style.height) || 240
+    })
+    Object.defineProperty(body, 'scrollHeight', { configurable: true, get: () => 0 })
+    Object.defineProperty(frameDocument.documentElement, 'scrollHeight', { configurable: true, get: () => 0 })
+    vi.spyOn(content, 'getBoundingClientRect').mockReturnValue({ bottom: 180, height: 180, width: 100 } as DOMRect)
+
+    fireEvent.load(iframe)
+    expect(surface).toHaveStyle({ height: '180px' })
+
+    const observeSpy = vi.spyOn(ResizeObserver.prototype, 'observe')
+    const tall = frameDocument.createElement('div')
+    vi.spyOn(tall, 'getBoundingClientRect').mockReturnValue({ bottom: 300, height: 300, width: 100 } as DOMRect)
+
+    await act(async () => {
+      content.appendChild(tall)
+    })
+
+    // The mutation re-measured through syncHeight with the new content bottom.
+    expect(surface).toHaveStyle({ height: '300px' })
+
+    // Count only observer activity from here on: a size-neutral mutation must
+    // re-measure without rebuilding observers.
+    observeSpy.mockClear()
+    const idle = frameDocument.createElement('span')
+    vi.spyOn(idle, 'getBoundingClientRect').mockReturnValue({ bottom: 300, height: 0, width: 0 } as DOMRect)
+
+    await act(async () => {
+      content.appendChild(idle)
+    })
+
+    expect(surface).toHaveStyle({ height: '300px' })
+    expect(observeSpy).not.toHaveBeenCalled()
+  })
+
   it('renders a streaming fragment as a restricted DOM preview without controls', () => {
     const html = '<div><script>document.body.textContent = "interactive"</script></div>'
     render(<HtmlArtifactView html={html} title="Preview" kind="fragment" isStreaming />)


### PR DESCRIPTION
### What this PR does

Before this PR:

`AdaptiveHtmlPreview`'s height measurement (`getIframeContentHeight`) swept **every element** inside the preview iframe with `getBoundingClientRect` + `getComputedStyle` (two layout-property queries per element) — even for scrollable documents whose height is already authoritatively given by `scrollHeight`. The sweep is re-triggered from many sources (ResizeObserver on body + documentElement + **every direct child**, MutationObserver rebuilding all observers on any DOM change, load, fonts, resize), so during streamed artifact rebuilds each paced update paid a full-document layout sweep.

After this PR:

- **Fast path**: scrollable documents (`documentScrollHeight > clientHeight + 1`) return `scrollHeight` directly and skip the per-element sweep entirely. The sweep is preserved verbatim for the non-scrolling case, where it is genuinely load-bearing: collapsed bottom margins can extend the natural document height beyond `scrollHeight` (dropping it would make the preview alternate between two heights forever).
- **ResizeObserver thinning**: only `body` + `documentElement` are observed. In-flow child layout changes propagate to body size, so per-child observation was redundant — and quadratic during streamed rebuilds. (Trade-off, stated in a code comment: an out-of-flow child that self-resizes without any DOM change is no longer individually reported; it is re-measured by the next mutation/load/resize/fonts trigger.)
- **MutationObserver**: any DOM mutation now calls `syncHeight` only, instead of tearing down and rebuilding every observer; document replacement is still covered by the iframe `load` listener.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- For scrollable docs the preview height may be shorter by the collapsed-margin overhang than the old `max(scrollHeight, sweep)` — measured at ~1px on real Chromium margin-collapse fixtures (see below); accepted as invisible.
- Out-of-flow self-resizing children trade on other triggers (above).

The following alternatives were considered:

- Keep the sweep but debounce it — rejected: the sweep itself is the cost; frequency limits don't remove it.
- Fast-path semantics were **spiked before implementation** (grilling decision D5): a real-Chromium margin-collapse fixture showed scrollable docs have `sweep − scrollHeight = 1px`, non-scrollable docs return identical values on both paths, and applying the fast-path height converges in one step with no oscillation — the exact failure mode the original sweep comment feared.

Links to places where the discussion took place: internal perf audit 2026-08-17 (P7); batch-E grilling decisions D5/D7 in `.trellis/tasks/08-18-perf-renderer-batch/prd.md`.

### Special notes for your reviewer

- **This PR is stacked on `fix/html-preview-iframe-sandbox` (#18764)** on purpose: both change `HtmlArtifactView.tsx` (that PR owns the preview security surface, this one only touches measurement/observers). GitHub will retarget this PR to `main` automatically once #18764 merges. Review the last commit only.
- The pre-existing margin-collapse regression test (`stabilizes at the natural height when a nested bottom margin collapses through its wrapper`) passes unchanged — the sweep path is byte-identical for that scenario; two new tests pin (a) scrollable content returns scrollHeight with zero `querySelectorAll('*')` sweeps and (b) DOM mutations re-measure without rebuilding observers.
- Real-machine spike evidence (CDP against real Chromium): scrollable margin-collapse doc — `scrollH 1638 / sweep 1639`; non-scrollable — both paths 214; height application converges (1638 → 1639 → stable), no alternation.
- 29/29 in the `HtmlArtifactView` suite; oxlint clean; `typecheck:web` clean.

### Checklist

- [x] Branch: This PR targets `fix/html-preview-iframe-sandbox` (stacked; auto-retargets to `main` when #18764 merges)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of upgrade flows was considered and addressed if required
- [x] Documentation: user-guide update not required (no user-facing behavior change)
- [x] Self-review: reviewed via 3 rounds of adversarial subagent review (final round CLEAN)

### Release note

```release-note
Performance: HTML artifact previews skip a full-element layout sweep for scrollable content and stop rebuilding height observers on every DOM mutation.
```
