### PR TITLE
fix(pi-agent): resolve citations for pi's tool_call wrapper

### DIFF
--- a/src/main/ai/runtime/pi/piStreamAdapter.test.ts
+++ b/src/main/ai/runtime/pi/piStreamAdapter.test.ts
@@ -1,4 +1,6 @@
 import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent'
+import { webSearchOutputSchema } from '@shared/ai/builtinTools'
+import { PI_TOOL_CALL_TOOL_NAME } from '@shared/ai/piBuiltinTools'
 import type { CherryUIMessage, CherryUIMessageChunk } from '@shared/data/types/message'
 import { readUIMessageStream } from 'ai'
 import { describe, expect, it } from 'vitest'
@@ -249,24 +251,74 @@ describe('PiStreamAdapter', () => {
     })
   })
 
-  it('keeps full result for third-party MCP tools instead of projecting details', async () => {
-    const details = [{ id: 'a-1', title: 'First', url: 'https://a.com', content: 'x' }]
-    const result = { content: [{ type: 'text', text: 'results' }], details }
+  /**
+   * pi's code mode is unconditional, so cherry-tools is never a tool name of its own — every call
+   * arrives as `tool_call`, returning the target's MCP result verbatim. The renderer resolves
+   * `[cite:id]` markers by validating that output against `webSearchOutputSchema`, which a content
+   * block array never matches, so without the unwrap the markers stay literal.
+   */
+  it('unwraps a tool_call search result into the shape the citation resolver validates', async () => {
+    const results = [{ id: '19ff9dcd-1', title: 'First', url: 'https://a.com', content: 'x' }]
     const message = await accumulate(
       collect([
-        { type: 'tool_execution_start', toolCallId: 'm2', toolName: 'mcp__exa__search', args: {} },
+        {
+          type: 'tool_execution_start',
+          toolCallId: 'm2',
+          toolName: PI_TOOL_CALL_TOOL_NAME,
+          args: { name: 'mcp__cherry-tools__web_search', params: { query: 'x' } }
+        },
         {
           type: 'tool_execution_end',
           toolCallId: 'm2',
-          toolName: 'mcp__exa__search',
-          result,
+          toolName: PI_TOOL_CALL_TOOL_NAME,
+          result: { content: [{ type: 'text', text: JSON.stringify(results) }], details: null },
+          isError: false
+        }
+      ] as AgentSessionEvent[])
+    )
+    const output = (message.parts.find((part) => part.type === 'dynamic-tool') as { output?: unknown }).output
+    expect(webSearchOutputSchema.safeParse(output).success).toBe(true)
+  })
+
+  it('falls back to joined text when a tool_call result is not JSON', async () => {
+    const message = await accumulate(
+      collect([
+        { type: 'tool_execution_start', toolCallId: 'm3', toolName: PI_TOOL_CALL_TOOL_NAME, args: {} },
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'm3',
+          toolName: PI_TOOL_CALL_TOOL_NAME,
+          result: { content: [{ type: 'text', text: 'plain results' }], details: null },
           isError: false
         }
       ] as AgentSessionEvent[])
     )
     expect(message.parts.find((part) => part.type === 'dynamic-tool')).toMatchObject({
-      toolName: 'mcp__exa__search',
-      output: result
+      toolName: PI_TOOL_CALL_TOOL_NAME,
+      output: 'plain results'
+    })
+  })
+
+  it('keeps non-text tool_call content blocks as blocks', async () => {
+    const content = [
+      { type: 'text', text: 'shot' },
+      { type: 'image', data: 'aGk=', mimeType: 'image/png' }
+    ]
+    const message = await accumulate(
+      collect([
+        { type: 'tool_execution_start', toolCallId: 'm4', toolName: PI_TOOL_CALL_TOOL_NAME, args: {} },
+        {
+          type: 'tool_execution_end',
+          toolCallId: 'm4',
+          toolName: PI_TOOL_CALL_TOOL_NAME,
+          result: { content, details: null },
+          isError: false
+        }
+      ] as AgentSessionEvent[])
+    )
+    expect(message.parts.find((part) => part.type === 'dynamic-tool')).toMatchObject({
+      toolName: PI_TOOL_CALL_TOOL_NAME,
+      output: content
     })
   })
 })

--- a/src/main/ai/runtime/pi/piStreamAdapter.ts
+++ b/src/main/ai/runtime/pi/piStreamAdapter.ts
@@ -15,9 +15,9 @@
  * Tool parts are stamped with the pi runtime transport tag
  * (D8) so the renderer routes them to the generic pi tool card.
  */
-import type { AgentSessionEvent } from '@earendil-works/pi-coding-agent'
+import type { AgentSessionEvent, AgentToolResult } from '@earendil-works/pi-coding-agent'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
-import { PI_TOOL_EXEC_TOOL_NAME, PI_TOOL_SEARCH_TOOL_NAME } from '@shared/ai/piBuiltinTools'
+import { PI_TOOL_CALL_TOOL_NAME, PI_TOOL_EXEC_TOOL_NAME, PI_TOOL_SEARCH_TOOL_NAME } from '@shared/ai/piBuiltinTools'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import type { CherryUIMessageChunk } from '@shared/data/types/message'
 
