### PR TITLE
fix(notes): preserve navigation after renaming

### DIFF
--- a/src/renderer/hooks/__tests__/useInPlaceEdit.test.tsx
+++ b/src/renderer/hooks/__tests__/useInPlaceEdit.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { useInPlaceEdit } from '../useInPlaceEdit'
+
+function RenameNavigationHarness() {
+  const [treeRevision, setTreeRevision] = useState(0)
+  const [selectedNote, setSelectedNote] = useState('Current note')
+  const editor = useInPlaceEdit({
+    onSave: () => setTreeRevision((revision) => revision + 1)
+  })
+
+  return (
+    <div>
+      {editor.isEditing ? (
+        <input aria-label="Note name" {...editor.inputProps} />
+      ) : (
+        <button type="button" onClick={() => editor.startEdit('Current note')}>
+          Rename current note
+        </button>
+      )}
+      <button key={treeRevision} type="button" onClick={() => setSelectedNote('Other note')}>
+        Other note
+      </button>
+      <output aria-label="Selected note">{selectedNote}</output>
+      <output aria-label="Tree revision">{treeRevision}</output>
+    </div>
+  )
+}
+
+describe('useInPlaceEdit', () => {
+  it('lets the first click select another note while blur saves the rename', async () => {
+    const user = userEvent.setup()
+    render(<RenameNavigationHarness />)
+
+    await user.click(screen.getByRole('button', { name: 'Rename current note' }))
+    const input = screen.getByRole('textbox', { name: 'Note name' })
+    await user.clear(input)
+    await user.type(input, 'Renamed note')
+
+    await user.click(screen.getByRole('button', { name: 'Other note' }))
+
+    expect(screen.getByRole('status', { name: 'Selected note' })).toHaveTextContent('Other note')
+    await waitFor(() => expect(screen.getByRole('status', { name: 'Tree revision' })).toHaveTextContent('1'))
+  })
+})

--- a/src/renderer/hooks/__tests__/useInPlaceEdit.test.tsx
+++ b/src/renderer/hooks/__tests__/useInPlaceEdit.test.tsx
@@ -1,15 +1,17 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { useInPlaceEdit } from '../useInPlaceEdit'
 
