### PR TITLE
feat(sidebar): support middle-click and context menu to open in new tab

### DIFF
--- a/src/renderer/components/Sidebar/SidebarList.tsx
+++ b/src/renderer/components/Sidebar/SidebarList.tsx
@@ -61,6 +61,10 @@ function createAuxClickHandler(entry: ResolvedSidebarEntry, guardClick: SidebarC
   })
 }
 
+function preventMiddleClickAutoscroll(e: React.MouseEvent) {
+  if (e.button === 1) e.preventDefault()
+}
+
 function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListProps) {
   return (
     <SidebarSortableList
@@ -78,6 +82,7 @@ function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 type="button"
                 aria-label={entry.label}
                 onClick={guardClick(entry.key, entry.onOpen)}
+                onMouseDown={preventMiddleClickAutoscroll}
                 onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
                   isActive
@@ -114,6 +119,7 @@ function FullList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 label={entry.label}
                 active={isActive}
                 onClick={guardClick(entry.key, entry.onOpen)}
+                onMouseDown={preventMiddleClickAutoscroll}
                 onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className="rounded-xl data-[active=true]:bg-[var(--sidebar-active-bg)]"
               />

--- a/src/renderer/components/Sidebar/SidebarList.tsx
+++ b/src/renderer/components/Sidebar/SidebarList.tsx
@@ -51,6 +51,16 @@ function EntryContextMenu({
   )
 }
 
+function createAuxClickHandler(entry: ResolvedSidebarEntry, guardClick: SidebarClickGuard) {
+  if (!entry.onOpenNewTab) return undefined
+  return guardClick(entry.key, (e: React.MouseEvent) => {
+    if (e.button === 1) {
+      e.preventDefault()
+      entry.onOpenNewTab?.()
+    }
+  })
+}
+
 function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListProps) {
   return (
     <SidebarSortableList
@@ -68,6 +78,7 @@ function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 type="button"
                 aria-label={entry.label}
                 onClick={guardClick(entry.key, entry.onOpen)}
+                onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
                   isActive
                     ? 'bg-[var(--sidebar-active-bg)] text-foreground'
@@ -103,6 +114,7 @@ function FullList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 label={entry.label}
                 active={isActive}
                 onClick={guardClick(entry.key, entry.onOpen)}
+                onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className="rounded-xl data-[active=true]:bg-[var(--sidebar-active-bg)]"
               />
             </EntryContextMenu>

--- a/src/renderer/components/Sidebar/SidebarSortableList.tsx
+++ b/src/renderer/components/Sidebar/SidebarSortableList.tsx
@@ -10,7 +10,7 @@ import { useCallback, useRef } from 'react'
 const DRAG_CLICK_SUPPRESS_MS = 250
 
 /** Wrap a click handler so it is ignored right after that item was dragged. */
-export type SidebarClickGuard = (item: unknown, handler: () => void) => () => void
+export type SidebarClickGuard = <E = void>(item: unknown, handler?: (event: E) => void) => (event: E) => void
 
 interface SidebarSortableListProps<T> {
   items: T[]
@@ -46,9 +46,9 @@ export function SidebarSortableList<T>({
   }, [])
 
   const guardClick = useCallback<SidebarClickGuard>(
-    (item, handler) => () => {
+    (item, handler) => (event) => {
       if (String(item) === draggedItemIdRef.current && Date.now() < suppressClickUntilRef.current) return
-      handler()
+      handler?.(event)
     },
     []
   )

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -34,6 +34,7 @@ vi.mock('@cherrystudio/ui', () => ({
     icon,
     label,
     onClick,
+    onMouseDown,
     onAuxClick,
     className,
     active
@@ -41,6 +42,7 @@ vi.mock('@cherrystudio/ui', () => ({
     icon?: ReactNode
     label: string
     onClick?: () => void
+    onMouseDown?: (e: React.MouseEvent) => void
     onAuxClick?: (e: React.MouseEvent) => void
     className?: string
     active?: boolean
@@ -50,6 +52,7 @@ vi.mock('@cherrystudio/ui', () => ({
       data-active={active ? 'true' : 'false'}
       className={className}
       onClick={onClick}
+      onMouseDown={onMouseDown}
       onAuxClick={onAuxClick}>
       {icon}
       <span>{label}</span>
@@ -588,9 +591,12 @@ describe('Sidebar resize handle', () => {
     const chatButton = screen.getByRole('button', { name: 'Chat' })
     const agentButton = screen.getByRole('button', { name: 'Agent' })
 
+    const mouseDown = new MouseEvent('mousedown', { button: 1, bubbles: true, cancelable: true })
+    fireEvent(chatButton, mouseDown)
     fireEvent(chatButton, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
     fireEvent(agentButton, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
 
+    expect(mouseDown.defaultPrevented).toBe(true)
     expect(onChatOpenNewTab).not.toHaveBeenCalled()
     expect(onAgentOpenNewTab).toHaveBeenCalledTimes(1)
   })
@@ -643,8 +649,11 @@ describe('Sidebar resize handle', () => {
     )
 
     const button = screen.getByRole('button', { name: 'Chat' })
+    const mouseDown = new MouseEvent('mousedown', { button: 1, bubbles: true, cancelable: true })
+    fireEvent(button, mouseDown)
     fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
 
+    expect(mouseDown.defaultPrevented).toBe(true)
     expect(onChatOpenNewTab).toHaveBeenCalledTimes(1)
     expect(onChatOpen).not.toHaveBeenCalled()
   })
@@ -673,8 +682,11 @@ describe('Sidebar resize handle', () => {
     )
 
     const button = screen.getByRole('button', { name: /Chat/ })
+    const mouseDown = new MouseEvent('mousedown', { button: 1, bubbles: true, cancelable: true })
+    fireEvent(button, mouseDown)
     fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
 
+    expect(mouseDown.defaultPrevented).toBe(true)
     expect(onChatOpenNewTab).toHaveBeenCalledTimes(1)
     expect(onChatOpen).not.toHaveBeenCalled()
   })
@@ -698,8 +710,11 @@ describe('Sidebar resize handle', () => {
     )
 
     const button = screen.getByRole('button', { name: 'Chat' })
+    const mouseDown = new MouseEvent('mousedown', { button: 2, bubbles: true, cancelable: true })
+    fireEvent(button, mouseDown)
     fireEvent(button, new MouseEvent('auxclick', { button: 2, bubbles: true, cancelable: true }))
 
+    expect(mouseDown.defaultPrevented).toBe(false)
     expect(onChatOpenNewTab).not.toHaveBeenCalled()
     expect(onChatOpen).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -34,16 +34,23 @@ vi.mock('@cherrystudio/ui', () => ({
     icon,
     label,
     onClick,
+    onAuxClick,
     className,
     active
   }: {
     icon?: ReactNode
     label: string
     onClick?: () => void
+    onAuxClick?: (e: React.MouseEvent) => void
     className?: string
     active?: boolean
   }) => (
-    <button type="button" data-active={active ? 'true' : 'false'} className={className} onClick={onClick}>
+    <button
+      type="button"
+      data-active={active ? 'true' : 'false'}
+      className={className}
+      onClick={onClick}
+      onAuxClick={onAuxClick}>
       {icon}
       <span>{label}</span>
     </button>
@@ -542,6 +549,52 @@ describe('Sidebar resize handle', () => {
     expect(onAgentOpen).toHaveBeenCalledTimes(1)
   })
 
+  it('suppresses only the dragged sidebar entry middle-click after sorting settles', () => {
+    const onChatOpenNewTab = vi.fn()
+    const onAgentOpenNewTab = vi.fn()
+    const sortableEntries: ResolvedSidebarEntry[] = [
+      {
+        key: 'app:chat',
+        label: 'Chat',
+        renderIcon: () => null,
+        isActive: (active) => active.activeItem === 'chat',
+        onOpen: vi.fn(),
+        onOpenNewTab: onChatOpenNewTab
+      },
+      {
+        key: 'app:agent',
+        label: 'Agent',
+        renderIcon: () => null,
+        isActive: (active) => active.activeItem === 'agent',
+        onOpen: vi.fn(),
+        onOpenNewTab: onAgentOpenNewTab
+      }
+    ]
+
+    render(
+      <Sidebar
+        width={SIDEBAR_FULL_THRESHOLD}
+        setWidth={vi.fn()}
+        active={{ activeItem: 'chat' }}
+        entries={sortableEntries}
+        onEntriesReorder={vi.fn()}
+      />
+    )
+
+    const sortableCall = uiMocks.sortableCalls.at(-1)
+    sortableCall.onDragStart({ active: { id: 'app:chat' } })
+    sortableCall.onDragEnd()
+
+    const chatButton = screen.getByRole('button', { name: 'Chat' })
+    const agentButton = screen.getByRole('button', { name: 'Agent' })
+
+    fireEvent(chatButton, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+    fireEvent(agentButton, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(onChatOpenNewTab).not.toHaveBeenCalled()
+    expect(onAgentOpenNewTab).toHaveBeenCalledTimes(1)
+  })
+
   it('renders footer actions with the current sidebar layout', () => {
     const renderActions = (layout: 'icon' | 'full') => <button type="button">theme-{layout}</button>
 
@@ -569,5 +622,85 @@ describe('Sidebar resize handle', () => {
 
     expect(document.body).toHaveTextContent('theme-full')
     expect(document.body).not.toHaveTextContent('theme-icon')
+  })
+
+  it('triggers onOpenNewTab on middle-click (auxclick with button 1) in icon layout', () => {
+    const onChatOpen = vi.fn()
+    const onChatOpenNewTab = vi.fn()
+    const testEntries: ResolvedSidebarEntry[] = [
+      {
+        key: 'app:chat',
+        label: 'Chat',
+        renderIcon: () => <span>chat-icon</span>,
+        isActive: () => false,
+        onOpen: onChatOpen,
+        onOpenNewTab: onChatOpenNewTab
+      }
+    ]
+
+    render(
+      <Sidebar width={SIDEBAR_ICON_WIDTH} setWidth={vi.fn()} active={{ activeItem: 'chat' }} entries={testEntries} />
+    )
+
+    const button = screen.getByRole('button', { name: 'Chat' })
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(onChatOpenNewTab).toHaveBeenCalledTimes(1)
+    expect(onChatOpen).not.toHaveBeenCalled()
+  })
+
+  it('triggers onOpenNewTab on middle-click (auxclick with button 1) in full layout', () => {
+    const onChatOpen = vi.fn()
+    const onChatOpenNewTab = vi.fn()
+    const testEntries: ResolvedSidebarEntry[] = [
+      {
+        key: 'app:chat',
+        label: 'Chat',
+        renderIcon: () => <span>chat-icon</span>,
+        isActive: () => false,
+        onOpen: onChatOpen,
+        onOpenNewTab: onChatOpenNewTab
+      }
+    ]
+
+    render(
+      <Sidebar
+        width={SIDEBAR_FULL_THRESHOLD}
+        setWidth={vi.fn()}
+        active={{ activeItem: 'chat' }}
+        entries={testEntries}
+      />
+    )
+
+    const button = screen.getByRole('button', { name: /Chat/ })
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(onChatOpenNewTab).toHaveBeenCalledTimes(1)
+    expect(onChatOpen).not.toHaveBeenCalled()
+  })
+
+  it('does not trigger onOpenNewTab on auxclick with non-middle button', () => {
+    const onChatOpen = vi.fn()
+    const onChatOpenNewTab = vi.fn()
+    const testEntries: ResolvedSidebarEntry[] = [
+      {
+        key: 'app:chat',
+        label: 'Chat',
+        renderIcon: () => <span>chat-icon</span>,
+        isActive: () => false,
+        onOpen: onChatOpen,
+        onOpenNewTab: onChatOpenNewTab
+      }
+    ]
+
+    render(
+      <Sidebar width={SIDEBAR_ICON_WIDTH} setWidth={vi.fn()} active={{ activeItem: 'chat' }} entries={testEntries} />
+    )
+
+    const button = screen.getByRole('button', { name: 'Chat' })
+    fireEvent(button, new MouseEvent('auxclick', { button: 2, bubbles: true, cancelable: true }))
+
+    expect(onChatOpenNewTab).not.toHaveBeenCalled()
+    expect(onChatOpen).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/Sidebar/types.ts
+++ b/src/renderer/components/Sidebar/types.ts
@@ -35,6 +35,7 @@ export interface ResolvedSidebarEntry {
   renderIcon: (size: number, miniAppSize: 'md' | 'lg') => ReactNode
   isActive: (active: SidebarActiveState) => boolean
   onOpen: () => void
+  onOpenNewTab?: () => void
   contextMenuItems?: readonly CommandContextMenuExtraItem[]
 }
 

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -220,14 +220,12 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       if (!app) return
 
       const path = `${MINI_APP_ROUTE_PREFIX}${app.appId}`
-      if (!options?.inNewTab) {
-        if (activeTab?.url === path) return
+      if (activeTab?.url === path) return
 
-        const existingTab = tabs.find((tab) => tab.type === 'route' && tab.url === path)
-        if (existingTab) {
-          setActiveTab(existingTab.id)
-          return
-        }
+      const existingTab = tabs.find((tab) => tab.type === 'route' && tab.url === path)
+      if (existingTab) {
+        setActiveTab(existingTab.id)
+        return
       }
 
       const title = app.nameKey ? t(app.nameKey) : app.name

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -150,28 +150,17 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
 
   const activeItem = resolveSidebarActiveItem(pathname)
 
-  const handleNavigate = useCallback(
-    (menuItemId: string) => {
-      const menuId = menuItemId as SidebarAppId
-      const app = getSidebarApp(menuId)
-      const path = getSidebarMenuPath(menuId, defaultPaintingProvider)
-      if (!app || !path) return
+  const navigateRouteTab = useCallback(
+    (path: string, title: string, options?: { inNewTab?: boolean; icon?: string }) => {
+      if (options?.inNewTab) {
+        openTab(path, { forceNew: true, title, icon: options.icon })
+        return
+      }
 
-      // Conversation apps: any owned tab is already "there" — its URL carries its own
-      // conversation, and re-entering through the route interceptor would just rebind
-      // it. Message-only viewers are not an app entry, so they navigate like any
-      // foreign tab. Apps without sub-instances keep exact-URL matching.
-      const isActiveTarget =
-        !!activeTab &&
-        (app.conversationRoute
-          ? tabBelongsToApp(app, activeTab.url) && !isMessageOnlyConversationUrl(activeTab.url)
-          : activeTab.url === path)
-      if (isActiveTarget) return
-
-      const title = getDefaultRouteTitle(path)
+      if (activeTab?.url === path) return
 
       if (activeTab?.isPinned) {
-        openTab(path, { forceNew: true, title })
+        openTab(path, { forceNew: true, title, icon: options?.icon })
         return
       }
 
@@ -179,15 +168,40 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
         updateTab(activeTab.id, {
           url: path,
           title,
-          icon: undefined,
+          icon: options?.icon,
           metadata: undefined
         })
         return
       }
 
-      openTab(path, { forceNew: true, title })
+      openTab(path, { forceNew: true, title, icon: options?.icon })
     },
-    [activeTab, defaultPaintingProvider, openTab, updateTab]
+    [activeTab, openTab, updateTab]
+  )
+
+  const handleNavigate = useCallback(
+    (menuItemId: string, options?: { inNewTab?: boolean }) => {
+      const menuId = menuItemId as SidebarAppId
+      const app = getSidebarApp(menuId)
+      const path = getSidebarMenuPath(menuId, defaultPaintingProvider)
+      if (!app || !path) return
+
+      if (!options?.inNewTab) {
+        // Conversation apps: any owned tab is already "there" — its URL carries its own
+        // conversation, and re-entering through the route interceptor would just rebind
+        // it. Message-only viewers are not an app entry, so they navigate like any
+        // foreign tab. Apps without sub-instances keep exact-URL matching.
+        const isActiveTarget =
+          !!activeTab &&
+          (app.conversationRoute
+            ? tabBelongsToApp(app, activeTab.url) && !isMessageOnlyConversationUrl(activeTab.url)
+            : activeTab.url === path)
+        if (isActiveTarget) return
+      }
+
+      navigateRouteTab(path, getDefaultRouteTitle(path), options)
+    },
+    [activeTab, defaultPaintingProvider, navigateRouteTab]
   )
   const handleOpenLaunchpad = useCallback(() => {
     openTab('/app/launchpad', { title: getDefaultRouteTitle('/app/launchpad'), forceNew: true })
@@ -201,88 +215,46 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   }, [])
 
   const handleOpenMiniAppTab = useCallback(
-    (appId: string) => {
+    (appId: string, options?: { inNewTab?: boolean }) => {
       const app = openableMiniAppById.get(appId)
       if (!app) return
 
       const path = `${MINI_APP_ROUTE_PREFIX}${app.appId}`
-      if (activeTab?.url === path) return
+      if (!options?.inNewTab) {
+        if (activeTab?.url === path) return
 
-      const existingTab = tabs.find((tab) => tab.type === 'route' && tab.url === path)
-      if (existingTab) {
-        setActiveTab(existingTab.id)
-        return
+        const existingTab = tabs.find((tab) => tab.type === 'route' && tab.url === path)
+        if (existingTab) {
+          setActiveTab(existingTab.id)
+          return
+        }
       }
 
       const title = app.nameKey ? t(app.nameKey) : app.name
       // Uploaded logo → main-resolved `logoSrc`; preset key → `logo`.
       const icon = app.logoSrc ?? app.logo
-
-      if (activeTab?.isPinned) {
-        openTab(path, { forceNew: true, title, icon })
-        return
-      }
-
-      if (activeTab) {
-        updateTab(activeTab.id, {
-          url: path,
-          title,
-          icon,
-          metadata: undefined
-        })
-        return
-      }
-
-      openTab(path, {
-        forceNew: true,
-        title,
-        icon
-      })
+      navigateRouteTab(path, title, { ...options, icon })
     },
-    [activeTab, openableMiniAppById, openTab, setActiveTab, t, tabs, updateTab]
+    [activeTab, navigateRouteTab, openableMiniAppById, setActiveTab, t, tabs]
   )
 
   // Pinned entities reuse tabs like mini apps do; the route interceptor turns the
   // `agentId` / `assistantId` param into that entity's most recent conversation.
-  const handleOpenEntityTab = useCallback(
-    (path: string, title: string) => {
-      if (activeTab?.url === path) return
-
-      if (activeTab?.isPinned) {
-        openTab(path, { forceNew: true, title })
-        return
-      }
-
-      if (activeTab) {
-        updateTab(activeTab.id, {
-          url: path,
-          title,
-          icon: undefined,
-          metadata: undefined
-        })
-        return
-      }
-
-      openTab(path, { forceNew: true, title })
-    },
-    [activeTab, openTab, updateTab]
-  )
-
   const handleOpenAgentTab = useCallback(
-    (agentId: string) => {
+    (agentId: string, options?: { inNewTab?: boolean }) => {
       const agent = installedAgents.get(agentId)
       if (!agent) return
-      handleOpenEntityTab(`/app/agents?agentId=${encodeURIComponent(agentId)}`, agent.name)
+      navigateRouteTab(`/app/agents?agentId=${encodeURIComponent(agentId)}`, agent.name, options)
     },
-    [handleOpenEntityTab, installedAgents]
+    [installedAgents, navigateRouteTab]
   )
   const handleOpenAssistantTab = useCallback(
-    (assistantId: string) => {
+    (assistantId: string, options?: { inNewTab?: boolean }) => {
       const assistant = installedAssistants.get(assistantId)
       if (!assistant) return
-      handleOpenEntityTab(`/app/chat?assistantId=${encodeURIComponent(assistantId)}`, assistant.name)
+      navigateRouteTab(`/app/chat?assistantId=${encodeURIComponent(assistantId)}`, assistant.name, options)
     },
-    [handleOpenEntityTab, installedAssistants]
+    [installedAssistants, navigateRouteTab]
   )
 
   // All per-type sidebar knowledge (icon, label, route, active-match, open, remove)
@@ -336,10 +308,22 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
         const entry = resolveSidebarEntry(favorite, variantContext)
         if (!entry) return []
 
+        const newTabItem = entry.onOpenNewTab
+          ? [
+              {
+                type: 'item' as const,
+                id: `sidebar.open-in-new-tab.${entry.key}`,
+                label: t('common.open_in_new_tab'),
+                onSelect: entry.onOpenNewTab
+              }
+            ]
+          : []
+
         return [
           {
             ...entry,
             contextMenuItems: [
+              ...newTabItem,
               ...(entry.contextMenuItems ?? []),
               {
                 type: 'item' as const,

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -1033,6 +1033,25 @@ describe('app Sidebar', () => {
     })
   })
 
+  it('reuses an existing mini app tab on middle-click instead of creating a duplicate', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarMiniAppFavorites = [miniAppFavorite('mini-1')]
+    mocks.allApps = [{ appId: 'mini-1', name: 'Mini One', logo: 'logo-1.png', url: 'https://example.com/1' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      { id: 'mini-existing', type: 'route', url: '/app/mini-app/mini-1', title: 'Mini One' }
+    ]
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-mini-app-mini-1')
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('mini-existing')
+    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
+  })
+
   it('opens a new tab on middle-click (auxclick with button 1) on an agent item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -27,6 +27,16 @@ type FakeMiniApp = {
   url: string
 }
 
+type FakeAgent = {
+  id: string
+  name: string
+}
+
+type FakeAssistant = {
+  id: string
+  name: string
+}
+
 const mocks = vi.hoisted(() => ({
   emitResourceListReveal: vi.fn(),
   openTab: vi.fn(),
@@ -48,6 +58,10 @@ const mocks = vi.hoisted(() => ({
   tabs: [] as FakeTab[],
   sidebarFavorites: [{ type: 'app', id: 'assistants' }] as SidebarFavoriteItem[],
   sidebarMiniAppFavorites: [] as SidebarFavoriteItem[],
+  sidebarAgentFavorites: [] as SidebarFavoriteItem[],
+  sidebarAssistantFavorites: [] as SidebarFavoriteItem[],
+  agents: [] as FakeAgent[],
+  assistants: [] as FakeAssistant[],
   allApps: [] as FakeMiniApp[],
   visibleMiniApps: null as FakeMiniApp[] | null,
   pinnedMiniApps: [] as FakeMiniApp[],
@@ -70,9 +84,29 @@ vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
     if (key === 'app.user.name') return ['JD']
     if (key === 'ui.sidebar.favorites')
-      return [[...mocks.sidebarFavorites, ...mocks.sidebarMiniAppFavorites], mocks.setSidebarFavorites]
+      return [
+        [
+          ...mocks.sidebarFavorites,
+          ...mocks.sidebarMiniAppFavorites,
+          ...mocks.sidebarAgentFavorites,
+          ...mocks.sidebarAssistantFavorites
+        ],
+        mocks.setSidebarFavorites
+      ]
     return [undefined]
   }
+}))
+
+vi.mock('@renderer/hooks/agent/useAgent', () => ({
+  useAgents: () => ({
+    agents: mocks.agents
+  })
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistantsApi: () => ({
+    assistants: mocks.assistants
+  })
 }))
 
 vi.mock('@renderer/hooks/useAvatar', () => ({
@@ -176,6 +210,7 @@ type MockSidebarEntry = {
   label: string
   isActive: (active: { activeItem: string; activeTabId?: string }) => boolean
   onOpen: () => void
+  onOpenNewTab?: () => void
   contextMenuItems?: Array<{ id: string; label: string; enabled?: boolean; onSelect?: () => void }>
 }
 
@@ -229,6 +264,8 @@ vi.mock('../../Sidebar', async () => {
       const activeState = active ?? { activeItem: '' }
       const items = entries?.filter((entry) => parseEntryKey(entry.key).type === 'app')
       const dockedTabs = entries?.filter((entry) => parseEntryKey(entry.key).type === 'mini_app')
+      const agentItems = entries?.filter((entry) => parseEntryKey(entry.key).type === 'agent')
+      const assistantItems = entries?.filter((entry) => parseEntryKey(entry.key).type === 'assistant')
       return isFloating ? (
         <div
           className={isFloatingClosing ? 'slide-out-to-left-2 animate-out' : 'slide-in-from-left-2 animate-in'}
@@ -256,7 +293,10 @@ vi.mock('../../Sidebar', async () => {
                 <button
                   type="button"
                   data-testid={`sidebar-item-${parseEntryKey(item.key).id}`}
-                  onClick={() => item.onOpen()}>
+                  onClick={() => item.onOpen()}
+                  onAuxClick={(e) => {
+                    if (e.button === 1) item.onOpenNewTab?.()
+                  }}>
                   <span>{item.label}</span>
                 </button>
                 {item.contextMenuItems?.map((menuItem) => (
@@ -279,10 +319,63 @@ vi.mock('../../Sidebar', async () => {
                   type="button"
                   data-active={miniTab.isActive(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-mini-app-${parseEntryKey(miniTab.key).id}`}
-                  onClick={() => miniTab.onOpen()}>
+                  onClick={() => miniTab.onOpen()}
+                  onAuxClick={(e) => {
+                    if (e.button === 1) miniTab.onOpenNewTab?.()
+                  }}>
                   {miniTab.label}
                 </button>
                 {miniTab.contextMenuItems?.map((menuItem) => (
+                  <button
+                    key={menuItem.id}
+                    type="button"
+                    data-testid={`sidebar-menu-${menuItem.id}`}
+                    disabled={menuItem.enabled === false}
+                    onClick={menuItem.onSelect}>
+                    {menuItem.label}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+          <div data-testid="sidebar-agent-section">
+            {agentItems?.map((agentItem) => (
+              <div key={agentItem.key} role="group" aria-label={agentItem.label}>
+                <button
+                  type="button"
+                  data-testid={`sidebar-agent-${parseEntryKey(agentItem.key).id}`}
+                  onClick={() => agentItem.onOpen()}
+                  onAuxClick={(e) => {
+                    if (e.button === 1) agentItem.onOpenNewTab?.()
+                  }}>
+                  {agentItem.label}
+                </button>
+                {agentItem.contextMenuItems?.map((menuItem) => (
+                  <button
+                    key={menuItem.id}
+                    type="button"
+                    data-testid={`sidebar-menu-${menuItem.id}`}
+                    disabled={menuItem.enabled === false}
+                    onClick={menuItem.onSelect}>
+                    {menuItem.label}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>
+          <div data-testid="sidebar-assistant-section">
+            {assistantItems?.map((assistantItem) => (
+              <div key={assistantItem.key} role="group" aria-label={assistantItem.label}>
+                <button
+                  type="button"
+                  data-testid={`sidebar-assistant-${parseEntryKey(assistantItem.key).id}`}
+                  onClick={() => assistantItem.onOpen()}
+                  onAuxClick={(e) => {
+                    if (e.button === 1) assistantItem.onOpenNewTab?.()
+                  }}>
+                  {assistantItem.label}
+                </button>
+                {assistantItem.contextMenuItems?.map((menuItem) => (
                   <button
                     key={menuItem.id}
                     type="button"
@@ -315,6 +408,8 @@ import Sidebar from '../Sidebar'
 
 const appFavorite = (id: SidebarAppId): SidebarFavoriteItem => ({ type: 'app', id })
 const miniAppFavorite = (id: string): SidebarFavoriteItem => ({ type: 'mini_app', id })
+const agentFavorite = (id: string): SidebarFavoriteItem => ({ type: 'agent', id })
+const assistantFavorite = (id: string): SidebarFavoriteItem => ({ type: 'assistant', id })
 const calculatorMiniApp: FakeMiniApp = {
   appId: 'calculator',
   name: 'Calculator',
@@ -339,6 +434,10 @@ afterEach(() => {
   vi.clearAllMocks()
   mocks.sidebarFavorites = [appFavorite('assistants')]
   mocks.sidebarMiniAppFavorites = []
+  mocks.sidebarAgentFavorites = []
+  mocks.sidebarAssistantFavorites = []
+  mocks.agents = []
+  mocks.assistants = []
   mocks.setSidebarFavorites.mockReset()
   mocks.setSidebarFavorites.mockResolvedValue(undefined)
   mocks.reorderMiniAppsByStatus.mockReset()
@@ -892,5 +991,111 @@ describe('app Sidebar', () => {
 
     expect(screen.getByTestId('ui-sidebar')).toHaveAttribute('data-width', '50')
     expect(document.documentElement.style.getPropertyValue('--sidebar-width')).toBe('50px')
+  })
+
+  it('opens a new tab on middle-click (auxclick with button 1) on an app item', () => {
+    mocks.sidebarFavorites = [appFavorite('assistants')]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-item-assistants')
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/chat', { forceNew: true, title: 'Chat' })
+  })
+
+  it('opens a new tab via context menu "open in new tab" option on an app item', () => {
+    mocks.sidebarFavorites = [appFavorite('assistants')]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.app:assistants')
+    expect(menuButton).toHaveTextContent('common.open_in_new_tab')
+
+    fireEvent.click(menuButton)
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/chat', { forceNew: true, title: 'Chat' })
+  })
+
+  it('opens a new tab on middle-click (auxclick with button 1) on a mini app item', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarMiniAppFavorites = [miniAppFavorite('mini-1')]
+    mocks.allApps = [{ appId: 'mini-1', name: 'Mini One', logo: 'logo-1.png', url: 'https://example.com/1' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-mini-app-mini-1')
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/mini-app/mini-1', {
+      forceNew: true,
+      title: 'Mini One',
+      icon: 'logo-1.png'
+    })
+  })
+
+  it('opens a new tab on middle-click (auxclick with button 1) on an agent item', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-agent-agent-1')
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
+      forceNew: true,
+      title: 'Code Reviewer'
+    })
+  })
+
+  it('opens a new tab via context menu "open in new tab" option on an agent item', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.agent:agent-1')
+    expect(menuButton).toHaveTextContent('common.open_in_new_tab')
+
+    fireEvent.click(menuButton)
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
+      forceNew: true,
+      title: 'Code Reviewer'
+    })
+  })
+
+  it('opens a new tab on middle-click (auxclick with button 1) on an assistant item', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
+    mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-assistant-assistant-1')
+    fireEvent(button, new MouseEvent('auxclick', { button: 1, bubbles: true, cancelable: true }))
+
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
+      forceNew: true,
+      title: 'Helper'
+    })
+  })
+
+  it('opens a new tab via context menu "open in new tab" option on an assistant item', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
+    mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+
+    render(<Sidebar />)
+    const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.assistant:assistant-1')
+    expect(menuButton).toHaveTextContent('common.open_in_new_tab')
+
+    fireEvent.click(menuButton)
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
+      forceNew: true,
+      title: 'Helper'
+    })
   })
 })

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -122,4 +122,78 @@ describe('sidebarVariants icons', () => {
 
     expect(screen.getByTestId('icon')).not.toHaveTextContent('⭐️')
   })
+
+  describe('onOpen and onOpenNewTab actions', () => {
+    it('wires openApp with and without inNewTab for app variant', () => {
+      const openApp = vi.fn()
+      const ctx = createContext({ openApp })
+      const appFavorite: SidebarFavoriteItem = { type: 'app', id: 'assistants' }
+
+      const entry = resolveSidebarEntry(appFavorite, ctx)
+      expect(entry).not.toBeNull()
+
+      entry?.onOpen()
+      expect(openApp).toHaveBeenCalledWith('assistants')
+
+      entry?.onOpenNewTab?.()
+      expect(openApp).toHaveBeenCalledWith('assistants', { inNewTab: true })
+    })
+
+    it('wires openMiniApp with and without inNewTab for mini_app variant', () => {
+      const openMiniApp = vi.fn()
+      const miniApp = {
+        appId: 'mini-1',
+        name: 'Mini App',
+        url: 'https://example.com'
+      } as MiniApp
+      const ctx = createContext({
+        openMiniApp,
+        installedMiniApps: new Map([['mini-1', miniApp]])
+      })
+      const favorite: SidebarFavoriteItem = { type: 'mini_app', id: 'mini-1' }
+
+      const entry = resolveSidebarEntry(favorite, ctx)
+      expect(entry).not.toBeNull()
+
+      entry?.onOpen()
+      expect(openMiniApp).toHaveBeenCalledWith('mini-1')
+
+      entry?.onOpenNewTab?.()
+      expect(openMiniApp).toHaveBeenCalledWith('mini-1', { inNewTab: true })
+    })
+
+    it('wires openAgent with and without inNewTab for agent variant', () => {
+      const openAgent = vi.fn()
+      const ctx = createContext({
+        openAgent,
+        installedAgents: new Map([['agent-1', createAgent()]])
+      })
+
+      const entry = resolveSidebarEntry(agentFavorite, ctx)
+      expect(entry).not.toBeNull()
+
+      entry?.onOpen()
+      expect(openAgent).toHaveBeenCalledWith('agent-1')
+
+      entry?.onOpenNewTab?.()
+      expect(openAgent).toHaveBeenCalledWith('agent-1', { inNewTab: true })
+    })
+
+    it('wires openAssistant with and without inNewTab for assistant variant', () => {
+      const openAssistant = vi.fn()
+      const ctx = createContext({
+        openAssistant,
+        installedAssistants: new Map([['assistant-1', createAssistant()]])
+      })
+
+      const entry = resolveSidebarEntry(assistantFavorite, ctx)
+      expect(entry).not.toBeNull()
+
+      entry?.onOpen()
+      expect(openAssistant).toHaveBeenCalledWith('assistant-1')
+
+      entry?.onOpenNewTab?.()
+      expect(openAssistant).toHaveBeenCalledWith('assistant-1', { inNewTab: true })
+    })
+  })
 })

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -40,10 +40,10 @@ export interface SidebarVariantContext {
   agentIconType: AssistantIconType
   defaultModelId: string | null
   isRequiredApp: (id: SidebarAppId) => boolean
-  openApp: (id: SidebarAppId) => void
-  openMiniApp: (id: string) => void
-  openAgent: (id: string) => void
-  openAssistant: (id: string) => void
+  openApp: (id: SidebarAppId, options?: { inNewTab?: boolean }) => void
+  openMiniApp: (id: string, options?: { inNewTab?: boolean }) => void
+  openAgent: (id: string, options?: { inNewTab?: boolean }) => void
+  openAssistant: (id: string, options?: { inNewTab?: boolean }) => void
   removeApp: (id: SidebarAppId) => void
   removeMiniApp: (id: string) => void
   removeAgent: (id: string) => void
@@ -77,6 +77,7 @@ const appVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 
       renderIcon: (size) => <Icon size={size} strokeWidth={1.6} />,
       isActive: (active) => active.activeItem === id,
       onOpen: () => ctx.openApp(id),
+      onOpenNewTab: () => ctx.openApp(id, { inNewTab: true }),
       contextMenuItems: [
         {
           type: 'item',
@@ -110,6 +111,7 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       renderIcon: (_size, miniAppSize) => <MiniAppIcon tab={tab} size={miniAppSize} />,
       isActive: (active) => active.activeTabId === app.appId,
       onOpen: () => ctx.openMiniApp(app.appId),
+      onOpenNewTab: () => ctx.openMiniApp(app.appId, { inNewTab: true }),
       contextMenuItems: [
         {
           type: 'item',
@@ -144,6 +146,7 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
       // only navigates the conversation the interceptor resolves.
       isActive: () => false,
       onOpen: () => ctx.openAgent(agent.id),
+      onOpenNewTab: () => ctx.openAgent(agent.id, { inNewTab: true }),
       contextMenuItems: [
         {
           type: 'item',
@@ -177,6 +180,7 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
       // Active-state highlight stays on the built-in assistants app entry.
       isActive: () => false,
       onOpen: () => ctx.openAssistant(assistant.id),
+      onOpenNewTab: () => ctx.openAssistant(assistant.id, { inNewTab: true }),
       contextMenuItems: [
         {
           type: 'item',


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
- Clicking a sidebar item (built-in App, MiniApp, Agent, Assistant) only switches the view within the current tab (unless pinned).
- Middle-clicking a sidebar item does not open the destination in a new tab and may trigger browser middle-click autoscroll behavior.
- Sidebar right-click context menu does not provide an "Open in New Tab" option.

After this PR:
- Middle-clicking (`auxclick` with `button === 1`) any sidebar item (built-in Apps, MiniApps, Agents, Assistants) opens the route or entity in a new tab (`forceNew: true`) and prevents default middle-click scroll behavior.
- Added "Open in New Tab" (`common.open_in_new_tab`) to the top of the context menu for sidebar items.
- Extended drag click guard (`guardClick`) to support generic mouse events so middle clicks are also suppressed right after drag-reordering.
- Consolidated container-level route tab navigation into `navigateRouteTab` across App, MiniApp, Agent, and Assistant.
- Settings button at the bottom of the sidebar remains default and untouched.

https://github.com/user-attachments/assets/6f6d6eb7-2d9e-46fa-b405-c720563396bf

Fixes #

### Why we need it and why it was done in this way

- Improves tab multitasking ergonomics, allowing users to quickly open apps, mini apps, agents, or assistants in new tabs directly from the sidebar.
- Reuses existing multi-language translation key `common.open_in_new_tab` across all supported locales without introducing new localized strings.
- Consolidates duplicated tab navigation logic into a single helper and keeps sidebar variant descriptors clean and declarative.

The following tradeoffs were made:
None.

The following alternatives were considered:
None.

Links to places where the discussion took place: None

### Breaking changes

None

### Special notes for your reviewer

- **Diff Size Breakdown**: ~83% of the added lines (+420 lines) are comprehensive unit and integration tests covering the presentation layer (`Sidebar/`), variant layer (`sidebarVariants`), and container layer (`app/Sidebar`) for all 4 supported entity types (built-in Apps, MiniApps, Agents, Assistants) and drag-and-drop click suppression.
- **Production Code Impact**: Production code changes are minimal and result in a **net reduction** (-6 lines overall; `app/Sidebar.tsx` net -16 lines) due to consolidating repeated route navigation logic into `navigateRouteTab`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Support middle-click and context menu to open sidebar items in a new tab
```
