### PR TITLE
fix(shared): make the file URL codec separator-domain-correct

### DIFF
--- a/src/shared/utils/file/__tests__/url.test.ts
+++ b/src/shared/utils/file/__tests__/url.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema, type FileUrlString } from '@shared/types/file'
 import { describe, expect, it } from 'vitest'
 
+import { canonicalizeFilePath } from '../canonicalize'
 import { fileUrlToPath, isDangerExt, normalizeExt, toFileUrl, toSafeFileUrl } from '../url'
 
 describe('normalizeExt', () => {
@@ -91,8 +92,21 @@ describe('toFileUrl', () => {
     expect(toFileUrl('D:\\folder\\file.txt' as AbsoluteFilePath)).toBe('file:///D:/folder/file.txt')
   })
 
-  it('normalizes backslashes to forward slashes', () => {
+  it('normalizes backslashes to forward slashes for Windows drive paths', () => {
     expect(toFileUrl('C:\\a\\b\\c.txt' as AbsoluteFilePath)).toBe('file:///C:/a/b/c.txt')
+  })
+
+  // On POSIX a backslash is an ordinary filename character — folding it to `/`
+  // here denoted a different file. It must reach the per-segment encodeURIComponent
+  // and come out percent-encoded instead.
+  // See https://github.com/CherryHQ/cherry-studio/issues/18206
+  it('does NOT fold backslashes on POSIX input — percent-encodes them as filename bytes', () => {
+    expect(toFileUrl('/workspace/a\\b.txt' as AbsoluteFilePath)).toBe('file:///workspace/a%5Cb.txt')
+  })
+
+  it('round-trips a POSIX filename containing a backslash byte-faithfully', () => {
+    const url = toFileUrl('/workspace/a\\b.txt' as AbsoluteFilePath)
+    expect(fileUrlToPath(url)).toBe('/workspace/a\\b.txt')
   })
 
   it('encodes non-ASCII characters', () => {
@@ -114,7 +128,8 @@ describe('toFileUrl', () => {
   })
 
   it('treats the forward-slash UNC spelling identically', () => {
-    // `fileUrlToPath` decodes UNC to this form, so both spellings must agree.
+    // Both spellings encode to the same authority-form URL, so a decoded UNC
+    // path re-encodes byte-identically.
     expect(toFileUrl('//server/share/baz.pdf' as AbsoluteFilePath)).toBe('file://server/share/baz.pdf')
   })
 
@@ -123,12 +138,16 @@ describe('toFileUrl', () => {
     expect(fileURLToPath(url, { windows: true })).toBe('\\\\server\\share\\baz.pdf')
   })
 
-  it('round-trips UNC through fileUrlToPath into the forward-slash form', () => {
+  it('round-trips UNC through fileUrlToPath into the canonical backslash spelling', () => {
     const url = toFileUrl('\\\\server\\share\\report final.pdf' as AbsoluteFilePath)
     const decoded = fileUrlToPath(url)
-    expect(decoded).toBe('//server/share/report final.pdf')
+    expect(decoded).toBe('\\\\server\\share\\report final.pdf')
     // The decoded form is itself a valid input that maps to the same URL.
     expect(toFileUrl(decoded as AbsoluteFilePath)).toBe(url)
+    // And it is the spelling downstream UNC handling recognises: feeding it to
+    // canonicalizeFilePath raises the documented UNC rejection instead of
+    // silently collapsing a leading `//` into an unrelated POSIX path.
+    expect(() => canonicalizeFilePath(decoded)).toThrow(/UNC/i)
   })
 })
 
@@ -142,8 +161,8 @@ describe('fileUrlToPath', () => {
     expect(fileUrlToPath('file:///C:/foo/bar%20baz.pdf')).toBe('C:/foo/bar baz.pdf')
   })
 
-  it('preserves UNC hosts as network paths', () => {
-    expect(fileUrlToPath('file://server/share/report%20final.pdf')).toBe('//server/share/report final.pdf')
+  it('preserves UNC hosts as canonical backslash network paths', () => {
+    expect(fileUrlToPath('file://server/share/report%20final.pdf')).toBe('\\\\server\\share\\report final.pdf')
   })
 
   it('throws for a non-file: URL', () => {

--- a/src/shared/utils/file/url.ts
+++ b/src/shared/utils/file/url.ts
@@ -178,10 +178,14 @@ function dirnameSimple(absolutePath: AbsoluteFilePath): AbsoluteFilePath {
  * - Windows: `C:\foo\bar baz.pdf`       → `file:///C:/foo/bar%20baz.pdf`
  * - UNC:     `\\server\share\baz.pdf`   → `file://server/share/baz.pdf`
  *
- * Backslashes are normalized to forward slashes; each path segment is URL-encoded
- * (special chars like space, `#`, `?` become `%20` / `%23` / `%3F`). The Windows
- * drive letter segment (`C:`) is preserved unencoded because `%3A` would break
- * UNC / drive resolution in `<img src>` contexts.
+ * Backslash folding to `/` happens ONLY for Windows-shaped input (drive paths
+ * and backslash UNC): there `\` is a segment separator. On POSIX a backslash is
+ * an ordinary *filename* character, so it is left intact for the per-segment
+ * `encodeURIComponent` below — `/workspace/a\b.txt` must encode its segment as
+ * `a%5Cb.txt`, not silently become a directory hop into `a/`. Each path segment
+ * is URL-encoded (special chars like space, `#`, `?` become `%20` / `%23` /
+ * `%3F`). The Windows drive letter segment (`C:`) is preserved unencoded because
+ * `%3A` would break UNC / drive resolution in `<img src>` contexts.
  *
  * **UNC carries its server in the URL authority, not in the path.** After
  * separator normalization a UNC path is `//server/share/…`, whose leading `//`
@@ -193,14 +197,18 @@ function dirnameSimple(absolutePath: AbsoluteFilePath): AbsoluteFilePath {
  * to `\\server\share\…`. So a path already starting with `//` gets the `file:`
  * scheme only.
  *
- * This also makes the function the exact inverse of `fileUrlToPath`, which
- * decodes a `file://host/…` URL to the `//host/…` form.
+ * This makes the function the exact inverse of `fileUrlToPath` for every shape:
+ * POSIX byte-faithfully (backslash names included), drive paths, and UNC —
+ * whose decode lands on the `\\host\share\…` spelling that encodes identically.
  *
  * @param absolutePath Absolute filesystem path (Unix, Windows drive, or UNC form).
  * @returns `file://` URL suitable for `<img src>` / `<video src>` / `<embed>`.
  */
 export function toFileUrl(absolutePath: AbsoluteFilePath): FileUrlString {
-  let normalized: string = absolutePath.replace(/\\/g, '/')
+  // Windows-shaped = drive (`X:\…` / `X:/…`) or backslash UNC (`\\…`). Shape is
+  // read from the string, not `process.platform`, matching the rest of shared.
+  const isWindowsShaped = /^[A-Za-z]:[/\\]/.test(absolutePath) || absolutePath.startsWith('\\\\')
+  let normalized: string = isWindowsShaped ? absolutePath.replace(/\\/g, '/') : absolutePath
   if (/^[A-Za-z]:/.test(normalized)) {
     normalized = '/' + normalized
   }
@@ -219,7 +227,14 @@ export function toFileUrl(absolutePath: AbsoluteFilePath): FileUrlString {
  *
  * - Unix:    `file:///foo/bar%20baz.pdf`     → `/foo/bar baz.pdf`
  * - Windows: `file:///C:/foo/bar%20baz.pdf`  → `C:/foo/bar baz.pdf`
- * - UNC:     `file://server/share/file.pdf`  → `//server/share/file.pdf`
+ * - UNC:     `file://server/share/file.pdf`  → `\\server\share\file.pdf`
+ *
+ * UNC decodes to the canonical backslash spelling — the form the schema's UNC
+ * branch and `canonicalizeFilePath`'s UNC rejection both recognise. The former
+ * forward-slash output (`//server/share/…`) matched the schema's plain-POSIX
+ * branch instead, so a plain URI round-trip could re-brand a UNC path as an
+ * ordinary absolute path and silently corrupt it downstream. Matches Node's
+ * `fileURLToPath` behavior on Windows.
  *
  * Main-process code should use Node's `fileURLToPath` when it is already in a
  * Node-only module. This helper exists for shared / renderer-safe code.
@@ -234,7 +249,7 @@ export function fileUrlToPath(fileUrl: FileUrlString | URL): string {
   }
 
   const pathname = decodeURIComponent(url.pathname)
-  if (url.hostname) return `//${url.hostname}${pathname}`
+  if (url.hostname) return `\\\\${url.hostname}${pathname.replace(/\//g, '\\')}`
   if (/^\/[A-Za-z]:\//.test(pathname)) return pathname.slice(1)
   return pathname
 }


### PR DESCRIPTION
## Problem

`toFileUrl` / `fileUrlToPath` (`src/shared/utils/file/url.ts`) form a codec between the filesystem-path domain and the URI domain, but a filesystem rule leaked into both directions:

1. **Encode**: `toFileUrl` opened with an unconditional `\` → `/` fold. On POSIX a backslash is an ordinary *filename* character, so `/workspace/a\b.txt` encoded as `file:///workspace/a/b.txt` — a URL denoting a different file. The per-segment `encodeURIComponent` on the very next statement already produces the correct `a%5Cb.txt`; the fold destroyed its input first.

2. **Decode**: `fileUrlToPath` decoded a UNC authority to the forward-slash spelling `//server/share/…`. That form matches `AbsoluteFilePathSchema`'s plain-POSIX branch (`startsWith('/')`), so a plain URI round-trip let a UNC path be re-branded as an ordinary absolute path — and then silently corrupted downstream (the leading `//` collapse problem tracked in #18207).

## Fix

- `toFileUrl` folds `\` → `/` **only for Windows-shaped input** (drive paths `X:\…`/`X:/…` and backslash UNC), detected by string shape like the rest of shared. POSIX backslashes reach the percent-encoder byte-faithfully.
- `fileUrlToPath` decodes UNC authorities to the canonical backslash spelling `\\server\share\…` that both the schema's UNC branch and `canonicalizeFilePath`'s documented UNC rejection recognise — matching Node's own `fileURLToPath` on Windows. Both spellings still encode identically, so decode → encode is stable.

Caller impact audited: all `fileUrlToPath` results flow into `AbsoluteFilePathSchema.parse`, composer tokens, or `shell.open_path` — none compare against the forward-slash form; the backslash spelling passes the schema's UNC branch and is native for Windows shell APIs.

## Testing

- New: POSIX filename-with-backslash encodes percent-encoded and round-trips byte-faithfully
- New: UNC round-trip lands on `\\server\share\…`, re-encodes to the same URL, and raises `canonicalizeFilePath`'s UNC rejection instead of collapsing
- Updated: UNC decode expectations pinned to the backslash spelling
- Full `url.test.ts`: 31 passed (on a clean upstream/main base — independent of the #18207 fix)
- `typecheck:node` / `typecheck:web` clean; oxlint + eslint clean

Fixes #18206

Co-Authored-By: Claude <noreply@anthropic.com>