@@ -201,12 +201,40 @@ export class PiStreamAdapter {
   }
 }
 
+type PiToolContent = AgentToolResult<unknown>['content'][number]
+
+function isTextContent(block: PiToolContent): block is Extract<PiToolContent, { type: 'text' }> {
+  return block.type === 'text'
+}
+
+/** pi types `tool_execution_end`'s `result` as `any`, and its builtins may return a bare string. */
+function asToolResult(result: unknown): AgentToolResult<unknown> | undefined {
+  const candidate = result as AgentToolResult<unknown> | undefined
+  return candidate && Array.isArray(candidate.content) ? candidate : undefined
+}
+
 function projectPiToolOutput(toolName: string, result: unknown): unknown {
-  if (!result || typeof result !== 'object' || !('details' in result)) return result ?? null
+  const toolResult = asToolResult(result)
+  if (!toolResult) return result ?? null
   if (toolName === PI_TOOL_SEARCH_TOOL_NAME || toolName === PI_TOOL_EXEC_TOOL_NAME) {
-    return (result as { details?: unknown }).details ?? result
+    return toolResult.details ?? toolResult
   }
-  return result ?? null
+  return toolName === PI_TOOL_CALL_TOOL_NAME ? unwrapMcpContent(toolResult) : toolResult
+}
+
+/**
+ * `tool_call` returns the target tool's MCP result verbatim, hiding an all-text payload inside a
+ * JSON string. Unwrap it the way the Claude Code / dsh adapters do, so tool cards and citation
+ * resolution see one shape across runtimes.
+ */
+function unwrapMcpContent({ content }: AgentToolResult<unknown>): unknown {
+  if (!content.every(isTextContent)) return content
+  const text = content.map((block) => block.text).join('\n')
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
 }
 
 interface TurnUsageTotals {

--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -83,6 +83,17 @@ const toolInvokePart = (name: string, output: unknown): CherryMessagePart =>
     output
   }) as never
 
+/** pi runs every tool through code mode, so the part is always `tool_call` with the target in its input. */
+const piToolCallPart = (name: string, output: unknown): CherryMessagePart =>
+  ({
+    type: 'dynamic-tool',
+    toolName: 'tool_call',
+    toolCallId: 'c6',
+    state: 'output-available',
+    input: { name, params: { query: 'q' } },
+    output
+  }) as never
+
 const sourceUrlPart = (n: number, url: string, title?: string): CherryMessagePart =>
   ({ type: 'source-url', sourceId: `citation-${n}`, url, title }) as never
 
