### PR TITLE
fix(pdf-translation): show resource download progress

### DIFF
--- a/src/main/services/__tests__/PdfTranslationService.test.ts
+++ b/src/main/services/__tests__/PdfTranslationService.test.ts
@@ -136,7 +136,7 @@ describe('PdfTranslationService', () => {
       'babeldoc-stream': {
         name: 'babeldoc-stream',
         availability: { source: 'mise', path: MANAGED_BINARY },
-        application: { status: 'applied', version: '0.6.4.post2' }
+        application: { status: 'applied', version: '0.6.4.post3' }
       }
     })
     apiGateway.acquireLease.mockResolvedValue(undefined)

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -32,14 +32,14 @@ const ipcEventHandlers = vi.hoisted(() => new Map<string, (payload: unknown) => 
 const babeldocInstalledSnapshot: BinaryToolSnapshot = {
   name: 'babeldoc-stream',
   availability: { source: 'mise', path: '/shims/babeldoc-stream' },
-  application: { status: 'applied', version: '0.6.4.post2' }
+  application: { status: 'applied', version: '0.6.4.post3' }
 }
 const binaryMock = vi.hoisted(() => ({
   snapshots: {
     'babeldoc-stream': {
       name: 'babeldoc-stream',
       availability: { source: 'mise', path: '/shims/babeldoc-stream' },
-      application: { status: 'applied', version: '0.6.4.post2' }
+      application: { status: 'applied', version: '0.6.4.post3' }
     }
   } as Record<string, BinaryToolSnapshot>
 }))
@@ -903,7 +903,7 @@ describe('TranslatePage', () => {
     await waitFor(() =>
       expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', {
         name: 'babeldoc-stream',
-        targetVersion: '0.6.4.post2'
+        targetVersion: '0.6.4.post3'
       })
     )
   })

--- a/src/renderer/pages/translate/pdf/PdfTranslationView.tsx
+++ b/src/renderer/pages/translate/pdf/PdfTranslationView.tsx
@@ -393,12 +393,17 @@ const PdfTranslationResult = ({
 
       const roundedOverallProgress = Math.round(state.progress.overallProgress)
       const roundedStageProgress = Math.round(state.progress.stageProgress)
+      const displayProgress =
+        state.progress.stage === 'checking_assets' || state.progress.stage === 'downloading_assets'
+          ? state.progress.stageProgress
+          : state.progress.overallProgress
+      const roundedDisplayProgress = Math.round(displayProgress)
       return (
         <div className="flex h-full items-center justify-center">
           <PdfProgress
-            progress={state.progress.overallProgress}
+            progress={displayProgress}
             label={progressLabel}
-            percentLabel={t('translate.pdf.progress.percent', { progress: roundedOverallProgress })}
+            percentLabel={t('translate.pdf.progress.percent', { progress: roundedDisplayProgress })}
             valueText={t('translate.pdf.progress.value', {
               stage: progressLabel,
               overallProgress: roundedOverallProgress,

--- a/src/renderer/pages/translate/pdf/__tests__/PdfTranslationView.test.tsx
+++ b/src/renderer/pages/translate/pdf/__tests__/PdfTranslationView.test.tsx
@@ -146,7 +146,7 @@ describe('PdfTranslationView', () => {
     })
     expect(screen.getByRole('progressbar', { name: 'translate.pdf.progress.checking_assets' })).toHaveAttribute(
       'aria-valuenow',
-      '1'
+      '50'
     )
     expect(screen.queryByText('translate.pdf.progress.preparing_hint')).not.toBeInTheDocument()
 
@@ -160,7 +160,7 @@ describe('PdfTranslationView', () => {
     })
     expect(screen.getByRole('progressbar', { name: 'translate.pdf.progress.downloading_assets' })).toHaveAttribute(
       'aria-valuenow',
-      '2'
+      '42'
     )
 
     act(() => {

--- a/src/shared/data/presets/__tests__/binaryTools.test.ts
+++ b/src/shared/data/presets/__tests__/binaryTools.test.ts
@@ -50,6 +50,7 @@ describe('BabelDOC Stream preset', () => {
     [{ status: 'absent' } as const, 'missing'],
     [{ status: 'applied' } as const, 'outdated'],
     [{ status: 'applied', version: '0.6.4.post1' } as const, 'outdated'],
+    [{ status: 'applied', version: '0.6.4.post2' } as const, 'outdated'],
     [{ status: 'applied', version: BABELDOC_MINIMUM_VERSION } as const, 'available'],
     [{ status: 'applied', version: '0.6.5' } as const, 'available']
   ])('classifies application %j as %s', (application, expected) => {

--- a/src/shared/data/presets/binaryTools.ts
+++ b/src/shared/data/presets/binaryTools.ts
@@ -62,7 +62,7 @@ export interface BinaryToolPreset {
 
 /** The BinaryManager tool name for the BabelDOC PDF layout-preserving engine. */
 export const BABELDOC_TOOL_NAME = 'babeldoc-stream'
-export const BABELDOC_MINIMUM_VERSION = '0.6.4.post2'
+export const BABELDOC_MINIMUM_VERSION = '0.6.4.post3'
 
 export type BabelDocInstallationStatus = 'missing' | 'outdated' | 'available'
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

PDF asset preparation displayed the workflow-wide progress value, so ONNX, font, and CMap downloads appeared nearly static even when BabelDOC reported their real stage progress. Cherry also accepted BabelDOC Stream 0.6.4.post2, which does not contain the byte-weighted asset progress fix.

After this PR:

PDF asset checking and downloading display BabelDOC's `stageProgress`, while model loading and later translation stages continue to use `overallProgress`. Indeterminate asset events retain the existing loading state. The minimum BabelDOC Stream version is raised to 0.6.4.post3 so existing post2 installations are offered the compatible update.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The existing `babeldoc-stream/v2` protocol remains unchanged; Cherry only selects the progress field appropriate to the current stage.
- The minimum dependency version is raised because post2 remains protocol-compatible but cannot provide the corrected asset progress behavior.

The following alternatives were considered:

- Showing `overallProgress` for every stage was retained for later translation work but rejected for asset downloads because initialization intentionally occupies only the first 10% of the workflow.
- Extending the protocol with download-specific fields was rejected because `stageProgress` already represents the required contract.

Links to places where the discussion took place: https://github.com/eeee0717/BabelDOC/releases/tag/v0.6.4.post3

### Breaking changes

None. Existing BabelDOC Stream 0.6.4.post2 installations are upgraded through BinaryManager to 0.6.4.post3.

### Special notes for your reviewer

- BabelDOC Stream 0.6.4.post3 was tested with direct, proxy-disabled upgrades from post2 on macOS arm64 and Windows x64.
- Focused verification passed: 61 renderer tests, 26 main-process tests, and 19 shared tests.
- `pnpm lint` passed. A broader renderer run also exercised the affected tests successfully but retained two unrelated existing legacy-v1 cleanup test failures.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Show accurate, monotonic progress while PDF translation resources are downloading.
```
