### PR TITLE
feat(skills): open installed skill folders

### DIFF
--- a/src/main/ipc/handlers/__tests__/skill.test.ts
+++ b/src/main/ipc/handlers/__tests__/skill.test.ts
@@ -7,7 +7,10 @@ const {
   installFromDirectoryMock,
   listLocalMock,
   discoverSystemMock,
+  getByIdMock,
+  getInstalledSkillDirectoryMock,
   importSystemMock,
+  openPathMock,
   reconcileMock
 } = vi.hoisted(() => ({
   installMock: vi.fn(),
@@ -16,8 +19,15 @@ const {
   installFromDirectoryMock: vi.fn(),
   listLocalMock: vi.fn(),
   discoverSystemMock: vi.fn(),
+  getByIdMock: vi.fn(),
+  getInstalledSkillDirectoryMock: vi.fn(),
   importSystemMock: vi.fn(),
+  openPathMock: vi.fn(),
   reconcileMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  shell: { openPath: openPathMock }
 }))
 
 vi.mock('@main/ai/skills/SkillService', () => ({
@@ -28,6 +38,8 @@ vi.mock('@main/ai/skills/SkillService', () => ({
     installFromDirectory: installFromDirectoryMock,
     listLocal: listLocalMock,
     discoverSystem: discoverSystemMock,
+    getById: getByIdMock,
+    getInstalledSkillDirectory: getInstalledSkillDirectoryMock,
     importSystem: importSystemMock,
     reconcileSkills: reconcileMock
   }
@@ -106,6 +118,47 @@ describe('skillHandlers', () => {
 
     await expect(skillHandlers['skill.reconcile']({}, ctx)).resolves.toBeUndefined()
     expect(reconcileMock).toHaveBeenCalledWith()
+  })
+
+  it('opens the registered skill directory without accepting a renderer-supplied path', async () => {
+    const skill = { id: 's1', folderName: 'safe-skill' }
+    getByIdMock.mockResolvedValue(skill)
+    getInstalledSkillDirectoryMock.mockReturnValue('/managed/skills/safe-skill')
+    openPathMock.mockResolvedValue('')
+
+    await expect(skillHandlers['skill.folder.open']({ skillId: 's1' }, ctx)).resolves.toBeUndefined()
+
+    expect(getByIdMock).toHaveBeenCalledWith('s1')
+    expect(getInstalledSkillDirectoryMock).toHaveBeenCalledWith(skill)
+    expect(openPathMock).toHaveBeenCalledWith('/managed/skills/safe-skill')
+  })
+
+  it('does not open a path when the skill is no longer installed', async () => {
+    getByIdMock.mockResolvedValue(null)
+
+    await expect(skillHandlers['skill.folder.open']({ skillId: 'missing' }, ctx)).rejects.toThrow(
+      'Skill not found: missing'
+    )
+    expect(openPathMock).not.toHaveBeenCalled()
+  })
+
+  it('does not open a skill folder for a trusted but unmanaged renderer', async () => {
+    await expect(skillHandlers['skill.folder.open']({ skillId: 's1' }, { senderId: null })).rejects.toThrow(
+      'Skill folders can only be opened from a managed window'
+    )
+    expect(getByIdMock).not.toHaveBeenCalled()
+    expect(openPathMock).not.toHaveBeenCalled()
+  })
+
+  it('reports the OS error when the managed skill directory cannot be opened', async () => {
+    const skill = { id: 's1', folderName: 'missing-directory' }
+    getByIdMock.mockResolvedValue(skill)
+    getInstalledSkillDirectoryMock.mockReturnValue('/managed/skills/missing-directory')
+    openPathMock.mockResolvedValue('The file does not exist')
+
+    await expect(skillHandlers['skill.folder.open']({ skillId: 's1' }, ctx)).rejects.toThrow(
+      'Failed to open skill folder: The file does not exist'
+    )
   })
 
   it('import_system lets errors propagate to IpcApi', async () => {

--- a/src/main/ipc/handlers/skill.ts
+++ b/src/main/ipc/handlers/skill.ts
@@ -3,6 +3,7 @@ import { skillService } from '@main/ai/skills/SkillService'
 import type { skillRequestSchemas } from '@shared/ipc/schemas/skill'
 import type { IpcHandlersFor } from '@shared/ipc/types'
 import type { SkillResult } from '@shared/types/skill'
+import { shell } from 'electron'
 
 const logger = loggerService.withContext('skillHandlers')
 
@@ -32,5 +33,14 @@ export const skillHandlers: IpcHandlersFor<typeof skillRequestSchemas> = {
     toSkillResult(() => skillService.listLocal(workdir), 'Failed to list local plugins'),
   'skill.reconcile': () => skillService.reconcileSkills(),
   'skill.discover_system': () => skillService.discoverSystem(),
-  'skill.import_system': ({ directoryPath }) => skillService.importSystem({ directoryPath })
+  'skill.import_system': ({ directoryPath }) => skillService.importSystem({ directoryPath }),
+  'skill.folder.open': async ({ skillId }, { senderId }) => {
+    if (!senderId) throw new Error('Skill folders can only be opened from a managed window')
+
+    const skill = await skillService.getById(skillId)
+    if (!skill) throw new Error(`Skill not found: ${skillId}`)
+
+    const errorMessage = await shell.openPath(skillService.getInstalledSkillDirectory(skill))
+    if (errorMessage) throw new Error(`Failed to open skill folder: ${errorMessage}`)
+  }
 }

--- a/src/renderer/components/resourceCatalog/dialogs/detail/SkillDetailDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/detail/SkillDetailDialog.tsx
@@ -1,8 +1,11 @@
-import { Badge, Dialog, DialogContent, DialogHeader, DialogTitle, Separator } from '@cherrystudio/ui'
+import { Badge, Button, Dialog, DialogContent, DialogHeader, DialogTitle, Separator } from '@cherrystudio/ui'
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
+import { ipcApi } from '@renderer/ipc'
+import { loggerService } from '@renderer/services/LoggerService'
+import { toast } from '@renderer/services/toast'
 import { formatRelativeTime } from '@renderer/utils/time'
 import type { InstalledSkill } from '@shared/types/skill'
-import { Clock, ToolCase } from 'lucide-react'
+import { Clock, FolderOpen, ToolCase } from 'lucide-react'
 import { type FC, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -11,6 +14,8 @@ interface Props {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
+
+const logger = loggerService.withContext('SkillDetailDialog')
 
 function formatDate(dateStr: string, language: string): string {
   const date = new Date(dateStr)
@@ -62,6 +67,17 @@ const SkillDetailDialog: FC<Props> = ({ skill, open, onOpenChange }) => {
     [clearCloseTimer, onOpenChange]
   )
 
+  const handleOpenFolder = async () => {
+    if (!skill) return
+
+    try {
+      await ipcApi.request('skill.folder.open', { skillId: skill.id })
+    } catch (error) {
+      logger.error('Failed to open skill folder', error as Error)
+      toast.error(t('library.skill_detail.open_folder_failed'))
+    }
+  }
+
   if (!skill) return null
 
   const sourceTags = skill.sourceTags ?? []
@@ -95,12 +111,18 @@ const SkillDetailDialog: FC<Props> = ({ skill, open, onOpenChange }) => {
         </DialogHeader>
 
         <div className="max-h-[60vh] space-y-6 overflow-y-auto pr-1 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[var(--scrollbar-thumb)] [&::-webkit-scrollbar]:w-1">
-          <Badge
-            variant="secondary"
-            className="gap-1.5 border-0 bg-success-subtle px-2 py-0.5 text-success-subtle-foreground text-xs">
-            <span className="size-1.5 rounded-full bg-success" aria-hidden="true" />
-            {t('library.skill_detail.installed')}
-          </Badge>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Badge
+              variant="secondary"
+              className="gap-1.5 border-0 bg-success-subtle px-2 py-0.5 text-success-subtle-foreground text-xs">
+              <span className="size-1.5 rounded-full bg-success" aria-hidden="true" />
+              {t('library.skill_detail.installed')}
+            </Badge>
+            <Button type="button" variant="outline" size="sm" onClick={() => void handleOpenFolder()}>
+              <FolderOpen className="size-3.5" />
+              {t('library.skill_detail.open_folder')}
+            </Button>
+          </div>
           <section className="flex flex-col gap-3">
             <h3 className="font-medium text-muted-foreground text-sm">{t('library.skill_detail.description')}</h3>
             <p className="min-h-10 text-muted-foreground text-sm leading-6">

--- a/src/renderer/components/resourceCatalog/dialogs/detail/__tests__/SkillDetailDialog.test.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/detail/__tests__/SkillDetailDialog.test.tsx
@@ -1,15 +1,33 @@
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import type { InstalledSkill } from '@shared/types/skill'
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ComponentProps, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SkillDetailDialog from '../SkillDetailDialog'
 
-const { listFilesMock, readSkillFileMock, uiLanguage } = vi.hoisted(() => ({
-  listFilesMock: vi.fn(),
-  readSkillFileMock: vi.fn(),
-  uiLanguage: { current: 'en-US', resolved: undefined as string | undefined }
+const { ipcRequestMock, listFilesMock, loggerErrorMock, readSkillFileMock, toastErrorMock, uiLanguage } = vi.hoisted(
+  () => ({
+    ipcRequestMock: vi.fn(),
+    listFilesMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+    readSkillFileMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    uiLanguage: { current: 'en-US', resolved: undefined as string | undefined }
+  })
+)
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: ipcRequestMock }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: toastErrorMock }
+}))
+
+vi.mock('@renderer/services/LoggerService', () => ({
+  loggerService: { withContext: () => ({ error: loggerErrorMock }) }
 }))
 
 vi.mock('react-i18next', () => ({
@@ -86,8 +104,11 @@ function createSkill(overrides: Partial<InstalledSkill> = {}): InstalledSkill {
 
 describe('SkillDetailDialog', () => {
   beforeEach(() => {
+    ipcRequestMock.mockReset()
     listFilesMock.mockReset()
+    loggerErrorMock.mockReset()
     readSkillFileMock.mockReset()
+    toastErrorMock.mockReset()
     uiLanguage.current = 'en-US'
     uiLanguage.resolved = undefined
 
@@ -143,6 +164,26 @@ describe('SkillDetailDialog', () => {
     expect(screen.queryByRole('button', { name: 'library.action.uninstall' })).not.toBeInTheDocument()
     expect(listFilesMock).not.toHaveBeenCalled()
     expect(readSkillFileMock).not.toHaveBeenCalled()
+  })
+
+  it('opens the selected installed skill folder through the skill-scoped IPC route', async () => {
+    const user = userEvent.setup()
+    ipcRequestMock.mockResolvedValue(undefined)
+    render(<SkillDetailDialog skill={createSkill()} open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'library.skill_detail.open_folder' }))
+
+    expect(ipcRequestMock).toHaveBeenCalledWith('skill.folder.open', { skillId: 'skill-1' })
+  })
+
+  it('reports an OS failure to open the skill folder', async () => {
+    const user = userEvent.setup()
+    ipcRequestMock.mockRejectedValue(new Error('open failed'))
+    render(<SkillDetailDialog skill={createSkill()} open onOpenChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('button', { name: 'library.skill_detail.open_folder' }))
+
+    expect(toastErrorMock).toHaveBeenCalledWith('library.skill_detail.open_folder_failed')
   })
 
   it('keeps the selected skill mounted until the close animation finishes', async () => {

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Dateivorschau",
   "library.skill_detail.installed": "Installiert",
   "library.skill_detail.no_description": "Keine Beschreibung",
+  "library.skill_detail.open_folder": "Ordner öffnen",
+  "library.skill_detail.open_folder_failed": "Ordner konnte nicht geöffnet werden",
   "library.skill_detail.updated_at": "Kürzlich aktualisiert",
   "library.skill_marketplace.empty_description": "Suchen Sie in Online-Registern nach installierbaren Skills.",
   "library.skill_marketplace.empty_title": "Nach Fähigkeiten suchen",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Προεπισκόπηση αρχείου",
   "library.skill_detail.installed": "Εγκατεστημένο",
   "library.skill_detail.no_description": "Χωρίς περιγραφή",
+  "library.skill_detail.open_folder": "Άνοιγμα φακέλου",
+  "library.skill_detail.open_folder_failed": "Δεν ήταν δυνατό το άνοιγμα του φακέλου",
   "library.skill_detail.updated_at": "Πρόσφατα ενημερώθηκε",
   "library.skill_marketplace.empty_description": "Αναζητήστε σε διαδικτυακά μητρώα για να βρείτε εγκαταστάσιμες δεξιότητες.",
   "library.skill_marketplace.empty_title": "Αναζήτηση δεξιοτήτων",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "File preview",
   "library.skill_detail.installed": "Installed",
   "library.skill_detail.no_description": "No description",
+  "library.skill_detail.open_folder": "Open folder",
+  "library.skill_detail.open_folder_failed": "Could not open folder",
   "library.skill_detail.updated_at": "Recently updated",
   "library.skill_marketplace.empty_description": "Search online registries to find installable skills.",
   "library.skill_marketplace.empty_title": "Search for skills",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Vista previa del archivo",
   "library.skill_detail.installed": "Instalado",
   "library.skill_detail.no_description": "Sin descripción",
+  "library.skill_detail.open_folder": "Abrir carpeta",
+  "library.skill_detail.open_folder_failed": "No se pudo abrir la carpeta",
   "library.skill_detail.updated_at": "Actualizado recientemente",
   "library.skill_marketplace.empty_description": "Busca en los registros en línea para encontrar habilidades instalables.",
   "library.skill_marketplace.empty_title": "Buscar habilidades",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Aperçu du fichier",
   "library.skill_detail.installed": "Installé",
   "library.skill_detail.no_description": "Aucune description",
+  "library.skill_detail.open_folder": "Ouvrir le dossier",
+  "library.skill_detail.open_folder_failed": "Impossible d’ouvrir le dossier",
   "library.skill_detail.updated_at": "Récemment mis à jour",
   "library.skill_marketplace.empty_description": "Recherchez dans les registres en ligne pour trouver des compétences installables.",
   "library.skill_marketplace.empty_title": "Rechercher des compétences",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "ファイルプレビュー",
   "library.skill_detail.installed": "インストール済み",
   "library.skill_detail.no_description": "説明なし",
+  "library.skill_detail.open_folder": "フォルダーを開く",
+  "library.skill_detail.open_folder_failed": "フォルダーを開けませんでした",
   "library.skill_detail.updated_at": "最近更新",
   "library.skill_marketplace.empty_description": "オンラインのレジストリを検索して、インストール可能なスキルを見つけてください。",
   "library.skill_marketplace.empty_title": "スキルを検索",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Pré-visualização de ficheiro",
   "library.skill_detail.installed": "Instalado",
   "library.skill_detail.no_description": "Sem descrição",
+  "library.skill_detail.open_folder": "Abrir pasta",
+  "library.skill_detail.open_folder_failed": "Não foi possível abrir a pasta",
   "library.skill_detail.updated_at": "Atualizado recentemente",
   "library.skill_marketplace.empty_description": "Pesquise em registos online para encontrar competências instaláveis.",
   "library.skill_marketplace.empty_title": "Pesquisar competências",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Previzualizare fișier",
   "library.skill_detail.installed": "Instalat",
   "library.skill_detail.no_description": "Fără descriere",
+  "library.skill_detail.open_folder": "Deschide directorul",
+  "library.skill_detail.open_folder_failed": "Directorul nu a putut fi deschis",
   "library.skill_detail.updated_at": "Actualizat recent",
   "library.skill_marketplace.empty_description": "Caută în registrele online abilități care pot fi instalate.",
   "library.skill_marketplace.empty_title": "Caută abilități",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Предварительный просмотр файла",
   "library.skill_detail.installed": "Установлено",
   "library.skill_detail.no_description": "Нет описания",
+  "library.skill_detail.open_folder": "Открыть папку",
+  "library.skill_detail.open_folder_failed": "Не удалось открыть папку",
   "library.skill_detail.updated_at": "Недавно обновлено",
   "library.skill_marketplace.empty_description": "Поищите в онлайн-реестрах навыки, которые можно установить.",
   "library.skill_marketplace.empty_title": "Поиск навыков",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "Xem trước tệp",
   "library.skill_detail.installed": "Đã cài đặt",
   "library.skill_detail.no_description": "Không có mô tả",
+  "library.skill_detail.open_folder": "Mở thư mục",
+  "library.skill_detail.open_folder_failed": "Không thể mở thư mục",
   "library.skill_detail.updated_at": "Đã cập nhật gần đây",
   "library.skill_marketplace.empty_description": "Tìm kiếm trong các sổ đăng ký trực tuyến để tìm các kỹ năng có thể cài đặt.",
   "library.skill_marketplace.empty_title": "Tìm kiếm kỹ năng",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "文件预览",
   "library.skill_detail.installed": "已安装",
   "library.skill_detail.no_description": "暂无描述",
+  "library.skill_detail.open_folder": "打开文件夹",
+  "library.skill_detail.open_folder_failed": "无法打开文件夹",
   "library.skill_detail.updated_at": "最近更新",
   "library.skill_marketplace.empty_description": "搜索在线技能源，查找可安装的技能。",
   "library.skill_marketplace.empty_title": "搜索技能",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -1949,6 +1949,8 @@
   "library.skill_detail.file_preview": "檔案預覽",
   "library.skill_detail.installed": "已安裝",
   "library.skill_detail.no_description": "目前沒有描述",
+  "library.skill_detail.open_folder": "開啟資料夾",
+  "library.skill_detail.open_folder_failed": "無法開啟資料夾",
   "library.skill_detail.updated_at": "最近更新",
   "library.skill_marketplace.empty_description": "搜尋線上技能來源，尋找可安裝的技能。",
   "library.skill_marketplace.empty_title": "搜尋技能",

--- a/src/shared/ipc/schemas/skill.ts
+++ b/src/shared/ipc/schemas/skill.ts
@@ -9,7 +9,7 @@ import { defineRoute } from '../define'
  *
  * Legacy install/list routes keep the `SkillResult<T>` envelope: the handler catches and returns
  * `{ success, data } | { success, error }` (and logs on failure), and the renderer keeps
- * unwrapping it. New system-skill routes use IpcApi's native result/error contract and
+ * unwrapping it. New routes use IpcApi's native result/error contract and
  * therefore declare their data directly. Outputs are `z.custom` (IpcApi validates inputs,
  * not outputs). Skill_ReadFile / Skill_ListFiles stay on legacy IPC.
  */
@@ -45,5 +45,9 @@ export const skillRequestSchemas = {
   'skill.import_system': defineRoute({
     input: z.object({ directoryPath: z.string().min(1) }),
     output: z.custom<InstalledSkill>()
+  }),
+  'skill.folder.open': defineRoute({
+    input: z.object({ skillId: z.string().min(1) }),
+    output: z.void()
   })
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Installed skill details showed metadata and file previews, but offered no way to open the managed skill directory in the system file manager.

After this PR:

The Installed row includes an **Open folder** action. Renderer code sends only the registered `skillId`; the main process resolves the app-owned managed directory through `SkillService` before calling Electron `shell.openPath`. Builtin, system, local, ZIP, and marketplace installs all open their managed copy.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The route is skill-scoped and accepts no renderer-supplied filesystem path. It rejects callers without a managed window, unknown or removed skills, and non-empty OS errors from `shell.openPath`. This keeps path ownership in the main process and avoids widening the existing generic shell capability.

The following alternatives were considered:

Reusing `system.shell.open_path` was rejected because that route accepts an arbitrary renderer-provided path. Opening an original system or local source was rejected because every installed source already has an app-owned canonical copy, which is the directory users can safely inspect and edit consistently.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Exact commit: `a577621dd5364e671bd90d6c5191332b0caa8a8f`.
- Commit is SSH-signed and DCO-signed.
- Focused main handler tests: 13/13 passed.
- Focused renderer component tests: 8/8 passed.
- `pnpm lint` passed, including typecheck, i18n validation, and formatting.
- Real macOS Electron QA confirmed the action appears in Settings > Skills and opens an installed builtin skill directory without an error toast.
- Independent exact-commit review accepted with no findings.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact on installed skill storage and upgrade flows was considered; the existing canonical managed copy remains the source.
- [x] Documentation: User-guide changes were considered and are not required for this local convenience action.
- [x] Self-review: The exact commit received an independent Cherry Studio review before push.

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Installed skill details now include an action to open the managed skill folder.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path resolution stays in the main process with managed-window and skill-id checks; scope is a localized UI convenience with tests.
> 
> **Overview**
> Adds an **Open folder** action on installed skill details so users can jump to the app-managed skill directory in the system file manager.
> 
> The renderer sends only `skillId` via new IPC route `skill.folder.open`. The main process requires a managed window, loads the skill by id, resolves the path with `SkillService.getInstalledSkillDirectory`, and opens it with `shell.openPath`—no renderer-supplied paths. Missing skills, unmanaged callers, and OS open failures surface as errors; the UI shows a toast on failure.
> 
> i18n strings were added for the button and error message across locale bundles. Handler and dialog tests cover the happy path, security constraints, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a577621dd5364e671bd90d6c5191332b0caa8a8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->