### PR TITLE
fix(prompt-editor): align prompt action button styles

### DIFF
--- a/src/renderer/components/PromptEditorField.tsx
+++ b/src/renderer/components/PromptEditorField.tsx
@@ -158,8 +158,8 @@ export function PromptEditorField({
             variant="ghost"
             onClick={() => setShowPreview((v) => !v)}
             disabled={value.length === 0}
-            className="flex h-auto min-h-0 items-center gap-1 rounded-full border border-border px-2 py-[3px] font-normal text-muted-foreground text-xs shadow-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-40">
-            {effectiveShowPreview ? <Edit size={10} /> : <Eye size={10} />}
+            className="flex h-6 min-h-0 items-center gap-1 rounded-md border border-border-subtle px-2 py-0 font-normal text-muted-foreground! text-xs shadow-none transition-colors hover:bg-accent/50 hover:text-foreground! focus-visible:bg-accent/50 focus-visible:text-foreground! focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-40">
+            {effectiveShowPreview ? <Edit className="size-3" /> : <Eye className="size-3" />}
             <span>{t(effectiveShowPreview ? 'common.edit' : 'common.preview')}</span>
           </Button>
         </div>

--- a/src/renderer/components/resourceCatalog/dialogs/components/PromptPolishActions.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/components/PromptPolishActions.tsx
@@ -168,24 +168,24 @@ export function PromptPolishActions({
         <Tooltip content={t('common.undo')}>
           <Button
             type="button"
-            variant="outline"
+            variant="ghost"
             aria-label={t('common.undo')}
             aria-disabled={undoDisabled}
             onClick={handleUndo}
-            className="flex h-6 min-h-0 w-6 items-center justify-center rounded-full p-0 text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-0 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-40">
-            <Undo2 size={10} />
+            className="flex size-6 min-h-0 items-center justify-center rounded-md border border-border-subtle p-0 text-muted-foreground! shadow-none transition-colors hover:bg-accent/50 hover:text-foreground! focus-visible:bg-accent/50 focus-visible:text-foreground! focus-visible:ring-0 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-40">
+            <Undo2 className="size-3" />
           </Button>
         </Tooltip>
       ) : null}
       <Tooltip content={actionLabel}>
         <Button
           type="button"
-          variant="outline"
+          variant="ghost"
           aria-label={actionLabel}
           aria-disabled={actionDisabled}
           onClick={() => void handlePolish()}
-          className="flex h-6 min-h-0 w-6 items-center justify-center rounded-full p-0 text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-0 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-40">
-          {running ? <Loader2 size={10} className="animate-spin" /> : <Sparkles size={10} />}
+          className="flex size-6 min-h-0 items-center justify-center rounded-md border border-border-subtle p-0 text-muted-foreground! shadow-none transition-colors hover:bg-accent/50 hover:text-foreground! focus-visible:bg-accent/50 focus-visible:text-foreground! focus-visible:ring-0 aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-40">
+          {running ? <Loader2 className="size-3 animate-spin" /> : <Sparkles className="size-3" />}
         </Button>
       </Tooltip>
     </>

--- a/src/renderer/components/resourceCatalog/dialogs/edit/PromptEditDialog.tsx
+++ b/src/renderer/components/resourceCatalog/dialogs/edit/PromptEditDialog.tsx
@@ -144,8 +144,8 @@ const PromptEditDialog: FC<PromptEditDialogProps> = ({ open, prompt, saving, onS
           aria-label={t('library.config.prompt.insert_variable')}
           onClick={handleInsertVariable}
           disabled={isSaving}
-          className="flex h-6 min-h-0 w-6 items-center justify-center rounded-2xs border border-border-subtle p-0 text-muted-foreground shadow-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-40">
-          <BracesVariableIcon size={10} />
+          className="flex size-6 min-h-0 items-center justify-center rounded-md border border-border-subtle p-0 text-muted-foreground! shadow-none transition-colors hover:bg-accent/50 hover:text-foreground! focus-visible:bg-accent/50 focus-visible:text-foreground! focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-40">
+          <BracesVariableIcon className="size-3" />
         </Button>
       </Tooltip>
     </>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Prompt editor actions used a mix of circular, square, and pill-shaped buttons. Their border and dark-mode color treatments differed, and the shared Button SVG rule enlarged icons from the intended compact size.

After this PR:

Prompt generation, undo, variable insertion, and preview actions use a consistent 24px compact toolbar style with rounded corners, subtle borders, muted colors, matching hover/focus states, and explicit 12px icons.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when it gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The mixed action styles made controls in the same prompt editor toolbar look unrelated and caused unintended icon sizing. The fix reuses the existing shared Button primitive and semantic tokens while limiting changes to the three components that own these controls.

The following tradeoffs were made:

- The compact 24px size remains a local toolbar composition because the shared `icon-sm` Button size is 28px.
- Existing action behavior and disabled-state handling remain unchanged; this PR is visual only.

The following alternatives were considered:

- Adding a new shared Button size was rejected because this is a localized composition and does not yet establish a reusable cross-product requirement.
- Keeping circular icon buttons and only changing the variable button was rejected because the preview and action controls would still use conflicting shapes and states.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- `pnpm lint` passes, including type checks, i18n validation, and formatting.
- The command reports 42 pre-existing ESLint warnings outside the changed files.
- Tests and interactive UI verification were not run per repository verification policy.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string action required.
2. If no release note is required, write NONE.
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write NONE.
-->

```release-note
Align prompt editor action buttons for consistent sizing, shape, color, and icon scale.
```
