### PR TITLE
fix(api-gateway): downgrade inline system messages for Ollama

### DIFF
--- a/src/main/features/apiGateway/utils/__tests__/inlineSystemMessages.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/inlineSystemMessages.test.ts
@@ -80,7 +80,6 @@ describe('keepsSystemMessagesInPlace', () => {
   it('allows the chat endpoints whose converters were verified to pass a non-leading system through', () => {
     expect(ENDPOINT_CHAT_TARGETS.filter(keepsSystemMessagesInPlace)).toEqual([
       ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-      ENDPOINT_TYPE.OLLAMA_CHAT,
       ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
       ENDPOINT_TYPE.OPENAI_RESPONSES
     ])
@@ -120,6 +119,19 @@ describe('positionInlineSystemMessages', () => {
     expect(sdkAcceptsAsDowngradeSignal(status, message)).toBe(true)
   })
 
+  it('lets the Agent SDK downgrade inline system messages before sending them to Ollama', () => {
+    let thrown: unknown
+    try {
+      positionInlineSystemMessages(inline, ENDPOINT_TYPE.OLLAMA_CHAT, betaHeaders(AGENT_SDK_BETAS))
+    } catch (error) {
+      thrown = error
+    }
+
+    const { status, message } = thrown as Error & { status: number }
+    expect(status).toBe(400)
+    expect(sdkAcceptsAsDowngradeSignal(status, message)).toBe(true)
+  })
+
   it('folds instead of rejecting when the client cannot downgrade', () => {
     expect(
       positionInlineSystemMessages(inline, ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT, betaHeaders('claude-code-20250219'))
@@ -128,6 +140,13 @@ describe('positionInlineSystemMessages', () => {
 
   it('folds when there is no anthropic-beta header at all', () => {
     expect(positionInlineSystemMessages(inline, ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT, undefined)).toHaveLength(2)
+  })
+
+  it('folds Ollama inline system messages when the client cannot downgrade', () => {
+    expect(positionInlineSystemMessages(inline, ENDPOINT_TYPE.OLLAMA_CHAT, undefined)).toEqual([
+      { ...inline[0], parts: [{ type: 'text', text: 'Base.\n\nMCP connecting.' }] },
+      inline[1]
+    ])
   })
 
   it('never rejects a request that carries no inline system message', () => {

--- a/src/main/features/apiGateway/utils/inlineSystemMessages.ts
+++ b/src/main/features/apiGateway/utils/inlineSystemMessages.ts
@@ -28,7 +28,9 @@ import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
  * Deliberately excluded: `@ai-sdk/google` throws `system messages are only supported at
  * the beginning of the conversation` (`:523`), and the `*-text-completions` /
  * `ollama-generate` converters throw `Unexpected system message in prompt`. Ollama chat
- * serializes the message, but older model renderers such as Qwen3.8 still reject it.
+ * serializes the message, but renderer behavior varies: some fold instruction messages into
+ * a leading system turn while others only consume one at `messages[0]`. The gateway has no
+ * renderer capability signal, so it cannot safely leave a non-leading system message in place.
  */
 const SYSTEM_IN_PLACE_ENDPOINTS: ReadonlySet<EndpointType> = new Set([
   ENDPOINT_TYPE.ANTHROPIC_MESSAGES,

--- a/src/main/features/apiGateway/utils/inlineSystemMessages.ts
+++ b/src/main/features/apiGateway/utils/inlineSystemMessages.ts
@@ -24,17 +24,16 @@ import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
  *   `mid-conversation-system-2026-04-07` beta itself (`dist/index.mjs:2380`)
  * - `@ai-sdk/openai` 3.0.53 pushes it on both the chat and responses paths (`:114`, `:2761`)
  * - `@ai-sdk/openai-compatible` 2.0.62 pushes it (`:114`)
- * - `ollama-ai-provider-v2` 3.3.1 pushes it in `convertToOllamaChatMessages` (`:697`)
  *
  * Deliberately excluded: `@ai-sdk/google` throws `system messages are only supported at
  * the beginning of the conversation` (`:523`), and the `*-text-completions` /
- * `ollama-generate` converters throw `Unexpected system message in prompt`.
+ * `ollama-generate` converters throw `Unexpected system message in prompt`. Ollama chat
+ * serializes the message, but older model renderers such as Qwen3.8 still reject it.
  */
 const SYSTEM_IN_PLACE_ENDPOINTS: ReadonlySet<EndpointType> = new Set([
   ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
   ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
-  ENDPOINT_TYPE.OPENAI_RESPONSES,
-  ENDPOINT_TYPE.OLLAMA_CHAT
+  ENDPOINT_TYPE.OPENAI_RESPONSES
 ])
 
 /** Whether `endpointType` keeps a non-leading system message in place instead of rejecting it. */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Ollama chat was allowlisted to receive non-leading `system` messages in place because `ollama-ai-provider-v2` can serialize that shape. However, `/api/chat` then hands the messages to the model's renderer, and renderer behavior is not uniform: some renderers fold instruction messages into one leading system turn, while others only consume a system message at `messages[0]` and silently drop a later one. The gateway has no capability signal for the renderer behind an `ollama:<model>` tag.

After this PR:

Ollama chat uses the existing compatibility paths: Agent SDK clients receive the recognized 400 downgrade signal and retry with `<system-reminder>` blocks, while clients without the negotiated beta have inline system messages folded into the leading system message. Both paths keep the instructions visible regardless of the downstream renderer.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #18643

This is not the complete fix for #18643's `no user query found in messages` error. That error comes from `validateMessages` during truncation and predates the Ollama allowlist. This PR fixes the separate silent-drop compatibility window introduced when #18697 allowed Ollama to receive inline system messages.

### Why we need it and why it was done in this way

Checking only whether the JavaScript provider can serialize a message is insufficient because the downstream Ollama renderer decides how instruction roles are interpreted. Since that behavior is per-renderer and opaque to the gateway, removing Ollama chat from the in-place allowlist is the only safe behavior across renderers. It reuses the downgrade and folding behavior already implemented for unsupported targets.

The following tradeoffs were made:

Ollama clients without the Agent SDK beta lose some prompt-prefix cache stability because system updates are folded, but the instructions are preserved consistently across renderers.

The following alternatives were considered:

Keeping Ollama allowlisted and detecting individual model families was rejected because the constraint belongs to the selected renderer/template, not reliably to a model family or Ollama version, and the gateway has no renderer capability signal.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18643, https://github.com/CherryHQ/cherry-studio/pull/18697

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regression coverage verifies both Ollama paths: SDK beta downgrade and non-beta folding. The targeted API gateway suite passes 15/15 tests. After the reviewer clarification, the full main test project passes 12,647/12,647 tests and the touched files pass Biome checks. No live Ollama reproduction is claimed; the compatibility decision is based on the renderer-dependent behavior and the absence of a gateway capability signal.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Claude Agent SDK system updates being dropped by some Ollama model renderers.
```
