### PR TITLE
fix(composer): preview Markdown attachments

### DIFF
--- a/src/renderer/components/FilePreview/hooks/__tests__/useOpenFilePreviewTab.test.tsx
+++ b/src/renderer/components/FilePreview/hooks/__tests__/useOpenFilePreviewTab.test.tsx
@@ -5,6 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   openTab: vi.fn(),
+  optionalTabsContext: null as {
+    openTab: ReturnType<typeof vi.fn>
+    tabs: Array<{ id: string; metadata?: Record<string, unknown>; type: 'route'; url: string }>
+    updateTab: ReturnType<typeof vi.fn>
+  } | null,
   tabs: [] as Array<{
     id: string
     metadata?: Record<string, unknown>
@@ -15,19 +20,27 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@renderer/hooks/tab', () => ({
+  useOptionalTabsContext: () => mocks.optionalTabsContext,
   useTabs: () => ({ openTab: mocks.openTab, tabs: mocks.tabs, updateTab: mocks.updateTab })
 }))
 
-import { useOpenFilePreviewTab } from '../useOpenFilePreviewTab'
+import { useOpenFilePreviewTab, useOptionalOpenFilePreviewTab } from '../useOpenFilePreviewTab'
 
 beforeEach(() => {
   mocks.openTab.mockReset()
   mocks.openTab.mockReturnValue('file-preview-tab')
+  mocks.optionalTabsContext = null
   mocks.tabs.length = 0
   mocks.updateTab.mockReset()
 })
 
 describe('useOpenFilePreviewTab', () => {
+  it('is unavailable outside a tabs provider when requested optionally', () => {
+    const { result } = renderHook(() => useOptionalOpenFilePreviewTab())
+
+    expect(result.current).toBeUndefined()
+  })
+
   it('opens a canonical route that reuses the same file tab', () => {
     const { result } = renderHook(() => useOpenFilePreviewTab())
     let tabId: string | undefined

--- a/src/renderer/components/FilePreview/hooks/useOpenFilePreviewTab.ts
+++ b/src/renderer/components/FilePreview/hooks/useOpenFilePreviewTab.ts
@@ -1,4 +1,4 @@
-import { useTabs } from '@renderer/hooks/tab'
+import { type TabsContextValue, useOptionalTabsContext, useTabs } from '@renderer/hooks/tab'
 import {
   createFilePreviewTabTarget,
   FILE_PREVIEW_REFRESH_KEY,
@@ -7,11 +7,18 @@ import {
 import type { AbsoluteFilePath } from '@shared/types/file'
 import { useCallback } from 'react'
 
-export function useOpenFilePreviewTab(): (filePath: AbsoluteFilePath, fileName?: string) => string {
-  const { openTab, tabs, updateTab } = useTabs()
+type OpenFilePreviewTab = (filePath: AbsoluteFilePath, fileName?: string) => string
+type FilePreviewTabsContext = Pick<TabsContextValue, 'openTab' | 'tabs' | 'updateTab'>
+
+function useOpenFilePreviewTabFromContext(tabsContext: FilePreviewTabsContext | null): OpenFilePreviewTab {
+  const openTab = tabsContext?.openTab
+  const tabs = tabsContext?.tabs
+  const updateTab = tabsContext?.updateTab
 
   return useCallback(
     (filePath: AbsoluteFilePath, fileName?: string) => {
+      if (!openTab || !tabs || !updateTab) throw new Error('File preview tabs are unavailable')
+
       const target = createFilePreviewTabTarget(filePath)
       const title = fileName || target.title
       const existingTab = tabs.find((tab) => tab.type === 'route' && tab.url === target.url)
@@ -34,4 +41,14 @@ export function useOpenFilePreviewTab(): (filePath: AbsoluteFilePath, fileName?:
     },
     [openTab, tabs, updateTab]
   )
+}
+
+export function useOpenFilePreviewTab(): OpenFilePreviewTab {
+  return useOpenFilePreviewTabFromContext(useTabs())
+}
+
+export function useOptionalOpenFilePreviewTab(): OpenFilePreviewTab | undefined {
+  const tabsContext = useOptionalTabsContext()
+  const openFilePreviewTab = useOpenFilePreviewTabFromContext(tabsContext)
+  return tabsContext ? openFilePreviewTab : undefined
 }

--- a/src/renderer/components/FilePreview/index.ts
+++ b/src/renderer/components/FilePreview/index.ts
@@ -1,3 +1,3 @@
 export { FilePreview, type FilePreviewProps } from './FilePreview'
-export { useOpenFilePreviewTab } from './hooks/useOpenFilePreviewTab'
+export { useOpenFilePreviewTab, useOptionalOpenFilePreviewTab } from './hooks/useOpenFilePreviewTab'
 export type { FilePreviewType } from './types'

--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -21,6 +21,11 @@ import { composerInputTokenComponentByKind, ComposerToken, FileComposerToken } f
 
 const ipcRequestMock = vi.hoisted(() => vi.fn())
 const imagePreviewShowMock = vi.hoisted(() => vi.fn())
+const openFilePreviewTabMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@renderer/components/FilePreview', () => ({
+  useOptionalOpenFilePreviewTab: () => openFilePreviewTabMock
+}))
 
 vi.mock('@renderer/ipc', () => ({
   ipcApi: {
@@ -213,6 +218,8 @@ beforeEach(() => {
   ipcRequestMock.mockResolvedValue(undefined)
   imagePreviewShowMock.mockReset()
   imagePreviewShowMock.mockResolvedValue(undefined)
+  openFilePreviewTabMock.mockReset()
+  openFilePreviewTabMock.mockReturnValue('file-preview-tab')
   readPastedTextMock.mockReset()
   readPastedTextMock.mockResolvedValue('第一段粘贴文本\n第二段粘贴文本')
   Object.defineProperty(window, 'api', {
@@ -521,6 +528,63 @@ describe('ComposerToken', () => {
     const token = expectFileTokenVariant(container, 'pdf')
     expect(token.querySelector('[data-composer-token-remove]')).toBeInTheDocument()
     expectTokenPathTooltip(container, '/tmp/report-q2-final.pdf', '2 KB')
+  })
+
+  it('opens an editable Markdown attachment in the file preview tab by pointer or keyboard', async () => {
+    const user = userEvent.setup()
+    render(
+      <ComposerToken
+        token={{
+          id: 'file:markdown',
+          kind: 'file',
+          label: 'requirements.md',
+          payload: createFileMetadata({
+            name: 'managed-file.md',
+            origin_name: 'requirements.md',
+            path: '/tmp/managed-file.md',
+            ext: '.md',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+      />
+    )
+
+    const attachment = screen.getByRole('button', { name: 'requirements.md' })
+    await user.click(attachment)
+
+    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/managed-file.md', 'requirements.md')
+
+    openFilePreviewTabMock.mockClear()
+    attachment.focus()
+    await user.keyboard('{Enter}')
+
+    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/managed-file.md', 'requirements.md')
+  })
+
+  it('opens a sent Markdown attachment from its managed file URL', async () => {
+    const user = userEvent.setup()
+    render(
+      <FileComposerToken
+        readOnly
+        readOnlyFilePreview={{ url: 'file:///tmp/message-files/managed-file.md', mediaType: 'text/markdown' }}
+        token={{
+          id: 'file:sent-markdown',
+          kind: 'file',
+          label: 'requirements.md',
+          payload: createFileMetadata({
+            name: 'managed-file.md',
+            origin_name: 'requirements.md',
+            path: '/tmp/original-file.md',
+            ext: '.md',
+            type: FILE_TYPE.TEXT
+          })
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'requirements.md' }))
+
+    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/message-files/managed-file.md', 'requirements.md')
   })
 
   it('renders office file tokens with dedicated variants', () => {

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -5,12 +5,14 @@ import {
   QUOTE_TOOLTIP_BODY_CLASS_NAME,
   QUOTE_TOOLTIP_CONTENT_CLASS_NAME
 } from '@renderer/components/composer/quoteToken'
+import { useOptionalOpenFilePreviewTab } from '@renderer/components/FilePreview'
 import { BracesVariableIcon } from '@renderer/components/icons/BracesVariableIcon'
 import Favicon from '@renderer/components/icons/FallbackFavicon'
 import { ipcApi } from '@renderer/ipc'
 import { ImagePreviewService } from '@renderer/services/ImagePreviewService'
 import { COMPOSER_FILE_KIND, type ComposerFileKind, FILE_TYPE } from '@renderer/types/file'
 import { formatFileSize } from '@renderer/utils/file'
+import { normalizeFilePreviewPath } from '@renderer/utils/filePreview'
 import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import type { FileUrlString } from '@shared/types/file'
 import { fileUrlToPath } from '@shared/utils/file'
@@ -326,7 +328,17 @@ function getReadOnlyFilePreviewPath(readOnlyFilePreview: ReadOnlyComposerFileTok
   if (!readOnlyFilePreview?.url) return undefined
 
   try {
-    return fileUrlToPath(readOnlyFilePreview.url as FileUrlString)
+    return normalizeFilePreviewPath(fileUrlToPath(readOnlyFilePreview.url as FileUrlString))
+  } catch {
+    return undefined
+  }
+}
+
+function getEditableFilePreviewPath(file: ComposerAttachment | undefined) {
+  if (!file?.path) return undefined
+
+  try {
+    return normalizeFilePreviewPath(file.path)
   } catch {
     return undefined
   }
@@ -697,6 +709,7 @@ function ComposerTokenHoverPopover({
 }
 
 export function FileComposerToken(props: FileComposerTokenProps) {
+  const openFilePreviewTab = useOptionalOpenFilePreviewTab()
   const { imageIconPreview = false, onRemove, removeLabel: removeLabelProp, tooltipActions } = props
   const tokenFile = isComposerAttachment(props.token.payload) ? props.token.payload : undefined
   const previewFileType = props.readOnlyFilePreview?.mediaType?.startsWith('image/') ? FILE_TYPE.IMAGE : undefined
@@ -723,7 +736,37 @@ export function FileComposerToken(props: FileComposerTokenProps) {
   const removeLabel = removeLabelProp ?? 'Remove'
   const shouldShowPopover =
     shouldShowFileTokenPopover(file) && (!props.readOnly || Boolean(props.readOnlyFilePreview?.url))
-  const pathTooltipPath = props.readOnly ? getReadOnlyFilePreviewPath(props.readOnlyFilePreview) : file?.path
+  const readOnlyFilePreviewPath = getReadOnlyFilePreviewPath(props.readOnlyFilePreview)
+  const pathTooltipPath = props.readOnly ? readOnlyFilePreviewPath : file?.path
+  const filePreviewPath = props.readOnly ? readOnlyFilePreviewPath : getEditableFilePreviewPath(file)
+  const canOpenFilePreview = presentation.variant === 'markdown' && Boolean(filePreviewPath && openFilePreviewTab)
+  const openFilePreview = useCallback(() => {
+    if (!canOpenFilePreview || !filePreviewPath || !openFilePreviewTab) return
+    openFilePreviewTab(filePreviewPath, label)
+  }, [canOpenFilePreview, filePreviewPath, label, openFilePreviewTab])
+  const handleFilePreviewClick = useCallback(
+    (event: ReactMouseEvent<HTMLSpanElement>) => {
+      if (!canOpenFilePreview || (event.target as HTMLElement | null)?.closest('[data-composer-token-remove]')) return
+      stopTokenActionEvent(event)
+      openFilePreview()
+    },
+    [canOpenFilePreview, openFilePreview]
+  )
+  const handleFilePreviewKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLSpanElement>) => {
+      if (
+        !canOpenFilePreview ||
+        (event.target as HTMLElement | null)?.closest('[data-composer-token-remove]') ||
+        (event.key !== 'Enter' && event.key !== ' ')
+      ) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      openFilePreview()
+    },
+    [canOpenFilePreview, openFilePreview]
+  )
   const shouldShowPathTooltip = Boolean(pathTooltipPath) && !shouldShowFileTokenPopover(file)
   const shouldUseNeutralImageIcon = imageIconPreview && presentation.variant === 'image'
   const tokenIcon = props.token.icon ? (
@@ -739,7 +782,8 @@ export function FileComposerToken(props: FileComposerTokenProps) {
       className={cn(
         'group/composer-token mx-0.5 my-0.5 inline-flex h-6 max-w-[calc(100%_-_0.25rem)] select-none items-center gap-1 overflow-hidden rounded-md border px-1.5 align-middle font-medium text-foreground text-xs leading-[inherit] transition-[color,box-shadow,border-color]',
         'group-focus-visible:border-primary',
-        props.readOnly && 'focus-visible:border-primary focus-visible:outline-none',
+        (props.readOnly || canOpenFilePreview) && 'focus-visible:border-primary focus-visible:outline-none',
+        canOpenFilePreview && 'cursor-pointer',
         presentation.containerClassName,
         props.selected && 'border-primary ring-1 ring-primary/40',
         props.className
@@ -747,6 +791,11 @@ export function FileComposerToken(props: FileComposerTokenProps) {
       title={props.readOnly || shouldShowPathTooltip ? undefined : title}
       data-composer-token-kind={props.token.kind}
       data-file-token-variant={presentation.variant}
+      role={canOpenFilePreview ? 'button' : undefined}
+      tabIndex={canOpenFilePreview ? 0 : undefined}
+      aria-label={canOpenFilePreview ? accessibleTitle : undefined}
+      onClick={canOpenFilePreview ? handleFilePreviewClick : undefined}
+      onKeyDown={canOpenFilePreview ? handleFilePreviewKeyDown : undefined}
       onMouseDown={props.onMouseDown}>
       <span
         className={cn(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Markdown attachments rendered as Composer tokens, but activating the token did not open the existing file preview. This affected both editable attachments and attachments in sent messages.

After this PR:

Markdown attachment tokens open the canonical `FilePreview` tab with mouse, Enter, or Space. Editable attachments use their managed local path, while sent attachments use the managed `file://` URL path. Tokens remain inert when rendered outside a tabs provider.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19090

### Why we need it and why it was done in this way

Cherry Studio already has a Markdown-capable file preview and canonical tab routing, so this change connects Composer tokens to that existing flow instead of introducing another preview implementation. It normalizes paths before opening the preview and keeps the integration optional because Composer tokens are also rendered in contexts without a `TabsProvider`.

The following tradeoffs were made:

- Preview activation is limited to Markdown attachments to keep the fix aligned with the reported regression.
- The token uses semantic button behavior only when preview is actually available, preserving current behavior in isolated or provider-free renderers.

The following alternatives were considered:

- Adding a new modal preview was rejected because the existing file-preview tab already owns Markdown rendering and tab reuse.
- Enabling every document token was deferred because other formats have different support and were not part of the issue.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19090

### Breaking changes

None.

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regression coverage includes editable and sent-message paths, pointer and keyboard activation, optional tabs context, the existing file-preview route behavior, and the main Composer variants.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Markdown attachments not opening in the file preview from the Composer or sent messages.
```
