### PR TITLE
fix(markdown): copy tables from local source blocks

### DIFF
--- a/packages/ui/src/components/composites/markdown/__tests__/streaming-markdown.test.tsx
+++ b/packages/ui/src/components/composites/markdown/__tests__/streaming-markdown.test.tsx
@@ -8,9 +8,12 @@
  * emits for the *unrevealed* tail.
  */
 
-import { render } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { JSX } from 'react'
+import type { ExtraProps } from 'streamdown'
 import { describe, expect, it } from 'vitest'
 
+import { useMarkdownBlockContext } from '../context'
 import { StreamingMarkdown } from '../streaming-markdown'
 
 describe('StreamingMarkdown', () => {
@@ -80,5 +83,43 @@ describe('StreamingMarkdown', () => {
     expect(animated).not.toBeNull()
     const animation = (animated as HTMLElement).style.getPropertyValue('--sd-animation')
     expect(animation).toBe('sd-fadeIn')
+  })
+
+  it('provides each streaming block source to custom renderers', () => {
+    const copied: string[] = []
+    const tableMarkdown = `| Name | Type |
+| :--- | ---: |
+| Project A | In progress |`
+    const content = `Intro paragraph\n\n${tableMarkdown}`
+
+    function CopyableTable({ node, ...props }: JSX.IntrinsicElements['table'] & ExtraProps) {
+      const markdownContext = useMarkdownBlockContext()
+      const position = node?.position
+      const source = position
+        ? markdownContext?.content
+            .split('\n')
+            .slice(position.start.line - 1, position.end.line)
+            .join('\n')
+            .trim()
+        : ''
+
+      return (
+        <div>
+          <table {...props} />
+          <button type="button" onClick={() => copied.push(source ?? '')}>
+            Copy table
+          </button>
+        </div>
+      )
+    }
+
+    render(
+      <StreamingMarkdown id="table-source" animated={false} components={{ table: CopyableTable }}>
+        {content}
+      </StreamingMarkdown>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy table' }))
+    expect(copied).toEqual([tableMarkdown])
   })
 })

--- a/packages/ui/src/components/composites/markdown/__tests__/streaming-markdown.test.tsx
+++ b/packages/ui/src/components/composites/markdown/__tests__/streaming-markdown.test.tsx
@@ -8,7 +8,8 @@
  * emits for the *unrevealed* tail.
  */
 
-import { fireEvent, render, screen } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { JSX } from 'react'
 import type { ExtraProps } from 'streamdown'
 import { describe, expect, it } from 'vitest'
@@ -85,7 +86,8 @@ describe('StreamingMarkdown', () => {
     expect(animation).toBe('sd-fadeIn')
   })
 
-  it('provides each streaming block source to custom renderers', () => {
+  it('provides each streaming block source to custom renderers', async () => {
+    const user = userEvent.setup()
     const copied: string[] = []
     const tableMarkdown = `| Name | Type |
 | :--- | ---: |
@@ -119,7 +121,7 @@ describe('StreamingMarkdown', () => {
       </StreamingMarkdown>
     )
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy table' }))
+    await user.click(screen.getByRole('button', { name: 'Copy table' }))
     expect(copied).toEqual([tableMarkdown])
   })
 })

--- a/packages/ui/src/components/composites/markdown/internal.tsx
+++ b/packages/ui/src/components/composites/markdown/internal.tsx
@@ -12,6 +12,8 @@ import { type ReactElement, useCallback, useMemo } from 'react'
 import remarkAlert from 'remark-github-blockquote-alert'
 import {
   type AnimateOptions,
+  Block,
+  type BlockProps,
   type Components,
   defaultRehypePlugins,
   defaultRemarkPlugins,
@@ -32,6 +34,16 @@ import {
 } from './utils'
 
 const STREAMDOWN_DEFAULT_REMARK_PLUGINS = Object.values(defaultRemarkPlugins)
+
+function MarkdownBlock({ content, ...props }: BlockProps): ReactElement {
+  const markdownCtx = useMemo(() => ({ content }), [content])
+
+  return (
+    <MarkdownBlockContext value={markdownCtx}>
+      <Block content={content} {...props} />
+    </MarkdownBlockContext>
+  )
+}
 
 interface ResolvedDefaultRehypePlugins {
   raw: Pluggable
@@ -144,6 +156,7 @@ export function MarkdownCore({
     <MarkdownBlockContext value={markdownCtx}>
       <div className={['markdown', className].filter(Boolean).join(' ')}>
         <Streamdown
+          BlockComponent={MarkdownBlock}
           mode={mode}
           plugins={plugins}
           rehypePlugins={rehypePlugins}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Table AST positions in streaming Markdown were relative to the local Streamdown block, while the table copy action applied those positions to the full message source. Tables preceded by other Markdown blocks could therefore copy unrelated message content.

After this PR:

Each Streamdown block provides its matching Markdown source through the existing `MarkdownBlockContext`, so table copy extracts the original table source using the correct coordinate space.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

AST source positions are only meaningful against the source string that produced the AST. The Markdown renderer now places the existing source context at Streamdown's block boundary while retaining the full-source provider for static rendering.

The following tradeoffs were made:

The streaming renderer gains one lightweight context provider around each Streamdown block. The existing table extraction and rich-copy behavior remain unchanged.

The following alternatives were considered:

Converting the rendered table DOM back into Markdown was rejected because it normalizes or loses original formatting. Compensating for block offsets inside the table component was also rejected because the renderer owns the source partitioning and coordinate system.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation:

- `pnpm --filter @cherrystudio/ui exec vitest run src/components/composites/markdown/__tests__/streaming-markdown.test.tsx`
- `pnpm exec vitest run src/renderer/components/chat/messages/markdown/__tests__/Table.test.tsx`
- `pnpm typecheck:web`
- Electron CDP verification confirmed that the table copy button writes the exact original Markdown table to the system clipboard.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed table copy actions returning unrelated message content instead of the original Markdown table.
```
