### PR TITLE
fix(quote): route message quotes to the originating window

### DIFF
--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -167,7 +167,9 @@ export class MainWindowService extends BaseService {
   }
 
   private registerIpcHandlers() {
-    this.ipcHandle(IpcChannel.App_QuoteToMain, (_, text: string) => this.quoteToMainWindow(text))
+    this.ipcHandle(IpcChannel.App_QuoteToMain, (event, text: string) => {
+      this.quoteToMainWindow(text, event.sender)
+    })
   }
 
   /** Set the main window's minimum size (window.main.set_minimum_size). */
@@ -625,11 +627,22 @@ export class MainWindowService extends BaseService {
   }
 
   /**
-   * 引用文本到主窗口
+   * 引用文本到发起窗口（子窗口）或主窗口
    * @param text 原始文本（未格式化）
+   * @param sourceWebContents 发起引用的 webContents（IPC 调用方）。当它属于一个
+   *   detached SubWindow（独立标签窗口）时，引用插入该子窗口自己的输入框，避免
+   *   内容总是落到主窗口；其余情况（主窗口、selection toolbar 等）保持发往主窗口。
    */
-  public quoteToMainWindow(text: string): void {
+  public quoteToMainWindow(text: string, sourceWebContents?: Electron.WebContents): void {
     try {
+      const sourceWindow = this.resolveQuoteSourceWindow(sourceWebContents)
+      if (sourceWindow && !sourceWindow.isDestroyed()) {
+        // SubWindow already has a composer mounted with the same App_QuoteToMain
+        // listener, so sending here inserts the quote into the detached window.
+        sourceWindow.webContents.send(IpcChannel.App_QuoteToMain, text)
+        return
+      }
+
       this.showMainWindow()
 
       const mainWindow = this.mainWindow
@@ -641,5 +654,16 @@ export class MainWindowService extends BaseService {
     } catch (error) {
       logger.error('Failed to quote to main window:', error as Error)
     }
+  }
+
+  /** Resolve the BrowserWindow that hosts a quote IPC sender, when it is a SubWindow. */
+  private resolveQuoteSourceWindow(sourceWebContents?: Electron.WebContents): BrowserWindow | null {
+    if (!sourceWebContents) return null
+    const windowManager = application.get('WindowManager')
+    const sourceWindowId = windowManager.getWindowIdByWebContents(sourceWebContents)
+    if (!sourceWindowId) return null
+    if (windowManager.getWindowType(sourceWindowId) !== WindowType.SubWindow) return null
+    const sourceWindow = windowManager.getWindow(sourceWindowId)
+    return sourceWindow && !sourceWindow.isDestroyed() ? sourceWindow : null
   }
 }

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -634,9 +634,14 @@ export class MainWindowService extends BaseService {
    *   内容总是落到主窗口；其余情况（主窗口、selection toolbar 等）保持发往主窗口。
    */
   public quoteToMainWindow(text: string, sourceWebContents?: Electron.WebContents): void {
+    // Track the intended landing spot so a failure log names the right window:
+    // quotes either go to a detached SubWindow (identified by id) or fall back
+    // to the main window — debugging them requires telling the two paths apart.
+    let quoteTarget = 'main window'
     try {
       const sourceWindow = this.resolveQuoteSourceWindow(sourceWebContents)
-      if (sourceWindow && !sourceWindow.isDestroyed()) {
+      if (sourceWindow) {
+        quoteTarget = `sub window ${sourceWindow.id}`
         // SubWindow already has a composer mounted with the same App_QuoteToMain
         // listener, so sending here inserts the quote into the detached window.
         sourceWindow.webContents.send(IpcChannel.App_QuoteToMain, text)
@@ -652,11 +657,15 @@ export class MainWindowService extends BaseService {
         }, 100)
       }
     } catch (error) {
-      logger.error('Failed to quote to main window:', error as Error)
+      logger.error(`Failed to quote to ${quoteTarget}:`, error as Error)
     }
   }
 
-  /** Resolve the BrowserWindow that hosts a quote IPC sender, when it is a SubWindow. */
+  /**
+   * Resolve the BrowserWindow that hosts a quote IPC sender, when it is a detached
+   * SubWindow. Returns null otherwise — including when that window is already
+   * destroyed — so callers need no further liveness check on the result.
+   */
   private resolveQuoteSourceWindow(sourceWebContents?: Electron.WebContents): BrowserWindow | null {
     if (!sourceWebContents) return null
     const windowManager = application.get('WindowManager')

--- a/src/main/services/MainWindowService.ts
+++ b/src/main/services/MainWindowService.ts
@@ -644,6 +644,9 @@ export class MainWindowService extends BaseService {
         quoteTarget = `sub window ${sourceWindow.id}`
         // SubWindow already has a composer mounted with the same App_QuoteToMain
         // listener, so sending here inserts the quote into the detached window.
+        // Deliberately no Dock-visibility side effects: quoting into a detached
+        // window must not undo the user's close-to-tray choice (macOS keeps the
+        // Dock icon hidden while Main stays hidden; the tray still shows the app).
         sourceWindow.webContents.send(IpcChannel.App_QuoteToMain, text)
         return
       }
@@ -653,7 +656,12 @@ export class MainWindowService extends BaseService {
       const mainWindow = this.mainWindow
       if (mainWindow && !mainWindow.isDestroyed()) {
         setTimeout(() => {
-          mainWindow.webContents.send(IpcChannel.App_QuoteToMain, text)
+          // Re-check at fire time: the window can be destroyed during the 100ms
+          // gap (e.g. user quits via tray), and sending to destroyed webContents
+          // would throw outside the enclosing try/catch.
+          if (!mainWindow.isDestroyed()) {
+            mainWindow.webContents.send(IpcChannel.App_QuoteToMain, text)
+          }
         }, 100)
       }
     } catch (error) {

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -27,6 +27,8 @@ const {
   const windowManagerMock = {
     getWindow: vi.fn(),
     getWindowId: vi.fn(),
+    getWindowIdByWebContents: vi.fn(),
+    getWindowType: vi.fn(),
     // Mirrors the real shape: runtime behavior setters live on `wm.behavior`
     // (see BehaviorController in src/main/core/window/behavior.ts).
     behavior: {
@@ -153,6 +155,7 @@ vi.mock('@main/core/lifecycle', async () => {
 })
 
 import { WindowType } from '@main/core/window/types'
+import { IpcChannel } from '@shared/IpcChannel'
 import { HTML_ARTIFACT_PREVIEW_DATA_URL_PREFIX, HTML_ARTIFACT_PREVIEW_PARTITION } from '@shared/utils/htmlArtifact'
 import { app } from 'electron'
 
@@ -180,6 +183,7 @@ interface MockBrowserWindow extends EventEmitter {
     on: ReturnType<typeof vi.fn>
     once: ReturnType<typeof vi.fn>
     setWindowOpenHandler: ReturnType<typeof vi.fn>
+    send: ReturnType<typeof vi.fn>
   }
 }
 
@@ -205,7 +209,8 @@ function createMockWindow(): MockBrowserWindow {
     // capture render-process-gone listener for crash-recovery tests
     on: vi.fn(),
     once: vi.fn(),
-    setWindowOpenHandler: vi.fn()
+    setWindowOpenHandler: vi.fn(),
+    send: vi.fn()
   }
   return win
 }
@@ -252,6 +257,9 @@ describe('MainWindowService', () => {
     applicationMock.forceExit.mockReset()
     windowManagerMock.behavior.setMacShowInDockByType.mockReset()
     windowManagerMock.getWindowId.mockReset()
+    windowManagerMock.getWindowIdByWebContents.mockReset()
+    windowManagerMock.getWindowType.mockReset()
+    windowManagerMock.getWindow.mockReset()
     windowManagerMock.open.mockClear()
     windowManagerMock.pushInitDataToType.mockClear()
     loggerMock.error.mockReset()
@@ -920,6 +928,71 @@ describe('MainWindowService', () => {
 
       expect(navigateTo('http://127.0.0.1:5173/windows/main/index.html').preventDefault).toHaveBeenCalledOnce()
       expect(navigateTo('file:///Users/victim/Downloads/evil.html').preventDefault).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('quoteToMainWindow routing', () => {
+    beforeEach(() => {
+      ;(svc as any).mainWindow = win
+    })
+
+    it('routes quotes originating from a detached SubWindow into that sub window', () => {
+      const subWindow = createMockWindow()
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('sub-window-1')
+      windowManagerMock.getWindowType.mockReturnValue(WindowType.SubWindow)
+      windowManagerMock.getWindow.mockReturnValue(subWindow)
+
+      svc.quoteToMainWindow('Selected text', { id: 9001 } as any)
+
+      expect(subWindow.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
+      // Must NOT force the main window to the front when quoting from a sub window.
+      expect(win.show).not.toHaveBeenCalled()
+      expect(win.focus).not.toHaveBeenCalled()
+      expect(win.webContents.send).not.toHaveBeenCalled()
+    })
+
+    it('routes quotes from the main window back to the main window', () => {
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('main-window-1')
+      windowManagerMock.getWindowType.mockReturnValue(WindowType.Main)
+
+      svc.quoteToMainWindow('Selected text', { id: 1000 } as any)
+
+      // showMainWindow focuses the main window so the quote lands in its composer.
+      expect(win.show).toHaveBeenCalled()
+      expect(win.focus).toHaveBeenCalled()
+    })
+
+    it('routes quotes from a non-SubWindow helper window (selection toolbar) to the main window', () => {
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('toolbar-window-1')
+      windowManagerMock.getWindowType.mockReturnValue(WindowType.SelectionToolbar)
+
+      svc.quoteToMainWindow('Selected text', { id: 500 } as any)
+
+      expect(win.show).toHaveBeenCalled()
+      expect(win.focus).toHaveBeenCalled()
+    })
+
+    it('falls back to the main window when the sender window cannot be resolved', () => {
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue(undefined)
+
+      svc.quoteToMainWindow('Selected text', { id: 999 } as any)
+
+      expect(win.show).toHaveBeenCalled()
+      expect(win.focus).toHaveBeenCalled()
+    })
+
+    it('falls back to the main window when the SubWindow has been destroyed', () => {
+      const subWindow = createMockWindow()
+      subWindow.isDestroyed.mockReturnValue(true)
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('sub-window-1')
+      windowManagerMock.getWindowType.mockReturnValue(WindowType.SubWindow)
+      windowManagerMock.getWindow.mockReturnValue(subWindow)
+
+      svc.quoteToMainWindow('Selected text', { id: 9002 } as any)
+
+      expect(subWindow.webContents.send).not.toHaveBeenCalled()
+      expect(win.show).toHaveBeenCalled()
+      expect(win.focus).toHaveBeenCalled()
     })
   })
 })

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -932,8 +932,15 @@ describe('MainWindowService', () => {
   })
 
   describe('quoteToMainWindow routing', () => {
+    // The main-window leg defers its send via setTimeout(100); fake timers make
+    // that callback reachable at assertion time instead of leaking past the test.
     beforeEach(() => {
+      vi.useFakeTimers()
       ;(svc as any).mainWindow = win
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
     })
 
     it('routes quotes originating from a detached SubWindow into that sub window', () => {
@@ -960,6 +967,8 @@ describe('MainWindowService', () => {
       // showMainWindow focuses the main window so the quote lands in its composer.
       expect(win.show).toHaveBeenCalled()
       expect(win.focus).toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
     })
 
     it('routes quotes from a non-SubWindow helper window (selection toolbar) to the main window', () => {
@@ -970,6 +979,8 @@ describe('MainWindowService', () => {
 
       expect(win.show).toHaveBeenCalled()
       expect(win.focus).toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
     })
 
     it('falls back to the main window when the sender window cannot be resolved', () => {
@@ -979,6 +990,8 @@ describe('MainWindowService', () => {
 
       expect(win.show).toHaveBeenCalled()
       expect(win.focus).toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
     })
 
     it('falls back to the main window when the SubWindow has been destroyed', () => {
@@ -993,6 +1006,8 @@ describe('MainWindowService', () => {
       expect(subWindow.webContents.send).not.toHaveBeenCalled()
       expect(win.show).toHaveBeenCalled()
       expect(win.focus).toHaveBeenCalled()
+      vi.advanceTimersByTime(100)
+      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
     })
   })
 })

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -1023,7 +1023,7 @@ describe('MainWindowService', () => {
       expect(win.webContents.send).not.toHaveBeenCalled()
     })
 
-    it('delivers quotes arriving through the registered App_QuoteToMain IPC handler', () => {
+    it('forwards event.sender from the registered IPC handler and routes the quote to the originating SubWindow', () => {
       ;(svc as any).registerIpcHandlers()
 
       // Exercise the actual wiring instead of the method directly: a wrong
@@ -1033,10 +1033,25 @@ describe('MainWindowService', () => {
       )
       expect(registered, 'handler must be registered under App_QuoteToMain').toBeDefined()
 
+      const subWindow = createMockWindow()
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue('sub-window-1')
+      windowManagerMock.getWindowType.mockReturnValue(WindowType.SubWindow)
+      windowManagerMock.getWindow.mockReturnValue(subWindow)
+
       const [, handler] = registered!
-      handler({ sender: { id: 1000 } }, 'Selected text')
+      const senderWebContents = { id: 9001 }
+      handler({ sender: senderWebContents }, 'Selected text')
+
+      // Regression guard for the original bug: if the handler drops event.sender,
+      // the sender is never resolved and the quote silently falls back to the
+      // main window — the two assertions below catch exactly that.
+      expect(windowManagerMock.getWindowIdByWebContents).toHaveBeenCalledWith(senderWebContents)
+      expect(subWindow.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
+
       vi.advanceTimersByTime(100)
-      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
+      expect(win.show).not.toHaveBeenCalled()
+      expect(win.focus).not.toHaveBeenCalled()
+      expect(win.webContents.send).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/main/services/__tests__/MainWindowService.test.ts
+++ b/src/main/services/__tests__/MainWindowService.test.ts
@@ -1009,5 +1009,34 @@ describe('MainWindowService', () => {
       vi.advanceTimersByTime(100)
       expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
     })
+
+    it('falls back to reopening via WindowManager when there is no main window', () => {
+      ;(svc as any).mainWindow = null
+      windowManagerMock.getWindowIdByWebContents.mockReturnValue(undefined)
+
+      svc.quoteToMainWindow('Selected text', { id: 999 } as any)
+      vi.advanceTimersByTime(100)
+
+      // The rebuild goes through WindowManager's open path and, with no live
+      // main window at send time, nothing is delivered anywhere.
+      expect(windowManagerMock.open).toHaveBeenCalled()
+      expect(win.webContents.send).not.toHaveBeenCalled()
+    })
+
+    it('delivers quotes arriving through the registered App_QuoteToMain IPC handler', () => {
+      ;(svc as any).registerIpcHandlers()
+
+      // Exercise the actual wiring instead of the method directly: a wrong
+      // channel constant or a dropped/misordered text argument fails here.
+      const registered = ((svc as any).ipcHandle.mock.calls as [string, (event: unknown, text: string) => void][]).find(
+        ([channel]) => channel === IpcChannel.App_QuoteToMain
+      )
+      expect(registered, 'handler must be registered under App_QuoteToMain').toBeDefined()
+
+      const [, handler] = registered!
+      handler({ sender: { id: 1000 } }, 'Selected text')
+      vi.advanceTimersByTime(100)
+      expect(win.webContents.send).toHaveBeenCalledWith(IpcChannel.App_QuoteToMain, 'Selected text')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes quoting selected text when Cherry Studio has more than one open window.

**Repro:** With the main window plus a detached sub window (independent tab window) open, select text inside the sub window and right-click → "引用" (quote). The quoted text is inserted into the **main window's** composer instead of the sub window — regardless of where the cursor is. The main window is also force-focused by the quote action.

## Root cause

The quote flow is hardwired to the main window:

1. `SelectionContextMenu.handleQuote` (and `SelectionToolbar`) call `window.api.quoteToMainWindow(text)` → IPC `App_QuoteToMain`.
2. The main-process handler `MainWindowService.registerIpcHandlers` drops the sender (`(_, text) => ...`), so the origin window is lost.
3. `quoteToMainWindow` then `showMainWindow()`s and sends the text only to `this.mainWindow`'s webContents.

The sub window's composer mounts the same `App_QuoteToMain` listener (`useComposerQuoteInsertion`), so it *can* receive quotes — it just never gets them, because the main process only ever sends to the main window.

## Fix

- Forward `event.sender` from the IPC handler into `quoteToMainWindow`.
- Resolve the sender back to its `BrowserWindow` via `WindowManager.getWindowIdByWebContents` / `getWindowType` / `getWindow`.
- When the sender belongs to a `SubWindow`, send the quote to that sub window's own webContents and skip the main-window show/focus lift.
- All other senders (main window, selection toolbar, unresolvable) keep the existing behavior of quoting into the main window.

## Tests

Adds coverage for:
- Sub-window sender → quote lands in the sub window, main window is not focused.
- Main-window sender → quote routes to the main window (existing behavior preserved).
- Selection-toolbar sender → routes to the main window.
- Unresolvable / destroyed sub window → falls back to the main window.

All 43 `MainWindowService` tests pass; `typecheck:node` and `oxlint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)