### PR TITLE
refactor(paintings): type config field variants

### DIFF
--- a/packages/provider-registry/src/__tests__/imageParamCatalog.test.ts
+++ b/packages/provider-registry/src/__tests__/imageParamCatalog.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
 import { CANONICAL_PARAM_KEY } from '../schemas/enums'
-import { IMAGE_PARAM_CATALOG_KEYS, imageParamsSchema } from '../schemas/imageParamCatalog'
+import { IMAGE_PARAM_CATALOG_KEYS, imageParamsSchema, parseImageParamValue } from '../schemas/imageParamCatalog'
 import type { ImageGenerationSupport } from '../schemas/model'
 import { buildParamsSchema } from '../utils/buildParamsSchema'
 
 describe('IMAGE_PARAM_CATALOG', () => {
   it('is exhaustive over CANONICAL_PARAM_KEY (no missing / extra keys)', () => {
     expect([...IMAGE_PARAM_CATALOG_KEYS].sort()).toEqual(Object.values(CANONICAL_PARAM_KEY).sort())
+  })
+
+  it('parses dynamic values through the canonical per-key value type', () => {
+    expect(parseImageParamValue('numImages', '2')).toBe(2)
+    expect(parseImageParamValue('numImages', '2.5')).toBeUndefined()
+    expect(parseImageParamValue('strength', '2.5')).toBe(2.5)
+    expect(parseImageParamValue('size', true)).toBeUndefined()
+    expect(parseImageParamValue('unknown', 'value')).toBeUndefined()
   })
 })
 

--- a/packages/provider-registry/src/__tests__/imageParamCatalog.test.ts
+++ b/packages/provider-registry/src/__tests__/imageParamCatalog.test.ts
@@ -20,6 +20,10 @@ describe('imageParamsSchema (catalog-only IPC boundary schema)', () => {
     })
   })
 
+  it.each([true, false, [], ['4.5']])('rejects non-string/number numeric input %#', (value) => {
+    expect(imageParamsSchema.safeParse({ cfg: value }).success).toBe(false)
+  })
+
   it('keeps catalog keys and strips non-catalog keys (z.infer is exactly ParamValues)', () => {
     expect(imageParamsSchema.parse({ cfg: 7.5, notAParam: 'x' })).toEqual({ cfg: 7.5 })
   })
@@ -64,6 +68,13 @@ describe('buildParamsSchema', () => {
       customSize_width: 1024,
       customSize_height: 768
     })
