### PR TITLE
fix(aiCore): send max_completion_tokens for GPT-5.x/o-series on openai-compatible providers

### DIFF
--- a/.changeset/openai-compatible-max-completion-tokens.md
+++ b/.changeset/openai-compatible-max-completion-tokens.md
@@ -1,0 +1,5 @@
+---
+'@cherrystudio/ai-core': patch
+---
+
+Rewrite legacy `max_tokens` to `max_completion_tokens` for GPT-5.x/o-series models on openai-compatible providers. The AI SDK's openai-compatible layer always emits `max_tokens` on the wire, which those model families reject outright (`400 Unsupported parameter`). A thin fetch wrapper at the provider construction boundary renames the parameter on matching request bodies while forwarding everything else untouched.

--- a/packages/aiCore/src/core/providers/core/__tests__/reasoningModelBodyRewrite.test.ts
+++ b/packages/aiCore/src/core/providers/core/__tests__/reasoningModelBodyRewrite.test.ts
@@ -74,7 +74,7 @@ describe('withReasoningModelBodyRewrite', () => {
   })
 
   it('rewrites only the body of matching reasoning-model requests', async () => {
-    const baseFetch = vi.fn(async (..._args: Parameters<typeof fetch>) => responseBody())
+    const baseFetch = vi.fn<typeof fetch>(async () => responseBody())
     const wrapped = withReasoningModelBodyRewrite(baseFetch)
     const headers = { 'content-type': 'application/json' }
     await wrapped('https://example.com/v1/chat/completions', {

--- a/packages/aiCore/src/core/providers/core/__tests__/reasoningModelBodyRewrite.test.ts
+++ b/packages/aiCore/src/core/providers/core/__tests__/reasoningModelBodyRewrite.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  isMaxCompletionTokensModel,
+  rewriteMaxTokensToMaxCompletionTokens,
+  withReasoningModelBodyRewrite
+} from '../reasoningModelBodyRewrite'
+
+describe('isMaxCompletionTokensModel', () => {
+  it('matches GPT-5.x and o-series ids, including vendor prefixes', () => {
+    for (const id of ['gpt-5', 'gpt-5-mini', 'gpt-5-2025-08-07', 'openai/gpt-5', 'o1', 'o3-mini', 'o4-mini']) {
+      expect(isMaxCompletionTokensModel(id), id).toBe(true)
+    }
+  })
+
+  it('does not match ids that merely resemble the reasoning families', () => {
+    for (const id of ['gpt-4o', 'gpt-4.1', 'gpt-50', 'omni-1', 'deepseek-v4-flash', 'openrouter/o1x']) {
+      expect(isMaxCompletionTokensModel(id), id).toBe(false)
+    }
+  })
+
+  it('rejects non-string input', () => {
+    expect(isMaxCompletionTokensModel(undefined)).toBe(false)
+    expect(isMaxCompletionTokensModel(123)).toBe(false)
+  })
+})
+
+describe('rewriteMaxTokensToMaxCompletionTokens', () => {
+  const body = (model: string, extra: Record<string, unknown> = {}) =>
+    JSON.stringify({ model, messages: [], max_tokens: 128000, ...extra })
+
+  it('moves max_tokens to max_completion_tokens for reasoning-family models', () => {
+    const rewritten = JSON.parse(rewriteMaxTokensToMaxCompletionTokens(body('gpt-5')))
+    expect(rewritten.max_completion_tokens).toBe(128000)
+    expect(rewritten.max_tokens).toBeUndefined()
+    expect(rewritten.model).toBe('gpt-5')
+  })
+
+  it('rewrites vendor-prefixed ids', () => {
+    expect(rewriteMaxTokensToMaxCompletionTokens(body('openai/o3-mini'))).toContain('"max_completion_tokens":128000')
+  })
+
+  it('leaves non-reasoning models untouched', () => {
+    const raw = body('deepseek-v4-flash')
+    expect(rewriteMaxTokensToMaxCompletionTokens(raw)).toBe(raw)
+  })
+
+  it('leaves bodies without max_tokens untouched', () => {
+    const raw = JSON.stringify({ model: 'gpt-5', messages: [] })
+    expect(rewriteMaxTokensToMaxCompletionTokens(raw)).toBe(raw)
+  })
+
+  it('never clobbers an explicit max_completion_tokens', () => {
+    const raw = body('gpt-5', { max_completion_tokens: 4096 })
+    expect(rewriteMaxTokensToMaxCompletionTokens(raw)).toBe(raw)
+  })
+
+  it('passes through malformed and non-object bodies', () => {
+    expect(rewriteMaxTokensToMaxCompletionTokens('not-json{')).toBe('not-json{')
+    expect(rewriteMaxTokensToMaxCompletionTokens('123')).toBe('123')
+    expect(rewriteMaxTokensToMaxCompletionTokens('["gpt-5"]')).toBe('["gpt-5"]')
+  })
+})
+
+describe('withReasoningModelBodyRewrite', () => {
+  const responseBody = () => new Response('{}', { status: 200 })
+
+  it('forwards requests without the legacy param untouched', async () => {
+    const baseFetch = vi.fn(async () => responseBody())
+    const wrapped = withReasoningModelBodyRewrite(baseFetch)
+    const init = { method: 'POST', body: JSON.stringify({ model: 'gpt-4o', messages: [] }) }
+    await wrapped('https://example.com/v1/chat/completions', init)
+    expect(baseFetch).toHaveBeenCalledWith('https://example.com/v1/chat/completions', init)
+  })
+
+  it('rewrites only the body of matching reasoning-model requests', async () => {
+    const baseFetch = vi.fn(async (..._args: Parameters<typeof fetch>) => responseBody())
+    const wrapped = withReasoningModelBodyRewrite(baseFetch)
+    const headers = { 'content-type': 'application/json' }
+    await wrapped('https://example.com/v1/chat/completions', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model: 'gpt-5', messages: [], max_tokens: 4096 })
+    })
+    const [, forwarded] = baseFetch.mock.calls[0]
+    expect(forwarded?.headers).toEqual(headers)
+    expect(JSON.parse(String(forwarded?.body))).toEqual({
+      model: 'gpt-5',
+      messages: [],
+      max_completion_tokens: 4096
+    })
+  })
+
+  it('passes through string bodies that fail the cheap pre-check without parsing', async () => {
+    const baseFetch = vi.fn(async () => responseBody())
+    const wrapped = withReasoningModelBodyRewrite(baseFetch)
+    const init = { method: 'POST', body: 'plain-text-echo' }
+    await wrapped('https://example.com/other', init)
+    expect(baseFetch).toHaveBeenCalledWith('https://example.com/other', init)
+  })
+
+  it('forwards Request-object invocations as-is', async () => {
+    const baseFetch = vi.fn(async () => responseBody())
+    const wrapped = withReasoningModelBodyRewrite(baseFetch)
+    const request = new Request('https://example.com/v1/chat/completions', { method: 'POST' })
+    await wrapped(request)
+    expect(baseFetch).toHaveBeenCalledWith(request, undefined)
+  })
+})

