### PR TITLE
perf(files): stabilize virtualized view callbacks

### DIFF
--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -809,14 +809,19 @@ function FilesPage() {
     setRenamingId(id)
   }, [])
 
+  const handleDeleteOne = useCallback((id: string) => handleDelete(new Set([id])), [handleDelete])
+  const handleRestoreOne = useCallback((id: string) => void handleRestore(new Set([id])), [handleRestore])
+  const handleRenameConfirm = useCallback((id: string, name: string) => void handleRename(id, name), [handleRename])
+  const handleRenameCancel = useCallback(() => setRenamingId(null), [])
+
   const listMenuActions = useMemo<FileContextMenuActions>(
     () => ({
       onRename: startInlineRename,
-      onDelete: (id) => handleDelete(new Set([id])),
-      onRestore: (id) => void handleRestore(new Set([id])),
+      onDelete: handleDeleteOne,
+      onRestore: handleRestoreOne,
       onShowInFolder: handleShowInFolder
     }),
-    [handleDelete, handleRestore, handleShowInFolder, startInlineRename]
+    [handleDeleteOne, handleRestoreOne, handleShowInFolder, startInlineRename]
   )
 
   const handleSort = useCallback(
@@ -1002,12 +1007,12 @@ function FilesPage() {
                     scrollRef={contentScrollRef}
                     onLayoutChange={maybeFillClientFilteredViewport}
                     onOpen={handleOpen}
-                    onDelete={(id) => handleDelete(new Set([id]))}
+                    onDelete={handleDeleteOne}
                     isTrash={isTrash}
                     menuActions={listMenuActions}
                     renamingId={renamingId}
-                    onRenameConfirm={(id, name) => void handleRename(id, name)}
-                    onRenameCancel={() => setRenamingId(null)}
+                    onRenameConfirm={handleRenameConfirm}
+                    onRenameCancel={handleRenameCancel}
                   />
                 ) : (
                   <FileList
@@ -1018,13 +1023,13 @@ function FilesPage() {
                     onOpen={handleOpen}
                     isTrash={isTrash}
                     menuActions={listMenuActions}
-                    onDelete={(id) => handleDelete(new Set([id]))}
-                    onRestore={(id) => void handleRestore(new Set([id]))}
+                    onDelete={handleDeleteOne}
+                    onRestore={handleRestoreOne}
                     onRename={startInlineRename}
                     onShowInFolder={handleShowInFolder}
                     renamingId={renamingId}
-                    onRenameConfirm={(id, name) => void handleRename(id, name)}
-                    onRenameCancel={() => setRenamingId(null)}
+                    onRenameConfirm={handleRenameConfirm}
+                    onRenameCancel={handleRenameCancel}
                   />
                 )}
               </>

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -714,9 +714,8 @@ function FilesPage() {
     [files, isTrash, refetchFiles, t]
   )
 
-  const handleDelete = useCallback(
-    (ids?: Set<string>) => {
-      const targetIds = ids ?? selectedIds
+  const requestDelete = useCallback(
+    (targetIds: Set<string>) => {
       const targets = files.filter((file) => targetIds.has(file.id))
       if (targets.length === 0) return
 
@@ -727,7 +726,12 @@ function FilesPage() {
 
       void performDelete(new Set(targets.map((file) => file.id)))
     },
-    [files, isTrash, performDelete, selectedIds]
+    [files, isTrash, performDelete]
+  )
+
+  const handleDelete = useCallback(
+    (ids?: Set<string>) => requestDelete(ids ?? selectedIds),
+    [requestDelete, selectedIds]
   )
 
   const emptyTrash = useCallback(async () => {
@@ -809,7 +813,7 @@ function FilesPage() {
     setRenamingId(id)
   }, [])
 
-  const handleDeleteOne = useCallback((id: string) => handleDelete(new Set([id])), [handleDelete])
+  const handleDeleteOne = useCallback((id: string) => requestDelete(new Set([id])), [requestDelete])
   const handleRestoreOne = useCallback((id: string) => void handleRestore(new Set([id])), [handleRestore])
   const handleRenameConfirm = useCallback((id: string, name: string) => void handleRename(id, name), [handleRename])
   const handleRenameCancel = useCallback(() => setRenamingId(null), [])


### PR DESCRIPTION
### What this PR does

Before this PR:

`FilesPage` passed newly allocated delete, restore, rename-confirm, and rename-cancel callbacks to the memoized virtualized `FileList` and `FileGrid` views on every parent render. Unrelated page state changes therefore invalidated their memo boundaries.

After this PR:

Stable `useCallback` adapters are shared by both virtualized views and the file context-menu actions. Unrelated `FilesPage` updates can now preserve callback identities and avoid unnecessary view reconciliation.

Fixes #19141

### Why we need it and why it was done in this way

Virtualized file views should not reconcile when unrelated parent state changes, such as preview, drag-overlay, or delete-dialog state.

The following tradeoffs were made:

- The change is intentionally limited to callback identity stability.
- Existing child component APIs and file-operation behavior remain unchanged.
- Small single-item adapters remain in `FilesPage`, where bulk file operations are already coordinated.

The following alternatives were considered:

- Moving `Set` construction into `FileList` and `FileGrid`, but that would duplicate parent operation semantics in both children.
- Ignoring callbacks in custom memo comparators, but that could retain stale closures and hide legitimate callback changes.

Links to places where the discussion took place: #19141

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- FilesPage regression suite: 48/48 passed
- Main-process suite: 12,832 passed
- Renderer tests: 9,828 passed
- Remaining workspace tests: 3,138 passed
- `pnpm lint`
- `pnpm format`
- `pnpm test:lint`
- `git diff --check`

The full renderer command still reports the repository's pre-existing asynchronous `Controller is already closed` unhandled rejection from `ExecutionStreamOverlayService.test.ts`; all renderer assertions themselves passed.

A dedicated test for callback reference identity was not added because it would test internal child props/render counts rather than user-visible behavior. Existing file-operation tests cover the preserved behavior.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The code was left cleaner than before
- [x] Upgrade: Upgrade impact was considered; none is required
- [ ] Documentation: No user-facing documentation change is required
- [x] Self-review: I have reviewed the diff before requesting review

### Release note

```release-note
NONE
```