@@ -117,6 +128,16 @@ describe('resolveMessageCitations', () => {
   it('resolves deferred tool_invoke parts by inner tool name', () => {
     const mc = resolveMessageCitations([toolInvokePart('web_search', webResults('t9k'))])
     expect(mc.byId.get('t9k-2')).toMatchObject({ number: 2, url: 'https://b.com/y' })
+  })
+
+  it('resolves pi tool_call parts by the cherry-tools target in its input', () => {
+    const mc = resolveMessageCitations([piToolCallPart('mcp__cherry-tools__web_search', webResults('bcef647b'))])
+    expect(mc.byId.get('bcef647b-1')).toMatchObject({ number: 1, url: 'https://a.com/x', type: 'websearch' })
+  })
+
+  it('ignores pi tool_call parts targeting a third-party MCP server', () => {
+    const mc = resolveMessageCitations([piToolCallPart('mcp__exa__web_search', webResults('bcef647b'))])
+    expect(mc.all).toHaveLength(0)
   })
 
   it('resolves citations from the skeleton of a bare entities envelope (cold load)', () => {

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -37,6 +37,7 @@ import {
   WEB_SEARCH_TOOL_NAME,
   webSearchOutputSchema
 } from '@shared/ai/builtinTools'
+import { PI_TOOL_CALL_TOOL_NAME } from '@shared/ai/piBuiltinTools'
 import { parseFunctionCallToolName } from '@shared/ai/tools/mcpToolName'
 import { isDeferredToolOutput, isPersistedToolOutput } from '@shared/ai/transport'
 import type { CherryMessagePart } from '@shared/data/types/message'
@@ -94,11 +95,18 @@ function sourceIdToNumber(sourceId: unknown): number | undefined {
   return Number.isFinite(value) && value >= 0 ? value + 1 : undefined
 }
 
+/** `mcp__cherry-tools__web_search` → `web_search`; null for any other server or tool. */
+function citableCherryToolName(wireName: string): string | null {
+  const parsed = parseFunctionCallToolName(wireName)
+  if (!parsed || parsed.serverPart !== CHERRY_TOOLS_MCP_SERVER) return null
+  return CITABLE_TOOL_NAMES.has(parsed.toolPart) ? parsed.toolPart : null
+}
+
 /**
  * The builtin lookup tool a part's completed output belongs to, across all
- * three wire shapes (static AI-SDK part, tool_invoke wrapper, cherry-tools
- * MCP dynamic-tool). Third-party MCP tools that happen to share a name are
- * deliberately excluded.
+ * four wire shapes (static AI-SDK part, tool_invoke wrapper, cherry-tools
+ * MCP dynamic-tool, pi's tool_call wrapper). Third-party MCP tools that happen
+ * to share a name are deliberately excluded.
  */
 function resolveCitableToolName(part: CherryMessagePart): string | null {
   if (!isToolUIPart(part as UIMessagePart<UIDataTypes, UITools>)) return null
@@ -122,12 +130,14 @@ function resolveCitableToolName(part: CherryMessagePart): string | null {
     return null
   }
 
-  const parsed = parseFunctionCallToolName(rawName)
-  if (parsed && parsed.serverPart === CHERRY_TOOLS_MCP_SERVER && CITABLE_TOOL_NAMES.has(parsed.toolPart)) {
-    return parsed.toolPart
+  // pi runs every tool through its code-mode `tool_call` wrapper, so the target's wire name lives
+  // in the input rather than the part's own name — the `tool_invoke` shape with an MCP-style name.
+  if (rawName === PI_TOOL_CALL_TOOL_NAME) {
+    const input = toolPart.input
+    return isRecord(input) && typeof input.name === 'string' ? citableCherryToolName(input.name) : null
   }
 
-  return null
+  return citableCherryToolName(rawName)
 }
 
 /**


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: in the Pi runtime, `[cite:19ff9dcd-1]` markers stayed as literal text — no badges, no source list — while Claude Code and DSH rendered them correctly.

After this PR: Pi citation markers resolve into badges with a source list, matching the other runtimes.

Pi's code mode is unconditional (`PiRuntimeConnection.ts:290`): `mcpBridge.tools` is only the *catalog* handed to `createPiCodeModeTools`, never registered as session tools, so `mcp__cherry-tools__web_search` is never a wire name Pi emits — every lookup arrives as `tool_call`. Two links were missing for that shape: `projectPiToolOutput` passed the `{ content, details }` envelope through untouched, so the resolver's `webSearchOutputSchema` check never matched a content-block array; and `resolveCitableToolName` did not recognise `tool_call` at all, dropping the part before its output was examined. This unwraps all-text MCP content the way `claudeCode/streamAdapter.normalizeToolResult` and `dshStreamAdapter.normalizeToolOutput` already do, and resolves `tool_call` via the target name in its input, exactly as the existing `tool_invoke` branch does.

Fixes #19062

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `tool_call` is resolved by name (its input names the target tool) rather than by output shape, so no third-party MCP result can be mistaken for a citable one.
- The `details` channel is left alone. Nothing in the renderer reads it (`extractOutputMetadata` already discards everything but `content`), so unwrapping `content` loses nothing that was previously displayed.
- `tool_exec` (code mode's JavaScript path) is **not** covered: one `tool_exec` can invoke several tools and return an arbitrary composed value, so there is no single citable tool and no well-defined output contract. Resolving it would need a shape-based fallback, which is a separate design decision.

The following alternatives were considered:

- Having `toMcpResult` set `structuredContent` and teaching the renderer to read `details`. Rejected: it opens a second delivery channel for the same payload — Pi in `details`, DSH in `data`, assistant as bare JSON — where this converges all three on one shape.
- A `webSearchOutputSchema` fallback in `resolveCitableToolName` for third-party MCP tools. Out of scope: third-party results carry no `id`, so the schema cannot match, and `resolveCitableToolName` rejects them in *every* runtime — a missing feature across the board, not a Pi regression.

Links to places where the discussion took place: #19062, #18787, #18829

### Breaking changes

None.

### Special notes for your reviewer

Two pre-existing dead branches are left in place rather than removed, since they are outside this fix: `toolProviderMetadata`'s `parseFunctionCallToolName` tagging in `piStreamAdapter.ts` (added by #18829) and the `mcp__cherry-tools__*` arm of `resolveCitableToolName` never fire for Pi, because Pi emits no `mcp__*` tool names. The latter is still live for the non-Pi agent runtime.

The test `keeps full result for third-party MCP tools instead of projecting details` (added by #18829) pinned the broken envelope shape as if it were the contract, and used a wire name Pi cannot emit, so it is replaced rather than updated.

Each new test was verified to fail without its half of the fix: reverting the adapter unwrap fails the 3 `piStreamAdapter` tests, and reverting the resolver branch fails the `tool_call` citation test.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: No upgrade impact — the projection is computed per stream, nothing persisted changes shape retroactively
- [x] Documentation: Not required — this restores the intended citation behavior rather than changing it
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
fix(pi-agent): Pi agent replies now render `[cite:...]` markers as citation badges with a source list, instead of leaving them as literal text
```
