### PR TITLE
fix(painting-size): keep selected chip outline visible

### DIFF
--- a/src/renderer/pages/paintings/form/__tests__/SizeChipsField.test.tsx
+++ b/src/renderer/pages/paintings/form/__tests__/SizeChipsField.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import SizeChipsField from '../fields/SizeChipsField'
+
+describe('SizeChipsField', () => {
+  it('keeps the selected outline inside the chip bounds', () => {
+    render(
+      <SizeChipsField
+        item={{
+          type: 'sizeChips',
+          key: 'imageResolution',
+          options: [
+            { label: '1K', value: '1K' },
+            { label: '2K', value: '2K' },
+            { label: '4K', value: '4K' }
+          ]
+        }}
+        fieldKey="imageResolution"
+        painting={{}}
+        translate={(key) => key}
+        onChange={vi.fn()}
+        currentValue="4K"
+        disabled={false}
+      />
+    )
+
+    // The chip can sit flush with a scrollport edge, so an outer ring would be clipped.
+    expect(screen.getByRole('button', { name: '4K' })).toHaveClass('ring-1', 'ring-inset')
+  })
+})

--- a/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
+++ b/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
@@ -12,7 +12,7 @@ const DEFAULT_COLUMNS = 3
 const chipClass = {
   base: 'flex min-h-10 min-w-0 cursor-pointer flex-col items-center justify-center gap-0.5 rounded-[10px] px-1 py-1 text-[11px] leading-tight transition-all',
   active:
-    'bg-secondary-active text-foreground ring-1 ring-[color:color-mix(in_oklch,var(--foreground)_33.3333%,transparent)]',
+    'bg-secondary-active text-foreground ring-1 ring-inset ring-[color:color-mix(in_oklch,var(--foreground)_33.3333%,transparent)]',
   inactive: 'bg-muted text-foreground-tertiary hover:bg-secondary-hover hover:text-foreground',
   disabled: 'cursor-not-allowed opacity-50'
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The selected painting size chip used an outer one-pixel ring. When the last chip sat flush with the chooser scrollport, the lower ring edge was clipped.

After this PR:

The selected ring paints inside the chip bounds, so every edge remains visible at the bottom of the chooser.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

Only the selected-state ring placement changes. Chip dimensions, layout, inactive styling, focus behavior, and the painting loader remain untouched.

The following alternatives were considered:

Adding page-local bottom padding was rejected because the clipping belongs to the selected chip paint and can recur at any scrollport edge. Changing the unrelated painting loader-density work was also rejected.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Exact commit: `10e0227bb372af06c475f314fb9e844bbff5c5b1`.
- Commit is SSH-signed and DCO-signed.
- Focused painting tests: 23/23 passed.
- `pnpm lint` passed.
- Real Electron QA covered light and dark themes at 90%, 100%, and 110% zoom.
- Independent exact-commit review accepted with no findings.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this visual correction.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If this PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Painting size selections now keep their full outline visible at the bottom of the chooser.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class visual tweak on size chip selection styling with a regression test; no auth, data, or behavior changes beyond outline rendering.
> 
> **Overview**
> Fixes **clipped selection outlines** on painting size chips when a chip sits flush against the chooser scrollport (e.g. the bottom edge).
> 
> The active chip style in `SizeChipsField` now uses **`ring-inset`** so the 1px ring draws **inside** the chip bounds instead of outside, matching the inset-ring pattern already used elsewhere in paintings UI.
> 
> A focused unit test asserts the selected chip keeps `ring-1` and `ring-inset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e0227bb372af06c475f314fb9e844bbff5c5b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->