### PR TITLE
fix(chat): restore clear-messages shortcut after event removal

### DIFF
--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -12,15 +12,19 @@ import {
 } from '@renderer/components/composer/variants/chat/ChatConversationControls'
 import type { ChatConversationControlsSnapshot } from '@renderer/components/composer/variants/ChatComposer'
 import PromptPopup from '@renderer/components/popups/PromptPopup'
+import { useClearTopicMessages } from '@renderer/hooks/chat/useClearTopicMessages'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { useIsActiveTab } from '@renderer/hooks/tab'
 import { useAssistant } from '@renderer/hooks/useAssistant'
 import { useProviders } from '@renderer/hooks/useProvider'
 import { useTopicMutations } from '@renderer/hooks/useTopic'
 import { EVENT_NAMES, EventEmitter } from '@renderer/services/EventService'
+import { popup } from '@renderer/services/popup'
+import { toast } from '@renderer/services/toast'
 import type { ConversationCenterSlot, PaneManualToggleSignal } from '@renderer/types/conversationLayout'
 import type { Citation } from '@renderer/types/message'
 import type { Topic } from '@renderer/types/topic'
+import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { FC, ReactNode } from 'react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -68,6 +72,7 @@ interface Props {
 
 const Chat: FC<Props> = (props) => {
   const { updateTopic: patchTopic } = useTopicMutations()
+  const clearTopicMessages = useClearTopicMessages()
   const { t } = useTranslation()
   const [messageStyle] = usePreference('chat.message.style')
   const [topicDisplayMode] = usePreference('topic.tab.display_mode')
@@ -134,9 +139,19 @@ const Chat: FC<Props> = (props) => {
   )
   useCommandHandler(
     'topic.clear_messages',
-    () => {
+    async () => {
       if (!activeTopic) return
-      void EventEmitter.emit(EVENT_NAMES.CLEAR_MESSAGES, activeTopic)
+      const confirmed = await popup.confirm({
+        title: t('chat.input.clear.title'),
+        content: t('chat.input.clear.content'),
+        centered: true
+      })
+      if (!confirmed) return
+      try {
+        await clearTopicMessages(activeTopic.id)
+      } catch (error) {
+        toast.error(formatErrorMessageWithPrefix(error, t('message.error.unknown')))
+      }
     },
     { enabled: showConversation && isActiveTab }
   )

--- a/src/renderer/pages/home/__tests__/Chat.test.tsx
+++ b/src/renderer/pages/home/__tests__/Chat.test.tsx
@@ -1,4 +1,5 @@
 import type * as ChatLayoutModeContextModule from '@renderer/components/chat/layout/ChatLayoutModeContext'
+import { popup } from '@renderer/services/popup'
 import type { Topic } from '@renderer/types/topic'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -20,6 +21,7 @@ const assistantContextMock = vi.hoisted(() => ({
 const providerHookArgs = vi.hoisted(() => [] as unknown[][])
 const commandHandlers = vi.hoisted(() => new Map<string, () => void | Promise<void>>())
 const eventEmitMock = vi.hoisted(() => vi.fn())
+const clearTopicMessagesMock = vi.hoisted(() => vi.fn(async () => undefined))
 const activeTabMock = vi.hoisted(() => ({ current: true }))
 
 const topic: Topic = {
@@ -132,9 +134,12 @@ vi.mock('@renderer/hooks/tab', () => ({
   useIsActiveTab: () => activeTabMock.current
 }))
 
+vi.mock('@renderer/hooks/chat/useClearTopicMessages', () => ({
+  useClearTopicMessages: () => clearTopicMessagesMock
+}))
+
 vi.mock('@renderer/services/EventService', () => ({
   EVENT_NAMES: {
-    CLEAR_MESSAGES: 'clear-messages',
     FOCUS_CHAT_COMPOSER: 'focus-chat-composer'
   },
   EventEmitter: {
@@ -215,14 +220,27 @@ describe('Chat', () => {
     activeTabMock.current = true
   })
 
-  it('routes the clear-messages command through the existing confirmation flow', () => {
+  it('clears the active topic once the confirmation is accepted', async () => {
     render(<Chat activeTopic={topic} />)
 
-    act(() => {
-      void commandHandlers.get('topic.clear_messages')?.()
+    await act(async () => {
+      await commandHandlers.get('topic.clear_messages')?.()
     })
 
-    expect(eventEmitMock).toHaveBeenCalledWith('clear-messages', topic)
+    expect(popup.confirm).toHaveBeenCalled()
+    expect(clearTopicMessagesMock).toHaveBeenCalledWith(topic.id)
+  })
+
+  it('leaves the topic untouched when the confirmation is dismissed', async () => {
+    vi.mocked(popup.confirm).mockResolvedValueOnce(false)
+
+    render(<Chat activeTopic={topic} />)
+
+    await act(async () => {
+      await commandHandlers.get('topic.clear_messages')?.()
+    })
+
+    expect(clearTopicMessagesMock).not.toHaveBeenCalled()
   })
 
   it('does not register the clear-messages command for a background tab', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`main` fails typecheck (`tsgo -p tsconfig.web.json`, `basic-checks` job): `Chat.tsx` emits `EVENT_NAMES.CLEAR_MESSAGES`, but that event name and its only consumer were removed in #19004 after #19021 landed the Ctrl+L shortcut. The shortcut was therefore also dead at runtime — nothing listened for the event.

After this PR:

The `topic.clear_messages` command confirms with the shared clear dialog and calls `useClearTopicMessages(activeTopic.id)` directly, the same path the topic context menu uses. Typecheck is green again and Ctrl+L clears the active conversation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

`main` CI is red and the shortcut is broken, so restoring the deleted event was not an option: #19004 removed the event deliberately because correctness depended on whichever conversation view happened to be mounted. Calling the shared mutation hook keeps every clear-messages surface on one path.

The following tradeoffs were made:

- The handler owns its own confirm + error toast instead of reusing the context-menu action registry, which is keyed on a `Topic` menu target rather than a keyboard command.

The following alternatives were considered:

- Re-adding `EVENT_NAMES.CLEAR_MESSAGES` and a consumer. Rejected: it reintroduces the mount-dependent bug #19004 fixed.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/32457397590/job/96697226712

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- The existing test asserted the `EventEmitter.emit` call, so it stayed green while the feature was dead; it now asserts the confirm-then-clear contract plus the cancel path.
- Verified locally: `tsgo --noEmit -p tsconfig.web.json` clean, `vitest run src/renderer/pages/home/__tests__/Chat.test.tsx` 10/10, biome + oxlint clean on the changed files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed the clear-messages shortcut, which no longer cleared the active conversation.
```
