### PR TITLE
fix(user-data-relocation): copy symlink targets during migration

### DIFF
--- a/src/main/services/userDataRelocation/__tests__/execution.test.ts
+++ b/src/main/services/userDataRelocation/__tests__/execution.test.ts
@@ -12,7 +12,6 @@ const {
   bootConfigPersistMock,
   bootConfigSetMock,
   electronState,
-  platformState,
   relaunchMock,
   updateProgressMock,
   windowCloseMock,
@@ -26,7 +25,6 @@ const {
   bootConfigPersistMock: vi.fn(),
   bootConfigSetMock: vi.fn(),
   electronState: { isPackaged: true },
-  platformState: { isLinux: false, isMac: false, isWin: false },
   relaunchMock: vi.fn(),
   updateProgressMock: vi.fn(),
   windowCloseMock: vi.fn(),
@@ -50,19 +48,6 @@ vi.mock('@application', () => ({
       return filename ? path.join(String(root), filename) : root
     },
     relaunch: relaunchMock
-  }
-}))
-vi.mock('@main/core/platform', () => ({
-  isDev: false,
-  isPortable: false,
-  get isLinux() {
-    return platformState.isLinux
-  },
-  get isMac() {
-    return platformState.isMac
-  },
-  get isWin() {
-    return platformState.isWin
   }
 }))
 // userDataLocation is intentionally NOT mocked: the private commit step runs
