### PR TITLE
perf(markdown-editor): defer preview rendering

### DIFF
--- a/src/renderer/components/MarkdownEditor.tsx
+++ b/src/renderer/components/MarkdownEditor.tsx
@@ -3,7 +3,7 @@ import '@renderer/assets/styles/vendor/katex.css'
 
 import { defaultMarkdownPlugins, Markdown, withMath } from '@cherrystudio/ui'
 import type { FC } from 'react'
-import React, { useEffect, useId, useState } from 'react'
+import { memo, useDeferredValue, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface MarkdownEditorProps {
@@ -14,6 +14,20 @@ interface MarkdownEditorProps {
   autoFocus?: boolean
 }
 
+interface MarkdownPreviewProps {
+  id: string
+  value: string
+  fallback: string
+}
+
+const MarkdownPreview = memo(({ id, value, fallback }: MarkdownPreviewProps) => (
+  <div className="markdown flex-1 overflow-auto bg-background p-3">
+    <Markdown id={id} plugins={{ cjk: defaultMarkdownPlugins.cjk, math: withMath() }}>
+      {value || fallback}
+    </Markdown>
+  </div>
+))
+
 const MarkdownEditor: FC<MarkdownEditorProps> = ({
   value,
   onChange,
@@ -23,32 +37,22 @@ const MarkdownEditor: FC<MarkdownEditorProps> = ({
 }) => {
   const { t } = useTranslation()
   const markdownId = useId()
-  const [inputValue, setInputValue] = useState(value || '')
-
-  useEffect(() => {
-    setInputValue(value || '')
-  }, [value])
-
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value
-    setInputValue(newValue)
-    onChange(newValue)
-  }
+  const deferredValue = useDeferredValue(value)
 
   return (
     <div className="flex w-full overflow-hidden rounded-lg border border-border" style={{ height }}>
       <textarea
         className="flex-1 resize-none border-0 border-border border-r bg-background p-3 font-[var(--font-family)] text-foreground text-sm leading-[1.5] outline-none placeholder:text-muted-foreground focus:outline-none"
-        value={inputValue}
-        onChange={handleChange}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
         placeholder={placeholder}
         autoFocus={autoFocus}
       />
-      <div className="markdown flex-1 overflow-auto bg-background p-3">
-        <Markdown id={markdownId} plugins={{ cjk: defaultMarkdownPlugins.cjk, math: withMath() }}>
-          {inputValue || t('settings.provider.notes.markdown_editor_default_value')}
-        </Markdown>
-      </div>
+      <MarkdownPreview
+        id={markdownId}
+        value={deferredValue}
+        fallback={t('settings.provider.notes.markdown_editor_default_value')}
+      />
     </div>
   )
 }

--- a/src/renderer/components/__tests__/MarkdownEditor.test.tsx
+++ b/src/renderer/components/__tests__/MarkdownEditor.test.tsx
@@ -1,0 +1,51 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import MarkdownEditor from '../MarkdownEditor'
+
+let resumePreview: (() => void) | undefined
+let pendingPreview: Promise<void> | undefined
+let previewReady = false
+
+vi.mock('@cherrystudio/ui', () => ({
+  defaultMarkdownPlugins: { cjk: [] },
+  Markdown: ({ children }: { children: string }) => {
+    if (children === 'updated notes' && !previewReady) {
+      pendingPreview ??= new Promise<void>((resolve) => {
+        resumePreview = () => {
+          previewReady = true
+          resolve()
+        }
+      })
+      throw pendingPreview
+    }
+
+    return <div>{children}</div>
+  },
+  withMath: () => []
+}))
+
+function ControlledMarkdownEditor() {
+  const [value, setValue] = useState('initial notes')
+  return <MarkdownEditor value={value} onChange={setValue} />
+}
+
+describe('MarkdownEditor', () => {
+  it('updates the textarea while the deferred preview is still rendering', async () => {
+    render(<ControlledMarkdownEditor />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'updated notes' } })
+
+    expect(textarea).toHaveValue('updated notes')
+    expect(screen.getByText('initial notes')).toBeVisible()
+
+    await act(async () => {
+      resumePreview?.()
+      await pendingPreview
+    })
+
+    expect(screen.getByText('updated notes', { selector: 'div' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Typing in the provider model-notes editor synchronously rebuilt the Markdown and KaTeX preview on every controlled value update.

After this PR:

The textarea remains controlled and updates urgently, while a memoized preview boundary renders a deferred value.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18939

### Why we need it and why it was done in this way

Long Markdown notes, especially notes containing math, could make typing compete directly with expensive preview parsing and reconciliation. `useDeferredValue` keeps the existing `value`/`onChange` contract while allowing React to prioritize the textarea update, and the memoized boundary prevents the preview from rendering urgent parent updates that do not change its deferred inputs.

The following tradeoffs were made:

The preview may briefly lag behind the textarea while React completes expensive Markdown rendering.

The following alternatives were considered:

Debouncing the preview would add a fixed delay and timer state. Mirroring the controlled value in local state would retain the redundant derived-state effect. Neither is needed for this fix.

Links to places where the discussion took place: #18939

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Focused regression coverage suspends the new preview render and verifies that the controlled textarea updates immediately while the previous preview remains visible.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Keep the provider model-notes editor responsive while rendering Markdown and math previews.
```
