### PR TITLE
fix(chat-shell): keep sidebar resize handle aligned after settings navigation

### DIFF
--- a/src/renderer/components/chat/shell/ConversationNavigationPane.tsx
+++ b/src/renderer/components/chat/shell/ConversationNavigationPane.tsx
@@ -8,14 +8,12 @@ export function ConversationNavigationPane({ children, className, ...props }: HT
   return (
     <div
       className={cn(
-        'conversation-navigation-pane relative flex w-[var(--assistants-width)] flex-col overflow-hidden transition-[width] duration-300',
+        'conversation-navigation-pane relative flex w-full flex-col overflow-hidden',
         isWindowFrame ? 'h-full' : 'h-[calc(100vh_-_var(--navbar-height))]',
         className
       )}
       {...props}>
-      <div className="conversation-navigation-pane-content flex flex-1 flex-col overflow-hidden transition-[width] duration-300">
-        {children}
-      </div>
+      <div className="conversation-navigation-pane-content flex flex-1 flex-col overflow-hidden">{children}</div>
     </div>
   )
 }

--- a/src/renderer/components/chat/shell/PageSidebar.tsx
+++ b/src/renderer/components/chat/shell/PageSidebar.tsx
@@ -2,7 +2,7 @@ import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { cn } from '@renderer/utils/style'
 import { AnimatePresence, motion } from 'motion/react'
 import type { CSSProperties, ReactNode } from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -36,7 +36,16 @@ export function PageSidebar({
   const { t } = useTranslation()
   const [hasOpened, setHasOpened] = useState(Boolean(open))
   const { isResizing, paneRef, paneWidth, startResizing, setPaneWidth } = useResourceListPaneResize({ onPaneCollapse })
-  const resolvedWidth = width ?? paneWidth
+  const resolvedWidth = width ?? CHAT_SHELL_PANE_WIDTH
+
+  // A hidden React Activity destroys effects while preserving Motion's internal values. When the
+  // activity resumes, Motion can restore the pre-resize numeric width even though the persisted
+  // width and CSS variable are current. Rebind the pane at the same layout-effect boundary so the
+  // handle (positioned from this box) and its visible content always share one width source.
+  useLayoutEffect(() => {
+    if (!open || !paneRef.current) return
+    paneRef.current.style.width = typeof resolvedWidth === 'number' ? `${resolvedWidth}px` : resolvedWidth
+  }, [open, paneRef, resolvedWidth])
 
   useEffect(() => {
     if (open) setHasOpened(true)
@@ -66,10 +75,7 @@ export function PageSidebar({
           data-ui="part:conversation-navigation"
           data-resource-list-pane
           data-resizing={isResizing || undefined}
-          className={cn(
-            'group/resource-list-pane relative shrink-0 overflow-visible data-[resizing=true]:[&_.conversation-navigation-pane-content]:transition-none data-[resizing=true]:[&_.conversation-navigation-pane]:transition-none',
-            className
-          )}
+          className={cn('group/resource-list-pane relative shrink-0 overflow-visible', className)}
           style={style}>
           {/* Keep the list clipped without covering its scrollbar with the resize hit area. */}
           <div data-resource-list-pane-content className="h-full min-h-0 overflow-hidden">

--- a/src/renderer/components/chat/shell/PageSidebar.tsx
+++ b/src/renderer/components/chat/shell/PageSidebar.tsx
@@ -2,7 +2,7 @@ import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import { cn } from '@renderer/utils/style'
 import { AnimatePresence, motion } from 'motion/react'
 import type { CSSProperties, ReactNode } from 'react'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -38,15 +38,6 @@ export function PageSidebar({
   const { isResizing, paneRef, paneWidth, startResizing, setPaneWidth } = useResourceListPaneResize({ onPaneCollapse })
   const resolvedWidth = width ?? CHAT_SHELL_PANE_WIDTH
 
-  // A hidden React Activity destroys effects while preserving Motion's internal values. When the
-  // activity resumes, Motion can restore the pre-resize numeric width even though the persisted
-  // width and CSS variable are current. Rebind the pane at the same layout-effect boundary so the
-  // handle (positioned from this box) and its visible content always share one width source.
-  useLayoutEffect(() => {
-    if (!open || !paneRef.current) return
-    paneRef.current.style.width = typeof resolvedWidth === 'number' ? `${resolvedWidth}px` : resolvedWidth
-  }, [open, paneRef, resolvedWidth])
-
   useEffect(() => {
     if (open) setHasOpened(true)
   }, [open])
@@ -67,7 +58,7 @@ export function PageSidebar({
           ref={paneRef}
           key="page-sidebar"
           initial={{ width: 0, opacity: 0 }}
-          animate={open ? { width: resolvedWidth || CHAT_SHELL_PANE_WIDTH, opacity: 1 } : { width: 0, opacity: 0 }}
+          animate={open ? { width: resolvedWidth, opacity: 1 } : { width: 0, opacity: 0 }}
           exit={{ width: 0, opacity: 0 }}
           transition={isResizing ? { duration: 0 } : CHAT_SHELL_TRANSITION}
           aria-hidden={!open}

--- a/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
@@ -1,17 +1,18 @@
+import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { render, waitFor } from '@testing-library/react'
 import { Activity } from 'react'
-import { afterEach, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, expect, it } from 'vitest'
 
 import { PageSidebar } from '../PageSidebar'
+import { RESOURCE_LIST_PANE_CACHE_KEY } from '../paneLayout'
 
-const cache = vi.hoisted(() => ({ width: 200 }))
-
-vi.mock('@data/hooks/useCache', () => ({
-  usePersistCache: () => [cache.width, vi.fn()]
-}))
+beforeEach(() => {
+  MockUseCacheUtils.resetMocks()
+  MockUseCacheUtils.setPersistCacheValue(RESOURCE_LIST_PANE_CACHE_KEY, 200)
+})
 
 afterEach(() => {
-  cache.width = 200
+  MockUseCacheUtils.resetMocks()
   document.documentElement.style.removeProperty('--assistants-width')
 })
 
@@ -25,7 +26,7 @@ it('keeps the restored width through the next transition', async () => {
   const { container, rerender } = render(<Sidebar visible />)
   const pane = container.querySelector<HTMLElement>('[data-resource-list-pane]')!
 
-  cache.width = 283
+  MockUseCacheUtils.setPersistCacheValue(RESOURCE_LIST_PANE_CACHE_KEY, 283)
   rerender(<Sidebar visible={false} />)
   rerender(<Sidebar visible />)
   await waitFor(() => {

--- a/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
@@ -1,71 +1,43 @@
-import { render } from '@testing-library/react'
-import { Activity, type ComponentProps, type PropsWithChildren, useLayoutEffect, useRef } from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { Activity } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 
 import { PageSidebar } from '../PageSidebar'
 
 const cache = vi.hoisted(() => ({ width: 200 }))
-type MotionDivProps = ComponentProps<'div'> & {
-  animate?: unknown
-  initial?: unknown
-  exit?: unknown
-  transition?: unknown
-}
 
 vi.mock('@data/hooks/useCache', () => ({
   usePersistCache: () => [cache.width, vi.fn()]
 }))
-
-vi.mock('motion/react', () => ({
-  AnimatePresence: ({ children }: PropsWithChildren) => children,
-  motion: {
-    div: ({ animate, initial, exit, transition, ...props }: MotionDivProps) => {
-      void animate
-      void initial
-      void exit
-      void transition
-      return <div {...props} />
-    }
-  }
-}))
-
-function RestoreStaleWidth() {
-  const ref = useRef<HTMLDivElement>(null)
-  const resumed = useRef(false)
-
-  useLayoutEffect(() => {
-    if (resumed.current) {
-      const pane = ref.current?.closest('[data-resource-list-pane]') as HTMLElement | null
-      pane?.style.setProperty('width', '200px')
-    }
-    resumed.current = true
-  }, [])
-
-  return <div ref={ref} />
-}
 
 afterEach(() => {
   cache.width = 200
   document.documentElement.style.removeProperty('--assistants-width')
 })
 
-it('restores the current sidebar width after Activity resumes', () => {
-  const Sidebar = ({ visible }: { visible: boolean }) => (
+it('keeps the restored width through the next transition', async () => {
+  const Sidebar = ({ visible, open = true }: { visible: boolean; open?: boolean }) => (
     <Activity mode={visible ? 'visible' : 'hidden'}>
-      <PageSidebar open>
-        <RestoreStaleWidth />
-      </PageSidebar>
+      <PageSidebar open={open}>content</PageSidebar>
     </Activity>
   )
 
   const { container, rerender } = render(<Sidebar visible />)
-  const pane = container.querySelector<HTMLElement>('[data-resource-list-pane]')
+  const pane = container.querySelector<HTMLElement>('[data-resource-list-pane]')!
 
   cache.width = 283
-  rerender(<Sidebar visible />)
   rerender(<Sidebar visible={false} />)
   rerender(<Sidebar visible />)
+  await waitFor(() => {
+    expect(document.documentElement.style.getPropertyValue('--assistants-width')).toBe('283px')
+    expect(pane.style.width).toBe('var(--assistants-width)')
+  })
 
-  expect(document.documentElement.style.getPropertyValue('--assistants-width')).toBe('283px')
-  expect(pane?.style.width).toBe('var(--assistants-width)')
+  rerender(<Sidebar visible open={false} />)
+  await waitFor(() => expect(pane.style.opacity).toBe('0'))
+  rerender(<Sidebar visible />)
+  await waitFor(() => {
+    expect(pane.style.width).toBe('var(--assistants-width)')
+    expect(pane.style.opacity).toBe('1')
+  })
 })

--- a/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
@@ -19,9 +19,13 @@ vi.mock('@data/hooks/useCache', () => ({
 vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: PropsWithChildren) => children,
   motion: {
-    div: ({ animate: _animate, initial: _initial, exit: _exit, transition: _transition, ...props }: MotionDivProps) => (
-      <div {...props} />
-    )
+    div: ({ animate, initial, exit, transition, ...props }: MotionDivProps) => {
+      void animate
+      void initial
+      void exit
+      void transition
+      return <div {...props} />
+    }
   }
 }))
 

--- a/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/PageSidebar.motion.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react'
+import { Activity, type ComponentProps, type PropsWithChildren, useLayoutEffect, useRef } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { PageSidebar } from '../PageSidebar'
+
+const cache = vi.hoisted(() => ({ width: 200 }))
+type MotionDivProps = ComponentProps<'div'> & {
+  animate?: unknown
+  initial?: unknown
+  exit?: unknown
+  transition?: unknown
+}
+
+vi.mock('@data/hooks/useCache', () => ({
+  usePersistCache: () => [cache.width, vi.fn()]
+}))
+
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: PropsWithChildren) => children,
+  motion: {
+    div: ({ animate: _animate, initial: _initial, exit: _exit, transition: _transition, ...props }: MotionDivProps) => (
+      <div {...props} />
+    )
+  }
+}))
+
+function RestoreStaleWidth() {
+  const ref = useRef<HTMLDivElement>(null)
+  const resumed = useRef(false)
+
+  useLayoutEffect(() => {
+    if (resumed.current) {
+      const pane = ref.current?.closest('[data-resource-list-pane]') as HTMLElement | null
+      pane?.style.setProperty('width', '200px')
+    }
+    resumed.current = true
+  }, [])
+
+  return <div ref={ref} />
+}
+
+afterEach(() => {
+  cache.width = 200
+  document.documentElement.style.removeProperty('--assistants-width')
+})
+
+it('restores the current sidebar width after Activity resumes', () => {
+  const Sidebar = ({ visible }: { visible: boolean }) => (
+    <Activity mode={visible ? 'visible' : 'hidden'}>
+      <PageSidebar open>
+        <RestoreStaleWidth />
+      </PageSidebar>
+    </Activity>
+  )
+
+  const { container, rerender } = render(<Sidebar visible />)
+  const pane = container.querySelector<HTMLElement>('[data-resource-list-pane]')
+
+  cache.width = 283
+  rerender(<Sidebar visible />)
+  rerender(<Sidebar visible={false} />)
+  rerender(<Sidebar visible />)
+
+  expect(document.documentElement.style.getPropertyValue('--assistants-width')).toBe('283px')
+  expect(pane?.style.width).toBe('var(--assistants-width)')
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

After resizing the left resource sidebar, opening Settings and returning to Chat or Agent could leave the resize handle at a stale position that no longer matched the visible sidebar edge.

After this PR:

`PageSidebar` is the single animated width owner, its navigation content fills that box, and Motion targets the current `--assistants-width` value instead of retaining a numeric snapshot. The pane, content, and resize handle therefore remain aligned after React Activity reconnects and through subsequent or interrupted transitions.

Fixes #19100

### Why we need it and why it was done in this way

The resize handle is positioned from the outer `PageSidebar`, while the visible navigation content previously maintained its own width. React Activity preserves the DOM while disconnecting and reconnecting effects, which allowed Motion's retained numeric width to diverge from the persisted width exposed through `--assistants-width`.

This change gives the outer Motion pane one stable width source and makes the inner navigation pane fill it. No reconnect effect writes to Motion's DOM node, so the animation state and rendered width cannot become separate owners.

The following tradeoffs were made:

- The shared pane width remains exposed through the existing `--assistants-width` custom property.
- An explicit `width` prop still overrides the shared pane width for supported custom layouts.

The following alternatives were considered:

- Imperatively repairing the DOM width during Activity reconnect was rejected because Motion could reapply its retained value on the next transition.
- Adding animation controls or a second Motion value was rejected because the existing CSS custom property already provides the required single source of truth.
- Remounting the sidebar after navigation was rejected because Activity intentionally preserves UI state.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19100

### Breaking changes

None.

### Special notes for your reviewer

- Replaced the mocked-Motion regression test with a focused test using real Motion and React Activity, including the next close/open transition after reconnect.
- Mutation-checked the test by restoring the stale numeric fallback; it failed with the retained `200px` width and passed with the CSS-variable target.
- Verified 42 targeted renderer tests, `pnpm typecheck:web`, scoped Oxlint, ESLint, and Biome checks.
- Verified the real Electron flow through CDP: resize from 274px to 314px, open Settings, return with 314px restored, and reverse an in-flight collapse back to 314px while the pane, content edge, and handle remain aligned.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the left sidebar resize handle becoming misaligned after returning from Settings in Chat and Agent views.
```
