### PR TITLE
chore(gh-create-issue): add restricted engineering task template

### DIFF
--- a/.agents/skills/gh-create-issue/SKILL.md
+++ b/.agents/skills/gh-create-issue/SKILL.md
@@ -24,17 +24,24 @@ Engineering Task is not a GitHub issue form and is not offered to regular users.
 
 #### Eligibility Check (Engineering Task only)
 
-Engineering Task is restricted to repository members and collaborators. Before collecting any
-information, confirm the authenticated user has write access to the repository:
+Engineering Task is restricted to repository members and collaborators with write access. Before
+collecting any information, confirm the authenticated user's permission level:
 
 ```bash
 repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 user="$(gh api user --jq .login)"
-gh api "repos/$repo/collaborators/$user" --silent >/dev/null 2>&1 && echo "eligible" || echo "not eligible"
+permission="$(gh api "repos/$repo/collaborators/$user/permission" --jq .permission 2>/dev/null)"
+case "$permission" in
+  admin | write) echo "eligible" ;;
+  *) echo "not eligible" ;;
+esac
 ```
 
-A `204` (`eligible`) means the user is a collaborator or an org member with repository access.
-Anything else means they are not.
+Only `admin` and `write` are eligible (`maintain` reports as `write`). Always compare the returned
+value: on a public repository this endpoint answers `read` for any user, including one who is not a
+collaborator at all, so a successful call proves nothing on its own. Do not use
+`repos/{owner}/{repo}/collaborators/{user}` here — collaborators can hold `read` or `triage` only,
+and those users cannot apply the restricted labels or the issue type anyway.
 
 If the check fails, **stop**. Tell the user this template is restricted to members and
 collaborators, and ask them to choose one of the public templates instead. Do not silently fall back

--- a/.agents/skills/gh-create-issue/SKILL.md
+++ b/.agents/skills/gh-create-issue/SKILL.md
@@ -15,14 +15,37 @@ Analyze the user's request to determine the issue type:
 - If the user describes a problem, error, crash, or something not working -> Bug Report
 - If the user requests a new feature, enhancement, or additional support -> Feature Request
 - If the user is asking a question or needs help with something -> Questions & Discussion
+- If the user describes engineering work with no user-facing behavior change (a follow-up deferred from a pull request, technical debt, refactoring, tooling or CI work) -> Engineering Task
 - Otherwise -> Others
 
+Engineering Task is not a GitHub issue form and is not offered to regular users. Only select it when the request clearly describes internal engineering work.
+
 **If unclear**, ask the user which template to use. Do not default to "Others" on your own.
+
+#### Eligibility Check (Engineering Task only)
+
+Engineering Task is restricted to repository members and collaborators. Before collecting any
+information, confirm the authenticated user has write access to the repository:
+
+```bash
+repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+user="$(gh api user --jq .login)"
+gh api "repos/$repo/collaborators/$user" --silent >/dev/null 2>&1 && echo "eligible" || echo "not eligible"
+```
+
+A `204` (`eligible`) means the user is a collaborator or an org member with repository access.
+Anything else means they are not.
+
+If the check fails, **stop**. Tell the user this template is restricted to members and
+collaborators, and ask them to choose one of the public templates instead. Do not silently fall back
+to another template, and do not create the issue with Engineering Task metadata.
 
 ### Step 2: Read the Selected Template
 
 1. Read the corresponding template file from `.github/ISSUE_TEMPLATE/` directory.
-2. Identify required fields (`validations.required: true`), title prefix (`title`), and labels (`labels`, if present).
+2. Identify required fields (`validations.required: true`), title prefix (`title`), labels (`labels`, if present), and issue type (`type`, if present).
+
+For Engineering Task, read [references/engineering-task.md](references/engineering-task.md) instead — it lives outside `.github/ISSUE_TEMPLATE/` on purpose and carries its own title prefix, labels, issue type, and body structure.
 
 ### Step 3: Collect Information
 
@@ -37,6 +60,7 @@ Create a temp file and write the issue content:
 - Apply labels exactly as defined by the template.
 - Keep all labels when there are multiple labels.
 - If template has no labels, do not add custom labels.
+- Apply the issue type exactly as defined by the template's `type` field.
 
 Preview the temp file content. **Show the file path** (e.g., `/tmp/gh-issue-body-XXXXXX.md`) and ask for confirmation before creating. **Skip this step if the user explicitly indicates no preview/confirmation is needed** (for example, automation workflows).
 
