### PR TITLE
fix(renderer): keep the theme context value stable across language-only updates

### DIFF
--- a/src/renderer/components/ThemeProvider.tsx
+++ b/src/renderer/components/ThemeProvider.tsx
@@ -6,7 +6,7 @@ import { ipcApi, useIpcOn } from '@renderer/ipc'
 import { isMac, isWin } from '@renderer/utils/platform'
 import { ThemeMode } from '@shared/data/preference/preferenceTypes'
 import type { PropsWithChildren } from 'react'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 interface ThemeProviderProps extends PropsWithChildren {
   defaultTheme?: ThemeMode
@@ -39,14 +39,23 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
   // listen for theme updates from main process
   useIpcOn('system.native_theme_updated', (actualTheme) => setActualTheme(actualTheme))
 
-  const toggleTheme = () => {
+  const toggleTheme = useCallback(() => {
     const nextTheme = {
       [ThemeMode.light]: ThemeMode.dark,
       [ThemeMode.dark]: ThemeMode.system,
       [ThemeMode.system]: ThemeMode.light
     }[settedTheme]
     void setSettedTheme(nextTheme || ThemeMode.system)
-  }
+  }, [settedTheme, setSettedTheme])
+
+  // The provider also subscribes to app.language (for the document lang effect
+  // above), so a language-only update re-renders it. Keep the context value
+  // referentially stable across those renders: dozens of consumers read only
+  // the theme fields and must not re-render when the theme has not changed.
+  const contextValue = useMemo(
+    () => ({ theme: actualTheme, settedTheme, toggleTheme, setTheme: setSettedTheme }),
+    [actualTheme, settedTheme, toggleTheme, setSettedTheme]
+  )
 
   useEffect(() => {
     // Set initial theme and OS attributes on body
@@ -98,9 +107,5 @@ export const ThemeProvider: React.FC<ThemeProviderProps> = ({ children }) => {
     }
   }, [settedTheme])
 
-  return (
-    <ThemeContext value={{ theme: actualTheme, settedTheme: settedTheme, toggleTheme, setTheme: setSettedTheme }}>
-      {children}
-    </ThemeContext>
-  )
+  return <ThemeContext value={contextValue}>{children}</ThemeContext>
 }

--- a/src/renderer/components/__tests__/ThemeProvider.test.tsx
+++ b/src/renderer/components/__tests__/ThemeProvider.test.tsx
@@ -93,3 +93,62 @@ describe('ThemeProvider first frame', () => {
     expect(ipcMocks.request).toHaveBeenCalledWith('system.get_native_theme')
   })
 })
+
+// NOTE: this describe must stay last in the file. mockPreferenceReturn swaps the
+// shared mock's implementation for the rest of the file (vitest isolates per file),
+// so no test declared after it would see the default preference behavior.
+describe('ThemeProvider context stability', () => {
+  beforeEach(() => {
+    MockUsePreferenceUtils.resetMocks()
+    MockUsePreferenceUtils.setPreferenceValue('ui.theme_user.color_primary', '#00b96b')
+    ipcMocks.request.mockReset()
+    ipcMocks.request.mockResolvedValue(ThemeMode.dark)
+    ipcMocks.useIpcOn.mockClear()
+  })
+
+  it('keeps the context value referentially stable across a language-only update', () => {
+    // The real usePreference memoizes the setter per key; the shared mock
+    // builds a fresh one per render, which would defeat the memoization this
+    // test locks in. Pin a stable setter for the theme key only.
+    const stableSetTheme = vi.fn().mockResolvedValue(undefined)
+    MockUsePreferenceUtils.mockPreferenceReturn('ui.theme_mode', ThemeMode.dark, stableSetTheme)
+    stubMatchMedia(false)
+
+    const seen: unknown[] = []
+    function ValueProbe(): null {
+      seen.push(useTheme())
+      return null
+    }
+
+    const { rerender } = render(
+      <ThemeProvider>
+        <ValueProbe />
+      </ThemeProvider>
+    )
+    expect(seen.length).toBeGreaterThan(0)
+
+    // A language-only update re-renders the provider (it subscribes to
+    // app.language for the document-lang effect); the theme context value
+    // must stay the same object so theme-only consumers do not rerender.
+    MockUsePreferenceUtils.setPreferenceValue('app.language', 'zh-CN')
+    MockUsePreferenceUtils.mockPreferenceReturn('ui.theme_mode', ThemeMode.dark, stableSetTheme)
+    rerender(
+      <ThemeProvider>
+        <ValueProbe />
+      </ThemeProvider>
+    )
+
+    expect(seen.at(-1)).toBe(seen[0])
+
+    // Control: a real theme change must produce a fresh value.
+    MockUsePreferenceUtils.mockPreferenceReturn('ui.theme_mode', ThemeMode.light, stableSetTheme)
+    rerender(
+      <ThemeProvider>
+        <ValueProbe />
+      </ThemeProvider>
+    )
+
+    expect(seen.at(-1)).not.toBe(seen[0])
+    expect((seen.at(-1) as { theme: ThemeMode }).theme).toBe(ThemeMode.light)
+  })
+})


### PR DESCRIPTION
Fixes #18936.

`ThemeProvider` subscribes to `app.language` for the document-lang effect, so a language-only update re-renders it. The context value was rebuilt inline and `toggleTheme` was a fresh closure each time, so every one of those renders invalidated all `useTheme()` consumers (message and editor surfaces included) even though neither `theme` nor `settedTheme` changed.

`toggleTheme` is now a `useCallback` and the context value a `useMemo`, so a language-only render keeps the value referentially identical and theme-only consumers stay put. `usePreference`'s setter is already memoized per key (its `options` here is a module-level constant), so the memo's inputs are all stable across a language update.

The `lang` side effect is untouched: `language` remains a dependency of the body effect, just not of the context value.

### Tests

New regression test: a language-only update leaves the context value referentially identical, and a real theme change produces a fresh one. The shared usePreference mock builds a fresh setter per render (the real hook memoizes it), so the test pins a stable setter for the theme key; that constraint is noted in the file since the mock override must stay last.

`pnpm vitest run src/renderer/components` — 384 files / 4058 tests pass. eslint clean on both touched files.
