### PR TITLE
fix(tabs): keep retained TabRouter subscriptions stable

### DIFF
--- a/src/renderer/components/layout/TabRouter.tsx
+++ b/src/renderer/components/layout/TabRouter.tsx
@@ -5,7 +5,7 @@ import { routeTree } from '@renderer/routeTree.gen'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router'
 import { Activity } from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react'
 
 interface TabRouterProps {
   tab: Tab
@@ -33,15 +33,29 @@ export const TabRouter = ({ tab, isActive, onUrlChange }: TabRouterProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab.id])
 
-  // Sync internal navigation back to tab state
+  // Read the latest props inside the subscription without re-subscribing:
+  // every shell/tab state update recreates the onUrlChange closure, and with
+  // it in the effect deps each retained router unsubscribed and resubscribed
+  // on unrelated tab operations (#19211).
+  const currentTabUrl = useEffectEvent(() => tab.url)
+  const reportUrlChange = useEffectEvent((nextHref: string) => onUrlChange(nextHref))
+
+  // Sync internal navigation back to tab state. Keyed by router only: the
+  // subscription lives for the router's lifetime, and the effect events above
+  // always observe the latest tab.url / onUrlChange.
   useEffect(() => {
     return router.subscribe('onResolved', ({ toLocation }) => {
       const nextHref = toLocation.href
-      if (nextHref !== tab.url) {
-        onUrlChange(nextHref)
+      if (nextHref !== currentTabUrl()) {
+        reportUrlChange(nextHref)
       }
     })
-  }, [router, tab.url, onUrlChange])
+    // `currentTabUrl` and `reportUrlChange` are Effect Events — they read the
+    // latest render's props, so they stay out of the deps (measured: their
+    // identities are not stable under this component's Activity boundary, and
+    // listing them re-triggered the subscription on every unrelated render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router])
 
   // Navigate when tab.url changes externally (e.g., from Sidebar)
   useEffect(() => {

--- a/src/renderer/components/layout/__tests__/TabRouter.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabRouter.test.tsx
@@ -257,6 +257,34 @@ describe('TabRouter', () => {
     expect(routerMocks.navigate).not.toHaveBeenCalled()
   })
 
+  it('keeps the onResolved subscription stable across unrelated rerenders (#19211)', () => {
+    routerMocks.subscribe.mockClear()
+    const unsub = vi.fn()
+    routerMocks.subscribe.mockReturnValueOnce(unsub)
+
+    const first = render(
+      <TabRouter
+        tab={tab('chat-tab', '/app/chat?topicId=t1', { title: 'Chat', lastAccessTime: 1, isDormant: false })}
+        isActive
+        onUrlChange={vi.fn()}
+      />
+    )
+    expect(routerMocks.subscribe).toHaveBeenCalledTimes(1)
+
+    // Unrelated shell state recreates the onUrlChange closure and re-renders
+    // with a new props object; the subscription must survive.
+    first.rerender(
+      <TabRouter
+        tab={tab('chat-tab', '/app/chat?topicId=t1', { title: 'Chat', lastAccessTime: 2, isDormant: false })}
+        isActive={false}
+        onUrlChange={vi.fn()}
+      />
+    )
+
+    expect(routerMocks.subscribe).toHaveBeenCalledTimes(1)
+    expect(unsub).not.toHaveBeenCalled()
+  })
+
   it('navigates when the tab entry URL changes externally', () => {
     const { rerender } = render(
       <TabRouter
@@ -285,5 +313,45 @@ describe('TabRouter', () => {
 
     expect(createMemoryHistory).toHaveBeenCalledTimes(1)
     expect(routerMocks.navigate).toHaveBeenCalledWith({ to: '/app/chat?topicId=current-topic' })
+  })
+
+  it('delivers resolved navigation to the latest onUrlChange without resubscribing', () => {
+    routerMocks.subscribe.mockClear()
+    let latestListener: ((event: { toLocation: { href: string } }) => void) | undefined
+    routerMocks.subscribe.mockImplementationOnce((_event: string, listener: any) => {
+      latestListener = listener
+      return vi.fn()
+    })
+    const onUrlChange = vi.fn()
+
+    const { rerender } = render(
+      <TabRouter
+        tab={tab('chat-tab', '/app/chat?topicId=t1', { title: 'Chat', lastAccessTime: 1, isDormant: false })}
+        isActive
+        onUrlChange={onUrlChange}
+      />
+    )
+
+    // A later render replaces the closure; the still-armed subscription must
+    // call the newest one and compare against the newest tab url.
+    const laterUrlChange = vi.fn()
+    rerender(
+      <TabRouter
+        tab={tab('chat-tab', '/app/chat?topicId=t2', { title: 'Chat', lastAccessTime: 2, isDormant: false })}
+        isActive
+        onUrlChange={laterUrlChange}
+      />
+    )
+
+    expect(latestListener).toBeDefined()
+    // Different url than the latest tab url -> reported
+    latestListener!({ toLocation: { href: '/app/chat?topicId=t3' } })
+    expect(laterUrlChange).toHaveBeenCalledWith('/app/chat?topicId=t3')
+    expect(onUrlChange).not.toHaveBeenCalled()
+
+    // Same url as the latest tab url -> echo suppression still works
+    latestListener!({ toLocation: { href: '/app/chat?topicId=t2' } })
+    expect(laterUrlChange).toHaveBeenCalledTimes(1)
+    expect(routerMocks.subscribe).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## What

`TabRouter`'s `onResolved` subscription effect depended on `onUrlChange` (and `tab.url`). `AppShell` / `SubWindowAppShell` build a fresh `onUrlChange` closure per render, so **every** tab activation, title/icon update, open/close or pin operation made every retained router unsubscribe and resubscribe (#19211). The effects live above the React `Activity` boundary, so hidden retained tabs kept churning too.

## How

- `tab.url` and `onUrlChange` are now read through React 19 `useEffectEvent` inside the subscription callback, and the effect is keyed by `[router]` only — the subscription now lives exactly as long as the router.
- One measurement worth recording (it's in the code comment): under this component's `Activity` boundary, the **effect-event function identities are not stable**, so they must stay out of the deps entirely — listing them re-triggered the subscription on every render, recreating the original bug. The repo already has this same omit-from-deps pattern in `RightPaneHost`.

## Testing

Two new cases in `TabRouter.test.tsx`:

- an unrelated rerender (new `onUrlChange` identity, changed `lastAccessTime`, `isActive` flip) does not unsubscribe/resubscribe — `subscribe` called exactly once, unsubscribe never;
- the still-armed subscription delivers to the **latest** `onUrlChange`, compares against the **latest** `tab.url` (echo suppression intact), and never fires the replaced closure.

Differential: with `TabRouter.tsx` stashed, the stability case fails (subscribe called twice). Full layout suite: 150/150 pass.

Fixes #19211
