### PR TITLE
fix(code-style): isolate theme catalog updates

### DIFF
--- a/src/renderer/components/CodeStyleProvider.tsx
+++ b/src/renderer/components/CodeStyleProvider.tsx
@@ -1,6 +1,6 @@
 import { type CodeMirrorTheme, getCmThemeByName, getCmThemeNames } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import { CodeStyleContext } from '@renderer/hooks/useCodeStyle'
+import { CodeStyleContext, CodeStyleThemeCatalogContext } from '@renderer/hooks/useCodeStyle'
 import { useTheme } from '@renderer/hooks/useTheme'
 import { shikiStreamService } from '@renderer/services/ShikiStreamService'
 import { getHighlighter, getMarkdownIt, getShiki, loadLanguageAndThemeIfNeeded } from '@renderer/utils/shiki'
@@ -181,8 +181,6 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
       getShikiPreProperties,
       highlightCode,
       shikiMarkdownIt,
-      loadThemeNames,
-      themeNames,
       activeShikiTheme,
       isShikiThemeDark,
       activeCmTheme
@@ -194,13 +192,23 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
       getShikiPreProperties,
       highlightCode,
       shikiMarkdownIt,
-      loadThemeNames,
-      themeNames,
       activeShikiTheme,
       isShikiThemeDark,
       activeCmTheme
     ]
   )
 
-  return <CodeStyleContext value={contextValue}>{children}</CodeStyleContext>
+  const themeCatalogContextValue = useMemo(
+    () => ({
+      loadThemeNames,
+      themeNames
+    }),
+    [loadThemeNames, themeNames]
+  )
+
+  return (
+    <CodeStyleContext value={contextValue}>
+      <CodeStyleThemeCatalogContext value={themeCatalogContextValue}>{children}</CodeStyleThemeCatalogContext>
+    </CodeStyleContext>
+  )
 }

--- a/src/renderer/components/__tests__/CodeStyleProvider.test.tsx
+++ b/src/renderer/components/__tests__/CodeStyleProvider.test.tsx
@@ -1,6 +1,6 @@
 import type * as codeEditorUtils from '@cherrystudio/ui/components/composites/code-editor/utils'
 import { CodeStyleProvider } from '@renderer/components/CodeStyleProvider'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCodeStyle, useCodeStyleThemeCatalog } from '@renderer/hooks/useCodeStyle'
 import { getHighlighter, getShiki, loadLanguageAndThemeIfNeeded } from '@renderer/utils/shiki'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -49,7 +49,8 @@ vi.mock('@renderer/utils/shiki', () => ({
 }))
 
 const Probe = () => {
-  const { highlightCode, loadThemeNames, themeNames, activeCmTheme, activeShikiTheme } = useCodeStyle()
+  const { highlightCode, activeCmTheme, activeShikiTheme } = useCodeStyle()
+  const { loadThemeNames, themeNames } = useCodeStyleThemeCatalog()
   return (
     <>
       <span data-testid="has-dracula">{String(themeNames.includes('dracula'))}</span>

--- a/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
+++ b/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
@@ -2,7 +2,7 @@ import { Flex, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Sl
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import Selector from '@renderer/components/Selector'
 import { SettingGroup as PageSettingGroup, SettingTitle } from '@renderer/components/SettingsPrimitives'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCodeStyleThemeCatalog } from '@renderer/hooks/useCodeStyle'
 import { useTheme } from '@renderer/hooks/useTheme'
 import { ipcApi } from '@renderer/ipc'
 import type { CodeStyleVarious } from '@renderer/types/app'
@@ -98,7 +98,7 @@ const ChatPreferenceSections: FC<ChatPreferenceSectionsProps> = ({ sectionClassN
   const setWideMode = (checked: boolean) => setNarrowMode(!checked)
 
   const { theme } = useTheme()
-  const { loadThemeNames, themeNames } = useCodeStyle()
+  const { loadThemeNames, themeNames } = useCodeStyleThemeCatalog()
   const [fontSizeValue, setFontSizeValue] = useState(fontSize)
   const { t } = useTranslation()
 

--- a/src/renderer/components/chat/settings/__tests__/ChatPreferenceSections.test.tsx
+++ b/src/renderer/components/chat/settings/__tests__/ChatPreferenceSections.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@renderer/hooks/useTheme', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ loadThemeNames: mocks.loadThemeNames, themeNames: ['auto', 'github'] })
+  useCodeStyleThemeCatalog: () => ({ loadThemeNames: mocks.loadThemeNames, themeNames: ['auto', 'github'] })
 }))
 
 vi.mock('@cherrystudio/ui/lib/utils', () => ({

--- a/src/renderer/hooks/useCodeStyle.ts
+++ b/src/renderer/hooks/useCodeStyle.ts
@@ -9,19 +9,31 @@ interface CodeStyleContextType {
   getShikiPreProperties: (language: string) => Promise<ShikiPreProperties>
   highlightCode: (code: string, language: string) => Promise<string>
   shikiMarkdownIt: (code: string) => Promise<string>
-  loadThemeNames: () => Promise<string[]>
-  themeNames: string[]
   activeShikiTheme: string
   isShikiThemeDark: boolean
   activeCmTheme: CodeMirrorTheme
 }
 
+interface CodeStyleThemeCatalogContextType {
+  loadThemeNames: () => Promise<string[]>
+  themeNames: string[]
+}
+
 export const CodeStyleContext = createContext<CodeStyleContextType | null>(null)
+export const CodeStyleThemeCatalogContext = createContext<CodeStyleThemeCatalogContextType | null>(null)
 
 export const useCodeStyle = () => {
   const context = use(CodeStyleContext)
   if (!context) {
     throw new Error('useCodeStyle must be used within a CodeStyleProvider')
+  }
+  return context
+}
+
+export const useCodeStyleThemeCatalog = () => {
+  const context = use(CodeStyleThemeCatalogContext)
+  if (!context) {
+    throw new Error('useCodeStyleThemeCatalog must be used within a CodeStyleProvider')
   }
   return context
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The code-style context exposed active runtime styling together with the settings-only theme catalog, so loading catalog names rerendered unrelated highlighting consumers.

After this PR:

`CodeStyleProvider` supplies a dedicated theme-catalog context for chat settings while the existing `useCodeStyle` context retains only active runtime styling.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19067

### Why we need it and why it was done in this way

The following tradeoffs were made:

The existing provider continues to own both state surfaces and all theme-loading behavior. The additional context is limited to the catalog values so runtime consumers no longer subscribe to settings-only updates.

The following alternatives were considered:

Moving catalog loading into chat settings or introducing a context-selector dependency was rejected because either option would change ownership or add unnecessary machinery for one consumer.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19067

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The provider and settings contract tests were updated to consume the dedicated catalog hook. No runtime styling or user-facing behavior changed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