+  })
+
+  it.each([true, false, [], ['1024']])('drops non-string/number numeric input %#', (value) => {
+    const parsed = schema.parse({ seed: value, customSize_width: value, customSize_height: value })
+    expect(parsed.seed).toBeUndefined()
+    expect(parsed.customSize_width).toBeUndefined()
+    expect(parsed.customSize_height).toBeUndefined()
   })
 
   it('passes through unknown/legacy keys untouched (loose)', () => {

--- a/packages/provider-registry/src/index.ts
+++ b/packages/provider-registry/src/index.ts
@@ -23,6 +23,7 @@ export {
   IMAGE_PARAM_CATALOG,
   IMAGE_PARAM_CATALOG_KEYS,
   imageParamsSchema,
+  normalizeImageParamNumber,
   paramCatalogEntry,
   wireName
 } from './schemas/imageParamCatalog'

--- a/packages/provider-registry/src/index.ts
+++ b/packages/provider-registry/src/index.ts
@@ -25,6 +25,7 @@ export {
   imageParamsSchema,
   normalizeImageParamNumber,
   paramCatalogEntry,
+  parseImageParamValue,
   wireName
 } from './schemas/imageParamCatalog'
 export { ImageGenerationModeSchema, ImageGenerationSupportSchema } from './schemas/model'

--- a/packages/provider-registry/src/schemas/imageParamCatalog.ts
+++ b/packages/provider-registry/src/schemas/imageParamCatalog.ts
@@ -103,6 +103,14 @@ export const IMAGE_PARAM_CATALOG = {
   upscaleFactor: { schema: optNumber }
 } as const satisfies Record<CanonicalParamKey, ImageParamCatalogEntry>
 
+/** Parse one dynamic form value through its canonical catalog schema. */
+export function parseImageParamValue(key: string, value: unknown): unknown {
+  const entry = (IMAGE_PARAM_CATALOG as Record<string, ImageParamCatalogEntry>)[key]
+  if (!entry) return undefined
+  const parsed = entry.schema.safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
 /** Static value type of a canonical param, derived from its catalog schema. */
 export type ParamValue<K extends CanonicalParamKey> = z.infer<(typeof IMAGE_PARAM_CATALOG)[K]['schema']>
 

--- a/packages/provider-registry/src/schemas/imageParamCatalog.ts
+++ b/packages/provider-registry/src/schemas/imageParamCatalog.ts
@@ -31,12 +31,26 @@ export interface ImageParamCatalogEntry<S extends z.ZodTypeAny = z.ZodTypeAny> {
 }
 
 // ── Value-type helpers ───────────────────────────────────────────────────────
-// A blank text input (`''`) must read as "omitted", not coerce to `0`/`NaN`.
-const blankToUndefined = (v: unknown): unknown => (v === '' || v == null ? undefined : v)
+/**
+ * Normalize only finite numbers and numeric strings from form controls.
+ * Other JavaScript-coercible values (booleans and arrays) stay invalid instead
+ * of silently becoming `0`, `1`, or another number at submission time.
+ */
+export function normalizeImageParamNumber(value: unknown): unknown {
+  if (value == null) return undefined
+  if (typeof value === 'number') return value
+  if (typeof value !== 'string') return value
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const numeric = Number(trimmed)
+  return Number.isFinite(numeric) ? numeric : value
+}
+
 const optString = z.string().optional()
 const optBool = z.boolean().optional()
-const optNumber = z.preprocess(blankToUndefined, z.coerce.number().optional())
-const optInt = z.preprocess(blankToUndefined, z.coerce.number().int().optional())
+const optNumber = z.preprocess(normalizeImageParamNumber, z.number().finite().optional())
+const optInt = z.preprocess(normalizeImageParamNumber, z.number().finite().int().optional())
 
 /**
  * Catalog. Plain object literal + `as const satisfies` so per-key schema types

--- a/packages/provider-registry/src/utils/buildParamsSchema.ts
+++ b/packages/provider-registry/src/utils/buildParamsSchema.ts
@@ -13,7 +13,7 @@
 import * as z from 'zod'
 
 import type { CanonicalParamKey } from '../schemas/enums'
-import { IMAGE_PARAM_CATALOG } from '../schemas/imageParamCatalog'
+import { IMAGE_PARAM_CATALOG, normalizeImageParamNumber } from '../schemas/imageParamCatalog'
 import type { ImageGenerationMode, ImageGenerationSupport, SupportSpec } from '../schemas/model'
 
 function resolveModeSupports(
@@ -75,8 +75,8 @@ export function buildParamsSchema(
     // `<key>_width` / `<key>_height` keys (not canonical), bounded by the spec.
     if (spec.type === 'size') {
       const side = z.preprocess(
-        (v) => (v === '' || v == null ? undefined : v),
-        z.coerce.number().min(spec.minSide).max(spec.maxSide).optional()
+        normalizeImageParamNumber,
+        z.number().finite().min(spec.minSide).max(spec.maxSide).optional()
       )
       shape[`${key}_width`] = side.catch(undefined)
       shape[`${key}_height`] = side.catch(undefined)

--- a/src/renderer/pages/paintings/components/PaintingComposer.tsx
+++ b/src/renderer/pages/paintings/components/PaintingComposer.tsx
@@ -28,7 +28,8 @@ import { Settings2 } from 'lucide-react'
 import { type FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { BaseConfigItem } from '../form/baseConfigItem'
+import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
+import { controlValue } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 import { SIZE_PREVIEW_KEYS, sizeOptionLabel } from '../form/paintingSize'
 import { resolveOptions } from '../form/resolveOptions'
@@ -59,8 +60,17 @@ const SUMMARY_TYPES = new Set<BaseConfigItem['type']>([
   'styleToggle'
 ])
 
+type SummaryConfigItem = Extract<
+  BaseConfigItem,
+  { type: 'select' | 'sizeChips' | 'slider' | 'radio' | 'iconRadio' | 'styleToggle' }
+>
+
+function isSummaryConfigItem(item: BaseConfigItem): item is SummaryConfigItem {
+  return SUMMARY_TYPES.has(item.type)
+}
+
 function formatSummaryValue(
-  item: BaseConfigItem,
+  item: SummaryConfigItem,
   value: unknown,
   params: PaintingData['params'],
   translate: (key: string) => string
@@ -70,16 +80,19 @@ function formatSummaryValue(
     if (value === 'custom') {
       const w = params?.customSize_width
       const h = params?.customSize_height
-      return w && h ? `${String(w)}×${String(h)}` : undefined
+      const width = controlValue(w)
+      const height = controlValue(h)
+      return width && height ? `${width}×${height}` : undefined
     }
     // Localize the selected option (e.g. `auto` → `自动`) the same way the chips
     // and the artboard prompt bar do, instead of formatting the raw enum.
-    return sizeOptionLabel(item, String(value), params, translate)
+    return isOptionsConfigItem(item) ? sizeOptionLabel(item, controlValue(value), params, translate) : undefined
   }
-  if (item.type === 'slider') return String(value)
+  if (item.type === 'slider') return controlValue(value)
   // Option-based: show the selected option's localized label.
-  const match = resolveOptions(item, params ?? {}, translate).find((opt) => String(opt.value) === String(value))
-  return match?.label ?? String(value)
+  const formattedValue = controlValue(value)
+  const match = resolveOptions(item, params ?? {}, translate).find((opt) => controlValue(opt.value) === formattedValue)
+  return match?.label ?? formattedValue
 }
 
 /**
@@ -95,7 +108,7 @@ function paramsSummary(
 ): string {
   const parts: string[] = []
   for (const item of items) {
-    if (!item.key || !SUMMARY_TYPES.has(item.type)) continue
+    if (!isSummaryConfigItem(item)) continue
     if (item.condition && !item.condition(params ?? {})) continue
     const value = params?.[item.key] ?? item.initialValue
     if (value === undefined || value === null || value === '') continue

--- a/src/renderer/pages/paintings/components/PaintingComposer.tsx
+++ b/src/renderer/pages/paintings/components/PaintingComposer.tsx
@@ -29,7 +29,7 @@ import { type FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
-import { controlValue, optionalFiniteNumber } from '../form/fieldValue'
+import { controlValue, finiteNumberOr, optionalFiniteNumber } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 import { SIZE_PREVIEW_KEYS, sizeOptionLabel } from '../form/paintingSize'
 import { resolveOptions } from '../form/resolveOptions'
@@ -86,7 +86,7 @@ function formatSummaryValue(
     // and the artboard prompt bar do, instead of formatting the raw enum.
     return isOptionsConfigItem(item) ? sizeOptionLabel(item, controlValue(value), params, translate) : undefined
   }
-  if (item.type === 'slider') return controlValue(value)
+  if (item.type === 'slider') return `${finiteNumberOr(value, item.initialValue)}`
   // Option-based: show the selected option's localized label.
   const formattedValue = controlValue(value)
   const match = resolveOptions(item, params ?? {}, translate).find((opt) => controlValue(opt.value) === formattedValue)

--- a/src/renderer/pages/paintings/components/PaintingComposer.tsx
+++ b/src/renderer/pages/paintings/components/PaintingComposer.tsx
@@ -29,10 +29,10 @@ import { type FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
-import { controlValue, finiteNumberOr, optionalFiniteNumber } from '../form/fieldValue'
+import { controlValue, finiteParamNumberOr, optionalFiniteNumber } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 import { SIZE_PREVIEW_KEYS, sizeOptionLabel } from '../form/paintingSize'
-import { resolveOptions } from '../form/resolveOptions'
+import { resolveOptions, resolveOptionValue } from '../form/resolveOptions'
 import { useImageGenerationSupport } from '../hooks/useImageGenerationSupport'
 import { type InputCapability, usePaintingComposerInputFiles } from '../hooks/usePaintingComposerInputFiles'
 import type { MaterializeInputs } from '../hooks/usePaintingGenerationSubmit'
@@ -86,7 +86,7 @@ function formatSummaryValue(
     // and the artboard prompt bar do, instead of formatting the raw enum.
     return isOptionsConfigItem(item) ? sizeOptionLabel(item, controlValue(value), params, translate) : undefined
   }
-  if (item.type === 'slider') return `${finiteNumberOr(value, item.initialValue)}`
+  if (item.type === 'slider') return `${finiteParamNumberOr(item.key, value, item.initialValue)}`
   // Option-based: show the selected option's localized label.
   const formattedValue = controlValue(value)
   const match = resolveOptions(item, params ?? {}, translate).find((opt) => controlValue(opt.value) === formattedValue)
@@ -108,7 +108,16 @@ function paramsSummary(
   for (const item of items) {
     if (!isSummaryConfigItem(item)) continue
     if (item.condition && !item.condition(params ?? {})) continue
-    const value = params?.[item.key] ?? item.initialValue
+    const storedValue = params?.[item.key]
+    // Preserve the custom-size sentinel even for older registry snapshots that
+    // did not yet append it to the option list. Its dimensions are validated in
+    // formatSummaryValue; every other option still goes through the typed
+    // catalog + declared-option boundary below.
+    const value = isOptionsConfigItem(item)
+      ? storedValue === 'custom' && (SIZE_PREVIEW_KEYS as readonly string[]).includes(item.key)
+        ? storedValue
+        : resolveOptionValue(item, storedValue, params ?? {}, translate)
+      : (params?.[item.key] ?? item.initialValue)
     if (value === undefined || value === null || value === '') continue
     const formatted = formatSummaryValue(item, value, params, translate)
     if (formatted) parts.push(formatted)

--- a/src/renderer/pages/paintings/components/PaintingComposer.tsx
+++ b/src/renderer/pages/paintings/components/PaintingComposer.tsx
@@ -29,7 +29,7 @@ import { type FC, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
-import { controlValue } from '../form/fieldValue'
+import { controlValue, optionalFiniteNumber } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 import { SIZE_PREVIEW_KEYS, sizeOptionLabel } from '../form/paintingSize'
 import { resolveOptions } from '../form/resolveOptions'
@@ -78,11 +78,9 @@ function formatSummaryValue(
   // Size-bearing fields render as chip-style dimensions, matching the size chips.
   if ((SIZE_PREVIEW_KEYS as readonly string[]).includes(item.key ?? '')) {
     if (value === 'custom') {
-      const w = params?.customSize_width
-      const h = params?.customSize_height
-      const width = controlValue(w)
-      const height = controlValue(h)
-      return width && height ? `${width}×${height}` : undefined
+      const width = optionalFiniteNumber(params?.customSize_width)
+      const height = optionalFiniteNumber(params?.customSize_height)
+      return width !== null && height !== null && width > 0 && height > 0 ? `${width}×${height}` : undefined
     }
     // Localize the selected option (e.g. `auto` → `自动`) the same way the chips
     // and the artboard prompt bar do, instead of formatting the raw enum.

--- a/src/renderer/pages/paintings/components/PaintingSettings.tsx
+++ b/src/renderer/pages/paintings/components/PaintingSettings.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import type { BaseConfigItem } from '../form/baseConfigItem'
+import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 import { PaintingFieldRenderer } from '../form/PaintingFieldRenderer'
 import { useImageGenerationSupport } from '../hooks/useImageGenerationSupport'
@@ -12,6 +12,7 @@ import { tabToImageGenerationMode } from '../utils/paintingProviderMode'
 import PaintingSectionTitle from './PaintingSectionTitle'
 
 function resolveItemOptions(item: BaseConfigItem, painting: Record<string, unknown>) {
+  if (!isOptionsConfigItem(item)) return []
   return typeof item.options === 'function' ? item.options(item, painting) : (item.options ?? [])
 }
 
@@ -56,7 +57,11 @@ const PaintingSettings: FC<PaintingSettingsProps> = ({ painting, onConfigChange,
               <PaintingSectionTitle>
                 {t(item.title)}
                 {/* range fields (e.g. numImages) interpolate their actual {{min}}-{{max}} */}
-                {item.tooltip && <InfoTooltip content={t(item.tooltip, { min: item.min, max: item.max })} />}
+                {item.tooltip && (
+                  <InfoTooltip
+                    content={t(item.tooltip, item.type === 'slider' ? { min: item.min, max: item.max } : undefined)}
+                  />
+                )}
               </PaintingSectionTitle>
             )}
             <PaintingFieldRenderer

--- a/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
@@ -404,6 +404,16 @@ describe('PaintingComposer', () => {
     expect(summaryParts).not.toContain('true')
   })
 
