### PR TITLE
test(agents-migration): fix flaky high-fan-out copy test on Windows CI

### DIFF
--- a/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
+++ b/src/main/data/migration/v2/migrators/__tests__/agentsFilesystemMigration.test.ts
@@ -839,9 +839,12 @@ describe('agentsFilesystemMigration', () => {
         sessions: [session]
       })
       try {
-        await vi.waitFor(() => {
-          expect(copyMutation.copyFileCalls.some(([source]) => source.endsWith('file-016.txt'))).toBe(true)
-        })
+        await vi.waitFor(
+          () => {
+            expect(copyMutation.copyFileCalls.some(([source]) => source.endsWith('file-016.txt'))).toBe(true)
+          },
+          { timeout: 10_000 }
+        )
       } finally {
         releaseFirst()
         await migration


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`agentsFilesystemMigration.test.ts > bounds and continuously refills filesystem work for a high-fan-out workspace` intermittently failed on `main` CI (`main-test (windows-2022)`), e.g. [run 32497575532](https://github.com/CherryHQ/cherry-studio/actions/runs/32497575532/job/96819584082) — `expected false to be true` at the `vi.waitFor` on line 843.

After this PR:

That `vi.waitFor` gets an explicit `{ timeout: 10_000 }`, so the assertion has enough headroom on slow runners.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

None

### Why we need it and why it was done in this way

The test deliberately blocks the copy of `file-000.txt` and then waits for `file-016.txt` to be copied, proving the bounded queue keeps refilling past a stalled task. Reaching the 17th copy requires 16 real filesystem copies to run, which on a Windows CI runner regularly exceeds `vi.waitFor`'s **1000 ms** default — while the surrounding `testTimeout` is 20000 ms. Raising only this wait aligns it with the file's actual work.

The following tradeoffs were made:

A wall-clock wait is still a wall-clock wait; a pathological hang now costs 10 s before failing instead of 1 s. Accepted, since the vitest `testTimeout` (20000 ms) still bounds the test.

The following alternatives were considered:

Making the copy queue deterministic/injectable so the test could await a scheduling signal instead of wall-clock progress. Rejected as disproportionate for a timeout-only flake; worth revisiting if this test flakes again for a reason other than slowness.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

None

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

<!-- optional -->

Test-only change; no production code touched. Note that the `basic-checks` failure in the linked run was fail-fast collateral (`The operation was canceled`) triggered by this same Windows test failure, not an independent break.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
