### PR TITLE
refactor(model-drawer): keep token limits numeric

### DIFF
--- a/packages/ui/src/components/primitives/__tests__/input-number.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/input-number.test.tsx
@@ -149,6 +149,35 @@ describe('InputNumber', () => {
     expect(onBlur).toHaveBeenCalledExactlyOnceWith(10)
   })
 
+  it('restores the pre-edit value instead of turning an incomplete number into null', async () => {
+    const user = userEvent.setup()
+    const onBlur = vi.fn()
+
+    function Controlled() {
+      const [value, setValue] = useState<number | null>(42)
+      return (
+        <InputNumber
+          aria-label="amount"
+          value={value}
+          onValueChange={setValue}
+          onBlur={(settled) => {
+            onBlur(settled)
+            setValue(settled)
+          }}
+        />
+      )
+    }
+
+    render(<Controlled />)
+    const input = screen.getByLabelText('amount')
+    await user.clear(input)
+    await user.type(input, '1e')
+    await user.tab()
+
+    expect(onBlur).toHaveBeenCalledExactlyOnceWith(42)
+    expect(input).toHaveValue('42')
+  })
+
   it('follows an external value change while unfocused', () => {
     const { rerender } = render(<InputNumber aria-label="amount" value={1} onValueChange={vi.fn()} />)
     expect(screen.getByLabelText('amount')).toHaveValue('1')

--- a/packages/ui/src/components/primitives/input-number.tsx
+++ b/packages/ui/src/components/primitives/input-number.tsx
@@ -11,6 +11,9 @@ import { Input } from './input'
  * blur/Enter the field normalizes what was typed — clamped into `[min, max]`,
  * truncated when `step` is an integer — and hands the result to `onBlur`.
  * **Settling is not configurable**; a field cannot be left showing `"1."`.
+ * An incomplete numeric prefix that is still not a number on commit restores
+ * the value from the start of the edit; only an actually empty field settles
+ * to `null`.
  *
  * What `onBlur` hands over is a fact — "this is the value the field settled
  * on" — and the meaning is the caller's: persist it, ignore it, diff it against
@@ -244,7 +247,8 @@ function InputNumber({
   }
 
   const handleBlur = () => {
-    const settled = discarding.current ? preEdit.current : parse(text, min, max, step)
+    const isIncomplete = text !== '' && !Number.isFinite(Number(text))
+    const settled = discarding.current || isIncomplete ? preEdit.current : parse(text, min, max, step)
     discarding.current = false
     const commit = onBlur?.(settled)
     if (!isPromise(commit)) {

--- a/src/main/data/api/handlers/__tests__/models.test.ts
+++ b/src/main/data/api/handlers/__tests__/models.test.ts
@@ -5,7 +5,8 @@ import {
   CreateModelsSchema,
   DeleteModelsQuerySchema,
   MODELS_BATCH_MAX_ITEMS,
-  MODELS_DELETE_MAX_IDS
+  MODELS_DELETE_MAX_IDS,
+  UpdateModelSchema
 } from '@shared/data/api/schemas/models'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -64,6 +65,13 @@ beforeEach(() => {
 })
 
 describe('Model handler validation', () => {
+  it('distinguishes setting, omitting, and clearing positive model token limits', () => {
+    expect(UpdateModelSchema.parse({ contextWindow: 128_000 })).toEqual({ contextWindow: 128_000 })
+    expect(UpdateModelSchema.parse({})).not.toHaveProperty('contextWindow')
+    expect(UpdateModelSchema.parse({ contextWindow: null })).toEqual({ contextWindow: null })
+    expect(() => UpdateModelSchema.parse({ contextWindow: 0 })).toThrow()
+  })
+
   it('accepts create payload arrays up to the configured limit', () => {
     const items = Array.from({ length: MODELS_BATCH_MAX_ITEMS }, (_, index) => ({
       providerId: 'openai',
@@ -379,6 +387,17 @@ describe('/models/:uniqueModelId*', () => {
 
     expect(updateMock).toHaveBeenCalledWith('qwen', 'qwen/qwen3-vl', { isEnabled: false })
     expect(result).toBe(updated)
+  })
+
+  it('forwards an explicit null model limit as a clear operation', async () => {
+    updateMock.mockReturnValueOnce({ id: 'openai::gpt-4o' })
+
+    await modelHandlers['/models/:uniqueModelId*'].PATCH({
+      params: { uniqueModelId: 'openai::gpt-4o' },
+      body: { maxOutputTokens: null }
+    } as never)
+
+    expect(updateMock).toHaveBeenCalledWith('openai', 'gpt-4o', { maxOutputTokens: null })
   })
   it('splits a slash-containing uniqueModelId at the first :: and forwards DELETE', async () => {
     deleteMock.mockReturnValueOnce(undefined)

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/AddModelFormPanel.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/AddModelFormPanel.tsx
@@ -186,9 +186,9 @@ export default function AddModelFormPanel({
         capabilities: submittedPurposeFields?.capabilities ?? classifiedCapabilities,
         ...(shouldSubmitInputModalities ? { inputModalities: submittedInputModalities } : {}),
         outputModalities: submittedPurposeFields?.outputModalities,
-        ...(values.contextWindow ? { contextWindow: Number(values.contextWindow) } : {}),
-        ...(values.maxInputTokens ? { maxInputTokens: Number(values.maxInputTokens) } : {}),
-        ...(values.maxOutputTokens ? { maxOutputTokens: Number(values.maxOutputTokens) } : {})
+        ...(values.contextWindow !== null ? { contextWindow: values.contextWindow } : {}),
+        ...(values.maxInputTokens !== null ? { maxInputTokens: values.maxInputTokens } : {}),
+        ...(values.maxOutputTokens !== null ? { maxOutputTokens: values.maxOutputTokens } : {})
       })
 
       return createUniqueModelId(providerId, modelId)
@@ -238,9 +238,9 @@ export default function AddModelFormPanel({
             modelId: singleId,
             name: singleId,
             group: '',
-            contextWindow: '',
-            maxInputTokens: '',
-            maxOutputTokens: '',
+            contextWindow: null,
+            maxInputTokens: null,
+            maxOutputTokens: null,
             endpointTypes: formState.endpointTypes
           })
 

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/EditModelDrawer.tsx
@@ -4,6 +4,7 @@ import { useModelMutations } from '@renderer/hooks/useModel'
 import { useProvider } from '@renderer/hooks/useProvider'
 import { toast } from '@renderer/services/toast'
 import { getDefaultGroupName } from '@renderer/utils/naming'
+import type { UpdateModelDto } from '@shared/data/api/schemas/models'
 import { type EndpointType, type Model } from '@shared/data/types/model'
 import { parseUniqueModelId } from '@shared/data/types/model'
 import { ChevronDown, ChevronUp, CircleHelp } from 'lucide-react'
@@ -57,15 +58,15 @@ interface BuildPatchOverrides {
   classification?: ModelClassificationState
   supportsStreaming?: boolean
   pricing?: Model['pricing']
-  contextWindow?: string
-  maxInputTokens?: string
-  maxOutputTokens?: string
+  contextWindow?: number | null
+  maxInputTokens?: number | null
+  maxOutputTokens?: number | null
 }
 
 interface AutoSaveQueueItem {
   providerId: string
   modelId: string
-  patch: Partial<Model>
+  patch: UpdateModelDto
 }
 
 export default function EditModelDrawer({ providerId, open, model: modelProp, onClose }: EditModelDrawerProps) {
@@ -86,9 +87,9 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
   const [showMoreSettings, setShowMoreSettings] = useState(true)
   const [classification, setClassification] = useState<ModelClassificationState>(() => getInitialModelClassification())
   const [supportsStreaming, setSupportsStreaming] = useState<Model['supportsStreaming']>(true)
-  const [contextWindow, setContextWindow] = useState('')
-  const [maxInputTokens, setMaxInputTokens] = useState('')
-  const [maxOutputTokens, setMaxOutputTokens] = useState('')
+  const [contextWindow, setContextWindow] = useState<number | null>(null)
+  const [maxInputTokens, setMaxInputTokens] = useState<number | null>(null)
+  const [maxOutputTokens, setMaxOutputTokens] = useState<number | null>(null)
   const [initializedModel, setInitializedModel] = useState<Model | null>(null)
   const autoSavePendingItemsRef = useRef(new Map<string, AutoSaveQueueItem>())
   const autoSaveRunningRef = useRef(false)
@@ -119,33 +120,21 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
     setShowMoreSettings(true)
     setClassification(getInitialModelClassification(model))
     setSupportsStreaming(model.supportsStreaming)
-    setContextWindow(model.contextWindow != null ? String(model.contextWindow) : '')
-    setMaxInputTokens(model.maxInputTokens != null ? String(model.maxInputTokens) : '')
-    setMaxOutputTokens(model.maxOutputTokens != null ? String(model.maxOutputTokens) : '')
+    setContextWindow(model.contextWindow ?? null)
+    setMaxInputTokens(model.maxInputTokens ?? null)
+    setMaxOutputTokens(model.maxOutputTokens ?? null)
     setInitializedModel(model)
   }, [model, open])
 
   const handleUpdateModel = useCallback(
     async ({ providerId, modelId, patch }: AutoSaveQueueItem) => {
-      await updateModel(providerId, modelId, {
-        name: patch.name,
-        group: patch.group,
-        capabilities: patch.capabilities,
-        inputModalities: patch.inputModalities,
-        outputModalities: patch.outputModalities,
-        supportsStreaming: patch.supportsStreaming,
-        endpointTypes: patch.endpointTypes,
-        contextWindow: patch.contextWindow,
-        maxInputTokens: patch.maxInputTokens,
-        maxOutputTokens: patch.maxOutputTokens,
-        ...(Object.hasOwn(patch, 'pricing') ? { pricing: patch.pricing } : {})
-      })
+      await updateModel(providerId, modelId, patch)
     },
     [updateModel]
   )
 
   const buildPatch = useCallback(
-    (overrides?: BuildPatchOverrides): Partial<Model> => {
+    (overrides?: BuildPatchOverrides): UpdateModelDto => {
       if (!model) {
         return {}
       }
@@ -155,6 +144,12 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
       const hasEndpointTypesOverride = overrides != null && Object.hasOwn(overrides, 'endpointTypes')
       const hasPurposeFieldsOverride = overrides != null && Object.hasOwn(overrides, 'purposeFields')
       const hasPricingOverride = overrides != null && Object.hasOwn(overrides, 'pricing')
+      const hasContextWindowOverride = overrides != null && Object.hasOwn(overrides, 'contextWindow')
+      const hasMaxInputTokensOverride = overrides != null && Object.hasOwn(overrides, 'maxInputTokens')
+      const hasMaxOutputTokensOverride = overrides != null && Object.hasOwn(overrides, 'maxOutputTokens')
+      const nextContextWindow = hasContextWindowOverride ? overrides?.contextWindow : contextWindow
+      const nextMaxInputTokens = hasMaxInputTokensOverride ? overrides?.maxInputTokens : maxInputTokens
+      const nextMaxOutputTokens = hasMaxOutputTokensOverride ? overrides?.maxOutputTokens : maxOutputTokens
       const nextPurposeFields = overrides?.purposeFields ?? purposeFields
       const nextClassification = overrides?.classification
       const shouldApplyPurpose = mode === 'purpose' && (hasPurposeFieldsOverride || nextClassification != null)
@@ -208,9 +203,13 @@ export default function EditModelDrawer({ providerId, open, model: modelProp, on
           ? { outputModalities: resolvedPurposeFields.outputModalities }
           : {}),
         supportsStreaming: overrides?.supportsStreaming ?? supportsStreaming,
-        contextWindow: Number(overrides?.contextWindow ?? contextWindow) || undefined,
-        maxInputTokens: Number(overrides?.maxInputTokens ?? maxInputTokens) || undefined,
-        maxOutputTokens: Number(overrides?.maxOutputTokens ?? maxOutputTokens) || undefined,
+        ...(hasContextWindowOverride && nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
+        ...(hasMaxInputTokensOverride && nextMaxInputTokens !== undefined
+          ? { maxInputTokens: nextMaxInputTokens }
+          : {}),
+        ...(hasMaxOutputTokensOverride && nextMaxOutputTokens !== undefined
+          ? { maxOutputTokens: nextMaxOutputTokens }
+          : {}),
         ...(hasPricingOverride ? { pricing: overrides.pricing } : {})
       }
     },

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/ModelContextWindowFields.tsx
@@ -5,55 +5,55 @@ import { useTranslation } from 'react-i18next'
 
 interface TokenLimitPreset {
   label: string
-  value: string
+  value: number
 }
 
 const CONTEXT_WINDOW_PRESETS: readonly TokenLimitPreset[] = [
-  { label: '128K', value: '128000' },
-  { label: '200K', value: '200000' },
-  { label: '256K', value: '262144' },
-  { label: '400K', value: '400000' },
-  { label: '512K', value: '524288' },
-  { label: '1M', value: '1000000' }
+  { label: '128K', value: 128000 },
+  { label: '200K', value: 200000 },
+  { label: '256K', value: 262144 },
+  { label: '400K', value: 400000 },
+  { label: '512K', value: 524288 },
+  { label: '1M', value: 1000000 }
 ]
 
 const MAX_INPUT_TOKEN_PRESETS: readonly TokenLimitPreset[] = [
-  { label: '128K', value: '128000' },
-  { label: '200K', value: '200000' },
-  { label: '256K', value: '256000' },
-  { label: '512K', value: '512000' },
-  { label: '1M', value: '1000000' }
+  { label: '128K', value: 128000 },
+  { label: '200K', value: 200000 },
+  { label: '256K', value: 256000 },
+  { label: '512K', value: 512000 },
+  { label: '1M', value: 1000000 }
 ]
 
 const MAX_OUTPUT_TOKEN_PRESETS: readonly TokenLimitPreset[] = [
-  { label: '16K', value: '16384' },
-  { label: '32K', value: '32768' },
-  { label: '64K', value: '65536' },
-  { label: '128K', value: '128000' },
-  { label: '256K', value: '256000' }
+  { label: '16K', value: 16384 },
+  { label: '32K', value: 32768 },
+  { label: '64K', value: 65536 },
+  { label: '128K', value: 128000 },
+  { label: '256K', value: 256000 }
 ]
 
 interface ModelContextWindowFieldsProps {
-  contextWindow: string
-  maxInputTokens: string
-  maxOutputTokens: string
-  onContextWindowChange: (value: string) => void
+  contextWindow: number | null
+  maxInputTokens: number | null
+  maxOutputTokens: number | null
+  onContextWindowChange: (value: number | null) => void
   /** Optional: the normalized value always reaches `onContextWindowChange` first. */
-  onContextWindowCommit?: (value: string) => void
-  onMaxInputTokensChange: (value: string) => void
-  onMaxInputTokensCommit?: (value: string) => void
-  onMaxOutputTokensChange: (value: string) => void
-  onMaxOutputTokensCommit?: (value: string) => void
+  onContextWindowCommit?: (value: number | null) => void
+  onMaxInputTokensChange: (value: number | null) => void
+  onMaxInputTokensCommit?: (value: number | null) => void
+  onMaxOutputTokensChange: (value: number | null) => void
+  onMaxOutputTokensCommit?: (value: number | null) => void
 }
 
 interface TokenLimitFieldProps {
   title: string
   presetsLabel: string
-  value: string
+  value: number | null
   placeholder: string
   presets: readonly TokenLimitPreset[]
-  onChange: (value: string) => void
-  onCommit?: (value: string) => void
+  onChange: (value: number | null) => void
+  onCommit?: (value: number | null) => void
 }
 
 function TokenLimitField({
@@ -65,17 +65,9 @@ function TokenLimitField({
   onChange,
   onCommit
 }: TokenLimitFieldProps) {
-  const selectPreset = (presetValue: string) => {
-    onChange(presetValue)
-    onCommit?.(presetValue)
-  }
-
-  // `InputNumber` renders `value`, not its own normalized result, so the settled
-  // value has to go back through `onChange` or the field keeps showing what was typed.
   const settle = (settled: number | null) => {
-    const next = settled === null ? '' : String(settled)
-    onChange(next)
-    onCommit?.(next)
+    onChange(settled)
+    onCommit?.(settled)
   }
 
   return (
@@ -85,7 +77,7 @@ function TokenLimitField({
           const active = value === preset.value
 
           return (
-            <Tooltip key={preset.value} content={preset.value}>
+            <Tooltip key={preset.value} content={String(preset.value)}>
               <Button
                 type="button"
                 variant={active ? 'secondary' : 'outline'}
@@ -93,7 +85,7 @@ function TokenLimitField({
                 aria-label={`${title}: ${preset.label} (${preset.value})`}
                 aria-pressed={active}
                 className="rounded-full"
-                onClick={() => selectPreset(preset.value)}>
+                onClick={() => settle(preset.value)}>
                 {preset.label}
               </Button>
             </Tooltip>
@@ -104,10 +96,10 @@ function TokenLimitField({
         min={1}
         step={1}
         aria-label={title}
-        value={value === '' ? null : Number(value)}
+        value={value}
         placeholder={placeholder}
         className={drawerClasses.input}
-        onValueChange={(next) => onChange(next === null ? '' : String(next))}
+        onValueChange={onChange}
         onBlur={settle}
       />
     </ProviderField>

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/EditModelDrawer.test.tsx
@@ -171,11 +171,58 @@ function makeTieredPricingModel(): Model {
 
 const modelWithFullPricing = makePricingModel({ cacheReadPrice: 0.3 })
 
-describe('EditModelDrawer pricing', () => {
+describe('EditModelDrawer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     ipcRequest.mockResolvedValue(undefined)
     useProviderMock.mockReturnValue({ provider: { id: 'openai', name: 'OpenAI' } })
+  })
+
+  it('autosaves the settled positive minimum instead of an invalid zero', async () => {
+    const user = userEvent.setup()
+    const model = {
+      ...makePricingModel(),
+      contextWindow: 128_000,
+      maxInputTokens: 64_000,
+      maxOutputTokens: 8_000
+    }
+    render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={model} />)
+
+    const contextWindow = screen.getByLabelText('settings.models.add.context_window.label')
+    expect(contextWindow).toHaveValue('128000')
+
+    await user.clear(contextWindow)
+    await user.type(contextWindow, '0')
+    await user.tab()
+
+    expect(updateModelMock).toHaveBeenCalledTimes(1)
+    expect(updateModelMock.mock.calls[0][2]).toEqual(expect.objectContaining({ contextWindow: 1 }))
+    expect(updateModelMock.mock.calls[0][2]).not.toHaveProperty('maxInputTokens')
+    expect(updateModelMock.mock.calls[0][2]).not.toHaveProperty('maxOutputTokens')
+  })
+
+  it('maps a cleared token limit to null without changing the other numeric limits', async () => {
+    const user = userEvent.setup()
+    const model = {
+      ...makePricingModel(),
+      contextWindow: 128_000,
+      maxInputTokens: 64_000,
+      maxOutputTokens: 8_000
+    }
+    render(<EditModelDrawer providerId="openai" open onClose={vi.fn()} model={model} />)
+
+    const maxOutputTokens = screen.getByLabelText('settings.models.add.max_output_tokens.label')
+    await user.clear(maxOutputTokens)
+    await user.tab()
+
+    expect(updateModelMock).toHaveBeenCalledTimes(1)
+    expect(updateModelMock.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        maxOutputTokens: null
+      })
+    )
+    expect(updateModelMock.mock.calls[0][2]).not.toHaveProperty('contextWindow')
+    expect(updateModelMock.mock.calls[0][2]).not.toHaveProperty('maxInputTokens')
   })
 
   it('keeps every pricing tier untouched when an unrelated field is edited', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/ModelContextWindowFields.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/ModelContextWindowFields.test.tsx
@@ -60,4 +60,33 @@ describe('ModelContextWindowFields', () => {
     expect(input).toHaveValue('1')
     expect(onContextWindowChange).toHaveBeenLastCalledWith(1)
   })
+
+  it('does not clear a saved limit when the edit ends on an incomplete number', async () => {
+    const user = userEvent.setup()
+    const onContextWindowCommit = vi.fn()
+
+    function ExistingFields() {
+      const [contextWindow, setContextWindow] = useState<number | null>(128_000)
+      return (
+        <ModelContextWindowFields
+          contextWindow={contextWindow}
+          maxInputTokens={null}
+          maxOutputTokens={null}
+          onContextWindowChange={setContextWindow}
+          onContextWindowCommit={onContextWindowCommit}
+          onMaxInputTokensChange={vi.fn()}
+          onMaxOutputTokensChange={vi.fn()}
+        />
+      )
+    }
+
+    render(<ExistingFields />)
+    const input = screen.getByLabelText('settings.models.add.context_window.label')
+    await user.clear(input)
+    await user.type(input, '1e')
+    await user.tab()
+
+    expect(onContextWindowCommit).toHaveBeenCalledExactlyOnceWith(128_000)
+    expect(input).toHaveValue('128000')
+  })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/ModelContextWindowFields.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/__tests__/ModelContextWindowFields.test.tsx
@@ -16,14 +16,14 @@ vi.mock('react-i18next', async (importOriginal) => {
 
 // The add form supplies no commit callbacks, so the normalized value reaches
 // the field only through the change callbacks.
-function AddFormFields({ onContextWindowChange }: { onContextWindowChange: (value: string) => void }) {
-  const [contextWindow, setContextWindow] = useState('')
+function AddFormFields({ onContextWindowChange }: { onContextWindowChange: (value: number | null) => void }) {
+  const [contextWindow, setContextWindow] = useState<number | null>(null)
 
   return (
     <ModelContextWindowFields
       contextWindow={contextWindow}
-      maxInputTokens=""
-      maxOutputTokens=""
+      maxInputTokens={null}
+      maxOutputTokens={null}
       onContextWindowChange={(value) => {
         setContextWindow(value)
         onContextWindowChange(value)
@@ -45,17 +45,19 @@ describe('ModelContextWindowFields', () => {
     await user.tab()
 
     expect(input).toHaveValue('3')
-    expect(onContextWindowChange).toHaveBeenLastCalledWith('3')
+    expect(onContextWindowChange).toHaveBeenLastCalledWith(3)
   })
 
   it('raises a value below the minimum on blur', async () => {
     const user = userEvent.setup()
-    render(<AddFormFields onContextWindowChange={vi.fn()} />)
+    const onContextWindowChange = vi.fn()
+    render(<AddFormFields onContextWindowChange={onContextWindowChange} />)
 
     const input = screen.getByLabelText('settings.models.add.context_window.label')
     await user.type(input, '0')
     await user.tab()
 
     expect(input).toHaveValue('1')
+    expect(onContextWindowChange).toHaveBeenLastCalledWith(1)
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/helpers.test.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   areModelClassificationsEqual,
   buildModelCapabilities,
   buildModelInputModalities,
+  getInitialAddModelFormState,
   getInitialModelClassification,
   MODEL_ENDPOINT_OPTIONS,
   splitModelIds
@@ -110,5 +111,26 @@ describe('model drawer classification helpers', () => {
 
     expect(capabilities).toEqual([MODEL_CAPABILITY.IMAGE_GENERATION])
     expect(getInitialModelClassification(makeModel({ capabilities })).primaryType).toBe('image')
+  })
+})
+
+describe('getInitialAddModelFormState', () => {
+  it('keeps persisted token limits numeric and uses null for missing limits', () => {
+    const form = getInitialAddModelFormState({
+      model: makeModel({
+        id: 'openai::gpt-test',
+        name: 'GPT Test',
+        contextWindow: 128_000,
+        maxInputTokens: 64_000
+      })
+    })
+
+    expect(form).toEqual(
+      expect.objectContaining({
+        contextWindow: 128_000,
+        maxInputTokens: 64_000,
+        maxOutputTokens: null
+      })
+    )
   })
 })

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/helpers.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/helpers.ts
@@ -65,9 +65,9 @@ export function getInitialAddModelFormState(
     modelId: prefill?.model ? getModelApiId(prefill.model) : '',
     name: prefill?.model?.name ?? '',
     group: prefill?.model?.group ?? '',
-    contextWindow: prefill?.model?.contextWindow != null ? String(prefill.model.contextWindow) : '',
-    maxInputTokens: prefill?.model?.maxInputTokens != null ? String(prefill.model.maxInputTokens) : '',
-    maxOutputTokens: prefill?.model?.maxOutputTokens != null ? String(prefill.model.maxOutputTokens) : '',
+    contextWindow: prefill?.model?.contextWindow ?? null,
+    maxInputTokens: prefill?.model?.maxInputTokens ?? null,
+    maxOutputTokens: prefill?.model?.maxOutputTokens ?? null,
     endpointTypes: resolveInitialEndpointTypes(prefill, defaultEndpointType)
   }
 }

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/types.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelDrawer/types.ts
@@ -21,9 +21,9 @@ export interface ModelBasicFormState {
   modelId: string
   name: string
   group: string
-  contextWindow: string
-  maxInputTokens: string
-  maxOutputTokens: string
+  contextWindow: number | null
+  maxInputTokens: number | null
+  maxOutputTokens: number | null
   endpointTypes?: ModelDrawerEndpointType[]
 }
 

--- a/src/shared/data/api/schemas/models.ts
+++ b/src/shared/data/api/schemas/models.ts
@@ -32,6 +32,8 @@ export const ListModelsQuerySchema = z.object({
 export type ListModelsQuery = z.infer<typeof ListModelsQuerySchema>
 
 /** DTO for creating a new model */
+const PositiveModelTokenLimitSchema = z.number().int().positive()
+
 export const CreateModelSchema = z.strictObject({
   /** Provider ID */
   providerId: z.string().min(1),
@@ -54,11 +56,11 @@ export const CreateModelSchema = z.strictObject({
   /** Endpoint types */
   endpointTypes: z.array(z.enum(objectValues(ENDPOINT_TYPE))).optional(),
   /** Context window size */
-  contextWindow: z.number().int().positive().optional(),
+  contextWindow: PositiveModelTokenLimitSchema.optional(),
   /** Maximum input tokens */
-  maxInputTokens: z.number().int().positive().optional(),
+  maxInputTokens: PositiveModelTokenLimitSchema.optional(),
   /** Maximum output tokens */
-  maxOutputTokens: z.number().int().positive().optional(),
+  maxOutputTokens: PositiveModelTokenLimitSchema.optional(),
   /** Streaming support */
   supportsStreaming: z.boolean().optional(),
   /** Parameter support (DB form) */
@@ -91,6 +93,10 @@ export const UpdateModelSchema = CreateModelSchema.omit({
 })
   .partial()
   .extend({
+    /** `null` explicitly clears a stored limit; `undefined` or an absent key leaves it unchanged. */
+    contextWindow: PositiveModelTokenLimitSchema.nullable().optional(),
+    maxInputTokens: PositiveModelTokenLimitSchema.nullable().optional(),
+    maxOutputTokens: PositiveModelTokenLimitSchema.nullable().optional(),
     isEnabled: z.boolean().optional(),
     isHidden: z.boolean().optional(),
     isDeprecated: z.boolean().optional(),


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - This PR is rebased on #19129 and intentionally uses its `InputNumber` contract.

### What this PR does

- Keeps `contextWindow`, `maxInputTokens`, and `maxOutputTokens` as `number | null` throughout the add/edit form state.
- Hydrates and persists numeric values directly, without number/string round trips.
- Routes the normalized value emitted by `InputNumber` on blur directly into edit-form autosave.
- Defines the update boundary explicitly:
  - a positive integer sets the stored limit;
  - `undefined` or an absent property leaves the stored limit unchanged;
  - `null` clears the stored limit.
- Extends `UpdateModelSchema` for the explicit clear operation while keeping create values positive.
- Keeps pricing state unchanged as a separate follow-up.

Part of #19165.

### Why

The persisted model schema is numeric, so the form should use the same domain type. The explicit three-state update contract also prevents an unrelated autosave from rewriting token limits and makes clearing a stored value unambiguous.

Because these limits must be positive integers, typing `0` settles to the `InputNumber` minimum of `1`; the API schema rejects `0`.

### Breaking changes

None. Existing positive stored values are unchanged.

### Verification

- Renderer regression tests: 23 passed.
- Model handler validation tests: 38 passed.
- Model service tests: 87 passed.
- Full `pnpm typecheck` passed.
- Biome, ESLint, and `git diff --check` passed.

### Checklist

- [x] Rebased on #19129
- [x] Numeric state matches the persisted domain type
- [x] Settled values flow directly into autosave
- [x] Set / no-update / clear semantics have regression coverage
- [x] No migration is required
- [x] Self-reviewed and locally verified

### Release note

```release-note
None
```