@@ -131,9 +116,6 @@ beforeEach(async () => {
   vi.resetModules()
   vi.clearAllMocks()
   electronState.isPackaged = true
-  platformState.isLinux = false
-  platformState.isMac = false
-  platformState.isWin = false
   await usePromises()
 
   const appTemp = makeRoot()
@@ -337,47 +319,29 @@ describe('userDataRelocation execution', () => {
     expectCommitted(target)
   })
 
-  it('rewrites an absolute symlink that points inside the copied source tree', async () => {
-    if (process.platform === 'win32') return
+  it.skipIf(process.platform === 'win32')('materializes symlinks without creating links in the target', async () => {
     const root = makeRoot()
     const source = path.join(root, 'source')
     const target = path.join(root, 'target')
-    fs.mkdirSync(source)
-    fs.writeFileSync(path.join(source, 'data.txt'), 'data')
-    fs.symlinkSync(path.join(source, 'data.txt'), path.join(source, 'data-link'))
+    const realDirectory = path.join(source, 'real')
+    fs.mkdirSync(realDirectory, { recursive: true })
+    fs.writeFileSync(path.join(realDirectory, 'data.txt'), 'data')
+    fs.symlinkSync(realDirectory, path.join(source, 'directory-link'), 'dir')
+    fs.symlinkSync(path.join(realDirectory, 'data.txt'), path.join(source, 'file-link'), 'file')
     relocationState['app.userdata'] = source
     relocationState['temp.user_data_relocation'] = pending(source, target)
-
-    const { runUserDataRelocation } = await loadDomain()
-    await expect(runUserDataRelocation()).resolves.toBe('handled')
-
-    expect(fs.readlinkSync(path.join(target, 'data-link'))).toBe(path.join(fs.realpathSync(target), 'data.txt'))
-    expect(updateProgressMock).toHaveBeenCalledWith(expect.objectContaining({ stage: 'completed' }))
-  })
-
-  it('resolves a relative directory link before creating a Windows junction', async () => {
-    const root = makeRoot()
-    const source = path.join(root, 'source')
-    const target = path.join(root, 'target')
-    fs.mkdirSync(path.join(source, 'real'), { recursive: true })
-    fs.symlinkSync('real', path.join(source, 'relative-link'), 'dir')
-    relocationState['app.userdata'] = source
-    relocationState['temp.user_data_relocation'] = pending(source, target)
-    platformState.isWin = true
-    const symlinkMock = vi.fn<typeof symlink>().mockImplementation(async (targetValue, linkPath) => {
-      fs.symlinkSync(targetValue, linkPath)
-    })
+    const permissionError = Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    const symlinkMock = vi.fn<typeof symlink>().mockRejectedValue(permissionError)
     await usePromises({ symlink: symlinkMock })
 
     const { runUserDataRelocation } = await loadDomain()
     await expect(runUserDataRelocation()).resolves.toBe('handled')
 
-    expect(symlinkMock).toHaveBeenCalledWith(
-      // `.native` to match fsp.realpath, which expands Windows 8.3 short names.
-      path.join(fs.realpathSync.native(target), 'real'),
-      path.join(root, `.target.cherry-relocation-${TASK_ID}-work`, 'payload', 'relative-link'),
-      'junction'
-    )
+    expect(symlinkMock).not.toHaveBeenCalled()
+    expect(fs.lstatSync(path.join(target, 'directory-link')).isSymbolicLink()).toBe(false)
+    expect(fs.lstatSync(path.join(target, 'file-link')).isSymbolicLink()).toBe(false)
+    expect(fs.readFileSync(path.join(target, 'directory-link', 'data.txt'), 'utf8')).toBe('data')
+    expect(fs.readFileSync(path.join(target, 'file-link'), 'utf8')).toBe('data')
     expectCommitted(target)
   })
 

--- a/src/main/services/userDataRelocation/__tests__/execution.test.ts
+++ b/src/main/services/userDataRelocation/__tests__/execution.test.ts
@@ -319,15 +319,21 @@ describe('userDataRelocation execution', () => {
     expectCommitted(target)
   })
 
-  it.skipIf(process.platform === 'win32')('materializes symlinks without creating links in the target', async () => {
+  it('materializes symlinks without creating links in the target', async () => {
     const root = makeRoot()
     const source = path.join(root, 'source')
     const target = path.join(root, 'target')
     const realDirectory = path.join(source, 'real')
     fs.mkdirSync(realDirectory, { recursive: true })
     fs.writeFileSync(path.join(realDirectory, 'data.txt'), 'data')
-    fs.symlinkSync(realDirectory, path.join(source, 'directory-link'), 'dir')
-    fs.symlinkSync(path.join(realDirectory, 'data.txt'), path.join(source, 'file-link'), 'file')
+    fs.symlinkSync(
+      realDirectory,
+      path.join(source, 'directory-link'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    if (process.platform !== 'win32') {
+      fs.symlinkSync(path.join(realDirectory, 'data.txt'), path.join(source, 'file-link'), 'file')
+    }
     relocationState['app.userdata'] = source
     relocationState['temp.user_data_relocation'] = pending(source, target)
     const permissionError = Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
@@ -339,9 +345,30 @@ describe('userDataRelocation execution', () => {
 
     expect(symlinkMock).not.toHaveBeenCalled()
     expect(fs.lstatSync(path.join(target, 'directory-link')).isSymbolicLink()).toBe(false)
-    expect(fs.lstatSync(path.join(target, 'file-link')).isSymbolicLink()).toBe(false)
     expect(fs.readFileSync(path.join(target, 'directory-link', 'data.txt'), 'utf8')).toBe('data')
-    expect(fs.readFileSync(path.join(target, 'file-link'), 'utf8')).toBe('data')
+    if (process.platform !== 'win32') {
+      expect(fs.lstatSync(path.join(target, 'file-link')).isSymbolicLink()).toBe(false)
+      expect(fs.readFileSync(path.join(target, 'file-link'), 'utf8')).toBe('data')
+    }
+    expectCommitted(target)
+  })
+
+  it('skips a circular directory symlink while materializing the rest of the tree', async () => {
+    const root = makeRoot()
+    const source = path.join(root, 'source')
+    const target = path.join(root, 'target')
+    const backups = path.join(source, 'backups')
+    fs.mkdirSync(backups, { recursive: true })
+    fs.writeFileSync(path.join(backups, 'data.txt'), 'data')
+    fs.symlinkSync(backups, path.join(backups, 'current'), process.platform === 'win32' ? 'junction' : 'dir')
+    relocationState['app.userdata'] = source
+    relocationState['temp.user_data_relocation'] = pending(source, target)
+
+    const { runUserDataRelocation } = await loadDomain()
+    await expect(runUserDataRelocation()).resolves.toBe('handled')
+
+    expect(fs.readFileSync(path.join(target, 'backups', 'data.txt'), 'utf8')).toBe('data')
+    expect(fs.existsSync(path.join(target, 'backups', 'current'))).toBe(false)
     expectCommitted(target)
   })
 

--- a/src/main/services/userDataRelocation/__tests__/execution.test.ts
+++ b/src/main/services/userDataRelocation/__tests__/execution.test.ts
@@ -372,6 +372,30 @@ describe('userDataRelocation execution', () => {
     expectCommitted(target)
   })
 
+  it('skips a broken symlink whose target traverses a file', async () => {
+    const root = makeRoot()
+    const source = path.join(root, 'source')
+    const target = path.join(root, 'target')
+    const obstructingFile = path.join(source, 'not-a-directory')
+    fs.mkdirSync(source)
+    fs.writeFileSync(path.join(source, 'data.txt'), 'data')
+    fs.writeFileSync(obstructingFile, 'file')
+    fs.symlinkSync(
+      path.join(obstructingFile, 'child'),
+      path.join(source, 'broken-link'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    relocationState['app.userdata'] = source
+    relocationState['temp.user_data_relocation'] = pending(source, target)
+
+    const { runUserDataRelocation } = await loadDomain()
+    await expect(runUserDataRelocation()).resolves.toBe('handled')
+
+    expect(fs.readFileSync(path.join(target, 'data.txt'), 'utf8')).toBe('data')
+    expect(fs.existsSync(path.join(target, 'broken-link'))).toBe(false)
+    expectCommitted(target)
+  })
+
   it('tolerates a source file that vanishes between enumeration and copy', async () => {
     const root = makeRoot()
     const source = path.join(root, 'source')

--- a/src/main/services/userDataRelocation/execution.ts
+++ b/src/main/services/userDataRelocation/execution.ts
@@ -4,7 +4,6 @@ import path from 'node:path'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { isWin } from '@main/core/platform'
 import { canonicalizeUserDataPath, getNormalizedExecutablePath } from '@main/core/preboot/userDataLocation'
 import { bootConfigService } from '@main/data/bootConfig'
 import type { RelocationProgress } from '@shared/types/userDataRelocation'
@@ -19,12 +18,9 @@ import {
   assertUserDataRelocationRequest,
   invalid,
   isErrno,
-  isPathInside,
   normalizeForCompare,
   pathEntryExists,
-  realPath,
   relocationArtifactPaths,
-  resolveEffectivePath,
   resolveExistingAncestor
 } from './validation'
 import { openUserDataRelocationWindow, type UserDataRelocationWindow } from './window'
@@ -248,8 +244,6 @@ async function executeRelocation(
     await writeRelocationOwner(workPath, pending.taskId)
     assertEffectiveSeparation(pending.from, workPath)
 
-    const sourceReal = realPath(pending.from)
-    const finalTargetEffective = resolveEffectivePath(pending.to)
     // File-granularity approximate progress: the filter observes each file
     // right before fsp.cp copies it, so the bar leads the actual writes by at
     // most the file currently being copied. Clamped to the pre-scan total
@@ -266,19 +260,18 @@ async function executeRelocation(
       publish(makeProgress('copying', pending, bytesCopied, total))
     }
     // Let Node own recursive copying. The filter only applies relocation-specific
-    // exclusions and records links that must stop pointing at the old userData tree.
+    // exclusions and records file-granularity progress.
     // fsp.cp with force:false + errorOnExist:true requires that payloadPath not
     // exist — Node 24 patch releases disagree on what happens when it does
     // (24.11 silently merges, 24.14 throws ERR_FS_CP_EEXIST), so the only
     // portable contract is to let cp create its own destination. That is why
     // the payload lives one level below the marker-carrying workPath.
-    const symlinks: Array<{ source: string; target: string; type: 'dir' | 'file' | 'junction' | undefined }> = []
     await fsp.cp(pending.from, payloadPath, {
       recursive: true,
       force: false,
       errorOnExist: true,
-      verbatimSymlinks: true,
-      filter: async (source, target) => {
+      dereference: true,
+      filter: async (source) => {
         const isSourceRootEntry = normalizeForCompare(path.dirname(source)) === normalizeForCompare(pending.from)
         const name = path.basename(source)
         // The reset marker is bound to the source profile.
@@ -299,47 +292,22 @@ async function executeRelocation(
           }
           throw error
         }
-        if (!stat.isSymbolicLink()) {
-          if (stat.isFile()) {
-            processedBytes += stat.size
-            publishCopyProgress()
+        if (stat.isSymbolicLink()) {
+          try {
+            stat = await fsp.stat(source)
+          } catch (error) {
+            if (!isErrno(error, 'ENOENT')) throw error
+            logger.warn('Skipping broken symlink during userData relocation', { source })
+            return false
           }
-          return stat.isDirectory() || stat.isFile()
         }
-
-        let type: 'dir' | 'file' | 'junction' | undefined
-        try {
-          const followed = await fsp.stat(source)
-          type = followed.isDirectory() ? (isWin ? 'junction' : 'dir') : 'file'
-        } catch (error) {
-          if (!isErrno(error, 'ENOENT')) throw error
-          type = isWin ? 'file' : undefined
+        if (stat.isFile()) {
+          processedBytes += stat.size
+          publishCopyProgress()
         }
-        symlinks.push({ source, target, type })
-        return true
+        return stat.isDirectory() || stat.isFile()
       }
     })
-
-    for (const symlink of symlinks) {
-      let linkTarget: string
-      try {
-        linkTarget = await fsp.readlink(symlink.target)
-      } catch (error) {
-        if (isErrno(error, 'ENOENT')) continue
-        throw error
-      }
-      const rewrittenTarget = await rewriteSymlinkTarget(
-        symlink.source,
-        linkTarget,
-        symlink.type,
-        sourceReal,
-        finalTargetEffective
-      )
-      if (rewrittenTarget !== linkTarget) {
-        await fsp.unlink(symlink.target)
-        await fsp.symlink(rewrittenTarget, symlink.target, symlink.type)
-      }
-    }
 
     publish(makeProgress('copying', pending, total, total))
 
@@ -482,45 +450,7 @@ async function rollbackCopy(options: {
   }
 }
 
-/**
- * Symlink policy: links resolving outside the copied tree are kept verbatim
- * (except Windows junctions, which cannot stay relative and are re-anchored
- * to their absolute resolution); links resolving inside the tree are
- * rewritten to the final target so the copy never points back into the old
- * userData. Relative in-tree links survive the whole-tree move as-is.
- */
-async function rewriteSymlinkTarget(
-  source: string,
-  linkTarget: string,
-  type: 'dir' | 'file' | 'junction' | undefined,
-  sourceRootReal: string,
-  finalTargetEffective: string
-): Promise<string> {
-  const isAbsolute = path.isAbsolute(linkTarget)
-  let effectiveLinkTarget = isAbsolute ? path.resolve(linkTarget) : path.resolve(path.dirname(source), linkTarget)
-  try {
-    effectiveLinkTarget = await fsp.realpath(effectiveLinkTarget)
-  } catch (error) {
-    if (!isErrno(error, 'ENOENT')) throw error
-  }
-
-  const sourceRoot = normalizeForCompare(sourceRootReal)
-  const effective = normalizeForCompare(effectiveLinkTarget)
-  if (effective !== sourceRoot && !isPathInside(effective, sourceRoot)) {
-    return isWin && type === 'junction' ? effectiveLinkTarget : linkTarget
-  }
-
-  const relative = path.relative(sourceRoot, effective)
-  const rewritten = path.join(finalTargetEffective, relative)
-  if (isAbsolute || (isWin && type === 'junction')) {
-    logger.info('Rewriting internal symlink during userData relocation', { source, linkTarget, rewritten })
-    return rewritten
-  }
-  return linkTarget
-}
-
-// Symlinks count as zero bytes — the copy recreates the link itself, never
-// its referent.
+// Symlinks are followed because relocation materializes their referents.
 async function calculateTotalBytes(root: string, allowMissing = false): Promise<number> {
   let stat: Awaited<ReturnType<typeof fsp.lstat>>
   try {
@@ -529,8 +459,16 @@ async function calculateTotalBytes(root: string, allowMissing = false): Promise<
     if (allowMissing && isErrno(error, 'ENOENT')) return 0
     throw error
   }
+  if (stat.isSymbolicLink()) {
+    try {
+      stat = await fsp.stat(root)
+    } catch (error) {
+      if (isErrno(error, 'ENOENT')) return 0
+      throw error
+    }
+  }
   if (stat.isFile()) return stat.size
-  if (stat.isSymbolicLink() || !stat.isDirectory()) return 0
+  if (!stat.isDirectory()) return 0
 
   let entries: fs.Dirent<string>[]
   try {

--- a/src/main/services/userDataRelocation/execution.ts
+++ b/src/main/services/userDataRelocation/execution.ts
@@ -18,6 +18,7 @@ import {
   assertUserDataRelocationRequest,
   invalid,
   isErrno,
+  isPathInside,
   normalizeForCompare,
   pathEntryExists,
   relocationArtifactPaths,
@@ -296,9 +297,27 @@ async function executeRelocation(
           try {
             stat = await fsp.stat(source)
           } catch (error) {
-            if (!isErrno(error, 'ENOENT')) throw error
-            logger.warn('Skipping broken symlink during userData relocation', { source })
-            return false
+            if (isErrno(error, 'ENOENT')) {
+              logger.warn('Skipping broken symlink during userData relocation', { source })
+              return false
+            }
+            if (isErrno(error, 'ELOOP')) {
+              logger.warn('Skipping circular symlink during userData relocation', { source })
+              return false
+            }
+            throw error
+          }
+          if (stat.isDirectory()) {
+            try {
+              if (await isCircularDirectorySymlink(source)) {
+                logger.warn('Skipping circular symlink during userData relocation', { source })
+                return false
+              }
+            } catch (error) {
+              if (!isErrno(error, 'ENOENT')) throw error
+              logger.warn('Skipping userData symlink that vanished during relocation', { source })
+              return false
+            }
           }
         }
         if (stat.isFile()) {
@@ -450,8 +469,38 @@ async function rollbackCopy(options: {
   }
 }
 
+async function isCircularDirectorySymlink(source: string): Promise<boolean> {
+  let targetReal: string
+  try {
+    targetReal = normalizeForCompare(await fsp.realpath(source))
+  } catch (error) {
+    if (isErrno(error, 'ELOOP')) return true
+    throw error
+  }
+
+  let ancestor = path.dirname(source)
+  while (true) {
+    let ancestorReal: string
+    try {
+      ancestorReal = normalizeForCompare(await fsp.realpath(ancestor))
+    } catch (error) {
+      if (isErrno(error, 'ELOOP')) return true
+      throw error
+    }
+    if (targetReal === ancestorReal || isPathInside(ancestorReal, targetReal)) return true
+
+    const parent = path.dirname(ancestor)
+    if (parent === ancestor) return false
+    ancestor = parent
+  }
+}
+
 // Symlinks are followed because relocation materializes their referents.
-async function calculateTotalBytes(root: string, allowMissing = false): Promise<number> {
+async function calculateTotalBytes(
+  root: string,
+  allowMissing = false,
+  ancestorDirectories: ReadonlySet<string> = new Set()
+): Promise<number> {
   let stat: Awaited<ReturnType<typeof fsp.lstat>>
   try {
     stat = await fsp.lstat(root)
@@ -464,11 +513,23 @@ async function calculateTotalBytes(root: string, allowMissing = false): Promise<
       stat = await fsp.stat(root)
     } catch (error) {
       if (isErrno(error, 'ENOENT')) return 0
+      if (isErrno(error, 'ELOOP')) return 0
       throw error
     }
   }
   if (stat.isFile()) return stat.size
   if (!stat.isDirectory()) return 0
+
+  let directoryReal: string
+  try {
+    directoryReal = normalizeForCompare(await fsp.realpath(root))
+  } catch (error) {
+    if (allowMissing && isErrno(error, 'ENOENT')) return 0
+    if (isErrno(error, 'ELOOP')) return 0
+    throw error
+  }
+  if (ancestorDirectories.has(directoryReal)) return 0
+  const childAncestors = new Set(ancestorDirectories).add(directoryReal)
 
   let entries: fs.Dirent<string>[]
   try {
@@ -479,7 +540,7 @@ async function calculateTotalBytes(root: string, allowMissing = false): Promise<
   }
   let total = 0
   for (const entry of entries) {
-    total += await calculateTotalBytes(path.join(root, entry.name), true)
+    total += await calculateTotalBytes(path.join(root, entry.name), true, childAncestors)
   }
   return total
 }

--- a/src/main/services/userDataRelocation/execution.ts
+++ b/src/main/services/userDataRelocation/execution.ts
@@ -297,7 +297,7 @@ async function executeRelocation(
           try {
             stat = await fsp.stat(source)
           } catch (error) {
-            if (isErrno(error, 'ENOENT')) {
+            if (isErrno(error, 'ENOENT') || isErrno(error, 'ENOTDIR')) {
               logger.warn('Skipping broken symlink during userData relocation', { source })
               return false
             }
@@ -512,7 +512,7 @@ async function calculateTotalBytes(
     try {
       stat = await fsp.stat(root)
     } catch (error) {
-      if (isErrno(error, 'ENOENT')) return 0
+      if (isErrno(error, 'ENOENT') || isErrno(error, 'ENOTDIR')) return 0
       if (isErrno(error, 'ELOOP')) return 0
       throw error
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

User-data relocation preserved symbolic links and then recreated or re-anchored links that pointed into the copied tree. On Windows, creating those links could fail with `EPERM` and abort an otherwise valid data-directory migration.

<img width="515" height="355" alt="wecom-temp-18716-b0d8a95c4ddf7713365e0731b50eee73" src="https://github.com/user-attachments/assets/a71fb059-fdee-4dfb-85ad-48ea65740401" />

After this PR:

Relocation dereferences symbolic links and materializes their targets as ordinary files or directories, skips broken links, and includes linked content in the free-space estimate. Regression coverage verifies that migration succeeds without invoking symbolic-link creation and that the copied entries are no longer links.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Materializing a link duplicates its target content in the relocated profile and can therefore use more disk space; the capacity pre-scan now accounts for that content.
- Broken links have no copyable content, so they are logged and omitted instead of failing the entire relocation.

The following alternatives were considered:

- Recreating links or Windows junctions was rejected because it retains the permission-dependent operation that caused the migration failure.
- Skipping all links was rejected because valid linked files and directories are part of the user's selected `userData` tree.

Links to places where the discussion took place: N/A

### Breaking changes

N/A. Symbolic links inside a relocated profile intentionally become ordinary files or directories in the destination.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validated with the focused main-process relocation suite (23 tests), `pnpm lint`, and `git diff --check`. `pnpm lint` completed successfully with 37 warnings in unrelated files; full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed data-directory migration failures caused by symbolic links on Windows by copying their contents as ordinary files and directories.
```
