### PR TITLE
fix(renderer): accept a pasted full API path as a custom provider host

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderEndpointActions.ts
+++ b/src/renderer/pages/settings/ProviderSettings/hooks/providerSetting/useProviderEndpointActions.ts
@@ -1,6 +1,6 @@
 import { loggerService } from '@logger'
 import { toast } from '@renderer/services/toast'
-import { validateApiHost } from '@renderer/utils/api'
+import { stripChatCompletionsRoute, validateApiHost } from '@renderer/utils/api'
 import { ErrorCode, isDataApiError, isSerializedDataApiError, toDataApiError } from '@shared/data/api/errors'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
@@ -91,7 +91,10 @@ export function useProviderEndpointActions({
         return false
       }
 
-      const trimmedApiHost = trim(nextApiHost)
+      // A pasted full API route (`…/v1/chat/completions`) must not be stored as
+      // the base: the request layer appends the route itself.
+      // See https://github.com/CherryHQ/cherry-studio/issues/18490
+      const trimmedApiHost = stripChatCompletionsRoute(trim(nextApiHost))
       if (!validateApiHost(trimmedApiHost)) {
         return false
       }
@@ -155,7 +158,10 @@ export function useProviderEndpointActions({
         debouncedPersistApiHost.cancel()
 
         const raw = explicitNext !== undefined ? explicitNext : apiHost
-        const trimmedApiHost = trim(raw)
+        // Same base-vs-route normalization as persistApiHostDraft: accept a pasted
+        // full API path, store the base the request layer expects.
+        // See https://github.com/CherryHQ/cherry-studio/issues/18490
+        const trimmedApiHost = stripChatCompletionsRoute(trim(raw))
         if (!validateApiHost(trimmedApiHost)) {
           setApiHost(providerApiHost)
           toast.error(t('settings.provider.api_host_no_valid'))

--- a/src/renderer/utils/__tests__/api.test.ts
+++ b/src/renderer/utils/__tests__/api.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatVertexApiHost, maskApiKey, routeToEndpoint, splitApiKeyString, validateApiHost } from '../api'
+import {
+  formatVertexApiHost,
+  maskApiKey,
+  routeToEndpoint,
+  splitApiKeyString,
+  stripChatCompletionsRoute,
+  validateApiHost
+} from '../api'
 
 describe('api', () => {
   describe('maskApiKey', () => {
@@ -111,6 +118,38 @@ describe('api', () => {
     it('validates supported endpoint fragments when using hash suffix', () => {
       expect(validateApiHost('https://api.example.com/v1/chat/completions#')).toBe(true)
       expect(validateApiHost('https://api.example.com/v1/unknown#')).toBe(true)
+    })
+  })
+
+  // Regression for https://github.com/CherryHQ/cherry-studio/issues/18490: a full
+  // API route pasted as the host must be stored as its base — the request layer
+  // appends `/chat/completions` itself.
+  describe('stripChatCompletionsRoute', () => {
+    it('strips a trailing chat-completion route down to the base URL', () => {
+      expect(stripChatCompletionsRoute('https://api.example.com/v1/chat/completions')).toBe(
+        'https://api.example.com/v1'
+      )
+      expect(stripChatCompletionsRoute('https://gateway.example.com/openai/v1/chat/completions')).toBe(
+        'https://gateway.example.com/openai/v1'
+      )
+    })
+
+    it('tolerates a trailing slash after the route and mixed casing', () => {
+      expect(stripChatCompletionsRoute('https://api.example.com/v1/chat/completions/')).toBe(
+        'https://api.example.com/v1'
+      )
+      expect(stripChatCompletionsRoute('https://api.example.com/v1/Chat/Completions')).toBe(
+        'https://api.example.com/v1'
+      )
+    })
+
+    it('returns non-route inputs byte-for-byte unchanged', () => {
+      expect(stripChatCompletionsRoute('https://api.example.com/v1')).toBe('https://api.example.com/v1')
+      expect(stripChatCompletionsRoute('https://api.example.com/v1/')).toBe('https://api.example.com/v1/')
+      expect(stripChatCompletionsRoute('https://api.example.com/v1/messages')).toBe(
+        'https://api.example.com/v1/messages'
+      )
+      expect(stripChatCompletionsRoute('')).toBe('')
     })
   })
 

--- a/src/renderer/utils/api.ts
+++ b/src/renderer/utils/api.ts
@@ -112,3 +112,21 @@ export function validateApiHost(apiHost: string): boolean {
     return false
   }
 }
+
+/**
+ * Normalize a user-entered OpenAI-compatible API host for storage as an
+ * endpoint base URL.
+ *
+ * Provider dashboards document the complete endpoint, so pasting a full route
+ * (`https://api.example.com/v1/chat/completions`) is common. The stored value,
+ * however, must be a BASE: the request layer appends `/chat/completions`
+ * itself, so keeping the route would double the path and break every call.
+ * Inputs that do not end with that route are returned byte-for-byte unchanged.
+ *
+ * See https://github.com/CherryHQ/cherry-studio/issues/18490
+ */
+export function stripChatCompletionsRoute(apiHost: string): string {
+  const trimmed = trim(apiHost)
+  const match = trimmed.match(/\/chat\/completions\/?$/i)
+  return match ? trimmed.slice(0, trimmed.length - match[0].length) : trimmed
+}


### PR DESCRIPTION
## Problem

The custom-provider API host field only worked with BaseURL form (`https://api.example.com/v1`). Provider dashboards document the complete endpoint, so users naturally paste the full route (`…/v1/chat/completions`) — which was stored verbatim as the endpoint base URL. The request layer then appended `/chat/completions` on top of it, producing a doubled path and failing every call.

## Fix

Normalize at both persistence points in `useProviderEndpointActions` — `commitApiHost` and the debounced draft persist: strip a trailing `/chat/completions` route before storing.

- Tolerates a trailing slash after the route and mixed casing
- **Non-route inputs are returned byte-for-byte unchanged** — existing BaseURL entries (with or without trailing slash, with query strings) are never churned
- The input field syncs to the normalized value on commit, so what the user sees matches what is stored

Scope note: this covers the reported OpenAI-compatible chat route. Other endpoint routes (`responses`, `messages`, …) could be added to the same helper later if reports accumulate; the `#`-suffix mechanism (`routeToEndpoint`) remains available for forcing non-default endpoints.

## Testing

- New `stripChatCompletionsRoute` unit tests: full-route stripping (incl. deep gateway paths), trailing-slash/case tolerance, byte-for-byte passthrough for plain bases / other routes / empty input
- `api.test.ts`: 34 passed
- `typecheck:web` clean; oxlint + eslint clean

Fixes #18490

Co-Authored-By: Claude <noreply@anthropic.com>