### PR TITLE
fix(citations): clear sources when switching conversations

### DIFF
--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -60,6 +60,11 @@ interface ModelSwitchTarget {
   model: Model
 }
 
+interface CitationPanelState {
+  sessionId: string
+  citations: Citation[]
+}
+
 function getNewSessionWorkspaceDefaults(
   session: AgentSessionEntity
 ): Pick<CreateAgentSessionDefaults, 'workspaceId' | 'workspaceMode'> {
@@ -177,7 +182,8 @@ const AgentChat = ({
   const [skipModelSwitchConfirmationsForAppRun, setSkipModelSwitchConfirmationsForAppRun] = useSharedCache(
     'agent.model_switch_confirmation.skipped'
   )
-  const [citationPanelCitations, setCitationPanelCitations] = useState<Citation[] | null>(null)
+  const currentSessionId = conversationBootstrap.session?.id
+  const [citationPanelState, setCitationPanelState] = useState<CitationPanelState | null>(null)
   const [modelSwitchTarget, setModelSwitchTarget] = useState<ModelSwitchTarget>()
   const [modelSwitchConfirmOpen, setModelSwitchConfirmOpen] = useState(false)
   const [skipModelSwitchConfirmation, setSkipModelSwitchConfirmation] = useState(false)
@@ -195,6 +201,8 @@ const AgentChat = ({
   const agentModelFilter = useAgentModelFilter(activeAgent?.type)
   const workspacePath = visibleWorkspace?.type === 'user' ? visibleWorkspace.path : undefined
   const workspaceWarning = useAgentWorkspaceWarning(workspacePath)
+  const citationPanelCitations =
+    citationPanelState && citationPanelState.sessionId === currentSessionId ? citationPanelState.citations : null
 
   useEffect(() => {
     if (visibleAgentId) onVisibleAgentChange?.(visibleAgentId)
@@ -202,10 +210,17 @@ const AgentChat = ({
   useEffect(() => {
     if (visibleWorkspaceId && visibleWorkspace?.type !== 'system') onVisibleWorkspaceChange?.(visibleWorkspaceId)
   }, [onVisibleWorkspaceChange, visibleWorkspace, visibleWorkspaceId])
+  useEffect(() => {
+    setCitationPanelState(null)
+  }, [currentSessionId])
 
-  const handleOpenCitationsPanel = useCallback(({ citations }: { citations: Citation[] }) => {
-    setCitationPanelCitations(citations)
-  }, [])
+  const handleOpenCitationsPanel = useCallback(
+    ({ citations }: { citations: Citation[] }) => {
+      if (!currentSessionId) return
+      setCitationPanelState({ sessionId: currentSessionId, citations })
+    },
+    [currentSessionId]
+  )
 
   const isInitializing = !sessionSnapshot && conversationBootstrap.sessionLoading
   const citationsPanelOpen = citationPanelCitations !== null
@@ -431,7 +446,7 @@ const AgentChat = ({
     sidePanel = (
       <CitationsPanel
         open={citationsPanelOpen}
-        onClose={() => setCitationPanelCitations(null)}
+        onClose={() => setCitationPanelState(null)}
         citations={citationPanelCitations ?? []}
       />
     )

--- a/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatSettingsPanel.test.tsx
@@ -1,5 +1,6 @@
 import type * as ChatPrimitives from '@renderer/components/chat/primitives'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ComponentProps, PropsWithChildren, ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -288,9 +289,17 @@ vi.mock('@renderer/components/composer/variants/AgentComposer', () => ({
 }))
 
 vi.mock('../components/AgentSessionMessages', () => ({
-  default: ({ onOpenCitationsPanel }: { onOpenCitationsPanel: (payload: { citations: unknown[] }) => void }) => (
+  default: ({
+    sessionId,
+    onOpenCitationsPanel
+  }: {
+    sessionId: string
+    onOpenCitationsPanel: (payload: { citations: unknown[] }) => void
+  }) => (
     <div data-testid="agent-messages">
-      <button type="button" onClick={() => onOpenCitationsPanel({ citations: [{ number: 1 }] })}>
+      <button
+        type="button"
+        onClick={() => onOpenCitationsPanel({ citations: [{ number: 1, url: `/tmp/${sessionId}.md` }] })}>
         open citations
       </button>
     </div>
@@ -298,8 +307,17 @@ vi.mock('../components/AgentSessionMessages', () => ({
 }))
 
 vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
-  default: ({ open, onClose, citations }: { open: boolean; onClose: () => void; citations: unknown[] }) => (
+  default: ({
+    open,
+    onClose,
+    citations
+  }: {
+    open: boolean
+    onClose: () => void
+    citations: Array<{ number: number; url: string }>
+  }) => (
     <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
+      {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
       {open && (
         <button type="button" onClick={onClose}>
           close citations
@@ -372,6 +390,22 @@ describe('AgentChat settings panel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'close citations' }))
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('closes citations when switching sessions', async () => {
+    const user = userEvent.setup()
+    const view = renderAgentChat()
+
+    await user.click(screen.getByRole('button', { name: 'open citations' }))
+    expect(screen.getByText('/tmp/session-1.md')).toBeInTheDocument()
+
+    view.rerender(
+      <AgentChat conversationBootstrap={createConversationBootstrap({ ...defaultSession, id: 'session-2' })} />
+    )
+    expect(screen.queryByText('/tmp/session-1.md')).not.toBeInTheDocument()
+
+    view.rerender(<AgentChat conversationBootstrap={createConversationBootstrap()} />)
+    expect(screen.queryByText('/tmp/session-1.md')).not.toBeInTheDocument()
   })
 
   it('uses page-owned resources without subscribing to agent and model', () => {

--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -65,12 +65,17 @@ interface Props {
   resourcePaneCount?: ResourcePaneCountButtonProps
 }
 
+interface CitationPanelState {
+  topicId: string
+  citations: Citation[]
+}
+
 const Chat: FC<Props> = (props) => {
   const { updateTopic: patchTopic } = useTopicMutations()
   const { t } = useTranslation()
   const [messageStyle] = usePreference('chat.message.style')
   const [topicDisplayMode] = usePreference('topic.tab.display_mode')
-  const [citationPanelCitations, setCitationPanelCitations] = useState<Citation[] | null>(null)
+  const [citationPanelState, setCitationPanelState] = useState<CitationPanelState | null>(null)
   const [branchLocateMessageId, setBranchLocateMessageId] = useState<string | undefined>()
   const setTopicBranchLiveState = useTopicBranchLiveStateSetter()
 
@@ -80,6 +85,8 @@ const Chat: FC<Props> = (props) => {
   const showConversation = Boolean(activeTopic && !centerSurface)
   const showConversationChrome = !centerSurface
   const activeTopicId = activeTopic?.id
+  const citationPanelCitations =
+    citationPanelState && citationPanelState.topicId === activeTopicId ? citationPanelState.citations : null
   const assistantContext = useAssistant(activeTopic?.assistantId, {
     loadDefaultModel: Boolean(activeTopic)
   })
@@ -99,6 +106,10 @@ const Chat: FC<Props> = (props) => {
   const { providers } = useProviders(undefined, { enabled: shouldLoadProviders })
   const locateMessageIdProp = props.locateMessageId
   const onLocateMessageHandledProp = props.onLocateMessageHandled
+
+  useEffect(() => {
+    setCitationPanelState(null)
+  }, [activeTopicId])
 
   useEffect(() => {
     setBranchLocateMessageId(undefined)
@@ -133,9 +144,13 @@ const Chat: FC<Props> = (props) => {
 
   const citationsPanelOpen = citationPanelCitations !== null
 
-  const handleOpenCitationsPanel = useCallback(({ citations }: { citations: Citation[] }) => {
-    setCitationPanelCitations(citations)
-  }, [])
+  const handleOpenCitationsPanel = useCallback(
+    ({ citations }: { citations: Citation[] }) => {
+      if (!activeTopicId) return
+      setCitationPanelState({ topicId: activeTopicId, citations })
+    },
+    [activeTopicId]
+  )
   const handleAssistantChange = useCallback(
     async (nextAssistantId: string | null) => {
       if (!activeTopic || !nextAssistantId || nextAssistantId === activeTopic.assistantId) return
@@ -261,7 +276,7 @@ const Chat: FC<Props> = (props) => {
         showConversation ? (
           <CitationsPanel
             open={citationsPanelOpen}
-            onClose={() => setCitationPanelCitations(null)}
+            onClose={() => setCitationPanelState(null)}
             citations={citationPanelCitations ?? []}
           />
         ) : undefined

--- a/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
+++ b/src/renderer/pages/home/__tests__/ChatSettingsPanel.test.tsx
@@ -1,5 +1,6 @@
 import type { Topic } from '@renderer/types/topic'
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { PropsWithChildren, ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -127,11 +128,13 @@ vi.mock('../components/TopicRightPane', () => {
 
 vi.mock('../ChatContent', () => ({
   default: ({
+    topic,
     onBranchLiveStateChange,
     onLocateMessageHandled,
     onOpenCitationsPanel,
     locateMessageId
   }: {
+    topic: Topic
     onBranchLiveStateChange?: (state: unknown) => void
     onLocateMessageHandled?: () => void
     onOpenCitationsPanel: (payload: { citations: unknown[] }) => void
@@ -144,7 +147,9 @@ vi.mock('../ChatContent', () => ({
         <button type="button" onClick={() => onLocateMessageHandled?.()}>
           handled locate
         </button>
-        <button type="button" onClick={() => onOpenCitationsPanel({ citations: [{ number: 1 }] })}>
+        <button
+          type="button"
+          onClick={() => onOpenCitationsPanel({ citations: [{ number: 1, url: `https://${topic.id}.example` }] })}>
           open citations
         </button>
         <button
@@ -165,8 +170,17 @@ vi.mock('../ChatContent', () => ({
 }))
 
 vi.mock('@renderer/components/chat/citations/CitationsPanel', () => ({
-  default: ({ open, onClose, citations }: { open: boolean; onClose: () => void; citations: unknown[] }) => (
+  default: ({
+    open,
+    onClose,
+    citations
+  }: {
+    open: boolean
+    onClose: () => void
+    citations: Array<{ number: number; url: string }>
+  }) => (
     <div data-testid="citations-panel" data-open={String(open)} data-count={citations.length}>
+      {open && citations.map((citation) => <span key={citation.number}>{citation.url}</span>)}
       {open && (
         <button type="button" onClick={onClose}>
           close citations
@@ -212,6 +226,20 @@ describe('Chat panels', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'close citations' }))
     expect(screen.getByTestId('citations-panel')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('closes citations when switching topics', async () => {
+    const user = userEvent.setup()
+    const view = renderChat(activeTopic)
+
+    await user.click(screen.getByRole('button', { name: 'open citations' }))
+    expect(screen.getByText('https://topic-1.example')).toBeInTheDocument()
+
+    view.rerender(<Chat activeTopic={{ ...activeTopic, id: 'topic-2' }} />)
+    expect(screen.queryByText('https://topic-1.example')).not.toBeInTheDocument()
+
+    view.rerender(<Chat activeTopic={activeTopic} />)
+    expect(screen.queryByText('https://topic-1.example')).not.toBeInTheDocument()
   })
 
   it('keeps navbar and branch pane actions visible for an empty persisted topic', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Opening the citations panel in one topic or agent session and then switching conversations could leave the previous conversation's URL or local-file sources visible.

After this PR:

Citation panel state is scoped to the active topic or agent session and cleared when that conversation identity changes. Regression coverage now protects both chat modes, including web URLs and local file paths.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Stale citation data is misleading and can expose a source from the wrong conversation. The state carries its owning conversation ID, so mismatched data is hidden during the switching render, and an identity-change effect clears it before it can reopen later.

The following tradeoffs were made:

- The citations panel closes whenever the active topic or agent session changes.

The following alternatives were considered:

- Keying the entire `Chat` or `AgentChat` component was rejected because it would also reset unrelated shell and layout state.
- Clearing only in an effect was rejected because stale citations could still be rendered during the conversation-switch render.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- `pnpm lint` passes with no errors; it reports 37 pre-existing warnings in unrelated files.
- Vitest and manual UI verification were not run in accordance with the repository's user-owned verification policy.
- No user-guide update is required because this restores the expected conversation-isolation behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Close the citations panel when switching conversations so sources from the previous topic or agent session are not shown.
```
