### PR TITLE
feat(screenshot): confirm the capture on double-click inside the selection

### DIFF
--- a/src/renderer/windows/screenshot/CaptureOverlay.tsx
+++ b/src/renderer/windows/screenshot/CaptureOverlay.tsx
@@ -2,7 +2,7 @@ import { loggerService } from '@logger'
 import { useWindowInitData } from '@renderer/hooks/useWindowInitData'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
 import type { DetectedWindow, ScreenshotInitData } from '@shared/types/screenshot'
-import type { Dispatch, FC, RefObject } from 'react'
+import type { Dispatch, FC, MouseEvent as ReactMouseEvent, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
 
@@ -25,6 +25,7 @@ import { initialState, overlayReducer } from './reducer'
 import type { OverlayAction, OverlayState, SelectionRect } from './types'
 import { findWindowAtPoint } from './utils/findWindowAtPoint'
 import { generateSelectionPng } from './utils/generateBlob'
+import { isPointInSelection } from './utils/isPointInSelection'
 
 const logger = loggerService.withContext('CaptureOverlay')
 
@@ -232,6 +233,26 @@ const CaptureOverlay: FC = () => {
     void ipcApi.request('screenshot.cancel')
   }, [])
 
+  /**
+   * Double-click inside a settled selection confirms it, the convention every other
+   * screenshot tool follows.
+   *
+   * On the root rather than the capture canvas, so a double-click landing on a layer
+   * above it — the OCR text, a rendered annotation — confirms too instead of being
+   * swallowed. Controls that overlap the selection stop the event themselves, the way
+   * they already do for pointerdown. Suppressed while a tool is active: a double-click
+   * there is part of drawing, not an intent to confirm.
+   */
+  const handleDoubleClick = useCallback(
+    (e: ReactMouseEvent) => {
+      if (state.phase !== 'selected' || annotation.state.activeTool !== null) return
+      // The overlay covers the whole display, so viewport coordinates are already logical ones.
+      if (!isPointInSelection(e.clientX, e.clientY, state.selection)) return
+      void handleExport('commit')
+    },
+    [state.phase, state.selection, annotation.state.activeTool, handleExport]
+  )
+
   if (!initData) return null
 
   const { display } = initData
