### PR TITLE
fix(agent-runtime): serialize stop retry connections

### DIFF
--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -332,6 +332,10 @@ export class AgentSessionRuntimeService extends BaseService {
   private readonly inFlightBackgroundFlowFlushes = new Map<Promise<void>, string>()
   /** Async connection resources live outside the pure state; attempt ids reject stale completions. */
   private readonly connectionAttempts = new Map<string, { id: string; promise: Promise<boolean> }>()
+  /** A stopped session is removed synchronously so a retry can create its successor, while the old
+   *  CLI query may still be releasing asynchronously. Successor connects wait on this per-session
+   *  barrier so the two subprocess lifetimes cannot overlap. */
+  private readonly sessionClosings = new Map<string, { promise: Promise<void>; resumeToken?: string }>()
   /** Promise resources for a rebuild-blocked connection; the state only owns the blocked phase. */
   private readonly backgroundWorkWaiters = new Map<
     string,
@@ -927,7 +931,7 @@ export class AgentSessionRuntimeService extends BaseService {
 
   closeSession(sessionId: string): Promise<void> {
     const entry = this.entries.get(sessionId)
-    if (!entry) return Promise.resolve()
+    if (!entry) return this.sessionClosings.get(sessionId)?.promise ?? Promise.resolve()
     const fallbackConnection = this.currentConnection(entry)
     let closing: Promise<void>
     try {
@@ -940,6 +944,17 @@ export class AgentSessionRuntimeService extends BaseService {
       this.entries.delete(sessionId)
       this._onRuntimeIdle.fire({ sessionId })
     }
+    const previousClosing = this.sessionClosings.get(sessionId)
+    const barrier = {
+      promise: Promise.allSettled(previousClosing ? [previousClosing.promise, closing] : [closing]).then(
+        () => undefined
+      ),
+      resumeToken: entry.lastResumeToken ?? previousClosing?.resumeToken
+    }
+    this.sessionClosings.set(sessionId, barrier)
+    void barrier.promise.then(() => {
+      if (this.sessionClosings.get(sessionId) === barrier) this.sessionClosings.delete(sessionId)
+    })
     return closing
   }
 
@@ -1417,6 +1432,22 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private async ensureConnection(entry: AgentSessionRuntimeEntry): Promise<boolean> {
     while (this.isCurrentEntry(entry)) {
+      // User Stop deletes the old entry immediately, but its SDK query closes asynchronously. A fast
+      // retry may already own a new entry for the same session; do not spawn its query until every
+      // predecessor is fully released, otherwise the SDK sessions can overlap and yield an empty or
+      // permanently stalled stream.
+      const closing = this.sessionClosings.get(entry.sessionId)
+      if (closing) {
+        await closing.promise
+        // Terminal persistence normally stores the token before the next turn connects, but an
+        // immediate retry can reach this boundary first. Carry the stopped connection's already
+        // observed token directly so the successor resumes the same CLI conversation and its frozen
+        // workspace snapshot.
+        if (this.isCurrentEntry(entry) && !entry.lastResumeToken && closing.resumeToken) {
+          entry.lastResumeToken = closing.resumeToken
+        }
+        continue
+      }
       const target = this.connectionTarget(entry)
       const connection = this.currentConnection(entry)
       if (connection) {
@@ -3046,7 +3077,8 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private closeAll(): Promise<void> {
     const closings = [...this.entries.keys()].map((sessionId) => this.closeSession(sessionId))
-    return Promise.allSettled(closings).then(() => undefined)
+    const pendingClosings = [...this.sessionClosings.values()].map(({ promise }) => promise)
+    return Promise.allSettled([...closings, ...pendingClosings]).then(() => undefined)
   }
 
   private closeEntry(entry: AgentSessionRuntimeEntry): Promise<void> {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3938,6 +3938,69 @@ describe('AgentSessionRuntimeService', () => {
     await reader.cancel().catch(() => undefined)
   })
 
+  it('waits for the aborted connection to close before connecting an immediate retry', async () => {
+    const firstEvents = createAsyncQueue<any>()
+    const secondEvents = createAsyncQueue<any>()
+    const firstClose = createDeferred<void>()
+    const firstConnection = {
+      events: firstEvents.iterable,
+      send: vi.fn(),
+      close: vi.fn(() => firstClose.promise)
+    }
+    const secondConnection = {
+      events: secondEvents.iterable,
+      send: vi.fn(),
+      close: vi.fn()
+    }
+    const connect = vi.fn().mockResolvedValueOnce(firstConnection).mockResolvedValueOnce(secondConnection)
+    runtimeDriverRegistry.register({
+      type: 'test-runtime',
+      capabilities: ['agent-session'],
+      connect,
+      validateSession: vi.fn(),
+      listAvailableTools: vi.fn().mockResolvedValue([])
+    })
+    const service = new AgentSessionRuntimeService()
+    const first = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+    const firstAbort = new AbortController()
+    const firstReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: first.turnId, signal: firstAbort.signal })
+      .getReader()
+
+    await expect(firstReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await vi.waitFor(() => expect(firstConnection.send).toHaveBeenCalledOnce())
+    firstEvents.push({ type: 'resume-token', token: 'resume-before-stop' })
+    await vi.waitFor(() => expect(service.inspect('session-1')).toMatchObject({ resumeToken: 'resume-before-stop' }))
+
+    firstAbort.abort('user-requested')
+    await vi.waitFor(() => expect(firstConnection.close).toHaveBeenCalledOnce())
+
+    const second = service.beginTurn({
+      ...baseTurnInput,
+      assistantMessageId: 'assistant-2',
+      userMessage: userMessage('user-2')
+    })
+    const secondReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: second.turnId, signal: new AbortController().signal })
+      .getReader()
+
+    await expect(secondReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(connect).toHaveBeenCalledOnce()
+    expect(secondConnection.send).not.toHaveBeenCalled()
+
+    firstClose.resolve()
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(2))
+    expect(connect).toHaveBeenLastCalledWith(expect.objectContaining({ resumeToken: 'resume-before-stop' }))
+    await vi.waitFor(() =>
+      expect(secondConnection.send).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: false })
+    )
+    void service.closeSession('session-1')
+    await firstReader.cancel().catch(() => undefined)
+    await secondReader.cancel().catch(() => undefined)
+  })
+
   it('closes a late runtime connection when the user aborts before connect resolves', async () => {
     const events = createAsyncQueue<any>()
     const connection = {


### PR DESCRIPTION
### What this PR does

Before this PR:

Stopping an Agent turn removed its runtime entry immediately while the previous Claude SDK query could still be closing asynchronously. An immediate retry could therefore start a successor connection before its predecessor had fully released, producing an empty or stalled stream. The retry could also miss the previous in-memory resume token and start a new CLI conversation, refreshing the supposedly frozen workspace snapshot.

After this PR:

Agent sessions keep a per-session closing barrier. A successor waits until all predecessor connections have fully closed before connecting, and receives the last observed resume token directly across that boundary. This prevents overlapping SDK query lifetimes and preserves the same Claude CLI conversation during an immediate stop-and-retry.

Fixes #19119, fixes #19040

### Why we need it and why it was done in this way

The following tradeoffs were made:

An immediate retry may wait briefly for the aborted SDK query to finish cleanup. This bounded delay is preferable to allowing overlapping session processes that can return an empty stream or remain stalled.

The following alternatives were considered:

Keeping the existing connection alive and interrupting only the current turn was considered, but the current Stop contract intentionally tears down the entire query and its subagents. The closing barrier preserves that behavior while making the successor lifecycle deterministic.

Links to places where the discussion took place:

- #19119
- #19040

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage verifies that:

- A successor connection does not start while the aborted predecessor is still closing.
- The stopped connection’s observed resume token is carried into the immediate retry.
- The retried user message is sent only after the predecessor has fully released.

Validation completed:

- 156 AgentSessionRuntimeService tests passed.
- Full project typecheck passed.
- Oxlint and changed-file ESLint passed with no errors.
- i18n validation passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The touched lifecycle code was left clearer and covered by regression tests
- [x] Upgrade: No upgrade-flow changes are required
- [x] Documentation: No user-guide update is required for this bug fix
- [x] Self-review: I have reviewed the code and diff before requesting review

### Release note

```release-note
Fixed Agent retries returning an empty or stalled response after stopping generation, while preserving the existing Claude session and workspace snapshot.
```