### PR TITLE
fix(conversation-routing): prevent stale session actions

### DIFF
--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -256,10 +256,9 @@ const AgentPage = () => {
     routeSessionId
   ])
   const lastVisibleSessionRef = useRef<AgentSessionEntity | null>(null)
-  const resolvedActiveSession = activeSession?.id === activeSessionId ? activeSession : null
   const visibleSession = isMessageOnlyView
     ? routeSession
-    : (resolvedActiveSession ??
+    : (activeSession ??
       (isActiveSessionLoading && lastVisibleSessionRef.current?.id === activeSessionId
         ? lastVisibleSessionRef.current
         : null))
@@ -367,8 +366,8 @@ const AgentPage = () => {
   }, [activeSession, isMessageOnlyView])
 
   useEffect(() => {
-    if (resolvedActiveSession) lastVisibleSessionRef.current = resolvedActiveSession
-  }, [resolvedActiveSession])
+    if (activeSession) lastVisibleSessionRef.current = activeSession
+  }, [activeSession])
 
   useEffect(() => {
     // Track "last focused session" only for persisted sessions. Gated on

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -42,7 +42,7 @@ import { AGENT_WORKSPACE_TYPE, type AgentSessionWorkspaceSource } from '@shared/
 import type { TopicTabPosition } from '@shared/data/preference/preferenceTypes'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { PropsWithChildren } from 'react'
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import AgentChat from './AgentChat'
@@ -148,7 +148,7 @@ const AgentPage = () => {
   })
   const isCreatingEmptySessionRef = useRef(false)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     ownerFallbackRequestIdRef.current += 1
     const previousRouteActiveSessionId = syncedRouteActiveSessionIdRef.current
     syncedRouteActiveSessionIdRef.current = routeActiveSessionId
@@ -256,9 +256,13 @@ const AgentPage = () => {
     routeSessionId
   ])
   const lastVisibleSessionRef = useRef<AgentSessionEntity | null>(null)
+  const resolvedActiveSession = activeSession?.id === activeSessionId ? activeSession : null
   const visibleSession = isMessageOnlyView
     ? routeSession