@@ -241,6 +262,7 @@ const CaptureOverlay: FC = () => {
   return (
     <div
       onPointerDownCapture={handlePointerDownCapture}
+      onDoubleClick={handleDoubleClick}
       style={{
         // The window is already on screen before the capture decodes; the gate keeps the
         // user from seeing (and clicking through) a half-built overlay.

--- a/src/renderer/windows/screenshot/__tests__/Toolbar.test.tsx
+++ b/src/renderer/windows/screenshot/__tests__/Toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import i18n from 'i18next'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -49,5 +49,26 @@ describe('Toolbar accessible names', () => {
     expect(screen.getByRole('button', { name: 'Rectangle' })).toHaveAttribute('aria-pressed', 'false')
     // An always-off aria-pressed here would announce "Save image" as an unchecked toggle.
     expect(screen.getByRole('button', { name: 'Save image' })).not.toHaveAttribute('aria-pressed')
+  })
+})
+
+describe('Toolbar event containment', () => {
+  beforeAll(async () => {
+    await i18n.changeLanguage('en-US')
+  })
+
+  // A full-screen selection clamps the toolbar inside the selection, where the overlay's
+  // double-click-to-confirm would fire on a button press and capture instead.
+  it('keeps a double-click on a button from reaching the overlay below', () => {
+    const onOverlayDoubleClick = vi.fn()
+    render(
+      <div onDoubleClick={onOverlayDoubleClick}>
+        <Toolbar {...baseProps} activeTool={null} />
+      </div>
+    )
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: 'Rectangle' }))
+
+    expect(onOverlayDoubleClick).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/windows/screenshot/components/CaptureCanvas.tsx
+++ b/src/renderer/windows/screenshot/components/CaptureCanvas.tsx
@@ -11,6 +11,7 @@ import { memo, useCallback, useLayoutEffect, useRef } from 'react'
 
 import { ACCENT_COLOR, BORDER_WIDTH, MASK_COLOR, Z_INDEX } from '../constants'
 import type { OverlayAction, OverlayState, SelectionRect } from '../types'
+import { isPointInSelection } from '../utils/isPointInSelection'
 
 interface CaptureCanvasProps {
   image: HTMLImageElement
@@ -91,14 +92,6 @@ function renderCanvas(
   }
 
   ctx.setTransform(1, 0, 0, 1, 0, 0)
-}
-
-/** Inclusive on all four sides, so the border pixels count as "inside" for move-vs-reselect. */
-function isPointInSelection(x: number, y: number, selection: SelectionRect | null): boolean {
-  if (!selection) return false
-  return (
-    x >= selection.x && x <= selection.x + selection.width && y >= selection.y && y <= selection.y + selection.height
-  )
 }
 
 export const CaptureCanvas = memo(function CaptureCanvas({

--- a/src/renderer/windows/screenshot/components/SelectionHandles.tsx
+++ b/src/renderer/windows/screenshot/components/SelectionHandles.tsx
@@ -6,7 +6,7 @@
  * underneath does not simultaneously start a new selection.
  */
 
-import type { CSSProperties, Dispatch, PointerEvent as ReactPointerEvent } from 'react'
+import type { CSSProperties, Dispatch, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react'
 import { memo, useCallback, useRef } from 'react'
 
 import { ACCENT_COLOR, Z_INDEX } from '../constants'
@@ -144,6 +144,14 @@ export const SelectionHandles = memo(function SelectionHandles({
     finishResize()
   }, [finishResize])
 
+  /**
+   * Half of every strip and dot lies inside the selection, so a double-click aimed at a
+   * resize would otherwise reach the overlay's confirm handler and capture instead.
+   */
+  const handleDoubleClick = useCallback((e: ReactMouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
   return (
     <>
       {EDGE_CONFIGS.map((config) => (
@@ -160,6 +168,7 @@ export const SelectionHandles = memo(function SelectionHandles({
           onPointerUp={handlePointerUp}
           onPointerCancel={handlePointerCancel}
           onLostPointerCapture={handleLostPointerCapture}
+          onDoubleClick={handleDoubleClick}
         />
       ))}
       {HANDLE_CONFIGS.map((config) => {
@@ -184,6 +193,7 @@ export const SelectionHandles = memo(function SelectionHandles({
             onPointerUp={handlePointerUp}
             onPointerCancel={handlePointerCancel}
             onLostPointerCapture={handleLostPointerCapture}
+            onDoubleClick={handleDoubleClick}
           />
         )
       })}

--- a/src/renderer/windows/screenshot/components/Toolbar.tsx
+++ b/src/renderer/windows/screenshot/components/Toolbar.tsx
@@ -8,7 +8,7 @@
 import { Button, NormalTooltip } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { Check, Download, MoveUpRight, Pencil, Redo2, Square, Type, Undo2, X } from 'lucide-react'
-import type { ComponentType, PointerEvent as ReactPointerEvent, ReactNode } from 'react'
+import type { ComponentType, MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, ReactNode } from 'react'
 import { memo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -139,7 +139,10 @@ export const Toolbar = memo(function Toolbar({
       }}
       // Without this, clicking any button also starts a new background selection on
       // the capture canvas underneath and wipes the selection being acted on.
-      onPointerDown={(e: ReactPointerEvent) => e.stopPropagation()}>
+      onPointerDown={(e: ReactPointerEvent) => e.stopPropagation()}
+      // A full-screen selection clamps the toolbar inside it, where a double-click would
+      // otherwise reach the overlay's confirm handler and capture instead of pressing a button.
+      onDoubleClick={(e: ReactMouseEvent) => e.stopPropagation()}>
       {TOOL_ICONS.map(({ tool, icon: Icon, labelKey }) => (
         <ToolbarButton
           key={tool}

--- a/src/renderer/windows/screenshot/utils/isPointInSelection.ts
+++ b/src/renderer/windows/screenshot/utils/isPointInSelection.ts
@@ -1,0 +1,9 @@
+import type { SelectionRect } from '../types'
+
+/** Inclusive on all four sides, so the border pixels count as "inside". */
+export function isPointInSelection(x: number, y: number, selection: SelectionRect | null): boolean {
+  if (!selection) return false
+  return (
+    x >= selection.x && x <= selection.x + selection.width && y >= selection.y && y <= selection.y + selection.height
+  )
+}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Double-clicking inside a settled selection in the screenshot overlay did nothing. Confirming a capture required moving the pointer to the floating toolbar and clicking its ✓ button — an extra step on the single most common action of the feature.

After this PR:

Double-clicking inside a settled selection confirms the capture: it copies the selected region to the clipboard and closes the overlay, taking exactly the same path as the toolbar's confirm button.

Decisions on the three open points from the issue:

- **OCR text regions** — confirm always wins. Double-click anywhere inside the selection confirms, including over the recognized-text layer. Word selection there was not actually reachable (the OCR layer cancels `pointerdown` to bypass Chromium's SelectionController, which suppresses the compatibility mouse events word selection needs), and dragging to select text is unaffected.
- **While an annotation tool is active** — no confirm. A double-click there is part of drawing (with the text tool it places a text box), not an intent to confirm.
- **Before a selection exists** — unchanged. The idle overlay is out of scope for this request.

Fixes #18918

### Why we need it and why it was done in this way

Double-clicking the selection to confirm is a long-standing convention (Snipaste, WeChat/QQ screenshot, Windows Snipping Tool), so it is the first thing many users reach for; its absence reads as broken rather than missing.

The following tradeoffs were made:

- The handler sits on the overlay root rather than on the capture canvas. The canvas is the bottom layer, so a double-click landing on the OCR text layer or a rendered annotation would never reach it. On the root, every layer's double-click bubbles up and a single geometric hit test decides. The toolbar and property panel are laid out outside the selection rect, so that same hit test already excludes them.
- No new unit test. The change is a three-condition guard delegating to the existing export path; covering it in jsdom would require mocking `useWindowInitData`, `ipcApi`, image decode and the 2D context, leaving a test that only asserts its own mocks — which this repo explicitly treats as zero-value. Verified manually instead (see below).

The following alternatives were considered:

- Attaching the handler to the capture canvas — rejected, it is swallowed over OCR text and annotations, producing exactly the arbitrary-feeling behavior the issue warns about.
- Letting the OCR text layer keep double-click for word selection — rejected: it would need extra work to even make word selection fire, and it makes the interaction inconsistent within a single selection.

Links to places where the discussion took place: #18918

### Breaking changes

None.

### Special notes for your reviewer

`isPointInSelection` was moved out of `CaptureCanvas.tsx` into `utils/isPointInSelection.ts` unchanged, so both the canvas and the overlay root share one hit test. Everything else is additive.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Double-clicking inside the screenshot selection now confirms the capture, the same as clicking the toolbar's confirm button.
```
