### PR TITLE
fix(renderer): dedup UNC folder mentions and make file:// degradation diagnosable

### DIFF
--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -62,6 +62,7 @@ import {
 } from '@renderer/utils/input'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { resolveReasoningEffortForModel } from '@renderer/utils/model'
+import { toPathKey } from '@renderer/utils/path'
 import type { ComposerQueuedMessagePayload } from '@shared/ai/transport'
 import type { AgentEntity } from '@shared/data/types/agent'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
@@ -194,15 +195,28 @@ const buildAccessiblePathFilePart = (
 /**
  * `AgentWorkspacePathSchema` only guarantees a non-empty string, so the stored
  * workspace path is asserted to be an absolute filesystem path here, before it
- * reaches the path helpers. A malformed one yields no accessible paths, which
- * degrades to inlining attachments instead of referencing them — still correct,
- * just less efficient.
+ * reaches the path helpers. A malformed — or un-canonicalizable — one yields no
+ * accessible paths, degrading attachments from `file://` references to base64
+ * inlining: a behavioural difference (the model gets a storage copy at a
+ * different path), not merely an efficiency loss, so each rejection logs.
  */
 const toAccessiblePaths = (workspacePath: string | undefined): AbsoluteFilePath[] => {
   if (!workspacePath) return []
   const parsed = AbsoluteFilePathSchema.safeParse(workspacePath)
   if (!parsed.success) {
     logger.warn('Ignoring agent workspace path that is not an absolute filesystem path', { path: workspacePath })
+    return []
+  }
+  // A UNC workspace passes the shape check but has no canonical form, so every
+  // containment test against it returns false and attachments would silently
+  // degrade to base64 inlining. Reject it by the same standard the path
+  // primitives use (`toPathKey === null`) so the degradation is diagnosable.
+  // See https://github.com/CherryHQ/cherry-studio/issues/18631
+  if (toPathKey(parsed.data) === null) {
+    logger.warn(
+      'Ignoring agent workspace path that has no canonical form (UNC); attachments will be inlined as base64',
+      { path: workspacePath }
+    )
     return []
   }
   return [parsed.data]

--- a/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
+++ b/src/renderer/components/composer/variants/agent/__tests__/accessiblePath.test.ts
@@ -136,10 +136,14 @@ describe('getPathComparisonKey', () => {
     expect(getPathComparisonKey('/workspace/a\\b.txt')).not.toBe(getPathComparisonKey('/workspace/a/b.txt'))
   })
 
-  it('leaves an un-canonicalizable UNC path spelled as it came in', async () => {
+  // Regression for https://github.com/CherryHQ/cherry-studio/issues/18631: the
+  // listing side spells a share separator-normalized while drag-and-drop carries
+  // the OS spelling — the fallback fold must make both key identically, or the
+  // same folder inserts twice.
+  it('dedups the two spellings of an un-canonicalizable UNC path', async () => {
     const { getPathComparisonKey } = await loadWithPlatform(LINUX)
 
-    expect(getPathComparisonKey('\\\\server\\share\\a.txt')).toBe('\\\\server\\share\\a.txt')
+    expect(getPathComparisonKey('\\\\server\\share\\docs')).toBe(getPathComparisonKey('//server/share/docs'))
   })
 
   it('falls back to the raw value for input that is not an absolute path', async () => {

--- a/src/renderer/components/composer/variants/agent/accessiblePath.ts
+++ b/src/renderer/components/composer/variants/agent/accessiblePath.ts
@@ -41,8 +41,9 @@ export const getAccessiblePathRelativePath = (
 }
 
 /**
- * Case-folding matches the main-side `isPathInside` (`src/main/utils/file/path.ts`):
- * case-insensitive on macOS/Windows (default APFS/NTFS), case-sensitive on Linux.
+ * UI-heuristic case folding for comparison keys only. Containment itself is
+ * case-sensitive on every platform (the path primitives refuse to guess), so
+ * this flag feeds nothing but `getPathComparisonKey`.
  */
 const isCaseInsensitivePlatform = isMac || isWin
 
@@ -63,13 +64,19 @@ const isCaseInsensitivePlatform = isMac || isWin
  * carries the OS's), so a case mismatch is genuinely reachable.
  *
  * Keying through `toPathKey` rather than folding separators here is what keeps
- * `/workspace/a\b.txt` — one POSIX file — from colliding with `/workspace/a/b.txt`.
- * Input that is not an absolute path, or has no canonical form (UNC), keys on
- * itself: unequal to everything but an identical spelling, which is the right
- * answer for dedup.
+ * `/workspace/a\b.txt` — one POSIX file — from colliding with `/workspace/a/b.txt`:
+ * it canonicalizes fine and never reaches the fallback below. Input that is not an
+ * absolute path, or has no canonical form (UNC), keys on a separator-folded
+ * spelling of itself — loose, but consistent across both spellings of one share,
+ * which is what folder-token dedup needs.
  */
 export const getPathComparisonKey = (value: string): string => {
   const parsed = AbsoluteFilePathSchema.safeParse(value)
-  const key = (parsed.success ? toPathKey(parsed.data) : null) ?? value
+  const canonical = parsed.success ? toPathKey(parsed.data) : null
+  // Un-canonicalizable input (UNC): fold separators so the listing side's
+  // normalized spelling and drag-and-drop's OS spelling of one share key
+  // identically instead of producing two tokens for the same folder.
+  // See https://github.com/CherryHQ/cherry-studio/issues/18631
+  const key = canonical ?? value.replace(/\\/g, '/')
   return isCaseInsensitivePlatform ? key.toLowerCase() : key
 }

--- a/src/renderer/utils/path.ts
+++ b/src/renderer/utils/path.ts
@@ -49,7 +49,7 @@ const isWindowsDrivePath = (path: string) => /^[A-Za-z]:[/\\]/.test(path)
  *   inside `canonicalizeFilePath` is arguably the real defect, but that function
  *   produces the persisted `file_entry.externalPath` key and changing its output
  *   requires a paired migration — see its "Rule-evolution discipline". Tracked
- *   in #17429.)
+ *   in #18207.)
  *
  * These are predicates, not parsers: a path we cannot canonicalize is simply not
  * provably the same as, or inside, anything. So degrade to `null` rather than


### PR DESCRIPTION
## Problem

Two defects on a UNC workspace, both rooted in the same gap: a UNC path passes `AbsoluteFilePathSchema` but has no canonical form, so the comparison layer never sees one.

**A — folder-mention dedup never matches.** The resource listing spells a share separator-normalized (`useAgentResourceMentionSource`), while drag-and-drop carries the OS spelling. `getPathComparisonKey` keyed un-canonicalizable input as-is, so one folder produced two keys: the `disabled` flag never engaged and the folder could be inserted repeatedly.

**B — UNC workspaces silently lose `file://` references.** `toAccessiblePaths` validated the workspace with the shape check only, which a UNC path passes — while every containment test against it returns `false`, so attachments silently degrade to base64 inlining with no log line. That is a behavioural difference, not an efficiency loss: `buildFileParts` copies the bytes into storage and hands the model a `file://` pointing at that copy, so an agent reading/writing workspace files in place gets a snapshot elsewhere.

## Fix

- **A**: `getPathComparisonKey`'s fallback now folds separators (`value.replace(/\\/g, '/')`). Safe precisely because a POSIX path with a backslash in a filename canonicalizes fine and never reaches the fallback.
- **B**: `toAccessiblePaths` rejects un-canonicalizable paths by the same standard the primitives use (`toPathKey(...) === null`) and logs, so the degradation is diagnosable.
- Corrects two comments these defects showed to be false: the case-folding note claiming to match main-side containment (containment is case-sensitive everywhere; the flag feeds only the comparison key), and the `//`-collapse defect reference (#17429 → #18207).

Note for reviewers: #19109 independently makes `canonicalizeFilePath` reject the forward-slash UNC spelling outright instead of collapsing it — complementary to A's fallback fold, which handles both spellings regardless of which fix lands.

Issue item 3 of the false-comment list (the `PosixRelativeFilePathSchema` "refuses exactly" wording in `path.ts`) was left untouched deliberately: correcting it accurately requires restating `pathSpec`'s pre-validation filtering, better done alongside that module's next touch.

## Testing

- New regression test: both UNC spellings produce one comparison key
- Updated the previous "keys on itself" expectation it replaces
- `accessiblePath.test.ts` + `path.test.ts`: 59 passed
- `typecheck:web` clean; oxlint + eslint clean

Fixes #18631

Co-Authored-By: Claude <noreply@anthropic.com>