### PR TITLE
fix(renderer): wire the Launch on Boot toggle to the app:set-launch-on-boot IPC

### DIFF
--- a/src/renderer/pages/settings/GeneralSettings/GeneralSettings.tsx
+++ b/src/renderer/pages/settings/GeneralSettings/GeneralSettings.tsx
@@ -75,6 +75,19 @@ const GeneralSettings: FC = () => {
     void setTrayPreferences(isLaunchToTray && !tray ? { enabled: true, onLaunch: true } : { onLaunch: isLaunchToTray })
   }
 
+  const updateLaunchOnBoot = async (checked: boolean) => {
+    await setLaunchOnBoot(checked)
+    // The preference alone does nothing to the OS: without this IPC the login
+    // item / Run entry (or the Linux autostart file) is never written or
+    // removed, so the toggle had no real effect.
+    // See https://github.com/CherryHQ/cherry-studio/issues/19061
+    try {
+      await window.api.setLaunchOnBoot(checked)
+    } catch (error) {
+      toast.error(formatErrorMessage(error))
+    }
+  }
+
   const onSetProxyUrl = () => {
     if (proxyUrl && !isValidProxyUrl(proxyUrl)) {
       toast.error(t('message.error.invalid.proxy.url'))
@@ -123,7 +136,7 @@ const GeneralSettings: FC = () => {
         <SettingDivider />
         <SettingRow>
           <SettingRowTitle>{t('settings.launch.onboot')}</SettingRowTitle>
-          <Switch checked={launchOnBoot} onCheckedChange={(checked) => void setLaunchOnBoot(checked)} />
+          <Switch checked={launchOnBoot} onCheckedChange={(checked) => void updateLaunchOnBoot(checked)} />
         </SettingRow>
         <SettingDivider />
         <SettingRow>


### PR DESCRIPTION
## Problem

Toggling **Settings → System → Launch on Boot** only wrote the `app.launch_on_boot` preference into Local Storage. It never invoked `window.api.setLaunchOnBoot()`, so the fully implemented main-process path (`app:set-launch-on-boot` → `AppService.setAppLaunchOnBoot` → `app.setLoginItemSettings` / Linux autostart file) was dead code from the UI's perspective:

- Toggling ON never created the Windows Run entry (`HKCU\Software\Microsoft\Windows\CurrentVersion\Run`) or the macOS login item / Linux autostart file
- Toggling OFF never removed one
- Restarting did not help — no startup-time sync of the preference exists either

A scan of the renderer found zero call sites of `window.api.setLaunchOnBoot` — the preload API and main handler were both already implemented and correct; only the UI wiring was missing.

## Fix

In `GeneralSettings`, replace the bare preference write with a handler that persists the preference **and** invokes the existing IPC, surfacing an error toast if the invocation fails (matching the component's existing error-handling idiom):

```tsx
const updateLaunchOnBoot = async (checked: boolean) => {
  await setLaunchOnBoot(checked)
  try {
    await window.api.setLaunchOnBoot(checked)
  } catch (error) {
    toast.error(formatErrorMessage(error))
  }
}
```

## Scope note

This is the minimal wiring fix from the issue's suggested approach. A startup-time sync ("apply `app.launch_on_boot` to OS login items on boot") would additionally heal installs where users toggled the switch while it was broken — left as a possible follow-up since it introduces its own policy questions (e.g. interaction with Task Manager–disabled entries).

## Testing

- `typecheck:web` clean; oxlint + eslint clean
- Renderer settings-page test suite: 903 passed
- Manual verification path (Windows): toggle ON → `HKCU\...\Run` gains the entry; toggle OFF → entry removed

Fixes #19061

Co-Authored-By: Claude <noreply@anthropic.com>