### PR TITLE
fix(right-pane): give the list its own width instead of the artifact pane's

### DIFF
--- a/src/renderer/components/chat/panes/Shell/RightPanel.tsx
+++ b/src/renderer/components/chat/panes/Shell/RightPanel.tsx
@@ -10,12 +10,7 @@ import type { ComponentProps, ComponentType, MouseEvent, ReactNode } from 'react
 import { Activity, createContext, use, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import {
-  ARTIFACT_RIGHT_PANE_CACHE_KEY,
-  ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH,
-  ARTIFACT_RIGHT_PANE_MAX_WIDTH,
-  ARTIFACT_RIGHT_PANE_MIN_WIDTH
-} from '../../shell/paneLayout'
+import { ARTIFACT_RIGHT_PANE_WIDTH_PROFILE, type RightPaneWidthProfile } from '../../shell/paneLayout'
 import { PersistentRightPaneHost, type RightPaneLayoutMode } from '../../shell/RightPaneHost'
 
 export type RightPanelReadiness = 'ready' | 'pending' | 'unavailable'
@@ -37,6 +32,8 @@ export interface RightPanelInstance {
   headerMode?: 'shell' | 'content'
   /** Whether this panel may enter maximized presentation. */
   canMaximize?: boolean
+  /** Width envelope + persisted width this panel wants; defaults to the artifact pane's. */
+  paneWidth?: RightPaneWidthProfile
 }
 
 /** Resolves one panel slot from domain-owned scope; null means the slot has no identity. */
@@ -59,6 +56,8 @@ interface ResolvedRightPanelEntry<TScope = unknown> extends RightPanelInstance {
 export interface RightPanelState {
   /** The ready panel selected for presentation; visibility is reported separately. */
   activePanelId?: string
+  /** Width envelope of the presented panel, so the host sizes it without knowing panel ids. */
+  activePaneWidth: RightPaneWidthProfile
   /** First ready entry, then first pending entry, then the first catalog entry. */
   defaultPanelId?: string
   /** Raw maximize intent, retained while environmental presentation is disabled. */
@@ -329,6 +328,7 @@ export function RightPanelProvider<TScope>({
   const state = useMemo<RightPanelState>(
     () => ({
       activePanelId: activeEntry?.id,
+      activePaneWidth: activeEntry?.paneWidth ?? ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
       defaultPanelId: defaultEntry?.id,
       maximized,
       presentationOpen,
@@ -344,6 +344,7 @@ export function RightPanelProvider<TScope>({
     }),
     [
       activeEntry?.id,
+      activeEntry?.paneWidth,
       defaultEntry?.id,
       fullWidthActive,
       isActive,
@@ -567,6 +568,7 @@ function RightPanelKeyboardShortcut() {
 export function RightPanelViewport({ children = <RightPanel /> }: { children?: ReactNode }) {
   const state = useRightPanelState()
   const actions = useRightPanelControllerActions()
+  const paneWidth = state.activePaneWidth
 
   return (
     <>
@@ -574,12 +576,10 @@ export function RightPanelViewport({ children = <RightPanel /> }: { children?: R
       <PersistentRightPaneHost
         open={state.presentationOpen}
         maximized={state.presentationMaximized}
-        width={ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH}
         resizable
-        minWidth={ARTIFACT_RIGHT_PANE_MIN_WIDTH}
-        defaultWidth={ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH}
-        maxWidth={ARTIFACT_RIGHT_PANE_MAX_WIDTH}
-        cacheKey={ARTIFACT_RIGHT_PANE_CACHE_KEY}
+        minWidth={paneWidth.minWidth}
+        maxWidth={paneWidth.maxWidth}
+        cacheKey={paneWidth.cacheKey}
         onLayoutAnimationComplete={actions.completeLayoutAnimation}
         onFullWidthPhaseChange={actions.reportFullWidthPhase}
         onResizingChange={actions.reportPaneResizing}

--- a/src/renderer/components/chat/panes/Shell/RightPanel.tsx
+++ b/src/renderer/components/chat/panes/Shell/RightPanel.tsx
@@ -10,7 +10,7 @@ import type { ComponentProps, ComponentType, MouseEvent, ReactNode } from 'react
 import { Activity, createContext, use, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ARTIFACT_RIGHT_PANE_WIDTH_PROFILE, type RightPaneWidthProfile } from '../../shell/paneLayout'
+import { getRightPaneWidthPolicy, type RightPaneWidthPolicy, type RightPaneWidthPreset } from '../../shell/paneLayout'
 import { PersistentRightPaneHost, type RightPaneLayoutMode } from '../../shell/RightPaneHost'
 
 export type RightPanelReadiness = 'ready' | 'pending' | 'unavailable'
@@ -32,14 +32,14 @@ export interface RightPanelInstance {
   headerMode?: 'shell' | 'content'
   /** Whether this panel may enter maximized presentation. */
   canMaximize?: boolean
-  /** Width envelope + persisted width this panel wants; defaults to the artifact pane's. */
-  paneWidth?: RightPaneWidthProfile
 }
 
 /** Resolves one panel slot from domain-owned scope; null means the slot has no identity. */
 export interface RightPanelCapability<TScope> {
   component: ComponentType<RightPanelComponentProps<TScope>>
   resolve: (scope: TScope) => RightPanelInstance | null
+  /** Which named width policy this panel sizes by; omitted means the inspector preset. */
+  widthPreset?: RightPaneWidthPreset
 }
 
 /** Shape every right-pane module exposes; apply with `satisfies` to keep component types precise. */
@@ -51,13 +51,14 @@ export interface RightPanelComposition {
 
 interface ResolvedRightPanelEntry<TScope = unknown> extends RightPanelInstance {
   component: ComponentType<RightPanelComponentProps<TScope>>
+  widthPreset?: RightPaneWidthPreset
 }
 
 export interface RightPanelState {
   /** The ready panel selected for presentation; visibility is reported separately. */
   activePanelId?: string
-  /** Width envelope of the presented panel, so the host sizes it without knowing panel ids. */
-  activePaneWidth: RightPaneWidthProfile
+  /** Width policy of the presented panel, so the host sizes it without knowing panel ids. */
+  activePaneWidth: RightPaneWidthPolicy
   /** First ready entry, then first pending entry, then the first catalog entry. */
   defaultPanelId?: string
   /** Raw maximize intent, retained while environmental presentation is disabled. */
@@ -129,7 +130,8 @@ function resolveRightPanelEntries<TScope>(
     panelIds.add(instance.id)
     entries.push({
       ...instance,
-      component: capability.component as ComponentType<RightPanelComponentProps<unknown>>
+      component: capability.component as ComponentType<RightPanelComponentProps<unknown>>,
+      widthPreset: capability.widthPreset
     })
   }
 
@@ -328,7 +330,7 @@ export function RightPanelProvider<TScope>({
   const state = useMemo<RightPanelState>(
     () => ({
       activePanelId: activeEntry?.id,
-      activePaneWidth: activeEntry?.paneWidth ?? ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
+      activePaneWidth: getRightPaneWidthPolicy(activeEntry?.widthPreset),
       defaultPanelId: defaultEntry?.id,
       maximized,
       presentationOpen,
@@ -344,7 +346,7 @@ export function RightPanelProvider<TScope>({
     }),
     [
       activeEntry?.id,
-      activeEntry?.paneWidth,
+      activeEntry?.widthPreset,
       defaultEntry?.id,
       fullWidthActive,
       isActive,

--- a/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
@@ -3,7 +3,7 @@ import type { ButtonHTMLAttributes, ErrorInfo, PropsWithChildren, ReactNode } fr
 import { Activity, useLayoutEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ARTIFACT_RIGHT_PANE_WIDTH_PROFILE, RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE } from '../../../shell/paneLayout'
+import { getRightPaneWidthPolicy } from '../../../shell/paneLayout'
 import { createResourcePaneCapability, type ResourcePaneConfig } from '../resourcePane'
 import {
   RightPanel,
@@ -19,6 +19,9 @@ import {
   useRightPanelPresentationMaximized,
   useRightPanelState
 } from '../RightPanel'
+
+const LIST_POLICY = getRightPaneWidthPolicy('navigation-list')
+const INSPECTOR_POLICY = getRightPaneWidthPolicy('inspector')
 
 const commandMock = vi.hoisted(() => ({ handler: undefined as (() => void) | undefined }))
 
@@ -162,12 +165,12 @@ const capabilities = [
   },
   {
     component: StatefulPanel,
+    widthPreset: 'navigation-list',
     resolve: (scope) => ({
       id: 'second',
       instanceKey: 'second',
       title: 'Second',
-      readiness: scope.secondReadiness,
-      paneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
+      readiness: scope.secondReadiness
     })
   }
 ] satisfies readonly RightPanelCapability<TestScope>[]
@@ -460,14 +463,14 @@ describe('RightPanel', () => {
     )
 
     const host = screen.getByTestId('right-pane-host')
-    expect(host).toHaveAttribute('data-cache-key', ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey)
-    expect(host).toHaveAttribute('data-max-width', String(ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
+    expect(host).toHaveAttribute('data-cache-key', INSPECTOR_POLICY.cacheKey)
+    expect(host).toHaveAttribute('data-max-width', String(INSPECTOR_POLICY.maxWidth))
 
     fireEvent.click(screen.getByRole('button', { name: 'open second' }))
 
-    expect(host).toHaveAttribute('data-cache-key', RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey)
-    expect(host).toHaveAttribute('data-max-width', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
-    expect(host).toHaveAttribute('data-min-width', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth))
+    expect(host).toHaveAttribute('data-cache-key', LIST_POLICY.cacheKey)
+    expect(host).toHaveAttribute('data-max-width', String(LIST_POLICY.maxWidth))
+    expect(host).toHaveAttribute('data-min-width', String(LIST_POLICY.minWidth))
   })
 
   it('rejects duplicate panel ids', () => {
@@ -485,11 +488,9 @@ describe('RightPanel', () => {
 })
 
 describe('createResourcePaneCapability', () => {
-  it("claims the list width envelope, so the list never inherits the artifact pane's", () => {
+  it('sizes by the navigation-list preset, so the list never inherits the inspector envelope', () => {
     const capability = createResourcePaneCapability<{ resourcePane: ResourcePaneConfig | null }>()
 
-    const entry = capability.resolve({ resourcePane: { node: null, label: 'Topics' } })
-
-    expect(entry?.paneWidth).toEqual(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE)
+    expect(capability.widthPreset).toBe('navigation-list')
   })
 })

--- a/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
@@ -3,6 +3,8 @@ import type { ButtonHTMLAttributes, ErrorInfo, PropsWithChildren, ReactNode } fr
 import { Activity, useLayoutEffect, useState } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ARTIFACT_RIGHT_PANE_WIDTH_PROFILE, RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE } from '../../../shell/paneLayout'
+import { createResourcePaneCapability, type ResourcePaneConfig } from '../resourcePane'
 import {
   RightPanel,
   type RightPanelCapability,
@@ -84,12 +86,18 @@ vi.mock('../../../shell/RightPaneHost', () => ({
   // Mirrors the host's phase reporting: it enters the full-width phase with the click and only
   // leaves it once the box has settled, which is what "settle pane" stands in for.
   PersistentRightPaneHost: ({
+    cacheKey,
     children,
     maximized,
+    maxWidth,
+    minWidth,
     open,
     onFullWidthPhaseChange
   }: PropsWithChildren<{
+    cacheKey?: string
     maximized?: boolean
+    maxWidth?: number
+    minWidth?: number
     open: boolean
     onFullWidthPhaseChange?: (active: boolean) => void
   }>) => {
@@ -98,7 +106,13 @@ vi.mock('../../../shell/RightPaneHost', () => ({
     }, [maximized, onFullWidthPhaseChange])
 
     return (
-      <div data-testid="right-pane-host" data-maximized={String(Boolean(maximized))} data-open={String(open)}>
+      <div
+        data-testid="right-pane-host"
+        data-cache-key={cacheKey}
+        data-maximized={String(Boolean(maximized))}
+        data-max-width={maxWidth}
+        data-min-width={minWidth}
+        data-open={String(open)}>
         <button type="button" onClick={() => onFullWidthPhaseChange?.(false)}>
           settle pane
         </button>
@@ -152,7 +166,8 @@ const capabilities = [
       id: 'second',
       instanceKey: 'second',
       title: 'Second',
-      readiness: scope.secondReadiness
+      readiness: scope.secondReadiness,
+      paneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
     })
   }
 ] satisfies readonly RightPanelCapability<TestScope>[]
@@ -435,6 +450,26 @@ describe('RightPanel', () => {
     consoleError.mockRestore()
   })
 
+  it('sizes the pane from the presented panel, so a list and an artifact never share a width', () => {
+    render(
+      <Harness defaultOpen>
+        <RightPanelViewport>
+          <RightPanel />
+        </RightPanelViewport>
+      </Harness>
+    )
+
+    const host = screen.getByTestId('right-pane-host')
+    expect(host).toHaveAttribute('data-cache-key', ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey)
+    expect(host).toHaveAttribute('data-max-width', String(ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
+
+    fireEvent.click(screen.getByRole('button', { name: 'open second' }))
+
+    expect(host).toHaveAttribute('data-cache-key', RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey)
+    expect(host).toHaveAttribute('data-max-width', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
+    expect(host).toHaveAttribute('data-min-width', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth))
+  })
+
   it('rejects duplicate panel ids', () => {
     const duplicateCapabilities = [capabilities[0], capabilities[0]]
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -446,5 +481,15 @@ describe('RightPanel', () => {
         </RightPanelProvider>
       )
     ).toThrow('Duplicate right-panel id: first')
+  })
+})
+
+describe('createResourcePaneCapability', () => {
+  it("claims the list width envelope, so the list never inherits the artifact pane's", () => {
+    const capability = createResourcePaneCapability<{ resourcePane: ResourcePaneConfig | null }>()
+
+    const entry = capability.resolve({ resourcePane: { node: null, label: 'Topics' } })
+
+    expect(entry?.paneWidth).toEqual(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE)
   })
 })

--- a/src/renderer/components/chat/panes/Shell/resourcePane.tsx
+++ b/src/renderer/components/chat/panes/Shell/resourcePane.tsx
@@ -1,7 +1,6 @@
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
 import { type ReactNode, useEffect, useRef } from 'react'
 
-import { RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE } from '../../shell/paneLayout'
 import { type RightPanelCapability, type RightPanelComponentProps, useRightPanelActions } from './RightPanel'
 
 // ── Resource-list-as-right-pane wiring ──────────────────────────────────────
@@ -36,12 +35,12 @@ export function createResourcePaneCapability<TScope extends ResourcePaneCapabili
 } = {}): RightPanelCapability<TScope> {
   return {
     component: ResourcePaneRightPanel,
+    widthPreset: 'navigation-list',
     resolve: (scope) => ({
       id: RESOURCE_PANE_TAB,
       instanceKey,
       title: scope.resourcePane?.label ?? '',
-      readiness: scope.resourcePane ? 'ready' : 'unavailable',
-      paneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
+      readiness: scope.resourcePane ? 'ready' : 'unavailable'
     })
   }
 }

--- a/src/renderer/components/chat/panes/Shell/resourcePane.tsx
+++ b/src/renderer/components/chat/panes/Shell/resourcePane.tsx
@@ -1,6 +1,7 @@
 import type { ResourceListRevealRequest } from '@renderer/components/chat/resourceList/base'
 import { type ReactNode, useEffect, useRef } from 'react'
 
+import { RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE } from '../../shell/paneLayout'
 import { type RightPanelCapability, type RightPanelComponentProps, useRightPanelActions } from './RightPanel'
 
 // ── Resource-list-as-right-pane wiring ──────────────────────────────────────
@@ -39,7 +40,8 @@ export function createResourcePaneCapability<TScope extends ResourcePaneCapabili
       id: RESOURCE_PANE_TAB,
       instanceKey,
       title: scope.resourcePane?.label ?? '',
-      readiness: scope.resourcePane ? 'ready' : 'unavailable'
+      readiness: scope.resourcePane ? 'ready' : 'unavailable',
+      paneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
     })
   }
 }

--- a/src/renderer/components/chat/shell/ChatAppShell.tsx
+++ b/src/renderer/components/chat/shell/ChatAppShell.tsx
@@ -10,10 +10,10 @@ import { useOptionalRightPanelState, useRightPanelComposerElevated } from '../pa
 import { OverlayHost } from './OverlayHost'
 import { PageSidebar } from './PageSidebar'
 import {
-  ARTIFACT_RIGHT_PANE_MAX_WIDTH,
-  ARTIFACT_RIGHT_PANE_MIN_WIDTH,
+  ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
   CHAT_SHELL_TRANSITION,
-  type ChatPanePosition
+  type ChatPanePosition,
+  type RightPaneWidthProfile
 } from './paneLayout'
 import { evaluateAutoCollapse, predictCenterWidth } from './paneWidthPolicy'
 import { RightPaneHost } from './RightPaneHost'
@@ -57,8 +57,8 @@ export type ChatAppShellProps = ChatAppShellMainProps | ChatAppShellCenterConten
 
 const MANUAL_EXPAND_RELEASE_NARROWING = 8
 
-function clampPaneStoredWidth(width: number): number {
-  return Math.min(ARTIFACT_RIGHT_PANE_MAX_WIDTH, Math.max(ARTIFACT_RIGHT_PANE_MIN_WIDTH, Math.round(width)))
+function clampPaneStoredWidth(width: number, { minWidth, maxWidth }: RightPaneWidthProfile): number {
+  return Math.min(maxWidth, Math.max(minWidth, Math.round(width)))
 }
 
 /**
@@ -91,7 +91,10 @@ function useResourceListAutoCollapse({
 }) {
   const rightPanelState = useOptionalRightPanelState()
   const [storedListWidth] = usePersistCache('ui.chat.sidebar.width')
-  const [storedPaneWidth] = usePersistCache('ui.chat.artifact_pane.width')
+  // The prediction must size the pane that is actually presented; a list and an artifact
+  // have different widths, and reading the wrong one strands the list collapsed.
+  const paneProfile = rightPanelState?.activePaneWidth ?? ARTIFACT_RIGHT_PANE_WIDTH_PROFILE
+  const [storedPaneWidth] = usePersistCache(paneProfile.cacheKey)
 
   const dockedPaneOpen = Boolean(rightPanelState?.presentationOpen && !rightPanelState.presentationMaximized)
   // `fullWidthActive` is host-reported one commit late; `presentationMaximized` and
@@ -120,14 +123,15 @@ function useResourceListAutoCollapse({
   const leftPaneOpenRef = useRef(leftPaneOpen)
   const frozenRef = useRef(frozen)
   const dockedPaneOpenRef = useRef(dockedPaneOpen)
-  const widthsRef = useRef({ listWidth: 0, paneWidth: 0 })
+  const widthsRef = useRef({ listWidth: 0, paneWidth: 0, paneMin: 0 })
   const onChangeRef = useRef(onPaneAutoCollapseChange)
   leftPaneOpenRef.current = leftPaneOpen
   frozenRef.current = frozen
   dockedPaneOpenRef.current = dockedPaneOpen
   widthsRef.current = {
     listWidth: clampResourceListPaneWidth(storedListWidth ?? 0),
-    paneWidth: clampPaneStoredWidth(storedPaneWidth ?? 0)
+    paneWidth: clampPaneStoredWidth(storedPaneWidth ?? 0, paneProfile),
+    paneMin: paneProfile.minWidth
   }
   useEffect(() => {
     onChangeRef.current = onPaneAutoCollapseChange
@@ -153,7 +157,8 @@ function useResourceListAutoCollapse({
         shellWidth,
         listWidth: widthsRef.current.listWidth,
         paneOpen: dockedPaneOpenRef.current,
-        paneWidth: widthsRef.current.paneWidth
+        paneWidth: widthsRef.current.paneWidth,
+        paneMin: widthsRef.current.paneMin
       })
       let next = evaluateAutoCollapse(predictedCenter, collapsedRef.current)
       // Never newly collapse a list the user is not showing; releasing stays allowed.

--- a/src/renderer/components/chat/shell/ChatAppShell.tsx
+++ b/src/renderer/components/chat/shell/ChatAppShell.tsx
@@ -10,10 +10,10 @@ import { useOptionalRightPanelState, useRightPanelComposerElevated } from '../pa
 import { OverlayHost } from './OverlayHost'
 import { PageSidebar } from './PageSidebar'
 import {
-  ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
   CHAT_SHELL_TRANSITION,
   type ChatPanePosition,
-  type RightPaneWidthProfile
+  getRightPaneWidthPolicy,
+  type RightPaneWidthPolicy
 } from './paneLayout'
 import { evaluateAutoCollapse, predictCenterWidth } from './paneWidthPolicy'
 import { RightPaneHost } from './RightPaneHost'
@@ -57,7 +57,7 @@ export type ChatAppShellProps = ChatAppShellMainProps | ChatAppShellCenterConten
 
 const MANUAL_EXPAND_RELEASE_NARROWING = 8
 
-function clampPaneStoredWidth(width: number, { minWidth, maxWidth }: RightPaneWidthProfile): number {
+function clampPaneStoredWidth(width: number, { minWidth, maxWidth }: RightPaneWidthPolicy): number {
   return Math.min(maxWidth, Math.max(minWidth, Math.round(width)))
 }
 
@@ -93,7 +93,7 @@ function useResourceListAutoCollapse({
   const [storedListWidth] = usePersistCache('ui.chat.sidebar.width')
   // The prediction must size the pane that is actually presented; a list and an artifact
   // have different widths, and reading the wrong one strands the list collapsed.
-  const paneProfile = rightPanelState?.activePaneWidth ?? ARTIFACT_RIGHT_PANE_WIDTH_PROFILE
+  const paneProfile = rightPanelState?.activePaneWidth ?? getRightPaneWidthPolicy()
   const [storedPaneWidth] = usePersistCache(paneProfile.cacheKey)
 
   const dockedPaneOpen = Boolean(rightPanelState?.presentationOpen && !rightPanelState.presentationMaximized)
@@ -213,10 +213,11 @@ function useResourceListAutoCollapse({
   }, [evaluate, userOpenSeq])
 
   // Persisted widths are live inputs (either side can be dragged); drag exemption
-  // rides on `frozen`, so mid-drag updates defer to the release evaluation.
+  // rides on `frozen`, so mid-drag updates defer to the release evaluation. The pane's floor
+  // is an input too: presets can hold equal widths, and then only the floor moves the verdict.
   useLayoutEffect(() => {
     evaluate()
-  }, [evaluate, storedListWidth, storedPaneWidth])
+  }, [evaluate, storedListWidth, storedPaneWidth, paneProfile.minWidth])
 
   // Unfreeze → evaluate once (hard-blocked by suppression like every deferred pass).
   useLayoutEffect(() => {

--- a/src/renderer/components/chat/shell/RightPaneHost.tsx
+++ b/src/renderer/components/chat/shell/RightPaneHost.tsx
@@ -7,6 +7,7 @@ import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode, RefObject
 import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import type { RESOURCE_LIST_RIGHT_PANE_CACHE_KEY } from './paneLayout'
 import {
   ARTIFACT_RIGHT_PANE_CACHE_KEY,
   ARTIFACT_RIGHT_PANE_CLOSE_DRAG_OVERSHOOT,
@@ -35,7 +36,7 @@ import { getVerticalSplitterProps } from './splitterA11y'
 
 export type { RightPaneLayoutMode } from './rightPaneTransition'
 
-type RightPaneResizeCacheKey = typeof ARTIFACT_RIGHT_PANE_CACHE_KEY
+type RightPaneResizeCacheKey = typeof ARTIFACT_RIGHT_PANE_CACHE_KEY | typeof RESOURCE_LIST_RIGHT_PANE_CACHE_KEY
 
 interface RightPaneFrameProps {
   children?: ReactNode
@@ -407,20 +408,20 @@ export function PersistentRightPaneHost({
   })
   const mainRegionWidth = useMainRegionWidth(paneRef)
   useLayoutEffect(() => {
-    spaceCapRef.current = mainRegionWidth === null ? null : getPaneSpaceCap(mainRegionWidth)
-  }, [mainRegionWidth])
+    spaceCapRef.current = mainRegionWidth === null ? null : getPaneSpaceCap(mainRegionWidth, minWidth)
+  }, [mainRegionWidth, minWidth])
   const resolvedWidth = resizable ? paneWidth : width
   // One expression drives both the pane and its spacer; diverging them would let the
   // pane paint wider than the reserved space and overlap the center.
-  const dockedWidthExpression = buildDockedPaneWidthExpression(resolvedWidth)
+  const dockedWidthExpression = buildDockedPaneWidthExpression(resolvedWidth, minWidth)
   const effectiveWidth =
     mainRegionWidth === null || typeof resolvedWidth !== 'number'
       ? paneWidth
-      : Math.round(resolveDockedPaneWidth(mainRegionWidth, resolvedWidth))
+      : Math.round(resolveDockedPaneWidth(mainRegionWidth, resolvedWidth, minWidth))
   const splitterMinWidth =
-    mainRegionWidth === null ? minWidth : Math.round(resolveDockedPaneWidth(mainRegionWidth, minWidth))
+    mainRegionWidth === null ? minWidth : Math.round(resolveDockedPaneWidth(mainRegionWidth, minWidth, minWidth))
   const splitterMaxWidth =
-    mainRegionWidth === null ? maxWidth : Math.round(resolveDockedPaneWidth(mainRegionWidth, maxWidth))
+    mainRegionWidth === null ? maxWidth : Math.round(resolveDockedPaneWidth(mainRegionWidth, maxWidth, minWidth))
   const hasChildren = children !== null && children !== undefined
   const targetMode: RightPaneLayoutMode = !open || !hasChildren ? 'closed' : maximized ? 'maximized' : 'docked'
   const [visualState, setVisualStateState] = useState<PersistentRightPaneVisualState>(() =>

--- a/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
@@ -11,7 +11,9 @@ import {
   RESOURCE_LIST_PANE_COLLAPSE_DRAG_THRESHOLD,
   RESOURCE_LIST_PANE_DEFAULT_WIDTH,
   RESOURCE_LIST_PANE_MAX_WIDTH,
-  RESOURCE_LIST_PANE_MIN_WIDTH
+  RESOURCE_LIST_PANE_MIN_WIDTH,
+  RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE,
+  type RightPaneWidthProfile
 } from '../paneLayout'
 
 const originalResizeObserver = globalThis.ResizeObserver
@@ -25,7 +27,7 @@ interface ResizeObserverMockInstance {
 const resizeObserverMockInstances: ResizeObserverMockInstance[] = []
 
 const persistCacheMock = vi.hoisted(() => {
-  const state = { width: 240, paneWidth: 460 }
+  const state = { width: 240, paneWidth: 460, listPaneWidth: 275 }
 
   return {
     state,
@@ -34,6 +36,9 @@ const persistCacheMock = vi.hoisted(() => {
     }),
     setPaneWidth: vi.fn((width: number) => {
       state.paneWidth = width
+    }),
+    setListPaneWidth: vi.fn((width: number) => {
+      state.listPaneWidth = width
     })
   }
 })
@@ -45,6 +50,7 @@ interface RightPanelStateMockValue {
   fullWidthActive?: boolean
   paneResizing?: boolean
   userOpenSeq?: number
+  activePaneWidth?: RightPaneWidthProfile
 }
 
 const composerElevatedMock = vi.hoisted(() => ({ current: false }))
@@ -57,11 +63,12 @@ vi.mock('@renderer/utils/style', () => ({
 }))
 
 vi.mock('@data/hooks/useCache', () => ({
-  usePersistCache: vi.fn((key: string) =>
-    key === 'ui.chat.artifact_pane.width'
-      ? [persistCacheMock.state.paneWidth, persistCacheMock.setPaneWidth]
-      : [persistCacheMock.state.width, persistCacheMock.setWidth]
-  )
+  usePersistCache: vi.fn((key: string) => {
+    if (key === 'ui.chat.artifact_pane.width') return [persistCacheMock.state.paneWidth, persistCacheMock.setPaneWidth]
+    if (key === 'ui.chat.resource_pane.width')
+      return [persistCacheMock.state.listPaneWidth, persistCacheMock.setListPaneWidth]
+    return [persistCacheMock.state.width, persistCacheMock.setWidth]
+  })
 }))
 
 vi.mock('@renderer/components/ErrorBoundary', () => ({
@@ -132,8 +139,10 @@ describe('ChatAppShell', () => {
   afterEach(() => {
     persistCacheMock.state.width = RESOURCE_LIST_PANE_DEFAULT_WIDTH
     persistCacheMock.state.paneWidth = 460
+    persistCacheMock.state.listPaneWidth = 275
     persistCacheMock.setWidth.mockClear()
     persistCacheMock.setPaneWidth.mockClear()
+    persistCacheMock.setListPaneWidth.mockClear()
     document.body.style.cursor = ''
     document.body.style.userSelect = ''
     document.documentElement.style.removeProperty('--assistants-width')
@@ -530,6 +539,38 @@ describe('ChatAppShell', () => {
 
     expect(onPaneAutoCollapseChange).toHaveBeenCalledTimes(1)
     expect(onPaneAutoCollapseChange).toHaveBeenCalledWith(true)
+  })
+
+  it('predicts the center from the presented panel, so a stale artifact width cannot strand the list', () => {
+    const onPaneAutoCollapseChange = vi.fn()
+    // The artifact pane was dragged wide once; the list actually on screen is only 275.
+    persistCacheMock.state.paneWidth = 720
+    persistCacheMock.state.listPaneWidth = 275
+    rightPanelStateMock.current = {
+      layoutAnimationPending: false,
+      presentationMaximized: false,
+      presentationOpen: true,
+      activePaneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
+    }
+
+    render(
+      <ChatAppShell
+        pane={<aside>topics</aside>}
+        paneOpen
+        onPaneAutoCollapseChange={onPaneAutoCollapseChange}
+        main={<div />}
+      />
+    )
+
+    notifyObservedShellWidth(500)
+    expect(onPaneAutoCollapseChange).toHaveBeenLastCalledWith(true)
+
+    // available = 940 - 240 = 700. With the list's own 275 the center is 425 and the list
+    // must come back; reading the artifact's width instead yields exactly 360 — inside the
+    // hysteresis band — and the list would stay collapsed forever.
+    notifyObservedShellWidth(940)
+
+    expect(onPaneAutoCollapseChange).toHaveBeenLastCalledWith(false)
   })
 
   it('ignores zero-width shell measurements', () => {

--- a/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/ChatAppShell.test.tsx
@@ -8,12 +8,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ChatAppShell } from '../ChatAppShell'
 import {
+  getRightPaneWidthPolicy,
   RESOURCE_LIST_PANE_COLLAPSE_DRAG_THRESHOLD,
   RESOURCE_LIST_PANE_DEFAULT_WIDTH,
   RESOURCE_LIST_PANE_MAX_WIDTH,
   RESOURCE_LIST_PANE_MIN_WIDTH,
-  RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE,
-  type RightPaneWidthProfile
+  type RightPaneWidthPolicy
 } from '../paneLayout'
 
 const originalResizeObserver = globalThis.ResizeObserver
@@ -50,7 +50,7 @@ interface RightPanelStateMockValue {
   fullWidthActive?: boolean
   paneResizing?: boolean
   userOpenSeq?: number
-  activePaneWidth?: RightPaneWidthProfile
+  activePaneWidth?: RightPaneWidthPolicy
 }
 
 const composerElevatedMock = vi.hoisted(() => ({ current: false }))
@@ -550,7 +550,7 @@ describe('ChatAppShell', () => {
       layoutAnimationPending: false,
       presentationMaximized: false,
       presentationOpen: true,
-      activePaneWidth: RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
+      activePaneWidth: getRightPaneWidthPolicy('navigation-list')
     }
 
     render(
@@ -571,6 +571,42 @@ describe('ChatAppShell', () => {
     notifyObservedShellWidth(940)
 
     expect(onPaneAutoCollapseChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('re-evaluates when the preset changes even though the stored width did not', () => {
+    const onPaneAutoCollapseChange = vi.fn()
+    // Both presets happen to hold 275, so only the floor (200 vs 255) separates the verdicts.
+    persistCacheMock.state.paneWidth = 275
+    persistCacheMock.state.listPaneWidth = 275
+    const baseState = { layoutAnimationPending: false, presentationMaximized: false, presentationOpen: true }
+    rightPanelStateMock.current = { ...baseState, activePaneWidth: getRightPaneWidthPolicy('navigation-list') }
+
+    const { rerender } = render(
+      <ChatAppShell
+        pane={<aside>topics</aside>}
+        paneOpen
+        onPaneAutoCollapseChange={onPaneAutoCollapseChange}
+        main={<div />}
+      />
+    )
+
+    // available = 840 - 240 = 600. The list floor of 200 leaves a 360 center: expanded.
+    notifyObservedShellWidth(840)
+    expect(onPaneAutoCollapseChange).not.toHaveBeenLastCalledWith(true)
+
+    // Switching to the inspector preset raises the floor to 255, squeezing the center to 345.
+    // Keying the evaluation off the stored width alone would miss this: the number is unchanged.
+    rightPanelStateMock.current = { ...baseState, activePaneWidth: getRightPaneWidthPolicy('inspector') }
+    rerender(
+      <ChatAppShell
+        pane={<aside>topics</aside>}
+        paneOpen
+        onPaneAutoCollapseChange={onPaneAutoCollapseChange}
+        main={<div />}
+      />
+    )
+
+    expect(onPaneAutoCollapseChange).toHaveBeenLastCalledWith(true)
   })
 
   it('ignores zero-width shell measurements', () => {

--- a/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
@@ -8,17 +8,22 @@ import {
   ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH,
   ARTIFACT_RIGHT_PANE_MAX_WIDTH,
   ARTIFACT_RIGHT_PANE_MIN_WIDTH,
-  CHAT_CENTER_MIN_USABLE_WIDTH
+  ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
+  CHAT_CENTER_MIN_USABLE_WIDTH,
+  RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
 } from '../paneLayout'
 import { PersistentRightPaneHost, RightPaneHost } from '../RightPaneHost'
 
 const persistCacheMock = vi.hoisted(() => {
-  const state = { width: 280 }
+  const state = { width: 280, byKey: {} as Record<string, number> }
 
   return {
     state,
     setWidth: vi.fn((width: number) => {
       state.width = width
+    }),
+    setByKey: vi.fn((key: string, width: number) => {
+      state.byKey[key] = width
     })
   }
 })
@@ -41,7 +46,13 @@ vi.mock('@renderer/components/ErrorBoundary', () => ({
 }))
 
 vi.mock('@data/hooks/useCache', () => ({
-  usePersistCache: vi.fn(() => [persistCacheMock.state.width, persistCacheMock.setWidth])
+  usePersistCache: vi.fn((key: string) => [
+    persistCacheMock.state.byKey[key] ?? persistCacheMock.state.width,
+    (width: number) => {
+      persistCacheMock.setByKey(key, width)
+      persistCacheMock.setWidth(width)
+    }
+  ])
 }))
 
 type MotionDivProps = HTMLAttributes<HTMLDivElement> & {
@@ -210,7 +221,9 @@ describe('RightPaneHost', () => {
     restoreResizeObserver?.()
     restoreResizeObserver = null
     persistCacheMock.state.width = ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH
+    persistCacheMock.state.byKey = {}
     persistCacheMock.setWidth.mockClear()
+    persistCacheMock.setByKey.mockClear()
     document.body.style.cursor = ''
     document.body.style.userSelect = ''
     vi.restoreAllMocks()
@@ -321,6 +334,87 @@ describe('RightPaneHost', () => {
     fireEvent.keyDown(handle as HTMLElement, { key: 'ArrowRight' })
 
     expect(persistCacheMock.setWidth).not.toHaveBeenCalled()
+  })
+
+  it('persists a list pane under its own key and lets it reach the list floor', () => {
+    mockMainRegionWidth(900)
+    persistCacheMock.state.byKey[RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 275
+    persistCacheMock.state.byKey[ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 460
+    const { container } = render(
+      <div data-main-region>
+        <PersistentRightPaneHost
+          open
+          resizable
+          minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
+          maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
+          cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+          <div>list pane</div>
+        </PersistentRightPaneHost>
+      </div>
+    )
+
+    const handle = container.querySelector('[data-right-pane-resize-handle]')
+    if (!handle) throw new Error('Expected resize handle')
+
+    // The artifact pane's 255 floor must not leak in: the list reports (and reaches) its own 200.
+    expect(handle).toHaveAttribute('aria-valuemin', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth))
+    expect(handle).toHaveAttribute('aria-valuemax', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
+
+    fireEvent.keyDown(handle, { key: 'Home' })
+
+    expect(persistCacheMock.setByKey).toHaveBeenCalledWith(
+      RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey,
+      RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth
+    )
+    expect(persistCacheMock.state.byKey[ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey]).toBe(460)
+  })
+
+  it('builds the list pane spacer expression from the list floor', () => {
+    const { container } = render(
+      <PersistentRightPaneHost
+        open
+        resizable
+        width={275}
+        minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
+        maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
+        cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+        <div>list pane</div>
+      </PersistentRightPaneHost>
+    )
+
+    // The reserved space must yield to the list's own 200 floor; leaving the artifact's 255
+    // here would let the pane paint wider than the space reserved for it and cover the center.
+    expect(container.querySelector('[data-right-pane-spacer]')).toHaveStyle({
+      maxWidth: 'max(min(280px, calc(100% - 360px)), min(200px, calc(100% * 200 / 400)))'
+    })
+  })
+
+  it('pins a list pane at its own floor in a narrow main region', () => {
+    mockMainRegionWidth(500)
+    persistCacheMock.state.byKey[RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 275
+    const { container } = render(
+      <div data-main-region>
+        <PersistentRightPaneHost
+          open
+          resizable
+          minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
+          maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
+          cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+          <div>list pane</div>
+        </PersistentRightPaneHost>
+      </div>
+    )
+
+    const handle = container.querySelector('[data-right-pane-resize-handle]')
+    if (!handle) throw new Error('Expected resize handle')
+
+    // 500 - 360 leaves less than the floor, so 200 is all the pane can show or reach.
+    expect(handle).toHaveAttribute('aria-valuemax', '200')
+
+    fireEvent.keyDown(handle, { key: 'Home' })
+    fireEvent.keyDown(handle, { key: 'End' })
+
+    expect(persistCacheMock.setByKey).not.toHaveBeenCalled()
   })
 
   it('limits the splitter maximum and End key to the currently reachable width', () => {

--- a/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/RightPaneHost.test.tsx
@@ -8,9 +8,8 @@ import {
   ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH,
   ARTIFACT_RIGHT_PANE_MAX_WIDTH,
   ARTIFACT_RIGHT_PANE_MIN_WIDTH,
-  ARTIFACT_RIGHT_PANE_WIDTH_PROFILE,
   CHAT_CENTER_MIN_USABLE_WIDTH,
-  RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE
+  getRightPaneWidthPolicy
 } from '../paneLayout'
 import { PersistentRightPaneHost, RightPaneHost } from '../RightPaneHost'
 
@@ -85,6 +84,9 @@ vi.mock('motion/react', () => ({
   useAnimationControls: () => motionTestState.controls,
   useReducedMotion: () => motionTestState.reducedMotion
 }))
+
+const LIST_POLICY = getRightPaneWidthPolicy('navigation-list')
+const INSPECTOR_POLICY = getRightPaneWidthPolicy('inspector')
 
 function mockMainRegionWidth(width: number) {
   vi.spyOn(HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(function (this: HTMLElement) {
@@ -338,16 +340,16 @@ describe('RightPaneHost', () => {
 
   it('persists a list pane under its own key and lets it reach the list floor', () => {
     mockMainRegionWidth(900)
-    persistCacheMock.state.byKey[RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 275
-    persistCacheMock.state.byKey[ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 460
+    persistCacheMock.state.byKey[LIST_POLICY.cacheKey] = 275
+    persistCacheMock.state.byKey[INSPECTOR_POLICY.cacheKey] = 460
     const { container } = render(
       <div data-main-region>
         <PersistentRightPaneHost
           open
           resizable
-          minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
-          maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
-          cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+          minWidth={LIST_POLICY.minWidth}
+          maxWidth={LIST_POLICY.maxWidth}
+          cacheKey={LIST_POLICY.cacheKey}>
           <div>list pane</div>
         </PersistentRightPaneHost>
       </div>
@@ -357,16 +359,13 @@ describe('RightPaneHost', () => {
     if (!handle) throw new Error('Expected resize handle')
 
     // The artifact pane's 255 floor must not leak in: the list reports (and reaches) its own 200.
-    expect(handle).toHaveAttribute('aria-valuemin', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth))
-    expect(handle).toHaveAttribute('aria-valuemax', String(RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth))
+    expect(handle).toHaveAttribute('aria-valuemin', String(LIST_POLICY.minWidth))
+    expect(handle).toHaveAttribute('aria-valuemax', String(LIST_POLICY.maxWidth))
 
     fireEvent.keyDown(handle, { key: 'Home' })
 
-    expect(persistCacheMock.setByKey).toHaveBeenCalledWith(
-      RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey,
-      RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth
-    )
-    expect(persistCacheMock.state.byKey[ARTIFACT_RIGHT_PANE_WIDTH_PROFILE.cacheKey]).toBe(460)
+    expect(persistCacheMock.setByKey).toHaveBeenCalledWith(LIST_POLICY.cacheKey, LIST_POLICY.minWidth)
+    expect(persistCacheMock.state.byKey[INSPECTOR_POLICY.cacheKey]).toBe(460)
   })
 
   it('builds the list pane spacer expression from the list floor', () => {
@@ -375,9 +374,9 @@ describe('RightPaneHost', () => {
         open
         resizable
         width={275}
-        minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
-        maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
-        cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+        minWidth={LIST_POLICY.minWidth}
+        maxWidth={LIST_POLICY.maxWidth}
+        cacheKey={LIST_POLICY.cacheKey}>
         <div>list pane</div>
       </PersistentRightPaneHost>
     )
@@ -391,15 +390,15 @@ describe('RightPaneHost', () => {
 
   it('pins a list pane at its own floor in a narrow main region', () => {
     mockMainRegionWidth(500)
-    persistCacheMock.state.byKey[RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey] = 275
+    persistCacheMock.state.byKey[LIST_POLICY.cacheKey] = 275
     const { container } = render(
       <div data-main-region>
         <PersistentRightPaneHost
           open
           resizable
-          minWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.minWidth}
-          maxWidth={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.maxWidth}
-          cacheKey={RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE.cacheKey}>
+          minWidth={LIST_POLICY.minWidth}
+          maxWidth={LIST_POLICY.maxWidth}
+          cacheKey={LIST_POLICY.cacheKey}>
           <div>list pane</div>
         </PersistentRightPaneHost>
       </div>

--- a/src/renderer/components/chat/shell/paneLayout.ts
+++ b/src/renderer/components/chat/shell/paneLayout.ts
@@ -21,3 +21,27 @@ export const ARTIFACT_RIGHT_PANE_CLOSE_DRAG_OVERSHOOT = 80
 export const ARTIFACT_RIGHT_PANE_DEFAULT_WIDTH = 280
 export const ARTIFACT_RIGHT_PANE_MAX_WIDTH = 720
 export const ARTIFACT_RIGHT_PANE_CACHE_KEY = 'ui.chat.artifact_pane.width'
+
+/**
+ * The topic/session list borrows the right pane but is a list, not an artifact: it keeps the left
+ * list's width envelope and its own persisted width, so dragging one never resizes the other.
+ */
+export const RESOURCE_LIST_RIGHT_PANE_CACHE_KEY = 'ui.chat.resource_pane.width'
+
+export type RightPaneWidthProfile = {
+  cacheKey: typeof ARTIFACT_RIGHT_PANE_CACHE_KEY | typeof RESOURCE_LIST_RIGHT_PANE_CACHE_KEY
+  minWidth: number
+  maxWidth: number
+}
+
+export const ARTIFACT_RIGHT_PANE_WIDTH_PROFILE = {
+  cacheKey: ARTIFACT_RIGHT_PANE_CACHE_KEY,
+  minWidth: ARTIFACT_RIGHT_PANE_MIN_WIDTH,
+  maxWidth: ARTIFACT_RIGHT_PANE_MAX_WIDTH
+} as const satisfies RightPaneWidthProfile
+
+export const RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE = {
+  cacheKey: RESOURCE_LIST_RIGHT_PANE_CACHE_KEY,
+  minWidth: RESOURCE_LIST_PANE_MIN_WIDTH,
+  maxWidth: RESOURCE_LIST_PANE_MAX_WIDTH
+} as const satisfies RightPaneWidthProfile

--- a/src/renderer/components/chat/shell/paneLayout.ts
+++ b/src/renderer/components/chat/shell/paneLayout.ts
@@ -28,20 +28,38 @@ export const ARTIFACT_RIGHT_PANE_CACHE_KEY = 'ui.chat.artifact_pane.width'
  */
 export const RESOURCE_LIST_RIGHT_PANE_CACHE_KEY = 'ui.chat.resource_pane.width'
 
-export type RightPaneWidthProfile = {
+/**
+ * Named width policies for the shared right pane. Panels pick a preset by name; the envelope
+ * and the persisted key behind each name are owned here, so width policy never becomes
+ * per-panel configuration.
+ *
+ * - `inspector` — artifacts, branches, traces: content sized for reading, its own wide envelope.
+ * - `navigation-list` — the topic/session list: a list, so it mirrors the left list's envelope
+ *   and keeps a separate persisted width; dragging one never resizes the other.
+ */
+export type RightPaneWidthPreset = 'inspector' | 'navigation-list'
+
+export type RightPaneWidthPolicy = {
   cacheKey: typeof ARTIFACT_RIGHT_PANE_CACHE_KEY | typeof RESOURCE_LIST_RIGHT_PANE_CACHE_KEY
   minWidth: number
   maxWidth: number
 }
 
-export const ARTIFACT_RIGHT_PANE_WIDTH_PROFILE = {
-  cacheKey: ARTIFACT_RIGHT_PANE_CACHE_KEY,
-  minWidth: ARTIFACT_RIGHT_PANE_MIN_WIDTH,
-  maxWidth: ARTIFACT_RIGHT_PANE_MAX_WIDTH
-} as const satisfies RightPaneWidthProfile
+const RIGHT_PANE_WIDTH_PRESETS = {
+  inspector: {
+    cacheKey: ARTIFACT_RIGHT_PANE_CACHE_KEY,
+    minWidth: ARTIFACT_RIGHT_PANE_MIN_WIDTH,
+    maxWidth: ARTIFACT_RIGHT_PANE_MAX_WIDTH
+  },
+  'navigation-list': {
+    cacheKey: RESOURCE_LIST_RIGHT_PANE_CACHE_KEY,
+    minWidth: RESOURCE_LIST_PANE_MIN_WIDTH,
+    maxWidth: RESOURCE_LIST_PANE_MAX_WIDTH
+  }
+} as const satisfies Record<RightPaneWidthPreset, RightPaneWidthPolicy>
 
-export const RESOURCE_LIST_RIGHT_PANE_WIDTH_PROFILE = {
-  cacheKey: RESOURCE_LIST_RIGHT_PANE_CACHE_KEY,
-  minWidth: RESOURCE_LIST_PANE_MIN_WIDTH,
-  maxWidth: RESOURCE_LIST_PANE_MAX_WIDTH
-} as const satisfies RightPaneWidthProfile
+export const DEFAULT_RIGHT_PANE_WIDTH_PRESET: RightPaneWidthPreset = 'inspector'
+
+export function getRightPaneWidthPolicy(preset: RightPaneWidthPreset = DEFAULT_RIGHT_PANE_WIDTH_PRESET) {
+  return RIGHT_PANE_WIDTH_PRESETS[preset]
+}

--- a/src/renderer/components/chat/shell/paneWidthPolicy.ts
+++ b/src/renderer/components/chat/shell/paneWidthPolicy.ts
@@ -1,8 +1,9 @@
 import { ARTIFACT_RIGHT_PANE_MIN_WIDTH, CHAT_CENTER_FLOOR_WIDTH, CHAT_CENTER_MIN_USABLE_WIDTH } from './paneLayout'
 
-const PANE_MIN = ARTIFACT_RIGHT_PANE_MIN_WIDTH
 const CENTER_MIN = CHAT_CENTER_MIN_USABLE_WIDTH
-const PROPORTIONAL_TOTAL = PANE_MIN + CHAT_CENTER_FLOOR_WIDTH
+
+/** The pane's own floor; panes declare it, so a list never inherits the artifact pane's. */
+const DEFAULT_PANE_MIN = ARTIFACT_RIGHT_PANE_MIN_WIDTH
 
 /**
  * Docked right-pane width for a given main-region width. Yield order: the pane
@@ -10,11 +11,11 @@ const PROPORTIONAL_TOTAL = PANE_MIN + CHAT_CENTER_FLOOR_WIDTH
  * center yields (CENTER_MIN → floor with the pane pinned at PANE_MIN), and below
  * PANE_MIN + floor both shrink proportionally so neither ever collapses to zero.
  */
-export function resolveDockedPaneWidth(available: number, resolvedWidth: number): number {
+export function resolveDockedPaneWidth(available: number, resolvedWidth: number, paneMin = DEFAULT_PANE_MIN): number {
   if (available <= 0) return 0
   return Math.max(
     Math.min(resolvedWidth, available - CENTER_MIN),
-    Math.min(PANE_MIN, (available * PANE_MIN) / PROPORTIONAL_TOTAL)
+    Math.min(paneMin, (available * paneMin) / (paneMin + CHAT_CENTER_FLOOR_WIDTH))
   )
 }
 
@@ -22,14 +23,15 @@ export function resolveDockedPaneWidth(available: number, resolvedWidth: number)
  * CSS mirror of {@link resolveDockedPaneWidth}; `100%` resolves against the
  * main-region (the pane's containing block and the spacer's flex parent).
  */
-export function buildDockedPaneWidthExpression(resolvedWidth: number | string): string {
+export function buildDockedPaneWidthExpression(resolvedWidth: number | string, paneMin = DEFAULT_PANE_MIN): string {
   const resolved = typeof resolvedWidth === 'number' ? `${resolvedWidth}px` : resolvedWidth
-  return `max(min(${resolved}, calc(100% - ${CENTER_MIN}px)), min(${PANE_MIN}px, calc(100% * ${PANE_MIN} / ${PROPORTIONAL_TOTAL})))`
+  const total = paneMin + CHAT_CENTER_FLOOR_WIDTH
+  return `max(min(${resolved}, calc(100% - ${CENTER_MIN}px)), min(${paneMin}px, calc(100% * ${paneMin} / ${total})))`
 }
 
 /** The largest width pointer/keyboard resizing can currently make visible. */
-export function getPaneSpaceCap(available: number): number {
-  return Math.max(PANE_MIN, available - CENTER_MIN)
+export function getPaneSpaceCap(available: number, paneMin = DEFAULT_PANE_MIN): number {
+  return Math.max(paneMin, available - CENTER_MIN)
 }
 
 export interface PredictCenterWidthInput {
@@ -38,6 +40,7 @@ export interface PredictCenterWidthInput {
   /** Docked-open: presentation open and not maximized. */
   paneOpen: boolean
   paneWidth: number
+  paneMin?: number
 }
 
 /**
@@ -45,9 +48,15 @@ export interface PredictCenterWidthInput {
  * of whether the list currently is expanded, so collapse/restore decisions have
  * no feedback loop.
  */
-export function predictCenterWidth({ shellWidth, listWidth, paneOpen, paneWidth }: PredictCenterWidthInput): number {
+export function predictCenterWidth({
+  shellWidth,
+  listWidth,
+  paneOpen,
+  paneWidth,
+  paneMin
+}: PredictCenterWidthInput): number {
   const available = shellWidth - listWidth
-  return available - (paneOpen ? resolveDockedPaneWidth(available, paneWidth) : 0)
+  return available - (paneOpen ? resolveDockedPaneWidth(available, paneWidth, paneMin) : 0)
 }
 
 const RESTORE_HYSTERESIS = 4

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -372,6 +372,9 @@ export type RendererPersistCacheSchema = {
   'ui.sidebar.width': number
   'ui.chat.sidebar.width': number
   'ui.chat.artifact_pane.width': number
+  // Right-pane width for the topic/session list tab. Separate from the artifact pane's key so a
+  // width dragged for an artifact never widens the list (and vice versa).
+  'ui.chat.resource_pane.width': number
   // Recent composer inputs shared by chat and agent surfaces (MRU order, capped by the consumer)
   'ui.composer.input_history': string[]
   'ui.chat.last_used_assistant_id': string | null
@@ -434,6 +437,7 @@ export const DefaultRendererPersistCache: RendererPersistCacheSchema = {
   'ui.sidebar.width': 50, // keep in sync with SIDEBAR_ICON_WIDTH (renderer Sidebar/constants.ts)
   'ui.chat.sidebar.width': 275,
   'ui.chat.artifact_pane.width': 460,
+  'ui.chat.resource_pane.width': 275, // keep in sync with 'ui.chat.sidebar.width'
   'ui.composer.input_history': [],
   'ui.chat.last_used_assistant_id': null,
   'ui.chat.last_used_topic_id': null,


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

The right pane hosts artifacts, branch management, traces, and the topic/session list from a single host. All of them therefore shared one width envelope (255–720), one default (460), and **one persisted key** (`ui.chat.artifact_pane.width`).

Before this PR: a list moved to the right side opened at the artifact pane's 460 — noticeably wider than the 275 left list it mirrors — and a width dragged for an artifact silently widened the list too (and vice versa).

After this PR: panels declare the width profile they want. The list claims the left list's envelope (200–360, default 275) and its own key, so it opens at the same width as the left list and neither pane can resize the other. Artifact panels are untouched.

| Before | After |
|---|---|
| <img src="https://pub-a9416c5573a34388b8d9465d8bef4257.r2.dev/20260822/pr-b-before.png" width="440"> | <img src="https://pub-a9416c5573a34388b8d9465d8bef4257.r2.dev/20260822/pr-b-after.png" width="440"> |

Same window (1364px). Left list 275 in both; the right conversation list goes 460 → 275.

Fixes #

### Why we need it and why it was done in this way

The host already accepted `cacheKey` / `minWidth` / `maxWidth` as props — it just had them hardcoded to the artifact constants at the one call site. Packaging those into a `RightPaneWidthProfile` that a panel entry declares keeps the shell free of business panel ids (no `panelId === 'resources'` branch in a generic component) and leaves room for a future panel to declare its own envelope.

Two defects fell out of that split and are fixed here:

- **The docked-width policy pinned every pane to the artifact floor of 255.** `PANE_MIN` sat inside a `Math.max`, so it was a rendering floor, not just a cap input. The list's 200 was unreachable, and a drag to 200 stored a width the pane never painted — violating the invariant the surrounding comment already states. Panes now pass their own floor in.
- **The left list's auto-collapse predicted the center from the artifact key.** With a wide artifact stored, a collapsed left list would not come back until the window grew far past the point where it actually fit (e.g. restoring at 1080px of main region instead of 635px).

The following tradeoffs were made:

- Existing users' list width resets once, because it no longer reads the artifact key. That is the correction, so no migration is written.
- Switching tabs inside an open pane moves the width between the two remembered values. Upstream #19083 already settles docked commits instantly, so this lands without an intermediate frame.

The following alternatives were considered:

- Only lowering the shared default to 275. Rejected: it leaves the two panes sharing one stored width, so the "remember what the user dragged" half of the request still breaks.
- Letting the host branch on the panel id. Rejected: it leaks a business identifier into a generic shell component.

### Breaking changes

A right-side conversation/task list that the user had resized reverts to the default 275 once, because its width now lives under a separate key. Artifact/branch/trace widths are unaffected.

### Special notes for your reviewer

`paneWidthPolicy`'s three exported helpers gained an optional `paneMin` parameter defaulting to the previous constant, so artifact behaviour is bit-for-bit unchanged; only callers that pass a profile see the new floor.

Every new test was mutation-verified (break the implementation → the test goes red → restore → green). Worth knowing: before those tests existed, deleting the single line in `resourcePane.tsx` that declares the profile reverted the entire feature while all 2260 tests stayed green — `createResourcePaneCapability` now has a test covering exactly that wiring.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — no user-facing doc describes the pane width
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
The conversation/task list shown on the right side now opens at the same width as the left list and remembers its own width, instead of inheriting the artifact pane's.
```
