### PR TITLE
fix(agents): use production migration SQL in session sync tests

### DIFF
--- a/src/main/services/agents/services/AgentService.ts
+++ b/src/main/services/agents/services/AgentService.ts
@@ -574,7 +574,16 @@ export class AgentService extends BaseService {
     rawOldAgent: Record<string, unknown>,
     serializedUpdates: Record<string, unknown>
   ): Promise<void> {
-    const syncFields = ['model', 'plan_model', 'small_model', 'allowed_tools', 'configuration', 'mcps', 'instructions']
+    const syncFields = [
+      'model',
+      'plan_model',
+      'small_model',
+      'allowed_tools',
+      'configuration',
+      'mcps',
+      'instructions',
+      'accessible_paths'
+    ]
 
     // rawOldAgent is already in DB-serialized form (JSON strings), so we can
     // compare directly against session rows without normalization mismatch.

--- a/src/main/services/agents/services/__tests__/AgentService.test.ts
+++ b/src/main/services/agents/services/__tests__/AgentService.test.ts
@@ -80,6 +80,7 @@ import {
   channelTaskSubscriptionsTable,
   scheduledTasksTable,
   sessionMessagesTable,
+  type SessionRow,
   sessionsTable,
   taskRunLogsTable
 } from '../../database/schema'
@@ -164,7 +165,13 @@ async function createAgentDatabase(rows: AgentRow[]) {
     database,
     cleanup: () => {
       client.close()
-      fs.rmSync(directory, { recursive: true, force: true })
+      // On Windows the libsql client may not release the DB file handle synchronously
+      // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
+      try {
+        fs.rmSync(directory, { recursive: true, force: true })
+      } catch {
+        // ignore
+      }
     }
   }
 }