@@ -67,7 +91,15 @@ gh issue create --title "<title_with_template_prefix>" --body-file "$issue_body_
 
 If the selected template has no labels, do not pass `--label`.
 
-You may use `--template` as a starting point (use the exact template name from the repository):
+If the selected template declares a `type`, pass it as well. `--body-file` does not carry the issue type over on its own, so omitting this leaves the issue untyped:
+
+```bash
+gh issue create --title "<title_with_template_prefix>" --body-file "$issue_body_file" --type "<type_from_template>"
+```
+
+`--template` and `--web` resolve against `.github/ISSUE_TEMPLATE/` on the default branch, so neither works for Engineering Task. Build the body locally for it.
+
+For the other templates you may use `--template` as a starting point (use the exact template name from the repository):
 
 ```bash
 gh issue create --template "<template_name>"
@@ -87,8 +119,8 @@ rm -f "$issue_body_file"
 
 ## Notes
 
-- Must read template files under `.github/ISSUE_TEMPLATE/` to ensure following the correct format.
-- Treat template files as the only source of truth. Do not hardcode title prefixes or labels in this skill.
+- Must read template files under `.github/ISSUE_TEMPLATE/` (or `references/` for Engineering Task) to ensure following the correct format.
+- Treat template files as the only source of truth. Do not hardcode title prefixes, labels, or issue types in this skill.
 - Title must be clear and concise, avoid vague terms like "a suggestion" or "stuck".
 - Provide as much detail as possible to help developers understand and resolve the issue.
 - If user doesn't specify a template type, ask them to choose one first.

--- a/.agents/skills/gh-create-issue/SKILL.md
+++ b/.agents/skills/gh-create-issue/SKILL.md
@@ -24,8 +24,13 @@ Engineering Task is not a GitHub issue form and is not offered to regular users.
 
 #### Eligibility Check (Engineering Task only)
 
-Engineering Task is restricted to repository members and collaborators with write access. Before
-collecting any information, confirm the authenticated user's permission level:
+Engineering Task is reserved by convention for repository members and collaborators with write
+access. This is a skill-level agreement, not an access control — nothing prevents anyone from
+calling `gh issue create` directly. The check below exists to fail early and to record that intent.
+(GitHub does enforce part of it independently: users with `read` or below cannot apply labels at
+all, so they cannot produce an issue that looks like an internal task.)
+
+Before collecting any information, confirm the authenticated user's permission level:
 
 ```bash
 repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"

--- a/.agents/skills/gh-create-issue/SKILL.md
+++ b/.agents/skills/gh-create-issue/SKILL.md
@@ -24,13 +24,12 @@ Engineering Task is not a GitHub issue form and is not offered to regular users.
 
 #### Eligibility Check (Engineering Task only)
 
-Engineering Task is reserved by convention for repository members and collaborators with write
-access. This is a skill-level agreement, not an access control — nothing prevents anyone from
-calling `gh issue create` directly. The check below exists to fail early and to record that intent.
-(GitHub does enforce part of it independently: users with `read` or below cannot apply labels at
-all, so they cannot produce an issue that looks like an internal task.)
+Engineering Task is meant for maintainers and collaborators with write access. This is a request,
+not an access control — nothing prevents anyone from calling `gh issue create` directly, and this
+skill does not try to. The check below is here so that a contributor without write access learns
+that early and gets pointed somewhere more useful.
 
