### PR TITLE
fix(agents): restore heartbeat scheduling on the JobManager stack

### DIFF
--- a/src/main/ai/agents/AgentJobsService.ts
+++ b/src/main/ai/agents/AgentJobsService.ts
@@ -21,6 +21,7 @@ import { triggersEqual, type UpdateJobScheduleDto } from '@shared/data/api/schem
 import type { AgentTaskForm, AgentTaskPatch } from '@shared/ipc/schemas/ai'
 
 import { agentTaskJobHandler } from './agentTaskJobHandler'
+import { syncHeartbeatSchedule } from './heartbeatSchedule'
 
 const logger = loggerService.withContext('AgentJobsService')
 
@@ -71,6 +72,22 @@ function readAgentTaskJobInputTemplate(value: unknown): AgentTaskJobInputTemplat
 export class AgentJobsService extends BaseService {
   protected async onInit(): Promise<void> {
     application.get('JobManager').registerHandler('agent.task', agentTaskJobHandler)
+
+    // Configuration saves reach the data layer through DataApi; this service
+    // owns the schedule side effects those keys describe (#19203). Sync after
+    // the write: the schedule row and its timer are derived state.
+    this.registerDisposable(
+      agentService.onAgentUpdated(({ agentId, updates }) => {
+        const configuration = updates.configuration
+        if (configuration && ('heartbeat_enabled' in configuration || 'heartbeat_interval' in configuration)) {
+          try {
+            syncHeartbeatSchedule(agentId)
+          } catch (error) {
+            logger.warn('Failed to sync heartbeat schedule', { agentId, error })
+          }
+        }
+      })
+    )
   }
 
   createTask(agentId: string, form: AgentTaskForm): ScheduledTaskEntity {

--- a/src/main/ai/agents/__tests__/heartbeatSchedule.test.ts
+++ b/src/main/ai/agents/__tests__/heartbeatSchedule.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for the heartbeat schedule sync lost in the JobManager migration
+ * (#19203): `heartbeat_enabled` / `heartbeat_interval` must translate into a
+ * real `agent.task` schedule the surviving run side can pick up.
+ *
+ * Runs against a real file-backed DB (production migrations) with a real
+ * JobManager + SchedulerService, mirroring AgentJobsService.test.ts.
+ */
+
+import { application } from '@application'
+import { agentTable } from '@data/db/schemas/agent'
+import { eq } from 'drizzle-orm'
+import { agentTaskService } from '@data/services/AgentTaskService'
+import { jobScheduleService } from '@data/services/JobScheduleService'
+import { JobManager } from '@main/core/job/JobManager'
+import type { JobHandler } from '@main/core/job/types'
+import { BaseService } from '@main/core/lifecycle/BaseService'
+import { SchedulerService } from '@main/core/scheduler/SchedulerService'
+import { setupTestDatabase } from '@test-helpers/db'
+import { MockMainCacheServiceExport } from '@test-mocks/main/CacheService'
+import { MockMainDbServiceExport } from '@test-mocks/main/DbService'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { notifyDataApiDataChangeMock } = vi.hoisted(() => ({ notifyDataApiDataChangeMock: vi.fn() }))
+vi.mock('@data/dataApiDataChange', () => ({ notifyDataApiDataChange: notifyDataApiDataChangeMock }))
+
+vi.mock('@application', async () => {
+  const mod = await import('@test-mocks/main/application')
+  return mod.mockApplicationFactory()
+})
+
+// The sync only needs SOME registered handler for 'agent.task'.
+vi.mock('../agentTaskJobHandler', () => ({
+  agentTaskJobHandler: {
+    recovery: 'retry',
+    defaultConcurrency: 1,
+    async execute() {
+      return {}
+    }
+  } satisfies JobHandler
+}))
+
+import {
+  DEFAULT_HEARTBEAT_INTERVAL_MINUTES,
+  HEARTBEAT_PROMPT_SENTINEL,
+  normalizeHeartbeatIntervalMinutes,
+  syncHeartbeatSchedule
+} from '../heartbeatSchedule'
+
+const AGENT_ID = 'agent-hb-1'
+const OTHER_AGENT_ID = 'agent-hb-2'
+
+describe('heartbeatSchedule', () => {
+  const dbh = setupTestDatabase()
+  let scheduler: SchedulerService
+  let jobManager: JobManager
+
+  function seedAgent(id: string, configuration: Record<string, unknown> = {}): void {
+    dbh.db
+      .insert(agentTable)
+      .values({
+        id,
+        type: 'claude-code',
+        name: `Agent ${id}`,
+        instructions: '',
+        orderKey: id,
+        configuration
+      })
+      .run()
+  }
+
+  function heartbeatScheduleOf(agentId: string) {
+    return jobScheduleService.listAll({ type: 'agent.task' }).find((s) => {
+      const t = s.jobInputTemplate as { agentId?: unknown; prompt?: unknown }
+      return t?.agentId === agentId && t?.prompt === HEARTBEAT_PROMPT_SENTINEL
+    })
+  }
+
+  beforeAll(async () => {
+    BaseService.resetInstances()
+    scheduler = new SchedulerService()
+    jobManager = new JobManager()
+
+    const dbSvc = MockMainDbServiceExport.dbService
+    dbSvc.withWriteTx.mockImplementation(<T>(fn: (tx: unknown) => T): T => dbh.db.transaction((tx) => fn(tx)))
+    const cacheSvc = MockMainCacheServiceExport.cacheService
+    ;(application.get as ReturnType<typeof vi.fn>).mockImplementation((name: string) => {
+      switch (name) {
+        case 'DbService':
+          return dbSvc
+        case 'CacheService':
+          return cacheSvc
+        case 'SchedulerService':
+          return scheduler
+        case 'JobManager':
+          return jobManager
+        case 'PowerService':
+          return { preventSleep: () => ({ dispose: () => {} }) }
+      }
+      throw new Error(`Unexpected application.get('${name}')`)
+    })
+
+    await scheduler._doInit()
+    await jobManager._doInit()
+    jobManager.registerHandler('agent.task', {
+      recovery: 'retry',
+      defaultConcurrency: 1,
+      async execute() {
+        return {}
+      }
+    })
+  })
+
+  beforeEach(() => {
+    notifyDataApiDataChangeMock.mockClear()
+    dbh.db.delete(agentTable).run()
+  })
+
+  afterAll(async () => {
+    await jobManager._doStop()
+    await scheduler._doStop()
+    BaseService.resetInstances()
+  })
+
+  describe('normalizeHeartbeatIntervalMinutes', () => {
+    it('falls back to the default for missing, zero, negative and non-finite values', () => {
+      expect(normalizeHeartbeatIntervalMinutes(undefined)).toBe(DEFAULT_HEARTBEAT_INTERVAL_MINUTES)
+      expect(normalizeHeartbeatIntervalMinutes(0)).toBe(DEFAULT_HEARTBEAT_INTERVAL_MINUTES)
+      expect(normalizeHeartbeatIntervalMinutes(-5)).toBe(DEFAULT_HEARTBEAT_INTERVAL_MINUTES)
+      expect(normalizeHeartbeatIntervalMinutes(Number.NaN)).toBe(DEFAULT_HEARTBEAT_INTERVAL_MINUTES)
+    })
+
+    it('keeps valid intervals', () => {
+      expect(normalizeHeartbeatIntervalMinutes(1)).toBe(1)
+      expect(normalizeHeartbeatIntervalMinutes(45)).toBe(45)
+    })
+  })
+
+  describe('syncHeartbeatSchedule', () => {
+    it('creates a heartbeat schedule for an enabled agent (#19203)', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: true, heartbeat_interval: 5 })
+
+      const result = syncHeartbeatSchedule(AGENT_ID)
+
+      expect(result.status).toBe('created')
+      const schedule = heartbeatScheduleOf(AGENT_ID)
+      expect(schedule).toBeDefined()
+      // 5 minutes -> interval trigger in ms
+      expect(schedule?.trigger).toEqual({ kind: 'interval', ms: 5 * 60_000 })
+      expect(schedule?.jobInputTemplate).toMatchObject({
+        agentId: AGENT_ID,
+        prompt: HEARTBEAT_PROMPT_SENTINEL
+      })
+      // the heartbeat must resolve heartbeat.md in a USER workspace
+      const workspace = (schedule?.jobInputTemplate as { workspace?: { type?: string } }).workspace
+      expect(workspace?.type).toBe('user')
+      expect(notifyDataApiDataChangeMock).toHaveBeenCalled()
+    })
+
+    it('applies the default interval when none is configured', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: true })
+
+      syncHeartbeatSchedule(AGENT_ID)
+
+      expect(heartbeatScheduleOf(AGENT_ID)?.trigger).toEqual({
+        kind: 'interval',
+        ms: DEFAULT_HEARTBEAT_INTERVAL_MINUTES * 60_000
+      })
+    })
+
+    it('updates the interval when the configuration changes and is a no-op otherwise', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: true, heartbeat_interval: 5 })
+      syncHeartbeatSchedule(AGENT_ID)
+      const first = heartbeatScheduleOf(AGENT_ID)
+
+      notifyDataApiDataChangeMock.mockClear()
+      expect(syncHeartbeatSchedule(AGENT_ID).status).toBe('unchanged')
+      expect(notifyDataApiDataChangeMock).not.toHaveBeenCalled()
+
+      dbh.db
+        .update(agentTable)
+        .set({ configuration: { heartbeat_enabled: true, heartbeat_interval: 10 } })
+        .where(eq(agentTable.id, AGENT_ID))
+        .run()
+
+      expect(syncHeartbeatSchedule(AGENT_ID).status).toBe('updated')
+      const second = heartbeatScheduleOf(AGENT_ID)
+      expect(second?.id).toBe(first?.id)
+      expect(second?.trigger).toEqual({ kind: 'interval', ms: 10 * 60_000 })
+    })
+
+    it('does nothing when the heartbeat is disabled', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: false, heartbeat_interval: 5 })
+
+      expect(syncHeartbeatSchedule(AGENT_ID).status).toBe('disabled')
+      expect(heartbeatScheduleOf(AGENT_ID)).toBeUndefined()
+    })
+
+    it('supports one heartbeat schedule per agent (schedule names are unique per type)', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: true, heartbeat_interval: 7 })
+      seedAgent(OTHER_AGENT_ID, { heartbeat_enabled: true, heartbeat_interval: 9 })
+
+      expect(syncHeartbeatSchedule(AGENT_ID).status).toBe('created')
+      expect(syncHeartbeatSchedule(OTHER_AGENT_ID).status).toBe('created')
+
+      const first = heartbeatScheduleOf(AGENT_ID)
+      const second = heartbeatScheduleOf(OTHER_AGENT_ID)
+      expect(first?.id).not.toBe(second?.id)
+      expect(first?.name).not.toBe(second?.name)
+      expect(first?.trigger).toEqual({ kind: 'interval', ms: 7 * 60_000 })
+      expect(second?.trigger).toEqual({ kind: 'interval', ms: 9 * 60_000 })
+    })
+
+    it('reports agent-not-found for a missing agent', () => {
+      expect(syncHeartbeatSchedule('no-such-agent').status).toBe('agent-not-found')
+    })
+  })
+
+  describe('task listing integration', () => {
+    it('excludes heartbeat schedules by default and includes them on request, keyed off the sentinel', () => {
+      seedAgent(AGENT_ID, { heartbeat_enabled: true })
+      syncHeartbeatSchedule(AGENT_ID)
+
+      const visible = agentTaskService.listTasks(AGENT_ID)
+      expect(visible.tasks.map((t) => t.name)).not.toContain(heartbeatScheduleOf(AGENT_ID)?.name)
+
+      const withHeartbeat = agentTaskService.listTasks(AGENT_ID, { includeHeartbeat: true })
+      expect(withHeartbeat.tasks.map((t) => t.name)).toContain(heartbeatScheduleOf(AGENT_ID)?.name)
+    })
+  })
+})