@@ -551,6 +558,161 @@ describe('AgentService data repair', () => {
 
       expect(result.agents[0].updated_at).toBe('2026-07-23T12:43:20.097Z')
       expect(stored[0].updated_at).toBe(concurrentUpdatedAt)
+    } finally {
+      cleanup()
+    }
+  })
+})
+
+describe('AgentService session settings sync', () => {
+  const service = AgentService.getInstance()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createSessionRow(agentId: string, id: string, overrides: Partial<SessionRow> = {}): SessionRow {
+    return {
+      id,
+      agent_type: 'claude-code',
+      agent_id: agentId,
+      name: 'Test Session',
+      description: null,
+      accessible_paths: '[]',
+      instructions: 'Test instructions',
+      model: 'test-model',
+      plan_model: null,
+      small_model: null,
+      mcps: null,
+      allowed_tools: null,
+      slash_commands: null,
+      configuration: null,
+      sort_order: 0,
+      created_at: '2026-07-06T11:47:07.757Z',
+      updated_at: '2026-07-06T11:47:07.757Z',
+      ...overrides
+    }
+  }
+
+  async function createAgentWithSessionsDatabase(agent: AgentRow, sessions: SessionRow[]) {
+    const fs = await vi.importActual<TestFsModule>('node:fs')
+    const os = await vi.importActual<TestOsModule>('node:os')
+    const path = await vi.importActual<TestPathModule>('node:path')
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sync-test-'))
+    const client = createClient({ url: `file:${path.join(directory, 'agents.db')}`, intMode: 'number' })
+    const database = drizzle(client)
+
+    await client.execute(`
+      CREATE TABLE agents (
+        id TEXT PRIMARY KEY,
+        type TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        deleted_at TEXT,
+        accessible_paths TEXT,
+        instructions TEXT,
+        model TEXT NOT NULL,
+        plan_model TEXT,
+        small_model TEXT,
+        mcps TEXT,
+        allowed_tools TEXT,
+        configuration TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    await client.execute(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        agent_type TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        description TEXT,
+        accessible_paths TEXT,
+        instructions TEXT,
+        model TEXT NOT NULL,
+        plan_model TEXT,
+        small_model TEXT,
+        mcps TEXT,
+        allowed_tools TEXT,
+        slash_commands TEXT,
+        configuration TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `)
+    await database.insert(agentsTable).values(agent)
+    await database.insert(sessionsTable).values(sessions)
+
+    return {
+      database,
+      cleanup: () => {
+        client.close()
+        // On Windows the libsql client may not release the DB file handle synchronously
+        // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
+        try {
+          fs.rmSync(directory, { recursive: true, force: true })
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  it('propagates accessible_paths changes to sessions that inherited the old agent value', async () => {
+    const agentId = 'agent_sync_test'
+    const inheritedSessionId = 'session_inherited'
+    const customizedSessionId = 'session_customized'
+    const oldPaths = JSON.stringify(['/old/workspace'])
+    const { cleanup, database } = await createAgentWithSessionsDatabase(
+      createAgentRow({ id: agentId, accessible_paths: oldPaths }),
+      [
+        createSessionRow(agentId, inheritedSessionId, { accessible_paths: oldPaths }),
+        createSessionRow(agentId, customizedSessionId, { accessible_paths: JSON.stringify(['/custom/workspace']) })
+      ]
+    )
+
+    try {
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      // Avoid creating real directories on disk while resolving paths in the test.
+      vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      const newPaths = ['/new/workspace']
+      await service.updateAgent(agentId, { accessible_paths: newPaths })
+
+      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+
+      expect(sessionsById.get(inheritedSessionId)?.accessible_paths).toBe(JSON.stringify(newPaths))
+      expect(sessionsById.get(customizedSessionId)?.accessible_paths).toBe(JSON.stringify(['/custom/workspace']))
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('does not sync accessible_paths to sessions when the agent value is unchanged', async () => {
+    const agentId = 'agent_sync_test'
+    const sessionId = 'session_inherited'
+    const paths = JSON.stringify(['/workspace'])
+    const { cleanup, database } = await createAgentWithSessionsDatabase(
+      createAgentRow({ id: agentId, accessible_paths: paths }),
+      [createSessionRow(agentId, sessionId, { accessible_paths: paths })]
+    )
+
+    try {
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      await service.updateAgent(agentId, { accessible_paths: ['/workspace'] })
+
+      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      expect(sessions[0].accessible_paths).toBe(paths)
     } finally {
       cleanup()
     }

--- a/src/main/services/agents/services/__tests__/AgentService.test.ts
+++ b/src/main/services/agents/services/__tests__/AgentService.test.ts
@@ -85,6 +85,7 @@ import {
   taskRunLogsTable
 } from '../../database/schema'
 import { AgentService } from '../AgentService'
+import { setupAgentsTestDatabase } from './setupAgentsTestDatabase'
 
 function createSelectQuery(rows: unknown[]) {
   return {
@@ -165,12 +166,11 @@ async function createAgentDatabase(rows: AgentRow[]) {
     database,
     cleanup: () => {
       client.close()
-      // On Windows the libsql client may not release the DB file handle synchronously
-      // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
       try {
         fs.rmSync(directory, { recursive: true, force: true })
       } catch {
-        // ignore
+        // On Windows the libsql client may not release the DB file handle
+        // synchronously after close(), leaving the temp dir locked.
       }
     }
   }
@@ -575,7 +575,7 @@ describe('AgentService session settings sync', () => {
     vi.restoreAllMocks()
   })
 
-  function createSessionRow(agentId: string, id: string, overrides: Partial<SessionRow> = {}): SessionRow {
+  function sessionRow(agentId: string, id: string, overrides: Partial<SessionRow> = {}): SessionRow {
     return {
       id,
       agent_type: 'claude-code',
@@ -598,95 +598,30 @@ describe('AgentService session settings sync', () => {
     }
   }
 
-  async function createAgentWithSessionsDatabase(agent: AgentRow, sessions: SessionRow[]) {
-    const fs = await vi.importActual<TestFsModule>('node:fs')
-    const os = await vi.importActual<TestOsModule>('node:os')
-    const path = await vi.importActual<TestPathModule>('node:path')
-    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sync-test-'))
-    const client = createClient({ url: `file:${path.join(directory, 'agents.db')}`, intMode: 'number' })
-    const database = drizzle(client)
-
-    await client.execute(`
-      CREATE TABLE agents (
-        id TEXT PRIMARY KEY,
-        type TEXT NOT NULL,
-        name TEXT NOT NULL,
-        description TEXT,
-        deleted_at TEXT,
-        accessible_paths TEXT,
-        instructions TEXT,
-        model TEXT NOT NULL,
-        plan_model TEXT,
-        small_model TEXT,
-        mcps TEXT,
-        allowed_tools TEXT,
-        configuration TEXT,
-        sort_order INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      )
-    `)
-    await client.execute(`
-      CREATE TABLE sessions (
-        id TEXT PRIMARY KEY,
-        agent_type TEXT NOT NULL,
-        agent_id TEXT NOT NULL,
-        name TEXT NOT NULL,
-        description TEXT,
-        accessible_paths TEXT,
-        instructions TEXT,
-        model TEXT NOT NULL,
-        plan_model TEXT,
-        small_model TEXT,
-        mcps TEXT,
-        allowed_tools TEXT,
-        slash_commands TEXT,
-        configuration TEXT,
-        sort_order INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      )
-    `)
-    await database.insert(agentsTable).values(agent)
-    await database.insert(sessionsTable).values(sessions)
-
-    return {
-      database,
-      cleanup: () => {
-        client.close()
-        // On Windows the libsql client may not release the DB file handle synchronously
-        // after close(), leaving the temp dir locked and making rmSync fail with EPERM.
-        try {
-          fs.rmSync(directory, { recursive: true, force: true })
-        } catch {
-          // ignore
-        }
-      }
-    }
-  }
-
   it('propagates accessible_paths changes to sessions that inherited the old agent value', async () => {
     const agentId = 'agent_sync_test'
     const inheritedSessionId = 'session_inherited'
     const customizedSessionId = 'session_customized'
     const oldPaths = JSON.stringify(['/old/workspace'])
-    const { cleanup, database } = await createAgentWithSessionsDatabase(
-      createAgentRow({ id: agentId, accessible_paths: oldPaths }),
-      [
-        createSessionRow(agentId, inheritedSessionId, { accessible_paths: oldPaths }),
-        createSessionRow(agentId, customizedSessionId, { accessible_paths: JSON.stringify(['/custom/workspace']) })
-      ]
-    )
+    const { db, cleanup } = await setupAgentsTestDatabase()
 
     try {
-      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(db as never)
       // Avoid creating real directories on disk while resolving paths in the test.
       vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      await db.insert(agentsTable).values(createAgentRow({ id: agentId, accessible_paths: oldPaths }))
+      await db
+        .insert(sessionsTable)
+        .values([
+          sessionRow(agentId, inheritedSessionId, { accessible_paths: oldPaths }),
+          sessionRow(agentId, customizedSessionId, { accessible_paths: JSON.stringify(['/custom/workspace']) })
+        ])
 
       const newPaths = ['/new/workspace']
       await service.updateAgent(agentId, { accessible_paths: newPaths })
 
-      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      const sessions = await db.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
       const sessionsById = new Map(sessions.map((session) => [session.id, session]))
 
       expect(sessionsById.get(inheritedSessionId)?.accessible_paths).toBe(JSON.stringify(newPaths))
@@ -700,18 +635,18 @@ describe('AgentService session settings sync', () => {
     const agentId = 'agent_sync_test'
     const sessionId = 'session_inherited'
     const paths = JSON.stringify(['/workspace'])
-    const { cleanup, database } = await createAgentWithSessionsDatabase(
-      createAgentRow({ id: agentId, accessible_paths: paths }),
-      [createSessionRow(agentId, sessionId, { accessible_paths: paths })]
-    )
+    const { db, cleanup } = await setupAgentsTestDatabase()
 
     try {
-      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(database as never)
+      vi.spyOn(service as never, 'getDatabase').mockResolvedValue(db as never)
       vi.spyOn(service as never, 'resolveAccessiblePaths').mockImplementation((paths: unknown) => paths as never)
+
+      await db.insert(agentsTable).values(createAgentRow({ id: agentId, accessible_paths: paths }))
+      await db.insert(sessionsTable).values(sessionRow(agentId, sessionId, { accessible_paths: paths }))
 
       await service.updateAgent(agentId, { accessible_paths: ['/workspace'] })
 
-      const sessions = await database.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
+      const sessions = await db.select().from(sessionsTable).where(eq(sessionsTable.agent_id, agentId))
       expect(sessions[0].accessible_paths).toBe(paths)
     } finally {
       cleanup()

--- a/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
+++ b/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
@@ -59,7 +59,7 @@ export async function setupAgentsTestDatabase(): Promise<{
         .split(';')
         .map((s: string) => s.trim())
         .filter(Boolean)) {
-        client.execute(single)
+        void client.execute(single)
       }
     }
   }
@@ -67,7 +67,7 @@ export async function setupAgentsTestDatabase(): Promise<{
   // Seed the migrations table so MigrationService.runMigrations() sees the
   // database as up-to-date if production code checks during the test.
   for (const entry of journal.entries) {
-    client.execute({
+    void client.execute({
       sql: 'INSERT OR IGNORE INTO migrations (version, tag, executed_at) VALUES (?, ?, ?)',
       args: [entry.idx, entry.tag, Date.now()]
     })

--- a/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
+++ b/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
@@ -1,0 +1,92 @@
+import { createClient } from '@libsql/client'
+import { drizzle, type LibSQLDatabase } from 'drizzle-orm/libsql'
+import { vi } from 'vitest'
+
+import * as schema from '../../database/schema'
+
+interface TestFsModule {
+  mkdtempSync(prefix: string): string
+  rmSync(p: string, options: { recursive: boolean; force: boolean }): void
+  existsSync(p: string): boolean
+  readFileSync(p: string, encoding: BufferEncoding): string
+}
+
+interface TestOsModule {
+  tmpdir(): string
+}
+
+interface TestPathModule {
+  join(...paths: string[]): string
+}
+
+/**
+ * Sets up a real libsql test database with the agents schema applied via
+ * production migration SQL files. Mirrors the `setupTestDatabase()` pattern
+ * from `@test-helpers/db` but for the agents subsystem's libsql database.
+ *
+ * Returns a handle with `.db` (Drizzle) and a `cleanup()` function.
+ * Call `cleanup()` in an `afterAll` or `finally` block.
+ */
+export async function setupAgentsTestDatabase(): Promise<{
+  db: LibSQLDatabase<typeof schema>
+  cleanup: () => void
+}> {
+  const fs = await vi.importActual<TestFsModule>('node:fs')
+  const os = await vi.importActual<TestOsModule>('node:os')
+  const pathMod = await vi.importActual<TestPathModule>('node:path')
+
+  const directory = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'agents-test-'))
+  const dbPath = pathMod.join(directory, 'agents.db')
+  const client = createClient({ url: `file:${dbPath}`, intMode: 'number' })
+  const db = drizzle(client, { schema })
+
+  // Apply production migration SQL files in order
+  const migrationDir = pathMod.join(process.cwd(), 'resources', 'database', 'drizzle')
+  const journalPath = pathMod.join(migrationDir, 'meta', '_journal.json')
+  const journal = JSON.parse(fs.readFileSync(journalPath, 'utf-8'))
+
+  for (const entry of journal.entries) {
+    const sqlPath = pathMod.join(migrationDir, `${entry.tag}.sql`)
+    if (!fs.existsSync(sqlPath)) continue
+    const raw = fs.readFileSync(sqlPath, 'utf-8')
+    const statements = raw
+      .split('--> statement-breakpoint')
+      .map((s: string) => s.trim())
+      .filter(Boolean)
+
+    for (const stmt of statements) {
+      for (const single of stmt
+        .split(';')
+        .map((s: string) => s.trim())
+        .filter(Boolean)) {
+        client.execute(single)
+      }
+    }
+  }
+
+  // Seed the migrations table so MigrationService.runMigrations() sees the
+  // database as up-to-date if production code checks during the test.
+  for (const entry of journal.entries) {
+    client.execute({
+      sql: 'INSERT OR IGNORE INTO migrations (version, tag, executed_at) VALUES (?, ?, ?)',
+      args: [entry.idx, entry.tag, Date.now()]
+    })
+  }
+
+  return {
+    db,
+    cleanup: () => {
+      try {
+        client.close()
+      } catch {
+        // On Windows the libsql client may not release the DB file handle
+        // synchronously after close().
+      }
+      try {
+        fs.rmSync(directory, { recursive: true, force: true })
+      } catch {
+        // Best-effort cleanup on Windows where the file may still be locked.
+      }
+    }
+  }
+}

--- a/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
+++ b/src/main/services/agents/services/__tests__/setupAgentsTestDatabase.ts
@@ -59,7 +59,7 @@ export async function setupAgentsTestDatabase(): Promise<{
         .split(';')
         .map((s: string) => s.trim())
         .filter(Boolean)) {
-        void client.execute(single)
+        await client.execute(single)
       }
     }
   }
@@ -67,7 +67,7 @@ export async function setupAgentsTestDatabase(): Promise<{
   // Seed the migrations table so MigrationService.runMigrations() sees the
   // database as up-to-date if production code checks during the test.
   for (const entry of journal.entries) {
-    void client.execute({
+    await client.execute({
       sql: 'INSERT OR IGNORE INTO migrations (version, tag, executed_at) VALUES (?, ?, ?)',
       args: [entry.idx, entry.tag, Date.now()]
     })


### PR DESCRIPTION
### What this PR does

Fixes #17796 — when an agent's working directory (`accessible_paths`) is changed in agent settings, existing sessions now receive the updated value.

Before this PR, `AgentService.syncSettingsToSessions()` did not include `accessible_paths` in its `syncFields` list, so changing the agent's working directory never propagated to existing sessions. The session workspace navbar (which reads `session.accessible_paths[0]`) continued showing the old directory.

After this PR, `accessible_paths` is included in the sync fields, so the working directory change propagates to sessions that inherited the old value. Sessions where the user customized the value are left untouched — matching the existing behavior of every other synced field.

Additionally resolves review feedback on [#17805](https://github.com/CherryHQ/cherry-studio/pull/17805) by refactoring the session sync tests to use production migration SQL instead of hand-written `CREATE TABLE` statements.

### Changes

**`AgentService.ts`** — production fix:
- Added `'accessible_paths'` to `syncFields` in `syncSettingsToSessions()`

**New file: `setupAgentsTestDatabase.ts`** — test infrastructure:
- Creates a real libsql temp database with the full agents schema via production migration SQL files from `resources/database/drizzle/`
- Mirrors the `setupTestDatabase()` pattern from `@test-helpers/db` for the agents subsystem's libsql database

**`AgentService.test.ts`** — test refactor:
- Replaced hand-written `CREATE TABLE` SQL with `setupAgentsTestDatabase()`
- Data seeded via `db.insert()` using the real Drizzle schema
- Kept `resolveAccessiblePaths` mock (filesystem behavior, not database)

### Why we need it and why it was done in this way

The production fix is minimal — one string added to an existing array. Only sessions that inherited the agent's default value are updated; sessions with a user-customized `accessible_paths` keep their own value.

The test refactor was required by review feedback: the original tests violated the project's database testing rules by hand-writing SQL and creating a local drizzle instance. The new helper applies the same production migration SQL files that `DatabaseManager` uses.

### Breaking changes

None. The change only makes the agent's working directory propagate to sessions that already inherited the old value; no schema or data migration is involved.

### Checklist

- [x] Code: Write code that humans can understand
- [x] Tests: All 17 AgentService tests pass
- [x] Self-review: Verified via local test run

### Release note

```release-note
Fixed an issue where changing an agent's working directory did not update existing sessions' displayed directory.
```