### PR TITLE
fix(code-block): keep toolbar visible on scroll

### DIFF
--- a/src/renderer/components/CodeBlockView/CodeBlockView.tsx
+++ b/src/renderer/components/CodeBlockView/CodeBlockView.tsx
@@ -412,7 +412,7 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
     <div
       data-ui="part:code-block"
       className={cn(
-        'code-block relative w-full min-w-0 overflow-hidden rounded-lg border-[0.5px] border-border bg-background-subtle',
+        'code-block relative w-full min-w-0 overflow-clip rounded-lg border-[0.5px] border-border bg-background-subtle',
         '[&_.code-toolbar]:transform-gpu [&_.code-toolbar]:opacity-0 [&_.code-toolbar]:transition-opacity [&_.code-toolbar]:duration-200 [&_.code-toolbar]:ease-in-out [&_.code-toolbar]:will-change-[opacity]',
         '[&:hover_.code-toolbar]:opacity-100 [&_.code-toolbar.show]:opacity-100',
         isInSpecialView

--- a/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
@@ -43,6 +43,19 @@ vi.mock('react-i18next', () => ({
 }))
 
 describe('CodeBlockView', () => {
+  it('keeps the sticky toolbar attached to the message scroll container', () => {
+    render(
+      <CodeBlockView language="javascript" editable={false}>
+        const value = 1
+      </CodeBlockView>
+    )
+
+    const codeBlock = screen.getByLabelText('Code viewer').closest('[data-ui~="part:code-block"]')
+
+    expect(codeBlock).toHaveClass('overflow-clip')
+    expect(codeBlock).not.toHaveClass('overflow-hidden')
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     Object.defineProperty(navigator, 'clipboard', {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR, the code block wrapper used `overflow-hidden`. That creates a scroll container for CSS `position: sticky`, so the copy/download toolbar can stop following the message viewport and require scrolling back toward the top.

After this PR, the wrapper uses `overflow-clip`, which preserves rounded-corner clipping without creating a scrolling mechanism. The existing sticky toolbar can therefore remain visible while the message containing a long code block is scrolled.

Fixes #18914

### Why we need it and why it was done in this way

`overflow-clip` is the smallest CSS-only change that keeps the visual clipping behavior while allowing the toolbar's existing sticky positioning to resolve against the message scroll container. No new dependency or layout wrapper is needed.

Before:

```
message scroll
└─ code block (overflow-hidden creates scroll container)
   └─ sticky toolbar stops following the message viewport
```

After:

```
message scroll
└─ code block (overflow-clip clips without a scroll container)
   └─ sticky toolbar follows the message viewport
```

### Breaking changes

None.

### Special notes for your reviewer

The regression test asserts the code block uses `overflow-clip` and no longer uses `overflow-hidden`, protecting the sticky-toolbar contract.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin Fowler#code-for-humans)
- [x] Refactor: I have left the code cleaner than I found it
- [x] Upgrade: No upgrade flow impact
- [x] Documentation: Not required for this CSS regression fix
- [x] Self-review: I reviewed the staged diff and focused test output

### Release note

```release-note
Fix code-block copy and download buttons staying out of view while scrolling.
```

### Verification

- `pnpm exec vitest run --project renderer src/renderer/components/CodeToolbar/__tests__/CodeToolbar.test.tsx src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx` (13 tests passed)
- `pnpm exec biome format src/renderer/components/CodeBlockView/CodeBlockView.tsx src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx`
- `pnpm exec oxlint src/renderer/components/CodeBlockView/CodeBlockView.tsx src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx`
- `pnpm exec eslint src/renderer/components/CodeBlockView/CodeBlockView.tsx src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx`
