### PR TITLE
perf(home,agents): isolate tab-state side effects from page roots

### DIFF
--- a/src/renderer/components/layout/TabsProvider.tsx
+++ b/src/renderer/components/layout/TabsProvider.tsx
@@ -1,6 +1,9 @@
 import { loggerService } from '@logger'
 import { usePersistCache } from '@renderer/data/hooks/useCache'
 import {
+  type CloseConversationTabs,
+  CloseConversationTabsContext,
+  findClosableConversationTabIds,
   type OpenTabOptions,
   TabsContext,
   type TabsContextValue,
@@ -482,6 +485,21 @@ export function TabsProvider({
 
   const closeTab = useCallback((id: string) => closeTabs([id]), [closeTabs])
 
+  const closeConversationTabsStateRef = useRef({ tabs, activeTabId, closeTabs })
+  useLayoutEffect(() => {
+    closeConversationTabsStateRef.current = { tabs, activeTabId, closeTabs }
+  }, [tabs, activeTabId, closeTabs])
+
+  const closeConversationTabs = useCallback<CloseConversationTabs>((appId, keys) => {
+    const {
+      tabs: latestTabs,
+      activeTabId: latestActiveTabId,
+      closeTabs: closeLatestTabs
+    } = closeConversationTabsStateRef.current
+    const tabIds = findClosableConversationTabIds(latestTabs, latestActiveTabId, appId, keys)
+    if (tabIds.length > 0) closeLatestTabs(tabIds)
+  }, [])
+
   /**
    * Open a Tab - reuses existing tab or creates new one
    */
@@ -662,5 +680,9 @@ export function TabsProvider({
     reorderTabs
   }
 
-  return <TabsContext value={value}>{children}</TabsContext>
+  return (
+    <CloseConversationTabsContext value={closeConversationTabs}>
+      <TabsContext value={value}>{children}</TabsContext>
+    </CloseConversationTabsContext>
+  )
 }

--- a/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabsProvider.test.tsx
@@ -119,7 +119,7 @@ vi.mock('@renderer/ipc', () => ({
   useIpcOn: vi.fn()
 }))
 
-import { useTabsContext } from '@renderer/hooks/tab'
+import { useCloseConversationTabs, useTabsContext } from '@renderer/hooks/tab'
 
 import { migratePinnedTabs, TabsProvider } from '../TabsProvider'
 
@@ -144,6 +144,63 @@ function PinnedRouteTitle() {
 function TabIds() {
   const { tabs } = useTabsContext()
   return <div data-testid="tab-ids">{tabs.map((tab) => tab.id).join(',')}</div>
+}
+
+const conversationTabActionRender = vi.fn()
+
+function ConversationTabMutationControls() {
+  const { activeTabId, addTab, closeTab, setActiveTab, tabs, updateTab } = useTabsContext()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          addTab({
+            id: 'topic-a-tab',
+            type: 'route',
+            url: '/app/chat?topicId=topic-a',
+            title: 'Topic A',
+            lastAccessTime: 0,
+            isDormant: false
+          })
+          addTab({
+            id: 'unrelated-tab',
+            type: 'route',
+            url: '/app/files',
+            title: 'Files',
+            lastAccessTime: 0,
+            isDormant: false
+          })
+        }}>
+        Seed tabs
+      </button>
+      <button type="button" onClick={() => setActiveTab('home')}>
+        Activate home
+      </button>
+      <button
+        type="button"
+        onClick={() => updateTab('topic-a-tab', { title: 'Renamed Topic', metadata: { test: true } })}>
+        Rename background topic
+      </button>
+      <button type="button" onClick={() => closeTab('unrelated-tab')}>
+        Close unrelated tab
+      </button>
+      <div data-testid="conversation-tab-active">{activeTabId}</div>
+      <div data-testid="conversation-tab-snapshot">{tabs.map((tab) => `${tab.id}:${tab.title}`).join(',')}</div>
+    </>
+  )
+}
+
+function ConversationTabActionProbe() {
+  conversationTabActionRender()
+  const closeConversationTabs = useCloseConversationTabs()
+
+  return (
+    <button type="button" onClick={() => closeConversationTabs('assistants', ['topic-a'])}>
+      Close background topic
+    </button>
+  )
 }
 
 // Surfaces restored-session state: active tab id, each tab's awake/dormant state, and the id list.
@@ -347,6 +404,7 @@ beforeEach(() => {
   pinnedTabsValue = [PINNED_FILES_TAB]
   normalTabsValue = []
   activeTabIdValue = ''
+  conversationTabActionRender.mockClear()
 })
 
 afterEach(() => {
@@ -355,6 +413,37 @@ afterEach(() => {
 })
 
 describe('TabsProvider', () => {
+  it('keeps conversation tab actions isolated while reading the latest tab state', async () => {
+    render(
+      <TabsProvider initialDefaultTab={HOME_TAB} includePinnedTabs={false}>
+        <ConversationTabMutationControls />
+        <ConversationTabActionProbe />
+      </TabsProvider>
+    )
+    const initialActionRenders = conversationTabActionRender.mock.calls.length
+
+    fireEvent.click(screen.getByRole('button', { name: 'Seed tabs' }))
+    await waitFor(() => expect(screen.getByTestId('conversation-tab-active')).toHaveTextContent('unrelated-tab'))
+    expect(screen.getByTestId('conversation-tab-snapshot')).toHaveTextContent('topic-a-tab:Topic A')
+    expect(conversationTabActionRender).toHaveBeenCalledTimes(initialActionRenders)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate home' }))
+    await waitFor(() => expect(screen.getByTestId('conversation-tab-active')).toHaveTextContent('home'))
+    expect(conversationTabActionRender).toHaveBeenCalledTimes(initialActionRenders)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename background topic' }))
+    await waitFor(() => expect(screen.getByTestId('conversation-tab-snapshot')).toHaveTextContent('Renamed Topic'))
+    expect(conversationTabActionRender).toHaveBeenCalledTimes(initialActionRenders)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close unrelated tab' }))
+    await waitFor(() => expect(screen.getByTestId('conversation-tab-snapshot')).not.toHaveTextContent('unrelated-tab'))
+    expect(conversationTabActionRender).toHaveBeenCalledTimes(initialActionRenders)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close background topic' }))
+    await waitFor(() => expect(screen.getByTestId('conversation-tab-snapshot')).not.toHaveTextContent('topic-a-tab'))
+    expect(conversationTabActionRender).toHaveBeenCalledTimes(initialActionRenders)
+  })
+
   it('preserves page-owned titles for the fixed home conversation tab', async () => {
     render(
       <TabsProvider

--- a/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useCloseConversationTabs.test.tsx
@@ -1,175 +1,84 @@
 // @vitest-environment jsdom
-import type { TabsContextValue } from '@renderer/hooks/tab'
-import { TabsContext } from '@renderer/hooks/tab/useTabsContext'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { act, renderHook } from '@testing-library/react'
 import type { ReactNode } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { useCloseConversationTabs } from '../useCloseConversationTabs'
-
-function createTabsContext(tabs: Tab[], closeTabs = vi.fn(), activeTabId = tabs[0]?.id ?? ''): TabsContextValue {
-  const activeTab = tabs.find((tab) => tab.id === activeTabId)
-
-  return {
-    tabs,
-    activeTabId,
-    activeTab,
-    isLoading: false,
-    addTab: vi.fn(),
-    closeTab: vi.fn(),
-    closeTabs,
-    setActiveTab: vi.fn(),
-    updateTab: vi.fn(),
-    openTab: vi.fn(),
-    pinTab: vi.fn(),
-    unpinTab: vi.fn(),
-    reorderTabs: vi.fn(),
-    detachTab: vi.fn(),
-    attachTab: vi.fn()
-  }
-}
-
-function wrapperFor(value: TabsContextValue) {
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return <TabsContext value={value}>{children}</TabsContext>
-  }
-}
+import {
+  CloseConversationTabsContext,
+  findClosableConversationTabIds,
+  useCloseConversationTabs
+} from '../useCloseConversationTabs'
 
 const activeConversationCases = [
   ['conversation', 'assistants', 'topic-a', '/app/chat', 'topicId'],
   ['agent session', 'agents', 'session-a', '/app/agents', 'sessionId']
 ] as const
 
-describe('useCloseConversationTabs', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
+describe('findClosableConversationTabIds', () => {
+  it('matches assistant tabs by topic id without crossing app routes', () => {
+    const tabs: Tab[] = [
+      { id: 'topic-a-tab', type: 'route', url: '/app/chat?topicId=topic-a', title: 'Topic A' },
+      { id: 'topic-b-tab', type: 'route', url: '/app/chat?topicId=topic-b', title: 'Topic B' },
+      { id: 'message', type: 'route', url: '/app/chat?view=message&topicId=topic-a', title: 'Message' },
+      { id: 'session', type: 'route', url: '/app/agents?sessionId=topic-a', title: 'Session' }
+    ]
+
+    expect(findClosableConversationTabIds(tabs, 'session', 'assistants', ['topic-a', 'topic-b'])).toEqual([
+      'topic-a-tab',
+      'topic-b-tab'
+    ])
   })
 
-  it('closes assistant tabs matching deleted topic ids', () => {
-    const closeTabs = vi.fn()
-    const context = createTabsContext(
-      [
-        {
-          id: 'topic-a-tab',
-          type: 'route',
-          url: '/app/chat?topicId=topic-a',
-          title: 'Topic A'
-        },
-        {
-          id: 'topic-b-url-tab',
-          type: 'route',
-          url: '/app/chat?topicId=topic-b',
-          title: 'Topic B'
-        },
-        {
-          id: 'message-only-tab',
-          type: 'route',
-          url: '/app/chat?view=message&topicId=topic-a',
-          title: 'Message'
-        },
-        {
-          id: 'session-tab',
-          type: 'route',
-          url: '/app/agents?sessionId=topic-a',
-          title: 'Session'
-        }
-      ],
-      closeTabs,
-      'session-tab'
-    )
+  it('matches agent tabs by session id without crossing app routes', () => {
+    const tabs: Tab[] = [
+      { id: 'session-a-tab', type: 'route', url: '/app/agents?sessionId=session-a', title: 'Session A' },
+      { id: 'session-b-tab', type: 'route', url: '/app/agents?sessionId=session-b', title: 'Session B' },
+      { id: 'topic', type: 'route', url: '/app/chat?topicId=session-a', title: 'Topic' }
+    ]
 
-    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
-
-    act(() => {
-      result.current('assistants', ['topic-a', 'topic-b'])
-    })
-
-    expect(closeTabs).toHaveBeenCalledWith(['topic-a-tab', 'topic-b-url-tab'])
-  })
-
-  it('closes agent tabs matching deleted session ids', () => {
-    const closeTabs = vi.fn()
-    const context = createTabsContext(
-      [
-        {
-          id: 'session-a-tab',
-          type: 'route',
-          url: '/app/agents?sessionId=session-a',
-          title: 'Session A'
-        },
-        {
-          id: 'session-b-url-tab',
-          type: 'route',
-          url: '/app/agents?sessionId=session-b',
-          title: 'Session B'
-        },
-        {
-          id: 'topic-tab',
-          type: 'route',
-          url: '/app/chat?topicId=session-a',
-          title: 'Topic'
-        }
-      ],
-      closeTabs,
-      'topic-tab'
-    )
-
-    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
-
-    act(() => {
-      result.current('agents', ['session-a', 'session-b'])
-    })
-
-    expect(closeTabs).toHaveBeenCalledWith(['session-a-tab', 'session-b-url-tab'])
+    expect(findClosableConversationTabIds(tabs, 'topic', 'agents', ['session-a', 'session-b'])).toEqual([
+      'session-a-tab',
+      'session-b-tab'
+    ])
   })
 
   it.each(activeConversationCases)('keeps the active matching %s tab open', (_label, appId, key, baseUrl, queryKey) => {
-    const activeTab: Tab = {
-      id: `active-${key}-tab`,
-      type: 'route',
-      url: `${baseUrl}?${queryKey}=${key}`,
-      title: 'Active'
-    }
-    const backgroundTab: Tab = {
-      id: `background-${key}-tab`,
-      type: 'route',
-      url: `${baseUrl}?${queryKey}=${key}`,
-      title: 'Background'
-    }
-    const closeTabs = vi.fn()
-    const context = createTabsContext([activeTab, backgroundTab], closeTabs, activeTab.id)
+    const tabs: Tab[] = [
+      { id: 'active', type: 'route', url: `${baseUrl}?${queryKey}=${key}`, title: 'Active' },
+      { id: 'background', type: 'route', url: `${baseUrl}?${queryKey}=${key}`, title: 'Background' }
+    ]
 
-    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
-
-    act(() => {
-      result.current(appId, [key])
-    })
-
-    expect(closeTabs).toHaveBeenCalledWith([backgroundTab.id])
+    expect(findClosableConversationTabIds(tabs, 'active', appId, [key])).toEqual(['background'])
   })
 
-  it('delegates an empty close list when only the active tab matches', () => {
-    const closeTabs = vi.fn()
-    const context = createTabsContext(
-      [
-        {
-          id: 'active-topic-tab',
-          type: 'route',
-          url: '/app/chat?topicId=topic-a',
-          title: 'Active Topic'
-        }
-      ],
-      closeTabs,
-      'active-topic-tab'
+  it('returns an empty list when only the active tab matches', () => {
+    const tabs: Tab[] = [{ id: 'active', type: 'route', url: '/app/chat?topicId=topic-a', title: 'Active Topic' }]
+
+    expect(findClosableConversationTabIds(tabs, 'active', 'assistants', ['topic-a'])).toEqual([])
+  })
+})
+
+describe('useCloseConversationTabs', () => {
+  it('returns the action supplied by its narrow context', () => {
+    const closeConversationTabs = vi.fn()
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CloseConversationTabsContext value={closeConversationTabs}>{children}</CloseConversationTabsContext>
     )
+    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper })
 
-    const { result } = renderHook(() => useCloseConversationTabs(), { wrapper: wrapperFor(context) })
+    act(() => result.current('assistants', ['topic-a']))
 
-    act(() => {
-      result.current('assistants', ['topic-a'])
-    })
+    expect(closeConversationTabs).toHaveBeenCalledWith('assistants', ['topic-a'])
+  })
 
-    expect(closeTabs).toHaveBeenCalledWith([])
+  it('is a stable no-op outside TabsProvider', () => {
+    const { result, rerender } = renderHook(() => useCloseConversationTabs())
+    const first = result.current
+
+    rerender()
+
+    expect(result.current).toBe(first)
+    expect(() => result.current('agents', ['session-a'])).not.toThrow()
   })
 })

--- a/src/renderer/hooks/tab/index.ts
+++ b/src/renderer/hooks/tab/index.ts
@@ -1,4 +1,9 @@
-export { useCloseConversationTabs } from './useCloseConversationTabs'
+export {
+  type CloseConversationTabs,
+  CloseConversationTabsContext,
+  findClosableConversationTabIds,
+  useCloseConversationTabs
+} from './useCloseConversationTabs'
 export { useConversationNavigationOwner } from './useConversationNavigationOwner'
 export { TabIdContext, useCurrentTab, useCurrentTabId, useIsActiveTab } from './useCurrentTab'
 export { useMainWindowNavigation } from './useMainWindowNavigation'

--- a/src/renderer/hooks/tab/useCloseConversationTabs.ts
+++ b/src/renderer/hooks/tab/useCloseConversationTabs.ts
@@ -1,33 +1,40 @@
 import type { ConversationAppId } from '@renderer/types/conversation'
 import { getSidebarApp, tabBelongsToApp } from '@renderer/utils/sidebar'
-import { useCallback } from 'react'
+import type { Tab } from '@shared/data/cache/cacheValueTypes'
+import { createContext, use } from 'react'
 
-import { useOptionalTabsContext } from './useTabsContext'
+export type CloseConversationTabs = (appId: ConversationAppId, keys: readonly string[]) => void
 
-export function useCloseConversationTabs() {
-  const tabsContext = useOptionalTabsContext()
+const closeNoConversationTabs: CloseConversationTabs = () => {}
 
-  return useCallback(
-    (appId: ConversationAppId, keys: readonly string[]) => {
-      if (!tabsContext || keys.length === 0) return
+export const CloseConversationTabsContext = createContext<CloseConversationTabs | null>(null)
 
-      const app = getSidebarApp(appId)
-      if (!app?.conversationRoute) return
+export function findClosableConversationTabIds(
+  tabs: readonly Tab[],
+  activeTabId: string,
+  appId: ConversationAppId,
+  keys: readonly string[]
+): string[] {
+  if (keys.length === 0) return []
 
-      const keySet = new Set(keys)
-      const tabIds: string[] = []
-      for (const tab of tabsContext.tabs) {
-        if (tab.id === tabsContext.activeTabId) continue
-        if (tab.type !== 'route' || !tabBelongsToApp(app, tab.url)) continue
+  const app = getSidebarApp(appId)
+  if (!app?.conversationRoute) return []
 
-        const key = app.conversationRoute.keyFromUrl(tab.url)
-        if (key && keySet.has(key)) {
-          tabIds.push(tab.id)
-        }
-      }
+  const keySet = new Set(keys)
+  const tabIds: string[] = []
+  for (const tab of tabs) {
+    if (tab.id === activeTabId) continue
+    if (tab.type !== 'route' || !tabBelongsToApp(app, tab.url)) continue
 
-      tabsContext.closeTabs(tabIds)
-    },
-    [tabsContext]
-  )
+    const key = app.conversationRoute.keyFromUrl(tab.url)
+    if (key && keySet.has(key)) {
+      tabIds.push(tab.id)
+    }
+  }
+
+  return tabIds
+}
+
+export function useCloseConversationTabs(): CloseConversationTabs {
+  return use(CloseConversationTabsContext) ?? closeNoConversationTabs
 }

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -22,9 +22,8 @@ import { usePersistCache } from '@renderer/data/hooks/useCache'
 import { useInvalidateCache } from '@renderer/data/hooks/useDataApi'
 import { useAgents } from '@renderer/hooks/agent/useAgent'
 import { useActiveSession, useSession, useUpdateSession } from '@renderer/hooks/agent/useSession'
-import { useCommandHandler } from '@renderer/hooks/command'
 import { useAgentSessionsSource } from '@renderer/hooks/resourceViewSources'
-import { useCloseConversationTabs, useCurrentTabId, useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
+import { useCloseConversationTabs, useCurrentTabId } from '@renderer/hooks/tab'
 import { useClassicLayoutRightPaneOpen } from '@renderer/hooks/useClassicLayoutRightPaneOpen'
 import { useComposerFocusRequest } from '@renderer/hooks/useComposerFocusRequest'
 import { useConversationCenterSurface } from '@renderer/hooks/useConversationCenterSurface'
@@ -50,6 +49,7 @@ import AgentChat from './AgentChat'
 import AgentSidePanel from './AgentSidePanel'
 import { AgentCreateDialog } from './components/AgentCreateDialog'
 import type { AgentFileNavigationRequest } from './components/AgentRightPane'
+import { AgentTabRuntime } from './components/AgentTabRuntime'
 import Sessions from './components/Sessions'
 import {
   createFeedbackComposerLaunch,
@@ -96,7 +96,6 @@ const AgentPage = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
   const isFeedbackIntent = routeSearch.intent === 'feedback'
-  const isActiveTab = useIsActiveTab()
   const currentTabId = useCurrentTabId()
   const routeSessionId = routeSearch.sessionId
   const routeAgentId = routeSearch.agentId
@@ -172,8 +171,8 @@ const AgentPage = () => {
       ownerFallbackRequestIdRef.current += 1
     }
   }, [routeActiveSessionId])
-  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
   const [lastUsedAgentId, setLastUsedAgentId] = usePersistCache('ui.agent.last_used_agent_id')
+  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
   const [lastUsedWorkspaceId, setLastUsedWorkspaceId] = usePersistCache('ui.agent.last_used_workspace_id')
   const lastRecordedRecentSessionRef = useRef<string | undefined>(undefined)
   const [sessionRevealRequest, setSessionRevealRequest] = useState<ResourceListRevealRequest>()
@@ -304,7 +303,7 @@ const AgentPage = () => {
   const manageAgentsActive = activeResourceKind === 'agent'
   const onManageAgents = conversationResourcesEnabled ? toggleAgentResourceView : undefined
   // All non-dormant tabs mount at once (Activity keep-alive), so each agent tab runs its
-  // own AgentPage. `useIsActiveTab` answers "am I the globally-focused tab" (gates last_used).
+  // own AgentPage.
   const clearSessionRevealRequestAfterPaint = useCallback((requestId: number) => {
     const clear = () => {
       setSessionRevealRequest((current) => (current?.requestId === requestId ? undefined : current))
@@ -349,15 +348,8 @@ const AgentPage = () => {
     visibleConversationId: visibleSession?.id
   })
   const preserveTabVisuals = !!targetSessionId && visibleSession?.id !== targetSessionId
-  useTabSelfVisuals({
-    title: visibleSession?.name?.trim() || visibleAgent?.name?.trim() || getDefaultRouteTitle('/app/agents'),
-    emoji: visibleAgent?.configuration?.avatar,
-    appId: 'agents',
-    preserveVisuals: preserveTabVisuals
-  })
 
   const [sessionPaneUserOpenIntentSeq, setSessionPaneUserOpenIntentSeq] = useState(0)
-  useCommandHandler('app.sidebar.toggle', toggleShellPane, { enabled: isActiveTab })
 
   useEffect(() => {
     if (isMessageOnlyView) return
@@ -373,16 +365,6 @@ const AgentPage = () => {
   useEffect(() => {
     if (activeSession) lastVisibleSessionRef.current = activeSession
   }, [activeSession])
-
-  useEffect(() => {
-    // Track "last focused session" only for persisted sessions. Gated on
-    // the active tab: `last_used` is a single global "what I'm looking at now",
-    // so background tabs must not clobber it and switching tabs must update it.
-    if (!isActiveTab) return
-    if (activeSession?.id && activeSessionSource === 'query') {
-      setLastUsedSessionId(activeSession.id)
-    }
-  }, [isActiveTab, activeSession, activeSessionSource, setLastUsedSessionId])
 
   const rememberLastUsedSession = useCallback(
     (agentId: string, userWorkspaceId?: string) => {
@@ -972,47 +954,57 @@ const AgentPage = () => {
   const centerSurface = historyRecordsCenter ?? resourceCenter
 
   return (
-    <Container>
-      <div className="flex min-w-0 flex-1 shrink flex-row overflow-hidden">
-        <AgentChat
-          centerSurface={centerSurface}
-          conversationBootstrap={conversationBootstrap}
-          pane={pane}
-          paneOpen={shellPaneOpen}
-          panePosition="left"
-          onPaneCollapse={() => setShellPaneOpenManually(false)}
-          onPaneAutoCollapseChange={handlePaneAutoCollapseChange}
-          onFileNavigationRequestChange={handleFileNavigationRequestChange}
-          requestFileNavigation={requestFileNavigation}
-          paneManualToggle={paneManualToggle}
-          showResourceListControls={!isMessageOnlyView}
-          sidebarOpen={shellPaneOpen}
-          onSidebarToggle={toggleShellPane}
-          missingAgentSelection={!isMessageOnlyView && missingAgentSelection && !visibleSession}
-          onCreateEmptySession={isMessageOnlyView ? undefined : createAndActivateEmptySession}
-          onMissingAgentSelectionAgentChange={isMessageOnlyView ? undefined : handleMissingAgentSelectionAgentChange}
-          onSessionWorkspaceChange={isMessageOnlyView ? undefined : replaceSessionWorkspace}
-          onVisibleAgentChange={isMessageOnlyView ? undefined : setLastUsedAgentId}
-          onVisibleWorkspaceChange={isMessageOnlyView ? undefined : setLastUsedWorkspaceId}
-          locateMessageId={locateMessageId}
-          onLocateMessageHandled={handleLocateMessageHandled}
-          selectingMissingAgent={selectingMissingAgent}
-          replacingSessionWorkspace={replacingSessionWorkspace}
-          resourcePane={resourcePane}
-          resourcePaneCount={sessionResourcePaneCount}
-          resourcePaneRevealRequest={sessionRevealRequest}
-          sessionPaneOpen={isClassicSessionLayout ? sessionPaneOpen : undefined}
-          onSessionPaneOpenChange={isClassicSessionLayout ? setSessionPaneOpen : undefined}
-          sessionPaneUserOpenIntentSeq={sessionPaneUserOpenIntentSeq}
-          composerLaunchOptions={composerLaunchOptions}
-        />
-      </div>
-      <AgentCreateDialog
-        open={agentCreateOpen}
-        onOpenChange={setAgentCreateOpen}
-        onCreated={handleAgentConversationSelect}
+    <>
+      <AgentTabRuntime
+        title={visibleSession?.name?.trim() || visibleAgent?.name?.trim() || getDefaultRouteTitle('/app/agents')}
+        emoji={visibleAgent?.configuration?.avatar}
+        preserveVisuals={preserveTabVisuals}
+        activeSession={activeSession ?? null}
+        activeSessionSource={activeSessionSource}
+        onToggleSidebar={toggleShellPane}
       />
-    </Container>
+      <Container>
+        <div className="flex min-w-0 flex-1 shrink flex-row overflow-hidden">
+          <AgentChat
+            centerSurface={centerSurface}
+            conversationBootstrap={conversationBootstrap}
+            pane={pane}
+            paneOpen={shellPaneOpen}
+            panePosition="left"
+            onPaneCollapse={() => setShellPaneOpenManually(false)}
+            onPaneAutoCollapseChange={handlePaneAutoCollapseChange}
+            onFileNavigationRequestChange={handleFileNavigationRequestChange}
+            requestFileNavigation={requestFileNavigation}
+            paneManualToggle={paneManualToggle}
+            showResourceListControls={!isMessageOnlyView}
+            sidebarOpen={shellPaneOpen}
+            onSidebarToggle={toggleShellPane}
+            missingAgentSelection={!isMessageOnlyView && missingAgentSelection && !visibleSession}
+            onCreateEmptySession={isMessageOnlyView ? undefined : createAndActivateEmptySession}
+            onMissingAgentSelectionAgentChange={isMessageOnlyView ? undefined : handleMissingAgentSelectionAgentChange}
+            onSessionWorkspaceChange={isMessageOnlyView ? undefined : replaceSessionWorkspace}
+            onVisibleAgentChange={isMessageOnlyView ? undefined : setLastUsedAgentId}
+            onVisibleWorkspaceChange={isMessageOnlyView ? undefined : setLastUsedWorkspaceId}
+            locateMessageId={locateMessageId}
+            onLocateMessageHandled={handleLocateMessageHandled}
+            selectingMissingAgent={selectingMissingAgent}
+            replacingSessionWorkspace={replacingSessionWorkspace}
+            resourcePane={resourcePane}
+            resourcePaneCount={sessionResourcePaneCount}
+            resourcePaneRevealRequest={sessionRevealRequest}
+            sessionPaneOpen={isClassicSessionLayout ? sessionPaneOpen : undefined}
+            onSessionPaneOpenChange={isClassicSessionLayout ? setSessionPaneOpen : undefined}
+            sessionPaneUserOpenIntentSeq={sessionPaneUserOpenIntentSeq}
+            composerLaunchOptions={composerLaunchOptions}
+          />
+        </div>
+        <AgentCreateDialog
+          open={agentCreateOpen}
+          onOpenChange={setAgentCreateOpen}
+          onCreated={handleAgentConversationSelect}
+        />
+      </Container>
+    </>
   )
 }
 

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -172,7 +172,6 @@ const AgentPage = () => {
     }
   }, [routeActiveSessionId])
   const [lastUsedAgentId, setLastUsedAgentId] = usePersistCache('ui.agent.last_used_agent_id')
-  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
   const [lastUsedWorkspaceId, setLastUsedWorkspaceId] = usePersistCache('ui.agent.last_used_workspace_id')
   const lastRecordedRecentSessionRef = useRef<string | undefined>(undefined)
   const [sessionRevealRequest, setSessionRevealRequest] = useState<ResourceListRevealRequest>()
@@ -232,10 +231,10 @@ const AgentPage = () => {
     // is never cleared on delete, so without this the bare re-entry re-reads the stale id in
     // `resolveAgentEntrySessionId`, 404s, and the NOT_FOUND recovery fires again — a navigate
     // loop React aborts as a maximum-update-depth render error that tears down the window.
-    setLastUsedSessionId(null)
+    cacheService.setPersist('ui.agent.last_used_session_id', null)
     clearActiveSession()
     void navigate({ to: '/app/agents', search: {}, replace: true })
-  }, [clearActiveSession, navigate, setLastUsedSessionId])
+  }, [clearActiveSession, navigate])
   // The URL-bound session no longer exists: its by-id query settled with NOT_FOUND (deleted while
   // this tab was dormant, or a rotted deep link). Recovery is a plain replace-navigation back
   // through the entry interceptor, which resolves the next target — no in-page state surgery.
@@ -959,7 +958,7 @@ const AgentPage = () => {
         title={visibleSession?.name?.trim() || visibleAgent?.name?.trim() || getDefaultRouteTitle('/app/agents')}
         emoji={visibleAgent?.configuration?.avatar}
         preserveVisuals={preserveTabVisuals}
-        activeSession={activeSession ?? null}
+        activeSessionId={activeSession?.id}
         activeSessionSource={activeSessionSource}
         onToggleSidebar={toggleShellPane}
       />

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -1450,7 +1450,7 @@ describe('AgentPage', () => {
 
     render(<AgentPage />)
 
-    await waitFor(() => expect(agentPageMocks.setLastUsedSessionId).toHaveBeenCalledWith(null))
+    await waitFor(() => expect(cacheService.setPersist).toHaveBeenCalledWith('ui.agent.last_used_session_id', null))
     // Recovery re-enters the bare route exactly once and does not loop.
     const recoveryNavigations = agentPageMocks.navigate.mock.calls.filter(
       (call) => call[0]?.search && Object.keys(call[0].search).length === 0

--- a/src/renderer/pages/agents/components/AgentTabRuntime.tsx
+++ b/src/renderer/pages/agents/components/AgentTabRuntime.tsx
@@ -1,0 +1,44 @@
+import { usePersistCache } from '@renderer/data/hooks/useCache'
+import { useCommandHandler } from '@renderer/hooks/command'
+import { useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
+import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
+import { useEffect } from 'react'
+
+type Props = {
+  title: string
+  emoji?: string | null
+  preserveVisuals: boolean
+  activeSession?: AgentSessionEntity | null
+  activeSessionSource: string
+  onToggleSidebar: () => void
+}
+
+export function AgentTabRuntime({
+  title,
+  emoji,
+  preserveVisuals,
+  activeSession,
+  activeSessionSource,
+  onToggleSidebar
+}: Props) {
+  const isActiveTab = useIsActiveTab()
+  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
+
+  useTabSelfVisuals({
+    title,
+    emoji,
+    appId: 'agents',
+    preserveVisuals
+  })
+
+  useCommandHandler('app.sidebar.toggle', onToggleSidebar, { enabled: isActiveTab })
+
+  useEffect(() => {
+    if (!isActiveTab) return
+    if (activeSession?.id && activeSessionSource === 'query') {
+      setLastUsedSessionId(activeSession.id)
+    }
+  }, [isActiveTab, activeSession, activeSessionSource, setLastUsedSessionId])
+
+  return null
+}

--- a/src/renderer/pages/agents/components/AgentTabRuntime.tsx
+++ b/src/renderer/pages/agents/components/AgentTabRuntime.tsx
@@ -1,15 +1,15 @@
-import { usePersistCache } from '@renderer/data/hooks/useCache'
+import { cacheService } from '@data/CacheService'
+import type { AgentSessionSource } from '@renderer/hooks/agent/useSession'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
-import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import { useEffect } from 'react'
 
 type Props = {
   title: string
   emoji?: string | null
   preserveVisuals: boolean
-  activeSession?: AgentSessionEntity | null
-  activeSessionSource: string
+  activeSessionId?: string | null
+  activeSessionSource: AgentSessionSource
   onToggleSidebar: () => void
 }
 
@@ -17,12 +17,11 @@ export function AgentTabRuntime({
   title,
   emoji,
   preserveVisuals,
-  activeSession,
+  activeSessionId,
   activeSessionSource,
   onToggleSidebar
 }: Props) {
   const isActiveTab = useIsActiveTab()
-  const [, setLastUsedSessionId] = usePersistCache('ui.agent.last_used_session_id')
 
   useTabSelfVisuals({
     title,
@@ -35,10 +34,10 @@ export function AgentTabRuntime({
 
   useEffect(() => {
     if (!isActiveTab) return
-    if (activeSession?.id && activeSessionSource === 'query') {
-      setLastUsedSessionId(activeSession.id)
+    if (activeSessionId && activeSessionSource === 'query') {
+      cacheService.setPersist('ui.agent.last_used_session_id', activeSessionId)
     }
-  }, [isActiveTab, activeSession, activeSessionSource, setLastUsedSessionId])
+  }, [isActiveTab, activeSessionId, activeSessionSource])
 
   return null
 }

--- a/src/renderer/pages/agents/components/__tests__/AgentTabRuntime.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/AgentTabRuntime.test.tsx
@@ -1,0 +1,75 @@
+import { cacheService } from '@data/CacheService'
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runtimeMocks = vi.hoisted(() => ({
+  isActiveTab: true,
+  useCommandHandler: vi.fn(),
+  useTabSelfVisuals: vi.fn()
+}))
+
+vi.mock('@renderer/hooks/command', () => ({ useCommandHandler: runtimeMocks.useCommandHandler }))
+vi.mock('@renderer/hooks/tab', () => ({
+  useIsActiveTab: () => runtimeMocks.isActiveTab,
+  useTabSelfVisuals: runtimeMocks.useTabSelfVisuals
+}))
+
+import { AgentTabRuntime } from '../AgentTabRuntime'
+
+describe('AgentTabRuntime', () => {
+  beforeEach(() => {
+    MockCacheUtils.resetMocks()
+    runtimeMocks.isActiveTab = true
+    runtimeMocks.useCommandHandler.mockReset()
+    runtimeMocks.useTabSelfVisuals.mockReset()
+  })
+
+  it('syncs visuals, registers the active command, and remembers a persisted session', () => {
+    const onToggleSidebar = vi.fn()
+
+    render(
+      <AgentTabRuntime
+        title="Session A"
+        emoji="agent-avatar"
+        preserveVisuals={false}
+        activeSessionId="session-a"
+        activeSessionSource="query"
+        onToggleSidebar={onToggleSidebar}
+      />
+    )
+
+    expect(runtimeMocks.useTabSelfVisuals).toHaveBeenCalledWith({
+      title: 'Session A',
+      emoji: 'agent-avatar',
+      appId: 'agents',
+      preserveVisuals: false
+    })
+    expect(runtimeMocks.useCommandHandler).toHaveBeenCalledWith('app.sidebar.toggle', onToggleSidebar, {
+      enabled: true
+    })
+    expect(cacheService.setPersist).toHaveBeenCalledWith('ui.agent.last_used_session_id', 'session-a')
+  })
+
+  it.each([
+    ['background tab', false, 'query'],
+    ['pending session', true, 'pending']
+  ] as const)('does not remember a session for a %s', (_label, isActiveTab, activeSessionSource) => {
+    runtimeMocks.isActiveTab = isActiveTab
+
+    render(
+      <AgentTabRuntime
+        title="Session A"
+        preserveVisuals={false}
+        activeSessionId="session-a"
+        activeSessionSource={activeSessionSource}
+        onToggleSidebar={vi.fn()}
+      />
+    )
+
+    expect(runtimeMocks.useCommandHandler).toHaveBeenCalledWith('app.sidebar.toggle', expect.any(Function), {
+      enabled: isActiveTab
+    })
+    expect(cacheService.setPersist).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -660,7 +660,7 @@ const HomePage: FC = () => {
           title={tabTitle}
           emoji={visibleAssistant?.emoji}
           preserveVisuals={preserveTabVisuals}
-          activeTopic={activeTopic}
+          activeTopicId={activeTopic?.id}
           activeTopicSource={activeTopicSource}
         />
         <Container id="home-page">
@@ -775,7 +775,7 @@ const HomePage: FC = () => {
         title={tabTitle}
         emoji={visibleAssistant?.emoji}
         preserveVisuals={preserveTabVisuals}
-        activeTopic={activeTopic}
+        activeTopicId={activeTopic?.id}
         activeTopicSource={activeTopicSource}
       />
       <Container id="home-page">

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -22,7 +22,7 @@ import { ConversationResourceView } from '@renderer/components/resourceCatalog/c
 import { usePersistCache } from '@renderer/data/hooks/useCache'
 import { useCommandHandler } from '@renderer/hooks/command'
 import { useAssistantTopicsSource } from '@renderer/hooks/resourceViewSources'
-import { useCurrentTabId, useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
+import { useCurrentTabId } from '@renderer/hooks/tab'
 import { useAssistants } from '@renderer/hooks/useAssistant'
 import { toCreateAssistantDtoFromCatalogPreset } from '@renderer/hooks/useAssistantCatalogPresets'
 import { useClassicLayoutRightPaneOpen } from '@renderer/hooks/useClassicLayoutRightPaneOpen'
@@ -51,6 +51,7 @@ import {
   AssistantConversationPickerDialog,
   type AssistantConversationSelection
 } from './components/AssistantConversationPickerDialog'
+import { HomeTabRuntime } from './components/HomeTabRuntime'
 import { TopicRightPane } from './components/TopicRightPane'
 import { parseChatRouteSearch } from './routeSearch'
 import { Topics } from './Tabs/components/Topics'
@@ -80,7 +81,6 @@ const HomePage: FC = () => {
   const isCreatingTopicRef = useRef(false)
   const ownerFallbackRequestIdRef = useRef(0)
   const [lastUsedAssistantId, setLastUsedAssistantId] = usePersistCache(LAST_USED_ASSISTANT_CACHE_KEY)
-  const [, setLastUsedTopicId] = usePersistCache('ui.chat.last_used_topic_id')
   const lastRecordedRecentTopicRef = useRef<string | undefined>(undefined)
   const [showSidebar, setShowSidebar] = usePreference('topic.tab.show')
   const [topicDisplayMode, setTopicDisplayMode] = usePreference('topic.tab.display_mode')
@@ -275,10 +275,8 @@ const HomePage: FC = () => {
   }, [activeTopic, setLastUsedAssistantId])
 
   // All non-dormant tabs mount at once (Activity keep-alive), so each chat tab runs its
-  // own HomePage. `currentTabId` is *this* tab; `useIsActiveTab` answers "am I the
-  // globally-focused tab".
+  // own HomePage. `currentTabId` is *this* tab's id.
   const currentTabId = useCurrentTabId()
-  const isActiveTab = useIsActiveTab()
 
   const clearTopicRevealRequestAfterPaint = useCallback((requestId: number) => {
     const clear = () => {
@@ -315,17 +313,6 @@ const HomePage: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `useEffectEvent` reads the latest topic without resubscribing.
   }, [currentTabId])
 
-  useEffect(() => {
-    // Track "last focused topic" for persisted topics. Drives the sidebar `assistants`
-    // dedupe key (mirror of agent's last_used_session).
-    // Gated on the active tab: `last_used` is a single global "what I'm looking
-    // at now", so background tabs (also mounted) must not clobber it.
-    if (!isActiveTab) return
-    if (activeTopic?.id && activeTopicSource === 'query') {
-      setLastUsedTopicId(activeTopic.id)
-    }
-  }, [isActiveTab, activeTopic, activeTopicSource, setLastUsedTopicId])
-
   // Label this tab with its assistant emoji + topic name so multiple chat tabs
   // are distinguishable in the tab bar (every tab labels itself — not gated on active).
   const visibleAssistantId = visibleTopic?.assistantId
@@ -348,12 +335,7 @@ const HomePage: FC = () => {
     visibleConversationId: visibleTopic?.id
   })
   const preserveTabVisuals = !!targetTopicId && visibleTopic?.id !== targetTopicId
-  useTabSelfVisuals({
-    title: visibleTopic?.name?.trim() || visibleAssistant?.name?.trim() || getDefaultRouteTitle('/app/chat'),
-    emoji: visibleAssistant?.emoji,
-    appId: 'assistants',
-    preserveVisuals: preserveTabVisuals
-  })
+  const tabTitle = visibleTopic?.name?.trim() || visibleAssistant?.name?.trim() || getDefaultRouteTitle('/app/chat')
 
   useEffect(() => {
     if (activeTopic) lastVisibleTopicRef.current = activeTopic
@@ -673,15 +655,24 @@ const HomePage: FC = () => {
   // the rail visible) instead of returning a blank frame.
   if (isMessageOnlyView && !visibleTopic && !resourceCenter) {
     return (
-      <Container id="home-page">
-        <ContentContainer>
-          <MessageOnlyStatus
-            loading={isRouteTopicLoading}
-            loadingLabel={t('common.loading')}
-            missingTitle={t('history.error.topic_not_found')}
-          />
-        </ContentContainer>
-      </Container>
+      <>
+        <HomeTabRuntime
+          title={tabTitle}
+          emoji={visibleAssistant?.emoji}
+          preserveVisuals={preserveTabVisuals}
+          activeTopic={activeTopic}
+          activeTopicSource={activeTopicSource}
+        />
+        <Container id="home-page">
+          <ContentContainer>
+            <MessageOnlyStatus
+              loading={isRouteTopicLoading}
+              loadingLabel={t('common.loading')}
+              missingTitle={t('history.error.topic_not_found')}
+            />
+          </ContentContainer>
+        </Container>
+      </>
     )
   }
 
@@ -780,6 +771,13 @@ const HomePage: FC = () => {
       onOpenChange={isClassicTopicLayout ? setTopicPaneOpen : undefined}
       userOpenIntentSeq={topicPaneUserOpenIntentSeq}
       revealRequest={topicRevealRequest}>
+      <HomeTabRuntime
+        title={tabTitle}
+        emoji={visibleAssistant?.emoji}
+        preserveVisuals={preserveTabVisuals}
+        activeTopic={activeTopic}
+        activeTopicSource={activeTopicSource}
+      />
       <Container id="home-page">
         <ContentContainer $detached={isWindowFrame}>
           <Chat

--- a/src/renderer/pages/home/components/HomeTabRuntime.tsx
+++ b/src/renderer/pages/home/components/HomeTabRuntime.tsx
@@ -1,0 +1,33 @@
+import { usePersistCache } from '@renderer/data/hooks/useCache'
+import { useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
+import type { Topic } from '@renderer/types/topic'
+import { useEffect } from 'react'
+
+type Props = {
+  title: string
+  emoji?: string | null
+  preserveVisuals: boolean
+  activeTopic?: Topic | null
+  activeTopicSource: string
+}
+
+export function HomeTabRuntime({ title, emoji, preserveVisuals, activeTopic, activeTopicSource }: Props) {
+  const isActiveTab = useIsActiveTab()
+  const [, setLastUsedTopicId] = usePersistCache('ui.chat.last_used_topic_id')
+
+  useTabSelfVisuals({
+    title,
+    emoji,
+    appId: 'assistants',
+    preserveVisuals
+  })
+
+  useEffect(() => {
+    if (!isActiveTab) return
+    if (activeTopic?.id && activeTopicSource === 'query') {
+      setLastUsedTopicId(activeTopic.id)
+    }
+  }, [isActiveTab, activeTopic, activeTopicSource, setLastUsedTopicId])
+
+  return null
+}

--- a/src/renderer/pages/home/components/HomeTabRuntime.tsx
+++ b/src/renderer/pages/home/components/HomeTabRuntime.tsx
@@ -1,19 +1,18 @@
-import { usePersistCache } from '@renderer/data/hooks/useCache'
+import { cacheService } from '@data/CacheService'
 import { useIsActiveTab, useTabSelfVisuals } from '@renderer/hooks/tab'
-import type { Topic } from '@renderer/types/topic'
+import type { ActiveTopicSource } from '@renderer/hooks/useTopic'
 import { useEffect } from 'react'
 
 type Props = {
   title: string
   emoji?: string | null
   preserveVisuals: boolean
-  activeTopic?: Topic | null
-  activeTopicSource: string
+  activeTopicId?: string | null
+  activeTopicSource: ActiveTopicSource
 }
 
-export function HomeTabRuntime({ title, emoji, preserveVisuals, activeTopic, activeTopicSource }: Props) {
+export function HomeTabRuntime({ title, emoji, preserveVisuals, activeTopicId, activeTopicSource }: Props) {
   const isActiveTab = useIsActiveTab()
-  const [, setLastUsedTopicId] = usePersistCache('ui.chat.last_used_topic_id')
 
   useTabSelfVisuals({
     title,
@@ -24,10 +23,10 @@ export function HomeTabRuntime({ title, emoji, preserveVisuals, activeTopic, act
 
   useEffect(() => {
     if (!isActiveTab) return
-    if (activeTopic?.id && activeTopicSource === 'query') {
-      setLastUsedTopicId(activeTopic.id)
+    if (activeTopicId && activeTopicSource === 'query') {
+      cacheService.setPersist('ui.chat.last_used_topic_id', activeTopicId)
     }
-  }, [isActiveTab, activeTopic, activeTopicSource, setLastUsedTopicId])
+  }, [isActiveTab, activeTopicId, activeTopicSource])
 
   return null
 }

--- a/src/renderer/pages/home/components/__tests__/HomeTabRuntime.test.tsx
+++ b/src/renderer/pages/home/components/__tests__/HomeTabRuntime.test.tsx
@@ -1,0 +1,62 @@
+import { cacheService } from '@data/CacheService'
+import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
+import { render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const tabMocks = vi.hoisted(() => ({
+  isActiveTab: true,
+  useTabSelfVisuals: vi.fn()
+}))
+
+vi.mock('@renderer/hooks/tab', () => ({
+  useIsActiveTab: () => tabMocks.isActiveTab,
+  useTabSelfVisuals: tabMocks.useTabSelfVisuals
+}))
+
+import { HomeTabRuntime } from '../HomeTabRuntime'
+
+describe('HomeTabRuntime', () => {
+  beforeEach(() => {
+    MockCacheUtils.resetMocks()
+    tabMocks.isActiveTab = true
+    tabMocks.useTabSelfVisuals.mockReset()
+  })
+
+  it('syncs visuals and remembers a persisted topic for the active tab', () => {
+    render(
+      <HomeTabRuntime
+        title="Topic A"
+        emoji="🍒"
+        preserveVisuals={false}
+        activeTopicId="topic-a"
+        activeTopicSource="query"
+      />
+    )
+
+    expect(tabMocks.useTabSelfVisuals).toHaveBeenCalledWith({
+      title: 'Topic A',
+      emoji: '🍒',
+      appId: 'assistants',
+      preserveVisuals: false
+    })
+    expect(cacheService.setPersist).toHaveBeenCalledWith('ui.chat.last_used_topic_id', 'topic-a')
+  })
+
+  it.each([
+    ['background tab', false, 'query'],
+    ['pending topic', true, 'pending']
+  ] as const)('does not remember a topic for a %s', (_label, isActiveTab, activeTopicSource) => {
+    tabMocks.isActiveTab = isActiveTab
+
+    render(
+      <HomeTabRuntime
+        title="Topic A"
+        preserveVisuals={false}
+        activeTopicId="topic-a"
+        activeTopicSource={activeTopicSource}
+      />
+    )
+
+    expect(cacheService.setPersist).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### What this PR does

Before this PR: `HomePage.tsx` and `AgentPage.tsx` subscribed to the full `TabsContext` (tabs array + activeTabId) at the page-root level via `useTabSelfVisuals` and `useIsActiveTab`. Every tab-array mutation (open/close/pin/metadata) therefore re-rendered the entire Home/Agent page, including retained background tabs. Title updates also triggered an extra `updateTab` → context change → full-page re-render cycle.

After this PR: Page roots retain only `useCurrentTabId` (narrow `TabIdContext`). All `TabsContext` subscriptions move into small runtime leaves:

* `src/renderer/pages/home/components/HomeTabRuntime.tsx` — owns `useTabSelfVisuals` + `useIsActiveTab`-gated `last_used_topic_id` persistence
* `src/renderer/pages/agents/components/AgentTabRuntime.tsx` — owns `useTabSelfVisuals` + `useIsActiveTab`-gated `last_used_session_id` persistence + active-tab-gated `app.sidebar.toggle` command registration

Leaves receive exact visual (`title`/`emoji`/`preserveVisuals`), session/topic, and command inputs as props; returns `null`.

Fixes #19140

### Why we need it and why it was done in this way

Violates `rerender-memo` and `state-context-interface`: narrow sync and active-tab side effects must not make feature pages subscribe to global tab state. Moving broad `TabsContext` reads below the page-root boundary isolates reconciliation to leaf components, scaling is O(leaf) not O(page).

### Checklist

- [x] Branch targets `main`
- [x] `pnpm lint` / typecheck and relevant renderer tests pass (`HomePage.test` green)
- [x] Page roots verify: `grep` shows only `useCurrentTabId` in `HomePage.tsx`/`AgentPage.tsx`

```release-note
NONE
```