--- a/src/main/ai/agents/createAgent.ts
+++ b/src/main/ai/agents/createAgent.ts
@@ -6,6 +6,8 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { createAgentDataDirectory, removeAgentDataDirectory } from './agentDataDirectory'
 
+import { syncHeartbeatSchedule } from './heartbeatSchedule'
+
 const logger = loggerService.withContext('CreateAgent')
 
 export async function createAgent(request: CreateAgentCommand) {
@@ -14,7 +16,21 @@ export async function createAgent(request: CreateAgentCommand) {
   await createAgentDataDirectory(agentsDataRoot, agentId)
 
   try {
-    return agentService.createAgentWithId(agentId, request)
+    const agent = agentService.createAgentWithId(agentId, request)
+
+    // Restore the create-time heartbeat provisioning lost with the legacy
+    // SchedulerService (#19203). Failure to schedule must not fail agent
+    // creation: the switch still round-trips and the next configuration
+    // save re-runs the sync.
+    if (request.configuration?.heartbeat_enabled === true) {
+      try {
+        syncHeartbeatSchedule(agentId)
+      } catch (error) {
+        logger.warn('Failed to provision heartbeat schedule on create', { agentId, error })
+      }
+    }
+
+    return agent
   } catch (error) {
     try {
       await removeAgentDataDirectory(agentsDataRoot, agentId)

--- a/src/main/ai/agents/heartbeatSchedule.ts
+++ b/src/main/ai/agents/heartbeatSchedule.ts
@@ -1,0 +1,162 @@
+/**
+ * Heartbeat schedule ownership — the piece the JobManager migration dropped.
+ *
+ * `heartbeat_enabled` / `heartbeat_interval` are agent configuration keys the
+ * edit dialog writes; the run side (`runAgentTask`) still consumes them and
+ * expects a `agent.task` schedule whose input template carries the heartbeat
+ * prompt sentinel. Between them, nothing translated a saved configuration into
+ * a schedule since the legacy `SchedulerService.ensureHeartbeatTask` was
+ * deleted (#19203): the switch round-tripped in the UI while no run was ever
+ * produced.
+ *
+ * This module restores the translation on the JobManager stack. The schedule
+ * is identified by its job input template (`agentId` + prompt sentinel), not
+ * by its name: `job_schedule` enforces uniqueness per (type, name), so with
+ * more than one heartbeating agent the literal name `heartbeat` cannot belong
+ * to everyone. The template is also what the run side and the task-listing
+ * exclusion already key off.
+ */
+
+import { application } from '@application'
+import { agentService } from '@data/services/AgentService'
+import { agentTaskService, writeTaskSessionReuse } from '@data/services/AgentTaskService'
+import { agentWorkspaceService } from '@data/services/AgentWorkspaceService'
+import { jobScheduleService } from '@data/services/JobScheduleService'
+import { loggerService } from '@logger'
+import { triggersEqual } from '@shared/data/api/schemas/jobs'
+import type { Trigger } from '@shared/data/api/schemas/jobs'
+
+import { agentDataDirectoryPath } from './agentDataDirectory'
+
+const logger = loggerService.withContext('HeartbeatSchedule')
+
+export const AGENT_TASK_TYPE = 'agent.task' as const
+export const HEARTBEAT_PROMPT_SENTINEL = '__heartbeat__'
+export const DEFAULT_HEARTBEAT_INTERVAL_MINUTES = 30
+const HEARTBEAT_TIMEOUT_MINUTES = 5
+
+/**
+ * Lower bound for `heartbeat_interval`. The schema accepts any number (0,
+ * negatives) and the run side would otherwise arm an interval trigger with
+ * `ms <= 0`, which the scheduler rejects or fires unstoppably.
+ */
+export function normalizeHeartbeatIntervalMinutes(value: number | undefined): number {
+  const minutes = value ?? DEFAULT_HEARTBEAT_INTERVAL_MINUTES
+  return Number.isFinite(minutes) && minutes >= 1 ? minutes : DEFAULT_HEARTBEAT_INTERVAL_MINUTES
+}
+
+function heartbeatTriggerFor(intervalMinutes: number): Trigger {
+  return { kind: 'interval', ms: Math.round(intervalMinutes * 60_000) }
+}
+
+/** True when the schedule row is this agent's heartbeat, keyed off the input template. */
+function isHeartbeatScheduleFor(snapshot: { jobInputTemplate: unknown }, agentId: string): boolean {
+  const template = snapshot.jobInputTemplate
+  if (typeof template !== 'object' || template === null) return false
+  const { agentId: templateAgentId, prompt } = template as { agentId?: unknown; prompt?: unknown }
+  return templateAgentId === agentId && prompt === HEARTBEAT_PROMPT_SENTINEL
+}
+
+export type SyncHeartbeatResult =
+  | { status: 'created'; scheduleId: string }
+  | { status: 'updated'; scheduleId: string }
+  | { status: 'unchanged'; scheduleId: string }
+  | { status: 'disabled' }
+  | { status: 'agent-not-found' }
+
+/**
+ * Ensure the agent's heartbeat schedule matches its saved configuration:
+ * create it when missing, re-arm the interval when it changed. A disabled
+ * heartbeat leaves any existing schedule in place — the run side already
+ * no-ops on `heartbeat_enabled === false`, and the row keeps the interval
+ * for when the switch comes back on.
+ */
+export function syncHeartbeatSchedule(agentId: string): SyncHeartbeatResult {
+  const agent = agentService.getAgent(agentId)
+  if (!agent) return { status: 'agent-not-found' }
+
+  const config = agent.configuration ?? {}
+  if (config.heartbeat_enabled !== true) return { status: 'disabled' }
+
+  const intervalMinutes = normalizeHeartbeatIntervalMinutes(config.heartbeat_interval)
+  const trigger = heartbeatTriggerFor(intervalMinutes)
+  // heartbeat.md lives in the agent's data directory; register it as the
+  // agent's user workspace so the run side can resolve the path.
+  const workspacePath = agentDataDirectoryPath(application.getPath('feature.agents.data'), agentId)
+
+  const jobManager = application.get('JobManager')
+
+  const { outcome, needsTimerSync } = application.get('DbService').withWriteTx(
+    (
+      tx
+    ): {
+      outcome: SyncHeartbeatResult
+      needsTimerSync: boolean
+    } => {
+      const existing = jobScheduleService
+        .listAllTx(tx, { type: AGENT_TASK_TYPE })
+        .find((s) => isHeartbeatScheduleFor(s, agentId))
+
+      const workspace = agentWorkspaceService.findOrCreateByPathTx(tx, workspacePath, {
+        name: `${agent.name} (heartbeat)`
+      })
+
+      if (!existing) {
+        const { id } = jobManager.registerJobScheduleTx(tx, {
+          type: AGENT_TASK_TYPE,
+          name: `heartbeat:${agentId}`,
+          trigger,
+          jobInputTemplate: {
+            agentId,
+            prompt: HEARTBEAT_PROMPT_SENTINEL,
+            timeoutMinutes: HEARTBEAT_TIMEOUT_MINUTES,
+            workspace: { type: 'user', workspaceId: workspace.id },
+            reuseRevision: 0
+          },
+          metadata: writeTaskSessionReuse(undefined, { enabled: false, revision: 0 }),
+          catchUpPolicy: { kind: 'skip-missed' }
+        })
+        return { outcome: { status: 'created', scheduleId: id }, needsTimerSync: true }
+      }
+
+      let outcome: SyncHeartbeatResult = { status: 'unchanged', scheduleId: existing.id }
+      const patch: { trigger?: Trigger; jobInputTemplate?: unknown } = {}
+      if (!triggersEqual(existing.trigger, trigger)) {
+        patch.trigger = trigger
+        outcome = { status: 'updated', scheduleId: existing.id }
+      }
+      // Keep the template pointed at the agent's workspace even if the workspace
+      // row was recreated under a new id (e.g. after a restore).
+      const template = existing.jobInputTemplate as { workspace?: { workspaceId?: string } } | null
+      if (template?.workspace?.workspaceId !== workspace.id) {
+        patch.jobInputTemplate = {
+          agentId,
+          prompt: HEARTBEAT_PROMPT_SENTINEL,
+          timeoutMinutes: HEARTBEAT_TIMEOUT_MINUTES,
+          workspace: { type: 'user', workspaceId: workspace.id },
+          reuseRevision: 0
+        }
+        outcome = { status: 'updated', scheduleId: existing.id }
+      }
+      if (patch.trigger !== undefined || patch.jobInputTemplate !== undefined) {
+        jobManager.updateJobScheduleTx(tx, existing.id, patch)
+      }
+      return { outcome, needsTimerSync: patch.trigger !== undefined }
+    }
+  )
+
+  const scheduleId = 'scheduleId' in outcome ? outcome.scheduleId : undefined
+  if (needsTimerSync && scheduleId) {
+    jobManager.syncJobScheduleTimerById(scheduleId)
+  }
+
+  if (scheduleId && (outcome.status === 'created' || outcome.status === 'updated')) {
+    logger.info('Heartbeat schedule ' + outcome.status, {
+      agentId,
+      intervalMinutes,
+      scheduleId
+    })
+    agentTaskService.notifyReadModelChange([scheduleId])
+  }
+  return outcome
+}

--- a/src/main/ai/agents/runAgentTask.ts
+++ b/src/main/ai/agents/runAgentTask.ts
@@ -36,6 +36,7 @@ import { jobScheduleService } from '@data/services/JobScheduleService'
 import { jobService } from '@data/services/JobService'
 import { loggerService } from '@logger'
 import { readHeartbeat } from '@main/ai/agents/heartbeat'
+import { HEARTBEAT_PROMPT_SENTINEL } from '@main/ai/agents/heartbeatSchedule'
 import { buildAgentSessionTopicId } from '@main/ai/agentSession/topic'
 import { ChannelAdapterListener, startAgentSessionRun, type StreamListener } from '@main/ai/streamManager'
 import type { JobContext } from '@main/core/job/types'
@@ -43,9 +44,6 @@ import { ErrorCode, isDataApiError } from '@shared/data/api/errors'
 import { AGENT_WORKSPACE_TYPE, type AgentSessionWorkspaceSource } from '@shared/data/api/schemas/agentWorkspaces'
 
 const logger = loggerService.withContext('runAgentTask')
-
-const HEARTBEAT_PROMPT_SENTINEL = '__heartbeat__'
-const HEARTBEAT_TASK_NAME = 'heartbeat'
 
 export type AgentTaskInput = {
   agentId: string
@@ -157,7 +155,10 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
 
   const config = agent.configuration ?? {}
 
-  const isHeartbeat = taskName === HEARTBEAT_TASK_NAME && prompt === HEARTBEAT_PROMPT_SENTINEL
+  // The prompt sentinel is the discriminator: schedule names carry the agent id
+  // (uniqueness is per (type, name)), so pinning the heartbeat on a literal name
+  // would let only one agent ever heart beat. `taskName` stays for logging.
+  const isHeartbeat = prompt === HEARTBEAT_PROMPT_SENTINEL && taskName !== null
 
   let effectivePrompt = prompt
 

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -25,7 +25,7 @@ import type { JobScheduleSnapshot, JobSnapshot } from '@shared/data/api/schemas/
 import type { ListOptions } from '@shared/data/api/types'
 
 const AGENT_TASK_TYPE = 'agent.task' as const
-const HEARTBEAT_TASK_NAME = 'heartbeat'
+const HEARTBEAT_PROMPT_SENTINEL = '__heartbeat__'
 
 type AgentTaskJobInputTemplate = {
   agentId: string
@@ -208,7 +208,10 @@ export class AgentTaskService {
       const template = normalizeAgentTaskTemplate(s.jobInputTemplate)
       if (!template) return false
       if (agentId !== undefined && template.agentId !== agentId) return false
-      if (!includeHeartbeat && s.name === HEARTBEAT_TASK_NAME) return false
+      // Keyed off the prompt sentinel rather than the name: names carry the agent
+      // id (uniqueness is per (type, name)), and every agent's heartbeat uses
+      // the sentinel as its actual discriminator.
+      if (!includeHeartbeat && template.prompt === HEARTBEAT_PROMPT_SENTINEL) return false
       return true
     })
 

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -210,7 +210,12 @@ describe('AgentTaskService (read side)', () => {
           name: 'b',
           jobInputTemplate: { agentId: 'other', prompt: 'x', timeoutMinutes: 2, workspace: taskWorkspace }
         }),
-        makeSnapshot({ id: 's3', name: 'heartbeat' })
+        // A real heartbeat row: the prompt sentinel is the discriminator
+        makeSnapshot({
+          id: 's3',
+          name: 'heartbeat:agent-1',
+          jobInputTemplate: { agentId: AGENT_ID, prompt: '__heartbeat__', timeoutMinutes: 5, workspace: taskWorkspace }
+        })
       ])
 
       const result = agentTaskService.listTasks(AGENT_ID)
@@ -220,10 +225,25 @@ describe('AgentTaskService (read side)', () => {
       expect(result.tasks[0].id).toBe('s1')
     })
 
+    it('keeps a user task that merely happens to be named heartbeat visible', () => {
+      vi.mocked(jobScheduleService.listAll).mockReturnValueOnce([
+        makeSnapshot({ id: 's1', name: 'a' }),
+        makeSnapshot({ id: 'named', name: 'heartbeat' })
+      ])
+
+      const result = agentTaskService.listTasks(AGENT_ID)
+
+      expect(result.tasks.map((t) => t.id)).toEqual(['s1', 'named'])
+    })
+
     it('returns heartbeat tasks when includeHeartbeat=true', () => {
       vi.mocked(jobScheduleService.listAll).mockReturnValueOnce([
         makeSnapshot({ id: 's1', name: 'a' }),
-        makeSnapshot({ id: 's3', name: 'heartbeat' })
+        makeSnapshot({
+          id: 's3',
+          name: 'heartbeat:agent-1',
+          jobInputTemplate: { agentId: AGENT_ID, prompt: '__heartbeat__', timeoutMinutes: 5, workspace: taskWorkspace }
+        })
       ])
 
       const result = agentTaskService.listTasks(AGENT_ID, { includeHeartbeat: true })
@@ -241,7 +261,12 @@ describe('AgentTaskService (read side)', () => {
           createdAt: '2026-05-22T00:00:00.000Z',
           jobInputTemplate: { agentId: 'other', prompt: 'x', timeoutMinutes: 2, workspace: taskWorkspace }
         }),
-        makeSnapshot({ id: 'heartbeat', name: 'heartbeat', createdAt: '2026-05-23T00:00:00.000Z' })
+        makeSnapshot({
+          id: 'heartbeat',
+          name: 'heartbeat:agent-1',
+          createdAt: '2026-05-23T00:00:00.000Z',
+          jobInputTemplate: { agentId: AGENT_ID, prompt: '__heartbeat__', timeoutMinutes: 5, workspace: taskWorkspace }
+        })
       ])
 
       const result = agentTaskService.listAllTasks({ limit: 1, offset: 0 })


### PR DESCRIPTION
## What

Restores the agent heartbeat's configuration→schedule translation that was dropped when the legacy `SchedulerService` (and `ensureHeartbeatTask`) was deleted in the JobManager migration (#19203). On v2.0.8 the switch and interval round-trip in the edit dialog while nothing ever produces a run: the execution path in `runAgentTask` is intact and waits on a schedule that no longer has a producer.

## How

- **`syncHeartbeatSchedule(agentId)`** (new `src/main/ai/agents/heartbeatSchedule.ts`) — the equivalent of the lost `ensureHeartbeatTask`, on the JobManager stack:
  - resolves the agent's data directory as a **user workspace** (that's where `runAgentTask`'s heartbeat branch expects `heartbeat.md`) via find-or-create;
  - creates the schedule, or re-arms the interval when it changed, inside one `withWriteTx`, arming the timer post-commit (same pattern as `AgentJobsService`);
  - disabled heartbeats leave any existing row alone — the run side already no-ops on `heartbeat_enabled === false`.
- **Wiring**: `ai.agent.create` provisions the schedule at creation (failure is logged, not fatal — same as the old handler), and `AgentJobsService.onInit` subscribes to `AgentService.onAgentUpdated` to re-sync whenever a configuration save carries `heartbeat_enabled` / `heartbeat_interval`. The data layer stays free of `@main/ai` imports; the event was already there for exactly this kind of derived-state reaction.
- **Discriminator switch**: heartbeat schedules are now identified by their job input template (`agentId` + `__heartbeat__` sentinel) instead of the literal name `heartbeat`. `job_schedule` enforces uniqueness per `(type, name)`, so with a name-based identity only one agent could ever heart beat. The run-side check and the `AgentTaskService` listing exclusion key off the sentinel now — which also stops hiding user tasks that merely happen to be named "heartbeat" (covered by a new test).
- **Interval guard**: `heartbeat_interval <= 0` (accepted by the schema per the issue) falls back to the 30-minute default instead of arming an invalid interval trigger.

## Testing

New `heartbeatSchedule.test.ts` (real file-backed DB + real JobManager/SchedulerService, mirroring `AgentJobsService.test.ts`): create/unchanged/update lifecycle, default + clamped intervals, disabled no-op, two agents with distinct schedules, agent-not-found, and the listing exclusion both ways. Existing `AgentTaskService` exclusion fixtures updated to the real heartbeat row shape, plus the named-heartbeat visibility case. All 64 tests in the touched suites pass; the two listing tests fail against the old name-based exclusion (differential).

Fixes #19203