--- a/packages/aiCore/src/core/providers/core/initialization.ts
+++ b/packages/aiCore/src/core/providers/core/initialization.ts
@@ -25,6 +25,7 @@ import type {
 import { extensionRegistry } from './ExtensionRegistry'
 import type { ProviderExtensionConfig } from './ProviderExtension'
 import { ProviderExtension } from './ProviderExtension'
+import { withReasoningModelBodyRewrite } from './reasoningModelBodyRewrite'
 
 // ==================== Core Extensions ====================
 
@@ -187,7 +188,16 @@ const OpenAICompatibleExtension = ProviderExtension.create({
     if (!settings) {
       throw new Error('OpenAI Compatible provider requires settings')
     }
-    return (await import('@ai-sdk/openai-compatible')).createOpenAICompatible(settings)
+    const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible')
+    return createOpenAICompatible({
+      ...settings,
+      // GPT-5.x / o-series reject legacy `max_tokens` (they require
+      // `max_completion_tokens`), but @ai-sdk/openai-compatible always emits the
+      // legacy name on the wire. Wrap the caller-injected fetch (e.g. the
+      // proxy-aware customFetch) so matching request bodies are rewritten before
+      // hitting the wire; everything else passes through untouched.
+      fetch: withReasoningModelBodyRewrite(settings.fetch ?? fetch.bind(globalThis))
+    })
   },
   createRerankingModel: (modelId, settings) => {
     if (!settings) {

--- a/packages/aiCore/src/core/providers/core/reasoningModelBodyRewrite.ts
+++ b/packages/aiCore/src/core/providers/core/reasoningModelBodyRewrite.ts
@@ -1,0 +1,77 @@
+/**
+ * Body-level compatibility rewrite for OpenAI-compatible endpoints.
+ *
+ * `@ai-sdk/openai-compatible` always serializes the AI SDK's `maxOutputTokens`
+ * as legacy `max_tokens` on the wire. That is correct for most compatible
+ * servers, but OpenAI reasoning families (GPT-5.x, o1, o3, o4) REJECT
+ * `max_tokens` outright (`400 Unsupported parameter … Use
+ * 'max_completion_tokens' instead`). Requests that cannot avoid declaring an
+ * output budget then fail hard — most visibly Agent-mode runs, where the local
+ * Anthropic-protocol gateway must translate the Anthropic-required `max_tokens`
+ * into stream options, but also ordinary chat requests that set a token limit.
+ *
+ * The provider package offers no hook to influence the wire parameter name, so
+ * the fix lives at the fetch boundary: a thin wrapper around the caller's
+ * (possibly proxy-aware) customFetch that renames `max_tokens` →
+ * `max_completion_tokens` on matching bodies. Everything else passes through
+ * byte-for-byte, and the cheap substring pre-check keeps non-matching traffic
+ * free of any JSON parsing.
+ */
+
+/**
+ * Model ids whose OpenAI-shaped chat API rejects legacy `max_tokens`.
+ * Matches GPT-5.x (`gpt-5`, `gpt-5-mini`, date-suffixed variants), the
+ * o-series (`o1`, `o3-mini`, `o4-mini`, …) and vendor-prefixed ids
+ * (`openai/gpt-5`). Deliberately narrow — this targets OpenAI's own naming;
+ * unrelated ids like `gpt-4o`, `gpt-50` or `omni-*` do not match.
+ */
+export const MAX_COMPLETION_TOKENS_MODEL_PATTERN = /(?:^|\/)(?:gpt-5|o[134])(?:[-._]|$)/
+
+export function isMaxCompletionTokensModel(modelId: unknown): boolean {
+  return typeof modelId === 'string' && MAX_COMPLETION_TOKENS_MODEL_PATTERN.test(modelId)
+}
+
+/**
+ * Rewrite a serialized chat-completions request body: for models that reject
+ * legacy `max_tokens`, move the value to `max_completion_tokens`. Any input
+ * that does not need rewriting is returned unchanged (same string).
+ */
+export function rewriteMaxTokensToMaxCompletionTokens(requestBody: string): string {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(requestBody)
+  } catch {
+    return requestBody
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return requestBody
+  }
+  const body = parsed as Record<string, unknown>
+  // Only touch bodies that carry the legacy param; never clobber an explicit
+  // `max_completion_tokens` if one was somehow already present.
+  if (!isMaxCompletionTokensModel(body.model)) return requestBody
+  if (typeof body.max_tokens !== 'number' || body.max_completion_tokens != null) return requestBody
+  const { max_tokens, ...rest } = body
+  return JSON.stringify({ ...rest, max_completion_tokens: max_tokens })
+}
+
+/**
+ * Wrap a fetch implementation so OpenAI-compatible chat bodies carrying
+ * `max_tokens` for reasoning-family models are rewritten before hitting the
+ * wire (see module docs). Non-matching requests reach `baseFetch` untouched.
+ */
+export function withReasoningModelBodyRewrite(baseFetch: typeof globalThis.fetch): typeof globalThis.fetch {
+  return async (input, init) => {
+    // The AI SDK invokes fetch as `(url, { body: jsonString })`; a Request-object
+    // invocation carries its body elsewhere and is passed through as-is.
+    const body = typeof init?.body === 'string' ? init.body : undefined
+    if (!body || !body.includes('"max_tokens"')) {
+      return baseFetch(input, init)
+    }
+    const rewritten = rewriteMaxTokensToMaxCompletionTokens(body)
+    if (rewritten === body) {
+      return baseFetch(input, init)
+    }
+    return baseFetch(input, { ...init, body: rewritten })
+  }
+}


### PR DESCRIPTION
## Problem

Agent mode fails against OpenAI-compatible gateways serving GPT-5.x models:

```
400 Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

while Chat mode with the same provider/model works.

### Root cause

`@ai-sdk/openai-compatible` always serializes the AI SDK's `maxOutputTokens` as legacy `max_tokens` on the wire (no reasoning-model conditional). OpenAI reasoning families (GPT-5.x, o1, o3, o4) reject that parameter outright.

- **Chat mode** works only because it happens not to declare an output budget by default — a user-set token limit hits the same 400.
- **Agent mode** always fails: the local Anthropic-protocol gateway translates the Anthropic-required `max_tokens` (`AnthropicMessageConverter`) into `maxOutputTokens`, which the compatible provider then emits as legacy `max_tokens`.

## Fix

The provider package exposes no hook to influence the wire parameter name, so the rewrite lives at the fetch boundary in aiCore's openai-compatible extension — the single construction point for every such provider:

- New `withReasoningModelBodyRewrite(fetch)` wrapper: when a request body contains `"max_tokens"` **and** its `model` matches the affected families (`gpt-5*`, `o1*`, `o3*`, `o4*`, incl. vendor-prefixed ids like `openai/gpt-5`), renames the key to `max_completion_tokens`, preserving the value.
- Composed around the caller-injected fetch, so existing proxy-aware customFetch chains keep working (the same concern documented on the Azure variant).
- Cheap substring pre-check → non-matching traffic never parses JSON. Malformed bodies, non-reasoning models, and explicit `max_completion_tokens` values pass through byte-for-byte.

Pattern is deliberately narrow (`(?:^|\/)(?:gpt-5|o[134])(?:[-._]|$)`): targets OpenAI's own naming; `gpt-4o`, `gpt-50`, `omni-*` etc. don't match.

## Testing

- New unit tests (13): pattern match/negative cases, body rewrite incl. vendor prefixes and no-clobber semantics, fetch-wrapper forwarding/preservation/Request-object passthrough
- Full `packages/aiCore/src/core/providers` suite: 165 passed
- `aiCore` tsc clean; oxlint + eslint clean

Fixes #18765

Co-Authored-By: Claude <noreply@anthropic.com>