### PR TITLE
fix(quick-panel): keep skill names readable

### DIFF
--- a/src/renderer/components/QuickPanel/__tests__/row.test.tsx
+++ b/src/renderer/components/QuickPanel/__tests__/row.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { QuickPanelRow } from '../list'
+
+describe('QuickPanelRow', () => {
+  it('keeps inline descriptions next to the label and lets the description yield space first', () => {
+    render(
+      <QuickPanelRow
+        active={false}
+        item={{
+          id: 'skill:short-name',
+          label: 'short-name',
+          description: 'A description long enough to exercise the single-line overflow contract.',
+          inlineDescription: true,
+          icon: 'icon',
+          suffix: 'Skill'
+        }}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const label = screen.getByText('short-name')
+    const description = screen.getByText(/A description long enough/)
+    const suffix = screen.getByText('Skill')
+
+    expect(label.parentElement).toHaveClass('max-w-full', 'min-w-0', 'shrink-0')
+    expect(label.parentElement?.parentElement).toBe(description.parentElement)
+    expect(label).toHaveClass('min-w-0', 'truncate')
+    expect(label).not.toHaveClass('max-w-[50%]')
+    expect(description).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(suffix.parentElement?.parentElement).not.toBe(description.parentElement)
+  })
+
+  it('keeps trailing descriptions in the metadata column by default', () => {
+    render(
+      <QuickPanelRow
+        active={false}
+        item={{
+          id: 'permission:auto',
+          label: 'Auto',
+          description: 'Recommended',
+          icon: 'icon',
+          suffix: 'suffix'
+        }}
+        onSelect={vi.fn()}
+      />
+    )
+
+    const label = screen.getByText('Auto')
+    const description = screen.getByText('Recommended')
+
+    expect(label.parentElement).not.toBe(description.parentElement)
+    expect(description.parentElement).toHaveClass('min-w-[20%]', 'justify-end')
+    expect(description.parentElement).not.toHaveClass('max-w-[60%]')
+  })
+})

--- a/src/renderer/components/QuickPanel/list.tsx
+++ b/src/renderer/components/QuickPanel/list.tsx
@@ -13,6 +13,7 @@ export interface QuickPanelRowData {
   id?: string
   label: ReactNode | string
   description?: ReactNode | string
+  inlineDescription?: boolean
   tooltip?: ReactNode | string
   /** In-row element used as the controlled Tooltip trigger. */
   tooltipAnchor?: ReactElement
@@ -176,6 +177,19 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
   ) : item.isMenu && !item.disabled && !readOnly ? (
     <ChevronRight size={14} />
   ) : null
+  const hasInlineDescription = item.inlineDescription === true && !!item.description
+  const primaryContent = (
+    <>
+      {reserveIconSlot || item.icon ? (
+        <span className="flex shrink-0 items-center justify-center text-[13px] text-muted-foreground [&>svg:not([class*='text-'])]:text-muted-foreground [&>svg]:size-[1em]">
+          {item.icon}
+        </span>
+      ) : null}
+      <span className={cn('min-w-0 truncate text-[13px] leading-4', !hasInlineDescription && 'flex-1')}>
+        {item.label}
+      </span>
+    </>
+  )
   const canHover = hoverEnabled && !isReadOnlyLocked && !item.disabled
   const isUnavailable = isReadOnlyLocked || item.disabled
   const tooltipAnchor =
@@ -224,25 +238,33 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
         event.stopPropagation()
         onSelect()
       }}>
