### PR TITLE
perf(chat): lazy-load disabled message outline

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -10,11 +10,10 @@ import { captureScrollable, captureScrollableAsDataUrl } from '@renderer/utils/i
 import { classNames } from '@renderer/utils/style'
 import type { MultiModelMessageStyle } from '@shared/data/preference/preferenceTypes'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { type ComponentProps, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ComponentProps, lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import NarrowLayout from '../layout/NarrowLayout'
 import { PartsProvider, usePartsMap } from './blocks/MessagePartsContext'
-import MessageOutline from './frame/MessageOutline'
 import { MessageListInitialLoading } from './layout/MessageListLoading'
 import { MessagesContainer } from './layout/shared'
 import MessageAnchorLine from './list/MessageAnchorLine'
@@ -45,6 +44,7 @@ import { createStableGroupedMessagesCache, stableGroupedMessages } from './utils
 
 const MULTI_SELECT_BOTTOM_PADDING_PX = 96
 const MESSAGE_OUTLINE_LAYOUTS: MultiModelMessageStyle[] = ['horizontal', 'vertical', 'fold', 'grid']
+const MessageOutline = lazy(() => import('./frame/MessageOutline'))
 /** Chat content's side padding — matches NarrowLayout's `px-6`, so the inline
  * override is invisible until the rail gutter adds onto it. */
 const CHAT_SIDE_PADDING_PX = 24
@@ -844,11 +844,13 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
         />
       )}
       {activeOutline && activeOutlineMessage && (
-        <MessageOutline
-          message={activeOutlineMessage}
-          multiModelMessageStyle={activeOutline.multiModelMessageStyle}
-          onNavigateToElement={scrollToOutlineElement}
-        />
+        <Suspense fallback={null}>
+          <MessageOutline
+            message={activeOutlineMessage}
+            multiModelMessageStyle={activeOutline.multiModelMessageStyle}
+            onNavigateToElement={scrollToOutlineElement}
+          />
+        </Suspense>
       )}
       {messageNavigation === 'buttons' && (
         <MessageNavigation

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -29,6 +29,7 @@ const messageVirtualListMocks = vi.hoisted(() => ({
 }))
 const messageGroupRenderCounts = vi.hoisted(() => new Map<string, number>())
 const messageGroupMountCounts = vi.hoisted(() => new Map<string, number>())
+const messageOutlineModule = vi.hoisted(() => ({ loaded: false }))
 const messageListSearchMock = vi.hoisted(() => ({
   props: null as {
     messages: MessageListItem[]
@@ -127,10 +128,13 @@ vi.mock('../layout/NarrowLayout', () => ({
   }
 }))
 
-vi.mock('../frame/MessageOutline', () => ({
-  __esModule: true,
-  default: () => null
-}))
+vi.mock('../frame/MessageOutline', () => {
+  messageOutlineModule.loaded = true
+  return {
+    __esModule: true,
+    default: () => null
+  }
+})
 
 vi.mock('../layout/MessageListLoading', () => ({
   MessageListInitialLoading: () => <div data-testid="message-list-loading" />
@@ -347,6 +351,12 @@ describe('MessageList', () => {
     messageListSearchMock.props = null
     chatLayoutModeMock.railGutterPx = 0
     chatLayoutModeMock.setRailGutterPx.mockReset()
+  })
+
+  it('does not load the message outline module while outline is disabled', () => {
+    renderMessageList([createMessage('assistant-1', 'assistant')])
+
+    expect(messageOutlineModule.loaded).toBe(false)
   })
 
   it('exposes a stable message-list boundary', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`MessageList` statically imported `MessageOutline`, so the outline's Markdown parser dependencies were included in the base chat module graph even though message outlines are disabled by default.

After this PR:

`MessageOutline` is loaded with `React.lazy` and rendered inside a null-fallback `Suspense` boundary only when an active outline is present. Existing outline tracking and navigation behavior remain unchanged, and a regression test verifies that the module is not loaded while the feature is disabled.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18937

### Why we need it and why it was done in this way

The message outline is an optional feature and its parser dependencies are not needed for the default chat experience. Moving the import behind the existing active-outline condition keeps the initial chat bundle smaller without changing the preference or outline state flow.

The following tradeoffs were made:

- A `null` Suspense fallback keeps the optional overlay from introducing a loading placeholder or layout shift while its small chunk loads.
- The existing `activeOutline` tracking logic is preserved, so this change only moves the module boundary and does not alter when outlines are selected or how navigation works.

The following alternatives were considered:

- A manual `import()` with local loading state would duplicate the loading behavior already provided by `React.lazy` and `Suspense`.
- Preloading the module when the preference changes would load parser code before the outline is actually needed, weakening the conditional-loading benefit.

Links to places where the discussion took place: [#18937](https://github.com/CherryHQ/cherry-studio/issues/18937)

### Breaking changes

<!-- optional -->

None. The outline remains available when enabled.

### Special notes for your reviewer

<!-- optional -->

- The `showMessageOutline` preference remains disabled by default.
- The focused renderer tests, web typecheck, lint, and production build all pass.
- The production build emits a separate `MessageOutline` renderer chunk containing the outline parser code.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required; no documentation changes are needed for this internal performance optimization.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
