### PR TITLE
fix(oauth): clean up popup message listeners on every exit path

### DIFF
--- a/src/renderer/services/__tests__/oauth.test.ts
+++ b/src/renderer/services/__tests__/oauth.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import { loggerService } from '@logger'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+  }
+}))
+
+vi.mock('@renderer/i18n/resolver', () => ({
+  default: { t: (key: string) => key },
+  getLanguageCode: async () => 'en'
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { on: vi.fn(() => () => {}), request: vi.fn() }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: vi.fn() }
+}))
+
+import { listenForPopupMessage } from '../popupMessage'
+import { oauthWith302AI, oauthWithAiOnly, oauthWithSiliconFlow } from '../oauth'
+
+function fakeWindow(): Window {
+  return { closed: false } as unknown as Window
+}
+
+function postMessage(data: unknown, source: unknown = null): void {
+  window.dispatchEvent(new MessageEvent('message', { data, source }))
+}
+
+describe('listenForPopupMessage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('delivers a matching payload exactly once and removes the listener', async () => {
+    const popup = fakeWindow()
+    const setKey = vi.fn()
+    const isExpected = (d: unknown): d is string => typeof d === 'string'
+    listenForPopupMessage({ popup, isExpected, onMessage: setKey })
+
+    postMessage('the-key', popup)
+    postMessage('the-key', popup)
+
+    await vi.runAllTimersAsync()
+    expect(setKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('never throws on null / string / unrelated payloads', async () => {
+    const popup = fakeWindow()
+    const onMessage = vi.fn()
+    listenForPopupMessage({ popup, isExpected: (d): d is string => typeof d === 'string', onMessage })
+
+    expect(() => {
+      postMessage(null, popup)
+      postMessage({ other: 'shape' }, popup)
+      postMessage(undefined, popup)
+    }).not.toThrow()
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('ignores messages whose source is not the popup', () => {
+    const popup = fakeWindow()
+    const onMessage = vi.fn()
+    listenForPopupMessage({ popup, isExpected: (d): d is string => typeof d === 'string', onMessage })
+
+    postMessage('the-key', fakeWindow())
+    postMessage('the-key', null)
+
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('cleans up when the popup is closed by the user', () => {
+    const popup = fakeWindow()
+    const onMessage = vi.fn()
+    listenForPopupMessage({ popup, isExpected: (d): d is string => typeof d === 'string', onMessage })
+
+    ;(popup as unknown as { closed: boolean }).closed = true
+    vi.advanceTimersByTime(1500)
+
+    postMessage('the-key', popup)
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('does not arm a listener at all when the popup was blocked', () => {
+    const onMessage = vi.fn()
+    listenForPopupMessage({ popup: null, isExpected: (d): d is string => typeof d === 'string', onMessage })
+
+    postMessage('the-key', null)
+    expect(onMessage).not.toHaveBeenCalled()
+  })
+
+  it('removes the listener when onMessage throws', async () => {
+    const popup = fakeWindow()
+    const boom = vi.fn(() => {
+      throw new Error('boom')
+    })
+    listenForPopupMessage({ popup, isExpected: (d): d is string => typeof d === 'string', onMessage: boom })
+
+    expect(() => postMessage('k', popup)).not.toThrow()
+    postMessage('k', popup)
+
+    await vi.runAllTimersAsync()
+    expect(boom).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('oauth flows use the popup listener helper (#19210)', () => {
+  const popups: Window[] = []
+
+  beforeEach(() => {
+    popups.length = 0
+    vi.spyOn(window, 'open').mockImplementation(() => {
+      const w = fakeWindow()
+      popups.push(w)
+      return w
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('oauthWithSiliconFlow sets the key once and removes its listener', async () => {
+    const setKey = vi.fn()
+    await oauthWithSiliconFlow(setKey)
+
+    postMessage([{ secretKey: 'sk-sf' }], popups[0])
+    postMessage([{ secretKey: 'sk-sf' }], popups[0])
+
+    expect(setKey).toHaveBeenCalledTimes(1)
+    expect(setKey).toHaveBeenCalledWith('sk-sf')
+  })
+
+  it('oauthWithSiliconFlow ignores same-shaped payloads from other windows', async () => {
+    const setKey = vi.fn()
+    await oauthWithSiliconFlow(setKey)
+
+    // A stale flow's message shape arriving from a foreign source.
+    postMessage([{ secretKey: 'sk-evil' }], fakeWindow())
+
+    expect(setKey).not.toHaveBeenCalled()
+  })
+
+  it('oauthWithAiOnly completes exactly once', async () => {
+    const setKey = vi.fn()
+    await oauthWithAiOnly(setKey)
+
+    postMessage([{ secretKey: 'sk-only' }], popups[0])
+    postMessage([{ secretKey: 'sk-only' }], popups[0])
+
+    expect(setKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('oauthWith302AI tolerates null-data messages', async () => {
+    const setKey = vi.fn()
+    await oauthWith302AI(setKey)
+
+    expect(() => postMessage(null, popups[0])).not.toThrow()
+    postMessage({ data: { apikey: 'k302' } }, popups[0])
+
+    expect(setKey).toHaveBeenCalledTimes(1)
+    expect(setKey).toHaveBeenCalledWith('k302')
+  })
+})
+
+// keep the logger import referenced for the module graph under test
+void loggerService

--- a/src/renderer/services/oauth.ts
+++ b/src/renderer/services/oauth.ts
@@ -2,6 +2,7 @@ import { loggerService } from '@logger'
 import i18n, { getLanguageCode } from '@renderer/i18n/resolver'
 import { ipcApi } from '@renderer/ipc'
 import { toast } from '@renderer/services/toast'
+import { listenForPopupMessage } from '@renderer/services/popupMessage'
 import { SystemProviderIds } from '@shared/utils/systemProviderId'
 
 const logger = loggerService.withContext('oauth')
@@ -19,16 +20,15 @@ export const oauthWithSiliconFlow = async (setKey) => {
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
   )
 
-  const messageHandler = (event) => {
-    if (event.data.length > 0 && event.data[0]['secretKey'] !== undefined) {
-      setKey(event.data[0]['secretKey'])
+  listenForPopupMessage({
+    popup,
+    isExpected: (data): data is Array<{ secretKey?: string }> =>
+      Array.isArray(data) && data.length > 0 && typeof data[0]?.['secretKey'] === 'string',
+    onMessage: (data) => {
+      setKey(data[0]['secretKey'])
       popup?.close()
-      window.removeEventListener('message', messageHandler)
     }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+  })
 }
 
 export const oauthWithAihubmix = async (setKey) => {
@@ -40,12 +40,12 @@ export const oauthWithAihubmix = async (setKey) => {
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
   )
 
-  const messageHandler = async (event) => {
-    const data = event.data
-
-    if (data && data.key === 'cherry_studio_oauth_callback') {
+  listenForPopupMessage({
+    popup,
+    isExpected: (data): data is { key: string; data: { iv: string; encryptedData: string } } =>
+      typeof data === 'object' && data !== null && (data as { key?: unknown }).key === 'cherry_studio_oauth_callback',
+    onMessage: async (data) => {
       const { iv, encryptedData } = data.data
-
       try {
         const secret = import.meta.env.RENDERER_VITE_AIHUBMIX_SECRET || ''
         const decryptedData: any = await window.api.aes.decrypt(encryptedData, iv, secret)
@@ -53,7 +53,6 @@ export const oauthWithAihubmix = async (setKey) => {
         if (api_keys && api_keys.length > 0) {
           setKey(api_keys[0].value)
           popup?.close()
-          window.removeEventListener('message', messageHandler)
         }
       } catch (error) {
         logger.error('[oauthWithAihubmix] error', error as Error)
@@ -61,10 +60,7 @@ export const oauthWithAihubmix = async (setKey) => {
         toast.error(i18n.t('settings.provider.oauth.error'))
       }
     }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+  })
 }
 
 export const oauthWithPPIO = async (setKey) => {
@@ -151,16 +147,17 @@ export const oauthWith302AI = async (setKey) => {
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
   )
 
-  const messageHandler = (event) => {
-    if (event.data && event.data.data.apikey !== undefined) {
-      setKey(event.data.data.apikey)
+  listenForPopupMessage({
+    popup,
+    isExpected: (data): data is { data: { apikey?: string } } =>
+      typeof data === 'object' &&
+      data !== null &&
+      typeof (data as { data?: { apikey?: unknown } }).data?.apikey === 'string',
+    onMessage: (data) => {
+      setKey(data.data.apikey)
       popup?.close()
-      window.removeEventListener('message', messageHandler)
     }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+  })
 }
 
 export const oauthWithAiOnly = async (setKey) => {
@@ -172,16 +169,15 @@ export const oauthWithAiOnly = async (setKey) => {
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
   )
 
-  const messageHandler = (event) => {
-    if (event.data.length > 0 && event.data[0]['secretKey'] !== undefined) {
-      setKey(event.data[0]['secretKey'])
+  listenForPopupMessage({
+    popup,
+    isExpected: (data): data is Array<{ secretKey?: string }> =>
+      Array.isArray(data) && data.length > 0 && typeof data[0]?.['secretKey'] === 'string',
+    onMessage: (data) => {
+      setKey(data[0]['secretKey'])
       popup?.close()
-      window.removeEventListener('message', messageHandler)
     }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+  })
 }
 
 export interface NewApiOAuthConfig {

--- a/src/renderer/services/popupMessage.ts
+++ b/src/renderer/services/popupMessage.ts
@@ -1,0 +1,83 @@
+import { loggerService } from '@logger'
+
+const logger = loggerService.withContext('popupMessage')
+
+export interface PopupMessageListenerOptions<T> {
+  /** The popup the payload is expected from. `event.source` must match it. */
+  popup: Window | null
+  /**
+   * Non-throwing shape guard: returns whether the event data carries the
+   * expected payload. Called for every message event, so it must tolerate
+   * `null`, plain strings and unrelated objects.
+   */
+  isExpected: (data: unknown) => data is T
+  /** Invoked exactly once per flow, only for events passing `isExpected`. */
+  onMessage: (data: T) => void | Promise<void>
+}
+
+/**
+ * Listen for a single postMessage from an OAuth popup with exact-reference
+ * cleanup on every exit path (#19210).
+ *
+ * The previous flow shapes removed the listener only on success, registered a
+ * fresh closure that a no-op pre-add `removeEventListener` could never match,
+ * and dereferenced `event.data` unguarded — a message with `null` data threw
+ * inside the handler. Listeners from cancelled, closed or failing popups
+ * accumulated forever, and a later flow's message could still reach a stale
+ * handler's `setKey`.
+ *
+ * This helper:
+ *  - keeps one stable handler reference and one `cleanup()` for success,
+ *    failure, popup-closed and popup-blocked paths alike;
+ *  - ignores events whose `source` is not the popup we opened;
+ *  - never throws from the handler itself (errors in `onMessage` are logged
+ *    and reported through `onError`, then the listener is removed);
+ *  - polls `popup.closed` so a user-closed popup still tears the listener down.
+ *
+ * @returns the cleanup function (idempotent).
+ */
+export function listenForPopupMessage<T>(options: PopupMessageListenerOptions<T>): () => void {
+  const { popup, isExpected, onMessage } = options
+
+  let timer: ReturnType<typeof setInterval> | null = null
+  let removed = false
+
+  const cleanup = (): void => {
+    if (removed) return
+    removed = true
+    if (timer !== null) {
+      clearInterval(timer)
+      timer = null
+    }
+    window.removeEventListener('message', handler)
+  }
+
+  const handler = async (event: MessageEvent): Promise<void> => {
+    // Constrain to the popup we opened: any other frame or window posting a
+    // same-shaped payload must not complete (or corrupt) this flow.
+    if (popup && event.source !== popup) return
+    if (!isExpected(event.data)) return
+
+    cleanup()
+    try {
+      await onMessage(event.data)
+    } catch (error) {
+      logger.error('popup message handler failed', error as Error)
+    }
+  }
+
+  window.addEventListener('message', handler)
+
+  // A blocked popup (window.open returning null or an already-closed window)
+  // can never deliver the payload — do not leave the listener armed.
+  if (!popup || popup.closed) {
+    cleanup()
+    return cleanup
+  }
+
+  timer = setInterval(() => {
+    if (popup.closed) cleanup()
+  }, 1000)
+
+  return cleanup
+}


### PR DESCRIPTION
## What

The four popup-based OAuth flows (`oauthWithSiliconFlow`, `oauthWithAihubmix`, `oauthWith302AI`, `oauthWithAiOnly`) leaked their `window` message listeners (#19210):

- the pre-add `removeEventListener('message', messageHandler)` passed a **fresh closure** that no prior registration could ever match — a no-op;
- removal happened **only on the success branch** (Aihubmix's catch closed the popup but kept the listener), so cancelled popups, user-closed popups, failed decrypts and malformed payloads all left permanent listeners behind;
- repeated attempts accumulated stale `setKey` closures, and a later flow's same-shaped message could still complete an earlier attempt's handler;
- the handlers dereferenced `event.data` unguarded (`event.data.length` / `event.data.data.apikey` throw when `data` is `null` or a plain string — any unrelated frame posting such a message threw inside the listener);
- no source constraint: same-shaped payloads from any window were accepted.

## How

New `src/renderer/services/popupMessage.ts` — `listenForPopupMessage({ popup, isExpected, onMessage })` owns the whole lifecycle:

- **one stable handler reference, one idempotent `cleanup()`** returned to the caller, invoked on success, on `onMessage` failure (logged, not thrown), on detected popup closure (1s `popup.closed` poll), and immediately when the popup was blocked (`window.open` → `null`/already closed — a listener that can never fire is never armed);
- **source-constrained**: events whose `event.source` is not the popup we opened are ignored;
- **non-throwing shape guard**: `isExpected` is called for every message event and must tolerate `null`, strings and unrelated objects; `onMessage` runs at most once per flow.

The four flows are rewritten on top of it; their payload shapes and success behavior are unchanged.

## Testing

New `src/renderer/services/__tests__/oauth.test.ts` (jsdom): helper-level cases (exactly-once delivery, null/string payloads don't throw, foreign source ignored, user-closed popup cleanup, blocked popup never arms, handler-throw still cleans up) plus flow-level cases. Differential: with `oauth.ts` stashed, the three flow-level cases fail on the old code (double `setKey`, foreign-source payload accepted); with the fix, 10/10 pass.

Fixes #19210
