### PR TITLE
fix(ai): fail fast when a non-chat model is selected for a chat turn

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -34,7 +34,13 @@ import type { ImageGenerationMode } from '@shared/data/types/model'
 import { type Model, parseUniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import type { Base64String, CreateInternalEntryIpcParams, UrlString } from '@shared/types/file'
-import { isEmbeddingModel, isFunctionCallingModel, isGenerateImageModel, isRerankModel } from '@shared/utils/model'
+import {
+  isEmbeddingModel,
+  isFunctionCallingModel,
+  isGenerateImageModel,
+  isNonChatModel,
+  isRerankModel
+} from '@shared/utils/model'
 import { isOllamaProvider } from '@shared/utils/provider'
 import {
   type EmbeddingModelUsage,
@@ -538,6 +544,17 @@ export class AiService extends BaseService {
       nativeFileSupport,
       fileAttachments
     } = await this.buildAgentParamsFor(request, signal, extraFeatures, () => repairUsagePlugins.current ?? [])
+
+    // An embedding/rerank/media-generation model cannot answer chat turns; sending one
+    // to /chat/completions only surfaces an opaque provider error (e.g. a bare 403).
+    // Fail fast with an actionable message instead.
+    // See https://github.com/CherryHQ/cherry-studio/issues/18883
+    if (isNonChatModel(model)) {
+      throw new Error(
+        `"${model.name}" is not a chat model — embedding/rerank/generation-only models cannot be used for conversations`
+      )
+    }
+
     const usageContext = createCaptureContext({
       provider,
       model,
@@ -666,6 +683,15 @@ export class AiService extends BaseService {
       hookParts,
       nativeFileSupport
     } = await this.buildAgentParamsFor(request, signal, extraFeatures, () => repairUsagePlugins.current ?? [])
+
+    // Same chat-only contract as streamText: non-chat models fail fast here with an
+    // actionable message instead of an opaque provider error downstream.
+    if (isNonChatModel(model)) {
+      throw new Error(
+        `"${model.name}" is not a chat model — embedding/rerank/generation-only models cannot be used for conversations`
+      )
+    }
+
     const usageContext = createCaptureContext({
       provider,
       model,

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -295,6 +295,33 @@ describe('AiService', () => {
     expect(mockApplicationGet).not.toHaveBeenCalled()
   })
 
+  // Regression for https://github.com/CherryHQ/cherry-studio/issues/18883: an
+  // embedding-type model selected as the chat model used to reach
+  // /chat/completions and fail with an opaque provider error (e.g. a bare 403).
+  it('fails fast when a non-chat model is selected for a chat turn', async () => {
+    const service = createService()
+    vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({
+      sdkConfig: { providerId: 'test-provider', providerSettings: {}, modelId: 'xop3qwen0b6embedding' },
+      provider: { id: 'test-provider' },
+      model: {
+        id: 'test-provider::xop3qwen0b6embedding',
+        providerId: 'test-provider',
+        name: 'xop3qwen0b6embedding',
+        capabilities: ['embedding'],
+        endpointTypes: ['openai-embeddings']
+      },
+      assistant: {}
+    } as never)
+
+    await expect(
+      service.streamText({
+        chatId: 'chat-1',
+        trigger: 'submit-message',
+        requestOptions: { signal: new AbortController().signal }
+      } as any)
+    ).rejects.toThrow('is not a chat model')
+  })
+
   it('detects only native attachment shapes that the primary model preserves', () => {
     const primarySupport = { image: true, pdf: true, audio: false, video: true }
     const messages = [


### PR DESCRIPTION
## Problem

Selecting an embedding-type model (e.g. iFlytek MaaS `xop3qwen0b6embedding`) as the chat model sent it to `/chat/completions` anyway. The provider rejects it with an opaque error:

```
AI_APICallError: Forbidden
Status Code: 403
Response Content: {"message":"not found"}
```

Nothing in the UI or error text hints that the selected model itself cannot hold a conversation.

## Fix

Guard both chat entries — `AiService.streamText` and `AiService.generateText` — with the existing `isNonChatModel` predicate immediately after request parameters are built. A non-chat model now fails fast with an actionable message:

> `"xop3qwen0b6embedding" is not a chat model — embedding/rerank/generation-only models cannot be used for conversations`

Design notes:

- **The guard lives only in the chat entry points on purpose**: `buildAgentParamsFor` is shared with `embedMany` / `rerank`, where embedding/rerank models are the *correct* kind of input — guarding there would break legitimate knowledge-base flows.
- Mirrors the validation `DeepSeekHarnessService` already applies ("The selected DeepSeek Harness model must support chat"), generalized to the main chat path.
- The Pi runtime already filters such models out of its picker; this closes the regular-chat path regardless of what the picker shows.

## Testing

- New regression test in `AiService.test.ts`: an embedding-capable model reaching `streamText` rejects with the actionable message
- Full `AiService.test.ts`: 57 passed
- `typecheck:node` clean; oxlint + eslint clean

Fixes #18883

Co-Authored-By: Claude <noreply@anthropic.com>