### PR TITLE
fix(models): hydrate custom model registry limits

### DIFF
--- a/src/main/data/services/ModelService.ts
+++ b/src/main/data/services/ModelService.ts
@@ -657,9 +657,9 @@ class ModelService {
   /**
    * Registry resolution shared by every row-serving path. Preset-backed rows
    * use the current registry as their baseline and apply every non-null sparse
-   * config column. Complete custom rows keep their row-owned capabilities and
-   * receive only the narrow metadata/reasoning enrichment used for recognized
-   * models. Nothing is written back.
+   * config column. Complete custom rows keep their row-owned identity and
+   * capabilities while recognized models receive narrow metadata/reasoning
+   * enrichment plus missing limits and pricing. Nothing is written back.
    */
   private enrichRowsFromRegistry(rows: UserModelRow[]): Model[] {
     const reasoningConfigCache = new Map<string, ReasoningProviderContext>()
@@ -700,9 +700,31 @@ class ModelService {
         const { presetModel, registryOverride, reasoningProfile, serviceTierControl } =
           providerRegistryService.lookupModel(model.providerId, modelId, reasoningConfigCache)
         const imageGeneration = registryOverride?.imageGeneration ?? presetModel?.imageGeneration
+        const registryModel = presetModel
+          ? mergePresetModel(
+              presetModel,
+              registryOverride,
+              model.providerId,
+              reasoningProfile.wire,
+              reasoningProfile.support,
+              serviceTierControl
+            )
+          : undefined
 
         const updates: Partial<Model> = {}
         if (imageGeneration) updates.imageGeneration = imageGeneration
+        if (model.contextWindow === undefined && registryModel?.contextWindow !== undefined) {
+          updates.contextWindow = registryModel.contextWindow
+        }
+        if (model.maxInputTokens === undefined && registryModel?.maxInputTokens !== undefined) {
+          updates.maxInputTokens = registryModel.maxInputTokens
+        }
+        if (model.maxOutputTokens === undefined && registryModel?.maxOutputTokens !== undefined) {
+          updates.maxOutputTokens = registryModel.maxOutputTokens
+        }
+        if (model.pricing === undefined && registryModel?.pricing !== undefined) {
+          updates.pricing = registryModel.pricing
+        }
         if (registryOverride?.supportsFastMode) updates.supportsFastMode = true
         if (serviceTierControl) {
           updates.requestControls = {
@@ -712,15 +734,8 @@ class ModelService {
         const ownedBy = registryOverride?.ownedBy ?? presetModel?.ownedBy ?? inferReasoningOwnedBy(modelId)
         if (ownedBy) updates.ownedBy = ownedBy
         let reasoning: RuntimeReasoning | undefined
-        if (presetModel) {
-          reasoning = mergePresetModel(
-            presetModel,
-            registryOverride,
-            model.providerId,
-            reasoningProfile.wire,
-            reasoningProfile.support,
-            serviceTierControl
-          ).reasoning
+        if (registryModel) {
+          reasoning = registryModel.reasoning
         } else if (model.reasoning?.controls?.length) {
           reasoning = projectRuntimeReasoning(model.reasoning, reasoningProfile.wire)
         } else {

--- a/src/main/data/services/__tests__/ModelService.test.ts
+++ b/src/main/data/services/__tests__/ModelService.test.ts
@@ -1119,6 +1119,55 @@ describe('ModelService.list — registry enrichment', () => {
     expect(storedAfterRegistryUpdate).toEqual(storedBeforeRegistryUpdate)
   })
 
+  it('hydrates missing limits and pricing when a custom model later gains a registry match', async () => {
+    await dbh.db.insert(userProviderTable).values(providerRow('openai', 'OpenAI'))
+    await dbh.db.insert(userModelTable).values(
+      modelRow('openai', 'future-model', {
+        presetModelId: null,
+        name: 'Future Model',
+        contextWindow: null,
+        maxInputTokens: null,
+        maxOutputTokens: 4096,
+        pricing: null
+      })
+    )
+    const storedBeforeRegistryUpdate = dbh.db.select().from(userModelTable).get()
+
+    lookupModelMock.mockReturnValue({
+      presetModel: {
+        id: 'future-model',
+        name: 'Future Model (registry)',
+        contextWindow: 128_000,
+        maxInputTokens: 120_000,
+        maxOutputTokens: 16_384,
+        pricing: {
+          input: { perMillionTokens: 5 },
+          output: { perMillionTokens: 15 }
+        }
+      },
+      registryOverride: {
+        limits: { contextWindow: 256_000, maxOutputTokens: 32_768 }
+      },
+      reasoningProfile: OPENAI_CHAT_REASONING_PROFILE
+    })
+
+    const [model] = modelService.list({ providerId: 'openai' })
+    const storedAfterRegistryUpdate = dbh.db.select().from(userModelTable).get()
+
+    expect(model).toMatchObject({
+      presetModelId: null,
+      name: 'Future Model',
+      contextWindow: 256_000,
+      maxInputTokens: 120_000,
+      maxOutputTokens: 4096,
+      pricing: {
+        input: { perMillionTokens: 5 },
+        output: { perMillionTokens: 15 }
+      }
+    })
+    expect(storedAfterRegistryUpdate).toEqual(storedBeforeRegistryUpdate)
+  })
+
   it('refreshes every registry-owned field while preserving row identity and status', async () => {
     await dbh.db.insert(userProviderTable).values(providerRow('openai', 'OpenAI'))
     await dbh.db.insert(userModelTable).values(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A custom model created before the provider registry recognized its API model ID stayed detached from later catalog limits and pricing. Even after a registry update produced an exact normalized match, reads still returned no `contextWindow`, `maxInputTokens`, `maxOutputTokens`, or `pricing` unless those values were already stored in the custom row.

After this PR:

Recognized custom models inherit missing limits and pricing from the current registry at read time. Explicitly stored custom values continue to win, the row remains a custom model with `presetModelId: null`, and no database fields are rewritten.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19147

### Why we need it and why it was done in this way

Registry catalogs can gain models after users have already added them. The existing custom-row enrichment already performs a normalized registry lookup for metadata and reasoning, so using the same resolved registry model to fill only missing limits and pricing keeps all read paths consistent without changing ownership or requiring users to delete and recreate models.

The following tradeoffs were made:

- Registry values are applied at read time, so they remain current without a migration or database write.
- Backfilling is limited to the four reported limits/pricing fields; custom names, capabilities, modalities, endpoint types, and streaming settings remain row-owned.

The following alternatives were considered:

- Rebinding matching rows by writing `presetModelId` during reconciliation was rejected because it changes custom-model ownership and sparse-delta semantics.
- Copying catalog values into nullable database columns was rejected because those copies would become stale and indistinguishable from user overrides.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19147

### Breaking changes

None.

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The regression test models a custom row created before catalog support, then adds a registry match with both preset limits and an override. It verifies missing values are hydrated, an explicit `maxOutputTokens` remains authoritative, custom identity is preserved, and the stored database row is unchanged.

Validation completed: 87/87 focused ModelService tests, full build, typecheck, `pnpm lint`, `pnpm test:lint`, Biome, and `git diff --check`.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed existing custom models not inheriting context limits and pricing when a later registry update recognizes them.
```
