### PR TITLE
fix(agent-creation): show go-to-chat action after tool creation

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/assistant.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/assistant.test.ts
@@ -349,7 +349,10 @@ describe('create_agent', () => {
     const server = new AssistantServer()
     const result = await (
       server as unknown as {
-        createAgent: (args: Record<string, string>) => Promise<{ content: Array<{ text: string }> }>
+        createAgent: (args: Record<string, string>) => Promise<{
+          content: Array<{ text: string }>
+          structuredContent: unknown
+        }>
       }
     ).createAgent({
       name: ' Reviewer ',
@@ -370,7 +373,14 @@ describe('create_agent', () => {
       }
     })
     expect(mocks.modelGetByKey).toHaveBeenCalledWith('anthropic', 'claude-sonnet')
-    expect(result.content[0].text).toContain('agent-created')
+    const output = {
+      ok: true,
+      agentId: 'agent-created',
+      name: 'Reviewer',
+      model: 'anthropic::claude-sonnet'
+    }
+    expect(result.structuredContent).toEqual(output)
+    expect(JSON.parse(result.content[0].text)).toEqual(output)
   })
 
   it("defaults to Cherry Assistant's current model when model is omitted", async () => {

--- a/src/main/ai/mcp/servers/assistant.ts
+++ b/src/main/ai/mcp/servers/assistant.ts
@@ -174,7 +174,7 @@ Safety rules:
 - a workspace is selected when the user opens a session for the new agent
 - permission_mode defaults to 'default' (read-mostly); user can change later in the UI
 
-The tool returns the new agent id. After creation, query product_info and navigate to the current package's Agents route.`,
+The tool returns the new agent details, and Cherry Studio presents a Go to chat action. Do not call navigate after a successful creation.`,
   inputSchema: {
     type: 'object',
     properties: {
@@ -198,6 +198,17 @@ The tool returns the new agent id. After creation, query product_info and naviga
       }
     },
     required: ['name', 'instructions']
+  },
+  outputSchema: {
+    type: 'object',
+    properties: {
+      ok: { type: 'boolean', const: true },
+      agentId: { type: 'string' },
+      name: { type: 'string' },
+      model: { type: 'string' }
+    },
+    required: ['ok', 'agentId', 'name', 'model'],
+    additionalProperties: false
   }
 }
 
@@ -492,13 +503,15 @@ class AssistantServer {
         }
       })
       logger.info('create_agent succeeded', { agentId: result.id, name })
+      const output = {
+        ok: true as const,
+        agentId: result.id,
+        name: result.name,
+        model: result.model
+      }
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text: `Agent created. id=${result.id}, name=${result.name}, model=${result.model}. Query product_info for the current Agents route, then use navigate to open it.`
-          }
-        ]
+        content: [{ type: 'text' as const, text: JSON.stringify(output) }],
+        structuredContent: output
       }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { notifyDataApiDataChange } from '@data/dataApiDataChange'
 import { type AgentRow, agentTable as agentsTable, type InsertAgentRow } from '@data/db/schemas/agent'
 import { agentKnowledgeBaseTable, agentMcpServerTable } from '@data/db/schemas/assistantRelations'
 import { knowledgeBaseTable } from '@data/db/schemas/knowledge'
@@ -252,10 +253,8 @@ export class AgentService {
   readonly onAgentDeleted: Event<AgentDeletedEvent> = this._onAgentDeleted.event
 
   /**
-   * DB-only create primitive for main-process command orchestration.
-   *
-   * The caller owns non-database side effects (for example provisioning the
-   * agent data directory) and supplies the already-reserved id.
+   * Create primitive for main-process command orchestration. The caller owns
+   * non-data side effects and supplies the already-reserved id.
    */
   createAgentWithId(id: string, req: AgentCreateInput): AgentEntity {
     // Reserved capability identity — see getBuiltinRole. Seeding writes via createAgentTx.
@@ -333,6 +332,7 @@ export class AgentService {
     }
 
     const agent = rowToAgent(row.agent, row.modelName || null, mcps, knowledgeBaseIds)
+    notifyDataApiDataChange([{ endpoint: '/agents', kind: 'membership', entityIds: [id] }])
     this._onAgentCreated.fire({ agentId: id, agent })
     return agent
   }

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -178,6 +178,20 @@ describe('AgentService', () => {
   }
 
   describe('createAgent', () => {
+    it('notifies live agent lists after creation', () => {
+      notifyDataApiDataChangeMock.mockClear()
+
+      const agent = createAgentForTest({
+        type: 'claude-code',
+        name: 'Externally Created',
+        model: TEST_MODEL_ID
+      })
+
+      expect(notifyDataApiDataChangeMock).toHaveBeenCalledExactlyOnceWith([
+        { endpoint: '/agents', kind: 'membership', entityIds: [agent.id] }
+      ])
+    })
+
     it('persists plan and small models when provided', async () => {
       const agent = createAgentForTest({
         type: 'claude-code',

--- a/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
+++ b/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
@@ -602,6 +602,32 @@ describe('projectCompletedMessageParts', () => {
     expect(indexes(layout.resultEntries)).toEqual([1])
   })
 
+  it('keeps a created Agent action outside completed history', () => {
+    const layout = projectCompletedMessageParts(
+      entries([
+        { type: 'dynamic-tool', toolCallId: 'read', toolName: 'Read', state: 'output-available' },
+        {
+          type: 'dynamic-tool',
+          toolCallId: 'create-agent',
+          toolName: 'mcp__assistant__create_agent',
+          state: 'output-available',
+          output: {
+            content: [
+              {
+                type: 'text',
+                text: 'Agent created. id=agent-created, name=Reviewer, model=anthropic::claude-sonnet. Query product_info for supported capabilities.'
+              }
+            ]
+          }
+        },
+        { type: 'text', text: 'Created successfully.' }
+      ])
+    )
+
+    expect(indexes(layout.historyEntries)).toEqual([0])
+    expect(indexes(layout.resultEntries)).toEqual([1, 2])
+  })
+
   it.each(GENERATED_IMAGE_RESULTS)('keeps %s outside completed history', (_label, toolName, output) => {
     const layout = projectCompletedMessageParts(
       entries([

--- a/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
+++ b/src/renderer/components/chat/messages/blocks/__tests__/messagePartLayouts.test.ts
@@ -615,7 +615,7 @@ describe('projectCompletedMessageParts', () => {
             content: [
               {
                 type: 'text',
-                text: 'Agent created. id=agent-created, name=Reviewer, model=anthropic::claude-sonnet. Query product_info for supported capabilities.'
+                text: '{"ok":true,"agentId":"agent-created","name":"Reviewer","model":"anthropic::claude-sonnet"}'
               }
             ]
           }

--- a/src/renderer/components/chat/messages/blocks/messagePartLayouts.ts
+++ b/src/renderer/components/chat/messages/blocks/messagePartLayouts.ts
@@ -4,6 +4,7 @@ import type { CherryMessagePart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { getToolName, isToolUIPart } from 'ai'
 
+import { isCreateAgentResultPart } from '../tools/agent'
 import { isChannelAuthQrPart } from '../tools/channelConfigTool'
 import { isGeneratedImageResultPart } from '../tools/painting/generateImageTool'
 import { isAskUserQuestionToolName } from '../tools/shared/agentToolTypes'
@@ -133,7 +134,7 @@ function isAskUserQuestionPart(part: CherryMessagePart): boolean {
 }
 
 function isInlineResultToolPart(part: CherryMessagePart): boolean {
-  return isChannelAuthQrPart(part) || isGeneratedImageResultPart(part)
+  return isChannelAuthQrPart(part) || isCreateAgentResultPart(part) || isGeneratedImageResultPart(part)
 }
 
 function isVisibleReasoningPart(part: CherryMessagePart): boolean {

--- a/src/renderer/components/chat/messages/tools/MessageTools.tsx
+++ b/src/renderer/components/chat/messages/tools/MessageTools.tsx
@@ -8,7 +8,12 @@ import { useMemo } from 'react'
 
 import { useMessagePartsScopeId } from '../blocks/MessagePartsContext'
 import { useOptionalMessageListTopicId } from '../MessageListProvider'
-import { isReportArtifactsToolResponse, MessageChannelConfigTool } from './agent'
+import {
+  CreateAgentToolInline,
+  getCreateAgentResult,
+  isReportArtifactsToolResponse,
+  MessageChannelConfigTool
+} from './agent'
 import { isChannelAuthQrToolResponse } from './channelConfigTool'
 import MessageMcpTool from './mcp/MessageMcpTool'
 import MessageTool, { canRenderMessageToolResponse } from './MessageTool'
@@ -87,6 +92,8 @@ export default function MessageTools({ toolResponse }: Props) {
     return { ...toolResponse, response: normalizeToolOutputResponse(output) }
   }, [deferredOutput, error, isLoading, output, toolResponse])
 
+  const createAgentResult = getCreateAgentResult(resolvedToolResponse)
+  if (createAgentResult) return <CreateAgentToolInline result={createAgentResult} />
   if (isReportArtifactsToolResponse(resolvedToolResponse)) return null
   if (isChannelAuthQrToolResponse(resolvedToolResponse)) {
     return <MessageChannelConfigTool toolResponse={resolvedToolResponse} />

--- a/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/AgentToolRenderer.test.tsx
@@ -1,5 +1,5 @@
 import type * as CherryUi from '@cherrystudio/ui'
-import type { NormalToolResponse } from '@renderer/types/mcpTool'
+import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { parse as parsePartialJson } from 'partial-json'
@@ -170,6 +170,8 @@ describe('AgentToolRenderer', () => {
     'agent.askUserQuestion.title': 'Questions from Agent',
     'agent.askUserQuestion.answered': 'answered',
     'agent.sidebar_title': 'Agents',
+    'common.create_success': 'Created successfully',
+    'library.assistant_catalog.go_to_chat': 'Go to chat',
     'settings.tool.file_processing.features.document_to_markdown.title': 'Document Processing',
     'message.tools.status.done': 'Done',
     'message.tools.units.item_one': '{{count}} item',
@@ -875,6 +877,47 @@ describe('AgentToolRenderer', () => {
       expect(screen.getByText('Questions from Agent')).toBeInTheDocument()
       fireEvent.click(screen.getAllByRole('button')[0])
       expect(screen.getByText('Winston')).toBeVisible()
+    })
+  })
+
+  describe('assistant create_agent tool rendering', () => {
+    it('opens the newly created Agent conversation from the success action', async () => {
+      const user = userEvent.setup()
+      const navigateToRoute = vi.fn()
+      mockMessageListActions.mockReturnValue({ navigateToRoute })
+      const result = {
+        ok: true,
+        agentId: 'agent-created',
+        name: 'Reviewer',
+        model: 'anthropic::claude-sonnet'
+      }
+      const toolResponse: McpToolResponse = {
+        id: 'call-create-agent',
+        tool: {
+          id: 'assistant__mcp__assistant__create_agent',
+          name: 'create_agent',
+          description: 'Create Agent',
+          type: 'mcp',
+          serverId: 'assistant',
+          serverName: 'assistant',
+          inputSchema: { type: 'object', properties: {}, required: [] }
+        },
+        arguments: undefined,
+        status: 'done',
+        response: {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+          structuredContent: result
+        },
+        toolCallId: 'call-create-agent'
+      }
+
+      render(<MessageTools toolResponse={toolResponse} />)
+
+      await user.click(screen.getByRole('button', { name: 'Go to chat: Reviewer' }))
+      expect(navigateToRoute).toHaveBeenCalledWith({
+        path: '/app/agents',
+        query: { agentId: 'agent-created' }
+      })
     })
   })
 

--- a/src/renderer/components/chat/messages/tools/__tests__/MessageTools.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/MessageTools.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MessagePartsScopeProvider } from '../../blocks/MessagePartsContext'
+import type * as AgentTools from '../agent'
 import MessageTools from '../MessageTools'
 
 const { useToolResultMock, renderedResponses, topicIdMock } = vi.hoisted(() => ({
@@ -21,7 +22,8 @@ vi.mock('../MessageTool', () => ({
   canRenderMessageToolResponse: () => true
 }))
 vi.mock('../mcp/MessageMcpTool', () => ({ default: () => <div data-testid="mcp-tool" /> }))
-vi.mock('../agent', () => ({
+vi.mock('../agent', async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentTools>()),
   isReportArtifactsToolResponse: () => false,
   MessageChannelConfigTool: () => null
 }))

--- a/src/renderer/components/chat/messages/tools/agent/CreateAgentTool.tsx
+++ b/src/renderer/components/chat/messages/tools/agent/CreateAgentTool.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@cherrystudio/ui'
+import { Bot, Check } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { useOptionalMessageListActions } from '../../MessageListProvider'
+import type { CreateAgentResult } from './createAgentResult'
+
+export function CreateAgentToolInline({ result }: { result: CreateAgentResult }) {
+  const { t } = useTranslation()
+  const actions = useOptionalMessageListActions()
+  const openLabel = t('library.assistant_catalog.go_to_chat')
+
+  return (
+    <div className="my-1 flex min-h-12 max-w-full items-center gap-3 rounded-lg border border-border bg-background px-3 py-2">
+      <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-success-subtle text-success-subtle-foreground">
+        <Bot aria-hidden="true" size={16} strokeWidth={1.8} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1 text-success-subtle-foreground text-xs">
+          <Check aria-hidden="true" size={13} strokeWidth={2} />
+          <span>{t('common.create_success')}</span>
+        </div>
+        <div className="truncate font-medium text-foreground text-sm" title={result.name}>
+          {result.name}
+        </div>
+      </div>
+      {actions?.navigateToRoute ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          aria-label={`${openLabel}: ${result.name}`}
+          onClick={() => void actions.navigateToRoute?.({ path: '/app/agents', query: { agentId: result.agentId } })}>
+          {openLabel}
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/src/renderer/components/chat/messages/tools/agent/createAgentResult.ts
+++ b/src/renderer/components/chat/messages/tools/agent/createAgentResult.ts
@@ -1,0 +1,92 @@
+import type { McpToolResponse, NormalToolResponse } from '@renderer/types/mcpTool'
+import { isDeferredToolOutput } from '@shared/ai/transport'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { isToolUIPart } from 'ai'
+
+import { buildToolResponseFromPart } from '../toolResponse'
+
+const CREATE_AGENT_TOOL_NAME = 'mcp__assistant__create_agent'
+
+export interface CreateAgentResult {
+  ok: true
+  agentId: string
+  name: string
+  model: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseLegacyResult(value: string): CreateAgentResult | undefined {
+  const match = /^Agent created\. id=([^,]+), name=(.+), model=(.+)\. Query product_info/u.exec(value.trim())
+  if (!match) return undefined
+
+  return { ok: true, agentId: match[1], name: match[2], model: match[3] }
+}
+
+function parseText(value: string): unknown {
+  try {
+    return JSON.parse(value)
+  } catch {
+    return parseLegacyResult(value)
+  }
+}
+
+export function parseCreateAgentResult(value: unknown): CreateAgentResult | undefined {
+  let candidate: unknown = value
+
+  if (isRecord(value)) {
+    candidate = value.structuredContent ?? value.data ?? value.details ?? value
+    if (candidate === value && Array.isArray(value.content)) candidate = value.content
+  }
+
+  if (Array.isArray(candidate)) {
+    candidate = parseText(
+      candidate
+        .map((item) => (isRecord(item) && typeof item.text === 'string' ? item.text : ''))
+        .filter(Boolean)
+        .join('\n')
+    )
+  } else if (typeof candidate === 'string') {
+    candidate = parseText(candidate)
+  }
+
+  if (
+    !isRecord(candidate) ||
+    candidate.ok !== true ||
+    typeof candidate.agentId !== 'string' ||
+    typeof candidate.name !== 'string' ||
+    typeof candidate.model !== 'string'
+  ) {
+    return undefined
+  }
+
+  return {
+    ok: true,
+    agentId: candidate.agentId,
+    name: candidate.name,
+    model: candidate.model
+  }
+}
+
+export function isCreateAgentToolResponse(toolResponse: McpToolResponse | NormalToolResponse): boolean {
+  const { tool } = toolResponse
+  if (tool.name === CREATE_AGENT_TOOL_NAME || tool.id === CREATE_AGENT_TOOL_NAME) return true
+  return tool.type === 'mcp' && 'serverId' in tool && tool.serverId === 'assistant' && tool.name === 'create_agent'
+}
+
+export function getCreateAgentResult(
+  toolResponse: McpToolResponse | NormalToolResponse
+): CreateAgentResult | undefined {
+  if (toolResponse.status !== 'done' || !isCreateAgentToolResponse(toolResponse)) return undefined
+  return parseCreateAgentResult(toolResponse.response)
+}
+
+export function isCreateAgentResultPart(part: CherryMessagePart): boolean {
+  if (!isToolUIPart(part) || part.state !== 'output-available') return false
+
+  const toolResponse = buildToolResponseFromPart(part)
+  if (!toolResponse || !isCreateAgentToolResponse(toolResponse)) return false
+  return isDeferredToolOutput(toolResponse.response) || getCreateAgentResult(toolResponse) !== undefined
+}

--- a/src/renderer/components/chat/messages/tools/agent/createAgentResult.ts
+++ b/src/renderer/components/chat/messages/tools/agent/createAgentResult.ts
@@ -18,18 +18,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
-function parseLegacyResult(value: string): CreateAgentResult | undefined {
-  const match = /^Agent created\. id=([^,]+), name=(.+), model=(.+)\. Query product_info/u.exec(value.trim())
-  if (!match) return undefined
-
-  return { ok: true, agentId: match[1], name: match[2], model: match[3] }
-}
-
 function parseText(value: string): unknown {
   try {
     return JSON.parse(value)
   } catch {
-    return parseLegacyResult(value)
+    return undefined
   }
 }
 

--- a/src/renderer/components/chat/messages/tools/agent/index.ts
+++ b/src/renderer/components/chat/messages/tools/agent/index.ts
@@ -2,6 +2,8 @@ export { colorizeShellOutput, shellColorPalettes, TERMINAL_SURFACE_CLASS } from 
 export { AgentExecutionTimeline, AgentToolRenderer } from './AgentExecutionTimeline'
 export { AskUserQuestionCard } from './AskUserQuestionCard'
 export { AskUserQuestionOptimisticInputProvider } from './AskUserQuestionOptimisticContext'
+export { getCreateAgentResult, isCreateAgentResultPart } from './createAgentResult'
+export { CreateAgentToolInline } from './CreateAgentTool'
 export { MessageChannelConfigTool } from './MessageChannelConfigTool'
 export { isKnownNavigationPath, NavigateToolInline } from './NavigateTool'
 export { isReportArtifactsToolResponse, MessageReportArtifacts } from './ReportArtifacts'

--- a/src/renderer/hooks/agent/__tests__/useAgent.test.ts
+++ b/src/renderer/hooks/agent/__tests__/useAgent.test.ts
@@ -142,6 +142,19 @@ describe('useAgents', () => {
   })
 
   describe('agents list', () => {
+    it('refetches after a main-process Agent creation notification', () => {
+      const refetch = vi.fn().mockResolvedValue(undefined)
+      MockUseDataApiUtils.mockQueryResult('/agents', {
+        data: { items: [], total: 0, page: 1 } as any,
+        refetch
+      })
+
+      renderHook(() => useAgents())
+      MockUseDataApiUtils.emitDataChange([{ endpoint: '/agents', kind: 'membership', entityIds: ['agent-created'] }])
+
+      expect(refetch).toHaveBeenCalledOnce()
+    })
+
     it('returns empty array when data is undefined', () => {
       MockUseDataApiUtils.mockQueryLoading('/agents')
 

--- a/src/renderer/hooks/agent/useAgent.ts
+++ b/src/renderer/hooks/agent/useAgent.ts
@@ -7,7 +7,7 @@
  */
 
 import { loggerService } from '@logger'
-import { useInvalidateCache, useMutation, useQuery } from '@renderer/data/hooks/useDataApi'
+import { useDataChange, useInvalidateCache, useMutation, useQuery } from '@renderer/data/hooks/useDataApi'
 import { ipcApi } from '@renderer/ipc'
 import { createAgentAndRefresh } from '@renderer/services/createAgent'
 import { toast } from '@renderer/services/toast'
@@ -72,10 +72,12 @@ export const useAgent = (id: string | null) => {
  */
 export const useAgents = (options: { enabled?: boolean } = {}) => {
   const { t } = useTranslation()
+  const enabled = options.enabled ?? true
   const { data, isLoading, error, refetch } = useQuery('/agents', {
-    enabled: options.enabled ?? true,
+    enabled,
     query: { limit: AGENTS_MAX_LIMIT }
   })
+  useDataChange(enabled ? '/agents' : [], () => void refetch())
   const agents = useMemo<AgentEntity[]>(() => (data?.items ?? []) as unknown as AgentEntity[], [data])
   const invalidate = useInvalidateCache()
 

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -500,6 +500,12 @@ const AgentPage = () => {
     ]
   )
 
+  useEffect(() => {
+    if (!routeAgentId || routeSessionId || activeSessionId || isAgentsLoading) return
+    if (!agents.some((agent) => agent.id === routeAgentId)) return
+    void createAndActivateEmptySession({ agentId: routeAgentId, workspaceMode: 'system' })
+  }, [activeSessionId, agents, createAndActivateEmptySession, isAgentsLoading, routeAgentId, routeSessionId])
+
   const showMissingAgentSelection = useCallback(() => {
     closeSurface()
     clearLocate()

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -124,6 +124,7 @@ const AgentPage = () => {
     isMessageOnlyView ? routeSessionId : null
   )
   const { agents, isLoading: isAgentsLoading } = useAgents()
+  const routeAgentExists = !!routeAgentId && agents.some((agent) => agent.id === routeAgentId)
   const [activeSessionId, setActiveSessionIdState] = useState<string | null>(() => routeActiveSessionId)
   const requestComposerFocus = useComposerFocusRequest(
     activeSessionId ? buildAgentSessionTopicId(activeSessionId) : null
@@ -149,6 +150,11 @@ const AgentPage = () => {
     defaultOpen: !isWindowFrame && panePosition === 'right'
   })
   const isCreatingEmptySessionRef = useRef(false)
+  const routeAgentActivationGenerationRef = useRef(0)
+  const routeAgentSessionRequestRef = useRef<{
+    agentId: string
+    promise: Promise<AgentSessionEntity>
+  } | null>(null)
 
   useLayoutEffect(() => {
     ownerFallbackRequestIdRef.current += 1
@@ -501,10 +507,49 @@ const AgentPage = () => {
   )
 
   useEffect(() => {
-    if (!routeAgentId || routeSessionId || activeSessionId || isAgentsLoading) return
-    if (!agents.some((agent) => agent.id === routeAgentId)) return
-    void createAndActivateEmptySession({ agentId: routeAgentId, workspaceMode: 'system' })
-  }, [activeSessionId, agents, createAndActivateEmptySession, isAgentsLoading, routeAgentId, routeSessionId])
+    const generation = ++routeAgentActivationGenerationRef.current
+    if (!routeAgentId || routeSessionId || activeSessionId || isAgentsLoading || !routeAgentExists) return
+
+    closeSurface()
+    const pendingRequest = routeAgentSessionRequestRef.current
+    const sessionPromise =
+      pendingRequest?.agentId === routeAgentId
+        ? pendingRequest.promise
+        : resolveEmptySession(routeAgentId, { agentId: routeAgentId, workspaceMode: 'system' })
+    routeAgentSessionRequestRef.current = { agentId: routeAgentId, promise: sessionPromise }
+
+    void sessionPromise
+      .then((session) => {
+        if (generation !== routeAgentActivationGenerationRef.current) return
+        activateSession(session, routeAgentId)
+      })
+      .catch((err) => {
+        if (generation !== routeAgentActivationGenerationRef.current) return
+        logger.error('Failed to create empty agent session', err as Error, { agentId: routeAgentId })
+        toast.error(formatErrorMessageWithPrefix(err, t('agent.session.create.error.failed')))
+      })
+      .finally(() => {
+        if (routeAgentSessionRequestRef.current?.promise === sessionPromise) {
+          routeAgentSessionRequestRef.current = null
+        }
+      })
+
+    return () => {
+      if (generation === routeAgentActivationGenerationRef.current) {
+        routeAgentActivationGenerationRef.current += 1
+      }
+    }
+  }, [
+    activeSessionId,
+    activateSession,
+    closeSurface,
+    isAgentsLoading,
+    resolveEmptySession,
+    routeAgentExists,
+    routeAgentId,
+    routeSessionId,
+    t
+  ])
 
   const showMissingAgentSelection = useCallback(() => {
     closeSurface()

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -2556,6 +2556,66 @@ describe('AgentPage', () => {
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-pinned-agent'))
   })
 
+  it('does not let a stale agentId entry replace a newer Agent conversation', async () => {
+    type RouteSessionResult = {
+      session: typeof agentPageMocks.persistedSession
+      created: boolean
+      deletedDuplicateSessionIds: string[]
+    }
+    let resolveAgentA!: (result: RouteSessionResult) => void
+    let resolveAgentB!: (result: RouteSessionResult) => void
+    const sessionA = { ...agentPageMocks.persistedSession, id: 'session-agent-a', agentId: 'agent-a' }
+    const sessionB = { ...agentPageMocks.persistedSession, id: 'session-agent-b', agentId: 'agent-b' }
+
+    agentPageMocks.routeSearch = { agentId: 'agent-a' }
+    agentPageMocks.agents = [
+      { id: 'agent-a', model: 'model-a', name: 'Agent A' },
+      { id: 'agent-b', model: 'model-b', name: 'Agent B' }
+    ]
+    agentPageMocks.reuseOrCreateSession.mockImplementation(
+      (agentId: string) =>
+        new Promise<RouteSessionResult>((resolve) => {
+          if (agentId === 'agent-a') resolveAgentA = resolve
+          if (agentId === 'agent-b') resolveAgentB = resolve
+        })
+    )
+
+    const { rerender } = render(<AgentPage />)
+    await waitFor(() => expect(resolveAgentA).toEqual(expect.any(Function)))
+
+    agentPageMocks.routeSearch = { agentId: 'agent-b' }
+    rerender(<AgentPage />)
+    await waitFor(() => expect(resolveAgentB).toEqual(expect.any(Function)))
+
+    await act(async () => {
+      resolveAgentB({ session: sessionB, created: true, deletedDuplicateSessionIds: [] })
+      await Promise.resolve()
+    })
+    await waitFor(() =>
+      expect(agentPageMocks.navigate).toHaveBeenCalledWith({
+        to: '/app/agents',
+        search: { sessionId: 'session-agent-b' },
+        replace: true
+      })
+    )
+
+    await act(async () => {
+      resolveAgentA({ session: sessionA, created: true, deletedDuplicateSessionIds: [] })
+      await Promise.resolve()
+    })
+
+    expect(agentPageMocks.navigate).toHaveBeenCalledWith({
+      to: '/app/agents',
+      search: { sessionId: 'session-agent-b' },
+      replace: true
+    })
+    expect(agentPageMocks.navigate).not.toHaveBeenCalledWith({
+      to: '/app/agents',
+      search: { sessionId: 'session-agent-a' },
+      replace: true
+    })
+  })
+
   it('records the visible agent reported by the chat body', async () => {
     render(<AgentPage />)
 

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -2529,7 +2529,7 @@ describe('AgentPage', () => {
     expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
   })
 
-  it('creates for the sidebar agentId when the pinned agent has no session yet', async () => {
+  it('creates and activates a conversation for an agentId entry with no session yet', async () => {
     agentPageMocks.routeSearch = { agentId: 'agent-a' }
     agentPageMocks.agents = [
       { id: 'agent-a', model: 'model-a', name: 'Agent A' },
@@ -2547,16 +2547,13 @@ describe('AgentPage', () => {
 
     render(<AgentPage />)
 
-    // The composer create path carries no agent id, so without the route fallback it
-    // would resolve to the visible session's agent (none here) and stall.
-    fireEvent.click(screen.getByRole('button', { name: 'Create empty session from composer' }))
-
     await waitFor(() =>
       expect(agentPageMocks.dataApiPost).toHaveBeenCalledWith(
         '/agent-sessions',
         expect.objectContaining({ body: expect.objectContaining({ agentId: 'agent-a' }) })
       )
     )
+    await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-pinned-agent'))
   })
 
   it('records the visible agent reported by the chat body', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Agents created through `assistant.create_agent` did not refresh existing Agent lists.
- The completed creation result was hidden inside collapsed process history, while the generated navigation action only opened the Agents page without starting a conversation.

After this PR:

- Main-process Agent creation broadcasts an `/agents` membership change so active lists refetch.
- `create_agent` returns structured details and renders a persistent success card with a **Go to chat** action outside process history, including compatibility for persisted legacy results and MCP runtime tool shapes.
- Opening the created Agent creates or reuses a system-workspace session and activates the conversation.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Agent creation can originate in the main process, outside the renderer mutation that normally invalidates the list. The implementation uses the existing DataApi change notification path, keeps tool-result rendering at the shared message boundary, and leaves session ownership with the Agents page.

The following tradeoffs were made:

- A narrow parser for the previous `create_agent` success text is retained so already persisted conversations gain the action after upgrading.
- The action routes by `agentId`; session creation remains asynchronous and owned by the destination page.

The following alternatives were considered:

- Continuing to ask the model to call `navigate` was rejected because it only produced a route link and could not guarantee an active conversation.
- Updating only local renderer cache state was rejected because main-process creation must refresh every active Agent list consistently.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Verification: `pnpm lint` passed.
- Targeted tests and manual UI verification were not run under the workspace's user-owned verification policy.
- No user-guide update is required; this corrects the behavior of an existing creation flow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent creation tools now refresh the Agent list and show a Go to chat action that opens an active conversation with the newly created Agent.
```
