### PR TITLE
fix(agents): walk endpoint candidates for pi/dsh model compatibility

### DIFF
--- a/src/shared/ai/__tests__/dshModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/dshModelCompatibility.test.ts
@@ -77,3 +77,42 @@ describe('isDshCompatibleModel', () => {
     expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: [] }))).toBe(false)
   })
 })
+
+describe('endpoint candidate walk (#19184)', () => {
+  it('falls through to a later declared endpoint when the first has no dsh protocol', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'openai-chat-completions': { adapterFamily: 'openai-compatible' }
+      }
+    })
+    const model = makeModel({ endpointTypes: ['ollama', 'openai-chat-completions'] })
+    expect(resolveDshApi(provider, model)).toBe('openai-completions')
+    expect(isDshCompatibleModel(provider, model)).toBe(true)
+  })
+
+  it('falls through to the provider default when no declared endpoint maps natively', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'anthropic-messages',
+      endpointConfigs: {
+        'anthropic-messages': { adapterFamily: 'anthropic' },
+        'openai-embeddings': { adapterFamily: 'openai-compatible' }
+      }
+    })
+    const model = makeModel({ endpointTypes: ['openai-embeddings'] })
+    expect(resolveDshApi(provider, model)).toBe('anthropic-messages')
+  })
+
+  it('still prefers the first declared endpoint when it maps', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'openai-chat-completions': { adapterFamily: 'openai-compatible' },
+        'anthropic-messages': { adapterFamily: 'anthropic' }
+      }
+    })
+    expect(
+      resolveDshApi(provider, makeModel({ endpointTypes: ['anthropic-messages', 'openai-chat-completions'] }))
+    ).toBe('anthropic-messages')
+  })
+})

--- a/src/shared/ai/__tests__/piModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/piModelCompatibility.test.ts
@@ -136,3 +136,52 @@ describe('resolvePiApi', () => {
     expect(isPiCompatibleModel(provider, makeModel({}))).toBe(true)
   })
 })
+
+describe('endpoint candidate walk (#19184)', () => {
+  it('falls through to a later declared endpoint when the first has no pi protocol', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'openai-chat-completions': { adapterFamily: 'openai-compatible' }
+      }
+    })
+    // First declared endpoint (ollama) has no pi protocol; the second does.
+    const model = makeModel({ endpointTypes: ['ollama', 'openai-chat-completions'] })
+    expect(resolvePiApi(provider, model)).toBe('openai-completions')
+    expect(isPiCompatibleModel(provider, model)).toBe(true)
+  })
+
+  it('falls through to the provider default when no declared endpoint maps', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'anthropic-messages',
+      endpointConfigs: {
+        'anthropic-messages': { adapterFamily: 'anthropic' },
+        'openai-embeddings': { adapterFamily: 'openai-compatible' }
+      }
+    })
+    const model = makeModel({ endpointTypes: ['openai-embeddings'] })
+    expect(resolvePiApi(provider, model)).toBe('anthropic-messages')
+    expect(isPiCompatibleModel(provider, model)).toBe(true)
+  })
+
+  it('still prefers the first declared endpoint when it maps', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: {
+        'openai-chat-completions': { adapterFamily: 'openai-compatible' },
+        'anthropic-messages': { adapterFamily: 'anthropic' }
+      }
+    })
+    expect(
+      resolvePiApi(provider, makeModel({ endpointTypes: ['anthropic-messages', 'openai-chat-completions'] }))
+    ).toBe('anthropic-messages')
+  })
+
+  it('returns undefined when no candidate maps', () => {
+    const provider = makeProvider({
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: { 'openai-chat-completions': { adapterFamily: 'azure' } }
+    })
+    expect(resolvePiApi(provider, makeModel({ endpointTypes: ['ollama'] }))).toBeUndefined()
+  })
+})

--- a/src/shared/ai/dshModelCompatibility.ts
+++ b/src/shared/ai/dshModelCompatibility.ts
@@ -65,11 +65,34 @@ export function mapEndpointToDshApi(
   }
 }
 
