### PR TITLE
fix(api-gateway): fold client system messages into the system prompt

### DIFF
--- a/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
@@ -16,6 +16,37 @@ describe('AnthropicMessageConverter.toUIMessages', () => {
     expect(msgs[1]).toMatchObject({ role: 'user', parts: [{ type: 'text', text: 'hi' }] })
   })
 
+  it('folds a client-sent system message into the system prompt instead of faking an assistant turn', () => {
+    // Claude Code appends `role: 'system'` reminders to `messages`; converting one to an
+    // assistant turn leaves a text-only assistant tail the model is asked to continue from.
+    const msgs = converter.toUIMessages(
+      params({
+        system: 'Be terse.',
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'system', content: 'Available agent types: claude, Explore.' }
+        ] as never
+      })
+    )
+
+    expect(msgs.map((msg) => msg.role)).toEqual(['system', 'user'])
+    expect(msgs[0].parts).toEqual([{ type: 'text', text: 'Be terse.\nAvailable agent types: claude, Explore.' }])
+  })
+
+  it('folds a block-shaped system message that arrives before the user turn', () => {
+    const msgs = converter.toUIMessages(
+      params({
+        messages: [
+          { role: 'system', content: [{ type: 'text', text: 'Reminder.' }] },
+          { role: 'user', content: 'hi' }
+        ] as never
+      })
+    )
+
+    expect(msgs.map((msg) => msg.role)).toEqual(['system', 'user'])
+    expect(msgs[0].parts).toEqual([{ type: 'text', text: 'Reminder.' }])
+  })
+
   it('joins a structured (text-block) system prompt', () => {
     const msgs = converter.toUIMessages(
       params({

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -29,6 +29,25 @@ const RESPONSES_TOOL_NAME_PATTERN = /^[A-Za-z0-9_-]+$/
 const RESPONSES_TOOL_NAME_MAX_LENGTH = 64
 const TOOL_NAME_HASH_LENGTH = 12
 
+/**
+ * Claude Code sends per-turn reminders as `role: 'system'` entries inside `messages`,
+ * which the loosely-validated route forwards as-is. Coercing them to `assistant`
+ * would fabricate a turn the model never took, so they are folded into the system prompt.
+ */
+function isSystemMessage(msg: MessageCreateParams['messages'][number]): boolean {
+  return (msg.role as string) === 'system'
+}
+
+/** Anthropic system content — a string or text blocks — as plain text. */
+function systemContentToText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((block): block is { type: 'text'; text: string } => block?.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+}
+
 function isResponsesCompatibleToolName(name: string): boolean {
   return name.length <= RESPONSES_TOOL_NAME_MAX_LENGTH && RESPONSES_TOOL_NAME_PATTERN.test(name)
 }
@@ -140,7 +159,8 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
   /**
    * Convert Anthropic MessageCreateParams to AI SDK `CherryUIMessage[]`.
    *
-   * The leading system prompt is emitted as a `role: 'system'` UIMessage —
+   * The system prompt — `params.system` plus any `role: 'system'` entry the client
+   * placed in `messages` — is emitted as one leading `role: 'system'` UIMessage;
    * `convertToModelMessages` (run by main) lifts that to the SDK `system`.
    * Tool calls become `dynamic-tool` parts; a matching tool_result in a later
    * message upgrades the part to `output-available` so history stays coherent.
@@ -149,18 +169,13 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
     this.prepareToolNames(params.tools)
     const messages: CherryUIMessage[] = []
 
-    // System message
-    if (params.system) {
-      const systemText =
-        typeof params.system === 'string'
-          ? params.system
-          : params.system
-              .filter((block) => block.type === 'text')
-              .map((block) => block.text)
-              .join('\n')
-      if (systemText) {
-        messages.push({ id: nextUIMessageId(), role: 'system', parts: [{ type: 'text', text: systemText }] })
-      }
+    // System message, plus any `role: 'system'` entry the client put in `messages`.
+    const systemText = [params.system, ...params.messages.filter(isSystemMessage).map((msg) => msg.content)]
+      .map(systemContentToText)
+      .filter(Boolean)
+      .join('\n')
+    if (systemText) {
+      messages.push({ id: nextUIMessageId(), role: 'system', parts: [{ type: 'text', text: systemText }] })
     }
 
     // tool_use id → name (for tool_result parts) and tool_use id → result conversion.
@@ -181,6 +196,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
     }
 
     for (const msg of params.messages) {
+      if (isSystemMessage(msg)) continue
       const role = msg.role === 'user' ? 'user' : 'assistant'
 
       if (typeof msg.content === 'string') {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Claude Code appends per-turn reminders to `messages` as `role: 'system'` entries, and `/v1/messages` forwards them because `MessagesBodySchema` is loose by design. `AnthropicMessageConverter.toUIMessages` mapped every non-`user` role to `assistant`:

```ts
const role = msg.role === 'user' ? 'user' : 'assistant'
```

so a 6 KB system reminder was delivered to the model as a turn the assistant never took.

Captured from a real `claude` 2.1.223 session (`ANTHROPIC_BASE_URL` pointed at a recording proxy, one `Bash` tool call):

| Turn | Wire messages the provider received |
| --- | --- |
| 1 | `system(6221B) → user(388B) → assistant(6148B) → user(142B)` |
| 2 | `system(6221B) → user(388B) → assistant(6148B) → assistant(122B) → tool(111B)` |

Three separate problems are visible there:

1. The 6 KB reminder is attributed to the assistant.
2. On turn 1 it lands last, producing the text-only assistant tail that `appendInternalAgentContinuation` exists to work around — so the trailing `user(142B)` is a **fabricated** message telling the model to ignore the turn above it.
3. On turn 2 it yields two consecutive `assistant` messages, and the real 388-byte user query sits behind 6 KB of misattributed text. Backends that truncate from the front to fit a small context window drop the user query first.

After this PR:

| Turn | Wire messages the provider received |
| --- | --- |
| 1 | `system(12344B) → user(388B)` |
| 2 | `system(12344B) → user(388B) → assistant(122B) → tool(111B)` |

The reminder is folded into the leading system UIMessage, the fabricated assistant turn is gone, the continuation workaround no longer triggers, and the conversation matches what the client sent.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #18643

### Why we need it and why it was done in this way

Folding into the system prompt rather than emitting a mid-conversation `role: 'system'` message: the AI SDK accepts system messages anywhere in `messages`, but `standardizePrompt` warns on every such request ("System messages in the prompt or messages fields can be a security risk…") unless `allowSystemInMessages` is passed, which this codebase does not set. Hoisting is also unconditionally valid for every provider and dialect the gateway targets, while a non-leading system message is not.

The following tradeoffs were made:

- Positional context is lost: a reminder the client placed after the user turn is merged into the leading system prompt. For Claude Code these reminders are re-sent verbatim every turn, so nothing is dropped, and system content belongs in the system slot regardless.
- The entries are trusted as system content. This grants no new capability, since any caller that can set `messages` can already set `system` on the same request.

The following alternatives were considered:

- Mapping `role: 'system'` to a system UIMessage in place was rejected for the SDK warning noise and the provider-compatibility risk described above.
- Dropping the entries to match the Anthropic `MessageParam` type (`role` is `'user' | 'assistant'`) was rejected because it would silently discard instructions the primary client relies on.
- Removing `appendInternalAgentContinuation` now that its documented trigger is fixed was left out of scope. A text-only assistant tail can still arrive from a genuine assistant prefill, so removing it needs its own change.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18643

### Breaking changes

NONE

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The `(msg.role as string) === 'system'` cast is deliberate: the Anthropic SDK types `role` as `'user' | 'assistant'`, but the route is loose by design and the real payload above proves clients send `'system'`. The cast is isolated in `isSystemMessage` so the comparison is explained once.

Validation completed:

- `src/main/features/apiGateway` (main project, 28 files): 384 tests passed
- `tsgo --noEmit -p tsconfig.node.json`: no errors in the changed files
- Biome + ESLint via pre-commit: passed

Two new converter tests cover a string-shaped reminder after the user turn and a block-shaped one before it; both assert the roles are `['system', 'user']` and fail on `main`, where the third role is `assistant`.

Relation to #18780: that PR hardens a different crash in the same method (`tools` entries with no `input_schema`). The two are independent and do not conflict.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Agent sessions routed through the API gateway sending the client's system reminders to the model as assistant messages, which confused the conversation and could push the user's actual request out of a small context window.
```
