### PR TITLE
fix(agent-composer): show full AskUserQuestion titles

### DIFF
--- a/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
@@ -202,7 +202,7 @@ export default function AskUserQuestionComposer({ request, onRespond, className 
         className="rounded-[17px] border-[0.5px] border-border p-2.5 backdrop-blur"
         style={{ backgroundColor: 'color-mix(in srgb, var(--background) 88%, transparent)' }}>
         <div className="flex items-center justify-between gap-3 px-1">
-          <h2 className="min-w-0 flex-1 whitespace-pre-wrap break-words font-semibold text-foreground text-sm leading-5">
+          <h2 className="max-h-36 min-w-0 flex-1 overflow-y-auto whitespace-pre-wrap break-words font-semibold text-foreground text-sm leading-5">
             {currentQuestion.question}
           </h2>
 

--- a/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
@@ -202,7 +202,7 @@ export default function AskUserQuestionComposer({ request, onRespond, className 
         className="rounded-[17px] border-[0.5px] border-border p-2.5 backdrop-blur"
         style={{ backgroundColor: 'color-mix(in srgb, var(--background) 88%, transparent)' }}>
         <div className="flex items-center justify-between gap-3 px-1">
-          <h2 className="line-clamp-1 min-w-0 flex-1 font-semibold text-foreground text-sm leading-5">
+          <h2 className="min-w-0 flex-1 whitespace-pre-wrap break-words font-semibold text-foreground text-sm leading-5">
             {currentQuestion.question}
           </h2>
 

--- a/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
@@ -68,6 +68,15 @@ function makeRequest(): AskUserQuestionComposerRequest {
 }
 
 describe('AskUserQuestionComposer', () => {
+  it('keeps the full question visible instead of clamping it to one line', () => {
+    render(<AskUserQuestionComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    const heading = screen.getByRole('heading', { name: 'Choose logger' })
+    // The wrapping classes are the layout contract for the reported long-question truncation.
+    expect(heading).toHaveClass('whitespace-pre-wrap', 'break-words')
+    expect(heading).not.toHaveClass('line-clamp-1')
+  })
+
   it('marks the root panel as a composer viewport inset target', () => {
     const { container } = render(<AskUserQuestionComposer request={makeRequest()} onRespond={vi.fn()} />)
 

--- a/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
@@ -42,12 +42,12 @@ const questions = [
   }
 ]
 
-function makeRequest(): AskUserQuestionComposerRequest {
+function makeRequest(requestQuestions = questions): AskUserQuestionComposerRequest {
   const part = {
     type: 'tool-AskUserQuestion',
     toolCallId: 'call-1',
     state: 'approval-requested',
-    input: { questions },
+    input: { questions: requestQuestions },
     approval: { id: 'approval-1' }
   } as unknown as CherryMessagePart
 
@@ -55,14 +55,14 @@ function makeRequest(): AskUserQuestionComposerRequest {
     messageId: 'message-1',
     toolCallId: 'call-1',
     approvalId: 'approval-1',
-    input: { questions },
+    input: { questions: requestQuestions },
     match: {
       part,
       state: 'approval-requested',
       toolCallId: 'call-1',
       messageId: 'message-1',
       approvalId: 'approval-1',
-      input: { questions }
+      input: { questions: requestQuestions }
     }
   }
 }
@@ -75,6 +75,37 @@ describe('AskUserQuestionComposer', () => {
     // The wrapping classes are the layout contract for the reported long-question truncation.
     expect(heading).toHaveClass('whitespace-pre-wrap', 'break-words')
     expect(heading).not.toHaveClass('line-clamp-1')
+  })
+
+  it('caps a long multiline question with vertical scrolling so answer controls stay reachable', () => {
+    const longQuestion = [
+      'Which logging approach should the agent use for this multi-service workspace?',
+      'Please consider structured JSON output, rotation, and how traces should correlate across the renderer and main process.',
+      'The answer will be applied to every new session, so pick the option that stays readable when the composer dock is only 150px tall.'
+    ].join('\n')
+
+    render(
+      <AskUserQuestionComposer
+        request={makeRequest([
+          {
+            question: longQuestion,
+            header: 'Logger',
+            options: [
+              { label: 'Winston', description: 'Mature ecosystem' },
+              { label: 'Pino', description: 'JSON native' }
+            ],
+            multiSelect: false
+          }
+        ])}
+        onRespond={vi.fn()}
+      />
+    )
+
+    const heading = screen.getByRole('heading', { name: longQuestion })
+    expect(heading).toHaveClass('whitespace-pre-wrap', 'break-words', 'max-h-36', 'overflow-y-auto')
+    expect(heading).not.toHaveClass('line-clamp-1')
+    expect(screen.getByRole('button', { name: /Winston/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
   })
 
   it('marks the root panel as a composer viewport inset target', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Long AskUserQuestion prompts were clamped to one line in the Agent composer.

After this PR:

Question titles wrap and remain fully readable.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The full question is required context for choosing an answer. The change removes only the one-line clamp and preserves the existing composer layout.

The following tradeoffs were made:

Long questions may make the approval composer taller.

The following alternatives were considered:

A tooltip or manual expansion control was rejected because it would keep essential question text hidden by default.

Links to places where the discussion took place: DEV record recvrvueGRpDaP

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Focused renderer coverage verifies that the title wraps instead of using the one-line clamp.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this visual fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent questions now show their full title instead of truncating it to one line.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only class change on the question heading with matching tests; no logic, auth, or data-handling changes.
> 
> **Overview**
> Stops truncating AskUserQuestion titles to a single line so users can read the full prompt when choosing an answer.
> 
> The heading now wraps (`whitespace-pre-wrap` / `break-words`) and scrolls after `max-h-36`, keeping option and close controls reachable. Tests cover wrapping vs `line-clamp-1` and the scroll cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d737dde24932ebccb1295e57507e60fd04e9fea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->