### PR TITLE
test(trace-viewer): drop the virtualizer scroll debounce before jsdom teardown

### DIFF
--- a/src/renderer/components/chat/trace/__tests__/TraceTreeVirtualizer.test.tsx
+++ b/src/renderer/components/chat/trace/__tests__/TraceTreeVirtualizer.test.tsx
@@ -35,6 +35,7 @@ describe('TraceTree with TanStack Virtual', () => {
   })
 
   it('moves the bounded render window when the real scroller moves', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
     const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
     const originalOffsetWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetWidth')
     Object.defineProperties(HTMLElement.prototype, {
@@ -71,6 +72,9 @@ describe('TraceTree with TanStack Virtual', () => {
       expect(screen.getAllByRole('treeitem').length).toBeLessThan(30)
     } finally {
       view?.unmount()
+      // virtual-core's isScrolling reset debounce survives unmount and would fire after jsdom teardown.
+      vi.clearAllTimers()
+      vi.useRealTimers()
       if (originalOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight)
       else Reflect.deleteProperty(HTMLElement.prototype, 'offsetHeight')
       if (originalOffsetWidth) Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`TraceTreeVirtualizer.test.tsx` scrolls a real TanStack virtualizer. On the first `scroll` event `@tanstack/virtual-core` arms a 150 ms `isScrolling` reset debounce (`isScrollingResetDelay`) with `window.setTimeout`, and its unmount cleanup only removes the scroll listener — the timer handle is private to the debounce closure, so nothing clears it. The file has a single test, so Vitest tears the jsdom environment down right after it; when the timer fires it dispatches a React update that reads `window` and throws `ReferenceError: window is not defined`. Vitest reports it as an unhandled error and the shard fails with every test green (seen on `renderer-test (3/5)` of run [32466561313](https://github.com/CherryHQ/cherry-studio/actions/runs/32466561313) for #19094).

After this PR:

The test runs on a fake clock (`shouldAdvanceTime: true`, so the existing `waitFor` calls keep working) and discards the leftover debounce with `vi.clearAllTimers()` after unmount, before restoring real timers. No timer can outlive the environment.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

A flaky shard turns every PR's CI into a coin toss and hides real failures behind reruns. The leak is in library code the test cannot reach, so the test has to own the timer's lifetime.

The following tradeoffs were made:

- The test now mixes fake timers into a flow that otherwise uses real ones. `shouldAdvanceTime: true` keeps the `waitFor` assertions unchanged instead of rewriting them around `advanceTimersByTime`.

The following alternatives were considered:

- Enabling `useScrollendEvent` on `TraceTree`: changes production scroll handling to fix a test, and the debounce fallback still exists wherever `scrollend` is unsupported.
- Sleeping past the 150 ms delay after unmount: slower and tied to a library default that can change.
- Clearing the timer from the component: not possible, the handle never leaves virtual-core's debounce closure.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

Verified the mechanism with a probe before fixing: with fake timers installed, `vi.getTimerCount()` was `1` right after `unmount()`, matching the `Timeout._onTimeout → utils.ts debounce → observeElementOffset → maybeNotify` stack in the CI log. After the fix the file passed 10/10 local runs with no unhandled errors.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
