### PR TITLE
feat(security): encrypt provider credentials at rest (core)

### DIFF
--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -49,6 +49,7 @@ import { OpenClawService } from '@main/services/OpenClawService'
 import { OvmsManager } from '@main/services/OvmsManager'
 import { PdfTranslationService } from '@main/services/PdfTranslationService'
 import { ProtocolService } from '@main/services/protocol/ProtocolService'
+import { ProviderCredentialSweepService } from '@main/services/ProviderCredentialSweepService'
 import { ProviderRegistryUpdaterService } from '@main/services/ProviderRegistryUpdaterService'
 import { ProxyService } from '@main/services/proxy/ProxyService'
 import { PythonService } from '@main/services/PythonService'
@@ -150,6 +151,7 @@ export const services = {
   ApiGatewayService,
   AppUpdaterService,
   AutoBackupService,
+  ProviderCredentialSweepService,
   ProviderRegistryUpdaterService,
   SchedulerService,
   JobManager

--- a/src/main/core/security/__tests__/secretCipher.test.ts
+++ b/src/main/core/security/__tests__/secretCipher.test.ts
@@ -1,0 +1,284 @@
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+
+// The safeStorage mock is a reversible transform (encrypt ∘ decrypt = identity,
+// decrypt throws on foreign input) with a random nonce per call — mirroring the
+// real cipher's non-determinism — so tests assert round-trip contracts, not
+// byte-level snapshots.
+const { ssState, ssEncrypt, ssDecrypt } = vi.hoisted(() => ({
+  ssState: { available: true },
+  ssEncrypt: vi.fn((plain: string) => {
+    const nonce = Math.random().toString(36).slice(2)
+    return Buffer.from(`mock-ss:${nonce}:${plain}`, 'utf8')
+  }),
+  ssDecrypt: vi.fn((buffer: Buffer) => {
+    const text = buffer.toString('utf8')
+    const match = /^mock-ss:[^:]+:(.*)$/s.exec(text)
+    if (!match) {
+      throw new Error('mock safeStorage: ciphertext was not produced by this key')
+    }
+    return match[1]
+  })
+}))
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => ssState.available,
+    encryptString: ssEncrypt,
+    decryptString: ssDecrypt
+  }
+}))
+
+// Imported after the electron mock is declared.
+const { secretCipher } = await import('../secretCipher')
+
+beforeEach(() => {
+  ssState.available = true
+  ssEncrypt.mockClear()
+  ssDecrypt.mockClear()
+})
+
+afterEach(() => {
+  vi.resetModules()
+})
+
+describe('secretCipher value envelope (safeStorage backend)', () => {
+  it('round-trips a secret through a v1:ss: envelope without exposing plaintext', () => {
+    const envelope = secretCipher.encryptValue('sk-live-abc123')
+    expect(envelope).toMatch(/^v1:ss:/)
+    expect(envelope).not.toContain('sk-live-abc123')
+    expect(secretCipher.decryptValue(envelope)).toEqual({ value: 'sk-live-abc123', failed: false })
+  })
+
+  it('produces a fresh envelope per call (random IV), both decryptable', () => {
+    const a = secretCipher.encryptValue('same-secret')
+    const b = secretCipher.encryptValue('same-secret')
+    expect(a).not.toBe(b)
+    expect(secretCipher.decryptValue(a).value).toBe('same-secret')
+    expect(secretCipher.decryptValue(b).value).toBe('same-secret')
+  })
+
+  it('passes legacy plaintext (no v1: prefix) through unchanged', () => {
+    expect(secretCipher.decryptValue('sk-plain-legacy')).toEqual({ value: 'sk-plain-legacy', failed: false })
+  })
+
+  it('passes an empty string through unchanged instead of wrapping it', () => {
+    expect(secretCipher.encryptValue('')).toBe('')
+    expect(secretCipher.decryptValue('')).toEqual({ value: '', failed: false })
+  })
+
+  it('fails (does not crash, does not leak the envelope) when safeStorage cannot decrypt', () => {
+    const garbage = `v1:ss:${Buffer.from('not-from-this-key').toString('base64')}`
+    expect(secretCipher.decryptValue(garbage)).toEqual({ value: '', failed: true })
+  })
+
+  it('fails on an unknown envelope method instead of returning the envelope as the key', () => {
+    expect(secretCipher.decryptValue('v1:xyz:whatever')).toEqual({ value: '', failed: true })
+  })
+
+  it('reports the safe-storage backend when the OS keyring is available', () => {
+    expect(secretCipher.getBackend()).toBe('safe-storage')
+    expect(secretCipher.getReport()).toMatchObject({ backend: 'safe-storage' })
+  })
+})
+
+describe('secretCipher fail-closed encryption', () => {
+  it('throws when safeStorage.encryptString throws (never falls back to plaintext)', () => {
+    ssEncrypt.mockImplementationOnce(() => {
+      throw new Error('Keychain access denied')
+    })
+    expect(() => secretCipher.encryptValue('sk-denied')).toThrow(/Failed to encrypt credential/)
+  })
+
+  it('reports unavailable when neither safeStorage nor the key file can be prepared', async () => {
+    ssState.available = false
+    const fresh = await importFreshCipher({ keyfileRoot: '/nonexistent-root-no-write/z' })
+    expect(fresh.getBackend()).toBe('unavailable')
+    expect(() => fresh.encryptValue('sk-any')).toThrow(/Failed to prepare local credential key file/)
+  })
+})
+
+describe('secretCipher API-key entries', () => {
+  it('decrypts every entry and preserves id/label/isEnabled', () => {
+    const stored = secretCipher.encryptApiKeys([
+      { id: 'k1', key: 'sk-one', isEnabled: true, label: 'primary' },
+      { id: 'k2', key: 'sk-two', isEnabled: false }
+    ])
+    expect(secretCipher.decryptApiKeys('openai', stored)).toEqual([
+      { id: 'k1', key: 'sk-one', isEnabled: true, label: 'primary' },
+      { id: 'k2', key: 'sk-two', isEnabled: false }
+    ])
+  })
+
+  it('marks an undecryptable entry decryptFailed with an empty key and notifies listeners', () => {
+    const failures: unknown[] = []
+    const unsubscribe = secretCipher.onDecryptFailure((record) => failures.push(record))
+    const stored = secretCipher.encryptApiKeys([{ id: 'k1', key: 'sk-one', isEnabled: true }])
+    stored[0].key = `v1:ss:${Buffer.from('foreign').toString('base64')}`
+
+    const decrypted = secretCipher.decryptApiKeys('openai', stored)
+    unsubscribe()
+
+    expect(decrypted).toEqual([{ id: 'k1', key: '', isEnabled: true, decryptFailed: true }])
+    expect(failures).toEqual([{ providerId: 'openai', kind: 'api-key', label: 'k1' }])
+  })
+
+  it('uses the entry label in failure records when present', () => {
+    const failures: unknown[] = []
+    secretCipher.onDecryptFailure((record) => failures.push(record))
+    const decrypted = secretCipher.decryptApiKeys('openai', [
+      { id: 'k1', key: 'v1:xyz:future-format', isEnabled: true, label: 'work key' }
+    ])
+    expect(decrypted[0].decryptFailed).toBe(true)
+    expect(failures).toEqual([{ providerId: 'openai', kind: 'api-key', label: 'work key' }])
+  })
+
+  it('skips decryptFailed and empty-key entries when re-encrypting (echo round-trip)', () => {
+    const echoed = [
+      { id: 'k1', key: '', isEnabled: true, decryptFailed: true },
+      { id: 'k2', key: '', isEnabled: false }
+    ]
+    expect(secretCipher.encryptApiKeys(echoed)).toEqual(echoed)
+  })
+})
+
+describe('secretCipher authConfig field-level envelopes', () => {
+  it('wraps only the oauth tokens; clientId stays plaintext at rest', () => {
+    const stored = secretCipher.encryptAuthConfig({
+      type: 'oauth',
+      clientId: 'client-id-plain',
+      accessToken: 'at-secret',
+      refreshToken: 'rt-secret'
+    })
+    expect(stored).toMatchObject({ type: 'oauth', clientId: 'client-id-plain' })
+    expect(stored.accessToken).toMatch(/^v1:ss:/)
+    expect(stored.refreshToken).toMatch(/^v1:ss:/)
+
+    expect(secretCipher.decryptAuthConfig('github', stored)).toEqual({
+      type: 'oauth',
+      clientId: 'client-id-plain',
+      accessToken: 'at-secret',
+      refreshToken: 'rt-secret'
+    })
+  })
+
+  it('wraps the AWS long-lived credentials and round-trips them', () => {
+    const stored = secretCipher.encryptAuthConfig({
+      type: 'iam-aws',
+      region: 'us-east-1',
+      accessKeyId: 'AKIA-secret',
+      secretAccessKey: 'wJal-secret'
+    })
+    expect(stored.region).toBe('us-east-1')
+    expect(stored.accessKeyId).toMatch(/^v1:ss:/)
+    expect(secretCipher.decryptAuthConfig('bedrock', stored)).toEqual({
+      type: 'iam-aws',
+      region: 'us-east-1',
+      accessKeyId: 'AKIA-secret',
+      secretAccessKey: 'wJal-secret'
+    })
+  })
+
+  it('moves GCP credentials into the shadow envelope at rest and restores the record on read', () => {
+    const credentials = { client_email: 'svc@project.iam', private_key: '-----BEGIN KEY-----' }
+    const stored = secretCipher.encryptAuthConfig({
+      type: 'iam-gcp',
+      project: 'p',
+      location: 'global',
+      credentials
+    })
+    expect(stored.credentials).toBeUndefined()
+    expect(stored.credentialsEnvelope).toMatch(/^v1:ss:/)
+
+    const restored = secretCipher.decryptAuthConfig('vertex', stored)
+    expect(restored.credentialsEnvelope).toBeUndefined()
+    expect(restored).toEqual({ type: 'iam-gcp', project: 'p', location: 'global', credentials })
+  })
+
+  it('passes non-secret auth variants (api-key) through untouched', () => {
+    const auth = { type: 'api-key' as const, headerName: 'Authorization' }
+    expect(secretCipher.encryptAuthConfig(auth)).toEqual(auth)
+    expect(secretCipher.decryptAuthConfig('ollama', auth)).toEqual(auth)
+  })
+
+  it('empties oauth tokens and flags decryptFailed when the stored envelope is undecryptable', () => {
+    const failures: unknown[] = []
+    secretCipher.onDecryptFailure((record) => failures.push(record))
+    const restored = secretCipher.decryptAuthConfig('github', {
+      type: 'oauth',
+      clientId: 'cid',
+      accessToken: `v1:ss:${Buffer.from('foreign').toString('base64')}`,
+      refreshToken: 'v1:xyz:unknown'
+    })
+    expect(restored).toMatchObject({ decryptFailed: true, accessToken: '', refreshToken: '' })
+    expect(failures).toEqual([{ providerId: 'github', kind: 'auth-config', label: 'oauth tokens' }])
+  })
+
+  it('flags GCP credentials decryptFailed when the envelope cannot be restored', () => {
+    const failures: unknown[] = []
+    secretCipher.onDecryptFailure((record) => failures.push(record))
+    const restored = secretCipher.decryptAuthConfig('vertex', {
+      type: 'iam-gcp',
+      project: 'p',
+      location: 'global',
+      credentialsEnvelope: `v1:ss:${Buffer.from('foreign').toString('base64')}`
+    })
+    expect(restored.credentials).toBeUndefined()
+    expect(restored.decryptFailed).toBe(true)
+    expect(failures).toEqual([{ providerId: 'vertex', kind: 'auth-config', label: 'GCP credentials' }])
+  })
+})
+
+describe('secretCipher AES key-file fallback (no OS keyring)', () => {
+  let dir: string
+
+  beforeEach(() => {
+    ssState.available = false
+    dir = mkdtempSync(join(tmpdir(), 'secret-cipher-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('creates a 0600 key file in userData and round-trips through a v1:aes: envelope', async () => {
+    const cipher = await importFreshCipher({ keyfileRoot: dir })
+    const envelope = cipher.encryptValue('sk-linux-user')
+    expect(envelope).toMatch(/^v1:aes:/)
+    expect(envelope).not.toContain('sk-linux-user')
+    expect(cipher.decryptValue(envelope)).toEqual({ value: 'sk-linux-user', failed: false })
+    expect(cipher.getBackend()).toBe('aes-keyfile')
+
+    const mode = statSync(join(dir, 'secret.key')).mode & 0o777
+    expect(mode).toBe(0o600)
+  })
+
+  it('reuses an existing key file across processes instead of regenerating it', async () => {
+    const first = await importFreshCipher({ keyfileRoot: dir })
+    const envelope = first.encryptValue('sk-persisted')
+
+    const second = await importFreshCipher({ keyfileRoot: dir })
+    expect(second.decryptValue(envelope)).toEqual({ value: 'sk-persisted', failed: false })
+  })
+
+  it('throws (fail-closed) when the key file cannot be written', async () => {
+    const blocker = join(dir, 'blocker')
+    writeFileSync(blocker, 'file-where-a-directory-should-be')
+    const cipher = await importFreshCipher({ keyfileRoot: blocker })
+    expect(() => cipher.encryptValue('sk-any')).toThrow(/Failed to prepare local credential key file/)
+  })
+})
+
+/**
+ * Re-import the cipher singleton with a clean module registry and `getPath`
+ * routed at `keyfileRoot`, so key-file tests get isolated keyfile state.
+ */
+async function importFreshCipher({ keyfileRoot }: { keyfileRoot: string }) {
+  vi.resetModules()
+  const { application: freshApp } = await import('@application')
+  ;(freshApp.getPath as Mock).mockImplementation((_ns: string, filename?: string) => join(keyfileRoot, filename ?? ''))
+  return import('../secretCipher').then((m) => m.secretCipher)
+}

--- a/src/main/core/security/__tests__/secretCipher.test.ts
+++ b/src/main/core/security/__tests__/secretCipher.test.ts
@@ -306,3 +306,39 @@ async function importFreshCipher({ keyfileRoot }: { keyfileRoot: string }) {
   ;(freshApp.getPath as Mock).mockImplementation((_ns: string, filename?: string) => join(keyfileRoot, filename ?? ''))
   return import('../secretCipher').then((m) => m.secretCipher)
 }
+
+describe('secretCipher encryptApiKeys hardening', () => {
+  it('encrypts a non-empty key even when the input carries a decryptFailed flag', () => {
+    // A caller-supplied flag must never act as a "skip encryption" switch.
+    const stored = secretCipher.encryptApiKeys([{ id: 'k1', key: 'sk-flagged', isEnabled: true, decryptFailed: true }])
+    expect(stored[0].key).toMatch(/^v1:ss:/)
+    expect(stored[0].key).not.toContain('sk-flagged')
+    expect(stored[0].decryptFailed).toBeUndefined()
+  })
+
+  it('passes stored envelopes through unchanged (idempotent re-encrypt)', () => {
+    const envelope = secretCipher.encryptValue('sk-real')
+    const stored = secretCipher.encryptApiKeys([{ id: 'k1', key: envelope, isEnabled: true }])
+    expect(stored[0].key).toBe(envelope)
+  })
+})
+
+describe('secretCipher AES key-file fallback (malformed file)', () => {
+  it('recreates a malformed key file as a fresh 0600 key', async () => {
+    ssState.available = false
+    const dir = mkdtempSync(join(tmpdir(), 'secret-cipher-test-'))
+    try {
+      writeFileSync(join(dir, 'secret.key'), Buffer.alloc(8))
+
+      const cipher = await importFreshCipher({ keyfileRoot: dir })
+      const envelope = cipher.encryptValue('sk-after-recreate')
+
+      expect(cipher.decryptValue(envelope)).toEqual({ value: 'sk-after-recreate', failed: false })
+      expect(statSync(join(dir, 'secret.key')).size).toBe(32)
+      expect(statSync(join(dir, 'secret.key')).mode & 0o777).toBe(0o600)
+    } finally {
+      ssState.available = true
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/core/security/__tests__/secretCipher.test.ts
+++ b/src/main/core/security/__tests__/secretCipher.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import type { AuthConfig } from '@shared/data/types/provider'
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 
 // The safeStorage mock is a reversible transform (encrypt ∘ decrypt = identity,
@@ -34,6 +35,14 @@ vi.mock('electron', () => ({
 
 // Imported after the electron mock is declared.
 const { secretCipher } = await import('../secretCipher')
+
+/** Narrow an authConfig result to one variant so variant fields type-check. */
+function expectVariant<T extends AuthConfig['type']>(auth: AuthConfig | null, type: T) {
+  if (auth?.type !== type) {
+    throw new Error(`expected ${type} authConfig, got ${String(auth?.type ?? auth)}`)
+  }
+  return auth
+}
 
 beforeEach(() => {
   ssState.available = true
@@ -147,12 +156,15 @@ describe('secretCipher API-key entries', () => {
 
 describe('secretCipher authConfig field-level envelopes', () => {
   it('wraps only the oauth tokens; clientId stays plaintext at rest', () => {
-    const stored = secretCipher.encryptAuthConfig({
-      type: 'oauth',
-      clientId: 'client-id-plain',
-      accessToken: 'at-secret',
-      refreshToken: 'rt-secret'
-    })
+    const stored = expectVariant(
+      secretCipher.encryptAuthConfig({
+        type: 'oauth',
+        clientId: 'client-id-plain',
+        accessToken: 'at-secret',
+        refreshToken: 'rt-secret'
+      }),
+      'oauth'
+    )
     expect(stored).toMatchObject({ type: 'oauth', clientId: 'client-id-plain' })
     expect(stored.accessToken).toMatch(/^v1:ss:/)
     expect(stored.refreshToken).toMatch(/^v1:ss:/)
@@ -166,12 +178,15 @@ describe('secretCipher authConfig field-level envelopes', () => {
   })
 
   it('wraps the AWS long-lived credentials and round-trips them', () => {
-    const stored = secretCipher.encryptAuthConfig({
-      type: 'iam-aws',
-      region: 'us-east-1',
-      accessKeyId: 'AKIA-secret',
-      secretAccessKey: 'wJal-secret'
-    })
+    const stored = expectVariant(
+      secretCipher.encryptAuthConfig({
+        type: 'iam-aws',
+        region: 'us-east-1',
+        accessKeyId: 'AKIA-secret',
+        secretAccessKey: 'wJal-secret'
+      }),
+      'iam-aws'
+    )
     expect(stored.region).toBe('us-east-1')
     expect(stored.accessKeyId).toMatch(/^v1:ss:/)
     expect(secretCipher.decryptAuthConfig('bedrock', stored)).toEqual({
@@ -184,16 +199,19 @@ describe('secretCipher authConfig field-level envelopes', () => {
 
   it('moves GCP credentials into the shadow envelope at rest and restores the record on read', () => {
     const credentials = { client_email: 'svc@project.iam', private_key: '-----BEGIN KEY-----' }
-    const stored = secretCipher.encryptAuthConfig({
-      type: 'iam-gcp',
-      project: 'p',
-      location: 'global',
-      credentials
-    })
+    const stored = expectVariant(
+      secretCipher.encryptAuthConfig({
+        type: 'iam-gcp',
+        project: 'p',
+        location: 'global',
+        credentials
+      }),
+      'iam-gcp'
+    )
     expect(stored.credentials).toBeUndefined()
     expect(stored.credentialsEnvelope).toMatch(/^v1:ss:/)
 
-    const restored = secretCipher.decryptAuthConfig('vertex', stored)
+    const restored = expectVariant(secretCipher.decryptAuthConfig('vertex', stored), 'iam-gcp')
     expect(restored.credentialsEnvelope).toBeUndefined()
     expect(restored).toEqual({ type: 'iam-gcp', project: 'p', location: 'global', credentials })
   })
@@ -207,12 +225,15 @@ describe('secretCipher authConfig field-level envelopes', () => {
   it('empties oauth tokens and flags decryptFailed when the stored envelope is undecryptable', () => {
     const failures: unknown[] = []
     secretCipher.onDecryptFailure((record) => failures.push(record))
-    const restored = secretCipher.decryptAuthConfig('github', {
-      type: 'oauth',
-      clientId: 'cid',
-      accessToken: `v1:ss:${Buffer.from('foreign').toString('base64')}`,
-      refreshToken: 'v1:xyz:unknown'
-    })
+    const restored = expectVariant(
+      secretCipher.decryptAuthConfig('github', {
+        type: 'oauth',
+        clientId: 'cid',
+        accessToken: `v1:ss:${Buffer.from('foreign').toString('base64')}`,
+        refreshToken: 'v1:xyz:unknown'
+      }),
+      'oauth'
+    )
     expect(restored).toMatchObject({ decryptFailed: true, accessToken: '', refreshToken: '' })
     expect(failures).toEqual([{ providerId: 'github', kind: 'auth-config', label: 'oauth tokens' }])
   })
@@ -220,12 +241,15 @@ describe('secretCipher authConfig field-level envelopes', () => {
   it('flags GCP credentials decryptFailed when the envelope cannot be restored', () => {
     const failures: unknown[] = []
     secretCipher.onDecryptFailure((record) => failures.push(record))
-    const restored = secretCipher.decryptAuthConfig('vertex', {
-      type: 'iam-gcp',
-      project: 'p',
-      location: 'global',
-      credentialsEnvelope: `v1:ss:${Buffer.from('foreign').toString('base64')}`
-    })
+    const restored = expectVariant(
+      secretCipher.decryptAuthConfig('vertex', {
+        type: 'iam-gcp',
+        project: 'p',
+        location: 'global',
+        credentialsEnvelope: `v1:ss:${Buffer.from('foreign').toString('base64')}`
+      }),
+      'iam-gcp'
+    )
     expect(restored.credentials).toBeUndefined()
     expect(restored.decryptFailed).toBe(true)
     expect(failures).toEqual([{ providerId: 'vertex', kind: 'auth-config', label: 'GCP credentials' }])

--- a/src/main/core/security/__tests__/secretCipher.test.ts
+++ b/src/main/core/security/__tests__/secretCipher.test.ts
@@ -316,6 +316,15 @@ describe('secretCipher encryptApiKeys hardening', () => {
     expect(stored[0].decryptFailed).toBeUndefined()
   })
 
+  it('encrypts a plaintext key that merely starts with the v1: prefix', () => {
+    // A real user key like `v1:custom-gateway-token` must not be mistaken for
+    // an envelope: it is stored wrapped and still decrypts back to itself.
+    const stored = secretCipher.encryptApiKeys([{ id: 'k1', key: 'v1:custom-gateway-token', isEnabled: true }])
+    expect(stored[0].key).toMatch(/^v1:ss:/)
+    expect(stored[0].key).not.toBe('v1:custom-gateway-token')
+    expect(secretCipher.decryptValue(stored[0].key)).toEqual({ value: 'v1:custom-gateway-token', failed: false })
+  })
+
   it('passes stored envelopes through unchanged (idempotent re-encrypt)', () => {
     const envelope = secretCipher.encryptValue('sk-real')
     const stored = secretCipher.encryptApiKeys([{ id: 'k1', key: envelope, isEnabled: true }])

--- a/src/main/core/security/__tests__/secretCipher.test.ts
+++ b/src/main/core/security/__tests__/secretCipher.test.ts
@@ -41,7 +41,7 @@ function expectVariant<T extends AuthConfig['type']>(auth: AuthConfig | null, ty
   if (auth?.type !== type) {
     throw new Error(`expected ${type} authConfig, got ${String(auth?.type ?? auth)}`)
   }
-  return auth
+  return auth as Extract<AuthConfig, { type: T }>
 }
 
 beforeEach(() => {

--- a/src/main/core/security/secretCipher.ts
+++ b/src/main/core/security/secretCipher.ts
@@ -44,12 +44,22 @@ export function isEnvelopeValue(value: string): boolean {
   return typeof value === 'string' && value.startsWith(ENVELOPE_PREFIX)
 }
 
-/** Classify a stored credential value by envelope method (boot diagnostics). */
+/**
+ * Classify a stored credential value by envelope method (boot diagnostics).
+ * Unknown `v1:*:` values and corrupt non-strings read as what they effectively
+ * are on this version — not a decryptable envelope.
+ */
 export function envelopeMethodOf(value: string | undefined | null): 'ss' | 'aes' | 'unknown' | 'plain' {
-  if (!value) return 'plain'
+  if (!value || typeof value !== 'string') return 'plain'
   if (value.startsWith(`${ENVELOPE_PREFIX}${METHOD_SAFE_STORAGE}:`)) return 'ss'
   if (value.startsWith(`${ENVELOPE_PREFIX}${METHOD_AES}:`)) return 'aes'
   return isEnvelopeValue(value) ? 'unknown' : 'plain'
+}
+
+/** Whether a stored value is an envelope THIS version can decrypt. */
+function isKnownEnvelope(value: string): boolean {
+  const method = envelopeMethodOf(value)
+  return method === 'ss' || method === 'aes'
 }
 
 export interface DecryptResult {
@@ -169,16 +179,17 @@ class SecretCipher {
 
   encryptApiKeys(entries: ApiKeyEntry[]): ApiKeyEntry[] {
     return entries.map((entry) => {
-      // Skip only empty values and envelopes carried through from the stored
-      // row; a caller-supplied decryptFailed flag must never disable encryption.
-      if (!entry.key || isEnvelopeValue(entry.key)) return entry
+      // Skip only empty values and envelopes this version can still decrypt;
+      // a caller-supplied decryptFailed flag must never disable encryption.
+      // Plaintext that merely starts with `v1:` still gets wrapped.
+      if (!entry.key || isKnownEnvelope(entry.key)) return entry
       return { ...entry, key: this.encryptValue(entry.key), decryptFailed: undefined }
     })
   }
 
   /** Whether any stored key value is still legacy plaintext (sweep detection). */
   needsEncryptionApiKeys(entries: ApiKeyEntry[]): boolean {
-    return entries.some((entry) => entry.key !== '' && !isEnvelopeValue(entry.key))
+    return entries.some((entry) => !!entry.key && !isKnownEnvelope(entry.key))
   }
 
   /** Whether any secret field of `auth` is still legacy plaintext (sweep detection). */
@@ -186,9 +197,9 @@ class SecretCipher {
     if (!auth) return false
     switch (auth.type) {
       case 'oauth':
-        return [auth.accessToken, auth.refreshToken].some((value) => !!value && !isEnvelopeValue(value))
+        return [auth.accessToken, auth.refreshToken].some((value) => !!value && !isKnownEnvelope(value))
       case 'iam-aws':
-        return [auth.accessKeyId, auth.secretAccessKey].some((value) => !!value && !isEnvelopeValue(value))
+        return [auth.accessKeyId, auth.secretAccessKey].some((value) => !!value && !isKnownEnvelope(value))
       case 'iam-gcp':
         return auth.credentials !== undefined
       default:

--- a/src/main/core/security/secretCipher.ts
+++ b/src/main/core/security/secretCipher.ts
@@ -39,6 +39,11 @@ const KEYFILE_NAME = 'secret.key'
 
 export type SecretBackend = 'safe-storage' | 'aes-keyfile' | 'unavailable'
 
+/** Whether a stored value is an encrypted envelope (vs legacy plaintext). */
+export function isEnvelopeValue(value: string): boolean {
+  return value.startsWith(ENVELOPE_PREFIX)
+}
+
 export interface DecryptResult {
   value: string
   failed: boolean
@@ -159,6 +164,26 @@ class SecretCipher {
     return entries.map((entry) =>
       entry.decryptFailed || !entry.key ? entry : { ...entry, key: this.encryptValue(entry.key) }
     )
+  }
+
+  /** Whether any stored key value is still legacy plaintext (sweep detection). */
+  needsEncryptionApiKeys(entries: ApiKeyEntry[]): boolean {
+    return entries.some((entry) => entry.key !== '' && !isEnvelopeValue(entry.key))
+  }
+
+  /** Whether any secret field of `auth` is still legacy plaintext (sweep detection). */
+  needsEncryptionAuthConfig(auth: AuthConfig | null | undefined): boolean {
+    if (!auth) return false
+    switch (auth.type) {
+      case 'oauth':
+        return [auth.accessToken, auth.refreshToken].some((value) => !!value && !isEnvelopeValue(value))
+      case 'iam-aws':
+        return [auth.accessKeyId, auth.secretAccessKey].some((value) => !!value && !isEnvelopeValue(value))
+      case 'iam-gcp':
+        return auth.credentials !== undefined
+      default:
+        return false
+    }
   }
 
   decryptApiKeys(providerId: string, entries: ApiKeyEntry[]): ApiKeyEntry[] {

--- a/src/main/core/security/secretCipher.ts
+++ b/src/main/core/security/secretCipher.ts
@@ -41,7 +41,15 @@ export type SecretBackend = 'safe-storage' | 'aes-keyfile' | 'unavailable'
 
 /** Whether a stored value is an encrypted envelope (vs legacy plaintext). */
 export function isEnvelopeValue(value: string): boolean {
-  return value.startsWith(ENVELOPE_PREFIX)
+  return typeof value === 'string' && value.startsWith(ENVELOPE_PREFIX)
+}
+
+/** Classify a stored credential value by envelope method (boot diagnostics). */
+export function envelopeMethodOf(value: string | undefined | null): 'ss' | 'aes' | 'unknown' | 'plain' {
+  if (!value) return 'plain'
+  if (value.startsWith(`${ENVELOPE_PREFIX}${METHOD_SAFE_STORAGE}:`)) return 'ss'
+  if (value.startsWith(`${ENVELOPE_PREFIX}${METHOD_AES}:`)) return 'aes'
+  return isEnvelopeValue(value) ? 'unknown' : 'plain'
 }
 
 export interface DecryptResult {
@@ -153,17 +161,19 @@ class SecretCipher {
         return { value: '', failed: true }
       }
     }
-    // Unknown envelope method: a future format read by this version. Failing
-    // (not returning the envelope string as if it were the credential) keeps
-    // garbage off the wire and routes the user to the re-entry UI.
+    // Unknown envelope method: fail rather than hand the envelope string to
+    // the network as if it were the credential (future-format safety).
     logger.warn('Unknown credential envelope method', { method: rest.split(':', 1)[0] })
     return { value: '', failed: true }
   }
 
   encryptApiKeys(entries: ApiKeyEntry[]): ApiKeyEntry[] {
-    return entries.map((entry) =>
-      entry.decryptFailed || !entry.key ? entry : { ...entry, key: this.encryptValue(entry.key) }
-    )
+    return entries.map((entry) => {
+      // Skip only empty values and envelopes carried through from the stored
+      // row; a caller-supplied decryptFailed flag must never disable encryption.
+      if (!entry.key || isEnvelopeValue(entry.key)) return entry
+      return { ...entry, key: this.encryptValue(entry.key), decryptFailed: undefined }
+    })
   }
 
   /** Whether any stored key value is still legacy plaintext (sweep detection). */
@@ -188,9 +198,13 @@ class SecretCipher {
 
   decryptApiKeys(providerId: string, entries: ApiKeyEntry[]): ApiKeyEntry[] {
     return entries.map((entry) => {
+      if (typeof entry.key !== 'string') {
+        this.notifyDecryptFailure({ providerId, kind: 'api-key', label: entry.label ?? entry.id })
+        return { ...entry, key: '', decryptFailed: true }
+      }
       const result = this.decryptValue(entry.key)
       if (!result.failed) {
-        return { ...entry, key: result.value }
+        return { ...entry, key: result.value, decryptFailed: undefined }
       }
       this.notifyDecryptFailure({ providerId, kind: 'api-key', label: entry.label ?? entry.id })
       return { ...entry, key: '', decryptFailed: true }

--- a/src/main/core/security/secretCipher.ts
+++ b/src/main/core/security/secretCipher.ts
@@ -258,6 +258,7 @@ class SecretCipher {
         const envelope = this.decryptValue(auth.credentialsEnvelope)
         if (!envelope.failed) {
           try {
+            // oxlint-disable-next-line no-unused-vars
             const { credentialsEnvelope: _dropped, ...rest } = auth
             return { ...rest, credentials: JSON.parse(envelope.value) as Record<string, unknown> }
           } catch (error) {
@@ -268,6 +269,7 @@ class SecretCipher {
           }
         }
         this.notifyDecryptFailure({ providerId, kind: 'auth-config', label: 'GCP credentials' })
+        // oxlint-disable-next-line no-unused-vars
         const { credentialsEnvelope: _dropped, ...rest } = auth
         return { ...rest, decryptFailed: true }
       }

--- a/src/main/core/security/secretCipher.ts
+++ b/src/main/core/security/secretCipher.ts
@@ -1,0 +1,290 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto'
+import { chmodSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { platform } from 'node:os'
+
+import { application } from '@application'
+import { loggerService } from '@logger'
+import type { ApiKeyEntry, AuthConfig } from '@shared/data/types/provider'
+import { safeStorage } from 'electron'
+
+const logger = loggerService.withContext('SecretCipher')
+
+/**
+ * At-rest encryption for provider credentials (security review S7).
+ *
+ * Envelope formats (the prefix itself is the plaintext/ciphertext marker — no
+ * extra schema column is needed; a value without the prefix is legacy plaintext
+ * and passes through unchanged):
+ *
+ *   v1:ss:<base64(safeStorage buffer)>          OS keychain / DPAPI / libsecret
+ *   v1:aes:<base64(iv(12) || tag(16) || ct)>    Linux fallback key file (0600)
+ *
+ * Both APIs are synchronous on purpose: the credential read/write boundary
+ * lives inside better-sqlite3 transactions (sync by contract), and each value
+ * is sub-kilobyte, so the sync cost is sub-millisecond (same tradeoff as
+ * CopilotService's safeStorage usage).
+ *
+ * Error model: encrypt failures THROW (fail-closed — a credential must never
+ * silently fall back to plaintext at rest); decrypt failures return a marker
+ * so the UI can guide re-entry instead of crashing the read path.
+ */
+
+const ENVELOPE_PREFIX = 'v1:'
+const METHOD_SAFE_STORAGE = 'ss'
+const METHOD_AES = 'aes'
+const AES_KEY_BYTES = 32
+const AES_IV_BYTES = 12
+const AES_TAG_BYTES = 16
+const KEYFILE_NAME = 'secret.key'
+
+export type SecretBackend = 'safe-storage' | 'aes-keyfile' | 'unavailable'
+
+export interface DecryptResult {
+  value: string
+  failed: boolean
+}
+
+/** One credential entry that could not be decrypted (drives the re-entry UI). */
+export interface DecryptFailureRecord {
+  providerId: string
+  kind: 'api-key' | 'auth-config'
+  /** Key label (falls back to the entry id) or the auth-config field name. */
+  label: string
+}
+
+export interface SecretCipherReport {
+  platform: string
+  backend: SecretBackend
+}
+
+type DecryptFailureListener = (record: DecryptFailureRecord) => void
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+class SecretCipher {
+  private aesKey: Buffer | null = null
+  private readonly listeners = new Set<DecryptFailureListener>()
+
+  /** Non-lifecycle singleton: no boot side effects, no long-lived resources. */
+  getBackend(): SecretBackend {
+    try {
+      if (safeStorage.isEncryptionAvailable()) {
+        return 'safe-storage'
+      }
+    } catch (error) {
+      logger.warn('safeStorage availability check failed', { error: errorMessage(error) })
+    }
+    return this.tryLoadAesKey() !== null ? 'aes-keyfile' : 'unavailable'
+  }
+
+  getReport(): SecretCipherReport {
+    return { platform: platform(), backend: this.getBackend() }
+  }
+
+  onDecryptFailure(listener: DecryptFailureListener): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private notifyDecryptFailure(record: DecryptFailureRecord): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(record)
+      } catch (error) {
+        logger.warn('Decrypt-failure listener threw', { error: errorMessage(error) })
+      }
+    }
+  }
+
+  encryptValue(plain: string): string {
+    if (!plain) return plain
+    try {
+      if (safeStorage.isEncryptionAvailable()) {
+        return ENVELOPE_PREFIX + METHOD_SAFE_STORAGE + ':' + safeStorage.encryptString(plain).toString('base64')
+      }
+    } catch (error) {
+      throw new Error(`Failed to encrypt credential via OS secure storage: ${errorMessage(error)}`)
+    }
+    const key = this.requireAesKey()
+    const iv = randomBytes(AES_IV_BYTES)
+    const cipher = createCipheriv('aes-256-gcm', key, iv)
+    const ciphertext = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()])
+    const tag = cipher.getAuthTag()
+    return ENVELOPE_PREFIX + METHOD_AES + ':' + Buffer.concat([iv, tag, ciphertext]).toString('base64')
+  }
+
+  decryptValue(envelope: string): DecryptResult {
+    if (!envelope.startsWith(ENVELOPE_PREFIX)) {
+      return { value: envelope, failed: false }
+    }
+    const rest = envelope.slice(ENVELOPE_PREFIX.length)
+    if (rest.startsWith(`${METHOD_SAFE_STORAGE}:`)) {
+      try {
+        const buffer = Buffer.from(rest.slice(METHOD_SAFE_STORAGE.length + 1), 'base64')
+        return { value: safeStorage.decryptString(buffer), failed: false }
+      } catch (error) {
+        logger.warn('safeStorage decrypt failed', { error: errorMessage(error) })
+        return { value: '', failed: true }
+      }
+    }
+    if (rest.startsWith(`${METHOD_AES}:`)) {
+      try {
+        const raw = Buffer.from(rest.slice(METHOD_AES.length + 1), 'base64')
+        const key = this.tryLoadAesKey()
+        if (!key || raw.length <= AES_IV_BYTES + AES_TAG_BYTES) {
+          return { value: '', failed: true }
+        }
+        const decipher = createDecipheriv('aes-256-gcm', key, raw.subarray(0, AES_IV_BYTES))
+        decipher.setAuthTag(raw.subarray(AES_IV_BYTES, AES_IV_BYTES + AES_TAG_BYTES))
+        const plain = Buffer.concat([
+          decipher.update(raw.subarray(AES_IV_BYTES + AES_TAG_BYTES)),
+          decipher.final()
+        ]).toString('utf8')
+        return { value: plain, failed: false }
+      } catch (error) {
+        logger.warn('AES key-file decrypt failed', { error: errorMessage(error) })
+        return { value: '', failed: true }
+      }
+    }
+    // Unknown envelope method: a future format read by this version. Failing
+    // (not returning the envelope string as if it were the credential) keeps
+    // garbage off the wire and routes the user to the re-entry UI.
+    logger.warn('Unknown credential envelope method', { method: rest.split(':', 1)[0] })
+    return { value: '', failed: true }
+  }
+
+  encryptApiKeys(entries: ApiKeyEntry[]): ApiKeyEntry[] {
+    return entries.map((entry) =>
+      entry.decryptFailed || !entry.key ? entry : { ...entry, key: this.encryptValue(entry.key) }
+    )
+  }
+
+  decryptApiKeys(providerId: string, entries: ApiKeyEntry[]): ApiKeyEntry[] {
+    return entries.map((entry) => {
+      const result = this.decryptValue(entry.key)
+      if (!result.failed) {
+        return { ...entry, key: result.value }
+      }
+      this.notifyDecryptFailure({ providerId, kind: 'api-key', label: entry.label ?? entry.id })
+      return { ...entry, key: '', decryptFailed: true }
+    })
+  }
+
+  encryptAuthConfig(auth: AuthConfig | null | undefined): AuthConfig | null {
+    if (!auth) return auth ?? null
+    switch (auth.type) {
+      case 'oauth':
+        return {
+          ...auth,
+          decryptFailed: undefined,
+          accessToken: this.encryptValue(auth.accessToken ?? ''),
+          refreshToken: this.encryptValue(auth.refreshToken ?? '')
+        }
+      case 'iam-aws':
+        return {
+          ...auth,
+          decryptFailed: undefined,
+          accessKeyId: this.encryptValue(auth.accessKeyId ?? ''),
+          secretAccessKey: this.encryptValue(auth.secretAccessKey ?? '')
+        }
+      case 'iam-gcp': {
+        const { credentials, ...rest } = auth
+        return {
+          ...rest,
+          decryptFailed: undefined,
+          // GCP credentials are a JSON record; the envelope lives in a shadow
+          // string field so the record shape stays schema-valid.
+          credentialsEnvelope: credentials ? this.encryptValue(JSON.stringify(credentials)) : undefined
+        }
+      }
+      default:
+        // api-key / api-key-aws / iam-azure carry no secrets — nothing to wrap.
+        return auth
+    }
+  }
+
+  decryptAuthConfig(providerId: string, auth: AuthConfig | null | undefined): AuthConfig | null {
+    if (!auth) return auth ?? null
+    switch (auth.type) {
+      case 'oauth': {
+        const accessToken = this.decryptValue(auth.accessToken ?? '')
+        const refreshToken = this.decryptValue(auth.refreshToken ?? '')
+        if (!accessToken.failed && !refreshToken.failed) {
+          return { ...auth, accessToken: accessToken.value, refreshToken: refreshToken.value }
+        }
+        this.notifyDecryptFailure({ providerId, kind: 'auth-config', label: 'oauth tokens' })
+        return { ...auth, accessToken: '', refreshToken: '', decryptFailed: true }
+      }
+      case 'iam-aws': {
+        const accessKeyId = this.decryptValue(auth.accessKeyId ?? '')
+        const secretAccessKey = this.decryptValue(auth.secretAccessKey ?? '')
+        if (!accessKeyId.failed && !secretAccessKey.failed) {
+          return { ...auth, accessKeyId: accessKeyId.value, secretAccessKey: secretAccessKey.value }
+        }
+        this.notifyDecryptFailure({ providerId, kind: 'auth-config', label: 'AWS credentials' })
+        return { ...auth, accessKeyId: '', secretAccessKey: '', decryptFailed: true }
+      }
+      case 'iam-gcp': {
+        if (!auth.credentialsEnvelope) {
+          return auth
+        }
+        const envelope = this.decryptValue(auth.credentialsEnvelope)
+        if (!envelope.failed) {
+          try {
+            const { credentialsEnvelope: _dropped, ...rest } = auth
+            return { ...rest, credentials: JSON.parse(envelope.value) as Record<string, unknown> }
+          } catch (error) {
+            logger.warn('GCP credentials envelope did not parse as JSON', {
+              providerId,
+              error: errorMessage(error)
+            })
+          }
+        }
+        this.notifyDecryptFailure({ providerId, kind: 'auth-config', label: 'GCP credentials' })
+        const { credentialsEnvelope: _dropped, ...rest } = auth
+        return { ...rest, decryptFailed: true }
+      }
+      default:
+        return auth
+    }
+  }
+
+  private tryLoadAesKey(): Buffer | null {
+    if (this.aesKey) return this.aesKey
+    try {
+      const keyfilePath = application.getPath('app.userdata', KEYFILE_NAME)
+      if (existsSync(keyfilePath)) {
+        const existing = readFileSync(keyfilePath)
+        if (existing.length === AES_KEY_BYTES) {
+          this.aesKey = existing
+          return existing
+        }
+        logger.warn('Malformed credential key file; recreating', { size: existing.length })
+      }
+      // Sync IO is deliberate: called at most once per process from within
+      // (sync) credential write paths, and the payload is 32 bytes.
+      const created = randomBytes(AES_KEY_BYTES)
+      writeFileSync(keyfilePath, created, { mode: 0o600 })
+      // writeFileSync mode only applies to newly created files; re-apply in
+      // case a pre-existing malformed file had drifted to looser permissions.
+      chmodSync(keyfilePath, 0o600)
+      this.aesKey = created
+      return created
+    } catch (error) {
+      logger.error('Failed to prepare AES credential key file', { error: errorMessage(error) })
+      return null
+    }
+  }
+
+  private requireAesKey(): Buffer {
+    const key = this.tryLoadAesKey()
+    if (!key) {
+      throw new Error('Failed to prepare local credential key file')
+    }
+    return key
+  }
+}
+
+export const secretCipher = new SecretCipher()

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -419,6 +419,7 @@ class ProviderService {
           providerSettings: userProviderTable.providerSettings,
           apiFeatures: userProviderTable.apiFeatures,
           endpointConfigs: userProviderTable.endpointConfigs,
+          authConfig: userProviderTable.authConfig,
           isEnabled: userProviderTable.isEnabled,
           presetProviderId: userProviderTable.presetProviderId
         })
@@ -447,7 +448,13 @@ class ProviderService {
           current.endpointConfigs
         )
       }
-      if (dto.authConfig !== undefined) updates.authConfig = secretCipher.encryptAuthConfig(dto.authConfig)
+      if (dto.authConfig !== undefined) {
+        // A decryptFailed echo carries empty secrets; overwriting would drop
+        // the stored envelope a later successful decrypt could still restore.
+        const isFailedEcho =
+          dto.authConfig !== null && 'decryptFailed' in dto.authConfig && dto.authConfig.decryptFailed === true
+        updates.authConfig = isFailedEcho ? current.authConfig : secretCipher.encryptAuthConfig(dto.authConfig)
+      }
       const presetMetadata =
         dto.defaultChatEndpoint !== undefined || dto.apiFeatures !== undefined
           ? getDataService('ProviderRegistryService').getProviderDisplayMetadata(providerId, current.presetProviderId)
@@ -551,7 +558,8 @@ class ProviderService {
       return matched ? toResolvedProviderApiKey(override, 'matched', matched) : unknownCredential(override)
     }
 
-    const enabledKeys = allKeys.filter((k) => k.isEnabled)
+    // decryptFailed entries hold an empty value — never serve them to the wire.
+    const enabledKeys = allKeys.filter((k) => k.isEnabled && !k.decryptFailed)
 
     if (enabledKeys.length === 0) {
       return unknownCredential('')
@@ -636,7 +644,8 @@ class ProviderService {
 
       // Decrypt for the plaintext dedupe below, re-encrypt the whole list on
       // write (envelopes are randomized and never comparable at rest).
-      const existingKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
+      const storedKeys = row.apiKeys ?? []
+      const existingKeys = secretCipher.decryptApiKeys(providerId, storedKeys)
 
       // Skip if key value already exists
       if (existingKeys.some((k) => k.key === key)) {
@@ -650,7 +659,12 @@ class ProviderService {
         isEnabled: true
       }
 
-      const updatedKeys = secretCipher.encryptApiKeys([...existingKeys, newEntry])
+      // Failed entries carry their original envelope through so a transient
+      // decrypt failure (e.g. one denied Keychain prompt) stays recoverable.
+      const updatedKeys = secretCipher.encryptApiKeys([
+        ...existingKeys.map((entry, index) => (entry.decryptFailed ? storedKeys[index] : entry)),
+        newEntry
+      ])
 
       const [updated] = tx
         .update(userProviderTable)
@@ -682,7 +696,8 @@ class ProviderService {
       const [current] = tx
         .select({
           providerId: userProviderTable.providerId,
-          presetProviderId: userProviderTable.presetProviderId
+          presetProviderId: userProviderTable.presetProviderId,
+          apiKeys: userProviderTable.apiKeys
         })
         .from(userProviderTable)
         .where(eq(userProviderTable.providerId, providerId))
@@ -692,10 +707,19 @@ class ProviderService {
       assertProviderAvailable(current, providerId)
 
       const normalizedApiKeys = normalizeApiKeyEntries(apiKeys)
+      // An echoed decryptFailed entry (empty key) has nothing to encrypt —
+      // keep the stored envelope for that id so the failure stays recoverable.
+      const storedById = new Map((current.apiKeys ?? []).map((entry) => [entry.id, entry]))
+      const carriedApiKeys = normalizedApiKeys.map((entry) => {
+        const stored = entry.key ? undefined : storedById.get(entry.id)
+        return stored
+          ? { ...stored, isEnabled: entry.isEnabled, ...(entry.label ? { label: entry.label } : {}) }
+          : entry
+      })
       // Fail-closed: an encrypt failure aborts the transaction, never stores plaintext.
       const [row] = tx
         .update(userProviderTable)
-        .set({ apiKeys: secretCipher.encryptApiKeys(normalizedApiKeys) })
+        .set({ apiKeys: secretCipher.encryptApiKeys(carriedApiKeys) })
         .where(eq(userProviderTable.providerId, providerId))
         .returning()
         .all()
@@ -739,7 +763,8 @@ class ProviderService {
 
       // Decrypt first: the dedupe compare and the entry merge below work on
       // plaintext; the result is re-encrypted as a whole before it lands.
-      const existingKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
+      const storedKeys = row.apiKeys ?? []
+      const existingKeys = secretCipher.decryptApiKeys(providerId, storedKeys)
       const keyIndex = existingKeys.findIndex((entry) => entry.id === keyId)
 
       if (keyIndex === -1) {
@@ -755,13 +780,19 @@ class ProviderService {
         throw DataApiErrorFactory.conflict('API key already exists', 'API key')
       }
 
+      // Failed entries keep their original envelope unless this update hands
+      // them a fresh key value (a transient decrypt failure stays recoverable).
       const updatedKeys = existingKeys.map((entry, index) => {
+        if (entry.decryptFailed && index !== keyIndex) {
+          return storedKeys[index]
+        }
+
         if (index !== keyIndex) {
           return entry
         }
 
         const updatedEntry = {
-          ...entry,
+          ...(entry.decryptFailed && !nextKeyValue ? storedKeys[index] : entry),
           ...(updates.isEnabled !== undefined ? { isEnabled: updates.isEnabled } : {}),
           // A fresh key value supersedes any decryptFailed marker.
           ...(nextKeyValue ? { key: nextKeyValue, decryptFailed: undefined } : {})

--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -24,6 +24,7 @@ import {
   reconcileLogoSlotTx
 } from '@data/services/utils/singleFileRef'
 import { loggerService } from '@logger'
+import { secretCipher } from '@main/core/security/secretCipher'
 import { DataApiError, DataApiErrorFactory, ErrorCode } from '@shared/data/api/errors'
 import type { OrderBatchRequest, OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
 import type { CreateProviderDto, ListProvidersQuery, UpdateProviderDto } from '@shared/data/api/schemas/providers'
@@ -117,7 +118,9 @@ function assertProviderAvailable<T extends ProviderIdentity>(
 
 function normalizeApiKeyEntry(entry: ApiKeyEntry): ApiKeyEntry {
   const key = entry.key.trim()
-  if (!key) {
+  // Empty is valid only as a decryptFailed echo (S7): the value is gone, only
+  // id/label/isEnabled survive; the rebuild below strips the marker.
+  if (!key && !entry.decryptFailed) {
     throw DataApiErrorFactory.validation({ key: ['API key cannot be empty'] })
   }
 
@@ -134,13 +137,14 @@ function normalizeApiKeyEntries(apiKeys: ApiKeyEntry[]): ApiKeyEntry[] {
   const seenIds = new Set<string>()
   return apiKeys.map((entry) => {
     const normalized = normalizeApiKeyEntry(entry)
-    if (seenKeys.has(normalized.key)) {
+    // Empty (decryptFailed echo) keys cannot meaningfully collide — skip them.
+    if (normalized.key && seenKeys.has(normalized.key)) {
       throw DataApiErrorFactory.conflict('API key already exists', 'API key')
     }
     if (seenIds.has(normalized.id)) {
       throw DataApiErrorFactory.conflict('API key id already exists', 'API key')
     }
-    seenKeys.add(normalized.key)
+    if (normalized.key) seenKeys.add(normalized.key)
     seenIds.add(normalized.id)
     return normalized
   })
@@ -371,8 +375,8 @@ class ProviderService {
             logoKey: logoCols.logoKey,
             endpointConfigs,
             defaultChatEndpoint,
-            apiKeys: dto.apiKeys ?? [],
-            authConfig: dto.authConfig ?? null,
+            apiKeys: secretCipher.encryptApiKeys(dto.apiKeys ?? []),
+            authConfig: secretCipher.encryptAuthConfig(dto.authConfig ?? null),
             apiFeatures,
             providerSettings: dto.providerSettings ?? null,
             isEnabled: false
@@ -443,7 +447,7 @@ class ProviderService {
           current.endpointConfigs
         )
       }
-      if (dto.authConfig !== undefined) updates.authConfig = dto.authConfig
+      if (dto.authConfig !== undefined) updates.authConfig = secretCipher.encryptAuthConfig(dto.authConfig)
       const presetMetadata =
         dto.defaultChatEndpoint !== undefined || dto.apiFeatures !== undefined
           ? getDataService('ProviderRegistryService').getProviderDisplayMetadata(providerId, current.presetProviderId)
@@ -539,7 +543,9 @@ class ProviderService {
 
     assertProviderAvailable(row, providerId)
 
-    const allKeys = row.apiKeys ?? []
+    // Decrypt inside the boundary: override matching, rotation, and masking all
+    // operate on plaintext, and connection signatures hash these values (S7).
+    const allKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
     if (override !== undefined) {
       const matched = allKeys.find((entry) => entry.key === override)
       return matched ? toResolvedProviderApiKey(override, 'matched', matched) : unknownCredential(override)
@@ -594,7 +600,7 @@ class ProviderService {
 
     assertProviderAvailable(row, providerId)
 
-    const apiKeys = row.apiKeys ?? []
+    const apiKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
     return options.enabled ? apiKeys.filter((k) => k.isEnabled) : apiKeys
   }
 
@@ -607,7 +613,7 @@ class ProviderService {
 
     assertProviderAvailable(row, providerId)
 
-    return row.authConfig ?? null
+    return secretCipher.decryptAuthConfig(providerId, row.authConfig)
   }
 
   /**
@@ -628,7 +634,9 @@ class ProviderService {
 
       assertProviderAvailable(row, providerId)
 
-      const existingKeys = row.apiKeys ?? []
+      // Decrypt for the plaintext dedupe below, re-encrypt the whole list on
+      // write (envelopes are randomized and never comparable at rest).
+      const existingKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
 
       // Skip if key value already exists
       if (existingKeys.some((k) => k.key === key)) {
@@ -642,7 +650,7 @@ class ProviderService {
         isEnabled: true
       }
 
-      const updatedKeys = [...existingKeys, newEntry]
+      const updatedKeys = secretCipher.encryptApiKeys([...existingKeys, newEntry])
 
       const [updated] = tx
         .update(userProviderTable)
@@ -684,9 +692,10 @@ class ProviderService {
       assertProviderAvailable(current, providerId)
 
       const normalizedApiKeys = normalizeApiKeyEntries(apiKeys)
+      // Fail-closed: an encrypt failure aborts the transaction, never stores plaintext.
       const [row] = tx
         .update(userProviderTable)
-        .set({ apiKeys: normalizedApiKeys })
+        .set({ apiKeys: secretCipher.encryptApiKeys(normalizedApiKeys) })
         .where(eq(userProviderTable.providerId, providerId))
         .returning()
         .all()
@@ -728,7 +737,9 @@ class ProviderService {
 
       assertProviderAvailable(row, providerId)
 
-      const existingKeys = row.apiKeys ?? []
+      // Decrypt first: the dedupe compare and the entry merge below work on
+      // plaintext; the result is re-encrypted as a whole before it lands.
+      const existingKeys = secretCipher.decryptApiKeys(providerId, row.apiKeys ?? [])
       const keyIndex = existingKeys.findIndex((entry) => entry.id === keyId)
 
       if (keyIndex === -1) {
@@ -752,7 +763,8 @@ class ProviderService {
         const updatedEntry = {
           ...entry,
           ...(updates.isEnabled !== undefined ? { isEnabled: updates.isEnabled } : {}),
-          ...(nextKeyValue ? { key: nextKeyValue } : {})
+          // A fresh key value supersedes any decryptFailed marker.
+          ...(nextKeyValue ? { key: nextKeyValue, decryptFailed: undefined } : {})
         }
 
         if (updates.label !== undefined) {
@@ -768,7 +780,7 @@ class ProviderService {
 
       const [updated] = tx
         .update(userProviderTable)
-        .set({ apiKeys: updatedKeys })
+        .set({ apiKeys: secretCipher.encryptApiKeys(updatedKeys) })
         .where(eq(userProviderTable.providerId, providerId))
         .returning()
         .all()

--- a/src/main/data/services/__tests__/ProviderService.apiKeys.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.apiKeys.test.ts
@@ -5,6 +5,7 @@ import { userProviderTable } from '@data/db/schemas/userProvider'
 import { providerRegistryService } from '@data/services/ProviderRegistryService'
 import { providerService } from '@data/services/ProviderService'
 import { generateOrderKeyBetween } from '@data/services/utils/orderKey'
+import { secretCipher } from '@main/core/security/secretCipher'
 import { ErrorCode } from '@shared/data/api/errors'
 import { AddProviderApiKeySchema, ReplaceProviderApiKeysSchema } from '@shared/data/api/schemas/providers'
 import { CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
@@ -12,6 +13,28 @@ import { setupTestDatabase } from '@test-helpers/db'
 import { MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Reversible safeStorage stand-in: encrypt ∘ decrypt = identity. The service's
+// write path fail-closes without a keyring, so these mutation tests need it.
+const { ssEncrypt, ssDecrypt } = vi.hoisted(() => ({
+  ssEncrypt: vi.fn((plain: string) => {
+    const nonce = Math.random().toString(36).slice(2)
+    return Buffer.from(`mock-ss:${nonce}:${plain}`, 'utf8')
+  }),
+  ssDecrypt: vi.fn((buffer: Buffer) => {
+    const match = /^mock-ss:[^:]+:(.*)$/s.exec(buffer.toString('utf8'))
+    if (!match) throw new Error('mock safeStorage: ciphertext was not produced by this key')
+    return match[1]
+  })
+}))
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: ssEncrypt,
+    decryptString: ssDecrypt
+  }
+}))
 
 // The API-key mutators are synchronous under better-sqlite3: failing calls throw
 // inline instead of rejecting a promise. Capture the thrown error to assert its shape.
@@ -52,9 +75,12 @@ describe('ProviderService API keys', () => {
     })
   }
 
+  // Reads the stored row decrypted, so assertions stay at the plaintext
+  // behavior level while writes persist envelopes (at-rest format is pinned
+  // separately in ProviderService.credentials.test.ts).
   async function readApiKeys() {
     const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, 'openai'))
-    return row?.apiKeys ?? []
+    return secretCipher.decryptApiKeys('openai', row?.apiKeys ?? [])
   }
 
   async function seedManagedCherryAiProvider() {
@@ -279,7 +305,7 @@ describe('ProviderService API keys', () => {
 
     const readApiKeysFor = async (providerId: string) => {
       const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId))
-      return row?.apiKeys ?? []
+      return secretCipher.decryptApiKeys(providerId, row?.apiKeys ?? [])
     }
 
     const [addedKey] = await readApiKeysFor('parity-add')

--- a/src/main/data/services/__tests__/ProviderService.credentials.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.credentials.test.ts
@@ -1,0 +1,207 @@
+// Load the sibling so it self-registers in the data-service registry (prod loads it via its DataApi handler).
+import '@data/services/ProviderRegistryService'
+
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import { providerService } from '@data/services/ProviderService'
+import { secretCipher } from '@main/core/security/secretCipher'
+import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it, vi } from 'vitest'
+
+// Reversible safeStorage stand-in so at-rest ciphertext assertions can verify
+// real envelopes (v1:ss:) and reads can be cross-checked against plaintext.
+const { ssEncrypt, ssDecrypt } = vi.hoisted(() => ({
+  ssEncrypt: vi.fn((plain: string) => {
+    const nonce = Math.random().toString(36).slice(2)
+    return Buffer.from(`mock-ss:${nonce}:${plain}`, 'utf8')
+  }),
+  ssDecrypt: vi.fn((buffer: Buffer) => {
+    const match = /^mock-ss:[^:]+:(.*)$/s.exec(buffer.toString('utf8'))
+    if (!match) throw new Error('mock safeStorage: ciphertext was not produced by this key')
+    return match[1]
+  })
+}))
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: ssEncrypt,
+    decryptString: ssDecrypt
+  }
+}))
+
+describe('ProviderService credential read/write boundary (S7)', () => {
+  const dbh = setupTestDatabase()
+
+  async function rawRow(providerId: string) {
+    const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId))
+    return row
+  }
+
+  async function seedProvider(providerId: string) {
+    await dbh.db.insert(userProviderTable).values({ providerId, name: providerId, orderKey: 'a0' })
+  }
+
+  it('stores API keys as envelopes while reads return plaintext', async () => {
+    await seedProvider('openai')
+
+    providerService.addApiKey('openai', 'sk-plain-1', 'primary')
+
+    const row = await rawRow('openai')
+    expect(row.apiKeys).toHaveLength(1)
+    expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(row.apiKeys[0].key).not.toContain('sk-plain-1')
+    expect(row.apiKeys[0]).toMatchObject({ label: 'primary', isEnabled: true })
+
+    expect(providerService.getApiKeys('openai')).toEqual([
+      { id: row.apiKeys[0].id, key: 'sk-plain-1', label: 'primary', isEnabled: true }
+    ])
+  })
+
+  it('dedupes a re-added key against the decrypted stored value', async () => {
+    await seedProvider('openai')
+
+    providerService.addApiKey('openai', 'sk-a')
+    providerService.addApiKey('openai', 'sk-a')
+
+    const row = await rawRow('openai')
+    expect(row.apiKeys).toHaveLength(1)
+  })
+
+  it('resolves API keys to plaintext for the wire (override match included)', async () => {
+    await seedProvider('openai')
+    providerService.addApiKey('openai', 'sk-a')
+    providerService.addApiKey('openai', 'sk-b')
+
+    const resolved = providerService.resolveApiKey('openai', 'sk-b')
+    expect(resolved.value).toBe('sk-b')
+    expect(resolved.apiKeySelection).toMatchObject({ attribution: 'matched', id: expect.any(String) })
+  })
+
+  it('rewrites a key update as a fresh envelope with the plaintext gone', async () => {
+    await seedProvider('openai')
+    providerService.addApiKey('openai', 'sk-old')
+    const rowBefore = await rawRow('openai')
+
+    providerService.updateApiKey('openai', rowBefore.apiKeys[0].id, { key: 'sk-new' })
+
+    const row = await rawRow('openai')
+    expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(row.apiKeys[0].key).not.toContain('sk-new')
+    expect(row.apiKeys[0].key).not.toBe(rowBefore.apiKeys[0].key)
+    expect(providerService.getApiKeys('openai')[0].key).toBe('sk-new')
+  })
+
+  it('strips the decryptFailed marker when replacing with echoed entries', async () => {
+    await seedProvider('openai')
+
+    providerService.replaceApiKeys('openai', [
+      { id: 'k-live', key: 'sk-live', isEnabled: true },
+      { id: 'k-failed', key: '', decryptFailed: true, isEnabled: true }
+    ])
+
+    const row = await rawRow('openai')
+    expect(row.apiKeys.find((entry) => entry.id === 'k-live')?.key).toMatch(/^v1:ss:/)
+    const failed = row.apiKeys.find((entry) => entry.id === 'k-failed')
+    expect(failed).toMatchObject({ key: '', isEnabled: true })
+    expect(failed?.decryptFailed).toBeUndefined()
+  })
+
+  it('clears decryptFailed when an updated key value re-secures the entry', async () => {
+    await seedProvider('openai')
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'echo',
+      name: 'echo',
+      orderKey: 'a1',
+      apiKeys: [{ id: 'k1', key: '', decryptFailed: true, isEnabled: true }]
+    })
+
+    providerService.updateApiKey('echo', 'k1', { key: 'sk-reentered' })
+
+    const decrypted = secretCipher.decryptApiKeys('echo', (await rawRow('echo')).apiKeys)
+    expect(decrypted[0]).toMatchObject({ key: 'sk-reentered', isEnabled: true })
+    expect(decrypted[0].decryptFailed).toBeUndefined()
+  })
+
+  it('wraps authConfig tokens on update and restores them on read', async () => {
+    await seedProvider('oauth-demo')
+
+    providerService.update('oauth-demo', {
+      authConfig: { type: 'oauth', clientId: 'client-plain', accessToken: 'at-secret', refreshToken: 'rt-secret' }
+    })
+
+    const row = await rawRow('oauth-demo')
+    expect(row.authConfig).toMatchObject({ type: 'oauth', clientId: 'client-plain' })
+    expect(row.authConfig?.accessToken).toMatch(/^v1:ss:/)
+    expect(row.authConfig?.refreshToken).not.toContain('rt-secret')
+
+    expect(providerService.getAuthConfig('oauth-demo')).toEqual({
+      type: 'oauth',
+      clientId: 'client-plain',
+      accessToken: 'at-secret',
+      refreshToken: 'rt-secret'
+    })
+  })
+
+  it('moves GCP credentials into the shadow envelope on create and restores them on read', async () => {
+    const credentials = { client_email: 'svc@p.iam', private_key: '-----BEGIN KEY-----' }
+    providerService.create({
+      providerId: 'vertex',
+      name: 'Vertex',
+      authConfig: { type: 'iam-gcp', project: 'p', location: 'global', credentials }
+    })
+
+    const row = await rawRow('vertex')
+    expect(row.authConfig?.credentials).toBeUndefined()
+    expect(row.authConfig?.credentialsEnvelope).toMatch(/^v1:ss:/)
+
+    expect(providerService.getAuthConfig('vertex')).toEqual({
+      type: 'iam-gcp',
+      project: 'p',
+      location: 'global',
+      credentials
+    })
+  })
+
+  it('encrypts apiKeys on the create path too', async () => {
+    providerService.create({
+      providerId: 'fresh',
+      name: 'Fresh',
+      apiKeys: [{ id: 'k1', key: 'sk-create', isEnabled: true }]
+    })
+
+    const row = await rawRow('fresh')
+    expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(providerService.getApiKeys('fresh')[0].key).toBe('sk-create')
+  })
+
+  it('marks an undecryptable stored envelope decryptFailed on read', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'broken',
+      name: 'broken',
+      orderKey: 'a0',
+      apiKeys: [
+        { id: 'k1', key: `v1:ss:${Buffer.from('foreign-key').toString('base64')}`, isEnabled: true, label: 'work' }
+      ]
+    })
+
+    expect(providerService.getApiKeys('broken')).toEqual([
+      { id: 'k1', key: '', isEnabled: true, label: 'work', decryptFailed: true }
+    ])
+  })
+
+  it('fails closed on an encrypt error: the write aborts and nothing lands in the row', async () => {
+    await seedProvider('openai')
+    providerService.addApiKey('openai', 'sk-first')
+    const before = (await rawRow('openai')).apiKeys
+
+    ssEncrypt.mockImplementationOnce(() => {
+      throw new Error('Keychain access denied')
+    })
+    expect(() => providerService.addApiKey('openai', 'sk-second')).toThrow(/Failed to encrypt credential/)
+
+    const row = await rawRow('openai')
+    expect(row.apiKeys).toEqual(before)
+    expect(JSON.stringify(row.apiKeys)).not.toContain('sk-second')
+  })
+})

--- a/src/main/data/services/__tests__/ProviderService.credentials.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.credentials.test.ts
@@ -1,9 +1,10 @@
 // Load the sibling so it self-registers in the data-service registry (prod loads it via its DataApi handler).
 import '@data/services/ProviderRegistryService'
 
-import { userProviderTable } from '@data/db/schemas/userProvider'
+import { type UserProviderRow, userProviderTable } from '@data/db/schemas/userProvider'
 import { providerService } from '@data/services/ProviderService'
 import { secretCipher } from '@main/core/security/secretCipher'
+import type { ApiKeyEntry, AuthConfig } from '@shared/data/types/provider'
 import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
@@ -33,9 +34,20 @@ vi.mock('electron', () => ({
 describe('ProviderService credential read/write boundary (S7)', () => {
   const dbh = setupTestDatabase()
 
-  async function rawRow(providerId: string) {
+  /** Narrow a stored authConfig to one variant so variant fields type-check. */
+  function expectVariant<T extends AuthConfig['type']>(auth: AuthConfig | null, type: T) {
+    if (auth?.type !== type) {
+      throw new Error(`expected ${type} authConfig, got ${String(auth?.type ?? auth)}`)
+    }
+    return auth as Extract<AuthConfig, { type: T }>
+  }
+
+  async function rawRow(providerId: string): Promise<UserProviderRow & { apiKeys: ApiKeyEntry[] }> {
     const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId))
-    return row
+    if (!row || row.apiKeys === null) {
+      throw new Error(`expected seeded row (with apiKeys array) for ${providerId}`)
+    }
+    return { ...row, apiKeys: row.apiKeys }
   }
 
   async function seedProvider(providerId: string) {
@@ -132,8 +144,9 @@ describe('ProviderService credential read/write boundary (S7)', () => {
 
     const row = await rawRow('oauth-demo')
     expect(row.authConfig).toMatchObject({ type: 'oauth', clientId: 'client-plain' })
-    expect(row.authConfig?.accessToken).toMatch(/^v1:ss:/)
-    expect(row.authConfig?.refreshToken).not.toContain('rt-secret')
+    const storedAuth = expectVariant(row.authConfig, 'oauth')
+    expect(storedAuth.accessToken).toMatch(/^v1:ss:/)
+    expect(storedAuth.refreshToken).not.toContain('rt-secret')
 
     expect(providerService.getAuthConfig('oauth-demo')).toEqual({
       type: 'oauth',
@@ -152,8 +165,9 @@ describe('ProviderService credential read/write boundary (S7)', () => {
     })
 
     const row = await rawRow('vertex')
-    expect(row.authConfig?.credentials).toBeUndefined()
-    expect(row.authConfig?.credentialsEnvelope).toMatch(/^v1:ss:/)
+    const storedAuth = expectVariant(row.authConfig, 'iam-gcp')
+    expect(storedAuth.credentials).toBeUndefined()
+    expect(storedAuth.credentialsEnvelope).toMatch(/^v1:ss:/)
 
     expect(providerService.getAuthConfig('vertex')).toEqual({
       type: 'iam-gcp',

--- a/src/main/data/services/__tests__/ProviderService.credentials.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.credentials.test.ts
@@ -204,6 +204,107 @@ describe('ProviderService credential read/write boundary (S7)', () => {
     ])
   })
 
+  it('preserves the stored envelope of an undecryptable entry when adding another key', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'half-broken',
+      name: 'HalfBroken',
+      orderKey: 'a0',
+      apiKeys: [
+        { id: 'bad', key: `v1:ss:${Buffer.from('foreign').toString('base64')}`, isEnabled: true, label: 'bad' },
+        { id: 'good', key: 'sk-good', isEnabled: true }
+      ]
+    })
+
+    providerService.addApiKey('half-broken', 'sk-second')
+
+    const row = await rawRow('half-broken')
+    const bad = row.apiKeys.find((entry) => entry.id === 'bad')
+    expect(bad?.key).toMatch(/^v1:ss:/)
+    expect(bad?.key).not.toBe('')
+    // The decrypt read still surfaces the re-entry marker for the bad entry.
+    expect(providerService.getApiKeys('half-broken')).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'bad', key: '', decryptFailed: true })])
+    )
+  })
+
+  it('preserves the stored envelope when replaceApiKeys echoes a decryptFailed entry', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'echo-keep',
+      name: 'EchoKeep',
+      orderKey: 'a0',
+      apiKeys: [
+        { id: 'bad', key: `v1:ss:${Buffer.from('foreign').toString('base64')}`, isEnabled: false, label: 'old' },
+        { id: 'gone', key: 'sk-old', isEnabled: true }
+      ]
+    })
+
+    providerService.replaceApiKeys('echo-keep', [
+      { id: 'bad', key: '', decryptFailed: true, isEnabled: true, label: 'renamed' },
+      { id: 'fresh', key: 'sk-fresh', isEnabled: true }
+    ])
+
+    const row = await rawRow('echo-keep')
+    const bad = row.apiKeys.find((entry) => entry.id === 'bad')
+    expect(bad?.key).toMatch(/^v1:ss:/)
+    expect(bad).toMatchObject({ isEnabled: true, label: 'renamed' })
+    expect(row.apiKeys.find((entry) => entry.id === 'fresh')?.key).toMatch(/^v1:ss:/)
+    expect(row.apiKeys.find((entry) => entry.id === 'gone')).toBeUndefined()
+  })
+
+  it('keeps the stored envelope when updateApiKey edits an undecryptable entry without a new value', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'label-edit',
+      name: 'LabelEdit',
+      orderKey: 'a0',
+      apiKeys: [{ id: 'bad', key: `v1:ss:${Buffer.from('foreign').toString('base64')}`, isEnabled: true }]
+    })
+
+    providerService.updateApiKey('label-edit', 'bad', { label: 'relabeled' })
+
+    const row = await rawRow('label-edit')
+    expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(row.apiKeys[0].label).toBe('relabeled')
+  })
+
+  it('keeps the stored authConfig when update receives a decryptFailed echo', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'gcp-echo',
+      name: 'GcpEcho',
+      orderKey: 'a0',
+      authConfig: {
+        type: 'iam-gcp',
+        project: 'p',
+        location: 'global',
+        credentialsEnvelope: `v1:ss:${Buffer.from('foreign').toString('base64')}`
+      }
+    })
+
+    providerService.update('gcp-echo', {
+      name: 'Renamed',
+      authConfig: { type: 'iam-gcp', project: 'p', location: 'global', decryptFailed: true }
+    })
+
+    const row = await rawRow('gcp-echo')
+    expect(row.name).toBe('Renamed')
+    const storedAuth = expectVariant(row.authConfig, 'iam-gcp')
+    expect(storedAuth.credentialsEnvelope).toMatch(/^v1:ss:/)
+  })
+
+  it('never serves a decryptFailed entry to the wire from resolveApiKey', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'rotation-broken',
+      name: 'RotationBroken',
+      orderKey: 'a0',
+      apiKeys: [
+        { id: 'bad', key: `v1:ss:${Buffer.from('foreign').toString('base64')}`, isEnabled: true },
+        { id: 'good', key: 'sk-good', isEnabled: true }
+      ]
+    })
+
+    const resolved = providerService.resolveApiKey('rotation-broken')
+    expect(resolved.value).toBe('sk-good')
+  })
+
   it('fails closed on an encrypt error: the write aborts and nothing lands in the row', async () => {
     await seedProvider('openai')
     providerService.addApiKey('openai', 'sk-first')

--- a/src/main/services/ProviderCredentialSweepService.ts
+++ b/src/main/services/ProviderCredentialSweepService.ts
@@ -1,0 +1,73 @@
+import { application } from '@application'
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import { loggerService } from '@logger'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { secretCipher } from '@main/core/security/secretCipher'
+import { eq } from 'drizzle-orm'
+
+const logger = loggerService.withContext('ProviderCredentialSweepService')
+
+export interface CredentialSweepResult {
+  converted: number
+  skipped: number
+}
+
+/**
+ * Boot-time migration for S7 at-rest encryption: converts legacy plaintext
+ * provider credentials in user_provider to v1: envelopes. Idempotent — rows
+ * already holding envelopes are skipped, so every boot is a cheap no-op once
+ * the table is clean, and a restored plaintext backup is re-encrypted on the
+ * next launch.
+ *
+ * WhenReady phase (no @DependsOn on DbService — the phase barrier already
+ * orders AfterDb behind migrations/seeders, and WhenReady also guarantees
+ * safeStorage availability on Windows). Renderer requests racing the sweep
+ * are safe: better-sqlite3 runs on one synchronous connection and reads
+ * pass prefix-less plaintext through unchanged, so a request landing before
+ * the sweep reads correct plaintext and one after reads the decrypted envelope.
+ */
+@Injectable('ProviderCredentialSweepService')
+@ServicePhase(Phase.WhenReady)
+export class ProviderCredentialSweepService extends BaseService {
+  protected override onReady(): void {
+    try {
+      const result = this.sweep()
+      logger.info('Provider credential sweep done', result)
+      logger.info('Secret storage backend', secretCipher.getReport())
+    } catch (error) {
+      // Boot must not break when the backend is temporarily unavailable —
+      // affected rows stay plaintext and the next boot retries (fail-closed
+      // applies to user-initiated writes, not to this idempotent sweep).
+      logger.error('Provider credential sweep failed; retrying next boot', { error })
+    }
+  }
+
+  sweep(): CredentialSweepResult {
+    return application.get('DbService').withWriteTx((tx) => {
+      const rows = tx.select().from(userProviderTable).all()
+      let converted = 0
+      let skipped = 0
+
+      for (const row of rows) {
+        const apiKeys = row.apiKeys ?? []
+        const needsKeys = secretCipher.needsEncryptionApiKeys(apiKeys)
+        const needsAuth = secretCipher.needsEncryptionAuthConfig(row.authConfig)
+        if (!needsKeys && !needsAuth) {
+          skipped += 1
+          continue
+        }
+
+        tx.update(userProviderTable)
+          .set({
+            ...(needsKeys ? { apiKeys: secretCipher.encryptApiKeys(apiKeys) } : {}),
+            ...(needsAuth ? { authConfig: secretCipher.encryptAuthConfig(row.authConfig) } : {})
+          })
+          .where(eq(userProviderTable.providerId, row.providerId))
+          .run()
+        converted += 1
+      }
+
+      return { converted, skipped }
+    })
+  }
+}

--- a/src/main/services/ProviderCredentialSweepService.ts
+++ b/src/main/services/ProviderCredentialSweepService.ts
@@ -2,7 +2,7 @@ import { application } from '@application'
 import { userProviderTable } from '@data/db/schemas/userProvider'
 import { loggerService } from '@logger'
 import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
-import { secretCipher } from '@main/core/security/secretCipher'
+import { envelopeMethodOf, secretCipher } from '@main/core/security/secretCipher'
 import { eq } from 'drizzle-orm'
 
 const logger = loggerService.withContext('ProviderCredentialSweepService')
@@ -10,6 +10,8 @@ const logger = loggerService.withContext('ProviderCredentialSweepService')
 export interface CredentialSweepResult {
   converted: number
   skipped: number
+  /** At-rest envelope distribution across all scanned credential values. */
+  envelopes: { ss: number; aes: number; plain: number; unknown: number }
 }
 
 /**
@@ -35,9 +37,8 @@ export class ProviderCredentialSweepService extends BaseService {
       logger.info('Provider credential sweep done', result)
       logger.info('Secret storage backend', secretCipher.getReport())
     } catch (error) {
-      // Boot must not break when the backend is temporarily unavailable —
-      // affected rows stay plaintext and the next boot retries (fail-closed
-      // applies to user-initiated writes, not to this idempotent sweep).
+      // Boot must not break on a temporarily unavailable backend — rows stay
+      // plaintext and the next boot retries (this sweep is idempotent).
       logger.error('Provider credential sweep failed; retrying next boot', { error })
     }
   }
@@ -47,11 +48,30 @@ export class ProviderCredentialSweepService extends BaseService {
       const rows = tx.select().from(userProviderTable).all()
       let converted = 0
       let skipped = 0
+      const envelopes = { ss: 0, aes: 0, plain: 0, unknown: 0 }
 
       for (const row of rows) {
         const apiKeys = row.apiKeys ?? []
+        for (const entry of apiKeys) {
+          if (entry.key) envelopes[envelopeMethodOf(entry.key)] += 1
+        }
+        const auth = row.authConfig
+        if (auth) {
+          const secrets =
+            auth.type === 'oauth'
+              ? [auth.accessToken, auth.refreshToken]
+              : auth.type === 'iam-aws'
+                ? [auth.accessKeyId, auth.secretAccessKey]
+                : auth.type === 'iam-gcp'
+                  ? [auth.credentialsEnvelope, auth.credentials ? JSON.stringify(auth.credentials) : undefined]
+                  : []
+          for (const value of secrets) {
+            if (value) envelopes[envelopeMethodOf(value)] += 1
+          }
+        }
+
         const needsKeys = secretCipher.needsEncryptionApiKeys(apiKeys)
-        const needsAuth = secretCipher.needsEncryptionAuthConfig(row.authConfig)
+        const needsAuth = secretCipher.needsEncryptionAuthConfig(auth)
         if (!needsKeys && !needsAuth) {
           skipped += 1
           continue
@@ -60,14 +80,14 @@ export class ProviderCredentialSweepService extends BaseService {
         tx.update(userProviderTable)
           .set({
             ...(needsKeys ? { apiKeys: secretCipher.encryptApiKeys(apiKeys) } : {}),
-            ...(needsAuth ? { authConfig: secretCipher.encryptAuthConfig(row.authConfig) } : {})
+            ...(needsAuth ? { authConfig: secretCipher.encryptAuthConfig(auth) } : {})
           })
           .where(eq(userProviderTable.providerId, row.providerId))
           .run()
         converted += 1
       }
 
-      return { converted, skipped }
+      return { converted, skipped, envelopes }
     })
   }
 }

--- a/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
+++ b/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
@@ -1,0 +1,102 @@
+import '@data/services/ProviderRegistryService'
+
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import { providerService } from '@data/services/ProviderService'
+import { ProviderCredentialSweepService } from '@main/services/ProviderCredentialSweepService'
+import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it, vi } from 'vitest'
+
+// Reversible safeStorage stand-in — the sweep encrypts what it converts.
+const { ssEncrypt, ssDecrypt } = vi.hoisted(() => ({
+  ssEncrypt: vi.fn((plain: string) => {
+    const nonce = Math.random().toString(36).slice(2)
+    return Buffer.from(`mock-ss:${nonce}:${plain}`, 'utf8')
+  }),
+  ssDecrypt: vi.fn((buffer: Buffer) => {
+    const match = /^mock-ss:[^:]+:(.*)$/s.exec(buffer.toString('utf8'))
+    if (!match) throw new Error('mock safeStorage: ciphertext was not produced by this key')
+    return match[1]
+  })
+}))
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: ssEncrypt,
+    decryptString: ssDecrypt
+  }
+}))
+
+describe('ProviderCredentialSweepService', () => {
+  const dbh = setupTestDatabase()
+  const service = new ProviderCredentialSweepService()
+
+  async function rawRow(providerId: string) {
+    const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId))
+    return row
+  }
+
+  it('converts plaintext apiKeys and authConfig rows to envelopes in one sweep', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'legacy',
+      name: 'Legacy',
+      orderKey: 'a0',
+      apiKeys: [{ id: 'k1', key: 'sk-legacy', label: 'main', isEnabled: true }],
+      authConfig: { type: 'oauth', clientId: 'cid', accessToken: 'at-plain', refreshToken: 'rt-plain' }
+    })
+
+    const result = service.sweep()
+
+    expect(result).toEqual({ converted: 1, skipped: 0 })
+    const row = await rawRow('legacy')
+    expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(row.apiKeys[0].key).not.toContain('sk-legacy')
+    expect(row.authConfig?.accessToken).toMatch(/^v1:ss:/)
+    expect(row.authConfig?.clientId).toBe('cid')
+
+    // Reads through the boundary still restore the plaintext values.
+    expect(providerService.getApiKeys('legacy')[0].key).toBe('sk-legacy')
+    expect(providerService.getAuthConfig('legacy')).toMatchObject({ accessToken: 'at-plain', refreshToken: 'rt-plain' })
+  })
+
+  it('is idempotent: enveloped rows are skipped, their bytes untouched', async () => {
+    await dbh.db.insert(userProviderTable).values({ providerId: 'openai', name: 'OpenAI', orderKey: 'a0' })
+    providerService.addApiKey('openai', 'sk-modern')
+    const before = await rawRow('openai')
+
+    const result = service.sweep()
+
+    expect(result).toEqual({ converted: 0, skipped: 1 })
+    expect(await rawRow('openai')).toEqual(before)
+  })
+
+  it('skips rows with nothing to protect', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'bare',
+      name: 'Bare',
+      orderKey: 'a0',
+      apiKeys: [],
+      authConfig: null
+    })
+
+    expect(service.sweep()).toEqual({ converted: 0, skipped: 1 })
+  })
+
+  it('re-encrypts a restored plaintext backup row while leaving neighbors untouched', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'restored',
+      name: 'Restored',
+      orderKey: 'a0',
+      apiKeys: [{ id: 'k1', key: 'sk-from-backup', isEnabled: true }]
+    })
+    await dbh.db.insert(userProviderTable).values({ providerId: 'clean', name: 'Clean', orderKey: 'a1' })
+    providerService.addApiKey('clean', 'sk-clean')
+    const cleanBefore = await rawRow('clean')
+
+    expect(service.sweep()).toEqual({ converted: 1, skipped: 1 })
+
+    expect((await rawRow('restored')).apiKeys[0].key).toMatch(/^v1:ss:/)
+    expect(await rawRow('clean')).toEqual(cleanBefore)
+  })
+})

--- a/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
+++ b/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
@@ -60,7 +60,10 @@ describe('ProviderCredentialSweepService', () => {
 
     const result = service.sweep()
 
-    expect(result).toEqual({ converted: 1, skipped: 0 })
+    expect(result.converted).toBe(1)
+    expect(result.skipped).toBe(0)
+    // 1 plaintext key + 2 plaintext oauth tokens counted pre-conversion.
+    expect(result.envelopes).toEqual({ ss: 0, aes: 0, plain: 3, unknown: 0 })
     const row = await rawRow('legacy')
     expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
     expect(row.apiKeys[0].key).not.toContain('sk-legacy')
@@ -80,7 +83,8 @@ describe('ProviderCredentialSweepService', () => {
 
     const result = service.sweep()
 
-    expect(result).toEqual({ converted: 0, skipped: 1 })
+    expect(result.converted).toBe(0)
+    expect(result.skipped).toBe(1)
     expect(await rawRow('openai')).toEqual(before)
   })
 
@@ -93,7 +97,7 @@ describe('ProviderCredentialSweepService', () => {
       authConfig: null
     })
 
-    expect(service.sweep()).toEqual({ converted: 0, skipped: 1 })
+    expect(service.sweep().converted).toBe(0)
   })
 
   it('re-encrypts a restored plaintext backup row while leaving neighbors untouched', async () => {
@@ -107,7 +111,7 @@ describe('ProviderCredentialSweepService', () => {
     providerService.addApiKey('clean', 'sk-clean')
     const cleanBefore = await rawRow('clean')
 
-    expect(service.sweep()).toEqual({ converted: 1, skipped: 1 })
+    expect(service.sweep().converted).toBe(1)
 
     expect((await rawRow('restored')).apiKeys[0].key).toMatch(/^v1:ss:/)
     expect(await rawRow('clean')).toEqual(cleanBefore)

--- a/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
+++ b/src/main/services/__tests__/ProviderCredentialSweepService.test.ts
@@ -1,8 +1,9 @@
 import '@data/services/ProviderRegistryService'
 
-import { userProviderTable } from '@data/db/schemas/userProvider'
+import { type UserProviderRow, userProviderTable } from '@data/db/schemas/userProvider'
 import { providerService } from '@data/services/ProviderService'
 import { ProviderCredentialSweepService } from '@main/services/ProviderCredentialSweepService'
+import type { ApiKeyEntry, AuthConfig } from '@shared/data/types/provider'
 import { setupTestDatabase } from '@test-helpers/db'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
@@ -32,9 +33,20 @@ describe('ProviderCredentialSweepService', () => {
   const dbh = setupTestDatabase()
   const service = new ProviderCredentialSweepService()
 
-  async function rawRow(providerId: string) {
+  /** Narrow a stored authConfig to one variant so variant fields type-check. */
+  function expectVariant<T extends AuthConfig['type']>(auth: AuthConfig | null, type: T) {
+    if (auth?.type !== type) {
+      throw new Error(`expected ${type} authConfig, got ${String(auth?.type ?? auth)}`)
+    }
+    return auth as Extract<AuthConfig, { type: T }>
+  }
+
+  async function rawRow(providerId: string): Promise<UserProviderRow & { apiKeys: ApiKeyEntry[] }> {
     const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, providerId))
-    return row
+    if (!row || row.apiKeys === null) {
+      throw new Error(`expected seeded row (with apiKeys array) for ${providerId}`)
+    }
+    return { ...row, apiKeys: row.apiKeys }
   }
 
   it('converts plaintext apiKeys and authConfig rows to envelopes in one sweep', async () => {
@@ -52,8 +64,9 @@ describe('ProviderCredentialSweepService', () => {
     const row = await rawRow('legacy')
     expect(row.apiKeys[0].key).toMatch(/^v1:ss:/)
     expect(row.apiKeys[0].key).not.toContain('sk-legacy')
-    expect(row.authConfig?.accessToken).toMatch(/^v1:ss:/)
-    expect(row.authConfig?.clientId).toBe('cid')
+    const storedAuth = expectVariant(row.authConfig, 'oauth')
+    expect(storedAuth.accessToken).toMatch(/^v1:ss:/)
+    expect(storedAuth.clientId).toBe('cid')
 
     // Reads through the boundary still restore the plaintext values.
     expect(providerService.getApiKeys('legacy')[0].key).toBe('sk-legacy')

--- a/src/shared/data/api/schemas/__tests__/providers.test.ts
+++ b/src/shared/data/api/schemas/__tests__/providers.test.ts
@@ -65,3 +65,46 @@ describe('Provider DTO logo validation', () => {
     expect(UpdateProviderSchema.safeParse({ name: 'Renamed' }).success).toBe(true)
   })
 })
+
+describe('ApiKeyEntry decryptFailed accommodation (S7 at-rest encryption)', () => {
+  // The decryptFailed entry is produced main-side when a stored envelope cannot
+  // be decrypted on this machine; an empty key is valid only in that state.
+  it('accepts an empty key only when decryptFailed is true', () => {
+    const decryptFailedEntry = { id: 'k1', key: '', isEnabled: true, decryptFailed: true }
+    expect(CreateProviderSchema.safeParse({ providerId: 'p', name: 'n', apiKeys: [decryptFailedEntry] }).success).toBe(
+      true
+    )
+
+    const plainEmptyEntry = { id: 'k1', key: '', isEnabled: true }
+    expect(CreateProviderSchema.safeParse({ providerId: 'p', name: 'n', apiKeys: [plainEmptyEntry] }).success).toBe(
+      false
+    )
+  })
+
+  it('still requires a non-empty key on ordinary entries', () => {
+    expect(
+      CreateProviderSchema.safeParse({
+        providerId: 'p',
+        name: 'n',
+        apiKeys: [{ id: 'k1', key: 'sk-real', isEnabled: true }]
+      }).success
+    ).toBe(true)
+    expect(
+      CreateProviderSchema.safeParse({
+        providerId: 'p',
+        name: 'n',
+        apiKeys: [{ id: 'k1', key: '   ', isEnabled: true }]
+      }).success
+    ).toBe(false)
+  })
+
+  it('accepts iam-gcp credentialsEnvelope as the at-rest credentials carrier', () => {
+    const authConfig = {
+      type: 'iam-gcp',
+      project: 'p',
+      location: 'global',
+      credentialsEnvelope: 'v1:ss:opaque'
+    }
+    expect(CreateProviderSchema.safeParse({ providerId: 'p', name: 'n', authConfig }).success).toBe(true)
+  })
+})

--- a/src/shared/data/types/provider.ts
+++ b/src/shared/data/types/provider.ts
@@ -76,19 +76,35 @@ export function isServiceTier(tier: string | null | undefined): tier is ServiceT
   return isGroqServiceTier(tier) || isOpenAIServiceTier(tier)
 }
 
-export const ApiKeyEntrySchema = z.object({
+// Base object kept separate from the refinement: RuntimeApiKeySchema derives
+// via .omit(), which zod v4 does not allow on refined schemas.
+const ApiKeyEntryObjectSchema = z.object({
   /** UUID for referencing this key */
   id: z.string().min(1),
-  /** Actual key value (trimmed; empty values are rejected) */
-  key: z.string().trim().min(1),
+  /**
+   * Actual key value (trimmed; empty values are rejected). Empty is allowed
+   * only on decryptFailed entries (S7 at-rest encryption): the value could
+   * not be decrypted on this machine and must be re-entered.
+   */
+  key: z.string().trim(),
   /** User-friendly label */
   label: z.string().optional(),
   /** Whether this key is enabled */
-  isEnabled: z.boolean()
+  isEnabled: z.boolean(),
+  /** Set by the main process when the stored envelope could not be decrypted. */
+  decryptFailed: z.boolean().optional()
 })
 
+export const ApiKeyEntrySchema = ApiKeyEntryObjectSchema.refine(
+  (entry) => entry.decryptFailed === true || entry.key.length > 0,
+  {
+    message: 'API key cannot be empty',
+    path: ['key']
+  }
+)
+
 export type ApiKeyEntry = z.infer<typeof ApiKeyEntrySchema>
-export const RuntimeApiKeySchema = ApiKeyEntrySchema.omit({ key: true })
+export const RuntimeApiKeySchema = ApiKeyEntryObjectSchema.omit({ key: true })
 export type RuntimeApiKey = z.infer<typeof RuntimeApiKeySchema>
 
 export const AuthTypeSchema = z.enum(['api-key', 'oauth', 'iam-aws', 'api-key-aws', 'iam-gcp', 'iam-azure'])
@@ -113,14 +129,18 @@ const AuthConfigOAuth = z.object({
    * provider needs it as a request header (e.g. OpenAI Codex's
    * `chatgpt-account-id`). Not every OAuth provider populates this.
    */
-  accountId: z.string().optional()
+  accountId: z.string().optional(),
+  /** Set by the main process when the stored tokens could not be decrypted. */
+  decryptFailed: z.boolean().optional()
 })
 
 const AuthConfigIamAws = z.object({
   type: z.literal('iam-aws'),
   region: z.string(),
   accessKeyId: z.string().optional(),
-  secretAccessKey: z.string().optional()
+  secretAccessKey: z.string().optional(),
+  /** Set by the main process when the stored credentials could not be decrypted. */
+  decryptFailed: z.boolean().optional()
 })
 
 /**
@@ -138,7 +158,15 @@ const AuthConfigIamGcp = z.object({
   type: z.literal('iam-gcp'),
   project: z.string(),
   location: z.string(),
-  credentials: z.record(z.string(), z.unknown()).optional()
+  credentials: z.record(z.string(), z.unknown()).optional(),
+  /**
+   * At-rest envelope for the GCP credentials JSON (S7). The record itself stays
+   * schema-shaped; when present, `credentials` is ignored at rest and restored
+   * from this envelope at read time.
+   */
+  credentialsEnvelope: z.string().optional(),
+  /** Set by the main process when the stored credentials could not be decrypted. */
+  decryptFailed: z.boolean().optional()
 })
 
 const AuthConfigIamAzure = z.object({

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-22-provider-credentials-encrypted-at-rest.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-22-provider-credentials-encrypted-at-rest.md
@@ -1,0 +1,25 @@
+---
+title: Provider API keys and OAuth tokens are now stored encrypted
+category: changed
+severity: notice
+introduced_in_pr: "#<PR-1 number>"
+date: 2026-08-22
+---
+
+## What changed
+
+Provider credentials in the local database (API keys, OAuth tokens, AWS/GCP credentials) are now stored as encrypted envelopes instead of plaintext. On first launch after the update, existing plaintext credentials are automatically encrypted in place; nothing needs to be re-entered on the same machine.
+
+## Why this matters to the user
+
+- On macOS, the first credential write may show a Keychain access prompt for "Cherry Studio Safe Storage" — choosing Allow is expected and safe. The prompt can also reappear once after switching between dev and packaged builds.
+- Credentials are bound to this machine's OS key store. Copying the database file to another computer (or restoring a backup there) will not carry usable credentials: affected entries show a "needs re-entry" state and the values must be re-entered.
+- On Linux without a keyring service, a local key file (`secret.key`, 0600) protects the values instead.
+
+## What the user should do
+
+Nothing — encryption is automatic. For cross-machine migration, wait for the plaintext-export backup option (follow-up PR) or re-enter credentials on the new machine. Before downgrading to an older version, note that older builds cannot read the encrypted values.
+
+## Notes for release manager
+
+Decrypt-failure UX (summary dialog + re-entry markers) lands separately in the renderer follow-up (c4); the data layer already returns `decryptFailed` markers. Plaintext-export backup option is PR-2 of the S7 security work.

--- a/v2-refactor-temp/docs/breaking-changes/2026-08-22-provider-credentials-encrypted-at-rest.md
+++ b/v2-refactor-temp/docs/breaking-changes/2026-08-22-provider-credentials-encrypted-at-rest.md
@@ -2,7 +2,7 @@
 title: Provider API keys and OAuth tokens are now stored encrypted
 category: changed
 severity: notice
-introduced_in_pr: "#<PR-1 number>"
+introduced_in_pr: "#19138"
 date: 2026-08-22
 ---
 


### PR DESCRIPTION
### What this PR does

Before this PR: every provider credential (API keys, OAuth tokens, AWS/GCP credentials) is stored as **plaintext JSON** in the `user_provider` table. Any process that can read the SQLite file (or a leaked backup) gets every credential in the clear. Full-repo security audit finding S7 (CONFIRMED).

After this PR: credentials are stored as **encrypted envelopes** (`v1:ss:<base64>` via OS safeStorage — macOS Keychain / Windows DPAPI / Linux libsecret; `v1:aes:<iv||tag||ct>` via an AES-256-GCM key file, 0600, on keyring-less Linux). Three pieces:

1. **`secretCipher`** (`src/main/core/security/secretCipher.ts`) — envelope encrypt/decrypt. Synchronous by design (better-sqlite3 write transactions are sync; sub-kilobyte values cost sub-milliseconds). Encrypt failures **throw and abort the write transaction** (fail-closed); decrypt failures return an empty value plus a `decryptFailed` marker and feed a listener for the future re-entry UX. The `v1:` prefix itself is the plaintext/ciphertext marker — no schema column, and prefix-less values (legacy plaintext) pass through unchanged.
2. **ProviderService read/write boundary** — every read (`resolveApiKey`, `getApiKeys`, `getAuthConfig`) decrypts inside the boundary so all ~20 main-process consumers (connection signatures, rotation, warm-up, OAuth token store) keep receiving plaintext with zero changes; every write (`addApiKey`, `replaceApiKeys`, `updateApiKey`, `update`, `create`) encrypts before persisting. Dedupe/override matching compare decrypted values (envelopes are randomized and never comparable). Consumers verified individually (pi/dsh signatures hash plaintext — no signature churn).
3. **Boot sweep** (`ProviderCredentialSweepService`, WhenReady lifecycle) — one write-transaction scan converting prefix-less values, idempotent (already-enveloped rows untouched), so v2存量 users, v1 upgrades, and **restored plaintext backups** all converge automatically. Logs `converted/skipped` plus an at-rest envelope distribution (`ss/aes/plain/unknown`) and the backend report.

Field-level treatment: oauth → accessToken/refreshToken; iam-aws → accessKeyId/secretAccessKey; iam-gcp → the whole credentials record moves into a `credentialsEnvelope` shadow string (JSON records can't hold an envelope); type/clientId/region/project stay plaintext. api-key / api-key-aws / iam-azure carry no secrets and are untouched. Seeders (`batchUpsertTx`) are untouched — verified they carry zero real credentials.

Fixes # (S7 of the 2026-08 security audit; no public issue yet)

### Why we need it and why it was done in this way

**Decision register (four grilling rounds, Q1–Q17):**

| # | Decision | Outcome |
|---|---|---|
| Q1/Q9 | Linux without keyring | AES-256-GCM key file 0600 + banner guiding keyring install + manual "upgrade protection" button (no auto-migration) |
| Q2 | Decrypt-failure thresholds | Dropped — the summary dialog names exact entries; no count/ratio heuristics |
| Q3/Q10 | Portability | Optional **plaintext version** + optional **password container** inside the backup dialog (covers local/WebDAV/S3/Nutstore) — **PR-2**, not a standalone export feature |
| Q4 | Rollback/downgrade self-help | Plaintext backup covers cross-machine/signing-change/downgrade; `decryptAll` script cancelled |
| Q5 | Encrypt failure + marker | **Fail-closed** (throw, block write); envelope prefix doubles as the marker — zero new schema columns |
| Q6 | Decrypt-failure shape | Empty value + `decryptFailed` flag; dialog lists provider name + key label, never values |
| Q7 | Diagnostics panel | Cut; `getReport()` downgraded to one boot log line (now incl. envelope distribution) |
| Q8 | Sweep hook | WhenReady lifecycle service, registered in `serviceRegistry`, **no** `@DependsOn(['DbService'])` (phase barrier already orders it; also guarantees Windows safeStorage readiness). Rejected: `DbService.onInit` (safeStorage race vs `whenReady`), appended seeder (journal is once-per-version → restored plaintext backups never re-scanned) |
| Q11 | Import semantics | No import feature; restore = full DB overwrite + sweep re-encrypts |
| Q12 | PR split | PR-1 encryption core (this PR, zero file overlap) → PR-2 backup integration (waits on #18793) |
| Q13 | Encrypt-failure confirm | Block + explicit error; user acknowledges |
| Q14 | Dialog shape | Once-per-session summary dialog "安全存储解密失败，部分值可能需要重新输入" — renderer follow-up (c4) |
| Q15 | auto-sync backups | Always ciphertext; "auto plaintext + forced password" is a future option (open point) |
| Q16 | Password container | Only on plaintext version; streaming AES-GCM + scrypt + magic header + `.enc` — PR-2 |
| Q17 | Plaintext UI placement | Per-backup checkbox, never persisted; bare plaintext requires a second strong warning — PR-2 |

**Implementation-period corrections (vs. the reviewed plan, code as authority):**

- Sweep service lives in `src/main/services/` — the plan suggested `data/services/`, but that directory's README mandates non-lifecycle singletons; `src/main/services/` matches the `AutoBackupService` boot-service precedent.
- `create()` also encrypts `dto.apiKeys` (plan listed only `authConfig`): `CreateProviderSchema.apiKeys` (`src/shared/data/api/schemas/providers.ts:80`) makes create a real credential write path.
- `normalizeApiKeyEntry` accepts empty keys only on `decryptFailed` echoes (the schema accommodation would be unusable otherwise), and empty keys skip the dedupe collision check.
- Draft fix: zod v4 `.omit()` throws at runtime on refined schemas — `ApiKeyEntrySchema` is now a base object + refinement so `RuntimeApiKeySchema` can still derive via `.omit()` (`src/shared/data/types/provider.ts`).
- Review hardening (subagent review, 2 rounds): a caller-supplied `decryptFailed` flag can never disable encryption; entries whose decryption transiently failed keep their at-rest envelope on every write path (a denied Keychain prompt must not become permanent data loss); `resolveApiKey` never serves failed entries; plaintext that merely starts with `v1:` is wrapped, not mistaken for an envelope.

**Known conservative trade-offs (deliberate, flag if you disagree):**
- A `decryptFailed` authConfig echo in `update()` preserves the stored authConfig verbatim — non-secret edits (e.g. clientId) in the same echo are silently dropped rather than risk overwriting the envelope.
- A forged `v1:ss:not-an-envelope` value passes through at rest but is fail-and-marked on read; judged acceptable (a compromised renderer can already GET plaintext keys).

The following alternatives were considered: SQL migration chain entry (rejected — one-shot, `status=completed` never re-enters, so restored plaintext backups would stay plaintext), `DbService.onInit` hook (safeStorage race), appended seeder (once-per-version journal), and updating `utils/aes.ts` (its only caller is legacy CBC data in `ipc.ts:165`; GCM logic stays cohesive in secretCipher).

### Breaking changes

User-perceivable — entry added at `v2-refactor-temp/docs/breaking-changes/2026-08-22-provider-credentials-encrypted-at-rest.md`:
- macOS may show a Keychain prompt ("Cherry Studio Safe Storage") on first credential write — Allow is expected; can reappear once after dev↔packaged switches.
- Credentials are bound to the machine's OS key store: copying the DB to another machine (or restoring a backup there) requires re-entering credentials (entries show a needs-re-entry state) until the plaintext-backup option lands in PR-2.
- Downgrading to an older build: older versions cannot read envelopes — take a plaintext backup first (PR-2) before downgrading.
- Nothing to do on the same machine — existing plaintext rows are encrypted automatically at next launch.

### Special notes for your reviewer

**Verification record:**
- Unit/integration: 46 credential tests across `secretCipher.test.ts` (26), `ProviderService.credentials.test.ts` (16), `ProviderCredentialSweepService.test.ts` (4), plus DTO schema cases in `providers.test.ts` and the adapted `ProviderService.apiKeys.test.ts`. Full main-process project: **832 files / 12810 tests green**; shared+scripts 1595 green; typecheck (node+web+ai-core), oxlint 0 warnings, ESLint 0 errors, i18n check (60480 keys), docs link check — all green. The renderer vitest project cannot load in the nested dev worktree (pre-existing `@vitest/web-worker` resolution issue, verified on a clean stash of this branch) — CI covers it; this PR touches zero renderer business files.
- Live app (CDP, isolated profile `BatchB`, real DataApi calls): **Path A** — POST `/providers/openai/api-keys` stores a `v1:ss:` envelope; `strings` over DB+WAL: **0 plaintext hits**. **Path B** — app restarted: GET `/providers/openai/api-keys` returns the exact plaintext; a plaintext row injected while stopped (key + oauth tokens) was auto-converted at boot (`Provider credential sweep done { converted: 1, skipped: 63 }` + backend report line); post-checkpoint `strings`: 0 hits. Credential resolution feeds model-list requests through the same boundary read verified above; a live network model fetch was not exercised (no real provider key in the test env).

**Follow-ups (explicitly out of scope here):** c4 — renderer decrypt-failure summary dialog (Q14), Linux keyring banner + upgrade button (Q1), i18n keys; PR-2 — backup plaintext version + password container + restore password prompt (blocked on #18793). Minor test gaps noted for c4/PR-2: Keychain-recovery flag clearing and authConfig clear-under-failure paths.

**Open discussion points (do not block this PR):**
1. "auto-sync plaintext + forced password" as a future option — schedule or drop (PR-2).
2. Announcement wording: security boundary / cross-machine flow / pre-downgrade plaintext backup / Keychain prompt is normal.
3. Phase 2 (Preference credentials: nutstore, S3, integration tokens) and Phase 3 (MCP secrets) scheduling.
4. Simplification lever: drop the password container and accept bare plaintext + strong warning? (recommendation: keep, ~1 day).
5. Linux banner wording strength (neutral hint vs explicit MITM risk) — c4.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch0815.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (boot sweep migrates existing data in place; breaking-changes entry added)
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered — release-time communication covered by the breaking-changes entry; user-guide update deferred to release prep with PR-2 (cross-machine flow changes again)
- [x] Self-review: I have reviewed my own code (two independent subagent review rounds against the Q1–Q17 decision register; all HIGH/MEDIUM findings fixed and pinned by tests) before requesting review from others

### Release note

```release-note
Provider API keys and OAuth/Cloud credentials are now stored encrypted at rest (OS keychain / DPAPI, AES-256-GCM key file on Linux without a keyring). Existing credentials are encrypted automatically on first launch — nothing to re-enter on the same machine. On macOS a Keychain prompt for "Cherry Studio Safe Storage" may appear once (choose Allow). Copying the database to another machine now requires re-entering credentials; a plaintext-backup option for cross-machine migration follows in a subsequent PR.
```
