### PR TITLE
perf(screenshot): make the capture overlay appear immediately

### DIFF
--- a/src/main/core/window/__tests__/WindowManager.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.test.ts
@@ -933,6 +933,26 @@ describe('WindowManager', () => {
         expect(win.destroy).toHaveBeenCalled()
       })
 
+      it('skips eager warmup on boot for a pool suspended beforehand', async () => {
+        // Feature-gated pools (screenshot overlays) suspend themselves during their
+        // owner's onInit when the feature is off. Warming them anyway at onAllReady
+        // would hold a hidden window — and its renderer's memory — for the whole run,
+        // for a feature the user has switched off.
+        wm.suspendPool('eagerPooled' as never)
+
+        await wm._doAllReady()
+
+        expect(wm.getWindowsByType('eagerPooled' as never)).toHaveLength(0)
+      })
+
+      it('eagerly warms a pool that was never suspended', async () => {
+        // Negative control: without this, the assertion above would also pass if
+        // eager warmup had simply stopped working.
+        await wm._doAllReady()
+
+        expect(wm.getWindowsByType('eagerPooled' as never)).toHaveLength(1)
+      })
+
       it('resumePool() clears suspended flag', () => {
         wm.suspendPool('pooled' as never)
         wm.resumePool('pooled' as never)

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -3,6 +3,7 @@ import { writeFileSync } from 'node:fs'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { ocrModelPaths } from '@main/ai/inference/ocrModelPaths'
+import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isDev, isMac, isWin } from '@main/core/platform'
 import { WindowType } from '@main/core/window/types'
@@ -47,6 +48,26 @@ const MIN_SNAP_TARGET_SIZE = 5
  * nothing about the renderer's health, so it must not tear the session down.
  */
 const ERR_ABORTED = -3
+
+/**
+ * Capture-path timings for one session, in ms from the moment the shortcut landed.
+ *
+ * Only populated under `CS_DIAGNOSTICS`. Exists because the latency this path was
+ * fixed for is invisible from the outside: "the overlay feels slow" cannot tell a
+ * cold renderer apart from a blocked main process, and the two have opposite fixes.
+ */
+interface CaptureTrace {
+  t0: number
+  /** Screen capture and PNG encode, i.e. everything before the first open(). */
+  captureMs: number
+  /** All overlays opened and shown at opacity 0. */
+  openMs: number
+  /** Overlays whose window had to be created; the rest came warm from the pool. */
+  created: number
+  /** Overlays this session opened, i.e. how many readiness reports to expect. */
+  expected: number
+  ready: number
+}
 
 /** One display's frozen capture, kept for the session so region OCR can crop it. */
 interface SessionCapture {
@@ -104,6 +125,12 @@ export class ScreenshotOverlayService extends BaseService {
   /** Overlays whose renderer reported a painted frame. Gates the Escape rescue below. */
   private renderersReady = new Set<WindowId>()
 
+  /** Timings of the live session. Null unless CS_DIAGNOSTICS is set. */
+  private trace: CaptureTrace | null = null
+
+  /** Overlay windows created since the session started; the rest came from the pool. */
+  private overlaysCreated = 0
+
   /** Token of the newest OCR request. At most one overlay is active, so "keep only
    *  the newest" is global — bucketing by window would let two chains run at once. */
   private latestOcrToken: symbol | null = null
@@ -115,6 +142,10 @@ export class ScreenshotOverlayService extends BaseService {
         // No declarative equivalent in WindowBehavior, and a macOS panel window can
         // still paint traffic lights over a frameless overlay.
         if (isMac) window.setWindowButtonVisibility(false)
+
+        // Counts creations, so a trace can say whether the pool actually served this
+        // session warm. Reset per session in startCapture; pool warmup bumps it too.
+        this.overlaysCreated++
 
         // Attached here rather than after open(): a recycled window never re-enters
         // this callback, so per-session listeners would pile up and still miss reuses.
@@ -191,6 +222,9 @@ export class ScreenshotOverlayService extends BaseService {
       // would let a blocked second attempt freeze the FIRST session's overlays at opacity 0.
       const generation = ++this.sessionGeneration
 
+      const t0 = performance.now()
+      this.overlaysCreated = 0
+
       try {
         // Started before the capture so the enumeration — hundreds of milliseconds of
         // native work — overlaps the PNG encode and the window opening rather than
@@ -198,6 +232,7 @@ export class ScreenshotOverlayService extends BaseService {
         const snapCandidates = collectSnapCandidates()
 
         const captures = await captureAllMonitors()
+        const captureMs = performance.now() - t0
         const windowManager = application.get('WindowManager')
         const mediaProtocol = application.get('MediaProtocolService')
         const displays = screen.getAllDisplays()
@@ -300,6 +335,17 @@ export class ScreenshotOverlayService extends BaseService {
         // Thrown into the catch below rather than returned: the user pressed a shortcut
         // and nothing appeared, which is a failed capture, not a quiet edge case.
         if (this.overlayWindowIds.length === 0) throw new Error('no display produced an overlay')
+
+        if (DIAGNOSTICS_ENABLED) {
+          this.trace = {
+            t0,
+            captureMs,
+            openMs: performance.now() - t0,
+            created: this.overlaysCreated,
+            expected: this.overlayWindowIds.length,
+            ready: 0
+          }
+        }
 
         void this.pushSnapTargets(generation, snapCandidates, snapOverlays, primaryScaleFactor)
 
@@ -449,6 +495,30 @@ export class ScreenshotOverlayService extends BaseService {
     if (this.overlayMediaIds.get(windowId) !== mediaId) return
     this.renderersReady.add(windowId)
     this.pendingReveals.get(windowId)?.reveal()
+    this.traceReady()
+  }
+
+  /**
+   * Report the capture path's timings once every overlay has painted.
+   *
+   * `usable` is the number that matters: the shortcut is pressed at t0 and the user
+   * can act at the last readiness report. `cold` tells whether the pool served this
+   * session — a cold overlay and a blocked main process both look like "slow" from
+   * the outside, and they have opposite fixes.
+   */
+  private traceReady(): void {
+    const trace = this.trace
+    if (!trace) return
+    trace.ready++
+    if (trace.ready < trace.expected) return
+    this.trace = null
+
+    const usable = performance.now() - trace.t0
+    logger.info(
+      `[Diagnostics/screenshot] usable=${usable.toFixed(0)}ms ` +
+        `capture=${trace.captureMs.toFixed(0)}ms open=${(trace.openMs - trace.captureMs).toFixed(0)}ms ` +
+        `paint=${(usable - trace.openMs).toFixed(0)}ms cold=${trace.created}/${trace.expected}`
+    )
   }
 
   /**
@@ -465,10 +535,19 @@ export class ScreenshotOverlayService extends BaseService {
     overlays: { windowId: WindowId; display: Display }[],
     primaryScaleFactor: number
   ): Promise<void> {
+    const startedAt = performance.now()
     const snapCandidates = await candidates
     // The session may have ended while the enumeration ran; a pooled overlay is only
     // hidden, so its renderer would happily apply targets for a capture it no longer shows.
     if (generation !== this.sessionGeneration) return
+
+    if (DIAGNOSTICS_ENABLED) {
+      logger.info(
+        `[Diagnostics/screenshot] snap targets ready ${(performance.now() - startedAt).toFixed(0)}ms ` +
+          `after the overlays opened, ${snapCandidates.length} candidates ` +
+          `(0 means the worker finished before the overlays did)`
+      )
+    }
 
     const ipcApiService = application.get('IpcApiService')
     for (const { windowId, display } of overlays) {
@@ -652,6 +731,7 @@ export class ScreenshotOverlayService extends BaseService {
 
     this.overlayWindowIds = []
     this.activeOverlayWindowId = null
+    this.trace = null
 
     // Invalidates every in-flight OCR result; the recognitions themselves run to completion.
     this.latestOcrToken = null

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -750,6 +750,15 @@ export class ScreenshotOverlayService extends BaseService {
 
     this.overlayWindowIds = []
     this.activeOverlayWindowId = null
+    if (DIAGNOSTICS_ENABLED && this.trace) {
+      // Deliberately no usable= number: every overlay left here was revealed by the
+      // fallback timer, so the only timestamp available is that timer's deadline —
+      // reporting it would pass a constant off as a measurement.
+      logger.info(
+        `[Diagnostics/screenshot] capture trace incomplete: ` +
+          `${this.trace.ready}/${this.trace.expected} overlays reported ready`
+      )
+    }
     this.trace = null
 
     // Invalidates every in-flight OCR result; the recognitions themselves run to completion.

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -125,6 +125,17 @@ export class ScreenshotOverlayService extends BaseService {
   /** Overlays whose renderer reported a painted frame. Gates the Escape rescue below. */
   private renderersReady = new Set<WindowId>()
 
+  /**
+   * Snap targets pushed before their overlay reported ready, kept for one repeat.
+   *
+   * The enumeration usually outlives the overlays, but not always — few windows or a
+   * failed enumeration resolves it in microtasks. That push can miss: a cold renderer
+   * has not subscribed yet, and a pooled one clears the previous session's targets on
+   * new init data, which would wipe it. Either way hover-to-window snapping is gone
+   * for the whole capture, silently, so the push is repeated at the ready handshake.
+   */
+  private pendingSnapTargets = new Map<WindowId, DetectedWindow[]>()
+
   /** Timings of the live session. Null unless CS_DIAGNOSTICS is set. */
   private trace: CaptureTrace | null = null
 
@@ -494,6 +505,11 @@ export class ScreenshotOverlayService extends BaseService {
   public markOverlayReady(windowId: WindowId, mediaId: string): void {
     if (this.overlayMediaIds.get(windowId) !== mediaId) return
     this.renderersReady.add(windowId)
+    const targets = this.pendingSnapTargets.get(windowId)
+    if (targets) {
+      this.pendingSnapTargets.delete(windowId)
+      application.get('IpcApiService').send(windowId, 'screenshot.snap_targets', { windows: targets })
+    }
     this.pendingReveals.get(windowId)?.reveal()
     this.traceReady()
   }
@@ -551,9 +567,11 @@ export class ScreenshotOverlayService extends BaseService {
 
     const ipcApiService = application.get('IpcApiService')
     for (const { windowId, display } of overlays) {
-      ipcApiService.send(windowId, 'screenshot.snap_targets', {
-        windows: projectSnapCandidates(display, snapCandidates, primaryScaleFactor)
-      })
+      const windows = projectSnapCandidates(display, snapCandidates, primaryScaleFactor)
+      ipcApiService.send(windowId, 'screenshot.snap_targets', { windows })
+      // This push is best-effort: an overlay that has not reported ready may not have
+      // subscribed yet, or may still clear it as stale. Repeat it once it has.
+      if (!this.renderersReady.has(windowId)) this.pendingSnapTargets.set(windowId, windows)
     }
   }
 
@@ -720,6 +738,7 @@ export class ScreenshotOverlayService extends BaseService {
     // Per-session: a recycled overlay that painted last time has to earn it again, or
     // the next session's never-painted window would have no Escape rescue.
     this.renderersReady.clear()
+    this.pendingSnapTargets.clear()
 
     // Explicit, not left to pool release: an overlay whose session ended mid-edit would
     // otherwise come back at the text editor's level and never cover the Dock again.

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -22,8 +22,9 @@ import type { DetectedWindow, ScreenshotInitData, ScreenshotResultData } from '@
 import dayjs from 'dayjs'
 import { app, BrowserWindow, clipboard, dialog, type Display, nativeImage, screen } from 'electron'
 
-import { captureAllMonitors, listMonitors, listWindows } from './screenCapture'
+import { captureAllMonitors, listMonitors } from './screenCapture'
 import { type CaptureResult, type MonitorInfo, type RawWindowInfo, ScreenCapturePermissionError } from './types'
+import { listWindowsOffThread } from './windowEnumerator'
 
 const logger = loggerService.withContext('ScreenshotOverlayService')
 
@@ -191,6 +192,11 @@ export class ScreenshotOverlayService extends BaseService {
       const generation = ++this.sessionGeneration
 
       try {
+        // Started before the capture so the enumeration — hundreds of milliseconds of
+        // native work — overlaps the PNG encode and the window opening rather than
+        // following them. It runs off the main thread; see listWindowsOffThread.
+        const snapCandidates = collectSnapCandidates()
+
         const captures = await captureAllMonitors()
         const windowManager = application.get('WindowManager')
         const mediaProtocol = application.get('MediaProtocolService')
@@ -207,10 +213,11 @@ export class ScreenshotOverlayService extends BaseService {
         // display's pixel grid, so its scale factor is the reference for normalizing.
         const primaryScaleFactor = screen.getPrimaryDisplay().scaleFactor
 
-        // Computed before any overlay exists so our own windows cannot become targets.
-        const snapCandidates = collectSnapCandidates()
         const autoOcr = preferenceService.get('feature.screenshot.auto_ocr')
         const ocrAvailable = isLocalModelReady('ocr')
+
+        // Which overlay covers which display, for the snap-target push below.
+        const snapOverlays: { windowId: WindowId; display: Display }[] = []
 
         for (const display of displays) {
           const captureResult = matchCapture(display, captures, monitorInfoList, primaryScaleFactor)
@@ -256,7 +263,6 @@ export class ScreenshotOverlayService extends BaseService {
                 height: captureResult.height,
                 scaleFactor: display.scaleFactor
               },
-              windows: projectSnapCandidates(display, snapCandidates, primaryScaleFactor),
               autoOcr,
               ocrAvailable
             }
@@ -272,6 +278,7 @@ export class ScreenshotOverlayService extends BaseService {
 
           this.overlayWindowIds.push(windowId)
           this.overlayMediaIds.set(windowId, mediaId)
+          snapOverlays.push({ windowId, display })
 
           // Transparent first so the OS show animation is never visible.
           window.setOpacity(0)
@@ -293,6 +300,8 @@ export class ScreenshotOverlayService extends BaseService {
         // Thrown into the catch below rather than returned: the user pressed a shortcut
         // and nothing appeared, which is a failed capture, not a quiet edge case.
         if (this.overlayWindowIds.length === 0) throw new Error('no display produced an overlay')
+
+        void this.pushSnapTargets(generation, snapCandidates, snapOverlays, primaryScaleFactor)
 
         logger.info(`Screenshot session started with ${this.overlayWindowIds.length} overlay(s)`)
       } catch (error) {
@@ -440,6 +449,33 @@ export class ScreenshotOverlayService extends BaseService {
     if (this.overlayMediaIds.get(windowId) !== mediaId) return
     this.renderersReady.add(windowId)
     this.pendingReveals.get(windowId)?.reveal()
+  }
+
+  /**
+   * Push each overlay the snap targets clipped to its own display.
+   *
+   * The list is pushed rather than carried in the init data because enumerating it
+   * takes hundreds of milliseconds; waiting for it before opening the overlays put
+   * it squarely on the shortcut's critical path. An overlay is fully usable before
+   * it lands — hovering just snaps to the whole display until then.
+   */
+  private async pushSnapTargets(
+    generation: number,
+    candidates: Promise<RawWindowInfo[]>,
+    overlays: { windowId: WindowId; display: Display }[],
+    primaryScaleFactor: number
+  ): Promise<void> {
+    const snapCandidates = await candidates
+    // The session may have ended while the enumeration ran; a pooled overlay is only
+    // hidden, so its renderer would happily apply targets for a capture it no longer shows.
+    if (generation !== this.sessionGeneration) return
+
+    const ipcApiService = application.get('IpcApiService')
+    for (const { windowId, display } of overlays) {
+      ipcApiService.send(windowId, 'screenshot.snap_targets', {
+        windows: projectSnapCandidates(display, snapCandidates, primaryScaleFactor)
+      })
+    }
   }
 
   /** Copy the overlay's result to the clipboard and end the session. */
@@ -785,9 +821,9 @@ function matchCapture(
 }
 
 /** The windows that may act as hover-to-snap targets, before any per-display work. */
-function collectSnapCandidates(): RawWindowInfo[] {
+async function collectSnapCandidates(): Promise<RawWindowInfo[]> {
   const selfPid = process.pid
-  return listWindows().filter(
+  return (await listWindowsOffThread()).filter(
     (w) =>
       // Filters by pid, so every window of this app is excluded — the main window
       // and the launcher are just as wrong a snap target as an overlay.
@@ -849,7 +885,7 @@ function projectSnapCandidates(
     // 5 physical pixels; reordering changes what gets dropped on HiDPI Windows.
     if (width < MIN_SNAP_TARGET_SIZE || height < MIN_SNAP_TARGET_SIZE) continue
 
-    projected.push({ title: w.title, appName: w.appName, x, y, width, height })
+    projected.push({ title: w.title, x, y, width, height })
   }
 
   return projected

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -560,8 +560,8 @@ export class ScreenshotOverlayService extends BaseService {
     if (DIAGNOSTICS_ENABLED) {
       logger.info(
         `[Diagnostics/screenshot] snap targets ready ${(performance.now() - startedAt).toFixed(0)}ms ` +
-          `after the overlays opened, ${snapCandidates.length} candidates ` +
-          `(0 means the worker finished before the overlays did)`
+          `after the overlays opened (0ms means the enumeration finished first), ` +
+          `${snapCandidates.length} candidates`
       )
     }
 

--- a/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
+++ b/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
@@ -278,6 +278,12 @@ const resetOverlayTargets = (): string[] =>
     .filter((call) => call[1] === 'screenshot.reset_overlay')
     .map((call) => call[0])
 
+/** Every snap-target push one overlay received, in order, as title lists. */
+const snapTargetPushesTo = (id: string): string[][] =>
+  container.ipcApiService.send.mock.calls
+    .filter((call) => call[0] === id && call[1] === 'screenshot.snap_targets')
+    .map((call) => call[2].windows.map((w: DetectedWindow) => w.title))
+
 /** The snap targets last pushed to one overlay, or undefined if it never got any. */
 const snapTargetsOf = (id: string): DetectedWindow[] | undefined =>
   [...container.ipcApiService.send.mock.calls]
@@ -710,6 +716,33 @@ describe('ScreenshotOverlayService', () => {
       await release()
 
       expect(snapTargetsOf('overlay-0-0')).toBeUndefined()
+    })
+
+    it('pushes the targets again when they landed before the overlay reported ready', async () => {
+      // The enumeration can beat the renderer: a cold one has not subscribed yet, and a
+      // pooled one clears the previous session's targets on new init data. Either drops
+      // that push, and hover-to-window snapping is gone for the whole capture.
+      singleDisplaySetup()
+      enumerator.listWindowsOffThread.mockResolvedValue([makeWindowInfo({ title: 'Visible' })])
+
+      await service.startCapture()
+      await settleSnapTargets()
+      expect(snapTargetPushesTo('overlay-0-0')).toEqual([['Visible']])
+
+      service.markOverlayReady('overlay-0-0', initDataOf('overlay-0-0').mediaId)
+
+      expect(snapTargetPushesTo('overlay-0-0')).toEqual([['Visible'], ['Visible']])
+    })
+
+    it('does not repeat the push to an overlay that was ready before the targets landed', async () => {
+      singleDisplaySetup()
+      const release = holdEnumeration([makeWindowInfo({ title: 'Visible' })])
+
+      await service.startCapture()
+      service.markOverlayReady('overlay-0-0', initDataOf('overlay-0-0').mediaId)
+      await release()
+
+      expect(snapTargetPushesTo('overlay-0-0')).toEqual([['Visible']])
     })
 
     it('excludes our own windows and minimized windows from the hit-test list', async () => {

--- a/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
+++ b/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import type * as NodeFs from 'node:fs'
 
 import { WindowType } from '@main/core/window/types'
+import type { DetectedWindow } from '@shared/types/screenshot'
 import type { Display } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -19,13 +20,15 @@ vi.mock('@main/core/platform', () => platform)
 const capture = vi.hoisted(() => ({
   captureAllMonitors: vi.fn(),
   listMonitors: vi.fn(),
-  listWindows: vi.fn(),
   getScreenCapturePermissionStatus: vi.fn(),
   requestScreenCapturePermission: vi.fn(),
   openScreenCaptureSettings: vi.fn()
 }))
 vi.mock('../screenCapture', () => capture)
 vi.mock('@main/utils/screenCapturePermission', () => capture)
+
+const enumerator = vi.hoisted(() => ({ listWindowsOffThread: vi.fn() }))
+vi.mock('../windowEnumerator', () => enumerator)
 
 const localModel = vi.hoisted(() => ({ isLocalModelReady: vi.fn(() => true) }))
 vi.mock('@main/services/localModel', () => localModel)
@@ -229,7 +232,6 @@ const makeCapture = (width = 1920, height = 1080): CaptureResult => ({
 const makeWindowInfo = (over: Partial<RawWindowInfo> = {}): RawWindowInfo => ({
   pid: 4242,
   title: 'Notes',
-  appName: 'Notes',
   x: 10,
   y: 20,
   width: 400,
@@ -249,6 +251,38 @@ const initDataOf = (id: string) => {
   const call = [...container.openCalls].reverse().find((c) => c.id === id)
   return call?.args.initData
 }
+
+/**
+ * Hold the enumeration open, so a test can assert what the capture path does while
+ * it is still running. Returns the release, which also flushes the resulting push.
+ */
+const holdEnumeration = (windows: RawWindowInfo[]) => {
+  let release!: () => void
+  enumerator.listWindowsOffThread.mockReturnValue(
+    new Promise<RawWindowInfo[]>((resolve) => {
+      release = () => resolve(windows)
+    })
+  )
+  return async () => {
+    release()
+    await vi.advanceTimersByTimeAsync(0)
+  }
+}
+
+/** Let the already-resolved enumeration reach the overlays. */
+const settleSnapTargets = () => vi.advanceTimersByTimeAsync(0)
+
+/** Every overlay that was told to drop its selection, in order. */
+const resetOverlayTargets = (): string[] =>
+  container.ipcApiService.send.mock.calls
+    .filter((call) => call[1] === 'screenshot.reset_overlay')
+    .map((call) => call[0])
+
+/** The snap targets last pushed to one overlay, or undefined if it never got any. */
+const snapTargetsOf = (id: string): DetectedWindow[] | undefined =>
+  [...container.ipcApiService.send.mock.calls]
+    .reverse()
+    .find((call) => call[0] === id && call[1] === 'screenshot.snap_targets')?.[2].windows
 
 const startService = () => {
   service = new ScreenshotOverlayService()
@@ -312,7 +346,7 @@ describe('ScreenshotOverlayService', () => {
     container.preferences.set('feature.screenshot.enabled', true)
     container.preferences.set('feature.screenshot.auto_ocr', true)
     capture.getScreenCapturePermissionStatus.mockReturnValue('authorized')
-    capture.listWindows.mockReturnValue([])
+    enumerator.listWindowsOffThread.mockResolvedValue([])
     capture.listMonitors.mockReturnValue([])
     capture.captureAllMonitors.mockReturnValue(new Map())
     localModel.isLocalModelReady.mockReturnValue(true)
@@ -532,8 +566,7 @@ describe('ScreenshotOverlayService', () => {
       service.markOverlayActive('overlay-0-0')
       service.markOverlayActive('overlay-1920-0')
 
-      expect(container.ipcApiService.send).toHaveBeenCalledTimes(1)
-      expect(container.ipcApiService.send).toHaveBeenCalledWith('overlay-0-0', 'screenshot.reset_overlay', undefined)
+      expect(resetOverlayTargets()).toEqual(['overlay-0-0'])
     })
 
     it('does not reset the active overlay when the same one re-reports activity', async () => {
@@ -543,7 +576,7 @@ describe('ScreenshotOverlayService', () => {
       service.markOverlayActive('overlay-0-0')
       service.markOverlayActive('overlay-0-0')
 
-      expect(container.ipcApiService.send).not.toHaveBeenCalled()
+      expect(resetOverlayTargets()).toEqual([])
     })
   })
 
@@ -623,29 +656,87 @@ describe('ScreenshotOverlayService', () => {
   })
 
   describe('hit-test list', () => {
+    it('opens every overlay without waiting for the enumeration', async () => {
+      // The whole point: enumeration costs hundreds of milliseconds, and blocking the
+      // overlays on it put that squarely on the shortcut's critical path.
+      electron.displays = [makeDisplay(1, 0, 0), makeDisplay(2, 1920, 0)]
+      electron.cursorDisplay = electron.displays[0]
+      capture.captureAllMonitors.mockReturnValue(
+        new Map([
+          [1, makeCapture()],
+          [2, makeCapture()]
+        ])
+      )
+      const release = holdEnumeration([
+        makeWindowInfo({ title: 'OnLeft' }),
+        makeWindowInfo({ title: 'OnRight', x: 2000, y: 20 })
+      ])
+
+      await service.startCapture()
+
+      expect(container.openCalls.map((c) => c.id)).toEqual(['overlay-0-0', 'overlay-1920-0'])
+      expect(snapTargetsOf('overlay-0-0')).toBeUndefined()
+
+      await release()
+
+      expect(snapTargetsOf('overlay-0-0')?.map((w) => w.title)).toEqual(['OnLeft'])
+      expect(snapTargetsOf('overlay-1920-0')?.map((w) => w.title)).toEqual(['OnRight'])
+    })
+
+    it('starts the enumeration before the capture, so the two overlap', async () => {
+      // Sequencing it after the capture would add its cost to the session instead of
+      // hiding it behind the PNG encode.
+      singleDisplaySetup()
+      let enumeratedDuringCapture = false
+      capture.captureAllMonitors.mockImplementation(async () => {
+        enumeratedDuringCapture = enumerator.listWindowsOffThread.mock.calls.length > 0
+        return new Map([[1, makeCapture()]])
+      })
+      enumerator.listWindowsOffThread.mockResolvedValue([])
+
+      await service.startCapture()
+
+      expect(enumeratedDuringCapture).toBe(true)
+    })
+
+    it('drops targets belonging to a session that ended before the enumeration finished', async () => {
+      // A pooled overlay is only hidden, so its renderer would apply these to a
+      // capture it no longer shows.
+      singleDisplaySetup()
+      const release = holdEnumeration([makeWindowInfo({ title: 'Visible' })])
+
+      await service.startCapture()
+      service.dismiss()
+      await release()
+
+      expect(snapTargetsOf('overlay-0-0')).toBeUndefined()
+    })
+
     it('excludes our own windows and minimized windows from the hit-test list', async () => {
       singleDisplaySetup()
-      capture.listWindows.mockReturnValue([
+      enumerator.listWindowsOffThread.mockResolvedValue([
         makeWindowInfo({ title: 'Our own window', pid: process.pid }),
         makeWindowInfo({ title: 'Minimized', isMinimized: true }),
         makeWindowInfo({ title: 'Visible' })
       ])
 
       await service.startCapture()
+      await settleSnapTargets()
 
-      expect(initDataOf('overlay-0-0').windows.map((w: { title: string }) => w.title)).toEqual(['Visible'])
+      expect(snapTargetsOf('overlay-0-0')?.map((w) => w.title)).toEqual(['Visible'])
     })
 
     it('drops the macOS Dock overlay by title, never by its localized owner name', async () => {
       singleDisplaySetup()
-      capture.listWindows.mockReturnValue([
-        makeWindowInfo({ title: 'Dock', appName: '程序坞', x: 0, y: 0, width: 1920, height: 1080 }),
+      enumerator.listWindowsOffThread.mockResolvedValue([
+        makeWindowInfo({ title: 'Dock', x: 0, y: 0, width: 1920, height: 1080 }),
         makeWindowInfo({ title: 'Visible' })
       ])
 
       await service.startCapture()
+      await settleSnapTargets()
 
-      expect(initDataOf('overlay-0-0').windows.map((w: { title: string }) => w.title)).toEqual(['Visible'])
+      expect(snapTargetsOf('overlay-0-0')?.map((w) => w.title)).toEqual(['Visible'])
     })
 
     it('keeps a window titled Dock off macOS', async () => {
@@ -654,28 +745,28 @@ describe('ScreenshotOverlayService', () => {
       platform.isMac = false
       platform.isWin = true
       singleDisplaySetup()
-      capture.listWindows.mockReturnValue([makeWindowInfo({ title: 'Dock' })])
+      enumerator.listWindowsOffThread.mockResolvedValue([makeWindowInfo({ title: 'Dock' })])
 
       await service.startCapture()
+      await settleSnapTargets()
 
-      expect(initDataOf('overlay-0-0').windows.map((w: { title: string }) => w.title)).toEqual(['Dock'])
+      expect(snapTargetsOf('overlay-0-0')?.map((w) => w.title)).toEqual(['Dock'])
     })
 
     it('clips windows to the display, drops non-overlapping ones and edge slivers', async () => {
       electron.displays = [makeDisplay(1, 100, 100, 800, 600)]
       electron.cursorDisplay = electron.displays[0]
       capture.captureAllMonitors.mockReturnValue(new Map([[1, makeCapture(800, 600)]]))
-      capture.listWindows.mockReturnValue([
+      enumerator.listWindowsOffThread.mockResolvedValue([
         makeWindowInfo({ title: 'Partial', x: 0, y: 150, width: 250, height: 100 }),
         makeWindowInfo({ title: 'Outside', x: 1000, y: 1000, width: 100, height: 100 }),
         makeWindowInfo({ title: 'EdgeLine', x: 100, y: 100, width: 1, height: 600 })
       ])
 
       await service.startCapture()
+      await settleSnapTargets()
 
-      expect(initDataOf('overlay-100-100').windows).toEqual([
-        { title: 'Partial', appName: 'Notes', x: 0, y: 50, width: 150, height: 100 }
-      ])
+      expect(snapTargetsOf('overlay-100-100')).toEqual([{ title: 'Partial', x: 0, y: 50, width: 150, height: 100 }])
     })
 
     it('converts window rects with each display own scale factor on Windows', async () => {
@@ -691,18 +782,17 @@ describe('ScreenshotOverlayService', () => {
           [2, makeCapture()]
         ])
       )
-      capture.listWindows.mockReturnValue([
+      enumerator.listWindowsOffThread.mockResolvedValue([
         makeWindowInfo({ title: 'OnPrimary', x: 300, y: 150, width: 600, height: 450 }),
         makeWindowInfo({ title: 'OnSecondary', x: 3000, y: 100, width: 400, height: 300 })
       ])
 
       await service.startCapture()
+      await settleSnapTargets()
 
-      expect(initDataOf('overlay-0-0').windows).toEqual([
-        { title: 'OnPrimary', appName: 'Notes', x: 200, y: 100, width: 400, height: 300 }
-      ])
-      expect(initDataOf('overlay-1920-0').windows).toEqual([
-        { title: 'OnSecondary', appName: 'Notes', x: 120, y: 100, width: 400, height: 300 }
+      expect(snapTargetsOf('overlay-0-0')).toEqual([{ title: 'OnPrimary', x: 200, y: 100, width: 400, height: 300 }])
+      expect(snapTargetsOf('overlay-1920-0')).toEqual([
+        { title: 'OnSecondary', x: 120, y: 100, width: 400, height: 300 }
       ])
     })
   })
@@ -1229,7 +1319,7 @@ describe('ScreenshotOverlayService', () => {
       // Hovering must only redirect the keyboard: routing it through
       // markOverlayActive would wipe the selection the user is still building.
       expect(fakeWindow('overlay-1920-0').show).toHaveBeenCalled()
-      expect(container.ipcApiService.send).not.toHaveBeenCalled()
+      expect(resetOverlayTargets()).toEqual([])
       expect(service.isActiveOverlay('overlay-0-0')).toBe(true)
     })
 

--- a/src/main/services/screenshot/__tests__/screenCapture.test.ts
+++ b/src/main/services/screenshot/__tests__/screenCapture.test.ts
@@ -1,19 +1,15 @@
 import { ScreenCaptureError, ScreenCapturePermissionError } from '@main/services/screenshot/types'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { monitorAll, windowAll, getMediaAccessStatus } = vi.hoisted(() => ({
+const { monitorAll, getMediaAccessStatus } = vi.hoisted(() => ({
   monitorAll: vi.fn(),
-  windowAll: vi.fn(),
   getMediaAccessStatus: vi.fn()
 }))
 
 // Mock the LOADER, not 'node-screenshots': the package is reached through require(), which vi.mock
 // cannot intercept. Being reachable as a plain ESM import is the whole reason the loader is separate.
 vi.mock('@main/services/screenshot/nativeCaptureBackend', () => ({
-  loadNativeCaptureBackend: () => ({
-    Monitor: { all: () => monitorAll() },
-    Window: { all: () => windowAll() }
-  })
+  loadNativeCaptureBackend: () => ({ Monitor: { all: () => monitorAll() } })
 }))
 vi.mock('electron', () => ({
   systemPreferences: { getMediaAccessStatus: () => getMediaAccessStatus() },
@@ -21,7 +17,7 @@ vi.mock('electron', () => ({
 }))
 vi.mock('@main/core/platform', () => ({ isMac: true }))
 
-const { captureAllMonitors, listWindows } = await import('@main/services/screenshot/screenCapture')
+const { captureAllMonitors } = await import('@main/services/screenshot/screenCapture')
 
 const toPng = vi.fn<(copyOutputData: boolean) => Promise<Buffer>>(async () => Buffer.from([1]))
 
@@ -40,7 +36,6 @@ const makeMonitor = (id: number) => ({
 describe('screenCapture', () => {
   beforeEach(() => {
     monitorAll.mockReset()
-    windowAll.mockReset()
     getMediaAccessStatus.mockReset()
     toPng.mockClear()
   })
@@ -98,33 +93,6 @@ describe('screenCapture', () => {
     // A serial loop finishes display 1 — encode included — before display 2 is sampled,
     // so the "frozen instant" the overlay presents differs per display.
     expect(peakInFlight).toBe(2)
-  })
-
-  it('keeps enumerating windows when one disappears mid-read', () => {
-    const alive = {
-      pid: () => 1,
-      title: () => 'A',
-      appName: () => 'App',
-      x: () => 0,
-      y: () => 0,
-      width: () => 10,
-      height: () => 10,
-      isMinimized: () => false
-    }
-    const dying = {
-      pid: () => 2,
-      title: () => {
-        throw new Error('window closed')
-      },
-      appName: () => 'Gone',
-      x: () => 0,
-      y: () => 0,
-      width: () => 10,
-      height: () => 10,
-      isMinimized: () => false
-    }
-    windowAll.mockReturnValue([dying, alive])
-    expect(listWindows().map((w) => w.pid)).toEqual([1])
   })
 
   it('captures every monitor keyed by its own id', async () => {

--- a/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
+++ b/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
@@ -1,5 +1,12 @@
-import { readWindowInfo } from '@main/services/screenshot/windowEnumerator'
-import { describe, expect, it } from 'vitest'
+import { listWindowsOffThread, readWindowInfo } from '@main/services/screenshot/windowEnumerator'
+import { describe, expect, it, vi } from 'vitest'
+
+const workerConstructor = vi.hoisted(() => vi.fn())
+
+vi.mock('node:worker_threads', () => ({ Worker: workerConstructor }))
+vi.mock('@main/services/screenshot/nativeCaptureBackend', () => ({
+  nativeCaptureBackendPath: () => '/fake/node-screenshots'
+}))
 
 const makeWindow = (over: Partial<Record<string, unknown>> = {}) => ({
   pid: () => 1,
@@ -37,5 +44,17 @@ describe('readWindowInfo', () => {
       height: 40,
       isMinimized: false
     })
+  })
+})
+
+describe('listWindowsOffThread', () => {
+  it('degrades to no snap targets when the worker cannot be spawned', async () => {
+    // Hover-to-snap is optional — it falls back to snapping to the whole display.
+    // A rejection here would escape the caller's fire-and-forget `void`.
+    workerConstructor.mockImplementationOnce(() => {
+      throw new Error('cannot spawn')
+    })
+
+    await expect(listWindowsOffThread()).resolves.toEqual([])
   })
 })

--- a/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
+++ b/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
@@ -1,0 +1,41 @@
+import { readWindowInfo } from '@main/services/screenshot/windowEnumerator'
+import { describe, expect, it } from 'vitest'
+
+const makeWindow = (over: Partial<Record<string, unknown>> = {}) => ({
+  pid: () => 1,
+  title: () => 'A',
+  x: () => 10,
+  y: () => 20,
+  width: () => 30,
+  height: () => 40,
+  isMinimized: () => false,
+  ...over
+})
+
+describe('readWindowInfo', () => {
+  it('skips a window that disappears between the enumeration and a property read', () => {
+    // Menus and tooltips close constantly, so a throwing accessor must cost that one
+    // window, not the whole hit-test list.
+    const dying = makeWindow({
+      title: () => {
+        throw new Error('window closed')
+      }
+    })
+
+    expect(readWindowInfo(dying)).toBeNull()
+  })
+
+  it('reads exactly the fields a snap target needs', () => {
+    // Each accessor re-queries the whole OS window list, so an unused field is
+    // ~30ms of native work per capture on a normal working set.
+    expect(readWindowInfo(makeWindow())).toEqual({
+      pid: 1,
+      title: 'A',
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+      isMinimized: false
+    })
+  })
+})

--- a/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
+++ b/src/main/services/screenshot/__tests__/windowEnumerator.test.ts
@@ -1,7 +1,31 @@
+import type { RawWindowInfo } from '@main/services/screenshot/types'
 import { listWindowsOffThread, readWindowInfo } from '@main/services/screenshot/windowEnumerator'
 import { describe, expect, it, vi } from 'vitest'
 
 const workerConstructor = vi.hoisted(() => vi.fn())
+
+/** Drives one worker's events from the test, in the order a real one would emit them. */
+class FakeWorker {
+  private handlers = new Map<string, (arg: unknown) => void>()
+  public unref = vi.fn()
+  public terminate = vi.fn()
+  public on(event: string, handler: (arg: unknown) => void) {
+    this.handlers.set(event, handler)
+    return this
+  }
+  public emit(event: string, arg?: unknown) {
+    this.handlers.get(event)?.(arg)
+  }
+}
+
+/** Start an enumeration and hand back the worker it spawned. */
+const spawn = () => {
+  const worker = new FakeWorker()
+  workerConstructor.mockImplementationOnce(() => worker)
+  return { worker, windows: listWindowsOffThread() }
+}
+
+const reply = (windows: RawWindowInfo[]) => ({ ok: true, windows, startedAt: 0, loadMs: 0, enumMs: 0 })
 
 vi.mock('node:worker_threads', () => ({ Worker: workerConstructor }))
 vi.mock('@main/services/screenshot/nativeCaptureBackend', () => ({
@@ -48,6 +72,41 @@ describe('readWindowInfo', () => {
 })
 
 describe('listWindowsOffThread', () => {
+  const enumerated: RawWindowInfo[] = [{ pid: 1, title: 'A', x: 0, y: 0, width: 100, height: 50, isMinimized: false }]
+
+  it('reports the windows the worker enumerated', async () => {
+    const { worker, windows } = spawn()
+
+    worker.emit('message', reply(enumerated))
+
+    await expect(windows).resolves.toEqual(enumerated)
+  })
+
+  it('degrades to no snap targets when the worker reports a failure', async () => {
+    const { worker, windows } = spawn()
+
+    worker.emit('message', { ok: false, message: 'the native backend could not be loaded' })
+
+    await expect(windows).resolves.toEqual([])
+  })
+
+  it('degrades to no snap targets when the worker errors', async () => {
+    const { worker, windows } = spawn()
+
+    worker.emit('error', new Error('worker crashed'))
+
+    await expect(windows).resolves.toEqual([])
+  })
+
+  it('degrades to no snap targets when the worker exits without reporting', async () => {
+    // Nothing else would settle the promise, and the caller awaits it before pushing.
+    const { worker, windows } = spawn()
+
+    worker.emit('exit', 1)
+
+    await expect(windows).resolves.toEqual([])
+  })
+
   it('degrades to no snap targets when the worker cannot be spawned', async () => {
     // Hover-to-snap is optional — it falls back to snapping to the whole display.
     // A rejection here would escape the caller's fire-and-forget `void`.

--- a/src/main/services/screenshot/index.ts
+++ b/src/main/services/screenshot/index.ts
@@ -6,6 +6,7 @@
  * The macOS permission gate deliberately lives in `@main/utils/screenCapturePermission`
  * instead: importing it through here would drag the overlay service into the caller.
  */
-export { captureAllMonitors, listMonitors, listWindows } from './screenCapture'
+export { captureAllMonitors, listMonitors } from './screenCapture'
 export { ScreenshotOverlayService } from './ScreenshotOverlayService'
 export { ScreenCaptureError, ScreenCapturePermissionError } from './types'
+export { listWindowsOffThread } from './windowEnumerator'

--- a/src/main/services/screenshot/index.ts
+++ b/src/main/services/screenshot/index.ts
@@ -9,4 +9,3 @@
 export { captureAllMonitors, listMonitors } from './screenCapture'
 export { ScreenshotOverlayService } from './ScreenshotOverlayService'
 export { ScreenCaptureError, ScreenCapturePermissionError } from './types'
-export { listWindowsOffThread } from './windowEnumerator'

--- a/src/main/services/screenshot/nativeCaptureBackend.ts
+++ b/src/main/services/screenshot/nativeCaptureBackend.ts
@@ -23,6 +23,18 @@ let cached: typeof NodeScreenshotsModule | null = null
  * `require` rather than `await import` keeps callers synchronous — display and
  * window enumeration have no asynchronous form in the backend.
  */
+export function loadNativeCaptureBackend(): typeof NodeScreenshotsModule {
+  if (!cached) {
+    try {
+      cached = require('node-screenshots') as typeof NodeScreenshotsModule
+    } catch (error) {
+      logger.error('Failed to load the native screen capture backend', error as Error)
+      throw new ScreenCaptureError('Screen capture backend is unavailable', { cause: error })
+    }
+  }
+  return cached
+}
+
 /**
  * Absolute path of the native backend, for a worker that cannot resolve it itself.
  *
@@ -38,16 +50,4 @@ export function nativeCaptureBackendPath(): string {
     logger.error('Failed to resolve the native screen capture backend', error as Error)
     throw new ScreenCaptureError('Screen capture backend is unavailable', { cause: error })
   }
-}
-
-export function loadNativeCaptureBackend(): typeof NodeScreenshotsModule {
-  if (!cached) {
-    try {
-      cached = require('node-screenshots') as typeof NodeScreenshotsModule
-    } catch (error) {
-      logger.error('Failed to load the native screen capture backend', error as Error)
-      throw new ScreenCaptureError('Screen capture backend is unavailable', { cause: error })
-    }
-  }
-  return cached
 }

--- a/src/main/services/screenshot/nativeCaptureBackend.ts
+++ b/src/main/services/screenshot/nativeCaptureBackend.ts
@@ -23,6 +23,23 @@ let cached: typeof NodeScreenshotsModule | null = null
  * `require` rather than `await import` keeps callers synchronous — display and
  * window enumeration have no asynchronous form in the backend.
  */
+/**
+ * Absolute path of the native backend, for a worker that cannot resolve it itself.
+ *
+ * A `worker_threads` worker spawned from an eval'd source string has no module
+ * path to resolve `node-screenshots` against, and the packaged app moves it into
+ * `app.asar.unpacked`. Resolving here — in the process that already loads it
+ * successfully — sidesteps both.
+ */
+export function nativeCaptureBackendPath(): string {
+  try {
+    return require.resolve('node-screenshots')
+  } catch (error) {
+    logger.error('Failed to resolve the native screen capture backend', error as Error)
+    throw new ScreenCaptureError('Screen capture backend is unavailable', { cause: error })
+  }
+}
+
 export function loadNativeCaptureBackend(): typeof NodeScreenshotsModule {
   if (!cached) {
     try {

--- a/src/main/services/screenshot/screenCapture.ts
+++ b/src/main/services/screenshot/screenCapture.ts
@@ -3,13 +3,7 @@ import { getScreenCapturePermissionStatus } from '@main/utils/screenCapturePermi
 import type { Monitor } from 'node-screenshots'
 
 import { loadNativeCaptureBackend } from './nativeCaptureBackend'
-import {
-  type CaptureResult,
-  type MonitorInfo,
-  type RawWindowInfo,
-  ScreenCaptureError,
-  ScreenCapturePermissionError
-} from './types'
+import { type CaptureResult, type MonitorInfo, ScreenCaptureError, ScreenCapturePermissionError } from './types'
 
 const logger = loggerService.withContext('screenCapture')
 
@@ -25,36 +19,6 @@ export function listMonitors(): MonitorInfo[] {
     scaleFactor: m.scaleFactor(),
     isPrimary: m.isPrimary()
   }))
-}
-
-/**
- * All windows, front-to-back.
- *
- * Every property accessor re-queries the OS window list, so an individual
- * window can fail if it closes between enumeration and the property read.
- * Such a window is skipped rather than failing the whole enumeration —
- * transient windows (menus, tooltips) close constantly, and aborting on one
- * would make hit-test list construction fail at random.
- */
-export function listWindows(): RawWindowInfo[] {
-  const result: RawWindowInfo[] = []
-  for (const w of loadNativeCaptureBackend().Window.all()) {
-    try {
-      result.push({
-        pid: w.pid(),
-        title: w.title(),
-        appName: w.appName(),
-        x: w.x(),
-        y: w.y(),
-        width: w.width(),
-        height: w.height(),
-        isMinimized: w.isMinimized()
-      })
-    } catch {
-      // Expected when a window closes mid-enumeration.
-    }
-  }
-  return result
 }
 
 /**

--- a/src/main/services/screenshot/types.ts
+++ b/src/main/services/screenshot/types.ts
@@ -24,7 +24,6 @@ export interface CaptureResult {
 export interface RawWindowInfo {
   pid: number
   title: string
-  appName: string
   x: number
   y: number
   width: number

--- a/src/main/services/screenshot/windowEnumerator.ts
+++ b/src/main/services/screenshot/windowEnumerator.ts
@@ -113,47 +113,52 @@ export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
       resolve(windows)
     }
 
-    const worker = new Worker(enumeratorSource, { eval: true, workerData: { backendPath } })
-    const spawnMs = performance.now() - t0
-    // A capture session is short-lived and this result is optional; it must never
-    // be the reason the app stays alive on quit.
-    worker.unref()
+    try {
+      const worker = new Worker(enumeratorSource, { eval: true, workerData: { backendPath } })
+      const spawnMs = performance.now() - t0
+      // A capture session is short-lived and this result is optional; it must never
+      // be the reason the app stays alive on quit.
+      worker.unref()
 
-    worker.on(
-      'message',
-      (
-        message:
-          | { ok: true; windows: RawWindowInfo[]; startedAt: number; loadMs: number; enumMs: number }
-          | { ok: false; message: string }
-      ) => {
-        if (message.ok) {
-          if (DIAGNOSTICS_ENABLED) {
-            // Splits the wall clock five ways, so a slow run names its own cause:
-            // `boot` = spawning the thread, `load` = the native binding, `enum` =
-            // the OS queries, `dispatch` = the main thread getting round to the
-            // reply. A large `dispatch` is a scheduling problem, not a native one.
-            const total = performance.now() - t0
-            const bootMs = message.startedAt - t0Wall
-            logger.info(
-              `[Diagnostics/screenshot] enumerator total=${total.toFixed(0)}ms ` +
-                `spawn=${spawnMs.toFixed(0)}ms boot=${bootMs.toFixed(0)}ms ` +
-                `load=${message.loadMs.toFixed(0)}ms enum=${message.enumMs.toFixed(0)}ms ` +
-                `dispatch=${(total - bootMs - message.loadMs - message.enumMs).toFixed(0)}ms`
-            )
+      worker.on(
+        'message',
+        (
+          message:
+            | { ok: true; windows: RawWindowInfo[]; startedAt: number; loadMs: number; enumMs: number }
+            | { ok: false; message: string }
+        ) => {
+          if (message.ok) {
+            if (DIAGNOSTICS_ENABLED) {
+              // Splits the wall clock five ways, so a slow run names its own cause:
+              // `boot` = spawning the thread, `load` = the native binding, `enum` =
+              // the OS queries, `dispatch` = the main thread getting round to the
+              // reply. A large `dispatch` is a scheduling problem, not a native one.
+              const total = performance.now() - t0
+              const bootMs = message.startedAt - t0Wall
+              logger.info(
+                `[Diagnostics/screenshot] enumerator total=${total.toFixed(0)}ms ` +
+                  `spawn=${spawnMs.toFixed(0)}ms boot=${bootMs.toFixed(0)}ms ` +
+                  `load=${message.loadMs.toFixed(0)}ms enum=${message.enumMs.toFixed(0)}ms ` +
+                  `dispatch=${(total - bootMs - message.loadMs - message.enumMs).toFixed(0)}ms`
+              )
+            }
+            settle(message.windows)
+          } else {
+            logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
+            settle([])
           }
-          settle(message.windows)
-        } else {
-          logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
-          settle([])
+          void worker.terminate()
         }
-        void worker.terminate()
-      }
-    )
-    worker.on('error', (error) => {
-      logger.warn('Skipping snap targets: the enumerator worker errored', error)
+      )
+      worker.on('error', (error) => {
+        logger.warn('Skipping snap targets: the enumerator worker errored', error)
+        settle([])
+      })
+      // Covers a worker that dies without reporting — otherwise the caller waits forever.
+      worker.on('exit', () => settle([]))
+    } catch (error) {
+      logger.warn('Skipping snap targets: the enumerator worker could not be spawned', error as Error)
       settle([])
-    })
-    // Covers a worker that dies without reporting — otherwise the caller waits forever.
-    worker.on('exit', () => settle([]))
+    }
   })
 }

--- a/src/main/services/screenshot/windowEnumerator.ts
+++ b/src/main/services/screenshot/windowEnumerator.ts
@@ -105,14 +105,6 @@ export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
   return new Promise((resolve) => {
     const t0 = performance.now()
     const t0Wall = Date.now()
-    // Resolves exactly once; `exit` fires after a successful `message` too.
-    let settled = false
-    const settle = (windows: RawWindowInfo[]) => {
-      if (settled) return
-      settled = true
-      resolve(windows)
-    }
-
     try {
       const worker = new Worker(enumeratorSource, { eval: true, workerData: { backendPath } })
       const spawnMs = performance.now() - t0
@@ -142,23 +134,24 @@ export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
                   `dispatch=${(total - bootMs - message.loadMs - message.enumMs).toFixed(0)}ms`
               )
             }
-            settle(message.windows)
+            resolve(message.windows)
           } else {
             logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
-            settle([])
+            resolve([])
           }
           void worker.terminate()
         }
       )
       worker.on('error', (error) => {
         logger.warn('Skipping snap targets: the enumerator worker errored', error)
-        settle([])
+        resolve([])
       })
       // Covers a worker that dies without reporting — otherwise the caller waits forever.
-      worker.on('exit', () => settle([]))
+      // Fires after a successful `message` too, where resolving again is a no-op.
+      worker.on('exit', () => resolve([]))
     } catch (error) {
       logger.warn('Skipping snap targets: the enumerator worker could not be spawned', error as Error)
-      settle([])
+      resolve([])
     }
   })
 }

--- a/src/main/services/screenshot/windowEnumerator.ts
+++ b/src/main/services/screenshot/windowEnumerator.ts
@@ -1,6 +1,7 @@
 import { Worker } from 'node:worker_threads'
 
 import { loggerService } from '@logger'
+import { DIAGNOSTICS_ENABLED } from '@main/core/diagnostics'
 
 import { nativeCaptureBackendPath } from './nativeCaptureBackend'
 import type { RawWindowInfo } from './types'
@@ -64,14 +65,22 @@ const enumeratorSource = `
 const { parentPort, workerData } = require('node:worker_threads')
 const readWindowInfo = ${readWindowInfo.toString()}
 
+// Wall clock, so the main thread can measure how long this worker took to boot.
+// performance.now() cannot: each thread's origin is its own start.
+const startedAt = Date.now()
+
 try {
+  const t0 = performance.now()
   const { Window } = require(workerData.backendPath)
+  const loadMs = performance.now() - t0
+
+  const t1 = performance.now()
   const windows = []
   for (const w of Window.all()) {
     const info = readWindowInfo(w)
     if (info) windows.push(info)
   }
-  parentPort.postMessage({ ok: true, windows })
+  parentPort.postMessage({ ok: true, windows, startedAt, loadMs, enumMs: performance.now() - t1 })
 } catch (error) {
   parentPort.postMessage({ ok: false, message: String((error && error.message) || error) })
 }
@@ -94,6 +103,8 @@ export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
   }
 
   return new Promise((resolve) => {
+    const t0 = performance.now()
+    const t0Wall = Date.now()
     // Resolves exactly once; `exit` fires after a successful `message` too.
     let settled = false
     const settle = (windows: RawWindowInfo[]) => {
@@ -103,19 +114,41 @@ export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
     }
 
     const worker = new Worker(enumeratorSource, { eval: true, workerData: { backendPath } })
+    const spawnMs = performance.now() - t0
     // A capture session is short-lived and this result is optional; it must never
     // be the reason the app stays alive on quit.
     worker.unref()
 
-    worker.on('message', (message: { ok: true; windows: RawWindowInfo[] } | { ok: false; message: string }) => {
-      if (message.ok) {
-        settle(message.windows)
-      } else {
-        logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
-        settle([])
+    worker.on(
+      'message',
+      (
+        message:
+          | { ok: true; windows: RawWindowInfo[]; startedAt: number; loadMs: number; enumMs: number }
+          | { ok: false; message: string }
+      ) => {
+        if (message.ok) {
+          if (DIAGNOSTICS_ENABLED) {
+            // Splits the wall clock five ways, so a slow run names its own cause:
+            // `boot` = spawning the thread, `load` = the native binding, `enum` =
+            // the OS queries, `dispatch` = the main thread getting round to the
+            // reply. A large `dispatch` is a scheduling problem, not a native one.
+            const total = performance.now() - t0
+            const bootMs = message.startedAt - t0Wall
+            logger.info(
+              `[Diagnostics/screenshot] enumerator total=${total.toFixed(0)}ms ` +
+                `spawn=${spawnMs.toFixed(0)}ms boot=${bootMs.toFixed(0)}ms ` +
+                `load=${message.loadMs.toFixed(0)}ms enum=${message.enumMs.toFixed(0)}ms ` +
+                `dispatch=${(total - bootMs - message.loadMs - message.enumMs).toFixed(0)}ms`
+            )
+          }
+          settle(message.windows)
+        } else {
+          logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
+          settle([])
+        }
+        void worker.terminate()
       }
-      void worker.terminate()
-    })
+    )
     worker.on('error', (error) => {
       logger.warn('Skipping snap targets: the enumerator worker errored', error)
       settle([])

--- a/src/main/services/screenshot/windowEnumerator.ts
+++ b/src/main/services/screenshot/windowEnumerator.ts
@@ -1,0 +1,126 @@
+import { Worker } from 'node:worker_threads'
+
+import { loggerService } from '@logger'
+
+import { nativeCaptureBackendPath } from './nativeCaptureBackend'
+import type { RawWindowInfo } from './types'
+
+const logger = loggerService.withContext('windowEnumerator')
+
+/** The subset of the native `Window` class this module reads. */
+type NativeWindow = {
+  pid(): number
+  title(): string
+  x(): number
+  y(): number
+  width(): number
+  height(): number
+  isMinimized(): boolean
+}
+
+/**
+ * One window's snap-relevant properties, or null if it closed mid-enumeration.
+ *
+ * Every accessor re-queries the OS window list, so a window that disappears between
+ * the enumeration and a property read throws. Transient windows (menus, tooltips)
+ * close constantly, so skipping the individual window is the only viable answer —
+ * aborting would make the hit-test list fail at random.
+ *
+ * Baked into the worker source below via `.toString()`, so the tested function and
+ * the shipped one cannot drift.
+ */
+export function readWindowInfo(w: NativeWindow): RawWindowInfo | null {
+  try {
+    return {
+      pid: w.pid(),
+      title: w.title(),
+      x: w.x(),
+      y: w.y(),
+      width: w.width(),
+      height: w.height(),
+      isMinimized: w.isMinimized()
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Window enumeration, as an eval'd `worker_threads` source string.
+ *
+ * A string rather than a file entry because electron-vite builds the main process
+ * as a single bundle (`inlineDynamicImports: true`), which Rollup forbids combining
+ * with multiple inputs — the inference and tool-exec workers take the same shape.
+ * The native backend's path arrives through `workerData`: an eval'd worker has no
+ * module path of its own to resolve it against.
+ *
+ * Every property accessor in the backend re-queries the whole OS window list, so
+ * this loop is hundreds of milliseconds of work with a normal working set. That is
+ * the entire reason it runs here: on the main thread it blocks Chromium's browser
+ * UI thread, which routes input events to the overlay's renderer, so the overlay
+ * would be painted but unable to respond to the drag the user is already making.
+ */
+const enumeratorSource = `
+const { parentPort, workerData } = require('node:worker_threads')
+const readWindowInfo = ${readWindowInfo.toString()}
+
+try {
+  const { Window } = require(workerData.backendPath)
+  const windows = []
+  for (const w of Window.all()) {
+    const info = readWindowInfo(w)
+    if (info) windows.push(info)
+  }
+  parentPort.postMessage({ ok: true, windows })
+} catch (error) {
+  parentPort.postMessage({ ok: false, message: String((error && error.message) || error) })
+}
+`
+
+/**
+ * All windows, front-to-back, enumerated off the main thread.
+ *
+ * Degrades to an empty list rather than throwing: the only consumer is hover-to-snap,
+ * which falls back to snapping to the whole display, and a capture session must not
+ * fail because an optional convenience could not be computed.
+ */
+export function listWindowsOffThread(): Promise<RawWindowInfo[]> {
+  let backendPath: string
+  try {
+    backendPath = nativeCaptureBackendPath()
+  } catch (error) {
+    logger.warn('Skipping snap targets: the native backend could not be resolved', error as Error)
+    return Promise.resolve([])
+  }
+
+  return new Promise((resolve) => {
+    // Resolves exactly once; `exit` fires after a successful `message` too.
+    let settled = false
+    const settle = (windows: RawWindowInfo[]) => {
+      if (settled) return
+      settled = true
+      resolve(windows)
+    }
+
+    const worker = new Worker(enumeratorSource, { eval: true, workerData: { backendPath } })
+    // A capture session is short-lived and this result is optional; it must never
+    // be the reason the app stays alive on quit.
+    worker.unref()
+
+    worker.on('message', (message: { ok: true; windows: RawWindowInfo[] } | { ok: false; message: string }) => {
+      if (message.ok) {
+        settle(message.windows)
+      } else {
+        logger.warn('Skipping snap targets: the enumerator worker failed', new Error(message.message))
+        settle([])
+      }
+      void worker.terminate()
+    })
+    worker.on('error', (error) => {
+      logger.warn('Skipping snap targets: the enumerator worker errored', error)
+      settle([])
+    })
+    // Covers a worker that dies without reporting — otherwise the caller waits forever.
+    worker.on('exit', () => settle([]))
+  })
+}

--- a/src/renderer/windows/screenshot/CaptureOverlay.tsx
+++ b/src/renderer/windows/screenshot/CaptureOverlay.tsx
@@ -1,7 +1,7 @@
 import { loggerService } from '@logger'
 import { useWindowInitData } from '@renderer/hooks/useWindowInitData'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
-import type { ScreenshotInitData } from '@shared/types/screenshot'
+import type { DetectedWindow, ScreenshotInitData } from '@shared/types/screenshot'
 import type { Dispatch, FC, RefObject } from 'react'
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import { useHotkeys } from 'react-hotkeys-hook'
@@ -35,6 +35,8 @@ const logger = loggerService.withContext('CaptureOverlay')
 const CaptureOverlay: FC = () => {
   const initData = useWindowInitData<ScreenshotInitData>()
   const [imageLoaded, setImageLoaded] = useState(false)
+  /** Pushed by main after the overlay paints; empty until then, which snaps to the display. */
+  const [snapTargets, setSnapTargets] = useState<DetectedWindow[]>([])
   const [mouseInWindow, setMouseInWindow] = useState(true)
   const imageRef = useRef<HTMLImageElement | null>(null)
   /** Held outside the load effect so the session-ended handler can revoke it too. */
@@ -146,6 +148,7 @@ const CaptureOverlay: FC = () => {
     imageRef.current = null
     setImageLoaded(false) // nothing may be drawn until the new capture has decoded
     setMouseInWindow(true)
+    setSnapTargets([]) // the previous session's targets are stale the moment it ends
     readyReportedRef.current = false
     resetOcr() // result state + the request generation, so no late result lands here
   }, [mediaId, resetAnnotations, resetOcr])
@@ -153,6 +156,8 @@ const CaptureOverlay: FC = () => {
   // Dropping imageLoaded unmounts the whole overlay body, which is what disposes the
   // toolbar's transient state (active panel, measured layout) and the text editor.
   const contentVisible = imageLoaded && !!imageRef.current
+
+  useIpcOn('screenshot.snap_targets', ({ windows }) => setSnapTargets(windows))
 
   // Another display's overlay took over; drop our selection but keep the capture.
   useIpcOn('screenshot.reset_overlay', () => {
@@ -254,7 +259,7 @@ const CaptureOverlay: FC = () => {
           logicalWidth={logicalWidth}
           logicalHeight={logicalHeight}
           mouseInWindow={mouseInWindow}
-          windows={initData.windows}
+          windows={snapTargets}
           annotation={annotation}
           annotationCanvasRef={annotationCanvasRef}
           ocr={ocr}
@@ -295,7 +300,7 @@ function OverlayContent({
   logicalWidth: number
   logicalHeight: number
   mouseInWindow: boolean
-  windows: ScreenshotInitData['windows']
+  windows: DetectedWindow[]
   annotation: ReturnType<typeof useAnnotation>
   annotationCanvasRef: RefObject<HTMLCanvasElement | null>
   ocr: ReturnType<typeof useOcr>

--- a/src/renderer/windows/screenshot/CaptureOverlay.tsx
+++ b/src/renderer/windows/screenshot/CaptureOverlay.tsx
@@ -35,7 +35,7 @@ const logger = loggerService.withContext('CaptureOverlay')
 const CaptureOverlay: FC = () => {
   const initData = useWindowInitData<ScreenshotInitData>()
   const [imageLoaded, setImageLoaded] = useState(false)
-  /** Pushed by main after the overlay paints; empty until then, which snaps to the display. */
+  /** Pushed by main once the enumeration finishes; empty until then, which snaps to the display. */
   const [snapTargets, setSnapTargets] = useState<DetectedWindow[]>([])
   const [mouseInWindow, setMouseInWindow] = useState(true)
   const imageRef = useRef<HTMLImageElement | null>(null)

--- a/src/renderer/windows/screenshot/__tests__/geometry.test.ts
+++ b/src/renderer/windows/screenshot/__tests__/geometry.test.ts
@@ -11,7 +11,7 @@ import { buildAnnotation, isSignificantAnnotation } from '../utils/annotation'
 import { findWindowAtPoint } from '../utils/findWindowAtPoint'
 
 function makeWindow(overrides: Partial<DetectedWindow>): DetectedWindow {
-  return { title: 'w', appName: 'app', x: 0, y: 0, width: 100, height: 100, ...overrides }
+  return { title: 'w', x: 0, y: 0, width: 100, height: 100, ...overrides }
 }
 
 describe('findWindowAtPoint', () => {

--- a/src/shared/ipc/schemas/screenshot.ts
+++ b/src/shared/ipc/schemas/screenshot.ts
@@ -1,4 +1,4 @@
-import type { ScreenshotResultData } from '@shared/types/screenshot'
+import type { DetectedWindow, ScreenshotResultData } from '@shared/types/screenshot'
 import * as z from 'zod'
 
 import { defineRoute } from '../define'
@@ -139,6 +139,15 @@ export const screenshotRequestSchemas = {
 export type ScreenshotEventSchemas = {
   /** Sent to an overlay that lost the interaction, telling it to drop its selection. */
   'screenshot.reset_overlay': void
+  /**
+   * The hover-to-snap targets for this overlay's display.
+   *
+   * Pushed instead of travelling in the init data: enumerating them costs hundreds
+   * of milliseconds with a normal working set, and paying that before the overlays
+   * open made it the dominant part of the shortcut's latency. An overlay is fully
+   * usable without it — until it arrives, hovering simply snaps to the whole display.
+   */
+  'screenshot.snap_targets': { windows: DetectedWindow[] }
   /**
    * The session is over. A pooled overlay is only hidden, never unmounted, so nothing
    * else tells its renderer to let go of the decoded capture until the next session.

--- a/src/shared/types/screenshot.ts
+++ b/src/shared/types/screenshot.ts
@@ -1,7 +1,6 @@
 /** A foreign window projected into one display's overlay coordinate space (DIP). */
 export interface DetectedWindow {
   title: string
-  appName: string
   x: number
   y: number
   width: number
@@ -24,8 +23,6 @@ export interface ScreenshotInitData {
     height: number
     scaleFactor: number
   }
-  /** Foreign windows overlapping this display, for hover-to-snap. */
-  windows: DetectedWindow[]
   /** Whether the overlay should run OCR once a selection settles. */
   autoOcr: boolean
   /** Whether the OCR model is on disk; false disables the OCR affordance. */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Collecting the hover-to-snap window list ran synchronously on the main process before any overlay opened. It costs **444ms warm / 990ms cold** in a production build (measured, 61–63 windows), and Electron's main-process JS runs on Chromium's browser UI thread — the same thread that routes input events to renderers. So the whole capture stalled behind it, and the overlay could not respond to input for its duration.

After this PR:

That enumeration runs in a `worker_threads` worker, started *before* the screen capture so it overlaps the PNG encode and the window opening. The projected list is pushed to each overlay over a new `screenshot.snap_targets` IPC event once it lands. `appName` — which no consumer read — is dropped, removing one native query per window.

A second commit adds capture-path timings behind the existing `CS_DIAGNOSTICS` flag.

Fixes #18923

### Why we need it and why it was done in this way

The root cause is upstream, not in this repo. Benchmarking `node-screenshots@0.2.8` directly (macOS, 64 windows) shows the cost is linear in the number of *property reads*, not windows:

| Operation | Time |
|---|---|
| `Window.all()` (warm) | 0.5ms |
| 1 window × 1 property | 0.4ms |
| 64 windows × 1 property | 28–34ms |
| 64 windows × 8 properties | 315–335ms |

A single property read costs about the same as a full `Window.all()` — every getter in the binding re-runs the equivalent of the whole OS window-list query. Enumeration itself is free; we were paying for it 512 times. The proper fix is for `xcap` to snapshot properties once in `Window::all()`, turning ~500ms into ~1ms. Everything here is mitigation until that exists.

**Measured result** (production build, 2 displays, `CS_DIAGNOSTICS=1`):

| | usable | capture | open | paint |
|---|---|---|---|---|
| cold (`cold=2/2`) | 381ms | 127 | 64 | 191 |
| warm (`cold=0/2`) | 171ms | 89 | 3 | 80 |

`usable` is shortcut-pressed to last-overlay-painted. Since the enumeration was serial and ahead of `open()`, the pre-fix figures are those plus the measured `enum` cost: **~615ms warm / ~1371ms cold**, roughly 3.6× on both paths. Note this pre-fix number is derived, not separately measured — the derivation rests on `enum` being strictly serial and ahead of the overlays, which the trace confirms.

The following tradeoffs were made:

- **Snap targets are pushed, not carried in init data.** An overlay is fully usable before they arrive — hovering snaps to the whole display until then (370–822ms in the measurements above). Far better than making every capture wait for them.
- **Worker thread rather than deferring on the main thread.** Deferring until after the overlay painted was tried first and was *not* enough: the overlay was painted and visible but could not respond to a drag for the duration. Verified with a 10ms liveness probe on the main thread: `elapsed: 441ms; main-thread ticks during it: 40` (~40 of a possible ~44 — live throughout, versus 0 when the enumeration runs on the main thread).
- **The enumeration is no longer a snapshot from before the overlays exist.** It now overlaps window creation, so the `pid !== process.pid` filter is what keeps our own overlays out of their own hit-test list. That filter already existed and is sufficient; the comment now marks it load-bearing.

The following alternatives were considered:

- **Pre-warming the overlay pool** (`standbySize: 1` + `warmup: 'eager'`). This was in an earlier revision of this PR and has been **removed**, because it was justified entirely by dev-build numbers. See "Special notes" below — in a production build it buys ~210ms for the cost of a permanently resident hidden window per display.
- **Slicing the enumeration into ~2–5ms chunks with `setImmediate`.** Smaller change, no new thread, but the main process still carries the load across the whole window, so smoothness is worse than the worker.
- **An Electron `utilityProcess`.** Stronger isolation, but heavier than `worker_threads` for work this short-lived, and the repo already has two `new Worker(source, { eval: true })` precedents.
- **Early-bail filtering** (read `pid`/`isMinimized` first, skip the rest). Measured the actual population: 0 minimized and 1 Dock window out of 64, so it would have saved almost nothing for real added complexity.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18923

### Breaking changes

None.

### Special notes for your reviewer

**The overlay pre-warming was dropped, and issue #18923's second problem does not reproduce in a production build.** The issue reports a ~2.7s cold overlay against a dev build, and an earlier revision of this PR pre-warmed the pool to fix it. Re-measuring the same code in dev versus production:

| | usable | paint | `ready-to-show` |
|---|---|---|---|
| dev, cold | 2995ms | 2555ms | +2353 / +2551ms |
| production, cold | 381ms | 191ms | +137 / +128ms |

The ~2.4s difference is Vite compiling the overlay entry on first load. In production a cold overlay paints in 191ms, so `REVEAL_FALLBACK_MS` (1000ms) never fires and the "safety net became the normal path" problem simply does not exist there. Pre-warming was buying ~210ms in exchange for a resident hidden window — two of them on a dual-display setup, since `usable` is the *last* overlay to paint. Thanks to @0xfullex for pushing back on the memory cost; the measurement was prompted by that review.

Other notes:

- `ScreenshotInitData.windows` is gone; snap targets now arrive only via `screenshot.snap_targets`. There is deliberately no dual source.
- The worker is an eval'd source string because electron-vite bundles the main process with `inlineDynamicImports: true`, which Rollup forbids combining with multiple inputs — same shape as `inferenceWorkerSource.ts` and `codeMode/worker.ts`. The native backend's absolute path is resolved in the main process and passed via `workerData`, sidestepping both the eval'd worker having no module path to resolve against and the packaged app moving the binary into `app.asar.unpacked`.
- The per-window read is an exported, unit-tested `readWindowInfo()` baked into the worker source via `.toString()`, so the tested function and the shipped one cannot drift — following the `l2normalize` precedent in `inferenceWorkerSource.ts`.
- The trace in the second commit is gated by `CS_DIAGNOSTICS`, so a normal run pays nothing. It earned its place by killing two wrong conclusions during this PR: that pre-warming was needed, and that a `worker.unref()` was delaying the enumerator's reply (`dispatch=1ms` — it was not).
- **Possibly out of scope**: the second commit also adds two `WindowManager` tests for a contract that had none — a pool suspended before `onAllReady` must not be eagerly warmed. It rests entirely on `suspendPool()` calling `getOrCreateWarmupState()` rather than `get()`; with `get()`, `state?.suspended` is `undefined` and warmup proceeds. Found while investigating the pre-warm question. Happy to drop it if you'd rather keep this PR narrow.
- Three existing tests asserted `ipcApiService.send` *total* call counts; they now filter by event name, which is what they meant in the first place.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. No update required: this is a latency fix with no new settings, UI, or user-visible controls.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the screenshot capture overlay taking about a second to appear. The overlay now opens immediately, and no longer gets slower the more windows you have open.
```
