### PR TITLE
fix(migration): preserve agent identity files when v1 source workspace is removed

### DIFF
--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -1732,6 +1732,44 @@ describe('agentsFilesystemMigration', () => {
     }
   )
 
+  it('preserves an Agent data directory that already contains identity files', async () => {
+    const { agentsDataRoot, legacyWorkspace } = await createFixture()
+    await mkdir(legacyWorkspace, { recursive: true })
+    await writeFile(path.join(legacyWorkspace, 'SOUL.md'), 'legacy soul')
+
+    const latestSession = sessionPlan(agentsDataRoot, legacyWorkspace, {
+      sourceSessionId: 'session_latest',
+      finalSessionId: FINAL_LATEST_SESSION_ID,
+      createdAt: Date.parse('2026-07-22T00:00:00Z'),
+      updatedAt: Date.parse('2026-07-23T00:00:00Z')
+    })
+    const agentDataPath = path.join(agentsDataRoot, FINAL_AGENT_ID)
+    await mkdir(agentDataPath, { recursive: true })
+    await writeFile(path.join(agentDataPath, 'SOUL.md'), 'existing soul')
+    await writeFile(path.join(agentDataPath, 'V2-ONLY.md'), 'stale agent data')
+
+    const input = {
+      agentsDataRoot,
+      agents: [{ sourceAgentId: SOURCE_AGENT_ID, finalAgentId: FINAL_AGENT_ID }],
+      sessions: [latestSession]
+    }
+
+    // First run: source exists, target is cleared and re-populated.
+    const result1 = await stageLegacyAgentFiles(input)
+    expect(result1.skippedTargetCount).toBe(0)
+    expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('legacy soul')
+    // V2-ONLY.md is removed because the target was cleared.
+    await expect(access(path.join(agentDataPath, 'V2-ONLY.md'))).rejects.toThrow()
+
+    // Remove the v1 source workspace to simulate an app update cleanup.
+    await rm(legacyWorkspace, { recursive: true })
+
+    // Second run: source is gone, target with identity files is preserved.
+    const result2 = await stageLegacyAgentFiles(input)
+    expect(result2.skippedTargetCount).toBe(1)
+    expect(await readFile(path.join(agentDataPath, 'SOUL.md'), 'utf8')).toBe('legacy soul')
+  })
+
   it('replaces an existing identity target without changing the legacy source', async () => {
     const { agentsDataRoot, legacyWorkspace } = await createFixture()
     await mkdir(legacyWorkspace, { recursive: true })

--- a/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
+++ b/src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts
@@ -1592,6 +1592,14 @@ function findCleanupTargetSourceOverlaps(
   return Array.from(overlaps.values())
 }
 
+async function targetHasIdentityFiles(targetPath: string): Promise<boolean> {
+  for (const name of ['SOUL.md', 'USER.md']) {
+    const stat = await lstatIfExists(path.join(targetPath, name))
+    if (stat && stat.size > 0) return true
+  }
+  return false
+}
+
 async function clearLegacyAgentMigrationTargets(input: {
   agentsDataRoot: string
   agents: Array<{ sourceAgentId: string; finalAgentId: string }>
@@ -1724,6 +1732,36 @@ async function clearLegacyAgentMigrationTargets(input: {
   }
 
   for (const targetKey of targetSourceOverlaps.keys()) skippedTargetKeys.add(targetKey)
+
+  // Preserve existing Agent data directories whose v1 source workspace no
+  // longer exists and that already contain identity files.
+  // After an app update the v1 workspace may have been cleaned up, but the
+  // user's identity files (SOUL.md, USER.md, memory) inside the v2 target
+  // must survive.
+  for (const target of targets) {
+    if (!target.exists || skippedTargetKeys.has(cleanupPathIndexKey(target.path))) continue
+    if (!(await targetHasIdentityFiles(target.path))) continue
+    const targetKey = cleanupPathIndexKey(target.path)
+    const sourceKeys = Array.from(targetKeysBySourcePath.entries())
+      .filter(([, tKeys]) => tKeys.has(targetKey))
+      .map(([sourceKey]) => sourceKey)
+    if (sourceKeys.length === 0) continue
+    let sourceExists = false
+    for (const sourceKey of sourceKeys) {
+      const sourcePath = Array.from(sourcePaths).find((p) => cleanupPathIndexKey(p) === sourceKey)
+      if (sourcePath !== undefined && (await lstatIfExists(sourcePath))) {
+        sourceExists = true
+        break
+      }
+    }
+    if (!sourceExists) {
+      skippedTargetKeys.add(targetKey)
+      logger.info('Preserving Agent data directory because its v1 source workspace no longer exists', {
+        targetPath: target.path
+      })
+    }
+  }
+
   const cleanupTargets = targets.filter(
     (target) => !target.preserveExactSource && !skippedTargetKeys.has(cleanupPathIndexKey(target.path))
   )


### PR DESCRIPTION
### What this PR does

Before this PR:
- Agent memory files (SOUL.md, USER.md, memory/) stored in `Data/Agents/<agentId>/` are reset after every app update, even though the `.claude` directory survives the update.
- The `clearLegacyAgentMigrationTargets` function in the v2 migration removes v2 agent data directories even when they contain user identity files and their v1 source workspace no longer exists.

After this PR:
- `clearLegacyAgentMigrationTargets` now preserves existing v2 agent data directories that contain non-empty identity files (SOUL.md, USER.md) when their v1 source workspace no longer exists on disk.
- This prevents user identity from being lost after an app update.

Fixes #18954

### Why we need it and why it was done in this way

The root cause is that `clearLegacyAgentMigrationTargets` removes all v2 agent data directories as cleanup targets before `copyIdentityFromWorkspace` copies from v1 workspaces. When a v1 workspace is cleaned up during an app update but the v2 target already contains user identity files, those files are lost.

The fix adds a preservation loop after the overlap check that:
1. Checks if a target exists and contains non-empty identity files (SOUL.md or USER.md with content)
2. Looks up all source paths that map to this target
3. Skips removing the target only if ALL of its source paths no longer exist on disk

This ensures that targets with identity files are preserved when their v1 source is gone, but targets that still have a valid source are re-created from that source (idempotent behavior).

The following alternatives were considered:
- Adding a skip-if-destination-exists guard to `copyIdentityFromWorkspace` — rejected because `ensureAgentStorageDirectory` recreates the directory before `copyIdentityFromWorkspace` runs
- Preserving ALL targets with identity files regardless of source existence — rejected because it broke idempotency (targets with identity files from a still-existing source should be re-created)

### Breaking changes

None.

### Special notes for your reviewer

- The fix is in `clearLegacyAgentMigrationTargets` in `src/main/data/migration/v2/migrators/agentsFilesystemMigration.ts`
- A new test "preserves an Agent data directory that already contains identity files" was added to verify the fix
- All 54 tests in the migration test file pass

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Left the code cleaner than found
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed
- [ ] Documentation: A user-guide update was considered and is not required for this internal migration fix
- [x] Self-review: I have reviewed my own code

### Release note

```release-note
Fixes agent memory (SOUL.md, USER.md, memory/) being reset after app updates by preserving v2 agent data directories that contain user identity files when their v1 source workspace no longer exists.
```
