### PR TITLE
ci(provider-registry): author catalog sync commits through GraphQL

### DIFF
--- a/.github/workflows/sync-registry-data.yml
+++ b/.github/workflows/sync-registry-data.yml
@@ -127,17 +127,49 @@ jobs:
             '{minAppVersion: $minAppVersion, sourceAppVersion: $sourceAppVersion, revision: $revision, schemaVersion: $schema, files: {"models.json": $models, "providers.json": $providers, "provider-models.json": $providerModels}}' \
             > "$DEST/manifest.json"
 
-      - name: Commit and push if changed
+      - name: Commit if changed
         working-directory: pub
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Commits go through GraphQL rather than `git push`: GitHub signs
+          # API-authored commits, which the branch's required-signatures rule demands.
           git add "${{ steps.ver.outputs.dir }}"
           if git diff --cached --quiet; then
             echo "No catalog changes to publish."
             exit 0
           fi
-          git commit -m "chore(provider-registry): sync catalog to ${{ steps.ver.outputs.dir }}" \
-            -m "Source: ${{ github.repository }}@${{ github.sha }}
-          Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          git push origin x-files/provider-registry
+
+          REPO="${{ github.repository }}"
+          REF=$(gh api graphql \
+            -f query='query($owner:String!,$name:String!,$ref:String!){repository(owner:$owner,name:$name){ref(qualifiedName:$ref){id target{oid}}}}' \
+            -f owner="${REPO%/*}" -f name="${REPO#*/}" -f ref="refs/heads/x-files/provider-registry")
+          REF_ID=$(jq -er '.data.repository.ref.id' <<< "$REF")
+          HEAD_OID=$(jq -er '.data.repository.ref.target.oid' <<< "$REF")
+
+          ADDITIONS=$(git diff --cached --name-only --diff-filter=ACMR \
+            | while read -r f; do
+                jq -n --arg path "$f" --arg contents "$(base64 -w0 "$f")" '{path: $path, contents: $contents}'
+              done | jq -sc .)
+          DELETIONS=$(git diff --cached --name-only --diff-filter=D | jq -Rc '{path: .}' | jq -sc .)
+
+          RESP=$(jq -n \
+            --arg refId "$REF_ID" \
+            --arg oid "$HEAD_OID" \
+            --arg headline "chore(provider-registry): sync catalog to ${{ steps.ver.outputs.dir }}" \
+            --arg body "Source: ${{ github.repository }}@${{ github.sha }}
+          Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --argjson additions "$ADDITIONS" \
+            --argjson deletions "$DELETIONS" \
+            '{query: "mutation($input:CreateCommitOnBranchInput!){createCommitOnBranch(input:$input){commit{oid url}}}",
+              variables: {input: {branch: {id: $refId}, expectedHeadOid: $oid,
+                                  message: {headline: $headline, body: $body},
+                                  fileChanges: {additions: $additions, deletions: $deletions}}}}' \
+            | gh api graphql --input -)
+
+          # gh does not always exit non-zero on a GraphQL `errors` payload.
+          if jq -e '.errors' <<< "$RESP" >/dev/null; then
+            echo "$RESP" >&2
+            exit 1
+          fi
+          jq -er '.data.createCommitOnBranch.commit.url' <<< "$RESP"


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- `sync-registry-data.yml` published the catalog with `git commit` + `git push` using `GITHUB_TOKEN`. Commits created that way are **unverified**, so the `x-files/provider-registry` ruleset's `required_signatures` rule rejected the push and the job failed ([run 32510087442](https://github.com/CherryHQ/cherry-studio/actions/runs/32510087442)).

After this PR:

- The publish step authors the commit with the GraphQL `createCommitOnBranch` mutation instead. GitHub signs API-authored commits server-side, so they land as **Verified** and satisfy the rule without any GPG key material in CI.
- Changed files are derived from the same staged diff as before (`--diff-filter=ACMR` → `additions`, `--diff-filter=D` → `deletions`) and sent base64-encoded; the "no catalog changes" early exit is unchanged.

Fixes # N/A

### Why we need it and why it was done in this way

`github-actions[bot]` is a system identity rather than an installable GitHub App, so it **cannot** be added to a ruleset bypass list ([community#25305](https://github.com/orgs/community/discussions/25305), [community#175332](https://github.com/orgs/community/discussions/175332)). That rules out simply exempting the workflow, and signing is the only way the bot can satisfy `required_signatures` on its own.

The following tradeoffs were made:

- The step is ~30 lines of `jq` plumbing instead of two `git` commands. In exchange CI holds no signing key, so there is nothing to rotate or leak.
- The mutation pins `expectedHeadOid`, so a concurrent branch move aborts the publish rather than silently overwriting it. The existing `concurrency` group already serialises runs, so no retry loop was added.
- The branch is addressed by its Ref node `id` (resolved via `qualifiedName`) rather than `branchName`, because the branch name contains a slash and `branchName` expects an unqualified name.
- The response is explicitly checked for `.errors`, because `gh api graphql` does not reliably exit non-zero on a GraphQL-layer error and would otherwise report a silent success.

The following alternatives were considered:

- **Import a GPG key into CI** (`crazy-max/ghaction-import-gpg`) — works, but adds a private key and passphrase as secrets plus rotation duty.
- **Create an org GitHub App, install it, bypass-list it, mint a token with `actions/create-github-app-token`** — the canonical bypass route, but it is a whole new credential to own for one data-mirror branch.
- **Drop `required_signatures` from the ruleset** — cheapest, but this branch ships provider/model config to every client, so commit provenance is worth keeping.

Links to places where the discussion took place: N/A

### Breaking changes

None. The workflow's inputs, triggers, permissions, published layout, and manifest contents are unchanged — only the mechanism that writes the commit differs.

### Special notes for your reviewer

**This PR alone does not make the workflow green.** The `x-files/provider-registry` ruleset also has `update` ("Restrict updates") enabled, which blocks every actor not on the bypass list and has no workaround available to the bot. A repository admin needs to remove that rule; `deletion`, `non_fast_forward`, and `required_signatures` can and should stay. Until then the job still fails, but the error narrows from two violations to `Cannot update this protected ref` alone — which is itself the signal that the signature half is fixed.

Verified before opening:

- Payload construction dry-run against the real catalog files — additions/deletions split correctly, base64 round-trips byte-identical, ~750 KB for `models.json` + `manifest.json`.
- The ref query was run against this repository and resolves the slashed branch name, returning the Ref `id` and current `oid`.
- The catalog currently on the branch was published manually (`de0ddb4b1d`, revision 3) to unblock users while this lands, so the workflow's next run has an in-sync starting point.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
