### PR TITLE
fix(provider-registry): expose LM Studio models to Pi

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -697,6 +697,7 @@
     },
     {
       "authOptional": true,
+      "defaultChatEndpoint": "openai-chat-completions",
       "description": "LM Studio - AI model provider",
       "endpointConfigs": {
         "anthropic-messages": {
@@ -2073,5 +2074,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "7dd1ae83c85245f9"
+  "version": "0207946078dd405b"
 }

--- a/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
@@ -27,6 +27,12 @@ const endpointsOf = (providerId: string, modelId: string): string[] | undefined 
   return entry.endpointTypes as string[] | undefined
 }
 
+describe('lmstudio endpoint matrix', () => {
+  it('defaults endpoint-less discovered models to OpenAI Chat Completions', () => {
+    expect(provider('lmstudio').defaultChatEndpoint).toBe('openai-chat-completions')
+  })
+})
+
 describe('dashscope (Bailian) endpoint matrix', () => {
   /**
    * Bailian serves the whole qwen line on Chat Completions — the OpenAI-compatible Chat doc

--- a/packages/provider-registry/src/providers/lmstudio.ts
+++ b/packages/provider-registry/src/providers/lmstudio.ts
@@ -4,6 +4,7 @@ export default defineProvider({
   id: 'lmstudio',
   name: 'LM Studio',
   authOptional: true,
+  defaultChatEndpoint: 'openai-chat-completions',
   endpointConfigs: {
     'anthropic-messages': {
       adapterFamily: 'anthropic',

--- a/packages/provider-registry/src/providers/types.ts
+++ b/packages/provider-registry/src/providers/types.ts
@@ -14,7 +14,7 @@ import type { ProviderModelOverride } from '../schemas/provider-models'
 /**
  * Connection config emitted to `providers.json`. `description` is templated, so it's omitted here;
  * `endpointConfigs` is relaxed to a partial map (a provider declares only the 1–2 endpoints it speaks);
- * `defaultChatEndpoint` is optional (dynamic/local providers like ollama/lmstudio/new-api omit it).
+ * `defaultChatEndpoint` is optional for providers whose chat route is resolved dynamically.
  */
 type ProviderConnection = Omit<
   ProviderConfig,

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -434,7 +434,7 @@
     }
   ],
   "providers": {
-    "version": "7dd1ae83c85245f9",
+    "version": "0207946078dd405b",
     "count": 62,
     "entries": [
       {

--- a/src/shared/ai/__tests__/piModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/piModelCompatibility.test.ts
@@ -78,6 +78,21 @@ describe('resolvePiApi', () => {
     )
   })
 
+  it('accepts endpoint-less LM Studio models through the provider default', () => {
+    const provider = makeProvider({
+      id: 'lmstudio',
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'anthropic-messages': { adapterFamily: 'anthropic', baseUrl: 'http://localhost:1234' },
+        'openai-chat-completions': { adapterFamily: 'openai-compatible', baseUrl: 'http://localhost:1234' }
+      }
+    })
+    const model = makeModel({ id: 'lmstudio::local-model', providerId: 'lmstudio', endpointTypes: undefined })
+
+    expect(resolvePiApi(provider, model)).toBe('openai-completions')
+    expect(isPiCompatibleModel(provider, model)).toBe(true)
+  })
+
   it('is false for an unmapped provider', () => {
     const provider = makeProvider({
       defaultChatEndpoint: 'ollama-chat',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

LM Studio models discovered from the local server have no model-level endpoint metadata, while the LM Studio provider preset had no default chat endpoint. Pi endpoint resolution therefore returned `undefined`, and the model picker silently filtered every LM Studio model out.

After this PR:

The LM Studio preset defaults to OpenAI Chat Completions. Endpoint-less discovered models now resolve to Pi's `openai-completions` API family and remain selectable when they satisfy the existing context-window requirement. Explicit model endpoint metadata still takes precedence.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19003

### Why we need it and why it was done in this way

The following tradeoffs were made:

OpenAI Chat Completions is selected as the deterministic fallback even though LM Studio also exposes an Anthropic-compatible endpoint. It matches LM Studio's established OpenAI-compatible model discovery path while preserving the existing endpoint precedence rules.

The following alternatives were considered:

Teaching Pi compatibility resolution to pick an arbitrary supported endpoint when a provider declares no default was rejected because it would introduce implicit routing semantics for every dynamic provider. Showing filtered models with compatibility reasons is useful UX work but is outside this focused provider fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19003

### Breaking changes

None.

### Special notes for your reviewer

The generated provider catalog and its version were regenerated from the source preset.

Validation:

- `pnpm lint`
- `pnpm test:provider-registry` — 331 tests passed
- Pi compatibility regression — 13 tests passed
- Provider catalog generation and frozen schema compatibility checks passed

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
LM Studio models with a configured context window are now available to Pi agents.
```
