### PR TITLE
fix(ui-input): stop native number/search UA controls leaking through Input

### DIFF
--- a/packages/ui/src/components/composites/search-input/index.tsx
+++ b/packages/ui/src/components/composites/search-input/index.tsx
@@ -5,7 +5,6 @@ import {
   InputGroupButton,
   InputGroupInput
 } from '@cherrystudio/ui/components/primitives/input-group'
-import { cn } from '@cherrystudio/ui/lib/utils'
 import { Search, X } from 'lucide-react'
 import type * as React from 'react'
 
@@ -44,13 +43,7 @@ function SearchInput({ className, value, disabled, onClear, clearLabel, size, ..
       <InputGroupAddon>
         <Search />
       </InputGroupAddon>
-      <InputGroupInput
-        type="search"
-        value={value}
-        disabled={disabled}
-        className={cn('[&::-webkit-search-cancel-button]:hidden', className)}
-        {...props}
-      />
+      <InputGroupInput type="search" value={value} disabled={disabled} className={className} {...props} />
       {showClear && (
         <InputGroupAddon align="inline-end">
           <InputGroupButton type="button" size="icon-xs" aria-label={clearLabel} disabled={disabled} onClick={onClear}>

--- a/packages/ui/src/components/primitives/__tests__/input.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/input.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
 
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
 import { Input } from '../input'
 
@@ -14,5 +14,29 @@ describe('Input', () => {
     expect(input.className).toContain('focus-visible:border-primary')
     expect(input.className).not.toMatch(/focus-visible:ring-(?!0)/)
     expect(input.className).not.toContain('focus-visible:outline-')
+  })
+
+  it('drops focus when wheeled so a number field cannot silently spin its value', () => {
+    const onWheel = vi.fn()
+    render(<Input type="number" aria-label="Port" onWheel={onWheel} />)
+
+    const input = screen.getByRole('spinbutton', { name: 'Port' })
+    input.focus()
+    const wheeled = fireEvent.wheel(input, { deltaY: 100 })
+
+    expect(document.activeElement).not.toBe(input)
+    expect(onWheel).toHaveBeenCalledOnce()
+    // Not preventDefault'd — the surrounding scroll container must still scroll.
+    expect(wheeled).toBe(true)
+  })
+
+  it('keeps focus when a non-number field is wheeled', () => {
+    render(<Input type="text" aria-label="Name" />)
+
+    const input = screen.getByRole('textbox', { name: 'Name' })
+    input.focus()
+    fireEvent.wheel(input, { deltaY: 100 })
+
+    expect(document.activeElement).toBe(input)
   })
 })

--- a/packages/ui/src/components/primitives/input.tsx
+++ b/packages/ui/src/components/primitives/input.tsx
@@ -3,14 +3,22 @@ import * as React from 'react'
 
 interface InputProps extends React.ComponentProps<'input'> {}
 
-function Input({ className, type, ...props }: InputProps) {
+function Input({ className, type, onWheel, ...props }: InputProps) {
   return (
     <input
       type={type}
       data-slot="input"
+      // Chromium spins a *focused* number field on wheel. Blur rather than
+      // preventDefault, so the value holds and the scroll still reaches the page.
+      onWheel={(event) => {
+        if (type === 'number') event.currentTarget.blur()
+        onWheel?.(event)
+      }}
       className={cn(
         'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed md:text-sm',
         'focus-visible:border-primary',
+        '[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+        '[&::-webkit-search-cancel-button]:hidden',
         'disabled:opacity-50',
         'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The `Input` primitive styled colors and borders but never neutralized the browser's own UA controls, so Chromium painted its light-grey spin buttons over every `type="number"` field (17 call sites, e.g. the model drawer's Context Window / Max Input Tokens / Max Output Tokens), wheeling a focused number field silently changed its value, and `CollapsibleSearchBar` showed Chromium's search cancel button stacked next to its own clear `X`.

After this PR:

Spin buttons and the search cancel button are suppressed at the primitive, and wheeling a number field blurs it instead of spinning the value.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

The wheel guard blurs rather than calling `preventDefault()`: Chromium only spins a *focused* number field, so blurring stops the value change while letting the wheel event still reach the surrounding scroll container — `preventDefault()` would have turned every number field into a scroll dead zone inside drawers and settings panes.

The following alternatives were considered:

Patching the three fields in the screenshot only, and switching all 17 sites to `type="text" inputMode="numeric"`; the first leaves the same defect in the other 14, and the second is 17 behavior changes that would drop load-bearing `min`/`max`/`step` (port range 1000-65535, `step="any"` decimal pricing, slider-paired painting fields). `composites/search-input` and `composites/editable-number` already applied these exact CSS fixes locally, which is the evidence that the primitive was the right place; the now-redundant copy in `search-input` is removed.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None

### Breaking changes

None. Scrolling the wheel over a number field no longer edits it — that path only ever produced accidental edits.

### Special notes for your reviewer

`InputGroupInput` forwards to `Input`, so `SearchInput` keeps its behavior with the local class removed. A user-guide update is not required for this fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Number fields such as Context Window and Max Input/Output Tokens no longer show the browser's mismatched grey spinner arrows, and scrolling over one no longer silently changes its value; the collapsible search bar no longer shows two clear buttons.
```