-/** The effective chat endpoint the dsh runtime uses, preserving the model's declared preference order. */
+/**
+ * Chat endpoints to consider for a model, in preference order: the model's
+ * declared endpoints first, then the gateway route, then the provider default.
+ */
+function dshCandidateEndpointTypes(provider: Provider, model: Model): EndpointType[] {
+  const candidates: EndpointType[] = [...(model.endpointTypes ?? [])]
+  const gateway = resolveGatewayChatRoute(provider, model)?.endpointType
+  if (gateway) candidates.push(gateway)
+  if (provider.defaultChatEndpoint) candidates.push(provider.defaultChatEndpoint)
+  return [...new Set(candidates)]
+}
+
+/**
+ * The effective chat endpoint the dsh runtime uses. Preference order is kept,
+ * but a declared endpoint with no dsh protocol no longer hides a later declared
+ * endpoint that has one (#19184): the model's first endpoint is used when it
+ * maps, else the first declared endpoint that does, else the first candidate
+ * (whose mapping is undefined — the gateway fallback then decides).
+ */
 export function resolveDshEndpointType(provider: Provider, model: Model): EndpointType | undefined {
-  return (
-    model.endpointTypes?.[0] ?? resolveGatewayChatRoute(provider, model)?.endpointType ?? provider.defaultChatEndpoint
-  )
+  const candidates = dshCandidateEndpointTypes(provider, model)
+  if (candidates.length === 0) return undefined
+  for (const candidate of candidates) {
+    if (mapEndpointToDshApi(candidate, provider.endpointConfigs?.[candidate]?.adapterFamily) !== undefined) {
+      return candidate
+    }
+  }
+  return candidates[0]
 }
 
 /** Resolve the dsh `api` protocol for a Cherry provider+model, or `undefined` if unsupported. */

--- a/src/shared/ai/piModelCompatibility.ts
+++ b/src/shared/ai/piModelCompatibility.ts
@@ -95,10 +95,33 @@ export function mapEndpointToPiApi(
  * `resolveEffectiveEndpoint`'s endpoint selection (kept pure here so the
  * renderer, which has no main-only resolver, can reuse it).
  */
+/**
+ * Chat endpoints to consider for a model, in preference order: the model's
+ * declared endpoints first, then the gateway route, then the provider default.
+ */
+function candidateEndpointTypes(provider: Provider, model: Model): EndpointType[] {
+  const candidates: EndpointType[] = [...(model.endpointTypes ?? [])]
+  const gateway = resolveGatewayChatRoute(provider, model)?.endpointType
+  if (gateway) candidates.push(gateway)
+  if (provider.defaultChatEndpoint) candidates.push(provider.defaultChatEndpoint)
+  return [...new Set(candidates)]
+}
+
+/**
+ * The effective chat endpoint the pi runtime uses. Preference order is kept,
+ * but a declared endpoint with no pi protocol no longer hides a later declared
+ * endpoint that has one (#19184): the model's first endpoint is used when it
+ * maps, else the first declared endpoint that does, else the first candidate.
+ */
 function resolveEndpointType(provider: Provider, model: Model): EndpointType | undefined {
-  return (
-    model.endpointTypes?.[0] ?? resolveGatewayChatRoute(provider, model)?.endpointType ?? provider.defaultChatEndpoint
-  )
+  const candidates = candidateEndpointTypes(provider, model)
+  if (candidates.length === 0) return undefined
+  for (const candidate of candidates) {
+    if (mapEndpointToPiApi(candidate, provider.endpointConfigs?.[candidate]?.adapterFamily) !== undefined) {
+      return candidate
+    }
+  }
+  return candidates[0]
 }
 
 /** Resolve the pi `api` family for a Cherry provider+model, or `undefined` if unsupported. */


### PR DESCRIPTION
## What

Implements suggestion 4 from #19184 (endpoint resolution). The pi and dsh compatibility resolvers picked **one** endpoint — `model.endpointTypes?.[0]` ?? gateway route ?? provider default — and mapped just that endpoint. A first-listed endpoint with no pi/dsh protocol (e.g. `ollama` on a model that also declares `openai-chat-completions`, or an embeddings endpoint listed first on a provider whose chat default is anthropic) hid every later candidate, so the model silently vanished from the Pi/DSH pickers while the Claude runtime still listed it — and reconfiguring the provider changed nothing.

## How

Both `resolveEndpointType` (pi) and `resolveDshEndpointType` (dsh) now build the candidate list in preference order — declared model endpoints, gateway route, provider default, deduplicated — and select the **first candidate that maps to a protocol**:

- when the first declared endpoint maps, behavior is identical to before (all 16 existing tests pass unchanged);
- when it does not, the resolver falls through to the next declared endpoint, then the gateway route, then the provider default;
- when nothing maps, the resolver still returns the first candidate whose mapping is `undefined` — so pi stays fail-closed and dsh's gateway-routable fallback decides exactly as before.

Because the dsh main-side injection (`modelInjection.resolveDshInjectionApi`) resolves through the same shared function, the endpoint actually driven matches the one the picker accepted — no drift between filter and runtime.

## Testing

Seven new cases across `piModelCompatibility.test.ts` / `dshModelCompatibility.test.ts`: fall-through to a later declared endpoint, fall-through to the provider default, first-maps preference preserved, and undefined when no candidate maps. Differential: with the two resolvers stashed, the 4 fall-through cases fail; with the fix, 23/23 pass, plus the main-side dsh runtime suites (91 tests) and the renderer `useAgentModelFilter` suite (112 tests) stay green.

Fixes #19184
