### PR TITLE
fix(api-gateway): fold inline system messages for openai-chat-completions

### DIFF
--- a/src/main/features/apiGateway/utils/__tests__/inlineSystemMessages.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/inlineSystemMessages.test.ts
@@ -80,7 +80,6 @@ describe('keepsSystemMessagesInPlace', () => {
   it('allows the chat endpoints whose converters were verified to pass a non-leading system through', () => {
     expect(ENDPOINT_CHAT_TARGETS.filter(keepsSystemMessagesInPlace)).toEqual([
       ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-      ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
       ENDPOINT_TYPE.OPENAI_RESPONSES
     ])
   })
@@ -101,9 +100,32 @@ describe('positionInlineSystemMessages', () => {
   const inline = [msg('system', 'Base.', 's0'), msg('user', 'go'), msg('system', 'MCP connecting.', 's1')]
 
   it('leaves them in place for a target that accepts them', () => {
-    expect(
+    expect(positionInlineSystemMessages(inline, ENDPOINT_TYPE.OPENAI_RESPONSES, betaHeaders(AGENT_SDK_BETAS))).toBe(
+      inline
+    )
+  })
+
+  // An OpenAI-compatible backend whose chat template requires `system` at messages[0]
+  // answers a non-leading one with a 400 the Agent SDK does not recognize, so the session
+  // fails every turn instead of downgrading. Never send it the shape.
+  it('lets the Agent SDK downgrade before sending them to an OpenAI-compatible backend', () => {
+    let thrown: unknown
+    try {
       positionInlineSystemMessages(inline, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, betaHeaders(AGENT_SDK_BETAS))
-    ).toBe(inline)
+    } catch (error) {
+      thrown = error
+    }
+
+    const { status, message } = thrown as Error & { status: number }
+    expect(status).toBe(400)
+    expect(sdkAcceptsAsDowngradeSignal(status, message)).toBe(true)
+  })
+
+  it('folds OpenAI-compatible inline system messages when the client cannot downgrade', () => {
+    expect(positionInlineSystemMessages(inline, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, undefined)).toEqual([
+      { ...inline[0], parts: [{ type: 'text', text: 'Base.\n\nMCP connecting.' }] },
+      inline[1]
+    ])
   })
 
   it('rejects with a 400 the Agent SDK downgrades from when the client negotiated the beta', () => {

--- a/src/main/features/apiGateway/utils/inlineSystemMessages.ts
+++ b/src/main/features/apiGateway/utils/inlineSystemMessages.ts
@@ -22,19 +22,22 @@ import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
  * Verified against the installed SDKs:
  * - `@ai-sdk/anthropic` 3.0.103 pushes `{ role: 'system' }` and adds the
  *   `mid-conversation-system-2026-04-07` beta itself (`dist/index.mjs:2380`)
- * - `@ai-sdk/openai` 3.0.53 pushes it on both the chat and responses paths (`:114`, `:2761`)
- * - `@ai-sdk/openai-compatible` 2.0.62 pushes it (`:114`)
+ * - `@ai-sdk/openai` 3.0.53 pushes it on the responses path (`:2761`)
  *
  * Deliberately excluded: `@ai-sdk/google` throws `system messages are only supported at
  * the beginning of the conversation` (`:523`), and the `*-text-completions` /
- * `ollama-generate` converters throw `Unexpected system message in prompt`. Ollama chat
- * serializes the message, but renderer behavior varies: some fold instruction messages into
- * a leading system turn while others only consume one at `messages[0]`. The gateway has no
- * renderer capability signal, so it cannot safely leave a non-leading system message in place.
+ * `ollama-generate` converters throw `Unexpected system message in prompt`.
+ *
+ * The two chat endpoints an arbitrary server can sit behind are excluded for the same
+ * reason: serializing the shape is not accepting it. `openai-chat-completions` reaches
+ * every OpenAI-compatible backend (litellm, vLLM, sglang), and a chat template that
+ * requires `system` at `messages[0]` answers `System message must be at the beginning`
+ * with a 400; Ollama chat hands the messages to a per-model renderer that may instead
+ * drop a later system message silently. The gateway resolves one endpoint type for all
+ * of them and has no per-backend capability signal, so neither can stay in place.
  */
 const SYSTEM_IN_PLACE_ENDPOINTS: ReadonlySet<EndpointType> = new Set([
   ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-  ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
   ENDPOINT_TYPE.OPENAI_RESPONSES
 ])
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

**Before this PR:**

`SYSTEM_IN_PLACE_ENDPOINTS` allowlisted `openai-chat-completions`, so the Claude Agent SDK's inline `role: 'system'` messages (agent/skill catalogs, deferred-tool notices, "MCP servers are still connecting") were forwarded to the target at their original index.

The allowlist entry was justified by reading `@ai-sdk/openai-compatible` 2.0.62 and confirming it *serializes* a non-leading system message rather than throwing (`dist/index.mjs:114`). That is a statement about the JavaScript client, not about the server on the other end — and `openai-chat-completions` is the endpoint type behind **every** OpenAI-compatible backend, not just `api.openai.com`.

A chat template that requires `system` at `messages[0]` rejects the shape outright:

```
litellm.BadRequestError: OpenAIException - System message must be at the beginning.
```

The Agent SDK does have a downgrade path for exactly this — it rebuilds the harness context as `<system-reminder>` blocks inside the user turn and sticky-disables the beta — but the trigger is a text match on the 400 body, requiring one of: the beta name plus `anthropic-beta`; `Unexpected role` + `input message role`; `cache_control` + a pattern; `not supported` + `role system`. A backend's own wording matches none of them, so the session fails identically on every turn instead of recovering.

**After this PR:**

`openai-chat-completions` uses the compatibility paths that already exist: a client that negotiated `mid-conversation-system-2026-04-07` gets the recognized downgrade 400 and retries with `<system-reminder>` blocks; a client that did not gets its inline system messages folded into the leading one. Both keep the instructions visible regardless of the backend's chat template.

Refs #19124

### Why we need it and why it was done in this way

This is the same defect class #19042 fixed for Ollama chat, and the same reasoning applies verbatim: whether a provider SDK can serialize a message says nothing about how the downstream template or renderer interprets it, and the gateway resolves one endpoint type for every backend behind it with no per-backend capability signal. Removing the entry reuses machinery that is already implemented and verified rather than adding a new code path.

The following tradeoffs were made:

- **Real OpenAI pays for this.** `api.openai.com` accepts a non-leading system message, and it shares the `openai-chat-completions` endpoint type with every self-hosted proxy. Those sessions move from in-place to folded, losing prompt-prefix stability: measured in #18697, folding drops the reusable prefix from 5/5 to 0/4 messages between consecutive turns, because the leading system message grows whenever a harness update arrives. Accepted here because the failure mode on the other side is a hard 400 on every turn with no recovery, and because Agent SDK clients — the ones that actually send inline system messages — take the downgrade path and keep *their* prefix stable via `<system-reminder>` rebuilds.
- **The allowlist stays an allowlist.** `anthropic-messages` and `openai-responses` remain; both address a known API surface rather than an arbitrary server.

The following alternatives were considered:

- **Distinguishing real OpenAI from an OpenAI-compatible proxy by host** — would preserve caching for `api.openai.com`. Rejected for now: `positionInlineSystemMessages` receives only an `EndpointType`, so this needs provider/base-URL identity threaded through `proxyStream`, and it is a separate change with its own review surface. Worth doing if prefix-cache loss on OpenAI proves material.
- **Detecting the backend from the 400 and retrying** — the gateway would have to speculatively send the shape, eat a failed turn, and cache the verdict per base URL. More moving parts than the constraint deserves.
- **Leaving it and asking users to reconfigure their proxy** — the failure is a silent-looking hard stop with an error message that names neither Cherry Studio nor the real cause.

Links to places where the discussion took place: #19124, #18697, #19042, #18643

### Breaking changes

None.

### Special notes for your reviewer

- **This PR does not fix #19124 as reported.** That user reaches litellm over the `direct` route (litellm configured as an Anthropic-compatible provider), where `ANTHROPIC_BASE_URL` points straight at the proxy and the gateway is not in the request path at all. I verified there is no lever on that route: the CLI's capability env vars (`ANTHROPIC_DEFAULT_*_MODEL_SUPPORTED_CAPABILITIES`) are inert whenever the base URL is non-Anthropic, because the lookup opens with `if (rm()) return` and `rm()` is true for the `firstParty` kind that any custom base URL still resolves to. Confirmed on the wire against the pinned `@anthropic-ai/claude-agent-sdk` 0.3.220 binary at a stub endpoint: declaring a capability list that omits everything but `temperature` changed nothing in the request body. What this PR does do is make the recommended workaround — add the proxy as an OpenAI-compatible provider — actually work.
- Measured baseline for a third-party model id on a custom base URL, first request of a stock session: `messages` roles `['user','system']`, `anthropic-beta` including `mid-conversation-system-2026-04-07`, `"thinking":{"type":"adaptive"}`, `"output_config":{"effort":"high"}`, no `temperature`. The inline system message is present from turn one, which is why the report shows an immediate failure.
- Test changes assert the contract rather than the allowlist's contents: an OpenAI-compatible target must either receive a 400 the SDK recognizes as a downgrade signal, or a folded prompt. The downgrade assertion runs against a transcription of the SDK's own matcher, so the error text cannot drift out of compatibility silently.
- Verification: `npx vitest run --project main src/main/features/apiGateway` → 29 files / 407 tests passed. `pnpm lint` clean (oxlint + eslint + typecheck + i18n + format).
- No visual change (main-process request conversion only).

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: Not required — no user-facing surface changes.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed Agent sessions that are routed through the local API gateway failing with "System message must be at the beginning" on OpenAI-compatible endpoints (litellm, vLLM, sglang and similar proxies). Sessions that reach such a proxy through a provider configured as Anthropic-compatible are not covered by this fix.
```
