### PR TITLE
fix(composer): preserve drafts when stream open is blocked

### DIFF
--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -821,6 +821,8 @@ const AgentComposerInner = ({
   const [shouldValidateSkills, setShouldValidateSkills] = useState(initialDraft.shouldValidateSkills)
   const [text, setTextState] = useState(() => initialDraft.text)
   const [draftTokens, setDraftTokens] = useState<ComposerSerializedToken[]>(() => initialDraft.tokens)
+  const [isDirectSending, setIsDirectSending] = useState(false)
+  const directSendInFlightRef = useRef(false)
   const draftTokensRef = useRef(draftTokens)
   const knowledgeBaseIdsRef = useRef([...initialDraft.knowledgeBaseIds])
   const observedKnowledgeBaseSelectionKeyRef = useRef<string | null>(
@@ -1495,6 +1497,7 @@ const AgentComposerInner = ({
   const handleSendDraft = useCallback(
     async (draft: ComposerSerializedDraft, options?: { steer?: boolean }) => {
       if (sendDisabled) return
+      if (directSendInFlightRef.current) return
       if (!model) {
         toast.error(t('code.model_required'))
         return
@@ -1515,54 +1518,25 @@ const AgentComposerInner = ({
         return
       }
 
-      const previousText = draft.text
-      const previousFiles = files
-      const previousSkills = selectedSkills
-      const previousDraftTokens = draftTokensRef.current
-      const previousShouldValidateSkills = shouldValidateSkills
-
-      clearCurrentDraft()
-      const sent = await sendQueuedPayload(payload)
-      if (!sent) {
-        clearTimeoutTimer('agentComposerSendMessage')
-        setText(previousText)
-        setFiles(previousFiles)
-        setSelectedSkills(previousSkills)
-        setShouldValidateSkills(previousShouldValidateSkills)
-        setDraftTokens(previousDraftTokens)
-        draftTokensRef.current = previousDraftTokens
-        if (draftPersistenceEnabled) {
-          writeAgentDraftCache(draftCacheKey, {
-            text: previousText,
-            tokens: previousDraftTokens,
-            files: previousFiles,
-            knowledgeBaseIds: knowledgeBaseIdsRef.current,
-            workspaceKey,
-            agentId,
-            shouldValidateSkills: previousShouldValidateSkills
-          })
-        }
+      directSendInFlightRef.current = true
+      setIsDirectSending(true)
+      try {
+        const sent = await sendQueuedPayload(payload)
+        if (sent) clearCurrentDraft()
+      } finally {
+        directSendInFlightRef.current = false
+        setIsDirectSending(false)
       }
     },
     [
       buildQueuedPayload,
-      clearTimeoutTimer,
       clearCurrentDraft,
-      agentId,
-      draftCacheKey,
-      draftPersistenceEnabled,
       enqueueFollowup,
-      files,
       isStreaming,
       model,
       sendDisabled,
       sendQueuedPayload,
-      setFiles,
-      setText,
-      selectedSkills,
-      shouldValidateSkills,
       t,
-      workspaceKey,
       workspaceWarning
     ]
   )
@@ -1702,6 +1676,7 @@ const AgentComposerInner = ({
         <ComposerSurface
           text={text}
           onTextChange={handleTextChange}
+          editable={!isDirectSending}
           tokens={tokens}
           draftTokens={draftTokens}
           managedTokenKinds={
@@ -1717,12 +1692,15 @@ const AgentComposerInner = ({
           steerShortcut={isStreaming ? resolvedSteerShortcut : undefined}
           sendDisabled={
             sendDisabled ||
+            isDirectSending ||
             hasPendingReference ||
             modelPending ||
             !!missingModelMessage ||
             (text.trim().length === 0 && files.length === 0 && selectedSkills.length === 0)
           }
-          sendBlockedReason={sendDisabled || hasPendingReference ? t('common.loading') : missingModelMessage}
+          sendBlockedReason={
+            sendDisabled || isDirectSending || hasPendingReference ? t('common.loading') : missingModelMessage
+          }
           isLoading={isStreaming}
           onSendDraft={handleSendDraft}
           onPause={abortAgentSession}

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -305,7 +305,7 @@ type Props = {
   resolvedModel: Model | undefined
   resolvedWorkspaceWarning: string | null
   externalContextControls?: boolean
-  sendMessage: (message?: { text: string }, options?: AgentComposerSendOptions) => Promise<void>
+  sendMessage: (message?: { text: string }, options?: AgentComposerSendOptions) => Promise<boolean | void>
   stop: () => Promise<void>
   onCreateEmptySession?: () => void | Promise<unknown>
   onAgentChange?: (agentId: string | null) => void | Promise<void>
@@ -1395,7 +1395,7 @@ const AgentComposerInner = ({
       try {
         const attachments = (payload.attachments as ComposerAttachment[] | undefined) ?? []
         const fileParts = await buildAgentFilePartsForAttachments(attachments, accessiblePaths)
-        await chatSendMessage(
+        const sent = await chatSendMessage(
           { text: payload.text },
           {
             body: {
@@ -1407,16 +1407,18 @@ const AgentComposerInner = ({
             }
           }
         )
+        if (sent === false) return false
         void EventEmitter.emit(EVENT_NAMES.SEND_MESSAGE, { topicId: sessionTopicId })
         saveHistory(getComposerHistoryText(payload.userMessageParts))
         launchOptions?.onSent?.()
         return true
       } catch (error: unknown) {
         logger.warn('Failed to send message:', error as Error)
+        toast.error(t('chat.input.send_failed'))
         return false
       }
     },
-    [accessiblePaths, agentId, chatSendMessage, launchOptions, saveHistory, sessionId, sessionTopicId]
+    [accessiblePaths, agentId, chatSendMessage, launchOptions, saveHistory, sessionId, sessionTopicId, t]
   )
 
   const clearCurrentDraft = useCallback(() => {
@@ -1467,8 +1469,7 @@ const AgentComposerInner = ({
     scopeKey: sessionTopicId,
     isFulfilled: sessionFulfilled,
     markSeen: markSessionSeen,
-    onDrain: sendQueuedPayload,
-    onDrainFailed: () => toast.error(t('chat.input.send_failed'))
+    onDrain: sendQueuedPayload
   })
 
   // Edit a queued item = atomically restore the whole editor draft, then synchronize live token
@@ -1541,7 +1542,6 @@ const AgentComposerInner = ({
             shouldValidateSkills: previousShouldValidateSkills
           })
         }
-        toast.error(t('chat.input.send_failed'))
       }
     },
     [
@@ -1740,7 +1740,6 @@ const AgentComposerInner = ({
                     // steer keeps it in the dock + toasts, matching the direct-send/auto-drain paths.
                     const sent = await sendQueuedPayload(item.payload)
                     if (sent) removeFollowup(id)
-                    else toast.error(t('chat.input.send_failed'))
                   }}
                   onEdit={(id) => {
                     const item = queuedFollowups.find((entry) => entry.id === id)

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -158,7 +158,7 @@ export interface ChatComposerProps {
       fastMode?: boolean
       chatTarget?: ComposerChatTarget
     }
-  ) => void | Promise<void>
+  ) => boolean | void | Promise<boolean | void>
   chatTarget?: ComposerChatTarget
   sendDisabled?: boolean
   useMentionedModelSelector?: boolean
@@ -1364,23 +1364,25 @@ const ChatComposerInner = ({
       try {
         const attachments = (payload.attachments as ComposerAttachment[] | undefined) ?? []
         const fileParts = await buildFilePartsForAttachments(attachments)
-        await onSend(payload.text, {
+        const sent = await onSend(payload.text, {
           mentionedModels: payload.mentionedModels,
           userMessageParts: [...payload.userMessageParts, ...fileParts],
           reasoningEffort: payload.reasoningEffort,
           ...(payload.fastMode ? { fastMode: true } : {}),
           chatTarget: payload.chatTarget
         })
+        if (sent === false) return false
         saveHistory(getComposerHistoryText(payload.userMessageParts))
         return true
       } catch (error) {
         logger.warn('send failed', { error })
+        toast.error(t('chat.input.send_failed'))
         return false
       } finally {
         setIsSending(false)
       }
     },
-    [onSend, saveHistory]
+    [onSend, saveHistory, t]
   )
 
   const clearCurrentDraft = useCallback(() => {
@@ -1410,8 +1412,7 @@ const ChatComposerInner = ({
     scopeKey: selectedKnowledgeBasesScopeKey,
     isFulfilled,
     markSeen,
-    onDrain: sendQueuedPayload,
-    onDrainFailed: () => toast.error(t('chat.input.send_failed'))
+    onDrain: sendQueuedPayload
   })
   const queuedFollowupModelsDataEnabled = queuedFollowups.some(
     (item) => (item.payload.mentionedModels?.length ?? 0) > 0
@@ -1628,22 +1629,23 @@ const ChatComposerInner = ({
 
       // Optimistically clear the draft so the cleared input doubles as the re-entry
       // guard, but snapshot it first: a pre-stream failure never reaches the streaming
-      // UI, so restore the draft (text + files + knowledge bases; tokens re-derive) and
-      // surface the failure instead of silently discarding what the user typed.
-      const previousText = text
+      // UI, so restore the full editor draft and its variant-owned tools.
+      const previousDraft = draft
       const previousFiles = files
       const previousKnowledgeBases = selectedKnowledgeBases
 
       clearCurrentDraft()
       const sent = await sendQueuedPayload(payload)
       if (!sent) {
-        setText(previousText)
+        actionsRef.current.replaceDraft(previousDraft)
+        setText(previousDraft.text)
+        setDraftTokens(previousDraft.tokens.length ? [...previousDraft.tokens] : undefined)
         setFiles(previousFiles)
         setSelectedKnowledgeBases(previousKnowledgeBases)
-        toast.error(t('chat.input.send_failed'))
       }
     },
     [
+      actionsRef,
       buildQueuedPayload,
       canSteer,
       clearCurrentDraft,
@@ -1669,8 +1671,7 @@ const ChatComposerInner = ({
       staleEditingMessage,
       stopEditing,
       restoreSavedDraft,
-      t,
-      text
+      t
     ]
   )
 
@@ -1817,7 +1818,6 @@ const ChatComposerInner = ({
                   // steer keeps it in the dock + toasts, matching the direct-send/auto-drain paths.
                   const sent = await sendQueuedPayload(item.payload)
                   if (sent) removeFollowup(id)
-                  else toast.error(t('chat.input.send_failed'))
                 }}
                 onEdit={(id) => {
                   const item = queuedFollowups.find((entry) => entry.id === id)

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -551,6 +551,8 @@ const ChatComposerInner = ({
   const staleEditingMessage = editingMessage && !editingMessageForCurrentTopic
   const { isPending, isFulfilled, markSeen } = useTopicStreamStatus(streamScopeKey)
   const [isSending, setIsSending] = useState(false)
+  const [isDirectSending, setIsDirectSending] = useState(false)
+  const directSendInFlightRef = useRef(false)
   const [isStartingNewContext, setIsStartingNewContext] = useState(false)
   const [savingEditingSessionId, setSavingEditingSessionId] = useState<number | null>(null)
   const [text, setText] = useState(() => initialDraft.text)
@@ -1581,6 +1583,8 @@ const ChatComposerInner = ({
 
   const handleSendDraft = useCallback(
     async (draft: ComposerSerializedDraft) => {
+      if (directSendInFlightRef.current) return
+
       if (staleEditingMessage) {
         restoreSavedDraft()
         stopEditing()
@@ -1623,51 +1627,38 @@ const ChatComposerInner = ({
         return
       }
 
-      if (selectedModelForMissingAssistantDefault) {
-        await handleModelSelect(selectedModelForMissingAssistantDefault)
-      }
+      directSendInFlightRef.current = true
+      setIsDirectSending(true)
+      try {
+        if (selectedModelForMissingAssistantDefault) {
+          await handleModelSelect(selectedModelForMissingAssistantDefault)
+        }
 
-      // Optimistically clear the draft so the cleared input doubles as the re-entry
-      // guard, but snapshot it first: a pre-stream failure never reaches the streaming
-      // UI, so restore the full editor draft and its variant-owned tools.
-      const previousDraft = draft
-      const previousFiles = files
-      const previousKnowledgeBases = selectedKnowledgeBases
-
-      clearCurrentDraft()
-      const sent = await sendQueuedPayload(payload)
-      if (!sent) {
-        actionsRef.current.replaceDraft(previousDraft)
-        setText(previousDraft.text)
-        setDraftTokens(previousDraft.tokens.length ? [...previousDraft.tokens] : undefined)
-        setFiles(previousFiles)
-        setSelectedKnowledgeBases(previousKnowledgeBases)
+        const sent = await sendQueuedPayload(payload)
+        if (sent) clearCurrentDraft()
+      } finally {
+        directSendInFlightRef.current = false
+        setIsDirectSending(false)
       }
     },
     [
-      actionsRef,
       buildQueuedPayload,
       canSteer,
       clearCurrentDraft,
       commitEditedMessage,
       editingMessageForCurrentTopic,
       enqueueFollowup,
-      files,
       handleModelSelect,
       loading,
       missingAssistantMessage,
       missingSelectedModelMessage,
       runtimeModel,
       runtimeModelPending,
-      selectedKnowledgeBases,
       selectedModelForMissingAssistantDefault,
       selectedModelForUnlinkedHome,
       sendDisabled,
       selectAssistantMessage,
       sendQueuedPayload,
-      setFiles,
-      setSelectedKnowledgeBases,
-      setText,
       staleEditingMessage,
       stopEditing,
       restoreSavedDraft,
@@ -1776,6 +1767,7 @@ const ChatComposerInner = ({
             (text.trim().length === 0 && files.length === 0) ||
             (loading && !canSteer) ||
             isSavingEdit ||
+            isDirectSending ||
             sendDisabled ||
             searching ||
             runtimeModelPending ||
@@ -1785,7 +1777,7 @@ const ChatComposerInner = ({
             !!missingSelectedModelMessage
           }
           sendBlockedReason={
-            isSavingEdit || sendDisabled || hasPendingReference
+            isSavingEdit || isDirectSending || sendDisabled || hasPendingReference
               ? t('common.loading')
               : (missingAssistantMessage ?? missingModelMessage ?? missingSelectedModelMessage)
           }
@@ -1839,7 +1831,7 @@ const ChatComposerInner = ({
           quickPanelEnabled={config.enableQuickPanel ?? true}
           enableDragDrop={config.enableDragDrop ?? true}
           enableSpellCheck={enableSpellCheck}
-          editable={!searching}
+          editable={!searching && !isDirectSending}
           fontSize={fontSize}
           narrowMode={forceNarrowLayout || narrowMode}
           railGutterPx={railGutterPx}

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -1250,7 +1250,7 @@ describe('AgentComposer', () => {
     expect(getQueueDock()).toBeFalsy()
   })
 
-  it('restores the draft and leaves the queue empty when a steer send fails while streaming', async () => {
+  it('keeps the draft and leaves the queue empty when a steer send fails while streaming', async () => {
     mocks.sendMessage.mockRejectedValueOnce(new Error('send failed'))
     render(
       <AgentComposer
@@ -1262,6 +1262,11 @@ describe('AgentComposer', () => {
       />
     )
 
+    act(() => {
+      mocks.surfaceProps?.onTextChange('hello')
+    })
+    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('hello'))
+
     await act(async () => {
       await mocks.surfaceProps?.onSendDraft({ text: 'hello', tokens: [] }, { steer: true })
     })
@@ -1269,8 +1274,6 @@ describe('AgentComposer', () => {
     expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
     expect(getQueueDock()).toBeFalsy()
     expect(toast.error).toHaveBeenCalledWith('chat.input.send_failed')
-    // The failed steer send must not wipe the draft: the composer keeps the pre-send text
-    // and the persisted draft cache is rewritten with the pre-send content.
     expect(mocks.surfaceProps?.text).toBe('hello')
     expect(vi.mocked(cacheService.set)).toHaveBeenLastCalledWith(
       'agent.composer_draft.session_session-1',
@@ -4731,10 +4734,12 @@ describe('AgentComposer', () => {
     )
 
     act(() => {
+      mocks.surfaceProps?.onTextChange('draft message')
       mocks.surfaceProps?.onTokensChange(mocks.draftTokens ?? [])
     })
 
     await waitFor(() => {
+      expect(mocks.surfaceProps?.text).toBe('draft message')
       expect(mocks.surfaceProps?.draftTokens).toEqual([skillToken, fileToken])
     })
 
@@ -4755,7 +4760,6 @@ describe('AgentComposer', () => {
     })
 
     await waitFor(() => expect(mocks.surfaceProps?.editable).toBe(true))
-    expect(mocks.replaceDraft).not.toHaveBeenCalled()
     expect(cacheService.set).toHaveBeenLastCalledWith(
       'agent.composer_draft.session_session-1',
       {

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -4699,7 +4699,7 @@ describe('AgentComposer', () => {
     expect(MockUseCacheUtils.getPersistCacheValue('ui.composer.input_history')).toEqual([])
   })
 
-  it('restores the current draft, files, and skill tokens when sending a new agent message fails', async () => {
+  it('restores the current draft, files, and skill tokens when Main blocks a new agent message', async () => {
     mocks.availableSkills = [pdfSkill]
     mocks.draftText = 'draft message'
     const skillToken = {
@@ -4717,7 +4717,7 @@ describe('AgentComposer', () => {
     } as ComposerSerializedToken
     mocks.draftTokens = [skillToken, fileToken]
     mocks.files = [file]
-    mocks.sendMessage.mockRejectedValueOnce(new Error('send failed'))
+    mocks.sendMessage.mockResolvedValueOnce(false)
 
     render(
       <AgentComposer
@@ -4762,7 +4762,7 @@ describe('AgentComposer', () => {
     )
     expect(mocks.clearTimeoutTimer).toHaveBeenCalledWith('agentComposerSendMessage')
     expect(mocks.timeoutCallbacks.has('agentComposerSendMessage')).toBe(false)
-    expect(toast.error).toHaveBeenCalledWith('chat.input.send_failed')
+    expect(toast.error).not.toHaveBeenCalledWith('chat.input.send_failed')
   })
 
   it('inserts quoted selected text as a quote token from the main-window quote IPC', async () => {

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -4699,7 +4699,7 @@ describe('AgentComposer', () => {
     expect(MockUseCacheUtils.getPersistCacheValue('ui.composer.input_history')).toEqual([])
   })
 
-  it('restores the current draft, files, and skill tokens when Main blocks a new agent message', async () => {
+  it('keeps the current draft, files, and skill tokens untouched when Main blocks a new agent message', async () => {
     mocks.availableSkills = [pdfSkill]
     mocks.draftText = 'draft message'
     const skillToken = {
@@ -4717,7 +4717,8 @@ describe('AgentComposer', () => {
     } as ComposerSerializedToken
     mocks.draftTokens = [skillToken, fileToken]
     mocks.files = [file]
-    mocks.sendMessage.mockResolvedValueOnce(false)
+    const pendingSend = createDeferred<boolean>()
+    mocks.sendMessage.mockReturnValueOnce(pendingSend.promise)
 
     render(
       <AgentComposer
@@ -4739,15 +4740,22 @@ describe('AgentComposer', () => {
 
     fireEvent.click(screen.getByText('send'))
 
-    await waitFor(() => {
-      expect(mocks.surfaceProps?.text).toBe('draft message')
-    })
-
-    expect(mocks.sendMessage).toHaveBeenCalled()
-    expect(mocks.setFiles).toHaveBeenCalledWith([])
-    expect(mocks.setFiles).toHaveBeenLastCalledWith([file])
+    await waitFor(() => expect(mocks.sendMessage).toHaveBeenCalled())
     expect(mocks.surfaceProps?.text).toBe('draft message')
     expect(mocks.surfaceProps?.draftTokens).toEqual([skillToken, fileToken])
+    expect(mocks.surfaceProps?.editable).toBe(false)
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
+    expect(mocks.setFiles).not.toHaveBeenCalledWith([])
+
+    fireEvent.click(screen.getByText('send'))
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      pendingSend.resolve(false)
+    })
+
+    await waitFor(() => expect(mocks.surfaceProps?.editable).toBe(true))
+    expect(mocks.replaceDraft).not.toHaveBeenCalled()
     expect(cacheService.set).toHaveBeenLastCalledWith(
       'agent.composer_draft.session_session-1',
       {
@@ -4760,7 +4768,6 @@ describe('AgentComposer', () => {
       },
       86400000
     )
-    expect(mocks.clearTimeoutTimer).toHaveBeenCalledWith('agentComposerSendMessage')
     expect(mocks.timeoutCallbacks.has('agentComposerSendMessage')).toBe(false)
     expect(toast.error).not.toHaveBeenCalledWith('chat.input.send_failed')
   })

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -2300,7 +2300,7 @@ describe('ChatComposer', () => {
     })
   })
 
-  it('restores the current text, attachment, and draft tokens when Main blocks the send', async () => {
+  it('keeps the current text, attachment, and draft tokens untouched when Main blocks the send', async () => {
     const file = { fileTokenSourceId: 'source-1', name: 'draft.pdf', path: '/tmp/draft.pdf' } as any
     const fileToken = {
       id: 'file:source-1',
@@ -2319,18 +2319,39 @@ describe('ChatComposer', () => {
       textOffset: 0
     } as ComposerSerializedToken
     const draft = { text: 'draft message', tokens: [fileToken, quoteToken] }
-    const onSend = vi.fn().mockResolvedValue(false)
+    const pendingSend = createDeferred<boolean>()
+    const onSend = vi.fn().mockReturnValue(pendingSend.promise)
     mocks.files = [file]
 
     render(<ChatComposer topic={topic} onSend={onSend} />)
 
     act(() => {
       mocks.surfaceProps?.onTextChange('draft message')
+      mocks.surfaceProps?.onTokensChange([fileToken, quoteToken])
     })
-    await waitFor(() => expect(mocks.surfaceProps?.text).toBe('draft message'))
+    await waitFor(() => {
+      expect(mocks.surfaceProps?.text).toBe('draft message')
+      expect(mocks.surfaceProps?.draftTokens).toEqual([fileToken, quoteToken])
+    })
+
+    let sendPromise: Promise<void | undefined> | undefined
+    act(() => {
+      sendPromise = Promise.resolve(mocks.surfaceProps?.onSendDraft(draft))
+    })
+
+    await waitFor(() => expect(onSend).toHaveBeenCalled())
+    expect(mocks.surfaceProps?.text).toBe('draft message')
+    expect(mocks.surfaceProps?.editable).toBe(false)
+    expect(mocks.surfaceProps?.sendDisabled).toBe(true)
 
     await act(async () => {
       await mocks.surfaceProps?.onSendDraft(draft)
+    })
+    expect(onSend).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      pendingSend.resolve(false)
+      await sendPromise
     })
 
     expect(onSend).toHaveBeenCalledWith(
@@ -2342,6 +2363,8 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.text).toBe('draft message')
     expect(mocks.files).toEqual([file])
     expect(mocks.surfaceProps?.draftTokens).toEqual([fileToken, quoteToken])
+    expect(mocks.surfaceProps?.editable).toBe(true)
+    expect(mocks.replaceDraft).not.toHaveBeenCalled()
     expect(MockUseCacheUtils.getPersistCacheValue('ui.composer.input_history')).toEqual([])
     expect(toast.error).not.toHaveBeenCalledWith('chat.input.send_failed')
   })

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -2300,8 +2300,27 @@ describe('ChatComposer', () => {
     })
   })
 
-  it('keeps the current draft when sending a new message fails', async () => {
-    const onSend = vi.fn().mockRejectedValue(new Error('open failed'))
+  it('restores the current text, attachment, and draft tokens when Main blocks the send', async () => {
+    const file = { fileTokenSourceId: 'source-1', name: 'draft.pdf', path: '/tmp/draft.pdf' } as any
+    const fileToken = {
+      id: 'file:source-1',
+      kind: 'file',
+      label: 'draft.pdf',
+      payload: file,
+      index: 0,
+      textOffset: 0
+    } as ComposerSerializedToken
+    const quoteToken = {
+      id: 'quote-1',
+      kind: 'quote',
+      label: 'Quote',
+      promptText: 'quoted text',
+      index: 1,
+      textOffset: 0
+    } as ComposerSerializedToken
+    const draft = { text: 'draft message', tokens: [fileToken, quoteToken] }
+    const onSend = vi.fn().mockResolvedValue(false)
+    mocks.files = [file]
 
     render(<ChatComposer topic={topic} onSend={onSend} />)
 
@@ -2311,16 +2330,20 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.text).toBe('draft message'))
 
     await act(async () => {
-      await mocks.surfaceProps?.onSendDraft({ text: 'draft message', tokens: [] })
+      await mocks.surfaceProps?.onSendDraft(draft)
     })
 
     expect(onSend).toHaveBeenCalledWith(
       'draft message',
       expect.objectContaining({
-        userMessageParts: [expect.objectContaining({ type: 'text', text: 'draft message' })]
+        userMessageParts: expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'draft message' })])
       })
     )
     expect(mocks.surfaceProps?.text).toBe('draft message')
+    expect(mocks.files).toEqual([file])
+    expect(mocks.surfaceProps?.draftTokens).toEqual([fileToken, quoteToken])
+    expect(MockUseCacheUtils.getPersistCacheValue('ui.composer.input_history')).toEqual([])
+    expect(toast.error).not.toHaveBeenCalledWith('chat.input.send_failed')
   })
 
   it('wires ArrowUp input history navigation and applies the latest history text to the composer', async () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -2322,13 +2322,15 @@ describe('ChatComposer', () => {
     const pendingSend = createDeferred<boolean>()
     const onSend = vi.fn().mockReturnValue(pendingSend.promise)
     mocks.files = [file]
+    vi.mocked(cacheService.get).mockReturnValue({
+      text: draft.text,
+      tokens: draft.tokens,
+      files: [file],
+      knowledgeBaseIds: []
+    })
 
     render(<ChatComposer topic={topic} onSend={onSend} />)
 
-    act(() => {
-      mocks.surfaceProps?.onTextChange('draft message')
-      mocks.surfaceProps?.onTokensChange([fileToken, quoteToken])
-    })
     await waitFor(() => {
       expect(mocks.surfaceProps?.text).toBe('draft message')
       expect(mocks.surfaceProps?.draftTokens).toEqual([fileToken, quoteToken])
@@ -2364,7 +2366,6 @@ describe('ChatComposer', () => {
     expect(mocks.files).toEqual([file])
     expect(mocks.surfaceProps?.draftTokens).toEqual([fileToken, quoteToken])
     expect(mocks.surfaceProps?.editable).toBe(true)
-    expect(mocks.replaceDraft).not.toHaveBeenCalled()
     expect(MockUseCacheUtils.getPersistCacheValue('ui.composer.input_history')).toEqual([])
     expect(toast.error).not.toHaveBeenCalledWith('chat.input.send_failed')
   })

--- a/src/renderer/hooks/__tests__/useConversationTurnController.test.tsx
+++ b/src/renderer/hooks/__tests__/useConversationTurnController.test.tsx
@@ -75,7 +75,7 @@ describe('useConversationTurnController', () => {
     mocks.streamOpen.mockReturnValueOnce(pendingAck.promise)
     const { result, rerender, historyAdapter, refreshMetadata } = renderController('agent-session:a')
 
-    let sendFromA!: Promise<AiStreamOpenResponse | null>
+    let sendFromA!: Promise<boolean>
     act(() => {
       sendFromA = result.current.send('from A')
     })
@@ -98,10 +98,12 @@ describe('useConversationTurnController', () => {
     )
 
     mocks.streamOpen.mockResolvedValueOnce({ mode: 'started', reservedMessages: [] })
+    let sentFromB: boolean | undefined
     await act(async () => {
-      await result.current.send('from B')
+      sentFromB = await result.current.send('from B')
     })
 
+    expect(sentFromB).toBe(true)
     expect(result.current.phase).toBe('streaming')
   })
 
@@ -113,10 +115,12 @@ describe('useConversationTurnController', () => {
     })
     const { result, historyAdapter } = renderController()
 
+    let sent: boolean | undefined
     await act(async () => {
-      await result.current.send('blocked message')
+      sent = await result.current.send('blocked message')
     })
 
+    expect(sent).toBe(false)
     expect(result.current.phase).toBe('ready')
     expect(mocks.toastError).toHaveBeenCalledWith('Workspace access is required')
     expect(historyAdapter.seedReservedMessages).not.toHaveBeenCalled()

--- a/src/renderer/hooks/useConversationTurnController.ts
+++ b/src/renderer/hooks/useConversationTurnController.ts
@@ -48,7 +48,7 @@ export function useConversationTurnController<TInput, TConversation>({
   }, [scopeKey])
 
   const send = useCallback(
-    async (input: TInput): Promise<AiStreamOpenResponse | null> => {
+    async (input: TInput): Promise<boolean> => {
       const scopeEpoch = scopeEpochRef.current
       const isCurrentScope = () => scopeEpochRef.current === scopeEpoch
       let conversation: TConversation | null = null
@@ -57,7 +57,7 @@ export function useConversationTurnController<TInput, TConversation>({
         conversation = await ensureConversation(input)
         if (!conversation) {
           if (isCurrentScope()) setPhase('draft')
-          return null
+          return false
         }
 
         if (isCurrentScope()) setPhase('opening')
@@ -68,12 +68,12 @@ export function useConversationTurnController<TInput, TConversation>({
         void Promise.resolve(refreshMetadata?.(conversation, ack)).catch((err) => {
           logger.warn('Failed to refresh conversation metadata after stream open', err as Error)
         })
-        if (!isCurrentScope()) return ack
+        if (!isCurrentScope()) return ack.mode !== 'blocked'
 
         if (ack.mode === 'blocked') {
           toast.error(getStreamBlockedMessage(ack))
           if (isCurrentScope()) setPhase('ready')
-          return ack
+          return false
         }
 
         const reservedMessages = ack.reservedMessages ?? []
@@ -85,7 +85,7 @@ export function useConversationTurnController<TInput, TConversation>({
         }
 
         if (isCurrentScope()) setPhase('streaming')
-        return ack
+        return true
       } catch (err) {
         if (isCurrentScope()) {
           try {

--- a/src/renderer/pages/agents/__tests__/useAgentChatRuntimeState.test.tsx
+++ b/src/renderer/pages/agents/__tests__/useAgentChatRuntimeState.test.tsx
@@ -149,6 +149,8 @@ describe('useAgentChatRuntimeState', () => {
     mocks.seedReservedMessages.mockResolvedValue(undefined)
     mocks.deleteSessionMessage.mockResolvedValue(undefined)
     mocks.chatStop.mockResolvedValue(undefined)
+    mocks.sendTurn.mockReset()
+    mocks.sendTurn.mockResolvedValue(true)
     mocks.useAgentSessionParts.mockReturnValue({
       messages: [assistantMessage],
       isLoading: false,
@@ -193,6 +195,24 @@ describe('useAgentChatRuntimeState', () => {
         warning: mocks.toastWarning
       }
     })
+  })
+
+  it('reports a blocked stream open as not sent', async () => {
+    mocks.sendTurn.mockResolvedValueOnce(false)
+    const { result } = renderHook(() =>
+      useAgentChatRuntimeState({
+        sessionId: 'session-1',
+        sessionMessagesEnabled: true,
+        reservedMessages: []
+      })
+    )
+
+    let sent: boolean | undefined
+    await act(async () => {
+      sent = await result.current.sendMessage({ text: 'keep this draft' })
+    })
+
+    expect(sent).toBe(false)
   })
 
   it('does not wire per-overlay finish refresh for agent sessions', () => {

--- a/src/renderer/pages/agents/useAgentChatRuntimeState.ts
+++ b/src/renderer/pages/agents/useAgentChatRuntimeState.ts
@@ -109,7 +109,7 @@ export interface AgentChatRuntimeState {
   loadOlder?: () => void
   isPending: boolean
   stop: () => Promise<void>
-  sendMessage: (message?: { text: string }, options?: AgentSendOptions) => Promise<void>
+  sendMessage: (message?: { text: string }, options?: AgentSendOptions) => Promise<boolean>
   deleteMessage: (messageId: string) => Promise<void>
   respondToolApproval: (input: MessageToolApprovalInput) => Promise<void>
   composerContext: ComposerContextValue
@@ -175,7 +175,7 @@ export function useAgentChatRuntimeState({
   })
   const sendMessage = useCallback(
     async (message?: { text: string }, options?: AgentSendOptions) => {
-      await send({ text: message?.text ?? '', options })
+      return send({ text: message?.text ?? '', options })
     },
     [send]
   )

--- a/src/renderer/pages/home/ChatComposerSlot.tsx
+++ b/src/renderer/pages/home/ChatComposerSlot.tsx
@@ -25,7 +25,7 @@ interface ChatComposerSlotBaseProps {
       userMessageParts?: CherryMessagePart[]
       chatTarget?: ComposerChatTarget
     }
-  ) => Promise<void>
+  ) => Promise<boolean>
   chatTarget: ComposerChatTarget
   onNewTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>
   onCreateEmptyTopic?: (payload?: AddNewTopicPayload) => void | Promise<void>

--- a/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
+++ b/src/renderer/pages/home/__tests__/useChatRuntimeState.test.tsx
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   overlayExecutions: [] as ActiveExecution[],
   liveMessageIds: [] as string[],
   liveAssistants: [] as CherryUIMessage[],
-  overlayOnFinish: null as ((executionId: string, event: ExecutionFinishEvent) => void) | null
+  overlayOnFinish: null as ((executionId: string, event: ExecutionFinishEvent) => void) | null,
+  sendTurn: vi.fn()
 }))
 
 vi.mock('@logger', () => ({
@@ -80,7 +81,7 @@ vi.mock('@renderer/hooks/useChatWithHistory', () => ({
 vi.mock('@renderer/hooks/useConversationTurnController', () => ({
   useConversationTurnController: (config: unknown) => {
     mocks.turnControllerConfig = config
-    return { send: vi.fn(), phase: 'idle' }
+    return { send: mocks.sendTurn, phase: 'idle' }
   }
 }))
 
@@ -125,6 +126,8 @@ vi.mock('../hooks/useTopicMessagesCache', () => ({
 
 import { useChatRuntimeState } from '../useChatRuntimeState'
 
+let latestRuntime: ReturnType<typeof useChatRuntimeState> | null = null
+
 function makeTopic(id: string): Topic {
   return {
     id,
@@ -156,7 +159,7 @@ function RuntimeHost({
   messages?: CherryUIMessage[]
 }) {
   const topic = useMemo(() => makeTopic(topicId), [topicId])
-  useChatRuntimeState({
+  latestRuntime = useChatRuntimeState({
     topic,
     isHistoryLoading: false,
     initialMessages: messages,
@@ -190,6 +193,21 @@ describe('useChatRuntimeState', () => {
     mocks.liveMessageIds = []
     mocks.liveAssistants = []
     mocks.overlayOnFinish = null
+    mocks.sendTurn.mockReset()
+    mocks.sendTurn.mockResolvedValue(true)
+    latestRuntime = null
+  })
+
+  it('reports a blocked stream open as not sent', async () => {
+    mocks.sendTurn.mockResolvedValueOnce(false)
+    render(<RuntimeHost topicId="topic-1" />)
+
+    let sent: boolean | undefined
+    await act(async () => {
+      sent = await latestRuntime?.sendMessage('keep this draft')
+    })
+
+    expect(sent).toBe(false)
   })
 
   it('keeps branch-live state across an <Activity> hide/show and clears it when the topic changes', async () => {

--- a/src/renderer/pages/home/useChatRuntimeState.ts
+++ b/src/renderer/pages/home/useChatRuntimeState.ts
@@ -470,7 +470,7 @@ export function useChatRuntimeState({
   const sendMessage = useCallback(
     async (text: string, options?: ChatTurnInput['options']) => {
       try {
-        await turnController.send({ text, options })
+        return await turnController.send({ text, options })
       } catch (err) {
         logger.warn('failed to open conversation turn', err as Error)
         throw err


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When `ai.stream.open` returned a handled `blocked` response, the turn controller showed the specific error but resolved normally. Chat and Agent composers therefore treated the send as successful, cleared direct-send drafts, and removed blocked follow-ups from the queue.

After this PR:

The turn controller reports whether Main accepted the stream open, both runtime paths propagate that result, and both composers preserve drafts or queued follow-ups when Main blocks the send. Chat restores the complete serialized draft, including attachments and structured tokens, while Agent restores its text, files, skills, and token state.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

A blocked stream open is an expected admission result rather than a transport exception. Returning an explicit boolean keeps the controller's specific blocked-reason toast while allowing the composer—the owner of draft and follow-up state—to commit destructive state changes only after Main accepts the send.

The following tradeoffs were made:

- Renderer send APIs now propagate an acceptance boolean through the Chat and Agent runtime layers.
- Generic send-failure toasts are emitted only for thrown errors; blocked responses keep their specific controller message without a duplicate toast.

The following alternatives were considered:

- Throwing for blocked responses was rejected because it would conflate expected admission rejection with transport/runtime failures and encourage duplicate generic error handling.
- Restoring only plain text was rejected because attachments and structured composer tokens are part of the user's draft contract.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- `blocked: paused` can occur while backup snapshot creation quiesces AI writes; `blocked: agent-session-workspace` can occur when Agent workspace validation fails.
- Regression coverage was added at the controller, runtime, and composer boundaries.
- Verification: `pnpm lint` passed (formatting, typecheck, and i18n checks). Targeted and full tests were not run in this workspace.
- No user-guide update is required for this corrective behavior.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where Chat and Agent Composer drafts, attachments, and structured tokens could be lost when the main process blocked a send request.
```
