### PR TITLE
fix(chat): preserve rapid message navigation targets

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -36,7 +36,11 @@ import {
   useMessageRenderConfig
 } from './MessageListProvider'
 import { defaultMessageRenderConfig } from './types'
-import { getLatestAssistantGroupKey } from './utils/messageGroupKey'
+import {
+  getLatestAssistantGroupKey,
+  getMessageGroupKey,
+  getOwningUserMessageIdByAssistantId
+} from './utils/messageGroupKey'
 import { shouldUseWideLayoutForMessageGroup } from './utils/messageGroupLayout'
 import { getDirectAssistantModelsByUserId, shareDirectAssistantModelsByUserId } from './utils/messageListItem'
 import { createStableAnchorMessagesCache, stableAnchorMessages } from './utils/stableAnchorMessages'
@@ -304,10 +308,26 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const scrollToMessageById = useCallback((messageId: string) => {
     const target = messageByIdRef.current.get(messageId)
     if (!target) return
-    const groupKey =
-      target.role === 'assistant' && target.parentId ? 'assistant' + target.parentId : target.role + target.id
-    messageListRef.current?.scrollToKey(groupKey, 'start')
+    messageListRef.current?.scrollToKey(getMessageGroupKey(target), 'start')
   }, [])
+
+  const getNavigationBaseMessageId = useCallback(() => {
+    const key = messageListRef.current?.getNavigationBaseKey()
+    if (!key) return null
+
+    const groupMessages = groupedMessages.find(([groupKey]) => groupKey === key)?.[1]
+    if (!groupMessages) return null
+
+    const userMessage = groupMessages.find((message) => message.role === 'user')
+    if (userMessage) return userMessage.id
+
+    const owningUserMessageIdByAssistantId = getOwningUserMessageIdByAssistantId(messages)
+    for (const message of groupMessages) {
+      const ownerId = owningUserMessageIdByAssistantId.get(message.id)
+      if (ownerId) return ownerId
+    }
+    return null
+  }, [groupedMessages, messages])
 
   const scrollToOutlineElement = useCallback((element: HTMLElement) => {
     messageListRef.current?.scrollToElement(element)
@@ -857,6 +877,7 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
         <MessageNavigation
           scrollContainerRef={scrollContainerRef}
           getMessageElement={getMessageElement}
+          getNavigationBaseMessageId={getNavigationBaseMessageId}
           messages={messages}
           scrollToMessageId={scrollToMessageById}
           scrollToTop={navigateToTop}

--- a/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageList.test.tsx
@@ -1,8 +1,9 @@
 import { captureScrollable, captureScrollableAsDataUrl } from '@renderer/utils/image'
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import i18n from 'i18next'
 import type { HTMLAttributes, ReactNode, Ref } from 'react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChatBottomOverlayInsetProvider } from '../../layout/ChatViewportInsetContext'
 import type { MessageVirtualListHandle } from '../list/MessageVirtualList'
@@ -23,6 +24,7 @@ const scrollToElement = vi.fn()
 const scrollToRange = vi.fn()
 const messageVirtualListMocks = vi.hoisted(() => ({
   deferScrollContainerReady: false,
+  navigationBaseKey: null as string | null,
   renderItemLimit: undefined as number | undefined,
   readyCallbacks: [] as ((element: HTMLDivElement) => void)[],
   scrollElement: null as HTMLDivElement | null
@@ -42,6 +44,15 @@ const chatLayoutModeMock = vi.hoisted(() => ({
   setForceWideLayout: () => {},
   setRailGutterPx: vi.fn()
 }))
+const originalLanguage = i18n.language
+
+beforeAll(async () => {
+  await i18n.changeLanguage('en-US')
+})
+
+afterAll(async () => {
+  await i18n.changeLanguage(originalLanguage)
+})
 
 vi.mock('@renderer/components/chat/layout/ChatLayoutModeContext', () => ({
   useChatLayoutMode: () => chatLayoutModeMock
@@ -78,6 +89,7 @@ vi.mock('@renderer/components/SelectionContextMenu', () => ({
 
 vi.mock('@renderer/hooks/useTimer', () => ({
   useTimer: () => ({
+    clearTimeoutTimer: vi.fn(),
     setTimeoutTimer: (_key: string, callback: () => void) => callback()
   })
 }))
@@ -218,11 +230,6 @@ vi.mock('../list/MessageGroup', async () => {
   }
 })
 
-vi.mock('../list/MessageNavigation', () => ({
-  __esModule: true,
-  default: () => null
-}))
-
 vi.mock('../list/MessageListSearch', () => ({
   MessageListSearch: (props: NonNullable<typeof messageListSearchMock.props>) => {
     messageListSearchMock.props = props
@@ -250,6 +257,7 @@ vi.mock('../list/MessageVirtualList', async () => {
       showScrollToBottomButton,
       topPadding
     }: any) => {
+      const renderedScrollElementRef = React.useRef<HTMLDivElement | null>(null)
       React.useImperativeHandle(
         handleRef as Ref<MessageVirtualListHandle>,
         () => ({
@@ -258,6 +266,7 @@ vi.mock('../list/MessageVirtualList', async () => {
           scrollToKey,
           scrollToElement,
           scrollToRange,
+          getNavigationBaseKey: () => messageVirtualListMocks.navigationBaseKey,
           isFollowing: () => false,
           getScrollElement: () => messageVirtualListMocks.scrollElement
         }),
@@ -269,8 +278,9 @@ vi.mock('../list/MessageVirtualList', async () => {
           messageVirtualListMocks.readyCallbacks.push(onScrollContainerReady)
           return
         }
-        if (messageVirtualListMocks.scrollElement) {
-          onScrollContainerReady(messageVirtualListMocks.scrollElement)
+        const scrollElement = messageVirtualListMocks.scrollElement ?? renderedScrollElementRef.current
+        if (scrollElement) {
+          onScrollContainerReady(scrollElement)
         }
       }, [onScrollContainerReady])
 
@@ -278,6 +288,7 @@ vi.mock('../list/MessageVirtualList', async () => {
 
       return (
         <div
+          ref={renderedScrollElementRef}
           data-keep-mounted-keys={(keepMountedKeys ?? []).join(',')}
           data-scroll-to-bottom-button-bottom-offset={scrollToBottomButtonBottomOffset ?? ''}
           data-scroll-to-bottom-button-enabled={String(Boolean(showScrollToBottomButton))}
@@ -337,12 +348,13 @@ describe('MessageList', () => {
   beforeEach(() => {
     scrollToBottom.mockClear()
     scrollToTop.mockClear()
-    scrollToKey.mockClear()
+    scrollToKey.mockReset()
     scrollToElement.mockClear()
     scrollToRange.mockClear()
     vi.mocked(captureScrollable).mockReset()
     vi.mocked(captureScrollableAsDataUrl).mockReset()
     messageVirtualListMocks.deferScrollContainerReady = false
+    messageVirtualListMocks.navigationBaseKey = null
     messageVirtualListMocks.renderItemLimit = undefined
     messageVirtualListMocks.readyCallbacks = []
     messageVirtualListMocks.scrollElement = document.createElement('div')
@@ -363,6 +375,53 @@ describe('MessageList', () => {
     const { container } = renderMessageList([createMessage('assistant-1', 'assistant')])
 
     expect(container.querySelector('[data-ui~="chat.message-list"]')).toHaveAttribute('id', 'messages')
+  })
+
+  it('keeps rapid navigation moving through assistant and user group owners', async () => {
+    const user = userEvent.setup()
+    const userMessage1 = createMessage('user-1', 'user')
+    const assistantMessage1 = { ...createMessage('assistant-1', 'assistant'), parentId: userMessage1.id }
+    const userMessage2 = createMessage('user-2', 'user')
+    const assistantMessage2 = { ...createMessage('assistant-2', 'assistant'), parentId: userMessage2.id }
+    const userMessage3 = createMessage('user-3', 'user')
+    const assistantMessage3 = { ...createMessage('assistant-3', 'assistant'), parentId: userMessage3.id }
+    messageVirtualListMocks.navigationBaseKey = `assistant${userMessage3.id}`
+    messageVirtualListMocks.scrollElement = null
+    scrollToKey.mockImplementationOnce((key: string) => {
+      messageVirtualListMocks.navigationBaseKey = key
+    })
+
+    render(
+      <MessageListProvider
+        value={createValue(
+          [userMessage1, assistantMessage1, userMessage2, assistantMessage2, userMessage3, assistantMessage3],
+          { messageNavigation: 'buttons' }
+        )}>
+        <MessageList />
+      </MessageListProvider>
+    )
+
+    const scrollElement = screen.getByTestId('virtual-list')
+    scrollElement.getBoundingClientRect = vi.fn(() => ({
+      bottom: 500,
+      height: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+      width: 500,
+      x: 0,
+      y: 0,
+      toJSON: () => ({})
+    }))
+    fireEvent.mouseMove(scrollElement, { clientX: 470, clientY: 250 })
+
+    await user.click(screen.getByRole('button', { name: 'Previous Message' }))
+    await user.click(screen.getByRole('button', { name: 'Previous Message' }))
+
+    expect(scrollToKey.mock.calls).toEqual([
+      [`user${userMessage2.id}`, 'start'],
+      [`user${userMessage1.id}`, 'start']
+    ])
   })
 
   it('keeps artifact popup and approval state when the source virtual row unmounts', async () => {

--- a/src/renderer/components/chat/messages/list/MessageNavigation.tsx
+++ b/src/renderer/components/chat/messages/list/MessageNavigation.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { MessageListItem } from '../types'
+import { getOwningUserMessageIdByAssistantId } from '../utils/messageGroupKey'
 
 const EXCLUDED_SELECTORS = [
   '.MessageFooter',
@@ -22,6 +23,7 @@ const TRIGGER_WIDTH = 60
 interface MessageNavigationProps {
   scrollContainerRef: RefObject<HTMLElement | null>
   getMessageElement: (messageId: string) => HTMLElement | null
+  getNavigationBaseMessageId: () => string | null
   messages: MessageListItem[]
   scrollToMessageId: (messageId: string) => void
   scrollToTop: () => void
@@ -31,6 +33,7 @@ interface MessageNavigationProps {
 const MessageNavigation: FC<MessageNavigationProps> = ({
   scrollContainerRef,
   getMessageElement,
+  getNavigationBaseMessageId,
   messages,
   scrollToMessageId,
   scrollToTop,
@@ -83,16 +86,7 @@ const MessageNavigation: FC<MessageNavigationProps> = ({
     const userMessages = messages.filter((message) => message.role === 'user')
     const assistantMessages = messages.filter((message) => message.role === 'assistant')
     const userIndexById = new Map(userMessages.map((message, index) => [message.id, index]))
-    const precedingUserIndexByAssistantId = new Map<string, number>()
-    let precedingUserIndex: number | undefined
-
-    for (const message of messages) {
-      if (message.role === 'user') {
-        precedingUserIndex = userIndexById.get(message.id)
-      } else if (message.role === 'assistant' && precedingUserIndex !== undefined) {
-        precedingUserIndexByAssistantId.set(message.id, precedingUserIndex)
-      }
-    }
+    const owningUserMessageIdByAssistantId = getOwningUserMessageIdByAssistantId(messages)
     const scrollContainer = scrollContainerRef.current
 
     if (!scrollContainer) return -1
@@ -128,10 +122,8 @@ const MessageNavigation: FC<MessageNavigationProps> = ({
       const visibleHeight =
         Math.min(messageRect.bottom, containerRect.bottom) - Math.max(messageRect.top, containerRect.top)
       if (visibleHeight > 0 && visibleHeight >= Math.min(messageRect.height, visibleThreshold)) {
-        const userIndex =
-          assistantMessage.parentId != null
-            ? userIndexById.get(assistantMessage.parentId)
-            : precedingUserIndexByAssistantId.get(assistantMessage.id)
+        const ownerId = owningUserMessageIdByAssistantId.get(assistantMessage.id)
+        const userIndex = ownerId ? userIndexById.get(ownerId) : undefined
         if (userIndex !== undefined) visibleIndices.push(userIndex)
       }
     }
@@ -141,6 +133,15 @@ const MessageNavigation: FC<MessageNavigationProps> = ({
     }
 
     return -1
+  }
+
+  const getNavigationBaseIndex = (userMessages: MessageListItem[]) => {
+    const navigationBaseMessageId = getNavigationBaseMessageId()
+    const explicitBaseIndex = navigationBaseMessageId
+      ? userMessages.findIndex((message) => message.id === navigationBaseMessageId)
+      : -1
+
+    return explicitBaseIndex >= 0 ? explicitBaseIndex : getCurrentVisibleIndex()
   }
 
   const handleCloseMessageNavigation = () => {
@@ -168,10 +169,10 @@ const MessageNavigation: FC<MessageNavigationProps> = ({
 
     if (userMessages.length === 0 && assistantMessages.length === 0) return scrollToBottom()
 
-    const visibleIndex = getCurrentVisibleIndex()
-    if (visibleIndex === -1) return scrollToBottom()
+    const baseIndex = getNavigationBaseIndex(userMessages)
+    if (baseIndex === -1) return scrollToBottom()
 
-    const targetIndex = visibleIndex + 1
+    const targetIndex = baseIndex + 1
     if (targetIndex >= userMessages.length) return scrollToBottom()
 
     scrollToMessageId(userMessages[targetIndex].id)
@@ -183,10 +184,10 @@ const MessageNavigation: FC<MessageNavigationProps> = ({
     const assistantMessages = messages.filter((message) => message.role === 'assistant')
     if (userMessages.length === 0 && assistantMessages.length === 0) return scrollToTop()
 
-    const visibleIndex = getCurrentVisibleIndex()
-    if (visibleIndex === -1) return scrollToTop()
+    const baseIndex = getNavigationBaseIndex(userMessages)
+    if (baseIndex === -1) return scrollToTop()
 
-    const targetIndex = visibleIndex - 1
+    const targetIndex = baseIndex - 1
     if (targetIndex < 0) return scrollToTop()
 
     scrollToMessageId(userMessages[targetIndex].id)

--- a/src/renderer/components/chat/messages/list/__tests__/MessageNavigation.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageNavigation.test.tsx
@@ -1,9 +1,31 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import i18n from 'i18next'
 import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
-import type { MessageListItem } from '../../types'
 import MessageNavigation from '../MessageNavigation'
+import {
+  createMessage,
+  createScrollContainerRef,
+  renderNavigation,
+  setRect,
+  showNavigation
+} from './messageNavigationTestHarness'
+
+const navigationButtonNames = {
+  bottom: 'Back to bottom',
+  next: 'Next Message',
+  prev: 'Previous Message',
+  top: 'Back to top'
+} as const
+const fourUserMessages = [
+  createMessage('user-1', 'user'),
+  createMessage('user-2', 'user'),
+  createMessage('user-3', 'user'),
+  createMessage('user-4', 'user')
+]
+const originalLanguage = i18n.language
 
 vi.mock('@cherrystudio/ui', () => ({
   Button: ({ children, ...props }: { children: ReactNode }) => (
@@ -21,78 +43,18 @@ vi.mock('@renderer/hooks/useTimer', () => ({
   })
 }))
 
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => key
-  })
-}))
-
-const createMessage = (id: string, role: MessageListItem['role'], parentId?: string | null): MessageListItem => ({
-  id,
-  role,
-  parentId,
-  topicId: 'topic-1',
-  createdAt: '2026-01-01T00:00:00.000Z',
-  status: 'success'
+beforeAll(async () => {
+  await i18n.changeLanguage('en-US')
 })
 
-const createScrollContainerRef = () => ({ current: null as HTMLDivElement | null })
+afterAll(async () => {
+  await i18n.changeLanguage(originalLanguage)
+})
 
-const setRect = (element: Element, rect: Partial<DOMRect>) => {
-  element.getBoundingClientRect = vi.fn(() => ({
-    bottom: 0,
-    height: 0,
-    left: 0,
-    right: 0,
-    top: 0,
-    width: 0,
-    x: 0,
-    y: 0,
-    toJSON: () => ({}),
-    ...rect
-  }))
-}
-
-const renderNavigation = (messages: MessageListItem[], visibleMessageIds: string[] = []) => {
-  const scrollContainerRef = createScrollContainerRef()
-  const scrollToMessageId = vi.fn()
-  const scrollToTop = vi.fn()
-  const scrollToBottom = vi.fn()
-
-  const { container } = render(
-    <>
-      <div id="messages">
-        <div ref={scrollContainerRef} data-message-virtual-list-scroller>
-          {messages.map((message) => (
-            <div key={message.id} id={`message-${message.id}`} />
-          ))}
-        </div>
-      </div>
-      <MessageNavigation
-        scrollContainerRef={scrollContainerRef}
-        getMessageElement={(messageId) => document.getElementById(`message-${messageId}`)}
-        messages={messages}
-        scrollToMessageId={scrollToMessageId}
-        scrollToTop={scrollToTop}
-        scrollToBottom={scrollToBottom}
-      />
-    </>
-  )
-
-  setRect(container.querySelector('[data-message-virtual-list-scroller]') as HTMLElement, {
-    bottom: 500,
-    height: 500,
-    top: 0
-  })
-  for (const message of messages) {
-    setRect(document.getElementById(`message-${message.id}`) as HTMLElement, {
-      bottom: visibleMessageIds.includes(message.id) ? 220 : -100,
-      height: 100,
-      top: visibleMessageIds.includes(message.id) ? 120 : -200
-    })
-  }
-
-  return { scrollToBottom, scrollToMessageId, scrollToTop }
+const renderVisibleNavigation = (...args: Parameters<typeof renderNavigation>) => {
+  const result = renderNavigation(...args)
+  showNavigation(result.scrollContainer)
+  return result
 }
 
 describe('MessageNavigation', () => {
@@ -109,6 +71,7 @@ describe('MessageNavigation', () => {
         <MessageNavigation
           scrollContainerRef={scrollContainerRef}
           getMessageElement={() => null}
+          getNavigationBaseMessageId={() => null}
           messages={[createMessage('user-1', 'user')]}
           scrollToMessageId={vi.fn()}
           scrollToTop={vi.fn()}
@@ -134,14 +97,14 @@ describe('MessageNavigation', () => {
 
     fireEvent.mouseMove(screen.getByTestId('active-message-list'), { clientX: 670, clientY: 300 })
 
-    const navigation = screen.getByRole('button', { name: 'chat.navigation.top' }).parentElement?.parentElement ?? null
+    const navigation =
+      screen.getByRole('button', { name: navigationButtonNames.top }).parentElement?.parentElement ?? null
     expect(container).toContainElement(navigation)
     expect(navigation).toHaveStyle({ opacity: '1' })
   })
 
-  it('navigates previous to older and next to newer messages from the full message list', () => {
-    const scrollContainerRef = createScrollContainerRef()
-    const scrollToMessageId = vi.fn()
+  it('navigates previous to older and next to newer messages from the full message list', async () => {
+    const user = userEvent.setup()
     const messages = [
       createMessage('user-1', 'user'),
       createMessage('assistant-1', 'assistant'),
@@ -150,91 +113,104 @@ describe('MessageNavigation', () => {
       createMessage('user-3', 'user')
     ]
 
-    const { container } = render(
-      <>
-        <div id="messages">
-          <div ref={scrollContainerRef} data-message-virtual-list-scroller>
-            <div id="message-user-2" />
-          </div>
-        </div>
-        <MessageNavigation
-          scrollContainerRef={scrollContainerRef}
-          getMessageElement={(messageId) => document.getElementById(`message-${messageId}`)}
-          messages={messages}
-          scrollToMessageId={scrollToMessageId}
-          scrollToTop={vi.fn()}
-          scrollToBottom={vi.fn()}
-        />
-      </>
-    )
+    const { scrollContainer, scrollToMessageId } = renderNavigation(messages, ['user-2'])
+    showNavigation(scrollContainer)
 
-    setRect(container.querySelector('[data-message-virtual-list-scroller]') as HTMLElement, {
-      bottom: 500,
-      height: 500,
-      top: 0
-    })
-    setRect(document.getElementById('message-user-2') as HTMLElement, {
-      bottom: 260,
-      height: 80,
-      top: 180
-    })
-
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.prev' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.prev }))
 
     expect(scrollToMessageId).toHaveBeenCalledWith('user-1')
 
     scrollToMessageId.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.next }))
 
     expect(scrollToMessageId).toHaveBeenCalledWith('user-3')
   })
 
-  it('delegates the top and bottom buttons to the runtime scroll callbacks', () => {
-    const scrollContainerRef = createScrollContainerRef()
-    const scrollToTop = vi.fn()
-    const scrollToBottom = vi.fn()
+  it('delegates the top and bottom buttons to the runtime scroll callbacks', async () => {
+    const user = userEvent.setup()
+    const { scrollContainer, scrollToBottom, scrollToTop } = renderNavigation([createMessage('user-1', 'user')])
+    showNavigation(scrollContainer)
 
-    render(
-      <>
-        <div id="messages">
-          <div ref={scrollContainerRef} data-message-virtual-list-scroller />
-        </div>
-        <MessageNavigation
-          scrollContainerRef={scrollContainerRef}
-          getMessageElement={() => null}
-          messages={[createMessage('user-1', 'user')]}
-          scrollToMessageId={vi.fn()}
-          scrollToTop={scrollToTop}
-          scrollToBottom={scrollToBottom}
-        />
-      </>
-    )
-
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.top' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.top }))
     expect(scrollToTop).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.bottom' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.bottom }))
     expect(scrollToBottom).toHaveBeenCalledTimes(1)
   })
 
-  it('moves one message at a time from the first visible user message', () => {
-    const messages = [
-      createMessage('user-1', 'user'),
-      createMessage('user-2', 'user'),
-      createMessage('user-3', 'user'),
-      createMessage('user-4', 'user')
-    ]
-    const { scrollToMessageId } = renderNavigation(messages, ['user-2', 'user-3'])
+  it('moves one message at a time from the first visible user message', async () => {
+    const user = userEvent.setup()
+    const { scrollToMessageId } = renderVisibleNavigation(fourUserMessages, ['user-2', 'user-3'])
 
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.prev' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.prev }))
     expect(scrollToMessageId).toHaveBeenCalledWith('user-1')
 
     scrollToMessageId.mockClear()
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.next }))
     expect(scrollToMessageId).toHaveBeenCalledWith('user-3')
   })
 
-  it('uses the owning user when the second assistant reply is visible', () => {
+  it.each<{
+    actions: ('prev' | 'next')[]
+    expectedMessageIds: string[]
+    name: string
+    visibleMessageId: string
+  }>([
+    {
+      actions: ['prev', 'prev', 'prev'],
+      expectedMessageIds: ['user-3', 'user-2', 'user-1'],
+      name: 'upward through consecutive turns',
+      visibleMessageId: 'user-4'
+    },
+    {
+      actions: ['next', 'next', 'next'],
+      expectedMessageIds: ['user-2', 'user-3', 'user-4'],
+      name: 'downward through consecutive turns',
+      visibleMessageId: 'user-1'
+    },
+    {
+      actions: ['prev', 'next'],
+      expectedMessageIds: ['user-2', 'user-3'],
+      name: 'in reverse from the latest semantic base',
+      visibleMessageId: 'user-3'
+    }
+  ])('moves $name before scrolling settles', async ({ actions, expectedMessageIds, visibleMessageId }) => {
+    const user = userEvent.setup()
+    let navigationBaseMessageId: string | null = null
+    const { scrollToMessageId } = renderVisibleNavigation(
+      fourUserMessages,
+      [visibleMessageId],
+      () => navigationBaseMessageId,
+      (messageId) => {
+        navigationBaseMessageId = messageId
+      }
+    )
+
+    for (const action of actions) {
+      await user.click(screen.getByRole('button', { name: navigationButtonNames[action] }))
+    }
+
+    expect(scrollToMessageId.mock.calls.map(([messageId]) => messageId)).toEqual(expectedMessageIds)
+  })
+
+  it('falls back to the visible turn after explicit navigation ownership is cleared', async () => {
+    const user = userEvent.setup()
+    let navigationBaseMessageId: string | null = 'user-3'
+    const { scrollToMessageId } = renderVisibleNavigation(fourUserMessages, ['user-4'], () => navigationBaseMessageId)
+
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.prev }))
+    expect(scrollToMessageId).toHaveBeenLastCalledWith('user-2')
+
+    navigationBaseMessageId = null
+    setRect(document.getElementById('message-user-4') as HTMLElement, { bottom: -100, height: 100, top: -200 })
+    setRect(document.getElementById('message-user-2') as HTMLElement, { bottom: 220, height: 100, top: 120 })
+
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.prev }))
+    expect(scrollToMessageId).toHaveBeenLastCalledWith('user-1')
+  })
+
+  it('uses the assistant reply owner when only that reply is visible', async () => {
+    const user = userEvent.setup()
     const messages = [
       createMessage('user-1', 'user'),
       createMessage('assistant-1a', 'assistant', 'user-1'),
@@ -243,42 +219,11 @@ describe('MessageNavigation', () => {
       createMessage('assistant-2', 'assistant', 'user-2'),
       createMessage('user-3', 'user')
     ]
-    const { scrollToMessageId } = renderNavigation(messages, ['assistant-1b'])
+    const { scrollToMessageId } = renderVisibleNavigation(messages, ['assistant-1b'])
 
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
-
-    expect(scrollToMessageId).toHaveBeenCalledWith('user-2')
-  })
-
-  it('uses the preceding user when a linear assistant message has no parent id', () => {
-    const messages = [
-      createMessage('user-1', 'user'),
-      createMessage('assistant-1a', 'assistant'),
-      createMessage('assistant-1b', 'assistant'),
-      createMessage('user-2', 'user'),
-      createMessage('assistant-2', 'assistant'),
-      createMessage('user-3', 'user')
-    ]
-    const { scrollToMessageId } = renderNavigation(messages, ['assistant-1b'])
-
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.next }))
 
     expect(scrollToMessageId).toHaveBeenCalledWith('user-2')
-  })
-
-  it('does not infer an owning user when an assistant parent id is invalid', () => {
-    const messages = [
-      createMessage('user-1', 'user'),
-      createMessage('user-2', 'user'),
-      createMessage('assistant-invalid', 'assistant', 'missing-user'),
-      createMessage('user-3', 'user')
-    ]
-    const { scrollToBottom, scrollToMessageId } = renderNavigation(messages, ['assistant-invalid'])
-
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
-
-    expect(scrollToBottom).toHaveBeenCalledTimes(1)
-    expect(scrollToMessageId).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -295,10 +240,11 @@ describe('MessageNavigation', () => {
       messages: [createMessage('user-1', 'user'), createMessage('user-2', 'user')],
       visibleMessageIds: ['user-2']
     }
-  ])('delegates next-message fallback to runtime scrollToBottom $name', ({ messages, visibleMessageIds }) => {
-    const { scrollToBottom, scrollToMessageId, scrollToTop } = renderNavigation(messages, visibleMessageIds)
+  ])('delegates next-message fallback to runtime scrollToBottom $name', async ({ messages, visibleMessageIds }) => {
+    const user = userEvent.setup()
+    const { scrollToBottom, scrollToMessageId, scrollToTop } = renderVisibleNavigation(messages, visibleMessageIds)
 
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.next' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.next }))
 
     expect(scrollToBottom).toHaveBeenCalledTimes(1)
     expect(scrollToTop).not.toHaveBeenCalled()
@@ -319,10 +265,11 @@ describe('MessageNavigation', () => {
       messages: [createMessage('user-1', 'user'), createMessage('user-2', 'user')],
       visibleMessageIds: ['user-1']
     }
-  ])('delegates prev-message fallback to runtime scrollToTop $name', ({ messages, visibleMessageIds }) => {
-    const { scrollToBottom, scrollToMessageId, scrollToTop } = renderNavigation(messages, visibleMessageIds)
+  ])('delegates prev-message fallback to runtime scrollToTop $name', async ({ messages, visibleMessageIds }) => {
+    const user = userEvent.setup()
+    const { scrollToBottom, scrollToMessageId, scrollToTop } = renderVisibleNavigation(messages, visibleMessageIds)
 
-    fireEvent.click(screen.getByRole('button', { name: 'chat.navigation.prev' }))
+    await user.click(screen.getByRole('button', { name: navigationButtonNames.prev }))
 
     expect(scrollToTop).toHaveBeenCalledTimes(1)
     expect(scrollToBottom).not.toHaveBeenCalled()

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -18,6 +18,7 @@ interface RuntimeProbeProps {
   keepMountedKeys?: readonly string[]
   onReachTop?: () => void
   onRuntime(runtime: ChatVirtualizerRuntime<string>): void
+  topicId?: string
   topPadding?: number
 }
 
@@ -32,6 +33,7 @@ function RuntimeProbe({
   keepMountedKeys,
   onReachTop,
   onRuntime,
+  topicId,
   topPadding
 }: RuntimeProbeProps) {
   const runtime = useChatVirtualizerRuntime({
@@ -42,6 +44,7 @@ function RuntimeProbe({
     handleRef,
     keepMountedKeys,
     onReachTop,
+    topicId,
     topPadding,
     topReachOverscanItems: 4,
     bottomPadding: 12
@@ -58,6 +61,7 @@ function RuntimeDomProbe({
   nonce,
   onReachTop,
   onRuntime,
+  topicId,
   topPadding
 }: RuntimeDomProbeProps) {
   void nonce
@@ -69,6 +73,7 @@ function RuntimeDomProbe({
     handleRef,
     keepMountedKeys,
     onReachTop,
+    topicId,
     topPadding,
     topReachOverscanItems: 4,
     bottomPadding: 12
@@ -683,6 +688,7 @@ describe('useChatVirtualizerRuntime', () => {
         handle!.scrollToTop('instant')
       })
       expect(scrollTop).toBe(0)
+      expect(handle!.getNavigationBaseKey()).toBe('message-a')
 
       act(() => callbacks[0]?.([], {} as ResizeObserver))
 
@@ -738,7 +744,7 @@ describe('useChatVirtualizerRuntime', () => {
   it.each([
     ['top', (handle: MessageVirtualListHandle) => handle.scrollToTop('instant')],
     ['a message key', (handle: MessageVirtualListHandle) => handle.scrollToKey('message-a', 'start')]
-  ])('keeps reading at %s when streaming content grows after explicit navigation', (_label, navigate) => {
+  ])('tracks the %s navigation base through growth until the user scrolls', (_label, navigate) => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)
     const raf = installQueuedAnimationFrame()
@@ -783,16 +789,78 @@ describe('useChatVirtualizerRuntime', () => {
       act(() => navigate(handle!))
       raf.tick(60)
       expect(scrollTop).toBe(0)
+      expect(handle!.getNavigationBaseKey()).toBe('message-a')
 
       scrollHeight = 1700
       act(() => callbacks.at(-1)?.([], {} as ResizeObserver))
       raf.tick(60)
 
       expect(scrollTop).toBe(0)
+      expect(handle!.getNavigationBaseKey()).toBe('message-a')
+
+      act(() => {
+        scrollTop = 1
+        runtime!.markUserInput()
+        runtime!.scrollerProps.onScroll(1)
+      })
+      expect(handle!.getNavigationBaseKey()).toBeNull()
     } finally {
       restoreResizeObserver()
       raf.restore()
     }
+  })
+
+  it('does not resurrect an explicit navigation target after leaving and returning to a topic', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    let handle: MessageVirtualListHandle | null = null
+    const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+      handle = nextHandle
+    }
+    const renderProbe = (topicId: string) => (
+      <RuntimeDomProbe
+        items={['message-a', 'message-b']}
+        handleRef={handleRef}
+        onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        topicId={topicId}
+      />
+    )
+    const view = render(renderProbe('topic-a'))
+    runtime!.vlistHandleRef.current = createHandle()
+
+    act(() => handle!.scrollToKey('message-b', 'start'))
+    expect(handle!.getNavigationBaseKey()).toBe('message-b')
+
+    view.rerender(renderProbe('topic-b'))
+    expect(handle!.getNavigationBaseKey()).toBeNull()
+
+    view.rerender(renderProbe('topic-a'))
+    expect(handle!.getNavigationBaseKey()).toBeNull()
+  })
+
+  it('does not resurrect an explicit navigation target after its item disappears and returns', () => {
+    let runtime: ChatVirtualizerRuntime<string> | undefined
+    let handle: MessageVirtualListHandle | null = null
+    const handleRef: Ref<MessageVirtualListHandle> = (nextHandle) => {
+      handle = nextHandle
+    }
+    const renderProbe = (items: string[]) => (
+      <RuntimeDomProbe
+        items={items}
+        handleRef={handleRef}
+        onRuntime={(nextRuntime) => (runtime = nextRuntime)}
+        topicId="topic-a"
+      />
+    )
+    const view = render(renderProbe(['message-a', 'message-b']))
+    runtime!.vlistHandleRef.current = createHandle()
+
+    act(() => handle!.scrollToKey('message-b', 'start'))
+    expect(handle!.getNavigationBaseKey()).toBe('message-b')
+
+    view.rerender(renderProbe(['message-a']))
+    view.rerender(renderProbe(['message-a', 'message-b']))
+
+    expect(handle!.getNavigationBaseKey()).toBeNull()
   })
 
   it('jumps instantly to a key more than a few viewports away', () => {
@@ -1034,6 +1102,7 @@ describe('useChatVirtualizerRuntime', () => {
       act(() => handle!.scrollToElement(heading))
       raf.tick(60)
       expect(scrollTop).toBe(300)
+      expect(handle!.getNavigationBaseKey()).toBe('message-a')
 
       headingDocumentTop = 350
       scrollHeight = 1700
@@ -1099,10 +1168,12 @@ describe('useChatVirtualizerRuntime', () => {
     })
     act(() => handle!.scrollToBottom())
     expect(handle!.isFollowing()).toBe(true)
+    expect(handle!.getNavigationBaseKey()).toBe('message-a')
     act(() => handle!.scrollToRange(range))
     expect(scrollTop).toBe(1100)
     expect(getRangeRect).toHaveBeenCalledTimes(1)
     expect(handle!.isFollowing()).toBe(false)
+    expect(handle!.getNavigationBaseKey()).toBe('message-a')
   })
 
   it('keeps key navigation aimed at the same message when history is prepended mid-animation', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/messageNavigationTestHarness.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/messageNavigationTestHarness.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render } from '@testing-library/react'
+import { vi } from 'vitest'
+
+import type { MessageListItem } from '../../types'
+import MessageNavigation from '../MessageNavigation'
+
+export const createMessage = (
+  id: string,
+  role: MessageListItem['role'],
+  parentId?: string | null
+): MessageListItem => ({
+  id,
+  role,
+  parentId,
+  topicId: 'topic-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  status: 'success'
+})
+
+export const createScrollContainerRef = () => ({ current: null as HTMLDivElement | null })
+
+export const setRect = (element: Element, rect: Partial<DOMRect>) => {
+  element.getBoundingClientRect = vi.fn(() => ({
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+    ...rect
+  }))
+}
+
+export const renderNavigation = (
+  messages: MessageListItem[],
+  visibleMessageIds: string[] = [],
+  getNavigationBaseMessageId: () => string | null = () => null,
+  onScrollToMessageId?: (messageId: string) => void
+) => {
+  const scrollContainerRef = createScrollContainerRef()
+  const scrollToMessageId = vi.fn(onScrollToMessageId)
+  const scrollToTop = vi.fn()
+  const scrollToBottom = vi.fn()
+
+  const { container } = render(
+    <>
+      <div id="messages">
+        <div ref={scrollContainerRef} data-message-virtual-list-scroller>
+          {messages.map((message) => (
+            <div key={message.id} id={`message-${message.id}`} />
+          ))}
+        </div>
+      </div>
+      <MessageNavigation
+        scrollContainerRef={scrollContainerRef}
+        getMessageElement={(messageId) => document.getElementById(`message-${messageId}`)}
+        getNavigationBaseMessageId={getNavigationBaseMessageId}
+        messages={messages}
+        scrollToMessageId={scrollToMessageId}
+        scrollToTop={scrollToTop}
+        scrollToBottom={scrollToBottom}
+      />
+    </>
+  )
+
+  setRect(container.querySelector('[data-message-virtual-list-scroller]') as HTMLElement, {
+    bottom: 500,
+    height: 500,
+    left: 0,
+    right: 500,
+    top: 0,
+    width: 500
+  })
+  for (const message of messages) {
+    setRect(document.getElementById(`message-${message.id}`) as HTMLElement, {
+      bottom: visibleMessageIds.includes(message.id) ? 220 : -100,
+      height: 100,
+      top: visibleMessageIds.includes(message.id) ? 120 : -200
+    })
+  }
+
+  return { scrollContainer: scrollContainerRef.current!, scrollToBottom, scrollToMessageId, scrollToTop }
+}
+
+export const showNavigation = (scrollContainer: HTMLElement) => {
+  fireEvent.mouseMove(scrollContainer, { clientX: 470, clientY: 250 })
+}

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -45,6 +45,8 @@ export interface MessageVirtualListHandle {
   scrollToBottom(): void
   scrollToTop(behavior?: ScrollBehavior): void
   scrollToKey(key: string, align?: 'start' | 'center' | 'end'): void
+  /** Base item for adjacent navigation: the latest item while following, otherwise the current explicit target. */
+  getNavigationBaseKey(): string | null
   /** Smooth-scroll `element` to the requested viewport alignment, then freeze the viewport on it. */
   scrollToElement(element: HTMLElement, align?: 'start' | 'center'): void
   /** Center an exact text range immediately, then freeze the viewport on its rendered content. */
@@ -97,6 +99,11 @@ interface FreezeAnchor {
   element: HTMLElement | null
   /** Element top relative to the scroller viewport at capture time. */
   elementViewportTop: number | null
+}
+
+interface ExplicitNavigationBase {
+  key: string
+  topicId?: string
 }
 
 export interface ChatVirtualizerRuntime<T> {
@@ -202,6 +209,7 @@ export function useChatVirtualizerRuntime<T>({
   const userScrollGestureRef = useRef(false)
   const scrollbarDragActiveRef = useRef(false)
   const readNavigationActiveRef = useRef(false)
+  const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
   const markUserInput = useCallback(() => {
     lastUserInputAtRef.current = performance.now()
@@ -230,6 +238,25 @@ export function useChatVirtualizerRuntime<T>({
     if (index < 0 || index >= list.length) return null
     return getItemKeyRef.current(list[index], index)
   }, [])
+  const rememberNavigationBase = useCallback(
+    (key: string) => {
+      if (!scrollerRef.current || findDataIndexByKey(key) < 0) return
+      explicitNavigationBaseRef.current = { key, topicId }
+    },
+    [findDataIndexByKey, topicId]
+  )
+  const getNavigationBaseKey = useCallback((): string | null => {
+    if (viewportFollow.isFollowing()) {
+      return getDataKeyAtIndex(itemsRef.current.length - 1)
+    }
+    const base = explicitNavigationBaseRef.current
+    if (!base) return null
+    if (base.topicId !== topicId || findDataIndexByKey(base.key) < 0) {
+      explicitNavigationBaseRef.current = null
+      return null
+    }
+    return base.key
+  }, [findDataIndexByKey, getDataKeyAtIndex, topicId, viewportFollow])
   const bottomFollowInsetRef = useRef(0)
   bottomFollowInsetRef.current = freezeSpacerHeightRef.current
   const setFreezeSpacerHeight = useCallback((height: number) => {
@@ -413,6 +440,7 @@ export function useChatVirtualizerRuntime<T>({
 
   const beginUserScrollGesture = useCallback(() => {
     if (userScrollGestureRef.current) return
+    explicitNavigationBaseRef.current = null
     // Any slack belongs to the old resting position. Once the user moves the
     // native thumb, its live scroll range must be the only range in play.
     setFreezeSpacerHeight(0)
@@ -445,6 +473,7 @@ export function useChatVirtualizerRuntime<T>({
 
   const enterFollowingMode = useCallback(
     (reason: FollowingReason) => {
+      explicitNavigationBaseRef.current = null
       viewportFollow.enterFollowing(reason)
       clearFreeze()
     },
@@ -473,6 +502,12 @@ export function useChatVirtualizerRuntime<T>({
   // ---- wrap items with stable DOM identity -----------------------------
 
   const dataKeys = useMemo(() => items.map((value, i) => getItemKey(value, i)), [items, getItemKey])
+  useLayoutEffect(() => {
+    const base = explicitNavigationBaseRef.current
+    if (base && (base.topicId !== topicId || !dataKeys.includes(base.key))) {
+      explicitNavigationBaseRef.current = null
+    }
+  }, [dataKeys, topicId])
   const previousDataKeysRef = useRef(dataKeys)
   const previousDataKeys = previousDataKeysRef.current
   const lengthDelta = dataKeys.length - previousDataKeys.length
@@ -840,13 +875,17 @@ export function useChatVirtualizerRuntime<T>({
 
   const scrollToTop = useCallback(
     (behavior: ScrollBehavior = 'instant') => {
+      const firstKey = getDataKeyAtIndex(0)
+      if (firstKey) rememberNavigationBase(firstKey)
       navigateForReading(() => 0, behavior)
     },
-    [navigateForReading]
+    [getDataKeyAtIndex, navigateForReading, rememberNavigationBase]
   )
 
   const scrollToElement = useCallback(
     (element: HTMLElement, align: 'start' | 'center' = 'start') => {
+      const itemKey = element.closest<HTMLElement>('[data-message-key]')?.dataset.messageKey
+      if (itemKey) rememberNavigationBase(itemKey)
       navigateForReading(
         (scroller) => {
           if (!element.isConnected) return scroller.scrollTop
@@ -859,7 +898,7 @@ export function useChatVirtualizerRuntime<T>({
         () => (element.isConnected ? element : null)
       )
     },
-    [navigateForReading]
+    [navigateForReading, rememberNavigationBase]
   )
 
   const scrollToRange = useCallback(
@@ -871,6 +910,8 @@ export function useChatVirtualizerRuntime<T>({
       }
       const scroller = scrollerRef.current
       if (!scroller || !getRangeElement()) return
+      const itemKey = getRangeElement()?.closest<HTMLElement>('[data-message-key]')?.dataset.messageKey
+      if (itemKey) rememberNavigationBase(itemKey)
 
       navigateForReading(
         (currentScroller) => {
@@ -889,7 +930,7 @@ export function useChatVirtualizerRuntime<T>({
         getRangeElement
       )
     },
-    [navigateForReading]
+    [navigateForReading, rememberNavigationBase]
   )
 
   useImperativeHandle(
@@ -899,6 +940,7 @@ export function useChatVirtualizerRuntime<T>({
       scrollToTop,
       scrollToKey: (key, align = 'start') => {
         if (findDataIndexByKey(key) < 0) return
+        rememberNavigationBase(key)
         const resolveTarget = (scroller: HTMLElement) => {
           const handle = vlistHandleRef.current
           const idx = findDataIndexByKey(key)
@@ -929,6 +971,7 @@ export function useChatVirtualizerRuntime<T>({
           return Array.from(elements).find((element) => element.dataset.messageKey === key) ?? null
         })
       },
+      getNavigationBaseKey,
       scrollToElement,
       scrollToRange,
       isFollowing: viewportFollow.isFollowing,
@@ -937,7 +980,9 @@ export function useChatVirtualizerRuntime<T>({
     [
       clampToReachable,
       findDataIndexByKey,
+      getNavigationBaseKey,
       navigateForReading,
+      rememberNavigationBase,
       scrollToBottom,
       scrollToElement,
       scrollToRange,

--- a/src/renderer/components/chat/messages/utils/__tests__/messageGroupKey.test.ts
+++ b/src/renderer/components/chat/messages/utils/__tests__/messageGroupKey.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import type { MessageListItem } from '../../types'
-import { getLatestAssistantGroupKey, getMessageGroupKey, groupMessageListItems } from '../messageGroupKey'
+import {
+  getLatestAssistantGroupKey,
+  getMessageGroupKey,
+  getOwningUserMessageIdByAssistantId,
+  groupMessageListItems
+} from '../messageGroupKey'
 
 const createMessage = (id: string, role: MessageListItem['role'], parentId?: string | null) =>
   ({
@@ -38,5 +43,27 @@ describe('messageGroupKey', () => {
     ]
 
     expect(getLatestAssistantGroupKey(messages)).toBe('assistantuser-2')
+  })
+
+  it.each([
+    {
+      assistant: createMessage('assistant-1', 'assistant', 'user-1'),
+      expectedOwnerId: 'user-1',
+      name: 'uses a valid explicit parent'
+    },
+    {
+      assistant: createMessage('assistant-1', 'assistant'),
+      expectedOwnerId: 'user-1',
+      name: 'falls back to the preceding user without a parent'
+    },
+    {
+      assistant: createMessage('assistant-1', 'assistant', 'missing-user'),
+      expectedOwnerId: undefined,
+      name: 'rejects an invalid explicit parent'
+    }
+  ])('$name when resolving an assistant owner', ({ assistant, expectedOwnerId }) => {
+    const messages = [createMessage('user-1', 'user'), assistant]
+
+    expect(getOwningUserMessageIdByAssistantId(messages).get(assistant.id)).toBe(expectedOwnerId)
   })
 })

--- a/src/renderer/components/chat/messages/utils/messageGroupKey.ts
+++ b/src/renderer/components/chat/messages/utils/messageGroupKey.ts
@@ -4,6 +4,31 @@ export function getMessageGroupKey(message: MessageListItem): string {
   return message.role === 'assistant' && message.parentId ? `assistant${message.parentId}` : message.role + message.id
 }
 
+/** Resolve assistant messages to the user turn that owns them. */
+export function getOwningUserMessageIdByAssistantId(messages: readonly MessageListItem[]): Map<string, string> {
+  const userMessageIds = new Set(messages.filter((message) => message.role === 'user').map((message) => message.id))
+  const result = new Map<string, string>()
+  let precedingUserMessageId: string | undefined
+
+  for (const message of messages) {
+    if (message.role === 'user') {
+      precedingUserMessageId = message.id
+      continue
+    }
+    if (message.role !== 'assistant') continue
+
+    const ownerId =
+      message.parentId != null
+        ? userMessageIds.has(message.parentId)
+          ? message.parentId
+          : undefined
+        : precedingUserMessageId
+    if (ownerId) result.set(message.id, ownerId)
+  }
+
+  return result
+}
+
 export function groupMessageListItems(messages: MessageListItem[]): Record<string, MessageListItem[]> {
   const grouped: Record<string, MessageListItem[]> = {}
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Rapidly clicking the previous or next message button before scrolling settled could repeatedly use the stale DOM-visible turn, causing navigation to stick or jump to the wrong turn.

After this PR:

Adjacent message navigation uses the virtual list's latest semantic navigation target. Message groups are resolved to their owning user turn, while genuine user scrolling clears the target and falls back to the visible DOM position.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

DOM visibility updates after scrolling and animation, so it cannot reliably represent the user's latest navigation intent during rapid consecutive clicks. The virtualizer already owns programmatic scrolling, making it the correct owner of the transient semantic target. `MessageList` adapts virtual group keys to user turns, and `MessageNavigation` only computes the adjacent turn.

The following tradeoffs were made:

- The navigation target is stored in a ref to avoid render-time state and streaming-message rerenders.
- Assistant ownership is resolved on demand when navigation is used rather than rebuilt during every streamed update.
- The target is invalidated when the user takes over scrolling, the topic changes, or the target item disappears.

The following alternatives were considered:

- Continuing to infer the current turn from DOM geometry after every click was rejected because the DOM can remain stale while scrolling is in progress.
- Keeping a local optimistic index inside `MessageNavigation` was rejected because search, outline, top, bottom, and other programmatic navigation paths could then disagree about the current target.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Relevant renderer tests: 121 passed.
- `typecheck:web`, Biome, ESLint, and `git diff --check` passed.
- The navigation controls were also manually verified in the application.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed rapid previous and next message navigation jumping to the wrong conversation turn.
```
