### PR TITLE
fix(screenshot): show the IME candidate window while annotating text

### DIFF
--- a/src/main/core/window/WindowManager.ts
+++ b/src/main/core/window/WindowManager.ts
@@ -1432,7 +1432,9 @@ export class WindowManager extends BaseService {
     // wrappers then transparently apply around any subsequent hide()/show()/close().
     // Also runs AFTER applyWindowBehavior so the behavior layer's initial setter
     // calls do not trigger the monkey-patched show/showInactive.
-    applyWindowQuirks(managedWindow.window, managedWindow.metadata.quirks, managedWindow.metadata.behavior)
+    applyWindowQuirks(managedWindow.window, managedWindow.metadata.quirks, managedWindow.metadata.behavior, () =>
+      this.behavior.getAlwaysOnTopLevelOverride(windowId)
+    )
 
     // 4c. Persist bounds on native close for singletons (GUI quit and
     // hide-to-tray, where the window is still alive). Attached to every singleton

--- a/src/main/core/window/behavior.ts
+++ b/src/main/core/window/behavior.ts
@@ -1,4 +1,10 @@
-import type { ManagedWindow, WindowBehavior, WindowOptions, WindowType } from '@main/core/window/types'
+import type {
+  AlwaysOnTopLevel,
+  ManagedWindow,
+  WindowBehavior,
+  WindowOptions,
+  WindowType
+} from '@main/core/window/types'
 import type { BrowserWindow } from 'electron'
 
 /**
@@ -116,6 +122,7 @@ export interface BehaviorHost {
  */
 export class BehaviorController {
   private hideOnBlurOverride = new Map<string, boolean>()
+  private alwaysOnTopLevelOverride = new Map<string, AlwaysOnTopLevel>()
   private macShowInDockOverrideByType = new Map<WindowType, boolean>()
 
   constructor(private readonly host: BehaviorHost) {}
@@ -165,7 +172,7 @@ export class BehaviorController {
   public setAlwaysOnTop(windowId: string, enabled: boolean): void {
     const managed = this.host.getManagedWindow(windowId)
     if (!managed || managed.window.isDestroyed()) return
-    const { level, relativeLevel } = managed.metadata.behavior?.alwaysOnTop ?? {}
+    const { level, relativeLevel } = this.resolveAlwaysOnTop(windowId, managed)
     // Pass only the arguments actually declared — avoids trailing `undefined`s
     // that would change the call signature observed by spies or future overloads.
     if (level !== undefined && relativeLevel !== undefined) {
@@ -216,7 +223,47 @@ export class BehaviorController {
    * registry-declared defaults.
    * @internal
    */
+  /**
+   * Temporarily run one window at a level other than the one its registry entry
+   * declares, and apply it immediately.
+   *
+   * The declared level stays the single source of truth: `null` drops the override
+   * and restores it. The override also wins in `quirks.reapplyAlwaysOnTop`, which
+   * would otherwise undo it on the next show.
+   *
+   * Only a bare level is overridable — `relativeLevel` is dropped while an override
+   * is in effect, since the two express one offset and mixing them silently produces
+   * a level neither caller asked for.
+   *
+   * Its reason to exist: the macOS IME candidate window sits at a fixed level, so an
+   * overlay above it hides the candidates and has to step below them while text is
+   * being entered.
+   *
+   * Lifetime: cleared on window destroy and pool release, like every other override.
+   */
+  public setAlwaysOnTopLevel(windowId: string, level: AlwaysOnTopLevel | null): void {
+    if (level === null) this.alwaysOnTopLevelOverride.delete(windowId)
+    else this.alwaysOnTopLevelOverride.set(windowId, level)
+    this.setAlwaysOnTop(windowId, true)
+  }
+
+  /** The runtime level override for this window, or undefined when none is set. */
+  public getAlwaysOnTopLevelOverride(windowId: string): AlwaysOnTopLevel | undefined {
+    return this.alwaysOnTopLevelOverride.get(windowId)
+  }
+
+  /** The override if one is set, else what the registry declares. */
+  private resolveAlwaysOnTop(
+    windowId: string,
+    managed: ManagedWindow
+  ): { level?: AlwaysOnTopLevel; relativeLevel?: number } {
+    const override = this.alwaysOnTopLevelOverride.get(windowId)
+    if (override !== undefined) return { level: override }
+    return managed.metadata.behavior?.alwaysOnTop ?? {}
+  }
+
   public clearForWindow(windowId: string): void {
     this.hideOnBlurOverride.delete(windowId)
+    this.alwaysOnTopLevelOverride.delete(windowId)
   }
 }

--- a/src/main/core/window/quirks.ts
+++ b/src/main/core/window/quirks.ts
@@ -1,5 +1,5 @@
 import { isMac } from '@main/core/platform'
-import type { WindowBehavior, WindowQuirks } from '@main/core/window/types'
+import type { AlwaysOnTopLevel, WindowBehavior, WindowQuirks } from '@main/core/window/types'
 import { BrowserWindow } from 'electron'
 
 /**
@@ -24,11 +24,15 @@ import { BrowserWindow } from 'electron'
  * @param behavior - The declarative behavior layer, consulted for the level
  *   to re-apply under `reapplyAlwaysOnTop` (single source of truth for
  *   level/relativeLevel — see `behavior.alwaysOnTop`).
+ * @param getLevelOverride - Closure returning the runtime level override for this
+ *   window, or undefined when none is set. Re-applying the declared level would
+ *   otherwise silently undo an override on the next show.
  */
 export function applyWindowQuirks(
   window: BrowserWindow,
   quirks: WindowQuirks | undefined,
-  behavior: WindowBehavior | undefined
+  behavior: WindowBehavior | undefined,
+  getLevelOverride?: () => AlwaysOnTopLevel | undefined
 ): void {
   if (!quirks) return
 
@@ -90,12 +94,17 @@ export function applyWindowQuirks(
     // When behavior doesn't declare a level, fall back to 'floating' explicitly
     // rather than relying on Electron's internal default — this keeps the
     // re-apply call signature stable across Electron upgrades.
-    const level = behavior?.alwaysOnTop?.level ?? 'floating'
-    const relativeLevel = behavior?.alwaysOnTop?.relativeLevel
+    const declaredLevel = behavior?.alwaysOnTop?.level ?? 'floating'
+    const declaredRelativeLevel = behavior?.alwaysOnTop?.relativeLevel
     const originalShow = window.show.bind(window)
     const originalShowInactive = window.showInactive.bind(window)
     const reapply = () => {
       if (window.isDestroyed()) return
+      // Read at fire time, not at patch time: the override is set long after this runs.
+      const override = getLevelOverride?.()
+      const level = override ?? declaredLevel
+      // An override replaces the declared offset rather than stacking onto it.
+      const relativeLevel = override !== undefined ? undefined : declaredRelativeLevel
       // Pass relativeLevel only when declared — avoids polluting the call
       // site with a trailing `undefined` that changes spy signatures.
       if (relativeLevel !== undefined) {

--- a/src/main/ipc/handlers/screenshot.ts
+++ b/src/main/ipc/handlers/screenshot.ts
@@ -63,6 +63,13 @@ export const screenshotHandlers: IpcHandlersFor<typeof screenshotRequestSchemas>
     if (!ctx.senderId || !service.isSessionOverlay(ctx.senderId)) return
     service.markOverlayReady(ctx.senderId, mediaId)
   },
+  // Active, not merely session: it changes how the window the user is typing in is
+  // stacked, which only the overlay holding the live selection has any business doing.
+  'screenshot.text_editing': async ({ editing }, ctx) => {
+    const service = application.get('ScreenshotOverlayService')
+    if (!ctx.senderId || !service.isActiveOverlay(ctx.senderId)) return
+    service.setTextEditing(ctx.senderId, editing)
+  },
   'screenshot.recognize_text': async ({ mediaId, region }, ctx) => {
     const service = application.get('ScreenshotOverlayService')
     // Active, not merely session: OCR is the most expensive thing an overlay can

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -608,8 +608,11 @@ export class ScreenshotOverlayService extends BaseService {
 
     // Explicit, not left to pool release: an overlay whose session ended mid-edit would
     // otherwise come back at the text editor's level and never cover the Dock again.
-    const windowManager = application.get('WindowManager')
-    for (const windowId of this.overlayWindowIds) windowManager.behavior.setAlwaysOnTopLevel(windowId, null)
+    // Only macOS ever steps an overlay down (see setTextEditing), so only macOS restores.
+    if (isMac) {
+      const windowManager = application.get('WindowManager')
+      for (const windowId of this.overlayWindowIds) windowManager.behavior.setAlwaysOnTopLevel(windowId, null)
+    }
 
     this.overlayWindowIds = []
     this.activeOverlayWindowId = null

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -355,6 +355,20 @@ export class ScreenshotOverlayService extends BaseService {
   }
 
   /**
+   * Step this overlay below the IME candidate window while its text editor is open.
+   *
+   * macOS only: for a Chromium client the candidate window is placed at a fixed, low
+   * level instead of above the client, so an overlay raised over the Dock and menu bar
+   * covers it — text can be composed but the candidates are never visible. Stepping down
+   * for the duration of the edit is the only lever available from this side; the Dock and
+   * the menu bar do show over the frozen capture while it lasts.
+   */
+  public setTextEditing(windowId: WindowId, editing: boolean): void {
+    if (!isMac) return
+    application.get('WindowManager').behavior.setAlwaysOnTopLevel(windowId, editing ? 'floating' : null)
+  }
+
+  /**
    * Recognize text inside one region of an overlay's frozen capture.
    *
    * Serialization is `OcrInferenceService`'s own `PQueue({ concurrency: 1 })`; this only
@@ -591,6 +605,11 @@ export class ScreenshotOverlayService extends BaseService {
     // Per-session: a recycled overlay that painted last time has to earn it again, or
     // the next session's never-painted window would have no Escape rescue.
     this.renderersReady.clear()
+
+    // Explicit, not left to pool release: an overlay whose session ended mid-edit would
+    // otherwise come back at the text editor's level and never cover the Dock again.
+    const windowManager = application.get('WindowManager')
+    for (const windowId of this.overlayWindowIds) windowManager.behavior.setAlwaysOnTopLevel(windowId, null)
 
     this.overlayWindowIds = []
     this.activeOverlayWindowId = null

--- a/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
+++ b/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
@@ -159,6 +159,7 @@ const container = vi.hoisted(() => {
       return id
     }),
     getWindow: vi.fn((id: string) => windows.get(id)),
+    behavior: { setAlwaysOnTopLevel: vi.fn() },
     close: vi.fn(() => true),
     setInitData: vi.fn(),
     suspendPool: vi.fn(() => 0),
@@ -377,6 +378,22 @@ describe('ScreenshotOverlayService', () => {
 
       expect(capture.captureAllMonitors).not.toHaveBeenCalled()
       expect(container.openCalls).toHaveLength(0)
+    })
+
+    it('restores the declared window level when a session ends while the text editor is open', async () => {
+      electron.displays = [makeDisplay(1, 0, 0)]
+      capture.captureAllMonitors.mockReturnValue(new Map([[1, makeCapture()]]))
+      await service.startCapture()
+      const [overlayId] = [...container.windows.keys()]
+      service.markOverlayActive(overlayId)
+      service.setTextEditing(overlayId, true)
+
+      service.dismiss()
+
+      // Overlays are pooled, so an override left behind comes back on the next capture:
+      // the whole overlay would sit at the text editor's level and stop covering the Dock.
+      const calls = container.windowManager.behavior.setAlwaysOnTopLevel.mock.calls
+      expect(calls.at(-1)).toEqual([overlayId, null])
     })
 
     it('releases every stored media entry AND session capture on dismiss', async () => {

--- a/src/renderer/windows/screenshot/components/TextInput.tsx
+++ b/src/renderer/windows/screenshot/components/TextInput.tsx
@@ -46,6 +46,16 @@ export function TextInput({ position, selection, fontSize, color, onConfirm, onC
   /** Guards against committing twice when blur and an explicit flush race. */
   const committedRef = useRef(false)
   const isComposingRef = useRef(false)
+  /**
+   * Whether the overlay has already been stepped below the IME candidate window.
+   *
+   * Driven by the first composition rather than by the editor opening, so someone
+   * typing without an IME never pays for this at all — the step-down uncovers the
+   * Dock and the menu bar, which then take the clicks over the strips they occupy.
+   * It is never undone mid-edit: restoring on `compositionend` would flash both of
+   * them on and off between every word of a sentence.
+   */
+  const steppedDownRef = useRef(false)
   /** A composition ended and its result is not trusted yet. See the file header. */
   const pendingAcceptRef = useRef(false)
   const acceptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -68,13 +78,14 @@ export function TextInput({ position, selection, fontSize, color, onConfirm, onC
     }
   }, [])
 
-  // The overlay outranks the macOS IME candidate window, which would leave the user
-  // composing blind; main steps it down for as long as this editor is open. Nothing to
-  // report elsewhere — the other platforms keep the overlay topmost throughout.
+  /**
+   * Restore the level when the editor closes, but only if a composition ever stepped
+   * it down — see {@link steppedDownRef} for why the step-down is not done on mount.
+   */
   useEffect(() => {
     if (!isMac) return
-    void ipcApi.request('screenshot.text_editing', { editing: true })
     return () => {
+      if (!steppedDownRef.current) return
       void ipcApi.request('screenshot.text_editing', { editing: false })
     }
   }, [])
@@ -139,6 +150,12 @@ export function TextInput({ position, selection, fontSize, color, onConfirm, onC
     }
 
     const onCompositionStart = () => {
+      // The candidate window sits below the overlay's level; step down once, on the
+      // first composition, so this costs nothing for a user with no IME.
+      if (isMac && !steppedDownRef.current) {
+        steppedDownRef.current = true
+        void ipcApi.request('screenshot.text_editing', { editing: true })
+      }
       // A new composition proves focus never left, so the previous result is good.
       // Without this, two IME words typed within the accept delay lose the first.
       acceptPending()

--- a/src/renderer/windows/screenshot/components/TextInput.tsx
+++ b/src/renderer/windows/screenshot/components/TextInput.tsx
@@ -10,6 +10,7 @@
  */
 
 import { ipcApi } from '@renderer/ipc'
+import { isMac } from '@renderer/utils/platform'
 import type { PointerEvent as ReactPointerEvent, RefObject } from 'react'
 import { useCallback, useEffect, useRef } from 'react'
 
@@ -68,8 +69,10 @@ export function TextInput({ position, selection, fontSize, color, onConfirm, onC
   }, [])
 
   // The overlay outranks the macOS IME candidate window, which would leave the user
-  // composing blind; main steps it down for as long as this editor is open.
+  // composing blind; main steps it down for as long as this editor is open. Nothing to
+  // report elsewhere — the other platforms keep the overlay topmost throughout.
   useEffect(() => {
+    if (!isMac) return
     void ipcApi.request('screenshot.text_editing', { editing: true })
     return () => {
       void ipcApi.request('screenshot.text_editing', { editing: false })

--- a/src/renderer/windows/screenshot/components/TextInput.tsx
+++ b/src/renderer/windows/screenshot/components/TextInput.tsx
@@ -9,6 +9,7 @@
  * by a non-composing keydown, or by the next composition starting. A blur rejects it.
  */
 
+import { ipcApi } from '@renderer/ipc'
 import type { PointerEvent as ReactPointerEvent, RefObject } from 'react'
 import { useCallback, useEffect, useRef } from 'react'
 
@@ -63,6 +64,15 @@ export function TextInput({ position, selection, fontSize, color, onConfirm, onC
       onConfirmRef.current(text)
     } else {
       onCancelRef.current()
+    }
+  }, [])
+
+  // The overlay outranks the macOS IME candidate window, which would leave the user
+  // composing blind; main steps it down for as long as this editor is open.
+  useEffect(() => {
+    void ipcApi.request('screenshot.text_editing', { editing: true })
+    return () => {
+      void ipcApi.request('screenshot.text_editing', { editing: false })
     }
   }, [])
 

--- a/src/shared/ipc/schemas/screenshot.ts
+++ b/src/shared/ipc/schemas/screenshot.ts
@@ -102,6 +102,15 @@ export const screenshotRequestSchemas = {
    */
   'screenshot.overlay_ready': defineRoute({ input: z.object({ mediaId: z.string() }), output: z.void() }),
   /**
+   * The text-annotation editor opened (`true`) or closed (`false`) on the calling overlay.
+   *
+   * macOS only in effect. The IME candidate window is placed at a fixed, low window level
+   * for a Chromium client, so an overlay sitting above the Dock and menu bar covers the
+   * candidates completely — text can be composed but nothing can be chosen. Main drops
+   * this overlay below that level while the editor is open and restores it on close.
+   */
+  'screenshot.text_editing': defineRoute({ input: z.object({ editing: z.boolean() }), output: z.void() }),
+  /**
    * OCR a region of the frozen capture. Cropping happens in main so the full-size
    * image never crosses the process boundary.
    *


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On macOS, entering text with the screenshot overlay's text-annotation tool showed no IME candidate window for input methods that use one (the built-in Simplified Chinese IME, and any other composition-based IME whose candidate window sits at a low window level). Characters could be composed and committed, but the candidate list was never visible, so choosing a character was guesswork.

After this PR:

The first time a composition starts in the text editor, the overlay steps down to the `floating` window level, below the candidate window, and returns to `screen-saver` when the editor closes or the session ends. The candidates are visible from then on.

The trigger is the first composition rather than the editor opening, so someone typing without an IME never pays for this: the overlay keeps covering the Dock and the menu bar exactly as before. The step-down is not undone on `compositionend` either — restoring between words would flash both strips on and off through a whole sentence.

N/A — reported directly, no tracking issue.

### Why we need it and why it was done in this way

The candidate window's placement is decided by the input method after querying the client through `NSTextInputClient`. For a Chromium client it lands at a fixed window level 20 rather than above the client window, so any overlay raised over the Dock (20) and the menu bar (24) covers it.

This was measured, not inferred. Sampling `CGWindowListCopyWindowInfo` while composing, with the overlay set to each level in turn:

| Overlay level | Candidate bar level | Candidates visible |
|---|---|---|
| 1000 `screen-saver` (before) | 20 | no |
| 103 | 20 | no |
| 102 | 20 | no |
| 25 `status` | 20 | no |
| 3 `floating` | 20 | yes |

The candidate bar is owned by the client process and tracks the caret correctly (`397x28`, moving with each keystroke, `alpha=1`, on-screen) — it is covered, not missing or mispositioned.

The following tradeoffs were made:

- **Once a composition has started, the Dock and the menu bar are visible and interactive for the rest of that edit.** They draw over the frozen capture, and clicks in those strips go to them rather than to the overlay — so the region they cover cannot receive a text annotation. This is a real limitation with no known way around it; it is confined to the text tool after an IME composition, and the exported PNG comes from the frozen bitmap and is unaffected.
- **`WindowManager` gained a temporary level override** (`behavior.setAlwaysOnTopLevel`) instead of the service calling `window.setAlwaysOnTop` directly. Going direct would bypass the registry as the single source of truth, and the `reapplyAlwaysOnTop` quirk re-applies the declared level on every show — it would silently undo the override.
- **No unit test for the level switch itself.** What is testable and worth testing is the regression it can cause: overlays are pooled, so an override left behind by a session that ended mid-edit would come back on the next capture and stop covering the Dock. That case is covered; the switch itself is verified manually.

The following alternatives were considered:

- **A static overlay level satisfying both constraints** — none exists. Covering the menu bar needs ≥25; showing the candidates needs <20.
- **Making the IME elevate the candidates above the overlay, as it does for Qt clients** (Snipaste, measured at level 102 with its candidates at 103) — this lives in Chromium's `NSTextInputClient` implementation and no Electron API reaches it. A native addon swizzling Chromium's private classes was judged too fragile, and an upstream Chromium change unrealistic to wait for, since Chrome itself never runs a renderer window above level 20.
- **Hiding the Dock and menu bar via macOS presentation options**, allowing a permanently low level — would avoid the visual split, but Electron does not expose the API directly and the overlay's own configuration notes that transparent windows crash on fullscreen-adjacent paths.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

**This fixes the problem on macOS only, and only macOS was tested.** The step-down is gated to macOS at all three call sites: the renderer reports editor open/close only there, `setTextEditing` returns early elsewhere, and session cleanup restores the level only there. On the other platforms the overlay keeps its topmost level throughout, exactly as before.

Whether input methods on Windows and Linux hit the same problem is **unverified** — I have no machine to test on. If a composition-based IME is covered by the overlay there too, it needs its own investigation and its own fix; please don't read this PR as clearing those platforms. Maintainers with access, your attention here would be appreciated.

The macOS behavior in this PR was verified on a real machine: candidates visible while editing, level restored on close, level correct on a second capture, multi-display, and — after the composition gate was added — candidates visible from the first composition onward, with the Dock and the menu bar staying covered throughout for input that never composes.

One pre-existing quirk survives and is out of scope here: the candidate window is placed slightly off on the very first composition and correct from the second on. It was present before the composition gate (observed while testing the plain `floating` level), it is a caret-rect timing problem inside Chromium rather than a stacking one, and it needs its own fix.

The platform gating could not be verified on a real machine — it only changes the non-macOS paths, and it is backed by static checks and unit tests alone.

The `reapplyAlwaysOnTop` quirk now reads the override at fire time rather than capturing the level when the patch is installed — the override is always set long after that. An override replaces the declared `relativeLevel` rather than stacking onto it, since the two express one offset.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the IME candidate window not being visible when adding text annotations to a screenshot on macOS. While the text editor is open the overlay no longer covers the Dock and the menu bar, so those two strips cannot receive a text annotation.
```



