### PR TITLE
fix(model-drawer): drop native number spinners from model settings inputs

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
@@ -35,9 +35,7 @@ export function ModelContextWindowFields({
         titleClassName={drawerClasses.fieldTitle}
         className={drawerClasses.field}>
         <Input
-          type="number"
-          min={1}
-          step={1}
+          type="text"
           inputMode="numeric"
           aria-label={t('settings.models.add.context_window.label')}
           value={contextWindow}
@@ -53,9 +51,7 @@ export function ModelContextWindowFields({
         titleClassName={drawerClasses.fieldTitle}
         className={drawerClasses.field}>
         <Input
-          type="number"
-          min={1}
-          step={1}
+          type="text"
           inputMode="numeric"
           aria-label={t('settings.models.add.max_input_tokens.label')}
           value={maxInputTokens}
@@ -71,9 +67,7 @@ export function ModelContextWindowFields({
         titleClassName={drawerClasses.fieldTitle}
         className={drawerClasses.field}>
         <Input
-          type="number"
-          min={1}
-          step={1}
+          type="text"
           inputMode="numeric"
           aria-label={t('settings.models.add.max_output_tokens.label')}
           value={maxOutputTokens}

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelPricingFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelPricingFields.tsx
@@ -30,6 +30,12 @@ interface ModelPricingFieldsProps {
   onCommit: (pricing: NonNullable<Model['pricing']>) => void
 }
 
+/** Keeps digits and at most one decimal point, so the field never holds a non-numeric draft. */
+function sanitizePriceInput(value: string): string {
+  const [integerPart, ...fractionParts] = value.replace(/[^\d.]/g, '').split('.')
+  return fractionParts.length > 0 ? `${integerPart}.${fractionParts.join('')}` : integerPart
+}
+
 interface TierPriceFieldProps {
   tierIndex: number
   field: Exclude<ModelPricingDraftField, 'minInputTokens'>
@@ -72,9 +78,8 @@ function TierPriceField({
       }>
       <div className={drawerClasses.responsiveValueRow}>
         <Input
-          type="number"
-          min="0"
-          step="any"
+          type="text"
+          inputMode="decimal"
           required={!optional}
           aria-label={ariaLabel}
           aria-invalid={Boolean(error)}
@@ -82,7 +87,7 @@ function TierPriceField({
           value={value}
           placeholder={optional ? t('models.price.use_input_price') : '0.00'}
           className={drawerClasses.input}
-          onChange={(event) => onChange(field, event.target.value)}
+          onChange={(event) => onChange(field, sanitizePriceInput(event.target.value))}
           onBlur={onBlur}
         />
         <span className={drawerClasses.valueSuffix}>
@@ -167,9 +172,8 @@ function ModelPricingTierFields({
             </div>
           }>
           <Input
-            type="number"
-            min="1"
-            step="1"
+            type="text"
+            inputMode="numeric"
             required
             aria-label={minInputTokensAriaLabel}
             aria-invalid={Boolean(errors.minInputTokens)}
@@ -177,7 +181,7 @@ function ModelPricingTierFields({
             value={tier.minInputTokens}
             placeholder="0"
             className={drawerClasses.input}
-            onChange={(event) => onChange(tierIndex, 'minInputTokens', event.target.value)}
+            onChange={(event) => onChange(tierIndex, 'minInputTokens', event.target.value.replace(/[^\d]/g, ''))}
             onBlur={onBlur}
           />
         </ProviderField>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
@@ -229,6 +229,28 @@ describe('EditModelDrawer pricing', () => {
     )
   })
 
+  it('rejects non-numeric characters and a second decimal point in price inputs', async () => {
+    const user = userEvent.setup()
+    render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={makeTieredPricingModel()} />)
+
+    const cacheReadPrice = screen.getByLabelText('models.price.cache_read')
+    await user.clear(cacheReadPrice)
+    await user.type(cacheReadPrice, '1a.2.5')
+
+    expect(cacheReadPrice).toHaveValue('1.25')
+  })
+
+  it('rejects non-digits in a tier boundary input', async () => {
+    const user = userEvent.setup()
+    render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={makeTieredPricingModel()} />)
+
+    const minInputTokens = screen.getByLabelText(/models\.price\.min_input_tokens/)
+    await user.clear(minInputTokens)
+    await user.type(minInputTokens, '12a.8')
+
+    expect(minInputTokens).toHaveValue('128')
+  })
+
   it('preserves explicit zero cache rates and unedited pricing fields when a price is saved', async () => {
     const user = userEvent.setup()
     const model = makeTieredPricingModel()


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The number inputs in the model settings drawer (Settings → Model Provider → a model's edit drawer, and the add-model dialog) used `type="number"`. That meant:

- the browser painted its native spinner buttons in every one of those fields;
- a focused field silently changed its value when the wheel scrolled over it;
- the tier boundary field accepted decimals, which `parseModelPricingDraft` then rejected as `invalidMinInputTokens` via `Number.isSafeInteger` — so the user could type a value the form would never accept.

After this PR:

The five fields (context window / max input tokens / max output tokens, plus the pricing amount and tier boundary fields) use `type="text"` with `inputMode="numeric"` or `inputMode="decimal"`, and filter the typed value themselves: digits only, plus at most one decimal point for prices. No spinners, no wheel-driven edits, and the tier boundary no longer accepts a decimal it cannot use.

Fixes: N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `min` / `step` were dropped together with `type="number"`. They were decorative here: the edit drawer's `<form>` is `onSubmit={(event) => event.preventDefault()}` and saves per field on blur, and the add dialog's submit button is a `type="button"` living outside the `<form>` that calls the handler directly — so no path in this drawer ever ran native constraint validation. The real bounds stay where they already were: `Number(value) || undefined` in `EditModelDrawer`, and `parseModelPricingDraft` for pricing.
- Values stay `string` end to end, exactly as `ModelBasicFormState` and `ModelPricingTierDraft` already store them. No state, validation, or save path changed; parsing still happens only at commit time.
- Three of the five fields already carried `inputMode="numeric"` and a `replace(/[^\d]/g, '')` filter, so they were text-input behaviour wearing a `type="number"` shell. This removes the shell rather than adding anything.

The following alternatives were considered:

- **Keep `type="number"` and hide the spinner via CSS.** Rejected: it needs an `::-webkit-inner-spin-button` override *and* a non-passive native `wheel` listener (React's `onWheel` is delegated and passive, so `preventDefault` is a no-op; the common `blur()` workaround would fire the drawer's blur-autosave on every scroll). It also keeps `type="number"`'s value sanitization, which blanks the field on intermediate input such as `1.2.`.
- **Extract a shared `InputNumber` / `NumberInput` primitive in `packages/ui`.** Rejected as speculative for five call sites: the only shared logic is a one-line digit filter that was already duplicated three times before this change. `EditableNumber` (`packages/ui/src/components/composites/editable-number`) exists but is a styled composite whose call sites all override its appearance; reusing or reshaping it is a separate concern and is untouched here.
- **Change the `Input` primitive itself.** Rejected: it would silently alter every other `type="number"` field in the app, which is out of scope for this fix.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `CLAUDE.md` carries a drive-by fix in its own commit: it documented `pnpm test <path>` for running a few files, but `pnpm test` chains several `vitest run --project ...` invocations, so the path only reaches the last one while every earlier project still runs in full. It now points at the per-project scripts (`pnpm test:renderer <path>`, etc.).
- The two added tests fail on `main` for genuine reasons — the second one catches the decimal-in-tier-boundary bug described above.
- Other files in the repo still use bare `type="number"`; they are deliberately left alone.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required — no new feature or setting, only input behaviour in an existing drawer.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Model settings inputs no longer show the browser's native number spinner buttons, and no longer change value when the mouse wheel scrolls over a focused field. The pricing tier boundary field now rejects decimals instead of accepting a value the form would reject.
```
