### PR TITLE
fix(agents): delete an agent's task schedules with the agent

### DIFF
--- a/src/main/ai/agents/AgentJobsService.ts
+++ b/src/main/ai/agents/AgentJobsService.ts
@@ -71,6 +71,18 @@ function readAgentTaskJobInputTemplate(value: unknown): AgentTaskJobInputTemplat
 export class AgentJobsService extends BaseService {
   protected async onInit(): Promise<void> {
     application.get('JobManager').registerHandler('agent.task', agentTaskJobHandler)
+
+    // Deleting an agent used to leave its schedules behind: nothing listened
+    // to onAgentDeleted, so every interval kept firing for an agent that no
+    // longer exists, each run failing with 'Agent not found'. The event fires
+    // post-commit, after the agent row is already gone.
+    this.registerDisposable(
+      agentService.onAgentDeleted(({ agentId }) => {
+        void this.deleteSchedulesForAgent(agentId).catch((error) => {
+          logger.warn('Failed to delete schedules for removed agent', { agentId, error })
+        })
+      })
+    )
   }
 
   createTask(agentId: string, form: AgentTaskForm): ScheduledTaskEntity {
@@ -213,6 +225,32 @@ export class AgentJobsService extends BaseService {
     // jobs keep their rows with scheduleId set NULL (ON DELETE SET NULL).
     const deleted = await application.get('JobManager').unregisterJobScheduleById(taskId)
     if (deleted) logger.info('Task deleted', { taskId, agentId })
+    return deleted
+  }
+
+  /**
+   * Delete every `agent.task` schedule owned by `agentId` — the schedule-side
+   * half of agent deletion. Historical jobs keep their rows with `scheduleId`
+   * set NULL (`ON DELETE SET NULL`, same as `deleteTask`).
+   *
+   * @returns How many schedule rows were removed.
+   */
+  async deleteSchedulesForAgent(agentId: string): Promise<number> {
+    const schedules = jobScheduleService.listAll({ type: AGENT_TASK_TYPE }).filter((s) => {
+      const template = readAgentTaskJobInputTemplate(s.jobInputTemplate)
+      return template?.agentId === agentId
+    })
+
+    let deleted = 0
+    for (const schedule of schedules) {
+      if (await application.get('JobManager').unregisterJobScheduleById(schedule.id)) {
+        deleted += 1
+      }
+    }
+    if (deleted > 0) {
+      logger.info('Deleted task schedules for removed agent', { agentId, deleted })
+      agentTaskService.notifyReadModelChange(schedules.map((s) => s.id))
+    }
     return deleted
   }
 

--- a/src/main/ai/agents/__tests__/AgentJobsService.test.ts
+++ b/src/main/ai/agents/__tests__/AgentJobsService.test.ts
@@ -10,6 +10,7 @@ import { application } from '@application'
 import { agentTable } from '@data/db/schemas/agent'
 import { agentChannelTable, agentChannelTaskTable } from '@data/db/schemas/agentChannel'
 import { agentChannelService } from '@data/services/AgentChannelService'
+import { agentService } from '@data/services/AgentService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import { jobScheduleService } from '@data/services/JobScheduleService'
 import { JobManager } from '@main/core/job/JobManager'
@@ -592,6 +593,37 @@ describe('AgentJobsService', () => {
 
       expect(jobScheduleService.getById(task.id)).toBeNull()
       expect(subscriptionRows(task.id)).toHaveLength(0)
+      expect(scheduler.has(`schedule:${task.id}`)).toBe(false)
+    })
+
+    it('deleting an agent removes its schedules and disposes their timers (orphan cleanup)', async () => {
+      seedAgent(OTHER_AGENT_ID)
+      const own = service.createTask(AGENT_ID, form)
+      const second = service.createTask(AGENT_ID, { ...form, name: 'hourly-rollup' })
+      const foreign = service.createTask(OTHER_AGENT_ID, { ...form, name: 'foreign-task' })
+
+      expect(await service.deleteSchedulesForAgent(AGENT_ID)).toBe(2)
+
+      expect(jobScheduleService.getById(own.id)).toBeNull()
+      expect(jobScheduleService.getById(second.id)).toBeNull()
+      // other agents' schedules are untouched
+      expect(jobScheduleService.getById(foreign.id)).not.toBeNull()
+      expect(scheduler.has(`schedule:${own.id}`)).toBe(false)
+      expect(scheduler.has(`schedule:${second.id}`)).toBe(false)
+      expect(scheduler.has(`schedule:${foreign.id}`)).toBe(true)
+    })
+
+    it('agent deletion fires the cleanup through onAgentDeleted', async () => {
+      const task = service.createTask(AGENT_ID, form)
+
+      // The full deleteAgent path needs the data-service registry (out of
+      // scope here); fire the real emitter the subscription listens on.
+      ;(
+        agentService as unknown as { _onAgentDeleted: { fire: (e: { agentId: string }) => void } }
+      )._onAgentDeleted.fire({ agentId: AGENT_ID })
+
+      // The subscription is fire-and-forget; let the microtask queue drain.
+      await vi.waitFor(() => expect(jobScheduleService.getById(task.id)).toBeNull())
       expect(scheduler.has(`schedule:${task.id}`)).toBe(false)
     })
 


### PR DESCRIPTION
## What

Deleting an agent leaves its scheduled tasks running forever. `AgentService.deleteAgentForDelivery` fires `onAgentDeleted` after the commit — sessions detach (or delete), pins and prompt bindings purge, junction rows cascade — but **nothing listens to `onAgentDeleted`**, so every `agent.task` schedule the agent owned survives as an orphan. Each interval keeps firing, every run fails with `Agent not found`, and failed job rows accumulate for the lifetime of the database.

## How

`AgentJobsService` (the command owner for agent scheduled tasks) now subscribes to `onAgentDeleted` in `onInit` and runs `deleteSchedulesForAgent(agentId)`:

- finds every `agent.task` schedule whose job input template belongs to the removed agent (same template-based ownership check the rest of the service uses);
- unregisters each one through `JobManager.unregisterJobScheduleById` — timer disposed, row deleted, historical jobs keep their rows with `scheduleId` set NULL via `ON DELETE SET NULL` (identical semantics to the existing `deleteTask`);
- other agents' schedules are untouched.

The subscription is registered via `registerDisposable`, matching the `AgentSessionRuntimeService` pattern for `onAgentUpdated`.

Found while restoring the heartbeat scheduling in #19203 (PR #19214): a heartbeat schedule created for an agent would have become exactly such an orphan when the agent was deleted.

## Testing

Two new cases in `AgentJobsService.test.ts` (real file-backed DB, real JobManager + SchedulerService):

- deleting an agent's schedules removes its rows and disposes its timers while another agent's schedule (and timer) survives;
- firing `onAgentDeleted` runs the cleanup end to end (the subscription wiring itself).

Both fail against the unpatched service (no cleanup happens); the full suite passes with the fix (32/32).

(PR does not reference an issue number — found by code audit; happy to link one if a report exists.)
