### PR TITLE
fix(deepseek-harness): suppress managed browser launch

### DIFF
--- a/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
+++ b/src/main/services/deepSeekHarness/DeepSeekHarnessService.ts
@@ -266,7 +266,7 @@ export class DeepSeekHarnessService extends BaseService {
       if (MANAGED_CREDENTIAL_ENV.test(name)) delete env[name]
     }
 
-    const child = crossPlatformSpawn(runtime.path, ['web', '--host', '127.0.0.1', '--port', '0'], {
+    const child = crossPlatformSpawn(runtime.path, ['web', '--host', '127.0.0.1', '--port', '0', '--no-open'], {
       cwd: application.getPath('feature.deepseek_harness.workspace'),
       env,
       detached: !isWin,

--- a/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts
@@ -203,7 +203,7 @@ describe('DeepSeekHarnessService', () => {
     expect(mocks.writeConfig).toHaveBeenCalledTimes(2)
     expect(mocks.spawn).toHaveBeenCalledWith(
       '/usr/local/bin/dsh',
-      ['web', '--host', '127.0.0.1', '--port', '0'],
+      ['web', '--host', '127.0.0.1', '--port', '0', '--no-open'],
       expect.objectContaining({ cwd: '/mock/userData/Data/DeepSeekHarness/Workspace', detached: true })
     )
     expect(mocks.spawn.mock.calls[0][2].env).not.toHaveProperty('CHERRY_STUDIO_CODEMATE_481BD06FDD6C_API_KEY')


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Starting or restarting Cherry Studio's managed DeepSeek Harness process could open the system default browser, even though Cherry owns the embedded client experience.

After this PR:

Cherry passes `--no-open` to the managed `dsh web` invocation. DeepSeek Harness still starts normally, reports its ready URL, and remains available to Cherry without opening an external browser.

Fixes #19096

### Why we need it and why it was done in this way

DeepSeek Harness opens the default browser unless `--no-open` is supplied. Cherry Studio manages the process and consumes its endpoint internally, so the external browser handoff is unnecessary and can interrupt the user.

The following tradeoffs were made:

- The flag is applied unconditionally to Cherry-managed launches because Cherry owns the UI for this integration.
- No new preference or lifecycle state was added, keeping the fix limited to the reported behavior.

The following alternatives were considered:

- Adding a user setting was rejected because opening an external browser is not useful for the managed integration.
- Suppressing the behavior through environment configuration was rejected because the documented CLI flag is more explicit and directly testable.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/issues/19096

### Breaking changes

None.

### Special notes for your reviewer

Validation completed:

- `pnpm vitest run --project main src/main/services/deepSeekHarness/__tests__/DeepSeekHarnessService.test.ts`
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

The existing spawn-argument assertion now protects the managed launch from losing `--no-open` in future changes.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: The code was left cleaner than it was found
- [x] Upgrade: Impact on upgrade flows was considered; none is required
- [x] Documentation: User-guide changes were considered and are not required for this bug fix
- [x] Self-review: I reviewed the final diff and validation results

### Release note

```release-note
Managed DeepSeek Harness sessions no longer open the system browser when they start or restart.
```
