### PR TITLE
fix(shared): reject forward-slash UNC spelling in canonicalizeFilePath

### DIFF
--- a/docs/references/file/file-manager-architecture.md
+++ b/docs/references/file/file-manager-architecture.md
@@ -55,7 +55,9 @@ Canonicalization is lexical and byte-faithful:
   form;
 - it does not Unicode-normalize or resolve symlinks at storage time;
 - `AbsoluteFilePath` accepts UNC shape, but `canonicalizeFilePath` rejects UNC because UNC is not a
-  supported persistent dedup key.
+  supported persistent dedup key; both the backslash (`\\server\share`) and forward-slash
+  (`//server/share`) spellings are rejected, so neither can be silently rewritten into an unrelated
+  single-root path.
 
 #### Duplicate-Entry Detection on Insert
 

--- a/src/shared/utils/file/__tests__/canonicalize.test.ts
+++ b/src/shared/utils/file/__tests__/canonicalize.test.ts
@@ -112,6 +112,20 @@ describe('canonicalizeFilePath — UNC', () => {
   it('does not let `..` escape the share root by silently canonicalizing', () => {
     expect(() => canonicalizeFilePath('\\\\server\\share\\..\\..\\secret')).toThrow(/UNC/i)
   })
+
+  // The forward-slash spelling is accepted as UNC by Win32 just as readily, and
+  // POSIX leaves exactly-two-leading-slash paths implementation-defined — the
+  // POSIX branch must not silently rewrite it into an unrelated single-root path.
+  // See https://github.com/CherryHQ/cherry-studio/issues/18207
+  it('rejects the forward-slash UNC spelling instead of silently rewriting it', () => {
+    expect(() => canonicalizeFilePath('//server/share/doc.pdf')).toThrow(/UNC/i)
+    expect(() => canonicalizeFilePath('//server/share')).toThrow(/UNC/i)
+    expect(() => canonicalizeFilePath('//server/share/../../secret')).toThrow(/UNC/i)
+  })
+
+  it('still collapses three or more leading slashes per POSIX', () => {
+    expect(canonicalizeFilePath('///foo/bar')).toBe('/foo/bar')
+  })
 })
 
 describe('CanonicalFilePathSchema (assert-only, no repair)', () => {
@@ -183,6 +197,10 @@ describe('AbsoluteFilePathSchema ↔ canonicalizeFilePath alignment', () => {
     // The one intended divergence: a valid path for `fs`, not a valid dedup key.
     { input: '\\\\server\\share\\doc.pdf', branded: true, canonicalizable: false },
     { input: '\\\\server\\share', branded: true, canonicalizable: false },
+    // Same divergence, forward-slash UNC spelling (Win32 accepts it; the POSIX
+    // branch must not silently rewrite it into a single-root path).
+    { input: '//server/share/doc.pdf', branded: true, canonicalizable: false },
+    { input: '//server/share', branded: true, canonicalizable: false },
     // Rejected by both — the brand still filters these out first.
     { input: 'relative/doc.pdf', branded: false, canonicalizable: false },
     { input: '\\\\server', branded: false, canonicalizable: false },

--- a/src/shared/utils/file/canonicalize.ts
+++ b/src/shared/utils/file/canonicalize.ts
@@ -20,7 +20,8 @@
  *
  * ## Scope (this function's contract)
  *
- *   0. Reject null bytes (`\0`) and UNC (`\\server\share\…`).
+ *   0. Reject null bytes (`\0`) and UNC (`\\server\share\…` or the
+ *      equivalent forward-slash spelling `//server/share/…`).
  *   1. Resolve segments (`.`, `..`, repeated separators).
  *   2. Strip trailing separator (except on a bare drive / POSIX root).
  *   3. Windows only: uppercase the drive letter, normalize separators to `\`.
@@ -48,9 +49,15 @@
  *
  * UNC (`\\server\share\…`) is a valid `AbsoluteFilePath` but is **rejected
  * here**: `\\server\share` is an indivisible root that `..` must not escape,
- * and neither branch models that. The brand gates what is safe to hand to
- * `fs`; this function gates what is safe to persist as a dedup key, and those
- * are deliberately not the same set.
+ * and neither branch models that. The same applies to its forward-slash
+ * spelling `//server/share/…`: Win32 accepts it as UNC just as readily, POSIX
+ * leaves a path beginning with exactly two slashes implementation-defined, and
+ * the POSIX branch would silently rewrite it into an unrelated single-root
+ * path — so it is rejected by the same rule (exactly two leading slashes
+ * followed by a non-slash; three or more leading slashes stay collapsible per
+ * POSIX). The brand gates what is safe to hand to `fs`; this function gates
+ * what is safe to persist as a dedup key, and those are deliberately not the
+ * same set.
  *
  * ## Rule-evolution discipline
  *
@@ -81,7 +88,15 @@ function canonicalizeAbsolutePath(raw: string): string {
   // `..` must not escape, which neither branch below models. Reject explicitly
   // — otherwise UNC falls through to `canonicalizePosix` and dies on the
   // misleading "path must be absolute".
-  if (raw.startsWith('\\\\')) {
+  //
+  // The backslash check alone only recognises one spelling: Win32 also accepts
+  // the forward-slash form `//server/share/…`, and POSIX leaves a path beginning
+  // with EXACTLY two slashes implementation-defined — while the POSIX branch
+  // below would silently rewrite it into an unrelated single-root path (and
+  // diverge from `path.resolve`, which preserves the double slash). Reject that
+  // spelling by shape too; three or more leading slashes remain collapsible per
+  // POSIX ("more than two leading slashes shall be treated as a single slash").
+  if (raw.startsWith('\\\\') || /^\/\/[^/]/.test(raw)) {
     throw new Error('canonicalizeAbsolutePath: UNC paths are not supported as canonical keys')
   }
   const isWindows = /^[A-Za-z]:[/\\]/.test(raw)


### PR DESCRIPTION
## Problem

`canonicalizeFilePath` (`src/shared/utils/file/canonicalize.ts`) rejects UNC (`\\server\share\…`) because `\\server\share` is an indivisible root that `..` must not escape and neither canonicalization branch models it. That defence only recognised the **backslash** spelling: the forward-slash form `//server/share/…` — which Win32 accepts as UNC just as readily — slipped past the rejection and was silently rewritten by `canonicalizePosix` into an unrelated single-root path:

- `//server/share/a/../b` → `/server/share/b` — a corrupted dedup key pointing at a different filesystem location
- On POSIX hosts this even diverges from the module's own `path.resolve` oracle, which preserves the double slash per POSIX's "implementation-defined" allowance for exactly-two-leading-slash paths

Because `AbsoluteFilePathSchema` accepts any `/…` shape, such a path passes the brand and then gets a bogus canonical key persisted in `file_entry.externalPath`.

## Fix

Extend the UNC rejection to the forward-slash spelling by shape: **exactly two leading slashes followed by a non-slash** raises the same UNC error as the backslash form. Three or more leading slashes remain collapsible per POSIX ("more than two leading slashes shall be treated as a single slash") — existing behavior and oracle agreement preserved.

Also updates the module JSDoc, the file-manager architecture doc (§1.2), and the brand↔canonicalizable alignment table, which now pins `//server/share` as branded-but-not-canonicalizable.

## Rule-evolution discipline

Per the documented rule, changes to this function require a paired migration re-canonicalizing `origin='external'` rows — with the current exemption that v2 has not shipped, so no such rows exist yet. This change converts a previously-"successful" output into a throw; no previously-valid canonical key changes meaning, so the exemption applies.

## Testing

- New cases in `canonicalize.test.ts`: forward-slash UNC (full path / bare share root / `..` escape) rejected with the UNC message; `///foo/bar` still collapses to `/foo/bar`
- Alignment table rows for `//server/share/doc.pdf` and `//server/share` (branded=true, canonicalizable=false)
- `pnpm vitest run canonicalize.test.ts absoluteFilePath.test.ts` — 51 passed
- `typecheck:node` / `typecheck:web` clean; oxlint + eslint clean on changed files

Fixes #18207

Co-Authored-By: Claude <noreply@anthropic.com>