### PR TITLE
perf(mini-app): stabilize pool callbacks

### DIFF
--- a/src/renderer/components/MiniApp/MiniAppTabsPool.tsx
+++ b/src/renderer/components/MiniApp/MiniAppTabsPool.tsx
@@ -114,24 +114,24 @@ const MiniAppTabsPool: React.FC = () => {
   }, [appMetadataSignature])
 
   /** 设置 ref 回调 */
-  const handleSetRef = (appid: string, el: WebviewTag | null) => {
+  const handleSetRef = useCallback((appid: string, el: WebviewTag | null) => {
     if (el) {
       webviewRefs.current.set(appid, el)
     } else {
       webviewRefs.current.delete(appid)
     }
-  }
+  }, [])
 
   /** WebView 加载完成回调 */
-  const handleLoaded = (appid: string) => {
+  const handleLoaded = useCallback((appid: string) => {
     setWebviewLoaded(appid, true)
     logger.debug(`TabPool webview loaded: ${appid}`)
-  }
+  }, [])
 
   /** Record navigation (URL state not yet exposed; can integrate with global URL Map later) */
-  const handleNavigate = (appid: string, url: string) => {
+  const handleNavigate = useCallback((appid: string, url: string) => {
     logger.debug(`TabPool webview navigate: ${appid} -> ${url}`)
-  }
+  }, [])
 
   // The context key is registered here rather than per pane: every container's effect
   // stays alive for the pool's lifetime, and the registry resolves to whichever


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`MiniAppTabsPool` recreated its ref, loaded, and navigation callbacks on every pool render. Passing those new function identities to each memoized `WebviewContainer` invalidated its memo boundary and could also churn the callback-ref path for retained webviews.

After this PR:

The three callbacks are stable across unrelated pool renders, allowing unchanged retained `WebviewContainer` instances to preserve their memo boundary and listener/ref wiring.

Fixes #19066

### Why we need it and why it was done in this way

The pool keeps multiple Electron webviews mounted, so unnecessary reconciliation cost grows with every retained mini app. Stable callbacks address the invalidating props at their source without changing webview lifecycle behavior.

The following tradeoffs were made:

- Each callback uses `useCallback` with an empty dependency list because it only reads a stable ref or module-level services.
- The change does not alter retention, visibility, navigation, loading, or focus behavior.
- No child API or memo comparator is changed.

The following alternatives were considered:

- Adding a custom `WebviewContainer` memo comparator that ignores callbacks, but that could conceal future callback behavior changes or retain stale closures.
- Moving the handlers outside the component, but the ref handler needs the pool-owned `webviewRefs` instance.

Links to places where the discussion took place: #19066

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- MiniAppTabsPool and WebviewContainer regression suites: 24/24 passed
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

A callback-identity or child-render-count test was intentionally not added because it would assert internal React implementation details. The production change directly establishes stable references, while the existing suites verify retained-webview behavior and lifecycle compatibility.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