+  it('uses typed catalog fallbacks for wrong-typed option and integer values', () => {
+    renderComposer({ painting: makePainting({ params: { size: true, numImages: '2.5' } }) })
+    const summaryParts = paramsButton().textContent?.split(' · ') ?? []
+
+    expect(summaryParts).toContain('1024×1024')
+    expect(summaryParts).toContain('1')
+    expect(summaryParts).not.toContain('true')
+    expect(summaryParts).not.toContain('2.5')
+  })
+
   it('folds the summary into the params button accessible name', () => {
     renderComposer({ painting: makePainting({ params: { size: '1536x1024' } }) })
     // Summary (incl. registry defaults) is appended after the settings label.

--- a/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
@@ -380,6 +380,13 @@ describe('PaintingComposer', () => {
     expect(paramsButton()).toHaveTextContent('800×600')
   })
 
+  it('does not preview invalid custom dimensions', () => {
+    renderComposer({
+      painting: makePainting({ params: { size: 'custom', customSize_width: 0, customSize_height: 600 } })
+    })
+    expect(paramsButton()).not.toHaveTextContent('0×600')
+  })
+
   it('previews count, quality and background alongside size', () => {
     renderComposer({ painting: makePainting({ params: { numImages: 6, quality: 'low', background: 'auto' } }) })
     const button = paramsButton()

--- a/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/PaintingComposer.test.tsx
@@ -397,6 +397,13 @@ describe('PaintingComposer', () => {
     expect(button).toHaveTextContent('paintings.background_options.auto')
   })
 
+  it('previews the typed slider fallback for a malformed stored value', () => {
+    renderComposer({ painting: makePainting({ params: { numImages: true } }) })
+    const summaryParts = paramsButton().textContent?.split(' · ') ?? []
+    expect(summaryParts).toContain('1')
+    expect(summaryParts).not.toContain('true')
+  })
+
   it('folds the summary into the params button accessible name', () => {
     renderComposer({ painting: makePainting({ params: { size: '1536x1024' } }) })
     // Summary (incl. registry defaults) is appended after the settings label.

--- a/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
+++ b/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import type { BaseConfigItem } from '../form/baseConfigItem'
 import { fieldRegistry } from './fieldRegistry'
+import { booleanOr, controlValue, finiteNumberOr, stringOr } from './fieldValue'
 import { resolveOptions } from './resolveOptions'
 
 export type { BaseConfigItem, OptionItem } from '../form/baseConfigItem'
@@ -18,33 +19,62 @@ export interface PaintingFieldRendererProps {
 export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRandomSeed }: PaintingFieldRendererProps) {
   const { t } = useTranslation()
   const fieldKey = item.key
-  if (!fieldKey) {
-    return null
-  }
 
   const disabled = typeof item.disabled === 'function' ? item.disabled(item, painting) : item.disabled
   const currentValue = painting[fieldKey] ?? item.initialValue
-  const RegisteredField = fieldRegistry[item.type]
-
-  if (RegisteredField) {
-    return (
-      <RegisteredField
-        item={item}
-        fieldKey={fieldKey}
-        painting={painting}
-        translate={t}
-        onChange={onChange}
-        onGenerateRandomSeed={onGenerateRandomSeed}
-        currentValue={currentValue}
-        disabled={disabled}
-      />
-    )
-  }
 
   switch (item.type) {
+    case 'select': {
+      const RegisteredField = fieldRegistry.select
+      return (
+        <RegisteredField
+          item={item}
+          fieldKey={fieldKey}
+          painting={painting}
+          translate={t}
+          onChange={onChange}
+          onGenerateRandomSeed={onGenerateRandomSeed}
+          currentValue={currentValue}
+          disabled={disabled}
+        />
+      )
+    }
+
+    case 'sizeChips': {
+      const RegisteredField = fieldRegistry.sizeChips
+      return (
+        <RegisteredField
+          item={item}
+          fieldKey={fieldKey}
+          painting={painting}
+          translate={t}
+          onChange={onChange}
+          onGenerateRandomSeed={onGenerateRandomSeed}
+          currentValue={currentValue}
+          disabled={disabled}
+        />
+      )
+    }
+
+    case 'customSize': {
+      const RegisteredField = fieldRegistry.customSize
+      return (
+        <RegisteredField
+          item={item}
+          fieldKey={fieldKey}
+          painting={painting}
+          translate={t}
+          onChange={onChange}
+          onGenerateRandomSeed={onGenerateRandomSeed}
+          currentValue={currentValue}
+          disabled={disabled}
+        />
+      )
+    }
+
     case 'radio': {
       const options = resolveOptions(item, painting, t)
-      const value = currentValue !== undefined && currentValue !== null ? String(currentValue) : ''
+      const value = controlValue(currentValue)
 
       return (
         <RadioGroup
@@ -66,15 +96,14 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
     }
 
     case 'slider': {
-      const numericValue = Number(currentValue ?? item.min ?? 0)
-      const min = item.min ?? 0
-      const max = item.max ?? 100
+      const numericValue = finiteNumberOr(currentValue, item.initialValue)
+      const { min, max } = item
       // Degenerate single-value range (e.g. numImages 1..1): the slider has
       // nowhere to move and Radix renders its thumb flush to the rail edge,
       // which the parent's `overflow-hidden` clips. Skip the slider and show
       // a read-only number input instead.
       if (min === max) {
-        return <Input className="w-20" type="number" value={String(numericValue)} readOnly disabled />
+        return <Input className="w-20" type="number" value={numericValue} readOnly disabled />
       }
       return (
         <div className="flex items-center gap-3">
@@ -92,15 +121,15 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
             min={min}
             max={max}
             step={item.step}
-            value={String(numericValue)}
+            value={numericValue}
             onChange={(event) => {
               const raw = event.target.value
               // Ignore the transient empty state (clearing to retype) — committing
               // `Number('')` → 0 would drop below `min`. Otherwise clamp to [min,max]
               // so the controlled value never escapes the field's range.
               if (raw === '') return
-              const parsed = Number(raw)
-              if (Number.isNaN(parsed)) return
+              const parsed = event.target.valueAsNumber
+              if (!Number.isFinite(parsed)) return
               onChange({ [fieldKey]: Math.min(max, Math.max(min, parsed)) })
             }}
           />
@@ -109,12 +138,13 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
     }
 
     case 'input': {
+      const value = stringOr(currentValue, item.initialValue)
       return (
         <div className="flex items-center gap-2">
           <Input
             disabled={disabled}
             className="flex-1"
-            value={currentValue === undefined || currentValue === null ? '' : String(currentValue)}
+            value={value}
             onChange={(event) => onChange({ [fieldKey]: event.target.value })}
           />
           {fieldKey.toLowerCase().includes('seed') && onGenerateRandomSeed ? (
@@ -127,27 +157,25 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
     }
 
     case 'textarea': {
+      const value = stringOr(currentValue, item.initialValue)
       return (
-        <Textarea.Input
-          value={currentValue === undefined || currentValue === null ? '' : String(currentValue)}
-          rows={4}
-          onValueChange={(nextValue) => onChange({ [fieldKey]: nextValue })}
-        />
+        <Textarea.Input value={value} rows={4} onValueChange={(nextValue) => onChange({ [fieldKey]: nextValue })} />
       )
     }
 
     case 'switch': {
+      const checked = booleanOr(currentValue, item.initialValue)
       return (
         <div className="flex items-center">
-          <Switch checked={Boolean(currentValue)} onCheckedChange={(checked) => onChange({ [fieldKey]: checked })} />
+          <Switch checked={checked} onCheckedChange={(nextChecked) => onChange({ [fieldKey]: nextChecked })} />
         </div>
       )
     }
 
     case 'iconRadio': {
       const options = resolveOptions(item, painting, t)
-      const value = currentValue !== undefined && currentValue !== null ? String(currentValue) : ''
-      const columns = item.columns || 3
+      const value = controlValue(currentValue)
+      const columns = item.columns ?? 3
 
       return (
         <RadioGroup
@@ -187,6 +215,7 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
     case 'styleToggle': {
       const options = resolveOptions(item, painting, t)
       const { toggleMode = 'single' } = item
+      const value = stringOr(currentValue, item.initialValue)
 
       return (
         <div className="flex flex-wrap items-start gap-2">
@@ -195,12 +224,12 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
               type="button"
               key={String(option.value)}
               className={`rounded-[6px] border px-[6px] py-[2px] transition-all ${
-                currentValue === String(option.value)
+                value === String(option.value)
                   ? 'border-primary bg-primary text-primary-foreground'
                   : 'border-border bg-background hover:bg-accent'
               }`}
               onClick={() => {
-                if (toggleMode === 'single' && currentValue === String(option.value)) {
+                if (toggleMode === 'single' && value === String(option.value)) {
                   onChange({ [fieldKey]: '' })
                 } else {
                   onChange({ [fieldKey]: String(option.value) })

--- a/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
+++ b/src/renderer/pages/paintings/form/PaintingFieldRenderer.tsx
@@ -2,10 +2,10 @@ import { Button, Input, RadioGroup, RadioGroupItem, Slider, Switch, Textarea } f
 import { RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import type { BaseConfigItem } from '../form/baseConfigItem'
+import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
 import { fieldRegistry } from './fieldRegistry'
-import { booleanOr, controlValue, finiteNumberOr, stringOr } from './fieldValue'
-import { resolveOptions } from './resolveOptions'
+import { booleanOr, controlValue, finiteParamNumberOr, stringOr } from './fieldValue'
+import { resolveOptions, resolveOptionValue } from './resolveOptions'
 
 export type { BaseConfigItem, OptionItem } from '../form/baseConfigItem'
 
@@ -21,7 +21,9 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
   const fieldKey = item.key
 
   const disabled = typeof item.disabled === 'function' ? item.disabled(item, painting) : item.disabled
-  const currentValue = painting[fieldKey] ?? item.initialValue
+  const currentValue = isOptionsConfigItem(item)
+    ? resolveOptionValue(item, painting[fieldKey], painting, t)
+    : (painting[fieldKey] ?? item.initialValue)
 
   switch (item.type) {
     case 'select': {
@@ -96,7 +98,7 @@ export function PaintingFieldRenderer({ item, painting, onChange, onGenerateRand
     }
 
     case 'slider': {
-      const numericValue = finiteNumberOr(currentValue, item.initialValue)
+      const numericValue = finiteParamNumberOr(item.key, currentValue, item.initialValue)
       const { min, max } = item
       // Degenerate single-value range (e.g. numImages 1..1): the slider has
       // nowhere to move and Radix renders its thumb flush to the rail edge,

--- a/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
+++ b/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 
+import { buildParamsSchema } from '@cherrystudio/provider-registry'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -16,6 +17,28 @@ describe('PaintingFieldRenderer dynamic value boundary', () => {
     )
 
     expect(screen.getByRole('spinbutton')).toHaveValue(4)
+  })
+
+  it('displays a numeric string using the same effective value as submit normalization', () => {
+    const support = {
+      modes: {
+        generate: {
+          supports: { strength: { type: 'range' as const, min: 0, max: 10, default: 4 } }
+        }
+      }
+    }
+    const submitted = buildParamsSchema(support, 'generate').parse({ strength: '4.5' })
+
+    render(
+      <PaintingFieldRenderer
+        item={{ type: 'slider', key: 'strength', min: 0, max: 10, initialValue: 4 }}
+        painting={{ strength: '4.5' }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(4.5)
+    expect(submitted.strength).toBe(4.5)
   })
 
   it('does not stringify an invalid text param into the input', () => {

--- a/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
+++ b/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
@@ -41,6 +41,28 @@ describe('PaintingFieldRenderer dynamic value boundary', () => {
     expect(submitted.strength).toBe(4.5)
   })
 
+  it.each([true, false, [], ['4.5']])('drops invalid numeric input %# in both display and submit paths', (value) => {
+    const support = {
+      modes: {
+        generate: {
+          supports: { strength: { type: 'range' as const, min: 0, max: 10, default: 4 } }
+        }
+      }
+    }
+    const submitted = buildParamsSchema(support, 'generate').parse({ strength: value })
+
+    render(
+      <PaintingFieldRenderer
+        item={{ type: 'slider', key: 'strength', min: 0, max: 10, initialValue: 4 }}
+        painting={{ strength: value }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(4)
+    expect(submitted.strength).toBeUndefined()
+  })
+
   it('does not stringify an invalid text param into the input', () => {
     render(
       <PaintingFieldRenderer

--- a/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
+++ b/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom/vitest'
+
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { PaintingFieldRenderer } from '../PaintingFieldRenderer'
+
+describe('PaintingFieldRenderer dynamic value boundary', () => {
+  it('falls back to the typed slider default for a non-numeric param', () => {
+    render(
+      <PaintingFieldRenderer
+        item={{ type: 'slider', key: 'strength', min: 0, max: 10, initialValue: 4 }}
+        painting={{ strength: 'not-a-number' }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(4)
+  })
+
+  it('does not stringify an invalid text param into the input', () => {
+    render(
+      <PaintingFieldRenderer
+        item={{ type: 'input', key: 'seed', initialValue: 'fallback' }}
+        painting={{ seed: { nested: true } }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('textbox')).toHaveValue('fallback')
+  })
+})

--- a/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
+++ b/src/renderer/pages/paintings/form/__tests__/PaintingFieldRenderer.test.tsx
@@ -74,4 +74,43 @@ describe('PaintingFieldRenderer dynamic value boundary', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('fallback')
   })
+
+  it('falls back to the typed option default for a wrong-typed persisted value', () => {
+    render(
+      <PaintingFieldRenderer
+        item={{
+          type: 'select',
+          key: 'size',
+          initialValue: '1024x1024',
+          options: [{ value: '1024x1024', label: '1024' }]
+        }}
+        painting={{ size: true }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('select')).toHaveAttribute('data-value', '1024x1024')
+  })
+
+  it('rejects a decimal persisted value for an integer-backed slider', () => {
+    const support = {
+      modes: {
+        generate: {
+          supports: { numImages: { type: 'range' as const, min: 1, max: 10, default: 1 } }
+        }
+      }
+    }
+    const submitted = buildParamsSchema(support, 'generate').parse({ numImages: '2.5' })
+
+    render(
+      <PaintingFieldRenderer
+        item={{ type: 'slider', key: 'numImages', min: 1, max: 10, initialValue: 1 }}
+        painting={{ numImages: '2.5' }}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(1)
+    expect(submitted.numImages).toBeUndefined()
+  })
 })

--- a/src/renderer/pages/paintings/form/__tests__/fieldValue.test.ts
+++ b/src/renderer/pages/paintings/form/__tests__/fieldValue.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from 'vitest'
 import { booleanOr, controlValue, finiteNumberOr, optionalFiniteNumber, stringOr } from '../fieldValue'
 
 describe('painting field value narrowing', () => {
-  it('accepts only finite numbers instead of coercing dynamic values', () => {
+  it('accepts finite numbers and the numeric strings normalized during submit', () => {
     expect(finiteNumberOr(4.5, 1)).toBe(4.5)
-    expect(finiteNumberOr('4.5', 1)).toBe(1)
+    expect(finiteNumberOr('4.5', 1)).toBe(4.5)
     expect(finiteNumberOr('', 1)).toBe(1)
     expect(finiteNumberOr(Number.NaN, 1)).toBe(1)
     expect(optionalFiniteNumber(0)).toBe(0)
-    expect(optionalFiniteNumber('0')).toBeNull()
+    expect(optionalFiniteNumber('0')).toBe(0)
+    expect(optionalFiniteNumber('not-a-number')).toBeNull()
   })
 
   it('does not stringify objects or reinterpret truthy values', () => {

--- a/src/renderer/pages/paintings/form/__tests__/fieldValue.test.ts
+++ b/src/renderer/pages/paintings/form/__tests__/fieldValue.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { booleanOr, controlValue, finiteNumberOr, optionalFiniteNumber, stringOr } from '../fieldValue'
+
+describe('painting field value narrowing', () => {
+  it('accepts only finite numbers instead of coercing dynamic values', () => {
+    expect(finiteNumberOr(4.5, 1)).toBe(4.5)
+    expect(finiteNumberOr('4.5', 1)).toBe(1)
+    expect(finiteNumberOr('', 1)).toBe(1)
+    expect(finiteNumberOr(Number.NaN, 1)).toBe(1)
+    expect(optionalFiniteNumber(0)).toBe(0)
+    expect(optionalFiniteNumber('0')).toBeNull()
+  })
+
+  it('does not stringify objects or reinterpret truthy values', () => {
+    expect(stringOr('seed', 'fallback')).toBe('seed')
+    expect(stringOr(42, 'fallback')).toBe('fallback')
+    expect(booleanOr(false, true)).toBe(false)
+    expect(booleanOr('false', true)).toBe(true)
+  })
+
+  it('serializes only supported primitive control values', () => {
+    expect(controlValue('1:1')).toBe('1:1')
+    expect(controlValue(2)).toBe('2')
+    expect(controlValue(Number.NaN)).toBe('')
+    expect(controlValue({ value: '1:1' })).toBe('')
+  })
+})

--- a/src/renderer/pages/paintings/form/__tests__/imageGenerationToFields.test.ts
+++ b/src/renderer/pages/paintings/form/__tests__/imageGenerationToFields.test.ts
@@ -1,7 +1,15 @@
 import type { ImageGenerationSupport } from '@shared/data/types/model'
 import { describe, expect, it } from 'vitest'
 
+import { type BaseConfigItem, isOptionsConfigItem, type OptionItem } from '../baseConfigItem'
 import { imageGenerationToFields } from '../imageGenerationToFields'
+
+function staticOptions(item: BaseConfigItem | undefined): OptionItem[] {
+  if (!item || !isOptionsConfigItem(item) || !Array.isArray(item.options)) {
+    throw new Error('Expected an option-based field with static options')
+  }
+  return item.options
+}
 
 /**
  * Locks the derivation contract under the unified schema: `modes[mode].supports`
@@ -41,12 +49,7 @@ describe('imageGenerationToFields', () => {
     expect(byKey.numImages?.min).toBe(1)
     expect(byKey.numImages?.max).toBe(10)
     expect(byKey.quality?.type).toBe('select')
-    expect((byKey.quality!.options as { value: string }[]).map((o) => o.value)).toEqual([
-      'low',
-      'medium',
-      'high',
-      'auto'
-    ])
+    expect(staticOptions(byKey.quality).map((o) => o.value)).toEqual(['low', 'medium', 'high', 'auto'])
     expect(byKey.moderation?.type).toBe('select')
     expect(byKey.background?.type).toBe('select')
   })
@@ -67,26 +70,26 @@ describe('imageGenerationToFields', () => {
     })
     const byKey = Object.fromEntries(items.map((i) => [i.key, i]))
     // Semantic enums → translatable i18n labelKey, no raw label.
-    expect(byKey.quality!.options).toEqual([
+    expect(staticOptions(byKey.quality)).toEqual([
       { labelKey: 'paintings.quality_options.standard', value: 'standard' },
       { labelKey: 'paintings.quality_options.hd', value: 'hd' }
     ])
-    expect(byKey.styleType!.options).toEqual([
+    expect(staticOptions(byKey.styleType)).toEqual([
       { labelKey: 'paintings.style_type_options.auto', value: 'AUTO' },
       { labelKey: 'paintings.style_type_options.realistic', value: 'REALISTIC' }
     ])
     // style / function: label is localized, but the option value is preserved
     // verbatim (incl. the `<...>` form) — that raw value is what reaches the request body.
-    expect(byKey.style!.options).toEqual([
+    expect(staticOptions(byKey.style)).toEqual([
       { labelKey: 'paintings.style_options.natural', value: 'natural' },
       { labelKey: 'paintings.style_options.photography', value: '<photography>' }
     ])
-    expect(byKey.function!.options).toEqual([
+    expect(staticOptions(byKey.function)).toEqual([
       { labelKey: 'paintings.dashscope.function_options.expand', value: 'expand' },
       { labelKey: 'paintings.dashscope.function_options.remove_watermark', value: 'remove_watermark' }
     ])
     // Literal enum (ratios) → raw value as label, no labelKey (nothing to translate).
-    expect(byKey.aspectRatio!.options).toEqual([
+    expect(staticOptions(byKey.aspectRatio)).toEqual([
       { label: '1:1', value: '1:1' },
       { label: '16:9', value: '16:9' }
     ])
@@ -107,17 +110,11 @@ describe('imageGenerationToFields', () => {
     })
     const byKey = Object.fromEntries(items.map((i) => [i.key, i]))
     expect(byKey.aspectRatio?.type).toBe('select')
-    expect((byKey.aspectRatio!.options as { value: string }[]).map((o) => o.value)).toEqual([
-      '1:1',
-      '9:16',
-      '16:9',
-      '3:4',
-      '4:3'
-    ])
+    expect(staticOptions(byKey.aspectRatio).map((o) => o.value)).toEqual(['1:1', '9:16', '16:9', '3:4', '4:3'])
     expect(byKey.numImages?.max).toBe(1)
     expect(byKey.seed?.type).toBe('input')
     expect(byKey.personGeneration?.type).toBe('select')
-    expect((byKey.personGeneration!.options as { value: string }[]).map((o) => o.value)).toContain('DONT_ALLOW')
+    expect(staticOptions(byKey.personGeneration).map((o) => o.value)).toContain('DONT_ALLOW')
   })
 
   it('flux-kontext-pro: safetyTolerance range slider with default 6', () => {
@@ -226,7 +223,7 @@ describe('imageGenerationToFields', () => {
     })
     const byKey = Object.fromEntries(items.map((i) => [i.key, i]))
     expect(byKey.size?.type).toBe('sizeChips')
-    const sizeValues = (byKey.size!.options as { value: string }[]).map((o) => o.value)
+    const sizeValues = staticOptions(byKey.size).map((o) => o.value)
     expect(sizeValues).toContain('1024x1024')
     expect(sizeValues).toContain('custom')
     expect(byKey.customSize?.type).toBe('customSize')
@@ -246,7 +243,7 @@ describe('imageGenerationToFields', () => {
     })
     const size = items.find((item) => item.key === 'size')
 
-    expect(size?.options).toEqual([{ labelKey: 'paintings.custom_size', value: 'custom' }])
+    expect(staticOptions(size)).toEqual([{ labelKey: 'paintings.custom_size', value: 'custom' }])
   })
 
   it('size without paired customSize: no custom chip', () => {

--- a/src/renderer/pages/paintings/form/baseConfigItem.ts
+++ b/src/renderer/pages/paintings/form/baseConfigItem.ts
@@ -1,12 +1,10 @@
 /**
  * Form field descriptor types produced by `imageGenerationToFields` and
- * consumed by `PaintingFieldRenderer`. The dispatcher in
- * `imageGenerationToFields` maps each registry `SupportSpec` arm onto a
- * `BaseConfigItem` whose `type` field selects a renderer in
- * `fieldRegistry`.
+ * consumed by `PaintingFieldRenderer`. `type` is the discriminant: every
+ * renderer receives only the constraints and initial value shape it supports.
  */
 
-type PrimitiveValue = string | number | boolean | undefined
+type PaintingParams = Record<string, unknown>
 
 export type OptionItem = {
   label?: string
@@ -17,40 +15,133 @@ export type OptionItem = {
   options?: OptionItem[]
 }
 
-export type BaseConfigItem = {
-  type:
-    | 'select'
-    | 'radio'
-    | 'slider'
-    | 'input'
-    | 'switch'
-    | 'textarea'
-    | 'image'
-    | 'customSize'
-    | 'iconRadio'
-    | 'styleToggle'
-    | 'sizeChips'
-  key?: string
+export type SizeValidation = {
+  minWidth?: number
+  maxWidth?: number
+  minHeight?: number
+  maxHeight?: number
+  divisibleBy?: number
+  maxPixels?: number
+}
+
+type CommonConfigItem = {
+  key: string
   title?: string
   tooltip?: string
-  options?: OptionItem[] | ((config: BaseConfigItem, painting: Record<string, unknown>) => OptionItem[])
-  min?: number
-  max?: number
-  step?: number
-  initialValue?: PrimitiveValue
-  disabled?: boolean | ((config: BaseConfigItem, painting: Record<string, unknown>) => boolean)
-  condition?: (painting: Record<string, unknown>) => boolean
-  widthKey?: string
-  heightKey?: string
-  sizeKey?: string
-  validation?: {
-    minWidth?: number
-    maxWidth?: number
-    minHeight?: number
-    maxHeight?: number
-    divisibleBy?: number
-    maxPixels?: number
+  disabled?: boolean | ((config: BaseConfigItem, painting: PaintingParams) => boolean)
+  condition?: (painting: PaintingParams) => boolean
+}
+
+type NonSliderConstraints = {
+  min?: never
+  max?: never
+  step?: never
+}
+
+type OptionSource = OptionItem[] | ((config: BaseConfigItem, painting: PaintingParams) => OptionItem[])
+
+export type SelectConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'select'
+    options: OptionSource
+    initialValue?: string
   }
-  columns?: number
-  toggleMode?: 'single' | 'multi'
+
+export type RadioConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'radio'
+    options: OptionSource
+    initialValue?: string | number
+  }
+
+export type SliderConfigItem = CommonConfigItem & {
+  type: 'slider'
+  min: number
+  max: number
+  step?: number
+  initialValue: number
+  options?: never
+}
+
+export type InputConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'input'
+    initialValue?: string
+    options?: never
+  }
+
+export type SwitchConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'switch'
+    initialValue: boolean
+    options?: never
+  }
+
+export type TextareaConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'textarea'
+    initialValue?: string
+    options?: never
+  }
+
+export type ImageConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'image'
+    initialValue?: string
+    options?: never
+  }
+
+export type CustomSizeConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'customSize'
+    widthKey: string
+    heightKey: string
+    sizeKey: string
+    validation: SizeValidation
+    initialValue?: never
+    options?: never
+  }
+
+export type IconRadioConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'iconRadio'
+    options: OptionSource
+    columns?: number
+    initialValue?: string | number
+  }
+
+export type StyleToggleConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'styleToggle'
+    options: OptionSource
+    toggleMode?: 'single' | 'multi'
+    initialValue?: string
+  }
+
+export type SizeChipsConfigItem = CommonConfigItem &
+  NonSliderConstraints & {
+    type: 'sizeChips'
+    options: OptionSource
+    columns?: number
+    initialValue?: string
+  }
+
+export type OptionsConfigItem =
+  | SelectConfigItem
+  | RadioConfigItem
+  | IconRadioConfigItem
+  | StyleToggleConfigItem
+  | SizeChipsConfigItem
+
+export type BaseConfigItem =
+  | OptionsConfigItem
+  | SliderConfigItem
+  | InputConfigItem
+  | SwitchConfigItem
+  | TextareaConfigItem
+  | ImageConfigItem
+  | CustomSizeConfigItem
+
+export function isOptionsConfigItem(item: BaseConfigItem): item is OptionsConfigItem {
+  return ['select', 'radio', 'iconRadio', 'styleToggle', 'sizeChips'].includes(item.type)
 }

--- a/src/renderer/pages/paintings/form/baseConfigItem.typecheck.ts
+++ b/src/renderer/pages/paintings/form/baseConfigItem.typecheck.ts
@@ -1,0 +1,44 @@
+import type { BaseConfigItem } from './baseConfigItem'
+
+function acceptConfigItem(item: BaseConfigItem): void {
+  void item
+}
+
+// @ts-expect-error slider defaults must be numeric
+acceptConfigItem({ type: 'slider', key: 'strength', min: 0, max: 1, initialValue: '0.5' })
+
+// @ts-expect-error sliders require both range bounds
+acceptConfigItem({ type: 'slider', key: 'strength', initialValue: 0.5 })
+
+// @ts-expect-error input fields cannot carry slider constraints
+acceptConfigItem({ type: 'input', key: 'seed', min: 0, max: 10 })
+
+// @ts-expect-error select fields require an option source
+acceptConfigItem({ type: 'select', key: 'quality' })
+
+// @ts-expect-error custom-size fields require their backing keys and validation
+acceptConfigItem({ type: 'customSize', key: 'customSize' })
+
+function assertDiscriminatedFields(item: BaseConfigItem): void {
+  if (item.type === 'slider') {
+    const initialValue: number = item.initialValue
+    const min: number = item.min
+    const max: number = item.max
+    void [initialValue, min, max]
+  }
+
+  if (item.type === 'select') {
+    const options = item.options
+    const initialValue: string | undefined = item.initialValue
+    void [options, initialValue]
+  }
+
+  if (item.type === 'customSize') {
+    const widthKey: string = item.widthKey
+    const heightKey: string = item.heightKey
+    const sizeKey: string = item.sizeKey
+    void [widthKey, heightKey, sizeKey, item.validation]
+  }
+}
+
+void assertDiscriminatedFields

--- a/src/renderer/pages/paintings/form/fieldRegistry.ts
+++ b/src/renderer/pages/paintings/form/fieldRegistry.ts
@@ -5,8 +5,8 @@ import SelectField from './fields/SelectField'
 import SizeChipsField from './fields/SizeChipsField'
 import SizeField from './fields/SizeField'
 
-export interface PaintingFieldComponentProps {
-  item: BaseConfigItem
+export interface PaintingFieldComponentProps<TType extends BaseConfigItem['type'] = BaseConfigItem['type']> {
+  item: Extract<BaseConfigItem, { type: TType }>
   fieldKey: string
   painting: Record<string, unknown>
   translate: (key: string) => string
@@ -16,10 +16,18 @@ export interface PaintingFieldComponentProps {
   disabled?: boolean
 }
 
-export type PaintingFieldComponent = ComponentType<PaintingFieldComponentProps>
+export type PaintingFieldComponent<TType extends BaseConfigItem['type']> = ComponentType<
+  PaintingFieldComponentProps<TType>
+>
 
-export const fieldRegistry: Partial<Record<BaseConfigItem['type'], PaintingFieldComponent>> = {
+type RegisteredFieldRegistry = {
+  select: PaintingFieldComponent<'select'>
+  sizeChips: PaintingFieldComponent<'sizeChips'>
+  customSize: PaintingFieldComponent<'customSize'>
+}
+
+export const fieldRegistry = {
   select: SelectField,
   sizeChips: SizeChipsField,
   customSize: SizeField
-}
+} satisfies RegisteredFieldRegistry

--- a/src/renderer/pages/paintings/form/fieldValue.ts
+++ b/src/renderer/pages/paintings/form/fieldValue.ts
@@ -1,0 +1,22 @@
+/** Checked reads at the dynamic painting-params boundary. */
+export function finiteNumberOr(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+export function optionalFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function stringOr(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback
+}
+
+export function booleanOr(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback
+}
+
+export function controlValue(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return `${value}`
+  return ''
+}

--- a/src/renderer/pages/paintings/form/fieldValue.ts
+++ b/src/renderer/pages/paintings/form/fieldValue.ts
@@ -1,4 +1,4 @@
-import { normalizeImageParamNumber } from '@cherrystudio/provider-registry'
+import { normalizeImageParamNumber, parseImageParamValue } from '@cherrystudio/provider-registry'
 
 /** Match the submit schema's strict numeric-input normalization. */
 function finiteNumber(value: unknown): number | null {
@@ -13,6 +13,20 @@ export function finiteNumberOr(value: unknown, fallback: number): number {
 
 export function optionalFiniteNumber(value: unknown): number | null {
   return finiteNumber(value)
+}
+
+export function finiteParamNumberOr(key: string, value: unknown, fallback: number): number {
+  const parsed = parseImageParamValue(key, value)
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : fallback
+}
+
+export function optionalParamNumber(key: string, value: unknown): number | null {
+  const parsed = parseImageParamValue(key, value)
+  return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : null
+}
+
+export function catalogValueOr(key: string, value: unknown, fallback: unknown): unknown {
+  return parseImageParamValue(key, value) ?? fallback
 }
 
 export function stringOr(value: unknown, fallback = ''): string {

--- a/src/renderer/pages/paintings/form/fieldValue.ts
+++ b/src/renderer/pages/paintings/form/fieldValue.ts
@@ -1,9 +1,9 @@
-/** Match the submit schema's blank handling and numeric-string coercion. */
-function finiteNumber(value: unknown): number | null {
-  if (value === '' || value == null) return null
+import { normalizeImageParamNumber } from '@cherrystudio/provider-registry'
 
-  const numeric = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
-  return Number.isFinite(numeric) ? numeric : null
+/** Match the submit schema's strict numeric-input normalization. */
+function finiteNumber(value: unknown): number | null {
+  const numeric = normalizeImageParamNumber(value)
+  return typeof numeric === 'number' && Number.isFinite(numeric) ? numeric : null
 }
 
 /** Checked reads at the dynamic painting-params boundary. */

--- a/src/renderer/pages/paintings/form/fieldValue.ts
+++ b/src/renderer/pages/paintings/form/fieldValue.ts
@@ -1,10 +1,18 @@
+/** Match the submit schema's blank handling and numeric-string coercion. */
+function finiteNumber(value: unknown): number | null {
+  if (value === '' || value == null) return null
+
+  const numeric = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN
+  return Number.isFinite(numeric) ? numeric : null
+}
+
 /** Checked reads at the dynamic painting-params boundary. */
 export function finiteNumberOr(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return finiteNumber(value) ?? fallback
 }
 
 export function optionalFiniteNumber(value: unknown): number | null {
-  return typeof value === 'number' && Number.isFinite(value) ? value : null
+  return finiteNumber(value)
 }
 
 export function stringOr(value: unknown, fallback = ''): string {

--- a/src/renderer/pages/paintings/form/fields/SelectField.tsx
+++ b/src/renderer/pages/paintings/form/fields/SelectField.tsx
@@ -9,6 +9,7 @@ import {
 } from '@cherrystudio/ui'
 
 import type { PaintingFieldComponentProps } from '../fieldRegistry'
+import { controlValue } from '../fieldValue'
 import { resolveOptions } from '../resolveOptions'
 
 export default function SelectField({
@@ -19,10 +20,10 @@ export default function SelectField({
   onChange,
   currentValue,
   disabled
-}: PaintingFieldComponentProps) {
+}: PaintingFieldComponentProps<'select'>) {
   const options = resolveOptions(item, painting, translate)
   const grouped = options.some((option) => Array.isArray(option.options) && option.options.length > 0)
-  const value = currentValue !== undefined && currentValue !== null ? String(currentValue) : ''
+  const value = controlValue(currentValue)
 
   return (
     <Select disabled={disabled} value={value} onValueChange={(nextValue) => onChange({ [fieldKey]: nextValue })}>

--- a/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
+++ b/src/renderer/pages/paintings/form/fields/SizeChipsField.tsx
@@ -2,6 +2,7 @@ import { cn } from '@cherrystudio/ui/lib/utils'
 
 import type { OptionItem } from '../../form/baseConfigItem'
 import type { PaintingFieldComponentProps } from '../fieldRegistry'
+import { controlValue } from '../fieldValue'
 import { resolveOptions } from '../resolveOptions'
 import { deriveChipLabel, type Dim, parseRatio } from '../sizeLabel'
 
@@ -67,9 +68,9 @@ export default function SizeChipsField({
   onChange,
   currentValue,
   disabled
-}: PaintingFieldComponentProps) {
+}: PaintingFieldComponentProps<'sizeChips'>) {
   const options = resolveOptions(item, painting, translate)
-  const value = currentValue == null ? '' : String(currentValue)
+  const value = controlValue(currentValue)
   const columns = autoColumns(options, item.columns)
 
   return (

--- a/src/renderer/pages/paintings/form/fields/SizeField.tsx
+++ b/src/renderer/pages/paintings/form/fields/SizeField.tsx
@@ -1,13 +1,14 @@
 import { Input, RowFlex } from '@cherrystudio/ui'
 import { useTranslation } from 'react-i18next'
 
+import { optionalFiniteNumber } from '../../form/fieldValue'
 import type { PaintingFieldComponentProps } from '../fieldRegistry'
 
-export default function SizeField({ item, painting, onChange }: PaintingFieldComponentProps) {
+export default function SizeField({ item, painting, onChange }: PaintingFieldComponentProps<'customSize'>) {
   const { t } = useTranslation()
-  const { widthKey = 'width', heightKey = 'height', validation = {} } = item
-  const widthValue = painting[widthKey] ?? ''
-  const heightValue = painting[heightKey] ?? ''
+  const { widthKey, heightKey, validation } = item
+  const widthValue = optionalFiniteNumber(painting[widthKey])
+  const heightValue = optionalFiniteNumber(painting[heightKey])
 
   // SizeField only renders when the parent chip widget has `sizeKey === 'custom'`
   // (see `condition` on the customSize item in imageGenerationToFields). The
@@ -23,9 +24,10 @@ export default function SizeField({ item, painting, onChange }: PaintingFieldCom
           aria-label={t('paintings.generate.width')}
           placeholder={t('paintings.generate.width')}
           type="number"
-          value={widthValue === undefined || widthValue === null ? '' : String(widthValue)}
+          value={widthValue ?? ''}
           onChange={(event) => {
-            const value = event.target.value === '' ? '' : Number(event.target.value)
+            const value = event.target.value === '' ? '' : event.target.valueAsNumber
+            if (typeof value === 'number' && !Number.isFinite(value)) return
             onChange({ [widthKey]: value })
           }}
           min={validation.minWidth}
@@ -37,9 +39,10 @@ export default function SizeField({ item, painting, onChange }: PaintingFieldCom
           aria-label={t('paintings.generate.height')}
           placeholder={t('paintings.generate.height')}
           type="number"
-          value={heightValue === undefined || heightValue === null ? '' : String(heightValue)}
+          value={heightValue ?? ''}
           onChange={(event) => {
-            const value = event.target.value === '' ? '' : Number(event.target.value)
+            const value = event.target.value === '' ? '' : event.target.valueAsNumber
+            if (typeof value === 'number' && !Number.isFinite(value)) return
             onChange({ [heightKey]: value })
           }}
           min={validation.minHeight}

--- a/src/renderer/pages/paintings/form/imageGenerationToFields.ts
+++ b/src/renderer/pages/paintings/form/imageGenerationToFields.ts
@@ -5,7 +5,7 @@ import type {
   SupportSpec
 } from '@shared/data/types/model'
 
-import type { BaseConfigItem, OptionItem } from '../form/baseConfigItem'
+import type { BaseConfigItem, CustomSizeConfigItem, OptionItem, SliderConfigItem } from '../form/baseConfigItem'
 
 /**
  * Canonical key → i18n labels. Exhaustive over `CanonicalParamKey`: every
@@ -174,7 +174,7 @@ function specToField(key: string, spec: SupportSpec, allSupports: Record<string,
     case 'text':
       return spec.multiline ? { type: 'textarea', key, ...labels } : { type: 'input', key, ...labels }
     case 'range': {
-      const item: BaseConfigItem = {
+      const item: SliderConfigItem = {
         type: 'slider',
         key,
         ...labels,
@@ -182,7 +182,7 @@ function specToField(key: string, spec: SupportSpec, allSupports: Record<string,
         max: spec.max,
         initialValue: spec.default ?? spec.min
       }
-      if (spec.step !== undefined) (item as { step?: number }).step = spec.step
+      if (spec.step !== undefined) item.step = spec.step
       return item
     }
     case 'enum': {
@@ -214,7 +214,7 @@ function specToField(key: string, spec: SupportSpec, allSupports: Record<string,
     }
     case 'size': {
       const pairedKey = spec.pairedEnumKey
-      const item: BaseConfigItem = {
+      const item: CustomSizeConfigItem = {
         type: 'customSize',
         key,
         widthKey: `${key}_width`,

--- a/src/renderer/pages/paintings/form/paintingSize.ts
+++ b/src/renderer/pages/paintings/form/paintingSize.ts
@@ -1,5 +1,6 @@
 import type { PaintingData } from '../model/types/paintingData'
-import type { BaseConfigItem } from './baseConfigItem'
+import { type BaseConfigItem, isOptionsConfigItem, type OptionsConfigItem } from './baseConfigItem'
+import { controlValue, optionalFiniteNumber } from './fieldValue'
 import { resolveOptions } from './resolveOptions'
 import { deriveChipLabel, parseRatio } from './sizeLabel'
 
@@ -11,12 +12,12 @@ import { deriveChipLabel, parseRatio } from './sizeLabel'
  * identically instead of drifting to the raw enum.
  */
 export function sizeOptionLabel(
-  item: BaseConfigItem,
+  item: OptionsConfigItem,
   value: string,
   params: PaintingData['params'],
   translate: (key: string) => string
 ): string {
-  const selected = resolveOptions(item, params ?? {}, translate).find((option) => String(option.value) === value)
+  const selected = resolveOptions(item, params ?? {}, translate).find((option) => controlValue(option.value) === value)
   return deriveChipLabel(selected?.label ?? value, value)
 }
 
@@ -46,9 +47,11 @@ export function resolveRatio(params: PaintingData['params'], items: BaseConfigIt
 
     const value = params?.[item.key] ?? item.initialValue
     if (value === 'custom') {
-      const customWidth = Number(params?.customSize_width)
-      const customHeight = Number(params?.customSize_height)
-      if (customWidth > 0 && customHeight > 0) return customWidth / customHeight
+      const customWidth = optionalFiniteNumber(params?.customSize_width)
+      const customHeight = optionalFiniteNumber(params?.customSize_height)
+      if (customWidth !== null && customHeight !== null && customWidth > 0 && customHeight > 0) {
+        return customWidth / customHeight
+      }
       continue
     }
 
@@ -86,13 +89,15 @@ export function resolveSizeLabel(
 
     const value = params?.[item.key] ?? item.initialValue
     if (value === 'custom') {
-      const customWidth = Number(params?.customSize_width)
-      const customHeight = Number(params?.customSize_height)
-      return customWidth > 0 && customHeight > 0 ? `${customWidth}×${customHeight}` : undefined
+      const customWidth = optionalFiniteNumber(params?.customSize_width)
+      const customHeight = optionalFiniteNumber(params?.customSize_height)
+      return customWidth !== null && customHeight !== null && customWidth > 0 && customHeight > 0
+        ? `${customWidth}×${customHeight}`
+        : undefined
     }
 
     if (typeof value !== 'string' || value === '') continue
-    return sizeOptionLabel(item, value, params, translate)
+    if (isOptionsConfigItem(item)) return sizeOptionLabel(item, value, params, translate)
   }
 
   return undefined

--- a/src/renderer/pages/paintings/form/resolveOptions.ts
+++ b/src/renderer/pages/paintings/form/resolveOptions.ts
@@ -1,4 +1,5 @@
 import type { OptionItem, OptionsConfigItem } from './baseConfigItem'
+import { catalogValueOr, controlValue } from './fieldValue'
 
 /**
  * Resolve a field's options — a static `OptionItem[]` or a
@@ -16,4 +17,19 @@ export function resolveOptions(
     ...option,
     label: option.labelKey ? translate(option.labelKey) : option.label
   }))
+}
+
+/** Resolve a persisted option value or fall back to the typed registry default. */
+export function resolveOptionValue(
+  item: OptionsConfigItem,
+  value: unknown,
+  painting: Record<string, unknown>,
+  translate: (key: string) => string
+): string | number | undefined {
+  const candidate = catalogValueOr(item.key, value, item.initialValue)
+  const normalized = controlValue(candidate)
+  const match = resolveOptions(item, painting, translate).find(
+    (option) => normalized !== '' && controlValue(option.value) === normalized
+  )
+  return match?.value ?? item.initialValue
 }

--- a/src/renderer/pages/paintings/form/resolveOptions.ts
+++ b/src/renderer/pages/paintings/form/resolveOptions.ts
@@ -1,4 +1,4 @@
-import type { BaseConfigItem, OptionItem } from './baseConfigItem'
+import type { OptionItem, OptionsConfigItem } from './baseConfigItem'
 
 /**
  * Resolve a field's options — a static `OptionItem[]` or a
@@ -7,7 +7,7 @@ import type { BaseConfigItem, OptionItem } from './baseConfigItem'
  * field renderers so the resolve-then-localize step lives in one place.
  */
 export function resolveOptions(
-  item: BaseConfigItem,
+  item: OptionsConfigItem,
   painting: Record<string, unknown>,
   translate: (key: string) => string
 ): OptionItem[] {

--- a/src/renderer/pages/paintings/model/__tests__/canonicalGenerate.test.ts
+++ b/src/renderer/pages/paintings/model/__tests__/canonicalGenerate.test.ts
@@ -75,6 +75,20 @@ describe('canonicalGenerate', () => {
     expect(call.inputImages).toBeUndefined()
   })
 
+  it('submits the same effective slider value rendered from a numeric string', async () => {
+    const support = {
+      modes: {
+        generate: {
+          supports: { strength: { type: 'range' as const, min: 0, max: 10, default: 4 } }
+        }
+      }
+    }
+
+    await canonicalGenerate(makeInput({ strength: '4.5' }), { support, mode: 'generate' })
+
+    expect(lastGenerateCall().paramValues.strength).toBe(4.5)
+  })
+
   it('composes the customSize widget trio into size and drops the companions', async () => {
     await canonicalGenerate(makeInput({ size: 'custom', customSize_width: 512, customSize_height: 768 }))
 

--- a/src/renderer/pages/paintings/model/__tests__/canonicalGenerate.test.ts
+++ b/src/renderer/pages/paintings/model/__tests__/canonicalGenerate.test.ts
@@ -89,6 +89,20 @@ describe('canonicalGenerate', () => {
     expect(lastGenerateCall().paramValues.strength).toBe(4.5)
   })
 
+  it.each([true, false, [], ['4.5']])('drops invalid numeric input %# instead of coercing it', async (value) => {
+    const support = {
+      modes: {
+        generate: {
+          supports: { strength: { type: 'range' as const, min: 0, max: 10, default: 4 } }
+        }
+      }
+    }
+
+    await canonicalGenerate(makeInput({ strength: value }), { support, mode: 'generate' })
+
+    expect(lastGenerateCall().paramValues.strength).toBeUndefined()
+  })
+
   it('composes the customSize widget trio into size and drops the companions', async () => {
     await canonicalGenerate(makeInput({ size: 'custom', customSize_width: 512, customSize_height: 768 }))
 

--- a/src/renderer/pages/paintings/utils/__tests__/computeModelFieldReset.test.ts
+++ b/src/renderer/pages/paintings/utils/__tests__/computeModelFieldReset.test.ts
@@ -218,6 +218,23 @@ describe('computeModelFieldReset', () => {
     expect(patch).toEqual({})
   })
 
+  it('resets a decimal carried into an integer-backed catalog slider', async () => {
+    mockSupportPerModel({
+      modelA: generateSupport({ numImages: { type: 'range', min: 1, max: 10, default: 1 } }),
+      modelB: generateSupport({ numImages: { type: 'range', min: 1, max: 10, default: 1 } })
+    })
+
+    const patch = await computeModelFieldReset({
+      providerId: 'aihubmix',
+      oldModelId: 'modelA',
+      newModelId: 'modelB',
+      mode: 'generate',
+      currentValues: { numImages: '2.5' }
+    })
+
+    expect(patch).toEqual({ numImages: 1 })
+  })
+
   it('resets a stale default-less enum value to undefined', async () => {
     mockSupportPerModel({
       modelA: generateSupport({ style: { type: 'enum', options: ['vivid', 'natural'] } }),

--- a/src/renderer/pages/paintings/utils/computeModelFieldReset.ts
+++ b/src/renderer/pages/paintings/utils/computeModelFieldReset.ts
@@ -3,7 +3,7 @@ import { loggerService } from '@logger'
 import type { ImageGenerationMode, ImageGenerationSupport } from '@shared/data/types/model'
 
 import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
-import { controlValue, optionalFiniteNumber } from '../form/fieldValue'
+import { controlValue, optionalParamNumber } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 
 const logger = loggerService.withContext('paintings/modelFieldReset')
@@ -120,7 +120,7 @@ export async function computeModelFieldReset(input: {
     }
 
     if (item.type === 'slider') {
-      const numeric = optionalFiniteNumber(currentValue)
+      const numeric = optionalParamNumber(item.key, currentValue)
       const outOfRange = numeric === null || numeric < item.min || numeric > item.max
       if (outOfRange) patch[item.key] = item.initialValue
     }

--- a/src/renderer/pages/paintings/utils/computeModelFieldReset.ts
+++ b/src/renderer/pages/paintings/utils/computeModelFieldReset.ts
@@ -2,7 +2,8 @@ import { prefetch } from '@data/hooks/useDataApi'
 import { loggerService } from '@logger'
 import type { ImageGenerationMode, ImageGenerationSupport } from '@shared/data/types/model'
 
-import type { BaseConfigItem } from '../form/baseConfigItem'
+import { type BaseConfigItem, isOptionsConfigItem } from '../form/baseConfigItem'
+import { controlValue, optionalFiniteNumber } from '../form/fieldValue'
 import { imageGenerationToFields } from '../form/imageGenerationToFields'
 
 const logger = loggerService.withContext('paintings/modelFieldReset')
@@ -73,10 +74,11 @@ export async function computeModelFieldReset(input: {
       // `customSize` widget aliases multiple persisted fields under one
       // BaseConfigItem (zhipu cogview). Collect each so the reset doesn't
       // half-clear the trio.
-      const widget = item as { widthKey?: string; heightKey?: string; sizeKey?: string }
-      if (widget.widthKey) keys.add(widget.widthKey)
-      if (widget.heightKey) keys.add(widget.heightKey)
-      if (widget.sizeKey) keys.add(widget.sizeKey)
+      if (item.type === 'customSize') {
+        keys.add(item.widthKey)
+        keys.add(item.heightKey)
+        keys.add(item.sizeKey)
+      }
     }
     return keys
   }
@@ -106,19 +108,20 @@ export async function computeModelFieldReset(input: {
     // Field carried a value over from the previous model. Validate it against
     // the new model's constraints; reset to the new default (or `undefined`
     // when there's none) whenever it no longer fits.
-    const options = typeof item.options === 'function' ? item.options(item, currentValues) : (item.options ?? [])
+    const options = isOptionsConfigItem(item)
+      ? typeof item.options === 'function'
+        ? item.options(item, currentValues)
+        : item.options
+      : []
     if (options.length > 0) {
-      const allowedValues = new Set(options.map((option) => String(option.value)))
-      if (!allowedValues.has(String(currentValue))) patch[item.key] = item.initialValue
+      const allowedValues = new Set(options.map((option) => controlValue(option.value)))
+      if (!allowedValues.has(controlValue(currentValue))) patch[item.key] = item.initialValue
       continue
     }
 
     if (item.type === 'slider') {
-      const numeric = typeof currentValue === 'number' ? currentValue : Number(currentValue)
-      const outOfRange =
-        Number.isNaN(numeric) ||
-        (typeof item.min === 'number' && numeric < item.min) ||
-        (typeof item.max === 'number' && numeric > item.max)
+      const numeric = optionalFiniteNumber(currentValue)
+      const outOfRange = numeric === null || numeric < item.min || numeric > item.max
       if (outOfRange) patch[item.key] = item.initialValue
     }
   }


### PR DESCRIPTION
## Summary

- replace the flat `BaseConfigItem` shape with a discriminated union whose variants own their valid constraints and initial-value types
- type the registered field components against their exact config variants
- narrow dynamic painting params through shared checked readers instead of coercing unknown values with `Number`, `String`, or `Boolean`
- use the discriminant in size/reset/summary consumers to remove optional-field casts and fallbacks

## Behavior

Valid registry-produced values render and update exactly as before. If a dynamic param contains a value of the wrong type, the field now falls back to its typed registry default (or empty state) instead of producing `NaN`, coercing an empty value to `0`, or stringifying an object.

## Tests

- `pnpm typecheck:web`
- focused ESLint and Oxlint checks for all changed files
- `pnpm exec biome check` for all changed files
- 70 focused renderer tests covering field derivation, checked value narrowing, slider/text rendering, size handling, model-switch resets, and composer summaries

Closes #19166
