### PR TITLE
fix(data-migration): skip Dexie records with unreadable large values

### DIFF
--- a/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
+++ b/src/renderer/windows/migrationV2/exporters/DexieExporter.ts
@@ -32,8 +32,14 @@ const REQUIRED_TABLES = [
 // Optional tables that may not exist in older versions
 const OPTIONAL_TABLES = ['settings', 'translate_history', 'quick_phrases', 'translate_languages']
 
-function isIrrecoverableRecord(error: unknown): error is DOMException {
-  return error instanceof DOMException && error.name === 'NotReadableError'
+/** Chromium's text for a large value whose backing file is gone; Dexie re-wraps it out of DOMException. */
+const LOST_LARGE_VALUE = 'Failed to read large IndexedDB value'
+
+// Two shapes for the same lost backing file: a NotReadableError DOMException, or an
+// UnknownError carrying the text above — matched by shape since neither type survives Dexie.
+function isIrrecoverableRecord(error: unknown): boolean {
+  const { name, message } = Object(error) as { name?: unknown; message?: unknown }
+  return name === 'NotReadableError' || (typeof message === 'string' && message.includes(LOST_LARGE_VALUE))
 }
 
 class JsonExportWriter {

--- a/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
+++ b/src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts
@@ -219,6 +219,22 @@ describe('DexieExporter', () => {
     expect(JSON.parse(exportedText())).toEqual(rows.slice(1))
   })
 
+  it('skips a record whose large IndexedDB value is unreadable', async () => {
+    const rows = [{ id: 'block-1' }, { id: 'block-2' }, { id: 'block-3' }]
+    const table = createTableMock(rows)
+    // Dexie re-wraps Chromium's UnknownError into a DexieError, so it is not a DOMException.
+    const wrapped = new Error(
+      'Failed to read large IndexedDB value\n UnknownError: Failed to read large IndexedDB value'
+    )
+    wrapped.name = 'UnknownError'
+    table.get.mockRejectedValueOnce(wrapped)
+    dexieMock.table.mockReturnValue(table)
+
+    await new DexieExporter('/export').exportAll()
+
+    expect(JSON.parse(exportedText())).toEqual(rows.slice(1))
+  })
+
   it('does not skip other IndexedDB read failures', async () => {
     const table = createTableMock([{ id: 'block-1' }])
     table.get.mockRejectedValueOnce(new DOMException('Temporary read failure', 'UnknownError'))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: #18783 skips a Dexie record whose large-value backing file is gone, but only when the failure arrives as a `NotReadableError` `DOMException`. Chromium also reports this as `UnknownError: Failed to read large IndexedDB value`, and Dexie's `mapError` re-wraps that name into its own `DexieError` (`UnknownError` is in `idbDomErrorNames`, `NotReadable` is not), so the `instanceof DOMException` guard never matches and the entire v1-to-v2 export aborts with "迁移失败".

After this PR: `isIrrecoverableRecord` matches on error shape — the `NotReadableError` name, or a message carrying Chromium's `Failed to read large IndexedDB value` text — so both spellings of the same lost backing file skip exactly that one record and the export continues. Skip granularity is unchanged (per record, inside the page loop); page queries and writer failures still abort the export, and an unrelated `UnknownError` still aborts.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: matching Chromium's English error text is exactly the option #18783 rejected as unstable, but Dexie strips the `DOMException` identity for this error and its remaining name (`UnknownError`) is Chromium's catch-all for any I/O failure — the message is the only signal narrow enough to skip a single record without silently swallowing a table-wide failure. The affected record stays unmigrated because its backing file no longer exists on disk.

The following alternatives were considered: keying off `error.name === 'UnknownError'` alone (too broad — would drop records on transient I/O errors and could empty a table without failing), and unwrapping `DexieError.inner` back to the `DOMException` (equally text-dependent, since the inner error's name is still just `UnknownError`).

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The doubled error text in the user report (`Failed to read large IndexedDB value UnknownError: Failed to read large IndexedDB value`) is the fingerprint of Dexie's wrapper: `message + "\n " + String(inner)` (`dexie/dist/dexie.js:405-419`). It confirms the thrown value is a `DexieError`, not a `DOMException`.

The predicate duck-types rather than using `instanceof Error`, because `DOMException` does not inherit from `Error` in the renderer test environment and that guard breaks the existing `NotReadableError` test.

Verified with `npx vitest run src/renderer/windows/migrationV2/exporters/__tests__/DexieExporter.test.ts` (11 passed, including a new case for the Dexie-wrapped error and the pre-existing case asserting unrelated failures still abort), `npx oxlint` and `npx biome check` on the changed files, and a `tsconfig.web.json` typecheck. Full `pnpm test` and `pnpm build:check` were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed v1-to-v2 migration failing with "Failed to read large IndexedDB value" when a record has already lost its backing file.
```
