### PR TITLE
fix(keyboard): make message scroll containers focusable for arrow-key navigation (#19070)

### DIFF
--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -206,6 +206,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
       <Scrollbar
         data-ui="part:message-content"
         className="message-content-container mt-0 min-h-0 max-w-full overflow-y-auto pl-0"
+        tabIndex={0}
         style={{
           fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
           fontSize,
@@ -359,6 +360,7 @@ const UserBubbleMessage = ({
           <Scrollbar
             data-ui="part:message-content"
             className="message-content-container mt-0 max-w-full overflow-y-auto rounded-[10px] bg-muted px-4 py-2.5 has-[.code-block]:w-full [&_.block-wrapper:last-child>*:last-child]:mb-0! [&_.markdown>p:last-child]:mb-0!"
+            tabIndex={0}
             style={{
               fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
               fontSize,


### PR DESCRIPTION
Closes #19070

## Problem
When clicking on AI message content, the focus lands on an inner text/button/link element rather than the scrollable container. This means arrow keys and Page Up/Page Down do not trigger scrolling until focus is moved to the scroll container (e.g., by pressing Tab).

## Fix
Add `tabIndex={0}` to both `<Scrollbar>` containers in `MessageFrame.tsx` so they become focusable via mouse click. Once the scroll container receives focus, keyboard navigation (arrow keys, Page Up/Page Down) works immediately to browse the message text.

## Verification
- Click on any assistant/user message content → the scroll container receives focus
- Arrow keys and Page Up/Down scroll the message immediately without needing Tab first
- No behavior change for screen readers or keyboard-only navigation (tabIndex=0 maintains tab order)
