### PR TITLE
fix(quick-panel): preserve labels while aligning descriptions

### DIFF
--- a/src/renderer/components/QuickPanel/QuickPanelView.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelView.tsx
@@ -927,7 +927,6 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
             disabled: item.disabled
           })}
           active={(!ctx.readOnly || !!item.fixedToBottom) && itemIndex === activeIndex}
-          contentClassName="max-w-[60%]"
           dataId={item.id}
           hoverEnabled={isMouseOver}
           item={item}

--- a/src/renderer/components/QuickPanel/__tests__/row.test.tsx
+++ b/src/renderer/components/QuickPanel/__tests__/row.test.tsx
@@ -4,54 +4,56 @@ import { describe, expect, it, vi } from 'vitest'
 import { QuickPanelRow } from '../list'
 
 describe('QuickPanelRow', () => {
-  it('keeps inline descriptions next to the label and lets the description yield space first', () => {
+  it('lets descriptions use the remaining width while protecting the label and aligning short text right', () => {
     render(
       <QuickPanelRow
         active={false}
         item={{
-          id: 'skill:short-name',
-          label: 'short-name',
+          id: 'slash-command:/long-command',
+          label: '/long-command',
           description: 'A description long enough to exercise the single-line overflow contract.',
-          inlineDescription: true,
           icon: 'icon',
-          suffix: 'Skill'
+          suffix: 'source'
         }}
         onSelect={vi.fn()}
       />
     )
 
-    const label = screen.getByText('short-name')
+    const label = screen.getByText('/long-command')
     const description = screen.getByText(/A description long enough/)
-    const suffix = screen.getByText('Skill')
+    const suffix = screen.getByText('source')
 
-    expect(label.parentElement).toHaveClass('max-w-full', 'min-w-0', 'shrink-0')
-    expect(label.parentElement?.parentElement).toBe(description.parentElement)
-    expect(label).toHaveClass('min-w-0', 'truncate')
-    expect(label).not.toHaveClass('max-w-[50%]')
-    expect(description).toHaveClass('min-w-0', 'flex-1', 'truncate')
-    expect(suffix.parentElement?.parentElement).not.toBe(description.parentElement)
+    expect(label.parentElement).toHaveClass('max-w-[40%]', 'min-w-0', 'shrink-0')
+    expect(label.parentElement).not.toHaveClass('basis-[60%]')
+    expect(label.parentElement).not.toBe(description.parentElement)
+    expect(label).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(description.parentElement).toHaveClass('min-w-0', 'flex-1', 'justify-end')
+    expect(description).toHaveClass('min-w-0', 'flex-1', 'truncate', 'text-right')
+    expect(suffix).toHaveClass('max-w-full', 'truncate')
   })
 
-  it('keeps trailing descriptions in the metadata column by default', () => {
+  it('lets labels use the remaining width when there is no description', () => {
     render(
       <QuickPanelRow
         active={false}
         item={{
-          id: 'permission:auto',
-          label: 'Auto',
-          description: 'Recommended',
+          id: 'prompt-load-error',
+          label: 'Unable to load prompts because the remote service returned a detailed error message.',
           icon: 'icon',
-          suffix: 'suffix'
+          disabled: true
         }}
         onSelect={vi.fn()}
       />
     )
 
-    const label = screen.getByText('Auto')
-    const description = screen.getByText('Recommended')
+    const label = screen.getByText(/Unable to load prompts/)
+    const primary = label.parentElement
+    const metadata = primary?.nextElementSibling
 
-    expect(label.parentElement).not.toBe(description.parentElement)
-    expect(description.parentElement).toHaveClass('min-w-[20%]', 'justify-end')
-    expect(description.parentElement).not.toHaveClass('max-w-[60%]')
+    expect(primary).toHaveClass('min-w-0', 'flex-1')
+    expect(primary).not.toHaveClass('max-w-[40%]')
+    expect(primary).not.toHaveClass('shrink-0')
+    expect(metadata).toHaveClass('shrink-0')
+    expect(metadata).not.toHaveClass('flex-1')
   })
 })

--- a/src/renderer/components/QuickPanel/list.tsx
+++ b/src/renderer/components/QuickPanel/list.tsx
@@ -13,7 +13,6 @@ export interface QuickPanelRowData {
   id?: string
   label: ReactNode | string
   description?: ReactNode | string
-  inlineDescription?: boolean
   tooltip?: ReactNode | string
   /** In-row element used as the controlled Tooltip trigger. */
   tooltipAnchor?: ReactElement
@@ -43,7 +42,6 @@ interface QuickPanelReadOnlyHeaderProps {
 interface QuickPanelRowProps<T extends QuickPanelRowData> {
   active: boolean
   className?: string
-  contentClassName?: string
   dataId?: string
   hoverEnabled?: boolean
   item: T
@@ -156,7 +154,6 @@ export function QuickPanelReadOnlyHeader({ onClose, title }: QuickPanelReadOnlyH
 export function QuickPanelRow<T extends QuickPanelRowData>({
   active,
   className,
-  contentClassName = 'max-w-[68%]',
   dataId,
   hoverEnabled = true,
   item,
@@ -177,19 +174,7 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
   ) : item.isMenu && !item.disabled && !readOnly ? (
     <ChevronRight size={14} />
   ) : null
-  const hasInlineDescription = item.inlineDescription === true && !!item.description
-  const primaryContent = (
-    <>
-      {reserveIconSlot || item.icon ? (
-        <span className="flex shrink-0 items-center justify-center text-[13px] text-muted-foreground [&>svg:not([class*='text-'])]:text-muted-foreground [&>svg]:size-[1em]">
-          {item.icon}
-        </span>
-      ) : null}
-      <span className={cn('min-w-0 truncate text-[13px] leading-4', !hasInlineDescription && 'flex-1')}>
-        {item.label}
-      </span>
-    </>
-  )
+  const hasDescription = Boolean(item.description)
   const canHover = hoverEnabled && !isReadOnlyLocked && !item.disabled
   const isUnavailable = isReadOnlyLocked || item.disabled
   const tooltipAnchor =
@@ -238,33 +223,27 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
         event.stopPropagation()
         onSelect()
       }}>
-      {hasInlineDescription ? (
-        <div className="flex min-w-0 flex-1 items-center gap-1.5">
-          <div className="flex min-w-0 max-w-full shrink-0 items-center gap-1.5">{primaryContent}</div>
-          <span className="min-w-0 flex-1 truncate text-[12px] text-muted-foreground leading-4">
-            {item.description}
+      <div className={cn('flex min-w-0 items-center gap-1.5', hasDescription ? 'max-w-[40%] shrink-0' : 'flex-1')}>
+        {reserveIconSlot || item.icon ? (
+          <span className="flex shrink-0 items-center justify-center text-[13px] text-muted-foreground [&>svg:not([class*='text-'])]:text-muted-foreground [&>svg]:size-[1em]">
+            {item.icon}
           </span>
-        </div>
-      ) : (
-        <div className={cn('flex min-w-0 flex-1 items-center gap-1.5', contentClassName)}>{primaryContent}</div>
-      )}
-      {!hasInlineDescription || tooltipAnchor || suffixContent ? (
-        <div
-          className={cn(
-            'flex items-center justify-end gap-1 text-[12px] text-muted-foreground leading-4',
-            hasInlineDescription ? 'shrink-0' : 'min-w-[20%]'
-          )}>
-          {!hasInlineDescription && item.description ? (
-            <span className="overflow-hidden text-ellipsis whitespace-nowrap">{item.description}</span>
-          ) : null}
-          {tooltipAnchor}
-          {suffixContent ? (
-            <span className="flex min-w-3 shrink-0 items-center justify-end gap-[3px] [&>svg]:size-[1em] [&>svg]:text-muted-foreground">
-              {suffixContent}
-            </span>
-          ) : null}
-        </div>
-      ) : null}
+        ) : null}
+        <span className="min-w-0 flex-1 truncate text-[13px] leading-4">{item.label}</span>
+      </div>
+      <div
+        className={cn(
+          'flex min-w-0 items-center justify-end gap-1 text-[12px] text-muted-foreground leading-4',
+          hasDescription ? 'flex-1' : 'shrink-0'
+        )}>
+        {hasDescription ? <span className="min-w-0 flex-1 truncate text-right">{item.description}</span> : null}
+        {tooltipAnchor}
+        {suffixContent ? (
+          <span className="flex min-w-3 max-w-full shrink-0 items-center justify-end gap-[3px] truncate [&>svg]:size-[1em] [&>svg]:text-muted-foreground">
+            {suffixContent}
+          </span>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/src/renderer/components/QuickPanel/types.ts
+++ b/src/renderer/components/QuickPanel/types.ts
@@ -122,8 +122,6 @@ export type QuickPanelListItem = {
   id?: string
   label: React.ReactNode | string
   description?: React.ReactNode | string
-  /** Render the description immediately after the label instead of in the trailing metadata column. */
-  inlineDescription?: boolean
   tooltip?: React.ReactNode | string
   /** In-row element used as the controlled Tooltip trigger. */
   tooltipAnchor?: React.ReactElement

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -270,7 +270,6 @@ const createSkillQuickPanelItems = (
     id: agentComposerTokenId.skill(skill),
     label: skill.name,
     description: skill.description ?? undefined,
-    inlineDescription: true,
     icon: <ToolCase size={16} />,
     suffix: options.skillLabel,
     // Skills still exclude descriptions from root-panel search; the category alias powers the persistent shortcut.

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3082,7 +3082,6 @@ describe('AgentComposer', () => {
         id: 'skill:pdf',
         label: 'pdf',
         description: 'Read and analyze PDFs',
-        inlineDescription: true,
         suffix: 'plugins.skills',
         filterText: 'pdf'
       })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

QuickPanel rows used consumer-specific width overrides and an inline-description mode. Long descriptions could hide or squeeze command and skill names, while short descriptions could leave excessive empty space or appear inconsistently positioned.

<img width="1341" height="605" alt="image" src="https://github.com/user-attachments/assets/ea5bcf90-f8a4-4a40-bfc0-f1b24f9811eb" />

After this PR:

QuickPanel rows use one shared layout contract. Labels remain readable in a content-driven column capped at 40% when a description is present, descriptions use the remaining width and align to the right, and labels expand into the available space when no description exists.

<img width="1276" height="591" alt="image" src="https://github.com/user-attachments/assets/5b5cbd31-49d8-44da-95b0-d119a37b43d9" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None

### Why we need it and why it was done in this way

The row component owns the relationship between its primary label and secondary metadata, so the layout is enforced once for every QuickPanel consumer. The primary label does not shrink when a description is present, while the secondary description yields space through truncation.

The following tradeoffs were made:

- Labels are capped at 40% only when a description exists, preserving room for useful metadata.
- Both labels and descriptions truncate at extreme widths to keep each row on one line.

The following alternatives were considered:

- Keeping per-consumer width overrides was rejected because it produced inconsistent behavior between the slash panel and the composer plus-button panel.
- Keeping the skill-only inline-description mode was rejected because it duplicated layout behavior and made skill rows diverge from other QuickPanel rows.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Verification:

- `pnpm exec vitest run --project renderer src/renderer/components/QuickPanel/__tests__/row.test.tsx src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx` (131 tests passed)
- `pnpm typecheck:web`
- `pnpm exec biome check` on all six changed files
- `pnpm exec oxlint --deny-warnings` on all six changed files

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved QuickPanel rows so command and skill names remain readable while descriptions use the available trailing space.
```
