### PR TITLE
fix(message-locate): cancel stale requests on conversation switch

### DIFF
--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -708,6 +708,7 @@ const AgentPage = () => {
   const setActiveSessionAndClearTransient = useCallback(
     (sessionId: string | null, session?: AgentSessionEntity | null) => {
       closeSurface()
+      setPendingLocateMessageId(undefined)
       if (!sessionId) {
         reenterAgentRoute()
         return

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -8,6 +8,7 @@ import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
 import { mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -2111,6 +2112,27 @@ describe('AgentPage', () => {
 
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-open'))
     expect(screen.getByTestId('locate-message-id')).toHaveTextContent('message-open')
+  })
+
+  it('cancels a pending message locate when the user selects another session', async () => {
+    const user = userEvent.setup()
+    render(<AgentPage />)
+
+    const sessionMessageHandler = vi
+      .mocked(EventEmitter.on)
+      .mock.calls.find(([eventName]) => eventName === EVENT_NAMES.GLOBAL_SEARCH_SELECT_AGENT_SESSION_MESSAGE)?.[1] as
+      | ((payload: unknown) => void)
+      | undefined
+
+    act(() => {
+      sessionMessageHandler?.({ sessionId: 'session-open', messageId: 'message-open', targetTabId: 'agent-tab' })
+    })
+    await waitFor(() => expect(screen.getByTestId('locate-message-id')).toHaveTextContent('message-open'))
+
+    await user.click(screen.getByRole('button', { name: 'Select session next' }))
+
+    expect(screen.getByTestId('active-session')).toHaveTextContent('session-next')
+    expect(screen.getByTestId('locate-message-id')).toHaveTextContent('')
   })
 
   it('waits for file-navigation confirmation before applying a global-search session jump', async () => {

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -362,6 +362,7 @@ const HomePage: FC = () => {
   const setActiveTopicAndCloseResourceView = useCallback(
     (topic: Topic) => {
       closeSurface()
+      setPendingLocateMessageId(undefined)
       setActiveTopic(topic)
       return true
     },

--- a/src/renderer/pages/home/__tests__/HomePage.test.tsx
+++ b/src/renderer/pages/home/__tests__/HomePage.test.tsx
@@ -6,6 +6,7 @@ import { DefaultPreferences } from '@shared/data/preference/preferenceSchemas'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
 import { mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import type * as ReactI18nextModule from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1768,6 +1769,27 @@ describe('HomePage', () => {
     expect(screen.getByTestId('locate-message-id')).toHaveTextContent('message-target')
 
     fireEvent.click(screen.getByRole('button', { name: 'Locate handled' }))
+    expect(screen.getByTestId('locate-message-id')).toHaveTextContent('')
+  })
+
+  it('cancels a pending message locate when the user selects another topic', async () => {
+    const user = userEvent.setup()
+    render(<HomePage />)
+
+    const topicMessageHandler = vi
+      .mocked(EventEmitter.on)
+      .mock.calls.find(([eventName]) => eventName === EVENT_NAMES.GLOBAL_SEARCH_SELECT_TOPIC_MESSAGE)?.[1] as
+      | ((payload: unknown) => void)
+      | undefined
+
+    act(() => {
+      topicMessageHandler?.({ topic: historyTopic, messageId: 'message-target', targetTabId: 'chat-tab' })
+    })
+    await waitFor(() => expect(screen.getByTestId('locate-message-id')).toHaveTextContent('message-target'))
+
+    await user.click(screen.getByRole('button', { name: 'Select topic next' }))
+
+    expect(screen.getByTestId('active-topic')).toHaveTextContent('topic-next')
     expect(screen.getByTestId('locate-message-id')).toHaveTextContent('')
   })
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A pending message locate request from global search remained active after the user manually switched to another assistant topic or agent session. The newly selected conversation could then load older history while looking for a message that belonged to the previous conversation.

After this PR:

Manual topic and session selection cancels the pending locate request before activating the new conversation. Regression coverage protects both assistant and agent conversation flows.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The pending locate state is transient interaction intent. Clearing it at the existing manual-selection boundaries keeps that intent from leaking across conversations without adding synchronization effects or changing the history pagination logic. Global-search navigation still works because its handler writes the new message target immediately after selecting the destination conversation.

The following tradeoffs were made:

A manual selection cancels an in-progress locate even when the user selects the currently active conversation; explicit user navigation takes precedence over the earlier search intent.

The following alternatives were considered:

Scoping every locate request with a topic or session ID was considered, but it would require a broader state and prop-contract change. The existing selection boundaries provide the smallest complete fix for the reported manual-switch race.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- `pnpm lint` passed with 0 errors; it reported 37 warnings in unrelated files.
- Targeted tests and interactive UI verification were not run, per the repository's user-owned verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix message search navigation from continuing to load history after switching conversations.
```
