### PR TITLE
fix(provider-registry): declare lmstudio defaultChatEndpoint so Pi can select its models

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -697,6 +697,7 @@
     },
     {
       "authOptional": true,
+      "defaultChatEndpoint": "openai-chat-completions",
       "description": "LM Studio - AI model provider",
       "endpointConfigs": {
         "anthropic-messages": {
@@ -2053,5 +2054,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "6f2078bd03cfc7de"
+  "version": "fdfb570a7fc921a1"
 }

--- a/packages/provider-registry/src/providers/lmstudio.ts
+++ b/packages/provider-registry/src/providers/lmstudio.ts
@@ -4,6 +4,15 @@ export default defineProvider({
   id: 'lmstudio',
   name: 'LM Studio',
   authOptional: true,
+  // Declared explicitly although LM Studio is a local provider: its baseUrl is
+  // hardcoded (`http://localhost:1234`) in both endpoint configs, so there is
+  // nothing dynamic to discover — and without a default the endpoint resolution
+  // in runtime gating (`resolvePiApi` → `resolveEndpointType`) falls through to
+  // `undefined` for models synced from `/models`, which carry no `endpointTypes`
+  // metadata. That silently filtered every LM Studio model out of the Pi model
+  // picker even though both declared endpoints are Pi-compatible.
+  // See https://github.com/CherryHQ/cherry-studio/issues/19003
+  defaultChatEndpoint: 'openai-chat-completions',
   endpointConfigs: {
     'anthropic-messages': {
       adapterFamily: 'anthropic',

--- a/packages/provider-registry/src/providers/types.ts
+++ b/packages/provider-registry/src/providers/types.ts
@@ -14,7 +14,8 @@ import type { ProviderModelOverride } from '../schemas/provider-models'
 /**
  * Connection config emitted to `providers.json`. `description` is templated, so it's omitted here;
  * `endpointConfigs` is relaxed to a partial map (a provider declares only the 1–2 endpoints it speaks);
- * `defaultChatEndpoint` is optional (dynamic/local providers like ollama/lmstudio/new-api omit it).
+ * `defaultChatEndpoint` is optional (dynamic/local providers like ollama/new-api omit it; lmstudio
+ * declares one because its baseUrl is hardcoded and both endpoints are runtime-gated).
  */
 type ProviderConnection = Omit<
   ProviderConfig,

--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -446,7 +446,7 @@
     }
   ],
   "providers": {
-    "version": "6f2078bd03cfc7de",
+    "version": "fdfb570a7fc921a1",
     "count": 61,
     "entries": [
       {

--- a/src/shared/ai/__tests__/piModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/piModelCompatibility.test.ts
@@ -78,6 +78,33 @@ describe('resolvePiApi', () => {
     )
   })
 
+  // Regression for https://github.com/CherryHQ/cherry-studio/issues/19003: a
+  // local provider whose baseUrl is hardcoded in BOTH endpoint configs (lmstudio)
+  // has nothing dynamic to discover, so omitting `defaultChatEndpoint` only
+  // breaks gating — models synced from `/models` carry no `endpointTypes`, the
+  // three-way fallback resolves to `undefined`, and every model is silently
+  // filtered out of the Pi picker despite both endpoints being Pi-speakable.
+  it('resolves a hardcoded-local-provider model once a default chat endpoint is declared', () => {
+    const lmstudioShape = (defaultChatEndpoint?: Provider['defaultChatEndpoint']) =>
+      makeProvider({
+        id: 'lmstudio',
+        name: 'LM Studio',
+        authOptional: true,
+        ...(defaultChatEndpoint ? { defaultChatEndpoint } : {}),
+        endpointConfigs: {
+          'anthropic-messages': { adapterFamily: 'anthropic', baseUrl: 'http://localhost:1234' },
+          'openai-chat-completions': { adapterFamily: 'openai-compatible', baseUrl: 'http://localhost:1234' }
+        }
+      })
+    const model = makeModel({ providerId: 'lmstudio', id: 'lmstudio::qwen' }) // no endpointTypes
+
+    // Without the default (the reported bug): silent exclusion.
+    expect(resolvePiApi(lmstudioShape(), model)).toBeUndefined()
+    // With the default: both declared endpoints are Pi-compatible; the openai
+    // chat route resolves to pi's openai-completions family.
+    expect(resolvePiApi(lmstudioShape('openai-chat-completions'), model)).toBe('openai-completions')
+  })
+
   it('is false for an unmapped provider', () => {
     const provider = makeProvider({
       defaultChatEndpoint: 'ollama-chat',


### PR DESCRIPTION
## Problem

No LM Studio model ever appears in the Pi runtime model picker, even though LM Studio's endpoints speak protocols Pi fully supports (`anthropic-messages` and `openai-chat-completions` → `openai-completions`).

### Root cause

The Pi gating chain `resolvePiApi` → `resolveEndpointType` resolves the effective chat endpoint as:

```ts
model.endpointTypes?.[0] ?? resolveGatewayChatRoute(...) ?? provider.defaultChatEndpoint
```

Models synced from LM Studio's local `/models` API carry no `endpointTypes` metadata, and the `lmstudio` preset omits `defaultChatEndpoint` — so resolution falls through to `undefined`, `mapEndpointToPiApi(undefined)` returns `undefined`, and every model is silently filtered out of the picker.

The omission follows the "dynamic/local provider" convention (`types.ts`), but unlike ollama/new-api there is nothing dynamic to discover here: the preset hardcodes `http://localhost:1234` in both endpoint configs, and both declared endpoints are Pi-compatible. The omission only cost LM Studio access to Pi/DSH runtimes while protecting nothing.

## Fix

- Declare `defaultChatEndpoint: 'openai-chat-completions'` in the `lmstudio` preset with a comment explaining why a hardcoded-local provider needs it
- Regenerate `data/providers.json` (one line + derived catalog version hash)
- Update the `types.ts` convention comment (lmstudio no longer in the omit-list; ollama/new-api unchanged)
- Add a `piModelCompatibility.test.ts` regression pinning the exact failure mode: without the default, a no-`endpointTypes` model resolves to `undefined`; with it, to `openai-completions`

## Testing

- `piModelCompatibility.test.ts`: 13 passed (incl. new regression)
- `packages/provider-registry` full suite from repo root: 330 passed (22 files), incl. `catalog-source-sync` / `catalog-invariants`
- Note: `pnpm generate` was run with network access; unrelated upstream models.dev drift in `models.json` / `provider-models.json` was deliberately excluded from this PR — only the lmstudio-derived line and the catalog version hash are included

Fixes #19003

Co-Authored-By: Claude <noreply@anthropic.com>