### PR TITLE
test(job-scheduler): fix flaky nextRun assertion on natural interval fire

### DIFF
--- a/src/main/core/job/__tests__/JobManager.schedule.test.ts
+++ b/src/main/core/job/__tests__/JobManager.schedule.test.ts
@@ -327,8 +327,9 @@ describe('JobManager schedule control APIs', () => {
       await new Promise((resolve) => setTimeout(resolve, 30))
 
       const advancedNextRun = jobScheduleService.getById(schedule.id)?.nextRun
-      expect(Date.parse(advancedNextRun ?? '')).toBeGreaterThan(Date.parse(initialNextRun ?? ''))
-      expect(Date.parse(advancedNextRun ?? '')).toBeGreaterThan(Date.now())
+      // Bound against the fire cadence, not Date.now(): a stalled event loop
+      // can let the interval fire again and leave the last write in the past.
+      expect(Date.parse(advancedNextRun ?? '')).toBeGreaterThanOrEqual(Date.parse(initialNextRun ?? '') + 20)
     })
 
     it('unregisterJobSchedule(type, name) deletes the row', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`JobManager.schedule.test.ts > advances persisted nextRun after an interval fires naturally` asserted that the persisted `nextRun` was still ahead of `Date.now()` at read time. `markFired` writes `nextRun` as `fireTime + interval` (`JobManager.ts:2148-2155`), so any event-loop stall longer than the test's 20ms interval leaves the last write in the past and the test fails — it did on `main` CI (`main-test (ubuntu-latest 3/3)`, 3ms behind).

After this PR:

The assertion is bounded against the fire cadence instead of the wall clock: every natural fire must push `nextRun` at least one interval past the previous value. That holds regardless of how long the loop stalls or how many extra fires slip in, and it still fails if `markFired` does not advance `nextRun` — so it subsumes the removed `advanced > initial` check.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The "`nextRun` points at a future fire" property is no longer asserted directly. It is not observable from the test without a race, and the cadence bound covers the defect it was there to catch.

The following alternatives were considered:

Raising the interval / sleep durations (only widens the flake window, does not close it) and driving the fire with fake timers (the schedule path is armed through real `setTimeout` chains in `SchedulerService`, so faking them would rewrite the test's subject rather than stabilise it).

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/32355975745/job/96385185633

### Breaking changes

None.

### Special notes for your reviewer

Test-only change; no production code touched. Verified with 5 consecutive local runs of the file (37/37 each).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
