### PR TITLE
fix(screenshot-overlay): keep the toolbar on screen for a full-screen selection

### DIFF
--- a/src/renderer/windows/screenshot/__tests__/geometry.test.ts
+++ b/src/renderer/windows/screenshot/__tests__/geometry.test.ts
@@ -4,7 +4,9 @@ import { createElement } from 'react'
 import { describe, expect, it } from 'vitest'
 
 import { OcrTextOverlay } from '../components/OcrTextOverlay'
+import { Toolbar } from '../components/Toolbar'
 import { mergeLine } from '../hooks/useOcr'
+import type { SelectionRect } from '../types'
 import { buildAnnotation, isSignificantAnnotation } from '../utils/annotation'
 import { findWindowAtPoint } from '../utils/findWindowAtPoint'
 
@@ -111,6 +113,39 @@ describe('isSignificantAnnotation', () => {
       ({ type: 'text', color: '#000', fontSize: 20, position: { x: 0, y: 0 }, content }) as const
     expect(isSignificantAnnotation(text(''))).toBe(false)
     expect(isSignificantAnnotation(text('a'))).toBe(true)
+  })
+})
+
+describe('Toolbar placement', () => {
+  const noop = () => {}
+  const actions = {
+    activeTool: null,
+    canUndo: false,
+    canRedo: false,
+    onToolChange: noop,
+    onUndo: noop,
+    onRedo: noop,
+    onOk: noop,
+    onSave: noop,
+    onCancel: noop
+  }
+
+  function renderToolbar(selection: SelectionRect, logicalHeight: number) {
+    const { container } = render(createElement(Toolbar, { selection, logicalHeight, ...actions }))
+    return container.firstElementChild as HTMLElement
+  }
+
+  it('keeps the toolbar on screen when the selection covers the whole display', () => {
+    // Neither below (no room left) nor above (the selection starts at y=0) fits, and these
+    // are the only controls a full-screen capture has — off-screen means Esc or nothing.
+    const top = Number.parseFloat(renderToolbar({ x: 0, y: 0, width: 1440, height: 900 }, 900).style.top)
+    expect(top).toBeGreaterThanOrEqual(0)
+    // 80 = toolbar + gap + property panel, the stack the toolbar reserves room for.
+    expect(top + 80).toBeLessThanOrEqual(900)
+  })
+
+  it('hangs below a selection that has room underneath it', () => {
+    expect(renderToolbar({ x: 0, y: 0, width: 400, height: 300 }, 900).style.top).toBe('308px')
   })
 })
 

--- a/src/renderer/windows/screenshot/components/Toolbar.tsx
+++ b/src/renderer/windows/screenshot/components/Toolbar.tsx
@@ -104,7 +104,9 @@ export const Toolbar = memo(function Toolbar({
   const aboveY = selection.y - TOOLBAR_HEIGHT - GAP
   const fitsBelow = belowY + totalHeight <= logicalHeight
   const isBelow = fitsBelow || aboveY < 0
-  const top = isBelow ? belowY : Math.max(0, aboveY)
+  // A full-screen selection fits on neither side; clamping covers its bottom edge, while
+  // off-screen would strand the toolbar with no way to act on the capture at all.
+  const top = isBelow ? Math.min(belowY, logicalHeight - totalHeight) : Math.max(0, aboveY)
 
   const right = selection.x + selection.width
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The V2 screenshot overlay picked the toolbar position from exactly two candidates — outside the selection below it, or outside it above. A full-screen selection fits neither: `belowY + totalHeight > logicalHeight` and `aboveY < 0`, so the fallback chose *below* and positioned the toolbar past the bottom edge of the display. On a 1440×900 screen it landed at `top: 908`. The user was left with an unreachable toolbar and a capture that swallowed every click (with a full-screen selection every point is inside it, so each press became a no-op move drag), so `Esc` was the only way out.

After this PR:

The below branch is clamped the same way the above branch already was, so the toolbar stays inside the viewport and overlays the bottom of the capture instead of leaving the screen. Selections with room underneath are unaffected — `Math.min` is a no-op there. Two tests in `geometry.test.ts` pin both halves: a full-screen selection keeps the whole toolbar stack on screen, and a selection with room still hangs 8 px below it.

Fixes #18969

### Why we need it and why it was done in this way

The fix restores symmetry that was already missing: the above branch had `Math.max(0, aboveY)` while the below branch had no clamp at all. `PropertyPanel.tsx` solves the identical "neither side fits" case by flipping over the toolbar and documents the tradeoff — covering part of the selection beats going off-screen — so the toolbar now follows the component it sits next to.

The following tradeoffs were made: with a full-screen selection the toolbar covers the bottom strip of the captured image. That strip is still captured and still annotatable once a tool moves the panel; an unreachable toolbar is not recoverable at all.

The following alternatives were considered: shrinking the selection to leave room below it (changes what the user captures), and making clicks outside a full-screen selection reset it (a separate interaction decision that does not restore the missing controls).

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18969

### Breaking changes

None.

### Special notes for your reviewer

Verified by the test, not by a packaged build: reverting the one-line change makes the new test fail with `expected 988 to be less than or equal to 900`, which is exactly the reporter's 1440×900 geometry. `pnpm lint` passes.

The "screen is unresponsive" half of the report is a consequence of the same bug, not a second one — `CaptureCanvas.handlePointerDown` routes presses inside the selection to a move drag, and a full-screen selection has no outside. With the toolbar back, cancel and confirm are reachable again; whether clicking a full-screen selection should also re-arm free-hand selection is left alone deliberately.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the V2 screenshot toolbar being positioned off-screen after a full-screen capture, which left the annotation step with no reachable controls.
```
