### PR TITLE
fix(deepseek-harness): heal stale managed keys at top-level of versioned credentials

### DIFF
--- a/src/main/services/deepSeekHarness/__tests__/config.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/config.test.ts
@@ -248,6 +248,25 @@ describe('DeepSeek Harness config transaction', () => {
     })
   })
 
+  it('heals every stale managed key at top-level of a version: 1 document while preserving user keys', async () => {
+    const identity = createDeepSeekHarnessDirectIdentity('anthropic', 'anthropic-messages')
+    const staleHex = 'CHERRY_STUDIO_CODEMATE_AAAAAAAAAAAA_API_KEY'
+    const staleGateway = 'CHERRY_STUDIO_CODEMATE_GATEWAY_API_KEY'
+    await writeFile(
+      path.join(dir, '.credentials.yaml'),
+      `version: 1\nrefs:\n  OTHER_KEY: keep\n${staleHex}: sk-stale-a\n${staleGateway}: sk-stale-b\nDEEPSEEK_API_KEY: sk-user\n`,
+      { mode: 0o600 }
+    )
+
+    await writeDeepSeekHarnessConfig(dir, projection())
+
+    expect(parse(await readFile(path.join(dir, '.credentials.yaml'), 'utf8'))).toEqual({
+      version: 1,
+      refs: { OTHER_KEY: 'keep', [identity.credentialRef]: 'sk-sensitive' },
+      DEEPSEEK_API_KEY: 'sk-user'
+    })
+  })
+
   it('keeps the flat layout pre-0.1.1 DSH reads, including a credential named version', async () => {
     const identity = createDeepSeekHarnessDirectIdentity('anthropic', 'anthropic-messages')
 

--- a/src/main/services/deepSeekHarness/config.ts
+++ b/src/main/services/deepSeekHarness/config.ts
@@ -54,6 +54,8 @@ const LOCK_TIMEOUT_MS = 2000
 const LOCK_INITIAL_DELAY_MS = 20
 const LOCK_MAX_DELAY_MS = 200
 
+const MANAGED_CREDENTIAL_REF_RE = /^CHERRY_STUDIO_CODEMATE_(?:[A-F0-9]{12}|GATEWAY)_API_KEY$/i
+
 const DIRECT_ENDPOINTS = [
   ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
   ENDPOINT_TYPE.OPENAI_RESPONSES,
@@ -297,9 +299,21 @@ function renderCredentials(snapshot: FileSnapshot, credentialRef: string, creden
   // DSH 0.1.1 nests entries under `version: 1` + `refs:` and rejects unknown
   // top-level keys, including the one Cherry used to write there. Any other
   // document stays flat: pre-0.1.1 builds read it, and 0.1.1 migrates it itself.
-  if (document.get('version') === 1) {
+  const version = document.get('version')
+  const isVersioned = version === 1 || String(version) === '1'
+  if (isVersioned) {
     if (document.getIn(['refs']) == null) document.setIn(['refs'], document.createNode({}))
-    document.delete(credentialRef)
+    // Heal files polluted by older Cherry builds that wrote managed keys at
+    // top-level: DSH 0.1.1 rejects any unknown top-level key, so every stale
+    // CHERRY_STUDIO_CODEMATE_*_API_KEY entry must be removed, not just the
+    // one for the current provider.
+    if (isMap(document.contents)) {
+      for (const pair of [...document.contents.items]) {
+        const rawKey = (pair.key as { value?: unknown })?.value
+        const key = typeof rawKey === 'string' ? rawKey : String(pair.key)
+        if (MANAGED_CREDENTIAL_REF_RE.test(key)) document.delete(key)
+      }
+    }
     document.setIn(['refs', credentialRef], credentialValue)
   } else {
     document.setIn([credentialRef], credentialValue)

--- a/src/main/services/deepSeekHarness/config.ts
+++ b/src/main/services/deepSeekHarness/config.ts
@@ -299,9 +299,7 @@ function renderCredentials(snapshot: FileSnapshot, credentialRef: string, creden
   // DSH 0.1.1 nests entries under `version: 1` + `refs:` and rejects unknown
   // top-level keys, including the one Cherry used to write there. Any other
   // document stays flat: pre-0.1.1 builds read it, and 0.1.1 migrates it itself.
-  const version = document.get('version')
-  const isVersioned = version === 1 || String(version) === '1'
-  if (isVersioned) {
+  if (document.get('version') === 1) {
     if (document.getIn(['refs']) == null) document.setIn(['refs'], document.createNode({}))
     // Heal files polluted by older Cherry builds that wrote managed keys at
     // top-level: DSH 0.1.1 rejects any unknown top-level key, so every stale


### PR DESCRIPTION
### What this PR does

Before this PR: `renderCredentials` only deleted the *current* `CHERRY_STUDIO_CODEMATE_*_API_KEY` from the top-level of a `version: 1` `.credentials.yaml`. Files polluted by older Cherry builds that had written several codemate providers at top-level (one per `cherry-studio-codemate-*` route in `settings.yaml`) still contained other stale `CHERRY_STUDIO_CODEMATE_*_API_KEY` entries. `dsh 0.1.1`'s `parseCredentialsDocument` rejects *any* unknown top-level key, so the leftover stale entry still aborted startup with:

```
credentials-local: unknown top-level key "CHERRY_STUDIO_CODEMATE_..._API_KEY"
```

After this PR: when the document is versioned (`version` is numeric `1`), `renderCredentials` heals the file by deleting **all** top-level keys matching `CHERRY_STUDIO_CODEMATE_(12HEX|GATEWAY)_API_KEY` before writing the current credential into `refs:`. A flat document (no numeric `version: 1`) is still kept flat for `dsh 0.1.0` compatibility — `dsh 0.1.1` migrates it itself on next boot.

Fixes #19152
Fixes #19117 (follow-up — prior fix #19131 healed only the current key)

### Why we need it and why it was done in this way

The following tradeoffs were made: healing is scoped to the known managed pattern rather than "any unknown top-level key", because the credentials file also contains user keys (e.g. `DEEPSEEK_API_KEY`) that may legitimately be at top-level in flat documents and are owned by `dsh`, not Cherry. The `version` discriminator stays strictly numeric (`=== 1`): DSH 0.1.1 defines `DOCUMENT_VERSION = 1` as a number and rejects a string `"1"`, so healing on a quoted `version: "1"` would both emit a string version DSH 0.1.1 still rejects and convert a valid legacy flat credential (`version: "1"` as a credential value) into a nested layout DSH 0.1.0 rejects.

The following alternatives were considered: always writing `version: 1` + `refs:` for fresh files — rejected, breaks `dsh 0.1.0`; passing the key via child env — rejected, leaks to every shell tool `dsh` spawns (the current code already strips managed env vars for this reason).

### Breaking changes

None.

### Special notes for your reviewer

Manually verified with `yaml` parse round-trip: stale top-level `CHERRY_...` keys are removed regardless of which provider is currently selected, `refs:` retains the new value, numeric `version: 1` triggers the versioned path (string `version: "1"` stays flat for compat), flat documents stay flat.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix DeepSeek Harness (CodeMate) failing to launch with dsh 0.1.1 when .credentials.yaml still contained stale top-level CHERRY_STUDIO_CODEMATE_*_API_KEY entries from older Cherry builds.
```