### PR TITLE
fix(api-gateway): restore Gemini 3 thought signatures on replayed tool calls

### DIFF
--- a/src/main/features/apiGateway/adapters/__tests__/AiSdkToAnthropicSse.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AiSdkToAnthropicSse.test.ts
@@ -262,8 +262,9 @@ describe('AiSdkToAnthropicSse', () => {
 
     // Anthropic's wire format has nowhere to carry Gemini's thought signature, and
     // Gemini 3 rejects a replayed functionCall without it — writer and reader must
-    // agree on the cache key.
-    it('round-trips a streamed thought signature onto the tool call replayed next turn', async () => {
+    // agree on the cache key. Two calls of the same tool pin that the key is the call
+    // id: keying by tool name hands both replays the second call's signature.
+    it('round-trips each parallel call signature onto the tool call replayed next turn', async () => {
       const model = 'gemini:models/gemini-flash-latest'
       const adapter = new AiSdkToAnthropicSse({ model })
 
@@ -272,10 +273,17 @@ describe('AiSdkToAnthropicSse', () => {
           createMockStream([
             {
               type: 'tool-input-available',
-              toolCallId: 'call_sig',
+              toolCallId: 'call_sig_1',
               toolName: 'Bash',
               input: { command: 'ls' },
               providerMetadata: { google: { thoughtSignature: 'sig-abc' } }
+            },
+            {
+              type: 'tool-input-available',
+              toolCallId: 'call_sig_2',
+              toolName: 'Bash',
+              input: { command: 'pwd' },
+              providerMetadata: { google: { thoughtSignature: 'sig-def' } }
             },
             createFinish('tool-calls')
           ])
@@ -286,13 +294,23 @@ describe('AiSdkToAnthropicSse', () => {
         model,
         max_tokens: 1024,
         messages: [
-          { role: 'assistant', content: [{ type: 'tool_use', id: 'call_sig', name: 'Bash', input: { command: 'ls' } }] }
+          {
+            role: 'assistant',
+            content: [
+              { type: 'tool_use', id: 'call_sig_1', name: 'Bash', input: { command: 'ls' } },
+              { type: 'tool_use', id: 'call_sig_2', name: 'Bash', input: { command: 'pwd' } }
+            ]
+          }
         ]
       } as MessageCreateParams)
 
-      expect((messages[0].parts[0] as { callProviderMetadata?: unknown }).callProviderMetadata).toMatchObject({
-        google: { thoughtSignature: 'sig-abc' }
-      })
+      const signatures = messages[0].parts.map(
+        (part) => (part as { callProviderMetadata?: { google?: { thoughtSignature?: string } } }).callProviderMetadata
+      )
+      expect(signatures).toEqual([
+        { google: { thoughtSignature: 'sig-abc' } },
+        { google: { thoughtSignature: 'sig-def' } }
+      ])
     })
   })
 

--- a/src/main/features/apiGateway/adapters/__tests__/AiSdkToAnthropicSse.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AiSdkToAnthropicSse.test.ts
@@ -1,7 +1,9 @@
-import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages'
+import type { MessageCreateParams, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages'
 import type { FinishReason, UIMessageChunk } from 'ai'
 import { describe, expect, it } from 'vitest'
 
+import { googleReasoningCache } from '../../reasoningCache'
+import { AnthropicMessageConverter } from '../converters/AnthropicMessageConverter'
 import { AnthropicSseFormatter } from '../formatters/AnthropicSseFormatter'
 import { AiSdkToAnthropicSse } from '../stream/AiSdkToAnthropicSse'
 
@@ -256,6 +258,41 @@ describe('AiSdkToAnthropicSse', () => {
         return false
       })
       expect(toolBlocks.length).toBe(1)
+    })
+
+    // Anthropic's wire format has nowhere to carry Gemini's thought signature, and
+    // Gemini 3 rejects a replayed functionCall without it — writer and reader must
+    // agree on the cache key.
+    it('round-trips a streamed thought signature onto the tool call replayed next turn', async () => {
+      const model = 'gemini:models/gemini-flash-latest'
+      const adapter = new AiSdkToAnthropicSse({ model })
+
+      await collectEvents(
+        adapter.transform(
+          createMockStream([
+            {
+              type: 'tool-input-available',
+              toolCallId: 'call_sig',
+              toolName: 'Bash',
+              input: { command: 'ls' },
+              providerMetadata: { google: { thoughtSignature: 'sig-abc' } }
+            },
+            createFinish('tool-calls')
+          ])
+        )
+      )
+
+      const messages = new AnthropicMessageConverter({ googleReasoningCache }).toUIMessages({
+        model,
+        max_tokens: 1024,
+        messages: [
+          { role: 'assistant', content: [{ type: 'tool_use', id: 'call_sig', name: 'Bash', input: { command: 'ls' } }] }
+        ]
+      } as MessageCreateParams)
+
+      expect((messages[0].parts[0] as { callProviderMetadata?: unknown }).callProviderMetadata).toMatchObject({
+        google: { thoughtSignature: 'sig-abc' }
+      })
     })
   })
 

--- a/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AnthropicMessageConverter.test.ts
@@ -264,6 +264,42 @@ describe('AnthropicMessageConverter.toUIMessages', () => {
     expect(msgs[0].parts[0]).toMatchObject({ type: 'dynamic-tool', toolCallId: 'c2', state: 'input-available' })
   })
 
+  // Gateway addresses are `providerId:apiModelId`, and the apiModelId carries a `models/`
+  // prefix for some providers but not others — the Gemini 3 check must survive both shapes.
+  it.each(['gemini:models/gemini-flash-latest', 'cherryin:gemini-flash-latest', 'gemini:gemini-3-pro-preview'])(
+    'restores the cached thought signature for %s',
+    (model) => {
+      const googleReasoningCache: ReasoningCache = { get: vi.fn(() => 'sig-abc'), set: vi.fn() }
+      const c = new AnthropicMessageConverter({ googleReasoningCache })
+      const msgs = c.toUIMessages(
+        params({
+          model,
+          messages: [
+            { role: 'assistant', content: [{ type: 'tool_use', id: 'c4', name: 'Bash', input: {} }] }
+          ] as MessageCreateParams['messages']
+        })
+      )
+      expect(googleReasoningCache.get).toHaveBeenCalledWith('google-c4')
+      expect((msgs[0].parts[0] as { callProviderMetadata?: unknown }).callProviderMetadata).toMatchObject({
+        google: { thoughtSignature: 'sig-abc' }
+      })
+    }
+  )
+
+  it('leaves the google thought signature off a non-Gemini target', () => {
+    const googleReasoningCache: ReasoningCache = { get: vi.fn(() => 'sig-abc'), set: vi.fn() }
+    const c = new AnthropicMessageConverter({ googleReasoningCache })
+    const msgs = c.toUIMessages(
+      params({
+        model: 'openai:gpt-5',
+        messages: [
+          { role: 'assistant', content: [{ type: 'tool_use', id: 'c5', name: 'Bash', input: {} }] }
+        ] as MessageCreateParams['messages']
+      })
+    )
+    expect((msgs[0].parts[0] as { callProviderMetadata?: unknown }).callProviderMetadata).toBeUndefined()
+  })
+
   it('reconstructs OpenRouter reasoning_details onto the tool call from the cache', () => {
     const details = [{ type: 'reasoning.text', text: 'because' }]
     const openRouterReasoningCache: ReasoningCache = { get: vi.fn(() => details), set: vi.fn() }

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -18,7 +18,6 @@ import type {
 import type { CherryUIMessage } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { toGatewayApiModelId } from '@shared/utils/apiGateway'
 import { isGemini3ModelId } from '@shared/utils/model'
 import type { DynamicToolUIPart, FileUIPart, JSONValue, ReasoningUIPart, TextUIPart, ToolSet } from 'ai'
 import { tool, zodSchema } from 'ai'
@@ -40,6 +39,12 @@ function buildResponsesToolName(name: string, attempt: number): string {
   const hash = createHash('sha1').update(`${name}\0${attempt}`).digest('hex').slice(0, TOOL_NAME_HASH_LENGTH)
   const prefixLength = RESPONSES_TOOL_NAME_MAX_LENGTH - hash.length - 1
   return `${sanitized.slice(0, prefixLength)}_${hash}`
+}
+
+/** The `apiModelId` half of a gateway `providerId:apiModelId` address, split at the
+ *  first `:` like the routes do — a bare model id passes through unchanged. */
+function toApiModelId(modelAddress: string): string {
+  return modelAddress.slice(modelAddress.indexOf(':') + 1)
 }
 
 let uiMessageSeq = 0
@@ -264,7 +269,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
    */
   private buildToolCallProviderOptions(model: string | undefined, toolCallId: string): ProviderOptions | undefined {
     const options: ProviderOptions = {}
-    if (model && isGemini3ModelId(toGatewayApiModelId(model))) {
+    if (model && isGemini3ModelId(toApiModelId(model))) {
       // Gemini 3 rejects a replayed functionCall whose signature is missing; the
       // Anthropic wire format has nowhere to carry it, so restore it from the cache.
       const thoughtSignature = this.googleReasoningCache?.get(`google-${toolCallId}`)

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -18,6 +18,7 @@ import type {
 import type { CherryUIMessage } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { toGatewayApiModelId } from '@shared/utils/apiGateway'
 import { isGemini3ModelId } from '@shared/utils/model'
 import type { DynamicToolUIPart, FileUIPart, JSONValue, ReasoningUIPart, TextUIPart, ToolSet } from 'ai'
 import { tool, zodSchema } from 'ai'
@@ -263,7 +264,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
    */
   private buildToolCallProviderOptions(model: string | undefined, toolCallId: string): ProviderOptions | undefined {
     const options: ProviderOptions = {}
-    if (model && isGemini3ModelId(model)) {
+    if (model && isGemini3ModelId(toGatewayApiModelId(model))) {
       // Gemini 3 rejects a replayed functionCall whose signature is missing; the
       // Anthropic wire format has nowhere to carry it, so restore it from the cache.
       const thoughtSignature = this.googleReasoningCache?.get(`google-${toolCallId}`)

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -18,6 +18,7 @@ import type {
 import type { CherryUIMessage } from '@shared/data/types/message'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
+import { isGemini3ModelId } from '@shared/utils/model'
 import type { DynamicToolUIPart, FileUIPart, JSONValue, ReasoningUIPart, TextUIPart, ToolSet } from 'ai'
 import { tool, zodSchema } from 'ai'
 
@@ -25,7 +26,6 @@ import type { IMessageConverter, StreamTextOptions } from '../interfaces'
 import { type JsonSchemaLike, jsonSchemaToZod } from './jsonSchemaToZod'
 import { mapAnthropicThinkingToProviderOptions } from './providerOptionsMapper'
 
-const MAGIC_STRING = 'skip_thought_signature_validator'
 const RESPONSES_TOOL_NAME_PATTERN = /^[A-Za-z0-9_-]+$/
 const RESPONSES_TOOL_NAME_MAX_LENGTH = 64
 const TOOL_NAME_HASH_LENGTH = 12
@@ -39,12 +39,6 @@ function buildResponsesToolName(name: string, attempt: number): string {
   const hash = createHash('sha1').update(`${name}\0${attempt}`).digest('hex').slice(0, TOOL_NAME_HASH_LENGTH)
   const prefixLength = RESPONSES_TOOL_NAME_MAX_LENGTH - hash.length - 1
   return `${sanitized.slice(0, prefixLength)}_${hash}`
-}
-
-/** Match the branch's `isGemini3ModelId`: a gemini-3 family model id. */
-function isGemini3ModelId(modelId?: string): boolean {
-  if (!modelId) return false
-  return modelId.toLowerCase().includes('gemini-3')
 }
 
 let uiMessageSeq = 0
@@ -232,7 +226,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
           }
         } else if (block.type === 'tool_use') {
           const toolName = this.toProviderToolName(block.name)
-          const callProviderMetadata = this.buildToolCallProviderOptions(params.model, block.name, block.id)
+          const callProviderMetadata = this.buildToolCallProviderOptions(params.model, block.id)
           const result = toolResults.get(block.id)
           const base = {
             type: 'dynamic-tool' as const,
@@ -267,14 +261,15 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
    * OpenRouter reasoning_details) from the reasoning caches, mirroring the
    * branch's assistant/tool-call providerOptions handling.
    */
-  private buildToolCallProviderOptions(
-    model: string | undefined,
-    toolName: string,
-    toolCallId: string
-  ): ProviderOptions | undefined {
+  private buildToolCallProviderOptions(model: string | undefined, toolCallId: string): ProviderOptions | undefined {
     const options: ProviderOptions = {}
-    if (isGemini3ModelId(model) && this.googleReasoningCache?.get(`google-${toolName}`)) {
-      options.google = { thoughtSignature: MAGIC_STRING }
+    if (model && isGemini3ModelId(model)) {
+      // Gemini 3 rejects a replayed functionCall whose signature is missing; the
+      // Anthropic wire format has nowhere to carry it, so restore it from the cache.
+      const thoughtSignature = this.googleReasoningCache?.get(`google-${toolCallId}`)
+      if (typeof thoughtSignature === 'string') {
+        options.google = { thoughtSignature }
+      }
     }
     const reasoningDetails = this.openRouterReasoningCache?.get(`openrouter-${toolCallId}`)
     if (reasoningDetails) {

--- a/src/main/features/apiGateway/adapters/stream/AiSdkToAnthropicSse.ts
+++ b/src/main/features/apiGateway/adapters/stream/AiSdkToAnthropicSse.ts
@@ -154,7 +154,7 @@ export class AiSdkToAnthropicSse extends BaseStreamAdapter<RawMessageStreamEvent
         const meta = chunk.providerMetadata as Record<string, any> | undefined
         const thoughtSignature = meta?.google?.thoughtSignature
         if (googleReasoningCache && typeof thoughtSignature === 'string') {
-          googleReasoningCache.set(`google-${toolName}`, thoughtSignature)
+          googleReasoningCache.set(`google-${chunk.toolCallId}`, thoughtSignature)
         }
         const reasoningDetails = meta?.openrouter?.reasoning_details
         if (openRouterReasoningCache && Array.isArray(reasoningDetails)) {

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -22,15 +22,6 @@ export function formatGatewayModelId(providerId: string, apiModelId: string): st
 }
 
 /**
- * The `apiModelId` half of a gateway address, split at the first `:` exactly like the
- * routes do. A bare model id (no provider prefix) is returned unchanged, so this is safe
- * on any model string a client may send.
- */
-export function toGatewayApiModelId(modelAddress: string): string {
-  return modelAddress.slice(modelAddress.indexOf(':') + 1)
-}
-
-/**
  * Sentinel suffix on the gateway model id handed to gemini-cli (`--model` and
  * `settings.model.name`). gemini-cli normalizes model names it thinks are its own:
  * its `resolveModel` rewrites anything satisfying `endsWith("flash")` (or equal to

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -22,6 +22,15 @@ export function formatGatewayModelId(providerId: string, apiModelId: string): st
 }
 
 /**
+ * The `apiModelId` half of a gateway address, split at the first `:` exactly like the
+ * routes do. A bare model id (no provider prefix) is returned unchanged, so this is safe
+ * on any model string a client may send.
+ */
+export function toGatewayApiModelId(modelAddress: string): string {
+  return modelAddress.slice(modelAddress.indexOf(':') + 1)
+}
+
+/**
  * Sentinel suffix on the gateway model id handed to gemini-cli (`--model` and
  * `settings.model.name`). gemini-cli normalizes model names it thinks are its own:
  * its `resolveModel` rewrites anything satisfying `endsWith("flash")` (or equal to

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -205,11 +205,17 @@ export const isAnthropicModel = (model: Model): boolean =>
 export const isGeminiModel = (model: Model): boolean =>
   VENDOR_PATTERNS.gemini.test(getLowerBaseModelName(getRawModelId(model)))
 
-/** Check if model is Gemini 3 series (sub-family of Gemini, ID-specific). */
-export const isGemini3Model = (model: Model): boolean => {
-  const id = getLowerBaseModelName(getRawModelId(model))
+/**
+ * Check if a raw model id is Gemini 3 series. The `*-latest` aliases resolve to
+ * Gemini 3, so an id-substring check alone misses them.
+ */
+export const isGemini3ModelId = (modelId: string): boolean => {
+  const id = getLowerBaseModelName(modelId)
   return id.includes('gemini-3') || id === 'gemini-flash-latest' || id === 'gemini-pro-latest'
 }
+
+/** Check if model is Gemini 3 series (sub-family of Gemini, ID-specific). */
+export const isGemini3Model = (model: Model): boolean => isGemini3ModelId(getRawModelId(model))
 
 /** Check if model is a Grok model */
 export const isGrokModel = (model: Model): boolean =>


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Routing an Anthropic-protocol client (Claude Code) through the API gateway to `gemini-flash-latest` failed on the second turn of every tool call:

```
400 INVALID_ARGUMENT: Function call is missing a thought_signature in functionCall parts.
Additional data, function call `default_api:Bash`, position 2.
```

`AnthropicMessageConverter` carried its own copy of the Gemini 3 check — a bare `modelId.includes('gemini-3')` — which misses the `gemini-flash-latest` / `gemini-pro-latest` aliases that `isGemini3Model` in `@shared/utils/model` explicitly handles. On those models the converter skipped `providerOptions.google.thoughtSignature`, so the replayed `tool_use` reached `generateContent` as a bare `functionCall` and Gemini 3 rejected the request.

Two latent defects sat behind it: the signature cache was keyed by **tool name** on write (`AiSdkToAnthropicSse`) — parallel calls of the same tool overwrite each other — and the cached value was discarded in favour of the `skip_thought_signature_validator` magic string, which Google documents for the OpenAI-compatibility endpoint (`extra_content.google.thought_signature`), not for native `generateContent`. That string appears zero times in local gateway logs, i.e. the path had never completed a Gemini 3 tool round-trip.

After this PR:

- `isGemini3ModelId(id: string)` is exported from `@shared/utils/model` and `isGemini3Model` delegates to it; the gateway's hand-rolled duplicate is deleted, so the alias list exists in exactly one place.
- The signature cache is keyed by `toolCallId` on both write and read (matching the OpenRouter branch beside it; Anthropic `tool_use` ids round-trip stably across turns).
- The converter echoes the **real** signature captured from the stream instead of the magic string.
- Orphaned `toolName` parameter and `MAGIC_STRING` constant removed.

N/A — no existing issue tracks this gateway case (#11418 / #12729 cover the OpenRouter and OpenAI-compatible variants and are closed).

### Why we need it and why it was done in this way

The regression class here is a duplicated predicate: the gateway copy was annotated "Match the branch's `isGemini3ModelId`" and then drifted from it. Rather than re-adding the two aliases to the copy (which would drift again), the shared predicate is split so both call sites share one definition.

The following tradeoffs were made:

- The signature cache remains main-process memory with a 30-minute TTL, so a cache miss (app restart, session resume, or a tool call older than the TTL still present in replayed history) still sends the call without a signature and can 400. Persisting signatures across restarts is a larger change and is deliberately out of scope; behaviour on cache miss is unchanged from before.
- No `skip_thought_signature_validator` fallback on cache miss: sending an unverified sentinel to the native endpoint risks trading one 400 for another.

The following alternatives were considered:

- Adding the two aliases to the gateway's local predicate — rejected, it preserves the drift that caused the bug.
- Keeping the magic string and only fixing the model check — rejected, unverified on the native API and it throws away a signature the adapter already has in hand.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Diagnosed from a captured failing request body: `contents[1]` was `{role: "model", parts: [{functionCall: {name: "Bash"}}]}` with no `thoughtSignature`, against `https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:streamGenerateContent`.

The new test in `AiSdkToAnthropicSse.test.ts` spans writer and reader on purpose — the defect lived in the contract between them (cache key agreement), not inside either one. It was verified to fail against the old predicate and against the old cache key.

Gemini-native and OpenAI-format gateway inputs are untouched: `GeminiMessageConverter` already round-trips real signatures, and the OpenAI-compat path is covered by the `skip-gemini-thought-signature` request feature.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix API gateway requests to Gemini 3 "latest" aliases (gemini-flash-latest, gemini-pro-latest) failing with "Function call is missing a thought_signature" after the first tool call.
```
