### PR TITLE
perf(message-selection): coalesce drag selection updates

### DIFF
--- a/src/renderer/components/chat/messages/list/SelectionBox.tsx
+++ b/src/renderer/components/chat/messages/list/SelectionBox.tsx
@@ -7,8 +7,19 @@ interface SelectionBoxProps {
   handleSelectMessage: (messageId: string, selected: boolean) => void
 }
 
+interface Position {
+  x: number
+  y: number
+}
+
+interface DragBox {
+  start: Position
+  current: Position
+}
+
 const INTERACTIVE_CHECKBOX_SELECTOR = 'input[type="checkbox"], [data-slot=checkbox], [role="checkbox"]'
 const MESSAGE_SELECT_CHECKBOX_SELECTOR = '[data-message-select-checkbox]'
+const DRAG_THRESHOLD = 5
 
 function getMessageCheckbox(element: HTMLElement): HTMLElement | null {
   return element.querySelector<HTMLElement>(MESSAGE_SELECT_CHECKBOX_SELECTOR)
@@ -28,28 +39,29 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({
   messageElements,
   handleSelectMessage
 }) => {
-  const [isDragging, setIsDragging] = useState(false)
-  const [dragStart, setDragStart] = useState({ x: 0, y: 0 })
-  const [dragCurrent, setDragCurrent] = useState({ x: 0, y: 0 })
-  const [isMouseDown, setIsMouseDown] = useState(false)
-
+  const [dragBox, setDragBox] = useState<DragBox | null>(null)
+  const isMouseDown = useRef(false)
+  const isDragging = useRef(false)
+  const dragStart = useRef<Position | null>(null)
+  const pendingPointer = useRef<Position | null>(null)
+  const animationFrame = useRef<number | null>(null)
   const dragSelectedIds = useRef<Set<string>>(new Set())
-
-  // 拖拽阈值，只有移动距离超过这个值才开始框选
-  // 避免触控板点击触发拖拽
-  const DRAG_THRESHOLD = 5
+  const highlightTimers = useRef<Set<ReturnType<typeof setTimeout>>>(new Set())
 
   useEffect(() => {
-    let handleMouseMoveTimer: NodeJS.Timeout
-    if (!isMultiSelectMode) return
+    if (!isMultiSelectMode) {
+      setDragBox(null)
+    }
+  }, [isMultiSelectMode])
 
-    const updateDragPos = (e: MouseEvent) => {
-      const container = scrollContainerRef.current!
-      if (!container) return { x: 0, y: 0 }
-      const rect = container.getBoundingClientRect()
+  useEffect(() => {
+    if (!isMultiSelectMode) return
+    const timers = highlightTimers.current
+
+    const updateDragPos = (pointer: Position, container: HTMLDivElement, containerRect: DOMRect): Position => {
       return {
-        x: e.clientX - rect.left + container.scrollLeft,
-        y: e.clientY - rect.top + container.scrollTop
+        x: pointer.x - containerRect.left + container.scrollLeft,
+        y: pointer.y - containerRect.top + container.scrollTop
       }
     }
 
@@ -59,54 +71,57 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({
 
       e.preventDefault()
 
-      setIsMouseDown(true)
-      const pos = updateDragPos(e)
-      setDragStart(pos)
-      setDragCurrent(pos)
+      const container = scrollContainerRef.current
+      if (!container) return
+
+      isMouseDown.current = true
+      dragStart.current = updateDragPos({ x: e.clientX, y: e.clientY }, container, container.getBoundingClientRect())
+      pendingPointer.current = null
       dragSelectedIds.current.clear()
     }
 
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isMouseDown) return
+    const processMouseMove = () => {
+      animationFrame.current = null
 
-      const pos = updateDragPos(e)
+      const pointer = pendingPointer.current
+      const start = dragStart.current
+      const container = scrollContainerRef.current
+      pendingPointer.current = null
+      if (!pointer || !start || !container || !isMouseDown.current) return
 
-      const deltaX = Math.abs(pos.x - dragStart.x)
-      const deltaY = Math.abs(pos.y - dragStart.y)
+      const containerRect = container.getBoundingClientRect()
+      const pos = updateDragPos(pointer, container, containerRect)
+
+      const deltaX = Math.abs(pos.x - start.x)
+      const deltaY = Math.abs(pos.y - start.y)
       const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY)
 
-      if (!isDragging && distance > DRAG_THRESHOLD) {
-        setIsDragging(true)
+      if (!isDragging.current && distance > DRAG_THRESHOLD) {
+        isDragging.current = true
         document.body.classList.add('no-select')
       }
 
-      if (!isDragging) return
+      if (!isDragging.current) return
 
-      e.preventDefault()
-      setDragCurrent(pos)
+      setDragBox({ start, current: pos })
 
-      // 计算当前框选矩形
-      const left = Math.min(dragStart.x, pos.x)
-      const right = Math.max(dragStart.x, pos.x)
-      const top = Math.min(dragStart.y, pos.y)
-      const bottom = Math.max(dragStart.y, pos.y)
+      const left = Math.min(start.x, pos.x)
+      const right = Math.max(start.x, pos.x)
+      const top = Math.min(start.y, pos.y)
+      const bottom = Math.max(start.y, pos.y)
 
       messageElements.forEach((el, id) => {
-        // 检查消息是否已被选中（不管是拖动选中还是手动选中）
         const checkbox = getMessageCheckbox(el)
         const isAlreadySelected = checkbox ? isCheckboxSelected(checkbox) : false
 
-        // 清除上下文这类消息也会被选中，所以需要跳过
         if (!checkbox) return
 
         const rect = el.getBoundingClientRect()
-        const container = scrollContainerRef.current!
-        const eTop = rect.top - container.getBoundingClientRect().top + container.scrollTop
-        const eLeft = rect.left - container.getBoundingClientRect().left + container.scrollLeft
+        const eTop = rect.top - containerRect.top + container.scrollTop
+        const eLeft = rect.left - containerRect.left + container.scrollLeft
         const eBottom = eTop + rect.height
         const eRight = eLeft + rect.width
 
-        // 检查消息是否在当前选择框内
         const isInSelectionBox = !(eRight < left || eLeft > right || eBottom < top || eTop > bottom)
 
         if (!isInSelectionBox) {
@@ -116,25 +131,49 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({
           return
         }
 
-        // 只有在选择框内且未被选中的消息才需要处理
         if (!dragSelectedIds.current.has(id) && !isAlreadySelected) {
           handleSelectMessage(id, true)
           dragSelectedIds.current.add(id)
           el.classList.add('selection-highlight')
-          handleMouseMoveTimer = setTimeout(() => el.classList.remove('selection-highlight'), 300)
+          const timer = setTimeout(() => {
+            el.classList.remove('selection-highlight')
+            timers.delete(timer)
+          }, 300)
+          timers.add(timer)
         }
       })
     }
 
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isMouseDown.current) return
+
+      if (isDragging.current) {
+        e.preventDefault()
+      }
+
+      pendingPointer.current = { x: e.clientX, y: e.clientY }
+      if (animationFrame.current === null) {
+        animationFrame.current = requestAnimationFrame(processMouseMove)
+      }
+    }
+
     const handleMouseUp = () => {
-      setIsMouseDown(false)
-      if (isDragging) {
-        setIsDragging(false)
+      if (animationFrame.current !== null) {
+        cancelAnimationFrame(animationFrame.current)
+        processMouseMove()
+      }
+
+      isMouseDown.current = false
+      dragStart.current = null
+      pendingPointer.current = null
+      if (isDragging.current) {
+        isDragging.current = false
+        setDragBox(null)
         document.body.classList.remove('no-select')
       }
     }
 
-    const container = scrollContainerRef.current!
+    const container = scrollContainerRef.current
     container?.addEventListener('mousedown', handleMouseDown)
     window.addEventListener('mousemove', handleMouseMove)
     window.addEventListener('mouseup', handleMouseUp)
@@ -144,20 +183,29 @@ const SelectionBox: React.FC<SelectionBoxProps> = ({
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', handleMouseUp)
       document.body.classList.remove('no-select')
-      clearTimeout(handleMouseMoveTimer)
+      if (animationFrame.current !== null) {
+        cancelAnimationFrame(animationFrame.current)
+      }
+      timers.forEach(clearTimeout)
+      timers.clear()
+      animationFrame.current = null
+      pendingPointer.current = null
+      dragStart.current = null
+      isMouseDown.current = false
+      isDragging.current = false
     }
-  }, [isMultiSelectMode, isDragging, isMouseDown, dragStart, scrollContainerRef, messageElements, handleSelectMessage])
+  }, [isMultiSelectMode, scrollContainerRef, messageElements, handleSelectMessage])
 
-  if (!isDragging || !isMultiSelectMode) return null
+  if (!dragBox || !isMultiSelectMode) return null
 
   return (
     <div
       className="pointer-events-none absolute z-100 border border-primary border-dashed bg-[rgba(0,114,245,0.1)]"
       style={{
-        left: Math.min(dragStart.x, dragCurrent.x),
-        top: Math.min(dragStart.y, dragCurrent.y),
-        width: Math.abs(dragCurrent.x - dragStart.x),
-        height: Math.abs(dragCurrent.y - dragStart.y)
+        left: Math.min(dragBox.start.x, dragBox.current.x),
+        top: Math.min(dragBox.start.y, dragBox.current.y),
+        width: Math.abs(dragBox.current.x - dragBox.start.x),
+        height: Math.abs(dragBox.current.y - dragBox.start.y)
       }}
     />
   )

--- a/src/renderer/components/chat/messages/list/__tests__/SelectionBox.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/SelectionBox.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SelectionBox from '../SelectionBox'
 
@@ -57,7 +57,45 @@ function createMessageElement({
   return element
 }
 
+function countEventListenerCalls(calls: ReadonlyArray<ReadonlyArray<unknown>>, eventType: string): number {
+  return calls.filter(([type]) => type === eventType).length
+}
+
 describe('SelectionBox', () => {
+  let animationFrames: Map<number, FrameRequestCallback>
+  let nextAnimationFrameId: number
+
+  beforeEach(() => {
+    animationFrames = new Map()
+    nextAnimationFrameId = 1
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = nextAnimationFrameId++
+        animationFrames.set(id, callback)
+        return id
+      })
+    )
+    vi.stubGlobal(
+      'cancelAnimationFrame',
+      vi.fn((id: number) => {
+        animationFrames.delete(id)
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+    document.body.classList.remove('no-select')
+  })
+
+  const flushAnimationFrame = () => {
+    const callbacks = [...animationFrames.values()]
+    animationFrames.clear()
+    act(() => callbacks.forEach((callback) => callback(performance.now())))
+  }
+
   it('selects messages inside the drag rectangle with Radix checkbox markup', () => {
     const scrollContainer = document.createElement('div')
     scrollContainer.getBoundingClientRect = vi.fn(() => createRect({ left: 0, top: 0, width: 300, height: 400 }))
@@ -101,6 +139,7 @@ describe('SelectionBox', () => {
     fireEvent.mouseDown(scrollContainer, { clientX: 0, clientY: 0 })
     fireEvent.mouseMove(window, { clientX: 20, clientY: 20 })
     fireEvent.mouseMove(window, { clientX: 130, clientY: 155 })
+    flushAnimationFrame()
 
     expect(handleSelectMessage).toHaveBeenCalledTimes(2)
     expect(handleSelectMessage).toHaveBeenNthCalledWith(1, 'first-unselected', true)
@@ -157,7 +196,9 @@ describe('SelectionBox', () => {
     fireEvent.mouseDown(scrollContainer, { clientX: 0, clientY: 0 })
     fireEvent.mouseMove(window, { clientX: 20, clientY: 20 })
     fireEvent.mouseMove(window, { clientX: 130, clientY: 155 })
+    flushAnimationFrame()
     fireEvent.mouseMove(window, { clientX: 130, clientY: 55 })
+    flushAnimationFrame()
 
     expect([...selectedMessageIds]).toEqual(['first'])
 
@@ -191,6 +232,7 @@ describe('SelectionBox', () => {
 
     fireEvent.mouseDown(checkbox, { clientX: 0, clientY: 0 })
     fireEvent.mouseMove(window, { clientX: 130, clientY: 55 })
+    flushAnimationFrame()
 
     expect(handleSelectMessage).not.toHaveBeenCalled()
 
@@ -224,12 +266,92 @@ describe('SelectionBox', () => {
     fireEvent.mouseDown(scrollContainer, { clientX: 0, clientY: 0 })
     fireEvent.mouseMove(window, { clientX: 20, clientY: 20 })
     fireEvent.mouseMove(window, { clientX: 130, clientY: 55 })
+    flushAnimationFrame()
 
     expect(handleSelectMessage).toHaveBeenCalledTimes(1)
     expect(handleSelectMessage).toHaveBeenCalledWith('message', true)
 
     fireEvent.mouseUp(window)
     view.unmount()
+    scrollContainer.remove()
+  })
+
+  it('coalesces pointer updates and selects from the latest position on the next frame', () => {
+    const scrollContainer = document.createElement('div')
+    scrollContainer.getBoundingClientRect = vi.fn(() => createRect({ left: 0, top: 0, width: 300, height: 400 }))
+
+    const message = createMessageElement({
+      checked: false,
+      rect: { left: 10, top: 110, width: 100, height: 40 }
+    })
+    scrollContainer.append(message)
+    document.body.appendChild(scrollContainer)
+
+    const handleSelectMessage = vi.fn()
+    const view = render(
+      <SelectionBox
+        isMultiSelectMode
+        scrollContainerRef={{ current: scrollContainer }}
+        messageElements={new Map([['message', message]])}
+        handleSelectMessage={handleSelectMessage}
+      />
+    )
+
+    fireEvent.mouseDown(scrollContainer, { clientX: 0, clientY: 0 })
+    fireEvent.mouseMove(window, { clientX: 20, clientY: 20 })
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 155 })
+
+    expect(handleSelectMessage).not.toHaveBeenCalled()
+    expect(scrollContainer.getBoundingClientRect).toHaveBeenCalledTimes(1)
+
+    flushAnimationFrame()
+
+    expect(handleSelectMessage).toHaveBeenCalledOnce()
+    expect(handleSelectMessage).toHaveBeenCalledWith('message', true)
+    expect(scrollContainer.getBoundingClientRect).toHaveBeenCalledTimes(2)
+
+    fireEvent.mouseUp(window)
+    view.unmount()
+    scrollContainer.remove()
+  })
+
+  it('keeps one set of global listeners while drag state renders', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener')
+    const removeEventListener = vi.spyOn(window, 'removeEventListener')
+    const scrollContainer = document.createElement('div')
+    scrollContainer.getBoundingClientRect = vi.fn(() => createRect({ left: 0, top: 0, width: 300, height: 400 }))
+
+    const message = createMessageElement({
+      checked: false,
+      rect: { left: 10, top: 10, width: 100, height: 40 }
+    })
+    scrollContainer.append(message)
+    document.body.appendChild(scrollContainer)
+
+    const view = render(
+      <SelectionBox
+        isMultiSelectMode
+        scrollContainerRef={{ current: scrollContainer }}
+        messageElements={new Map([['message', message]])}
+        handleSelectMessage={vi.fn()}
+      />
+    )
+
+    fireEvent.mouseDown(scrollContainer, { clientX: 0, clientY: 0 })
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 55 })
+    flushAnimationFrame()
+
+    expect(countEventListenerCalls(addEventListener.mock.calls, 'mousemove')).toBe(1)
+    expect(countEventListenerCalls(addEventListener.mock.calls, 'mouseup')).toBe(1)
+    expect(countEventListenerCalls(removeEventListener.mock.calls, 'mousemove')).toBe(0)
+    expect(countEventListenerCalls(removeEventListener.mock.calls, 'mouseup')).toBe(0)
+
+    fireEvent.mouseUp(window)
+    view.unmount()
+
+    expect(countEventListenerCalls(removeEventListener.mock.calls, 'mousemove')).toBe(1)
+    expect(countEventListenerCalls(removeEventListener.mock.calls, 'mouseup')).toBe(1)
+
     scrollContainer.remove()
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

SelectionBox handled every raw mousemove immediately, repeatedly read the container rect for each message, and recreated global listeners as transient drag state changed.

After this PR:

SelectionBox keeps transient gesture state in refs, coalesces mousemove work into one animation frame, reads the container rect once per frame, and preserves selection, deselection, highlight, and cleanup behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18938

### Why we need it and why it was done in this way

The following tradeoffs were made:

Selection intersection work remains linear in the rendered message count, but it now runs at most once per animation frame instead of once per raw mousemove event.

The following alternatives were considered:

Replacing the gesture implementation or selection state model was considered broader than necessary. The existing semantics are retained with a focused scheduling and state-lifetime change.

Links to places where the discussion took place: #18938

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage verifies that rapid pointer updates are coalesced and that drag-state renders do not churn global listeners, without asserting private ref or callback structure.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
