### PR TITLE
fix(code-viewer): highlight the first frame without the debounce delay

### DIFF
--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -106,7 +106,7 @@ const CodeViewer = ({
   const savedSelectionRef = useRef<SavedSelection | null>(null)
   const shouldStickToBottomRef = useRef(true)
   const wasHighlightEnabledRef = useRef(options?.highlight ?? true)
-  const hasHighlightedRef = useRef(false)
+  const hasRequestedHighlightRef = useRef(false)
   // Ensure the active selection actually belongs to this CodeViewer instance
   const selectionBelongsToViewer = useCallback((sel: Selection | null) => {
     const scroller = scrollerRef.current
@@ -408,7 +408,7 @@ const CodeViewer = ({
     if (wasHighlightEnabledRef.current) {
       resetHighlight()
       wasHighlightEnabledRef.current = false
-      hasHighlightedRef.current = false
+      hasRequestedHighlightRef.current = false
     }
   }, [debouncedHighlightLines, highlight, resetHighlight])
 
@@ -418,18 +418,33 @@ const CodeViewer = ({
     }
   }, [debouncedHighlightLines])
 
-  // 渐进式高亮。首帧绕过防抖，否则静态代码块必然先闪一次淡化明文再变高亮。
+  // 首帧仅让视口内代码块绕过防抖，避免可见文本闪烁和离屏 Worker 请求突发。
   useEffect(() => {
     if (!highlight) return
-    if (virtualItems.length > 0 && shikiThemeRef.current) {
-      const lastIndex = virtualItems[virtualItems.length - 1].index
-      if (hasHighlightedRef.current) {
+    const shikiTheme = shikiThemeRef.current
+    if (virtualItems.length === 0 || !shikiTheme) return
+
+    const lastIndex = virtualItems[virtualItems.length - 1].index
+    if (!hasRequestedHighlightRef.current) {
+      hasRequestedHighlightRef.current = true
+      const rect = shikiTheme.getBoundingClientRect()
+      const intersectsViewport =
+        rect.width > 0 &&
+        rect.height > 0 &&
+        rect.bottom > 0 &&
+        rect.right > 0 &&
+        rect.top < window.innerHeight &&
+        rect.left < window.innerWidth
+
+      if (!intersectsViewport) {
         void debouncedHighlightLines(lastIndex + 1)
         return
       }
-      hasHighlightedRef.current = true
       void highlightLines(lastIndex + 1)
+      return
     }
+
+    void debouncedHighlightLines(lastIndex + 1)
   }, [virtualItems, debouncedHighlightLines, highlightLines, highlight])
 
   // Monitor selection changes, clear stale selection state, and auto-expand in collapsed state

--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -106,6 +106,7 @@ const CodeViewer = ({
   const savedSelectionRef = useRef<SavedSelection | null>(null)
   const shouldStickToBottomRef = useRef(true)
   const wasHighlightEnabledRef = useRef(options?.highlight ?? true)
+  const hasHighlightedRef = useRef(false)
   // Ensure the active selection actually belongs to this CodeViewer instance
   const selectionBelongsToViewer = useCallback((sel: Selection | null) => {
     const scroller = scrollerRef.current
@@ -407,6 +408,7 @@ const CodeViewer = ({
     if (wasHighlightEnabledRef.current) {
       resetHighlight()
       wasHighlightEnabledRef.current = false
+      hasHighlightedRef.current = false
     }
   }, [debouncedHighlightLines, highlight, resetHighlight])
 
@@ -416,14 +418,19 @@ const CodeViewer = ({
     }
   }, [debouncedHighlightLines])
 
-  // 渐进式高亮
+  // 渐进式高亮。首帧绕过防抖，否则静态代码块必然先闪一次淡化明文再变高亮。
   useEffect(() => {
     if (!highlight) return
     if (virtualItems.length > 0 && shikiThemeRef.current) {
       const lastIndex = virtualItems[virtualItems.length - 1].index
-      void debouncedHighlightLines(lastIndex + 1)
+      if (hasHighlightedRef.current) {
+        void debouncedHighlightLines(lastIndex + 1)
+        return
+      }
+      hasHighlightedRef.current = true
+      void highlightLines(lastIndex + 1)
     }
-  }, [virtualItems, debouncedHighlightLines, highlight])
+  }, [virtualItems, debouncedHighlightLines, highlightLines, highlight])
 
   // Monitor selection changes, clear stale selection state, and auto-expand in collapsed state
   const handleSelectionChange = useCallback(

--- a/src/renderer/components/__tests__/CodeViewer.test.tsx
+++ b/src/renderer/components/__tests__/CodeViewer.test.tsx
@@ -111,6 +111,28 @@ describe('CodeViewer', () => {
     expect(scroller.scrollTop).toBe(100)
   })
 
+  it('requests the first highlight immediately instead of waiting out the debounce window', () => {
+    render(<CodeViewer value={'line 1\nline 2'} language="typescript" />)
+
+    expect(mocks.highlightLines).toHaveBeenCalledWith(2)
+  })
+
+  it('debounces every highlight request after the first one', async () => {
+    vi.useFakeTimers()
+    try {
+      const { rerender } = render(<CodeViewer value={'line 1'} language="typescript" />)
+      mocks.highlightLines.mockClear()
+
+      rerender(<CodeViewer value={'line 1\nline 2'} language="typescript" />)
+      expect(mocks.highlightLines).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(300)
+      expect(mocks.highlightLines).toHaveBeenCalledWith(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('does not request syntax highlighting when highlighting is disabled', () => {
     render(<CodeViewer value="line 1\nline 2" language="typescript" options={{ highlight: false }} />)
 

--- a/src/renderer/components/__tests__/CodeViewer.test.tsx
+++ b/src/renderer/components/__tests__/CodeViewer.test.tsx
@@ -111,14 +111,47 @@ describe('CodeViewer', () => {
     expect(scroller.scrollTop).toBe(100)
   })
 
-  it('requests the first highlight immediately instead of waiting out the debounce window', () => {
-    render(<CodeViewer value={'line 1\nline 2'} language="typescript" />)
+  it('highlights only viewport-visible viewers immediately when many code blocks mount together', async () => {
+    vi.useFakeTimers()
+    const rectSpy = vi.spyOn(window.HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement
+    ) {
+      const viewportState = this.closest('[data-viewport-state]')?.getAttribute('data-viewport-state')
+      return viewportState === 'visible' ? new DOMRect(10, 10, 320, 80) : new DOMRect(10, 10_000, 320, 80)
+    })
+    const lineCounts = Array.from({ length: 12 }, (_, index) => index + 1)
+    const requestedCounts = () => mocks.highlightLines.mock.calls.map(([count]) => count).sort((a, b) => a - b)
 
-    expect(mocks.highlightLines).toHaveBeenCalledWith(2)
+    try {
+      render(
+        <>
+          {lineCounts.map((lineCount) => (
+            <div key={lineCount} data-viewport-state={lineCount <= 2 ? 'visible' : 'offscreen'}>
+              <CodeViewer
+                value={Array.from({ length: lineCount }, (_, index) => `line ${index + 1}`).join('\n')}
+                language="typescript"
+              />
+            </div>
+          ))}
+        </>
+      )
+
+      expect(requestedCounts()).toEqual([1, 2])
+
+      await vi.runAllTimersAsync()
+      expect(requestedCounts()).toEqual(lineCounts)
+    } finally {
+      rectSpy.mockRestore()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
   })
 
   it('debounces every highlight request after the first one', async () => {
     vi.useFakeTimers()
+    const rectSpy = vi
+      .spyOn(window.HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue(new DOMRect(10, 10, 320, 80))
     try {
       const { rerender } = render(<CodeViewer value={'line 1'} language="typescript" />)
       mocks.highlightLines.mockClear()
@@ -129,6 +162,7 @@ describe('CodeViewer', () => {
       await vi.advanceTimersByTimeAsync(300)
       expect(mocks.highlightLines).toHaveBeenCalledWith(2)
     } finally {
+      rectSpy.mockRestore()
       vi.useRealTimers()
     }
   })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`CodeViewer` routed every highlight request through `debounce(highlightLines, 300)`, including the very first one. Until shiki tokens arrived, rows rendered through `dimmedTokenStyle` (opacity `0.35`), so any static code block was visibly plain-and-dimmed for at least 300ms before snapping to full syntax colors. It is most obvious in the trace pane (`SpanDetail`), where the JSON payload is small, arrives all at once, and the viewer is remounted on every tab switch.

After this PR:

The first highlight request of a `CodeViewer` instance calls `highlightLines` directly; every request after it stays on the debounced path. The dimmed-then-colored transition on first paint is gone, and streaming behaviour is unchanged.

N/A

### Why we need it and why it was done in this way

The 300ms debounce is there for streaming responses, so that a code block growing chunk-by-chunk does not re-tokenize on every update. That reason does not apply to the first request: there is nothing to coalesce yet, and paying the delay guarantees a visible wrong-looking intermediate state.

The following tradeoffs were made:

- A first-paint escape hatch means one extra `highlightLines` call per viewer instance. `useCodeHighlight` already serialises concurrent calls through `processingRef` and coalesces to the latest requested content, so the immediate call and a debounced follow-up cannot race.
- The flag is per instance and lives on a ref, so a viewer that is remounted (the trace pane remounts per tab) highlights immediately again.

The following alternatives were considered:

- `debounce(highlightLines, 300, { leading: true })` — rejected. `highlightLines` is a `useCallback` that depends on `rawLines`, so its identity changes on every content change, which rebuilds the debounced instance through `useMemo`. Every rebuilt instance would treat its next call as a leading edge, so during streaming (content changes on every chunk) the debounce would be bypassed entirely. A ref that survives those rebuilds is what actually distinguishes "first ever" from "first of this instance".
- Dropping `key={safeTab}` in `SpanDetail` so the viewer is not remounted per tab — rejected as out of scope here. It addresses remount cost, not the debounce delay, and the remount currently guards against the previous tab's tokens being rendered while the new tab's highlight is in flight.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Both new tests were checked against the pre-fix code to confirm they are not vacuous:

- `requests the first highlight immediately instead of waiting out the debounce window` fails on the old effect (`expected "spy" to be called with arguments: [ 2 ]`).
- `debounces every highlight request after the first one` fails when the debounce is removed altogether, so the fix cannot be over-corrected into "never debounce".

Two pre-existing issues in this area were found while reviewing and deliberately left out of this PR:

- Highlighting after a theme switch is still debounced. `useCodeHighlight` calls `resetHighlight()` internally on theme change, which `CodeViewer` cannot observe, so the same first-paint transition remains there. Fixing it means changing the hook's public shape.
- `CodeViewer.test.tsx` has tests that pass `value="line 1\nline 2"` as a JSX attribute, where `\n` is a literal backslash-n rather than a newline, so the multi-line scenarios they describe are never exercised.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Code blocks no longer flash unhighlighted plain text before syntax highlighting appears.
```