-      <div className={cn('flex min-w-0 flex-1 items-center gap-1.5', contentClassName)}>
-        {reserveIconSlot || item.icon ? (
-          <span className="flex items-center justify-center text-[13px] text-muted-foreground [&>svg:not([class*='text-'])]:text-muted-foreground [&>svg]:size-[1em]">
-            {item.icon}
+      {hasInlineDescription ? (
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <div className="flex min-w-0 max-w-full shrink-0 items-center gap-1.5">{primaryContent}</div>
+          <span className="min-w-0 flex-1 truncate text-[12px] text-muted-foreground leading-4">
+            {item.description}
           </span>
-        ) : null}
-        <span className="min-w-0 flex-1 truncate text-[13px] leading-4">{item.label}</span>
-      </div>
-      <div className="flex min-w-[20%] items-center justify-end gap-1 text-[12px] text-muted-foreground leading-4">
-        {item.description ? (
-          <span className="overflow-hidden text-ellipsis whitespace-nowrap">{item.description}</span>
-        ) : null}
-        {tooltipAnchor}
-        {suffixContent ? (
-          <span className="flex min-w-3 shrink-0 items-center justify-end gap-[3px] [&>svg]:size-[1em] [&>svg]:text-muted-foreground">
-            {suffixContent}
-          </span>
-        ) : null}
-      </div>
+        </div>
+      ) : (
+        <div className={cn('flex min-w-0 flex-1 items-center gap-1.5', contentClassName)}>{primaryContent}</div>
+      )}
+      {!hasInlineDescription || tooltipAnchor || suffixContent ? (
+        <div
+          className={cn(
+            'flex items-center justify-end gap-1 text-[12px] text-muted-foreground leading-4',
+            hasInlineDescription ? 'shrink-0' : 'min-w-[20%]'
+          )}>
+          {!hasInlineDescription && item.description ? (
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap">{item.description}</span>
+          ) : null}
+          {tooltipAnchor}
+          {suffixContent ? (
+            <span className="flex min-w-3 shrink-0 items-center justify-end gap-[3px] [&>svg]:size-[1em] [&>svg]:text-muted-foreground">
+              {suffixContent}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/components/QuickPanel/types.ts
+++ b/src/renderer/components/QuickPanel/types.ts
@@ -122,6 +122,8 @@ export type QuickPanelListItem = {
   id?: string
   label: React.ReactNode | string
   description?: React.ReactNode | string
+  /** Render the description immediately after the label instead of in the trailing metadata column. */
+  inlineDescription?: boolean
   tooltip?: React.ReactNode | string
   /** In-row element used as the controlled Tooltip trigger. */
   tooltipAnchor?: React.ReactElement

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -270,6 +270,7 @@ const createSkillQuickPanelItems = (
     id: agentComposerTokenId.skill(skill),
     label: skill.name,
     description: skill.description ?? undefined,
+    inlineDescription: true,
     icon: <ToolCase size={16} />,
     suffix: options.skillLabel,
     // Skills still exclude descriptions from root-panel search; the category alias powers the persistent shortcut.

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3082,6 +3082,7 @@ describe('AgentComposer', () => {
         id: 'skill:pdf',
         label: 'pdf',
         description: 'Read and analyze PDFs',
+        inlineDescription: true,
         suffix: 'plugins.skills',
         filterText: 'pdf'
       })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Skill descriptions shared the trailing metadata column with other quick-panel items. Long descriptions could consume the available row width and truncate or hide skill names, while short names could appear visually disconnected from their descriptions.

<img width="1341" height="609" alt="image" src="https://github.com/user-attachments/assets/b2c4c361-4409-4060-9bf0-0601ce09834e" />

After this PR:

Skill rows opt into an inline name-and-description layout. The skill name keeps priority, the description truncates when space is limited, and suffix metadata remains separate. Other quick-panel rows retain the existing trailing-description layout.

<img width="1211" height="612" alt="image" src="https://github.com/user-attachments/assets/eb2e41b4-af24-421b-ab73-938f2a85559d" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The shared quick-panel row has consumers with different presentation needs. A small per-item `inlineDescription` opt-in keeps the existing default intact while letting skill rows preserve name readability and keep short names adjacent to their descriptions.

The following tradeoffs were made:

- Skill descriptions may truncate earlier so the skill name and suffix remain readable.
- The shared item model gains one optional presentation flag, with no behavior change for existing consumers.

The following alternatives were considered:

- Applying the inline layout globally was rejected because permission, MCP, and other quick-panel rows rely on trailing metadata.
- Reserving a fixed-width name column was rejected because it would recreate excessive whitespace for short names and premature truncation for long names.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- `pnpm exec vitest run src/renderer/components/QuickPanel/__tests__/row.test.tsx src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx` (131 tests passed)
- `pnpm exec vitest run src/renderer/components/QuickPanel src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx` (59 tests passed)
- `pnpm typecheck:web`
- Biome and ESLint checks on the changed files
- `git diff --check HEAD`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed composer skill rows so skill names remain readable and short names stay visually connected to their descriptions.
```