-Before collecting any information, confirm the authenticated user's permission level:
+Before collecting any information, read the authenticated user's permission level:
 
 ```bash
 repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
@@ -45,12 +44,13 @@ esac
 Only `admin` and `write` are eligible (`maintain` reports as `write`). Always compare the returned
 value: on a public repository this endpoint answers `read` for any user, including one who is not a
 collaborator at all, so a successful call proves nothing on its own. Do not use
-`repos/{owner}/{repo}/collaborators/{user}` here — collaborators can hold `read` or `triage` only,
-and those users cannot apply the restricted labels or the issue type anyway.
+`repos/{owner}/{repo}/collaborators/{user}` here — it answers `204` for `read`- and `triage`-only
+collaborators, who are not the intended audience for this template.
 
-If the check fails, **stop**. Tell the user this template is restricted to members and
-collaborators, and ask them to choose one of the public templates instead. Do not silently fall back
-to another template, and do not create the issue with Engineering Task metadata.
+If the result is anything else, do not use this template. Explain that it is meant for maintainers
+with write access, politely ask the contributor to use one of the public templates instead, and
+offer to help them file it there — their report is welcome, just not under this template. Do not
+quietly switch templates while keeping the Engineering Task labels or issue type.
 
 ### Step 2: Read the Selected Template
 

--- a/.agents/skills/gh-create-issue/references/engineering-task.md
+++ b/.agents/skills/gh-create-issue/references/engineering-task.md
@@ -9,8 +9,9 @@ outside that directory is what stops regular users from picking it. It is used b
 
 ## Eligibility
 
-Restricted to repository members and collaborators holding `write` or `admin` permission. The skill
-verifies this before use; see [SKILL.md](../SKILL.md) Step 1.
+Reserved by convention for repository members and collaborators holding `write` or `admin`
+permission. This is a skill-level agreement rather than an access control; the skill checks it
+before use so that it fails early. See [SKILL.md](../SKILL.md) Step 1.
 
 ## Metadata
 

--- a/.agents/skills/gh-create-issue/references/engineering-task.md
+++ b/.agents/skills/gh-create-issue/references/engineering-task.md
@@ -9,8 +9,8 @@ outside that directory is what stops regular users from picking it. It is used b
 
 ## Eligibility
 
-Restricted to repository members and collaborators. The skill verifies this before use; see
-[SKILL.md](../SKILL.md) Step 1.
+Restricted to repository members and collaborators holding `write` or `admin` permission. The skill
+verifies this before use; see [SKILL.md](../SKILL.md) Step 1.
 
 ## Metadata
 

--- a/.agents/skills/gh-create-issue/references/engineering-task.md
+++ b/.agents/skills/gh-create-issue/references/engineering-task.md
@@ -9,9 +9,10 @@ outside that directory is what stops regular users from picking it. It is used b
 
 ## Eligibility
 
-Reserved by convention for repository members and collaborators holding `write` or `admin`
-permission. This is a skill-level agreement rather than an access control; the skill checks it
-before use so that it fails early. See [SKILL.md](../SKILL.md) Step 1.
+Meant for maintainers and collaborators holding `write` or `admin` permission. This is a request
+rather than an access control — please do not use this template without write access. The skill
+checks the permission level before use so that it comes up early; see [SKILL.md](../SKILL.md)
+Step 1.
 
 ## Metadata
 

--- a/.agents/skills/gh-create-issue/references/engineering-task.md
+++ b/.agents/skills/gh-create-issue/references/engineering-task.md
@@ -1,0 +1,69 @@
+# Engineering Task Template
+
+Reference template for engineering work that is neither a user-facing bug nor a product feature:
+follow-ups deferred from a merged pull request, technical debt, refactoring, tooling and CI work.
+
+This template is deliberately **not** a GitHub issue form. GitHub only scans
+`.github/ISSUE_TEMPLATE/` and lists everything there to every visitor, so keeping this file
+outside that directory is what stops regular users from picking it. It is used by this skill only.
+
+## Eligibility
+
+Restricted to repository members and collaborators. The skill verifies this before use; see
+[SKILL.md](../SKILL.md) Step 1.
+
+## Metadata
+
+| Field | Value |
+| --- | --- |
+| Title prefix | `[Task]: ` |
+| Labels | `internal-team`, `Dev Team` |
+| Issue type | `Task` |
+
+## Creating the Issue
+
+`--template` and `--web` do not work here — both resolve against `.github/ISSUE_TEMPLATE/` on the
+default branch. Build the body locally and pass the metadata explicitly:
+
+```bash
+gh issue create --title "[Task]: <summary>" --body-file "$issue_body_file" \
+  --label "internal-team" --label "Dev Team" --type "Task"
+```
+
+## Body
+
+Keep the section order. Drop the two optional sections when they would be empty.
+
+```markdown
+### Task Type
+
+<one of: Follow-up (deferred from a pull request) | Technical Debt | Refactor | Tooling & CI | Documentation | Other>
+
+### Context
+
+<Current state, and why this work needs to happen. Include the constraint or decision that led here.
+e.g. PR #12345 introduced a temporary alias to keep the diff reviewable. It should be removed once the callers migrate.>
+
+### Definition of Done
+
+<How we know this task is complete. A checklist is preferred over prose.>
+
+- [ ] ...
+- [ ] ...
+
+### References
+
+<Optional. Related pull requests, issues, documents, or code locations.>
+
+- PR: #12345
+- Code: `src/main/services/example.ts`
+
+### Additional Notes
+
+<Optional. Known risks, blockers, or anything else worth recording.>
+
+---
+
+This task is not reserved for the core team. Community contributions are welcome — if you would like
+to pick it up, leave a comment before you start so we can avoid duplicated work.
+```


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The `gh-create-issue` skill could only produce user-facing issues — bug reports, feature requests, questions, and a catch-all "Others". There was no format for internal engineering work such as follow-ups deferred from a merged pull request, technical debt, refactoring, or tooling and CI tasks. The skill also silently dropped the `type` field declared by every issue template, so issues created through it were left untyped.

After this PR:

- Adds an **Engineering Task** template at `.agents/skills/gh-create-issue/references/engineering-task.md`. It carries its own title prefix (`[Task]: `), labels (`internal-team`, `Dev Team`), issue type (`Task`), and body structure: Task Type / Context / Definition of Done / References / Additional Notes.
- Asks that the template be used by maintainers and collaborators holding `write` or `admin` permission. The skill reads `gh api repos/$repo/collaborators/$user/permission` before collecting any information and accepts only `admin`/`write` (`maintain` reports as `write`); otherwise it points the contributor at a public template and offers to help file it there. This is a request, not an access control — see the reviewer notes.
- Passes the template's issue type to `gh issue create --type`, which fixes untyped issues for the existing Bug and Feature templates as well.

No file under `.github/ISSUE_TEMPLATE/` is added or modified, so the public template picker is unchanged.

Fixes # None

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **The template is not a GitHub issue form.** GitHub lists everything in `.github/ISSUE_TEMPLATE/` to every visitor and offers no mechanism to hide a template by identity. Placing it there would have exposed an internal template to all users and auto-applied `internal-team` / `Dev Team` to any issue they filed with it. Keeping the file outside that directory is what makes the restriction possible.
- **Cost of that choice:** `gh issue create --template` and `--web` resolve against `.github/ISSUE_TEMPLATE/` on the default branch, so neither works for this template. The skill documents this and builds the body locally instead, which is the path it already used.
- **Eligibility is checked before information is collected**, so an ineligible user is not asked a series of questions and then refused.
- **The `help wanted` label is not hardcoded.** Not every engineering task suits an outside contributor; maintainers apply it per issue. The body instead carries a note inviting community contributors to comment before picking a task up.

The following alternatives were considered:

- Shipping it as a normal issue form and accepting misuse — rejected, because mislabeled issues would pollute the internal task queue automatically rather than costing one manual close.
- Nesting it under `.github/ISSUE_TEMPLATE/internal/` — GitHub does not scan subdirectories there, so the template would simply not exist rather than be hidden.
- A GitHub Actions workflow stripping the labels when the author is not an org member — rejected as an extra workflow to maintain for a problem that placement alone solves.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

The eligibility check was verified against both outcomes on this repository:

- `EurFelux` -> `permission=write` -> eligible
- `octocat` -> `permission=read` -> not eligible

The returned value must be compared rather than the call merely succeeding: on a public repository this endpoint answers `read` for any user, including a non-collaborator, so a truthiness test would let every GitHub user through. `repos/{owner}/{repo}/collaborators/{user}` was used in the first revision and rejected during review — it answers `204` for `read`- and `triage`-only collaborators, who cannot apply the restricted labels or the issue type.

Both labels and the issue type were verified live rather than by searching the repo tree: `internal-team` and `Dev Team` exist as repository labels, and `Task` is an enabled org-level issue type.

**On what the eligibility check is and is not.** It is a request, not an access control. The skill is an instruction file, not an execution path: nothing prevents anyone from calling `gh issue create --label internal-team --type Task` directly, and the skill deliberately does not try to stop them. Its value is surfacing the mismatch early — before a contributor is asked a series of questions — and pointing them at a template that fits, with an offer to help file it there.

The part that is actually enforced comes from GitHub rather than from this PR: applying labels requires the `triage` role or above, so users at `read` or below cannot produce an issue carrying `internal-team` / `Dev Team` at all. The skill asks for more than that (`write`/`admin`) because `triage` collaborators can apply labels but are not the audience for this template.

`pnpm skills:check` passes (9 public skills). The change touches only Markdown, so lint, typecheck, and tests were not run.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```