-    : (activeSession ?? (isActiveSessionLoading ? lastVisibleSessionRef.current : null))
+    : (resolvedActiveSession ??
+      (isActiveSessionLoading && lastVisibleSessionRef.current?.id === activeSessionId
+        ? lastVisibleSessionRef.current
+        : null))
   const visibleAgentFromList = agents.find((agent) => agent.id === visibleSession?.agentId)
   const conversationBootstrap = useAgentConversationBootstrap({
     session: visibleSession ?? null,
@@ -337,8 +341,8 @@ const AgentPage = () => {
   }, [currentTabId])
   // Label this tab with its agent emoji + session name so multiple agent tabs
   // are distinguishable (every tab labels itself — not gated on active).
-  // While the bound session is still loading (or the visible entity intentionally lags behind a
-  // selection), keep the tab's stored title/icon instead of stamping a stale or generic one.
+  // While the bound session is still loading, keep the tab's stored title/icon instead of stamping
+  // a generic one.
   const targetSessionId = isMessageOnlyView ? routeSessionId : (activeSessionId ?? undefined)
   const preserveTabVisuals = !!targetSessionId && visibleSession?.id !== targetSessionId
   useTabSelfVisuals({
@@ -363,8 +367,8 @@ const AgentPage = () => {
   }, [activeSession, isMessageOnlyView])
 
   useEffect(() => {
-    if (activeSession) lastVisibleSessionRef.current = activeSession
-  }, [activeSession])
+    if (resolvedActiveSession) lastVisibleSessionRef.current = resolvedActiveSession
+  }, [resolvedActiveSession])
 
   useEffect(() => {
     // Track "last focused session" only for persisted sessions. Gated on

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -2384,7 +2384,7 @@ describe('AgentPage', () => {
     )
   })
 
-  it('keeps the new tab session identity while the previous session remains visible', async () => {
+  it('does not expose the previous session while the new route session is loading', async () => {
     agentPageMocks.routeSearch = { sessionId: 'session-1' }
     activeSessionMocks.session = {
       id: 'session-1',
@@ -2408,7 +2408,7 @@ describe('AgentPage', () => {
     rerender(<AgentPage />)
 
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-2'))
-    expect(screen.getByTestId('active-session')).toHaveTextContent('session-1')
+    expect(screen.getByTestId('active-session')).toHaveTextContent('')
     expect(screen.getByTestId('active-session-loading')).toHaveTextContent('true')
     expect(vi.mocked(useTabSelfVisuals)).toHaveBeenLastCalledWith(
       expect.objectContaining({ appId: 'agents', preserveVisuals: true })

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -229,10 +229,9 @@ const HomePage: FC = () => {
     routeTopicId
   ])
   const lastVisibleTopicRef = useRef<Topic | undefined>(undefined)
-  const resolvedActiveTopic = activeTopic?.id === activeTopicId ? activeTopic : undefined
   const visibleTopic = isMessageOnlyView
     ? routeTopic
-    : (resolvedActiveTopic ??
+    : (activeTopic ??
       (isActiveTopicLoading && lastVisibleTopicRef.current?.id === activeTopicId
         ? lastVisibleTopicRef.current
         : undefined))
@@ -347,8 +346,8 @@ const HomePage: FC = () => {
   })
 
   useEffect(() => {
-    if (resolvedActiveTopic) lastVisibleTopicRef.current = resolvedActiveTopic
-  }, [resolvedActiveTopic])
+    if (activeTopic) lastVisibleTopicRef.current = activeTopic
+  }, [activeTopic])
 
   useEffect(() => {
     if (isMessageOnlyView) return

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -42,7 +42,7 @@ import { cn } from '@renderer/utils/style'
 import { isDataApiNotFoundError } from '@shared/data/api/errors'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { FC, HTMLAttributes } from 'react'
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import Chat from './Chat'
@@ -184,7 +184,7 @@ const HomePage: FC = () => {
     [isMessageOnlyView, navigate]
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     ownerFallbackRequestIdRef.current += 1
     setActiveTopicIdState(routeActiveTopicId)
     return () => {
@@ -229,9 +229,13 @@ const HomePage: FC = () => {
     routeTopicId
   ])
   const lastVisibleTopicRef = useRef<Topic | undefined>(undefined)
+  const resolvedActiveTopic = activeTopic?.id === activeTopicId ? activeTopic : undefined
   const visibleTopic = isMessageOnlyView
     ? routeTopic
-    : (activeTopic ?? (isActiveTopicLoading ? lastVisibleTopicRef.current : undefined) ?? undefined)
+    : (resolvedActiveTopic ??
+      (isActiveTopicLoading && lastVisibleTopicRef.current?.id === activeTopicId
+        ? lastVisibleTopicRef.current
+        : undefined))
   const requestComposerFocus = useComposerFocusRequest(visibleTopic?.id)
   const resourceConversationKey = useMemo(() => {
     if (visibleTopic?.id) return `topic:${visibleTopic.id}`
@@ -331,8 +335,8 @@ const HomePage: FC = () => {
       count: allTopics.filter((topic) => topic.assistantId === visibleAssistantId).length
     }
   }, [allTopics, isClassicTopicLayout, topicListPosition, t, visibleAssistantId])
-  // While the bound topic is still loading (or the visible entity intentionally lags behind a
-  // selection), keep the tab's stored title/icon instead of stamping a stale or generic one.
+  // While the bound topic is still loading, keep the tab's stored title/icon instead of stamping
+  // a generic one.
   const targetTopicId = isMessageOnlyView ? routeTopicId : (activeTopicId ?? undefined)
   const preserveTabVisuals = !!targetTopicId && visibleTopic?.id !== targetTopicId
   useTabSelfVisuals({
@@ -343,8 +347,8 @@ const HomePage: FC = () => {
   })
 
   useEffect(() => {
-    if (activeTopic) lastVisibleTopicRef.current = activeTopic
-  }, [activeTopic])
+    if (resolvedActiveTopic) lastVisibleTopicRef.current = resolvedActiveTopic
+  }, [resolvedActiveTopic])
 
   useEffect(() => {
     if (isMessageOnlyView) return

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1967,7 +1967,7 @@ describe('HomePage', () => {
     expect(homeMocks.activeTopicOptions?.passive).toBe(false)
   })
 
-  it('keeps the new tab topic identity while the previous topic remains visible', async () => {
+  it('does not expose the previous topic while the new route topic is loading', async () => {
     homeMocks.entryTopic = undefined
     homeMocks.routeSearch = { topicId: 'topic-a' }
     homeMocks.activeTopicOverride = { ...historyTopic, id: 'topic-a', name: 'Topic A' }
@@ -1981,7 +1981,7 @@ describe('HomePage', () => {
     rerender(<HomePage />)
 
     await waitFor(() => expect(homeMocks.activeTopicOptions?.activeTopicId).toBe('topic-b'))
-    expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-a')
+    expect(screen.queryByTestId('active-topic')).not.toBeInTheDocument()
     expect(vi.mocked(useTabSelfVisuals)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         appId: 'assistants',

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1978,6 +1978,7 @@ describe('HomePage', () => {
 
     homeMocks.routeSearch = { topicId: 'topic-b' }
     homeMocks.activeTopicLoading = true
+    homeMocks.forceActiveTopicUndefined = true
     rerender(<HomePage />)
 
     await waitFor(() => expect(homeMocks.activeTopicOptions?.activeTopicId).toBe('topic-b'))

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -1808,6 +1808,7 @@ describe('HomePage', () => {
   })
 
   it('keeps the current topic visible while the active topic is reloading', async () => {
+    homeMocks.routeSearch = { topicId: 'topic-initial' }
     const { rerender } = render(<HomePage />)
 
     await waitFor(() => expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-initial'))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When navigation switched from conversation A to conversation B, the previous assistant topic or agent session could remain visible and interactive while B was loading. Sending, stopping, or deleting a message during that window could target A.

After this PR:

Route-driven conversation identity is synchronized before paint, and a cached visible entity is reused only when its ID still matches the active target. While B is loading, A is no longer exposed to the interactive conversation tree.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Conversation switching is a primary user flow, and allowing writes to reach a stale conversation risks sending messages, aborting streams, or deleting messages from the wrong conversation. The fix enforces the route/entity identity invariant at the page boundary so all current and future conversation actions inherit the same protection.

The following tradeoffs were made:

A route transition now shows the loading state instead of leaving a different conversation interactive. Same-entity refreshes can still reuse their cached visual snapshot.

The following alternatives were considered:

Disabling send, stop, and delete independently was considered, but rejected because it would duplicate the identity rule and could miss future write actions.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

`pnpm lint` passed, including typecheck, i18n checks, and formatting. The repository reported 37 pre-existing ESLint warnings and no errors. Tests and interactive Electron verification were not run per the repository's user-owned verification rule.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Prevent actions from targeting the previous assistant or agent conversation while a newly selected conversation is loading.
```
