### PR TITLE
fix(horizontal-scroll): avoid duplicate resize listeners

### DIFF
--- a/src/renderer/components/HorizontalScrollContainer.tsx
+++ b/src/renderer/components/HorizontalScrollContainer.tsx
@@ -84,16 +84,23 @@ const HorizontalScrollContainer: React.FC<HorizontalScrollContainerProps> = ({
       checkScrollability()
     }
 
-    const resizeObserver = new ResizeObserver(checkScrollability)
-    resizeObserver.observe(scrollElement)
+    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(checkScrollability)
+
+    if (resizeObserver) {
+      resizeObserver.observe(scrollElement)
+    } else {
+      window.addEventListener('resize', checkScrollability)
+    }
 
     scrollElement.addEventListener('scroll', handleScroll)
-    window.addEventListener('resize', checkScrollability)
 
     return () => {
-      resizeObserver.disconnect()
+      if (resizeObserver) {
+        resizeObserver.disconnect()
+      } else {
+        window.removeEventListener('resize', checkScrollability)
+      }
       scrollElement.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('resize', checkScrollability)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies)

--- a/src/renderer/components/__tests__/HorizontalScrollContainer.test.tsx
+++ b/src/renderer/components/__tests__/HorizontalScrollContainer.test.tsx
@@ -51,6 +51,52 @@ describe('HorizontalScrollContainer', () => {
 
   afterEach(() => {
     globalThis.ResizeObserver = originalResizeObserver
+    vi.restoreAllMocks()
+  })
+
+  it('uses ResizeObserver without registering a window resize listener', () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = render(
+      <HorizontalScrollContainer>
+        <span>Tokens: 42</span>
+      </HorizontalScrollContainer>
+    )
+
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('resize', expect.any(Function))
+
+    unmount()
+
+    expect(resizeObserverInstances[0]?.disconnect).toHaveBeenCalledOnce()
+    expect(removeEventListenerSpy).not.toHaveBeenCalledWith('resize', expect.any(Function))
+  })
+
+  it('falls back to window resize events and removes the listener on unmount', () => {
+    globalThis.ResizeObserver = undefined as unknown as typeof ResizeObserver
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = render(
+      <HorizontalScrollContainer>
+        <span>Tokens: 42</span>
+      </HorizontalScrollContainer>
+    )
+
+    const content = screen.getByText('Tokens: 42').closest('[data-scrolling]') as HTMLElement
+    setElementSize(content, { clientWidth: 100, scrollWidth: 300 })
+    fireEvent.resize(window)
+
+    expect(document.querySelector('.scroll-right-button')).toBeInTheDocument()
+
+    const resizeListener = (
+      addEventListenerSpy.mock.calls as unknown as Array<[string, EventListenerOrEventListenerObject]>
+    ).find(([eventName]) => eventName === 'resize')?.[1]
+    expect(resizeListener).toBeTypeOf('function')
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', resizeListener)
   })
 
   it('renders the scroll button above the scroll content layer', () => {


### PR DESCRIPTION
### What this PR does

Before this PR:

Each `HorizontalScrollContainer` registered both a `ResizeObserver` and a global `window.resize` listener, so the same layout change could trigger duplicate measurements for every mounted container.

After this PR:

`ResizeObserver` is the sole resize signal when available. Environments without it fall back to `window.resize`, with both paths preserving scroll handling and cleaning up their own subscriptions.

Fixes #18935

### Why we need it and why it was done in this way

The following tradeoffs were made:

The fallback remains for environments without `ResizeObserver`, while modern environments avoid the duplicate global listener.

The following alternatives were considered:

Keeping both signals and deduplicating callbacks was rejected because it would retain one global listener per mounted container without adding useful coverage.

Links to places where the discussion took place: #18935

### Breaking changes

None.

### Special notes for your reviewer

Focused tests cover the `ResizeObserver` primary path, the `window.resize` fallback, and cleanup. `pnpm build:check` passes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