-function RenameNavigationHarness() {
+function RenameNavigationHarness({ onSave }: { onSave?: (value: string) => void }) {
   const [treeRevision, setTreeRevision] = useState(0)
   const [selectedNote, setSelectedNote] = useState('Current note')
   const editor = useInPlaceEdit({
-    onSave: () => setTreeRevision((revision) => revision + 1)
+    onSave: (value) => {
+      onSave?.(value)
+      setTreeRevision((revision) => revision + 1)
+    }
   })
 
   return (
@@ -31,18 +33,53 @@ function RenameNavigationHarness() {
 }
 
 describe('useInPlaceEdit', () => {
-  it('lets the first click select another note while blur saves the rename', async () => {
-    const user = userEvent.setup()
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('waits for the pointer click before blur-save remounts the target row', async () => {
+    vi.useFakeTimers()
     render(<RenameNavigationHarness />)
 
-    await user.click(screen.getByRole('button', { name: 'Rename current note' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Rename current note' }))
     const input = screen.getByRole('textbox', { name: 'Note name' })
-    await user.clear(input)
-    await user.type(input, 'Renamed note')
+    fireEvent.change(input, { target: { value: 'Renamed note' } })
+    const otherNote = screen.getByRole('button', { name: 'Other note' })
 
-    await user.click(screen.getByRole('button', { name: 'Other note' }))
+    fireEvent.pointerDown(otherNote)
+    fireEvent.blur(input, { relatedTarget: otherNote })
+    await act(async () => {
+      vi.runOnlyPendingTimers()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('status', { name: 'Tree revision' })).toHaveTextContent('0')
+
+    fireEvent.pointerUp(otherNote)
+    fireEvent.click(otherNote)
+    await act(async () => {
+      vi.runOnlyPendingTimers()
+      await Promise.resolve()
+    })
 
     expect(screen.getByRole('status', { name: 'Selected note' })).toHaveTextContent('Other note')
-    await waitFor(() => expect(screen.getByRole('status', { name: 'Tree revision' })).toHaveTextContent('1'))
+    expect(screen.getByRole('status', { name: 'Tree revision' })).toHaveTextContent('1')
+  })
+
+  it('flushes a pending blur-save when the editor unmounts', () => {
+    vi.useFakeTimers()
+    const onSave = vi.fn()
+    const view = render(<RenameNavigationHarness onSave={onSave} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename current note' }))
+    const input = screen.getByRole('textbox', { name: 'Note name' })
+    fireEvent.change(input, { target: { value: 'Renamed note' } })
+    const otherNote = screen.getByRole('button', { name: 'Other note' })
+    fireEvent.pointerDown(otherNote)
+    fireEvent.blur(input, { relatedTarget: otherNote })
+
+    view.unmount()
+
+    expect(onSave).toHaveBeenCalledWith('Renamed note')
   })
 })

--- a/src/renderer/hooks/useInPlaceEdit.ts
+++ b/src/renderer/hooks/useInPlaceEdit.ts
@@ -1,6 +1,6 @@
 import { loggerService } from '@logger'
 import { toast } from '@renderer/services/toast'
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useInPlaceEdit')
@@ -40,12 +40,25 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
   const originalValueRef = useRef('')
   const isSavingRef = useRef(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  const blurSaveTimerRef = useRef<number | null>(null)
 
-  const startEdit = useCallback((initialValue: string) => {
-    setIsEditing(true)
-    setEditValue(initialValue)
-    originalValueRef.current = initialValue
+  const clearPendingBlurSave = useCallback(() => {
+    if (blurSaveTimerRef.current === null) return
+    window.clearTimeout(blurSaveTimerRef.current)
+    blurSaveTimerRef.current = null
   }, [])
+
+  const startEdit = useCallback(
+    (initialValue: string) => {
+      clearPendingBlurSave()
+      setIsEditing(true)
+      setEditValue(initialValue)
+      originalValueRef.current = initialValue
+    },
+    [clearPendingBlurSave]
+  )
+
+  useEffect(() => clearPendingBlurSave, [clearPendingBlurSave])
 
   useLayoutEffect(() => {
     if (isEditing) {
@@ -58,6 +71,7 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
 
   const saveEdit = useCallback(async () => {
     if (isSavingRef.current) return
+    clearPendingBlurSave()
 
     const finalValue = trimOnSave ? editValue.trim() : editValue
     if (finalValue === originalValueRef.current) {
@@ -85,13 +99,14 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
       setIsSaving(false)
       isSavingRef.current = false
     }
-  }, [trimOnSave, editValue, onSave, onError, t])
+  }, [clearPendingBlurSave, trimOnSave, editValue, onSave, onError, t])
 
   const cancelEdit = useCallback(() => {
+    clearPendingBlurSave()
     setIsEditing(false)
     setEditValue('')
     onCancel?.()
-  }, [onCancel])
+  }, [clearPendingBlurSave, onCancel])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -115,14 +130,13 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
   }, [])
 
   const handleBlur = useCallback(() => {
-    // 这里的逻辑需要注意：
-    // 如果点击了“取消”按钮，可能会先触发 Blur 保存。
-    // 通常 InPlaceEdit 的逻辑是 Blur 即 Save。
-    // 如果不想 Blur 保存，可以去掉这一行，或者判断 relatedTarget。
-    if (!isSavingRef.current) {
+    if (isSavingRef.current) return
+    clearPendingBlurSave()
+    blurSaveTimerRef.current = window.setTimeout(() => {
+      blurSaveTimerRef.current = null
       void saveEdit()
-    }
-  }, [saveEdit])
+    }, 0)
+  }, [clearPendingBlurSave, saveEdit])
 
   return {
     isEditing,

--- a/src/renderer/hooks/useInPlaceEdit.ts
+++ b/src/renderer/hooks/useInPlaceEdit.ts
@@ -39,14 +39,58 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
   const [editValue, setEditValue] = useState('')
   const originalValueRef = useRef('')
   const isSavingRef = useRef(false)
+  const isMountedRef = useRef(true)
   const inputRef = useRef<HTMLInputElement>(null)
   const blurSaveTimerRef = useRef<number | null>(null)
+  const pendingBlurSaveRef = useRef<(() => void) | null>(null)
+  const pointerDownRef = useRef(false)
+  const pointerEndListenerRef = useRef<(() => void) | null>(null)
 
   const clearPendingBlurSave = useCallback(() => {
-    if (blurSaveTimerRef.current === null) return
-    window.clearTimeout(blurSaveTimerRef.current)
-    blurSaveTimerRef.current = null
+    if (blurSaveTimerRef.current !== null) {
+      window.clearTimeout(blurSaveTimerRef.current)
+      blurSaveTimerRef.current = null
+    }
+    if (pointerEndListenerRef.current) {
+      window.removeEventListener('pointerup', pointerEndListenerRef.current)
+      window.removeEventListener('pointercancel', pointerEndListenerRef.current)
+      pointerEndListenerRef.current = null
+    }
+    pendingBlurSaveRef.current = null
   }, [])
+
+  const flushPendingBlurSave = useCallback(() => {
+    const pendingSave = pendingBlurSaveRef.current
+    clearPendingBlurSave()
+    pendingSave?.()
+  }, [clearPendingBlurSave])
+
+  useEffect(() => {
+    isMountedRef.current = true
+    const handlePointerDown = () => {
+      pointerDownRef.current = true
+    }
+    const handlePointerEnd = () => {
+      pointerDownRef.current = false
+    }
+    const handleWindowBlur = () => {
+      pointerDownRef.current = false
+      flushPendingBlurSave()
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown, true)
+    window.addEventListener('pointerup', handlePointerEnd, true)
+    window.addEventListener('pointercancel', handlePointerEnd, true)
+    window.addEventListener('blur', handleWindowBlur)
+    return () => {
+      isMountedRef.current = false
+      window.removeEventListener('pointerdown', handlePointerDown, true)
+      window.removeEventListener('pointerup', handlePointerEnd, true)
+      window.removeEventListener('pointercancel', handlePointerEnd, true)
+      window.removeEventListener('blur', handleWindowBlur)
+      flushPendingBlurSave()
+    }
+  }, [flushPendingBlurSave])
 
   const startEdit = useCallback(
     (initialValue: string) => {
@@ -57,8 +101,6 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
     },
     [clearPendingBlurSave]
   )
-
-  useEffect(() => clearPendingBlurSave, [clearPendingBlurSave])
 
   useLayoutEffect(() => {
     if (isEditing) {
@@ -75,17 +117,19 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
 
     const finalValue = trimOnSave ? editValue.trim() : editValue
     if (finalValue === originalValueRef.current) {
-      setIsEditing(false)
+      if (isMountedRef.current) setIsEditing(false)
       return
     }
 
     isSavingRef.current = true
-    setIsSaving(true)
+    if (isMountedRef.current) setIsSaving(true)
 
     try {
       await onSave(finalValue)
-      setIsEditing(false)
-      setEditValue('')
+      if (isMountedRef.current) {
+        setIsEditing(false)
+        setEditValue('')
+      }
     } catch (error) {
       logger.error('Error saving in-place edit', { error })
 
@@ -96,7 +140,7 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
         toast.error(t('common.save_failed') || 'Failed to save')
       }
     } finally {
-      setIsSaving(false)
+      if (isMountedRef.current) setIsSaving(false)
       isSavingRef.current = false
     }
   }, [clearPendingBlurSave, trimOnSave, editValue, onSave, onError, t])
@@ -132,11 +176,26 @@ export function useInPlaceEdit(options: UseInPlaceEditOptions): UseInPlaceEditRe
   const handleBlur = useCallback(() => {
     if (isSavingRef.current) return
     clearPendingBlurSave()
+    pendingBlurSaveRef.current = () => void saveEdit()
+
+    if (pointerDownRef.current) {
+      const handlePointerEnd = () => {
+        window.removeEventListener('pointerup', handlePointerEnd)
+        window.removeEventListener('pointercancel', handlePointerEnd)
+        pointerEndListenerRef.current = null
+        blurSaveTimerRef.current = window.setTimeout(flushPendingBlurSave, 0)
+      }
+      pointerEndListenerRef.current = handlePointerEnd
+      window.addEventListener('pointerup', handlePointerEnd, { once: true })
+      window.addEventListener('pointercancel', handlePointerEnd, { once: true })
+      return
+    }
+
     blurSaveTimerRef.current = window.setTimeout(() => {
       blurSaveTimerRef.current = null
-      void saveEdit()
+      flushPendingBlurSave()
     }, 0)
-  }, [clearPendingBlurSave, saveEdit])
+  }, [clearPendingBlurSave, flushPendingBlurSave, saveEdit])
 
   return {
     isEditing,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Saving an inline note rename during blur could replace the clicked tree row before its click event, so the first click on another note was lost.

After this PR:

Blur-save is deferred until the click completes, preserving both the rename and the first navigation click.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The race originates in the shared inline-edit hook: synchronous blur-save can rerender keyed lists between pointer down and click. Deferring only blur-triggered saves fixes the upstream interaction while Enter, Escape, and cancellation remain immediate.

The following tradeoffs were made:

Blur persistence happens on the next task instead of in the blur handler itself.

The following alternatives were considered:

Changing Notes tree selection to pointer-down was rejected because it would duplicate interaction policy in one consumer and affect drag behavior.

Links to places where the discussion took place: DEV record recvsKaAQINg7H

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The regression harness replaces the clicked row during save, matching the event-order failure.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this bug fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
The first click after renaming a note now switches to the selected note correctly.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 07050533e49138d98992c195ca6a662facc2a90d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->