### PR TITLE
fix(knowledge-query): handle queries without searchable tokens

### DIFF
--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -1991,6 +1991,13 @@ describe('KnowledgeService', () => {
     )
   })
 
+  it('returns no knowledge results for a query without searchable tokens', async () => {
+    const service = new KnowledgeService()
+    knowledgeBaseGetByIdMock.mockReturnValue(createBase())
+
+    await expect(service.search('kb-1', '🔥🔥🔥')).resolves.toEqual([])
+  })
+
   it('searches embedding-backed bases with hybrid retrieval and keeps ranking scores', async () => {
     const service = new KnowledgeService()
     knowledgeBaseGetByIdMock.mockReturnValue(createBase())

--- a/src/main/features/knowledge/query/KnowledgeQueryService.ts
+++ b/src/main/features/knowledge/query/KnowledgeQueryService.ts
@@ -54,10 +54,7 @@ export class KnowledgeQueryService {
 
     // Same tokenization the FTS layer uses: no token means no BM25 hit is even possible.
     if (extractFtsTokens(query).length === 0) {
-      throw DataApiErrorFactory.validation(
-        { query: ['Query has no searchable tokens'] },
-        'Query has no searchable tokens'
-      )
+      return []
     }
 
     // Vector/hybrid retrieval needs an embedding model; a base without one is


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Knowledge base searches with emoji- or symbol-only queries failed with `Query has no searchable tokens`.

After this PR:

Queries without searchable FTS tokens return an empty result list.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18328

### Why we need it and why it was done in this way

Tokenless queries cannot produce BM25 matches. Returning early after the existing base guard treats them as valid zero-result searches and avoids unnecessary embedding or index work.

The following tradeoffs were made:

All queries without searchable tokens, including emoji-only and punctuation-only input, return no results. Invalid or failed knowledge bases are still rejected before this check.

The following alternatives were considered:

Translating the validation error at the API boundary was considered, but the knowledge search service itself should represent a valid zero-match query as an empty result.

Links to places where the discussion took place: #18328

### Breaking changes

None.

### Special notes for your reviewer

The regression test covers the reported `🔥🔥🔥` query. Locally verified with the full `KnowledgeService` test file, lint, typecheck, i18n checks, and Biome checks.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge base searches with emoji- or symbol-only queries now return no results instead of an error.
```
