### PR TITLE
fix(anthropic-provider): accept thinking blocks without a signature

### DIFF
--- a/patches/@ai-sdk__anthropic.patch
+++ b/patches/@ai-sdk__anthropic.patch
@@ -1,7 +1,16 @@
 diff --git a/dist/index.js b/dist/index.js
-index c180815..d39bc34 100644
+index c180815..5dd52b3 100644
 --- a/dist/index.js
 +++ b/dist/index.js
+@@ -108,7 +108,7 @@ var anthropicMessagesResponseSchema = (0, import_provider_utils2.lazySchema)(
+           import_v42.z.object({
+             type: import_v42.z.literal("thinking"),
+             thinking: import_v42.z.string(),
+-            signature: import_v42.z.string()
++            signature: import_v42.z.string().optional()
+           }),
+           import_v42.z.object({
+             type: import_v42.z.literal("redacted_thinking"),
 @@ -3474,7 +3474,7 @@ var AnthropicMessagesLanguageModel = class {
        warnings.push({
          type: "compatibility",
@@ -38,9 +47,18 @@ index c180815..d39bc34 100644
        if (isAnthropicModel && topP != null && temperature != null) {
          warnings.push({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index fe20f4d..e58418f 100644
+index fe20f4d..22561d5 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
+@@ -107,7 +107,7 @@ var anthropicMessagesResponseSchema = lazySchema2(
+           z2.object({
+             type: z2.literal("thinking"),
+             thinking: z2.string(),
+-            signature: z2.string()
++            signature: z2.string().optional()
+           }),
+           z2.object({
+             type: z2.literal("redacted_thinking"),
 @@ -3525,7 +3525,7 @@ var AnthropicMessagesLanguageModel = class {
        warnings.push({
          type: "compatibility",
@@ -77,9 +95,18 @@ index fe20f4d..e58418f 100644
        if (isAnthropicModel && topP != null && temperature != null) {
          warnings.push({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index b408db2..7cbffe6 100644
+index b408db2..b778ae1 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
+@@ -102,7 +102,7 @@ var anthropicMessagesResponseSchema = (0, import_provider_utils2.lazySchema)(
+           import_v42.z.object({
+             type: import_v42.z.literal("thinking"),
+             thinking: import_v42.z.string(),
+-            signature: import_v42.z.string()
++            signature: import_v42.z.string().optional()
+           }),
+           import_v42.z.object({
+             type: import_v42.z.literal("redacted_thinking"),
 @@ -1521,7 +1521,7 @@ async function prepareTools({
          anthropicTools2.push({
            name: tool.name,
@@ -134,9 +161,18 @@ index b408db2..7cbffe6 100644
        if (isAnthropicModel && topP != null && temperature != null) {
          warnings.push({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index 168f139..7365bc0 100644
+index 168f139..10d8eef 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
+@@ -91,7 +91,7 @@ var anthropicMessagesResponseSchema = lazySchema2(
+           z2.object({
+             type: z2.literal("thinking"),
+             thinking: z2.string(),
+-            signature: z2.string()
++            signature: z2.string().optional()
+           }),
+           z2.object({
+             type: z2.literal("redacted_thinking"),
 @@ -1536,7 +1536,7 @@ async function prepareTools({
          anthropicTools2.push({
            name: tool.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ overrides:
   ai: 6.0.185
 
 patchedDependencies:
-  '@ai-sdk/anthropic': b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46
+  '@ai-sdk/anthropic': a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
@@ -222,7 +222,7 @@ importers:
         version: 4.0.96(zod@4.3.4)
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+        version: 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -1420,7 +1420,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.4.3)
+        version: 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.64
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
@@ -1451,7 +1451,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+        version: 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -10949,6 +10949,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -10959,6 +10960,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -12162,6 +12164,7 @@ packages:
 
   koffi@3.1.4:
     resolution: {integrity: sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==}
+    deprecated: Unstable Windows builds
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -15957,7 +15960,7 @@ snapshots:
 
   '@ai-sdk/amazon-bedrock@4.0.96(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       '@smithy/eventstream-codec': 4.2.14
@@ -15965,13 +15968,13 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)':
+  '@ai-sdk/anthropic@3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
@@ -16031,7 +16034,7 @@ snapshots:
 
   '@ai-sdk/google-vertex@4.0.112(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.103(patch_hash=a6fee9768531a088c004ca35f2889025e90645eabb4aeb2a867d169ed1462b34)(zod@4.3.4)
       '@ai-sdk/google': 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.3.4)
       '@ai-sdk/openai-compatible': 2.0.41(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8

--- a/src/main/ai/provider/__tests__/anthropicThinkingSignaturePatch.test.ts
+++ b/src/main/ai/provider/__tests__/anthropicThinkingSignaturePatch.test.ts
@@ -1,0 +1,40 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { describe, expect, it } from 'vitest'
+
+// Guards patches/@ai-sdk__anthropic.patch. The upstream non-streaming response schema
+// requires `signature` on a thinking block, but anthropic-messages gateways (CherryIN's
+// `agent/*` models) return thinking blocks without one — a valid HTTP 200 that, unpatched,
+// fails schema validation (AI_TypeValidationError → "Invalid JSON response") and breaks
+// every non-streaming call, e.g. topic naming. The patch makes `signature` optional. If an
+// SDK upgrade drops the patch, this test fails loudly.
+describe('patched @ai-sdk/anthropic response schema tolerates a signature-less thinking block', () => {
+  it('parses a 200 whose thinking block omits signature', async () => {
+    const body = {
+      id: 'msg_1',
+      type: 'message',
+      role: 'assistant',
+      model: 'agent/deepseek-v4-pro',
+      content: [
+        { type: 'thinking', thinking: 'weighing the title' },
+        { type: 'text', text: 'Trip planning' }
+      ],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 12, output_tokens: 4 }
+    }
+    const model = createAnthropic({
+      apiKey: 'test',
+      fetch: async () =>
+        new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+    })('agent/deepseek-v4-pro')
+
+    const result = await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'name this chat' }] }],
+      maxOutputTokens: 64
+    })
+
+    expect(result.content).toEqual([
+      { type: 'reasoning', text: 'weighing the title', providerMetadata: { anthropic: { signature: undefined } } },
+      { type: 'text', text: 'Trip planning' }
+    ])
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `@ai-sdk/anthropic`'s non-streaming response schema requires `signature` on a thinking block, so any anthropic-messages gateway that returns a thinking block without one (e.g. CherryIN's `agent/deepseek-v4-pro`) made every non-streaming call fail with `AI_TypeValidationError` → `Invalid JSON response`; the user-visible symptom was the repeated "自动生成对话名失败 Invalid JSON response" toast from `TopicNamingService`.

After this PR: the patch makes `signature` optional in that schema, so a signature-less thinking block parses and auto topic naming succeeds. Streaming was never affected (it decodes `signature_delta` separately), which is why normal chats worked while one-shot calls did not.

Fixes #19121

### Why we need it and why it was done in this way

The following tradeoffs were made: the fix extends the existing `patches/@ai-sdk__anthropic.patch` rather than adding an app-level workaround, because the failure happens inside the provider's response decoding where the app has no seam; `pnpm-lock.yaml` changes only because the patch hash moved. A signature-less reasoning part now carries `providerMetadata.anthropic.signature === undefined`, and the SDK's message-conversion path already guards on `signature != null`, so a round-trip degrades to an "unsupported reasoning metadata" warning instead of throwing.

The following alternatives were considered: swallowing the error in `TopicNamingService` (hides a real decode failure and leaves every other non-streaming call broken) and upstreaming to the AI SDK (worth doing separately, but does not unblock users on the pinned 3.0.103).

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19121

### Breaking changes

None.

### Special notes for your reviewer

`src/main/ai/provider/__tests__/anthropicThinkingSignaturePatch.test.ts` guards the patch the same way `openaiCompatibleEmbeddingPatch.test.ts` guards its own: reverting the `.optional()` in `node_modules` makes it fail with the exact `AI_APICallError: Invalid JSON response` from the issue, so an SDK upgrade that drops the patch fails loudly.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix "Invalid JSON response" failures on anthropic-messages providers whose thinking blocks omit a signature (e.g. CherryIN agent models), which broke auto conversation naming.
```
