### PR TITLE
fix(topic-navigation): recover deleted active topics

### DIFF
--- a/src/renderer/hooks/__tests__/useTopic.test.ts
+++ b/src/renderer/hooks/__tests__/useTopic.test.ts
@@ -1,5 +1,6 @@
 import { dataApiService } from '@data/DataApiService'
 import type { Topic } from '@renderer/types/topic'
+import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { Topic as ApiTopic } from '@shared/data/types/topic'
 import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
 import {
@@ -508,6 +509,56 @@ describe('useActiveTopic', () => {
     expect(result.current.activeTopic?.id).toBe('topic-a')
     expect(result.current.topicSource).toBe('pending')
     expect(result.current.isLoading).toBe(false)
+  })
+
+  it('does not serve cached query data after the canonical query reports not found', () => {
+    MockUseDataApiUtils.mockQueryResult('/topics/topic-a', {
+      data: createApiTopic({ id: 'topic-a' }),
+      error: DataApiErrorFactory.notFound('Topic', 'topic-a'),
+      isLoading: false
+    })
+
+    const { result } = renderHook(() => useActiveTopic({ activeTopicId: 'topic-a', setActiveTopicId: vi.fn() }))
+
+    expect(result.current.activeTopic).toBeUndefined()
+    expect(result.current.topicSource).toBe('none')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('does not serve a pending topic after the canonical query reports not found', () => {
+    const pendingTopic = { id: 'topic-a', name: 'Pending topic' } as unknown as Topic
+    MockUseDataApiUtils.mockQueryResult('/topics/topic-a', {
+      data: undefined,
+      error: DataApiErrorFactory.notFound('Topic', 'topic-a'),
+      isLoading: false
+    })
+
+    const { result, rerender } = renderHook(
+      ({ activeTopicId }) => useActiveTopic({ activeTopicId, setActiveTopicId: vi.fn() }),
+      { initialProps: { activeTopicId: null as string | null } }
+    )
+
+    act(() => result.current.setActiveTopic(pendingTopic))
+    rerender({ activeTopicId: 'topic-a' })
+
+    expect(result.current.activeTopic).toBeUndefined()
+    expect(result.current.topicSource).toBe('none')
+  })
+
+  it('keeps a pending topic available after a transient query error', () => {
+    const pendingTopic = { id: 'topic-a', name: 'Pending topic' } as unknown as Topic
+    MockUseDataApiUtils.mockQueryResult('/topics/topic-a', {
+      data: undefined,
+      error: new Error('temporarily unavailable'),
+      isLoading: false
+    })
+
+    const { result } = renderHook(() =>
+      useActiveTopic({ initialTopic: pendingTopic, activeTopicId: 'topic-a', setActiveTopicId: vi.fn() })
+    )
+
+    expect(result.current.activeTopic).toBe(pendingTopic)
+    expect(result.current.topicSource).toBe('pending')
   })
 
   it('stays loading while a specific active id resolves with no pending fallback (route/tab restore)', () => {

--- a/src/renderer/hooks/useTopic.ts
+++ b/src/renderer/hooks/useTopic.ts
@@ -30,7 +30,7 @@ import { useIpcOn } from '@renderer/ipc'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
 import type { MessageExportView } from '@renderer/types/messageExport'
 import type { Topic as RendererTopic } from '@renderer/types/topic'
-import { ErrorCode } from '@shared/data/api/errors'
+import { ErrorCode, isDataApiNotFoundError } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateTopicDto, DeleteTopicsResult, UpdateTopicDto } from '@shared/data/api/schemas/topics'
 import { type BranchMessagesResponse, type Message as SharedMessage, toContentRole } from '@shared/data/types/message'
@@ -570,10 +570,15 @@ export function useActiveTopic({
     isLoading: isActiveTopicQueryLoading,
     error
   } = useTopicById(passive || !activeTopicId ? undefined : activeTopicId)
+  // NOT_FOUND is authoritative even if SWR still exposes cached data or a matching optimistic
+  // topic. Otherwise cross-window deletion can strand HomePage on a stale active topic.
+  const isNotFound = isDataApiNotFoundError(error)
   const queryTopic = useMemo<RendererTopic | undefined>(
     () =>
-      activeTopicId && apiActiveTopic?.id === activeTopicId ? mapApiTopicToRendererTopic(apiActiveTopic) : undefined,
-    [activeTopicId, apiActiveTopic]
+      !isNotFound && activeTopicId && apiActiveTopic?.id === activeTopicId
+        ? mapApiTopicToRendererTopic(apiActiveTopic)
+        : undefined,
+    [activeTopicId, apiActiveTopic, isNotFound]
   )
   // Holds the last Topic object passed to setActiveTopic, used as fallback while the
   // by-id query for the newly-selected topic is still resolving.
@@ -592,11 +597,12 @@ export function useActiveTopic({
 
   const activeTopic = useMemo<RendererTopic | undefined>(() => {
     if (passive) return undefined
+    if (isNotFound) return undefined
     if (!activeTopicId) return pendingTopic
     if (queryTopic) return queryTopic
     if (pendingTopic?.id === activeTopicId) return pendingTopic
     return undefined
-  }, [activeTopicId, passive, pendingTopic, queryTopic])
+  }, [activeTopicId, isNotFound, passive, pendingTopic, queryTopic])
 
   // Where the active topic resolved from. 'query' = persisted (fetched by id);
   // 'pending' = optimistic / temporary topic not yet persisted. Mirrors


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Deleting an assistant topic in another window could leave the current chat window rendering stale SWR data or a pending topic, preventing its missing-topic recovery navigation from running.

After this PR:

A `NOT_FOUND` response is authoritative for the active assistant topic, so cached and pending fallbacks are discarded and the chat route recovers to a valid conversation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The active agent-session hook already treats `NOT_FOUND` as authoritative, but the equivalent assistant-topic hook did not. Handling the condition at the active-topic resolution boundary keeps HomePage's existing recovery effect reachable and gives all consumers one consistent contract.

The following tradeoffs were made:

Only `NOT_FOUND` suppresses cached or optimistic topic data; transient query errors continue to preserve the pending topic to avoid unnecessary UI disruption.

The following alternatives were considered:

Clearing SWR state or changing HomePage to inspect the error before `activeTopic` was considered, but both leave stale active-topic semantics available to other consumers and duplicate reconciliation outside the owning hook.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- `pnpm lint` passed.
- Targeted tests and manual UI verification were not run under the workspace's user-owned verification policy.
- Regression coverage was added for cached topics, pending topics, and transient errors.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix chat windows that could remain on an assistant conversation after it was deleted elsewhere.
```
