### PR TITLE
fix(model-list): read the Ollama context window from /api/show

### DIFF
--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -10,14 +10,21 @@ import { DEFAULT_VERTEX_MODEL_PUBLISHERS } from '../listModels/vertex'
 // HTTP call through @ai-sdk/provider-utils' getFromApi. Mock all of them at the
 // module boundary: ProviderService / VertexAiService to avoid the DB and signing,
 // and provider-utils' getFromApi to capture the exact { url, headers } passed.
-const { getRotatedApiKeyMock, getAuthConfigMock, getAuthHeadersMock, getCopilotTokenMock, aiSdkGetFromApiMock } =
-  vi.hoisted(() => ({
-    getRotatedApiKeyMock: vi.fn<(providerId: string) => string>(),
-    getAuthConfigMock: vi.fn(),
-    getAuthHeadersMock: vi.fn(),
-    getCopilotTokenMock: vi.fn(),
-    aiSdkGetFromApiMock: vi.fn()
-  }))
+const {
+  getRotatedApiKeyMock,
+  getAuthConfigMock,
+  getAuthHeadersMock,
+  getCopilotTokenMock,
+  aiSdkGetFromApiMock,
+  aiSdkPostJsonToApiMock
+} = vi.hoisted(() => ({
+  getRotatedApiKeyMock: vi.fn<(providerId: string) => string>(),
+  getAuthConfigMock: vi.fn(),
+  getAuthHeadersMock: vi.fn(),
+  getCopilotTokenMock: vi.fn(),
+  aiSdkGetFromApiMock: vi.fn(),
+  aiSdkPostJsonToApiMock: vi.fn()
+}))
 
 vi.mock('@main/data/services/ProviderService', () => ({
   providerService: {
@@ -42,7 +49,8 @@ vi.mock('@ai-sdk/provider-utils', async (importOriginal) => {
   const actual = await importOriginal<typeof AiSdkProviderUtils>()
   return {
     ...actual,
-    getFromApi: aiSdkGetFromApiMock
+    getFromApi: aiSdkGetFromApiMock,
+    postJsonToApi: aiSdkPostJsonToApiMock
   }
 })
 
@@ -53,6 +61,7 @@ beforeEach(() => {
   vi.clearAllMocks()
   getRotatedApiKeyMock.mockReturnValue('AIza-secret-key')
   getCopilotTokenMock.mockResolvedValue({ token: 'copilot-token' })
+  aiSdkPostJsonToApiMock.mockResolvedValue({ value: {} })
   // listModels' getFromApi wrapper reads `value` off the provider-utils result.
   aiSdkGetFromApiMock.mockResolvedValue({
     value: {
@@ -142,6 +151,50 @@ describe('listModels — Ollama capabilities', () => {
     expect(aiSdkGetFromApiMock.mock.calls[0][0]).toMatchObject({
       url: 'http://ollama.test:11434/api/tags'
     })
+  })
+
+  it('reads the trained context window from /api/show so num_ctx is not left at Ollama default', async () => {
+    // /api/tags carries no context length; without this the model has no contextWindow, no
+    // num_ctx is sent, and Ollama runs the request at 2048 tokens (#18643).
+    aiSdkGetFromApiMock.mockResolvedValueOnce({
+      value: { models: [{ name: 'qwen3:32b', capabilities: ['completion', 'tools'] }] }
+    })
+    aiSdkPostJsonToApiMock.mockResolvedValueOnce({
+      value: { model_info: { 'general.architecture': 'qwen3', 'qwen3.context_length': 40960 } }
+    })
+
+    const models = await listModels(makeOllamaProvider())
+
+    expect(models[0]).toMatchObject({ apiModelId: 'qwen3:32b', contextWindow: 40960 })
+    expect(aiSdkPostJsonToApiMock.mock.calls[0][0]).toMatchObject({
+      url: 'http://ollama.test:11434/api/show',
+      body: { model: 'qwen3:32b' }
+    })
+  })
+
+  it('still lists a model whose /api/show call fails', async () => {
+    aiSdkGetFromApiMock.mockResolvedValueOnce({
+      value: { models: [{ name: 'qwen3:32b', capabilities: ['completion'] }] }
+    })
+    aiSdkPostJsonToApiMock.mockRejectedValueOnce(new Error('connection refused'))
+
+    const models = await listModels(makeOllamaProvider())
+
+    expect(models).toHaveLength(1)
+    expect(models[0].contextWindow).toBeUndefined()
+  })
+
+  it('ignores a context length that does not match the reported architecture', async () => {
+    aiSdkGetFromApiMock.mockResolvedValueOnce({
+      value: { models: [{ name: 'qwen3:32b', capabilities: ['completion'] }] }
+    })
+    aiSdkPostJsonToApiMock.mockResolvedValueOnce({
+      value: { model_info: { 'general.architecture': 'qwen3', 'llama.context_length': 8192 } }
+    })
+
+    const models = await listModels(makeOllamaProvider())
+
+    expect(models[0].contextWindow).toBeUndefined()
   })
 })
 

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -154,8 +154,9 @@ describe('listModels — Ollama capabilities', () => {
   })
 
   it('reads the trained context window from /api/show so num_ctx is not left at Ollama default', async () => {
-    // /api/tags carries no context length; without this the model has no contextWindow, no
-    // num_ctx is sent, and Ollama runs the request at 2048 tokens (#18643).
+    // /api/tags carries no context length; without this the model has no contextWindow and no
+    // num_ctx is sent, leaving Ollama to size by VRAM — 4k below 24 GiB, which an agent's tool
+    // preamble overruns on its own (#18643).
     aiSdkGetFromApiMock.mockResolvedValueOnce({
       value: { models: [{ name: 'qwen3:32b', capabilities: ['completion', 'tools'] }] }
     })

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -9,6 +9,7 @@ import {
   createJsonErrorResponseHandler,
   createJsonResponseHandler,
   getFromApi as aiSdkGetFromApi,
+  postJsonToApi,
   zodSchema
 } from '@ai-sdk/provider-utils'
 import { loggerService } from '@logger'
@@ -51,6 +52,7 @@ import {
   GeminiModelsResponseSchema,
   GitHubModelsResponseSchema,
   NewApiModelsResponseSchema,
+  OllamaShowResponseSchema,
   OllamaTagsResponseSchema,
   OpenAIModelsResponseSchema,
   OVMSConfigResponseSchema,
@@ -173,6 +175,46 @@ function pickPreferredString(values: Array<unknown>): string | undefined {
   return undefined
 }
 
+/** The trained context length from `/api/show`, whose `model_info` keys carry an architecture prefix. */
+function readOllamaContextLength(modelInfo: Record<string, unknown> | undefined): number | undefined {
+  const architecture = modelInfo?.['general.architecture']
+  if (typeof architecture !== 'string') return undefined
+  const contextLength = modelInfo?.[`${architecture}.context_length`]
+  return typeof contextLength === 'number' && contextLength > 0 ? contextLength : undefined
+}
+
+/**
+ * `/api/tags` carries no context length, so without this the model has no `contextWindow` and
+ * Ollama falls back to sizing by available VRAM — 4k below 24 GiB, where an agent's tool preamble
+ * alone overruns the window and Ollama truncates the conversation away (#18643). Its own guidance
+ * puts agent and coding workloads at 64k+, which only the model's real window can satisfy.
+ */
+async function fetchOllamaContextWindow(
+  baseUrl: string,
+  provider: Provider,
+  model: string,
+  signal?: AbortSignal
+): Promise<number | undefined> {
+  try {
+    const { value } = await postJsonToApi({
+      url: `${baseUrl}/api/show`,
+      headers: defaultHeaders(provider),
+      body: { model },
+      successfulResponseHandler: createJsonResponseHandler(zodSchema(OllamaShowResponseSchema)),
+      failedResponseHandler: createJsonErrorResponseHandler({
+        errorSchema: zodSchema(ApiErrorSchema),
+        errorToMessage: (error: ApiError) => error.error?.message || error.message || 'Unknown error'
+      }),
+      abortSignal: signal
+    })
+    return readOllamaContextLength(value.model_info)
+  } catch (error) {
+    // A model that cannot be inspected still belongs in the list; it falls back to the default window.
+    logger.warn('failed to read Ollama context length', { model, error })
+    return undefined
+  }
+}
+
 const ollamaFetcher: ModelFetcher = {
   match: (p) => isOllamaProvider(p),
   fetch: async (provider, signal) => {
@@ -185,10 +227,15 @@ const ollamaFetcher: ModelFetcher = {
       responseSchema: OllamaTagsResponseSchema,
       abortSignal: signal
     })
-    return dedup(response.models, (m) => m.name).map((m) =>
+    const models = dedup(response.models, (m) => m.name)
+    const contextWindows = await Promise.all(
+      models.map((m) => fetchOllamaContextWindow(baseUrl, provider, m.name, signal))
+    )
+    return models.map((m, index) =>
       toModel(m.name, provider, {
         ownedBy: 'ollama',
-        capabilities: m.capabilities?.includes('thinking') ? [MODEL_CAPABILITY.REASONING] : []
+        capabilities: m.capabilities?.includes('thinking') ? [MODEL_CAPABILITY.REASONING] : [],
+        ...(contextWindows[index] ? { contextWindow: contextWindows[index] } : {})
       })
     )
   }

--- a/src/main/ai/provider/listModelsSchemas.ts
+++ b/src/main/ai/provider/listModelsSchemas.ts
@@ -75,6 +75,15 @@ export const OllamaTagsResponseSchema = z.object({
   )
 })
 
+/**
+ * `POST /api/show`. `model_info` keys are architecture-prefixed
+ * (`llama.context_length`, `qwen3.context_length`, …), so the architecture has to be
+ * read first — `/api/tags` carries no context length at all.
+ */
+export const OllamaShowResponseSchema = z.looseObject({
+  model_info: z.record(z.string(), z.unknown()).optional()
+})
+
 // === Gemini ===
 
 export const GeminiModelsResponseSchema = z.object({

--- a/src/main/ai/utils/__tests__/options.test.ts
+++ b/src/main/ai/utils/__tests__/options.test.ts
@@ -559,7 +559,7 @@ describe('buildCapabilityProviderOptions', () => {
     expect(result).toMatchObject({ ollama: { options: { num_ctx: 32_768 } } })
   })
 
-  it('omits num_ctx for Ollama models without a configured contextWindow', () => {
+  it('omits num_ctx for an Ollama model whose contextWindow could not be read', () => {
     const result = buildCapabilityProviderOptions(
       {
         id: 'ollama::qwen3:32b',
@@ -590,6 +590,8 @@ describe('buildCapabilityProviderOptions', () => {
       }
     )
 
+    // Not a fixed floor: Ollama sizes by available VRAM (4k / 32k / 256k) when num_ctx is
+    // absent, so substituting a guess would shrink the window on a well-provisioned machine.
     expect(result.ollama).not.toHaveProperty('options')
   })
 })

--- a/src/main/ai/utils/options.ts
+++ b/src/main/ai/utils/options.ts
@@ -481,9 +481,9 @@ function buildOllamaProviderOptions(
   return {
     ollama: {
       ...reasoningOptions,
-      // Ollama defaults to a 2048-token context window unless num_ctx is supplied;
-      // forward the model's configured contextWindow so large-context models are
-      // not silently truncated.
+      // Forward the model's context window so large-context models are not silently
+      // truncated. Omitting it is deliberate when unknown: Ollama then sizes by available
+      // VRAM (4k / 32k / 256k), which beats any fixed guess we could substitute.
       ...(model.contextWindow ? { options: { num_ctx: model.contextWindow } } : {})
     }
   }

--- a/src/renderer/pages/settings/ProviderSettings/utils/__tests__/modelSync.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/__tests__/modelSync.test.ts
@@ -276,6 +276,39 @@ describe('toCreateModelDto', () => {
     expect(dto.capabilities).toEqual([MODEL_CAPABILITY.REASONING, MODEL_CAPABILITY.FUNCTION_CALL])
   })
 
+  it('persists a discovered context window so the runtime can send num_ctx', () => {
+    // Ollama's window is read from /api/show at listing time, not supplied by the registry;
+    // dropping it here leaves the stored row without one and num_ctx is never sent (#18643).
+    const dto = toCreateModelDto('ollama', {
+      id: 'ollama::qwen3:32b' as UniqueModelId,
+      providerId: 'ollama',
+      apiModelId: 'qwen3:32b',
+      name: 'qwen3:32b',
+      capabilities: [],
+      contextWindow: 40960,
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    } as Model)
+
+    expect(dto.contextWindow).toBe(40960)
+  })
+
+  it('omits contextWindow when the model has none', () => {
+    const dto = toCreateModelDto('ollama', {
+      id: 'ollama::acme:latest' as UniqueModelId,
+      providerId: 'ollama',
+      apiModelId: 'acme:latest',
+      name: 'acme:latest',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    } as Model)
+
+    expect(dto).not.toHaveProperty('contextWindow')
+  })
+
   it('keeps registry capabilities inherited for a preset-backed thinking model', () => {
     const dto = toCreateModelDto('ollama', {
       id: 'ollama::qwen3:32b' as UniqueModelId,

--- a/src/renderer/pages/settings/ProviderSettings/utils/modelSync.ts
+++ b/src/renderer/pages/settings/ProviderSettings/utils/modelSync.ts
@@ -62,7 +62,10 @@ export function toCreateModelDto(
     name: model.name,
     group: model.group,
     ...(capabilities ? { capabilities: [...capabilities] } : {}),
-    ...(resolvedEndpointTypes?.length ? { endpointTypes: [...resolvedEndpointTypes] } : {})
+    ...(resolvedEndpointTypes?.length ? { endpointTypes: [...resolvedEndpointTypes] } : {}),
+    // Discovered rather than registry-supplied for local providers — Ollama's window comes from
+    // `/api/show`, and dropping it here leaves the row without one, so no `num_ctx` is ever sent.
+    ...(model.contextWindow ? { contextWindow: model.contextWindow } : {})
   }
 }
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`ollamaFetcher` built models from `GET /api/tags`, which carries no context length, so every locally discovered Ollama model had `contextWindow` undefined. `buildOllamaProviderOptions` is conditional on it:

```ts
...(model.contextWindow ? { options: { num_ctx: model.contextWindow } } : {})
```

so no `num_ctx` was ever sent and Ollama sized the request by available VRAM — [4k below 24 GiB, 32k up to 48 GiB, 256k above](https://docs.ollama.com/context-length). An Agent session's tool preamble overruns 4k on its own.

`chatPrompt` then strips messages from the front until the prompt fits, re-rendering each time and aborting on the first render error:

```go
for i := 0; i <= lastMsgIdx; i++ {
    p, err := renderPrompt(m, append(system, msgs[i:]...), tools, think)
    if err != nil { return "", nil, err }
    if ctxLen <= opts.NumCtx { currMsgIdx = i; break }
    if i == lastMsgIdx { currMsgIdx = lastMsgIdx; break }   // always keep the last message
}
```

Once the user's turn is stripped, every remaining `user` message is a tool result, and Qwen3.8's renderer rejects that (`model/renderers/qwen35.go`):

```go
for _, message := range messages {
    if message.Role != "user" { continue }
    content := strings.TrimSpace(r.renderContent(message, 0))
    if !(strings.HasPrefix(content, "<tool_response>") && strings.HasSuffix(content, "</tool_response>")) {
        foundUserQuery = true
        break
    }
}
if !foundUserQuery { return fmt.Errorf("no user query found in messages") }
```

which surfaces as `chat prompt error` → `POST /api/chat 500` → an opaque 500 from the gateway. Ollama's own guidance puts agent and coding workloads at 64k+, which only the model's real window can satisfy.

After this PR:

Model listing reads the trained window per model from `POST /api/show` and stores it as `contextWindow`, so `num_ctx` is sent and the request runs at the window the model was trained for. `model_info` keys are architecture prefixed, so the architecture is read first:

```ts
const architecture = modelInfo?.['general.architecture']       // e.g. "qwen3"
const contextLength = modelInfo?.[`${architecture}.context_length`]
```

A model whose `/api/show` call fails or reports a mismatched architecture still lists, just without a window.

Refs #18643

### Why we need it and why it was done in this way

`/api/show` is the only endpoint that reports context length; `/api/tags` does not, which is why the field was empty in the first place. The calls run in parallel per model against a local server and read manifest metadata rather than loading weights.

The following tradeoffs were made:

- One extra request per model at listing time. They are concurrent and local.
- Requesting the model's full trained window allocates a correspondingly larger KV cache. This matches Ollama's own advice ("For best performance, use the maximum context length for a model") and is the behaviour Cherry already had for any model with a configured `contextWindow` — this change only extends it to models that were previously invisible to it.
- Reading the architecture prefix from `general.architecture` means a model that omits it reports no window rather than guessing across `model_info` keys.

The following alternatives were considered:

- **Substituting a fixed `num_ctx` when the window is unknown was rejected, and is worth recording.** It reads as a safe floor but is a regression: with `num_ctx` absent Ollama sizes by VRAM, so any constant small enough to be safe on a laptop (8k) would *shrink* the window on a 48 GiB machine that would otherwise have been given 256k. Omitting the parameter is the better default when the real value cannot be read, so `buildOllamaProviderOptions` stays conditional.
- Parsing the `parameters` block from `/api/show` for a Modelfile `num_ctx` was rejected: that is a per-Modelfile default, not the model's capability, and `contextWindow` means the latter.
- Calling `/api/show` lazily at request time rather than at listing time was rejected because it puts a round trip on the hot path for a value that only changes when the model is pulled.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18643

### Breaking changes

None.

### Special notes for your reviewer

The response shape is pinned by [Ollama's OpenAPI spec for `/api/show`](https://docs.ollama.com/api/show) — request body `{ model }`, response `model_info` with `general.architecture` and `<arch>.context_length`.

This is independent of #18780, #18697 and #19042, which fix three other defects behind the same report. It is the first one that addresses the `no user query found in messages` failure, and it is deliberately marked `Refs` rather than `Fixes`: the mechanism is established from Ollama's source, but no live Agent-plus-Ollama reproduction has been run against it, and the interaction is a heuristic in Ollama that can still fail on a long enough session.

Validation completed:

- `vitest run --project main src/main/ai` → 301 files / 4,480 tests passed
- `tsgo --noEmit -p tsconfig.node.json` clean, oxlint 0/0 across `src/main/ai`
- Three new listing tests: the window is read and sent, a failing `/api/show` still lists the model, and a `context_length` that does not match the reported architecture is ignored

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Local Ollama models now report their real context window, so requests are no longer capped by Ollama's default sizing. This fixes Agent sessions with tools failing against local Ollama models, where the shorter window caused the conversation to be truncated away.
```
