### PR TITLE
perf(chat): remove unused flow navigation listener

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -383,6 +383,42 @@ describe('MessageGroup', () => {
     }
   )
 
+  it('uses the injected runtime for grouped message navigation', () => {
+    let runtime: { locateMessage: (messageId: string) => void } | undefined
+    const bindMessageGroupRuntime = vi.fn(
+      (_messageIds: string[], nextRuntime: { locateMessage: (messageId: string) => void }) => {
+        runtime = nextRuntime
+        return vi.fn()
+      }
+    )
+    mocks.messageListActions.mockReturnValue({ bindMessageGroupRuntime })
+    const addEventListenerSpy = vi.spyOn(document, 'addEventListener')
+    const messages = [createMessage('msg-1', 0, 'fold'), createMessage('msg-2', 1, 'fold')]
+
+    try {
+      render(<MessageGroup messages={messages} />)
+
+      expect(addEventListenerSpy).not.toHaveBeenCalledWith('flow-navigate-to-message', expect.any(Function))
+      expect(bindMessageGroupRuntime).toHaveBeenCalledWith(
+        ['msg-1', 'msg-2'],
+        expect.objectContaining({ locateMessage: expect.any(Function) })
+      )
+      expect(runtime).toBeDefined()
+
+      act(() => {
+        runtime?.locateMessage('msg-1')
+      })
+
+      expect(mocks.scrollIntoView).toHaveBeenCalledWith(document.getElementById('message-msg-1'), {
+        behavior: 'smooth',
+        block: 'start',
+        container: 'nearest'
+      })
+    } finally {
+      addEventListenerSpy.mockRestore()
+    }
+  })
+
   it('uses two equal columns across the full width in grid layout', () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'grid',

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -90,7 +90,6 @@ const MessageGroup = ({
   const [_multiModelMessageStyle, setMultiModelMessageStyle] = useState<MultiModelMessageStyle>(() =>
     getEffectiveMultiModelMessageStyle(messages, getMessageUiState, multiModelMessageStyleSetting)
   )
-  const [selectedIndex, setSelectedIndex] = useState(messageLength - 1)
   const previousMessageIdsRef = useRef(messages.map((message) => message.id))
   const activeBranchSelectionQueueRef = useRef<Promise<void>>(Promise.resolve())
 
@@ -137,7 +136,6 @@ const MessageGroup = ({
       }
       updateMessageUiState(nextSelectedMessage.id, { foldSelected: true })
       setSelectedMessageIdState(nextSelectedMessage.id)
-      setSelectedIndex(messages.findIndex((message) => message.id === nextSelectedMessage.id))
     }
   }, [captureMode, getMessageUiState, messages, selectedMessageId, updateMessageUiState])
 
@@ -173,39 +171,6 @@ const MessageGroup = ({
     },
     [actions, navigateWithScrollRuntime, selectedMessageId, setTimeoutTimer, updateMessageUiState]
   )
-  // 添加对流程图节点点击事件的监听
-  useEffect(() => {
-    // 只在组件挂载和消息数组变化时添加监听器
-    if (captureMode || !isGrouped || messageLength <= 1) return
-
-    const handleFlowNavigate = (event: CustomEvent) => {
-      const { messageId } = event.detail
-
-      // 查找对应的消息在当前消息组中的索引
-      const targetIndex = messages.findIndex((msg) => msg.id === messageId)
-
-      // 如果找到消息且不是当前选中的索引，则切换标签
-      if (targetIndex !== -1 && targetIndex !== selectedIndex) {
-        setSelectedIndex(targetIndex)
-
-        // 使用setSelectedMessage函数来切换标签，这是处理foldSelected的关键
-        const targetMessage = messages[targetIndex]
-        if (targetMessage) {
-          setSelectedMessage(targetMessage)
-        }
-      }
-    }
-
-    // 添加事件监听器
-    document.addEventListener('flow-navigate-to-message', handleFlowNavigate as EventListener)
-
-    // 清理函数
-    return () => {
-      document.removeEventListener('flow-navigate-to-message', handleFlowNavigate as EventListener)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [messages, selectedIndex, isGrouped, messageLength, captureMode])
-
   useEffect(() => {
     if (captureMode) return
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Each grouped multi-model `MessageGroup` registered a document-level `flow-navigate-to-message` listener even though no dispatcher exists for the event. The listener also kept an otherwise unused `selectedIndex` state in each group.

After this PR: Remove the dead listener and its orphaned state. Grouped message navigation continues through the existing `bindMessageGroupRuntime` contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19068

### Why we need it and why it was done in this way

The per-group document subscription creates unnecessary global listener work and subscription churn as grouped messages mount or update. Removing only the unreachable path keeps the change small while preserving the supported runtime navigation behavior.

The following tradeoffs were made: The obsolete event path is removed instead of introducing another dispatcher or central listener because the existing runtime binding already owns message navigation.

The following alternatives were considered: Keeping the listener would preserve dead work; centralizing it would add a new owner for an event that is never dispatched. Neither option addresses the unused path.

Links to places where the discussion took place: [Issue #19068](https://github.com/CherryHQ/cherry-studio/issues/19068)

### Breaking changes

None. This removes an unused internal listener; supported grouped message navigation remains available through the existing runtime.

### Special notes for your reviewer

The focused MessageGroup regression test verifies both the absence of the obsolete listener and the existing runtime scroll behavior. The full renderer batch had one unrelated `Topics.test.tsx` failure; that file passes in isolation with 101/101 tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because this internal listener cleanup does not change user-facing behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
