### PR TITLE
fix(knowledge): reject empty document extraction

### DIFF
--- a/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
@@ -326,22 +326,38 @@ describe('index-documents job handler', () => {
     ).toHaveLength(0)
   })
 
-  it('warns when an item yields no indexable text, and still completes it with an empty material', async () => {
+  it('rejects a file when its reader yields no indexable text', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
-    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
-    knowledgeItemUpdateStatusMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+    knowledgeItemGetByIdMock.mockReturnValue(createFileItem(FILE_ITEM_ID))
     loadKnowledgeItemDocumentsMock.mockResolvedValueOnce([])
+    const failureReason =
+      'No indexable text was extracted. Check the source, OCR, or document processing settings, then reindex.'
 
-    await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
+    await expect(handler.execute(createCtx({ baseId: 'kb-1', itemId: FILE_ITEM_ID }))).rejects.toThrow(failureReason)
 
-    // An image-only PDF or failed extraction must leave a diagnosable trace —
-    // without the warn it would look indexed while matching nothing.
+    // JobManager forwards the thrown reason to onSettled; verify that the existing
+    // settlement seam makes the row visibly failed (and therefore reindexable).
+    await handler.onSettled?.({
+      jobId: 'index-job',
+      type: 'knowledge.index-documents',
+      scheduleId: null,
+      parentId: null,
+      status: 'failed',
+      input: { baseId: 'kb-1', itemId: FILE_ITEM_ID },
+      error: { code: 'FAILED', message: failureReason, retryable: false },
+      attempt: 1,
+      metadata: {}
+    })
+
+    expect(embedKnowledgeTextsMock).not.toHaveBeenCalled()
+    expect(rebuildMaterialMock).not.toHaveBeenCalled()
+    expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(FILE_ITEM_ID, 'embedding')
+    expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(FILE_ITEM_ID, 'completed')
+    expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(FILE_ITEM_ID, 'failed', { error: failureReason })
     expect(loggerWarnMock).toHaveBeenCalledWith(
-      'Knowledge item produced no indexable text; it will complete with an empty index',
-      expect.objectContaining({ baseId: 'kb-1', itemId: NOTE_ITEM_ID })
+      'Knowledge item produced no indexable text; failing indexing',
+      expect.objectContaining({ baseId: 'kb-1', itemId: FILE_ITEM_ID })
     )
-    expect(lastRebuildInput().units).toEqual([])
-    expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
   })
 
   it('uses the processed-artifact path (indexedRelativePath) as the material relative path', async () => {
@@ -365,21 +381,17 @@ describe('index-documents job handler', () => {
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(expect.objectContaining({ id: FILE_ITEM_ID }))
   })
 
-  it('completes with empty vectors when the reader returns no documents', async () => {
+  it('rejects whitespace-only reader output before embedding or material replacement', async () => {
     const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
-    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
-    knowledgeItemUpdateStatusMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
-    loadKnowledgeItemDocumentsMock.mockResolvedValueOnce([])
+    knowledgeItemGetByIdMock.mockReturnValue(createFileItem(FILE_ITEM_ID))
+    loadKnowledgeItemDocumentsMock.mockResolvedValueOnce([{ text: ' \n\t ', metadata: { source: FILE_ITEM_ID } }])
 
-    await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
-
-    expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'reading')
-    expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'embedding')
-    expect(rebuildMaterialMock).toHaveBeenCalledWith(
-      NOTE_ITEM_ID,
-      expect.objectContaining({ content: expect.objectContaining({ text: '' }), units: [], embeddings: [] })
+    await expect(handler.execute(createCtx({ baseId: 'kb-1', itemId: FILE_ITEM_ID }))).rejects.toThrow(
+      'No indexable text was extracted'
     )
-    expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
+
+    expect(embedKnowledgeTextsMock).not.toHaveBeenCalled()
+    expect(rebuildMaterialMock).not.toHaveBeenCalled()
   })
 
   it('skips vector write when the item becomes deleting inside the mutation lock', async () => {

--- a/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
+++ b/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
@@ -33,6 +33,9 @@ const logger = loggerService.withContext('Knowledge:IndexDocumentsJobHandler')
 // Chunks per embedMany call while rebuilding an item's material. Small enough to
 // surface incremental progress, large enough to not multiply request overhead.
 const EMBEDDING_PROGRESS_BATCH_SIZE = 10
+const EMPTY_INDEXABLE_TEXT_ERROR =
+  'No indexable text was extracted. Check the source, OCR, or document processing settings, then reindex.'
+
 /**
  * How long the final percentage lingers after the job exits. The list's item status
  * is polled, so deleting the key at completion time blanks the percentage while the
@@ -94,14 +97,15 @@ export function createIndexDocumentsJobHandler(
       const documents = await readItemDocuments(ctx, readableItem)
       const chunked = await chunkItemDocuments(base, documents, ctx.signal)
       if (chunked.chunks.length === 0) {
-        // Deliberate: the item still completes (an empty material is written) so the
-        // UI doesn't show a stuck/failed item, but leave a trace — an image-only PDF
-        // or failed extraction would otherwise look indexed while matching nothing.
-        logger.warn('Knowledge item produced no indexable text; it will complete with an empty index', {
+        // Completing here would make a scanned/image-only PDF look searchable while
+        // persisting an empty material. Reject before embedding or replacement so the
+        // normal settlement path exposes a failed, reindexable item with this reason.
+        logger.warn('Knowledge item produced no indexable text; failing indexing', {
           baseId: ctx.input.baseId,
           itemId: ctx.input.itemId,
           jobId: ctx.jobId
         })
+        throw new Error(EMPTY_INDEXABLE_TEXT_ERROR)
       }
 
       // Mark embedding separately so the UI reflects the current long-running phase.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Knowledge items whose reader or chunker produced no indexable text were rebuilt with an empty material and marked as completed. Scanned or image-only PDFs therefore appeared ready even though their content and chunks were empty.

After this PR:

Indexing rejects zero-chunk extraction results before embedding or material replacement. The existing job settlement path records a clear failure reason, so the item is shown as failed and remains available for reindexing after OCR or document-processing settings are corrected.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19095

### Why we need it and why it was done in this way

The zero-chunk boundary is the first shared point at which every reader result has been normalized and proven unusable for both vector and lexical retrieval. Rejecting there prevents paid embedding calls and avoids replacing a material with an empty index while reusing the existing failed-status, tooltip, and reindex behavior.

The following tradeoffs were made:

An empty extraction is treated as a failed indexing attempt instead of a successful empty document. This makes the failure visible but requires users to correct the source or processing configuration before reindexing.

The following alternatives were considered:

- Keeping the completed status and relying on a log warning was rejected because users cannot distinguish an empty extraction from a searchable item in the UI.
- Adding automatic OCR fallback was not included because processor selection and OCR configuration are separate concerns and may involve external services or user costs.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19095

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regression coverage includes readers returning no documents and whitespace-only documents. It also verifies that empty results never enter embedding or material replacement and that job settlement persists the actionable failure reason.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge files that produce no indexable text now show a clear failed status instead of appearing ready with empty content and chunks.
```
