### PR TITLE
fix(messages): isolate per-message selection subscriptions

### DIFF
--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -31,7 +31,8 @@ import {
   useMessageListActions,
   useMessageListData,
   useMessageListMeta,
-  useMessageListSelection,
+  useMessageSelectionMode,
+  useSelectedMessageIds,
   useMessageListUi,
   useMessageRenderConfig
 } from './MessageListProvider'
@@ -177,7 +178,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const actions = useMessageListActions()
   const meta = useMessageListMeta()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
+  const selectedIdsFromStore = useSelectedMessageIds()
   const messageUi = useMessageListUi()
   const partsByMessageId = usePartsMap()
   // The rail gutter lives in the chat layout context (single source of truth) so
@@ -188,8 +190,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const { topic, messages, beforeList, messageTail, hasOlder = false, messageNavigation } = data
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const { setTimeoutTimer } = useTimer()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-  const selectedMessageIds = selection?.selectedMessageIds ?? []
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+  const selectedMessageIds = selectedIdsFromStore
   const [activeOutline, setActiveOutline] = useState<ActiveMessageOutline | null>(null)
   const [activeAnchorMessageId, setActiveAnchorMessageId] = useState<string | null>(null)
   const bottomOverlayInsets = useChatBottomOverlayInset()

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -1,7 +1,8 @@
 import type { Context, ReactNode } from 'react'
-import { createContext, use, useMemo } from 'react'
+import { useCallback, createContext, use, useMemo, useSyncExternalStore } from 'react'
 
 import { PartsProvider } from './blocks/MessagePartsContext'
+import type { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import type {
   MessageListActions,
   MessageListItem,
@@ -80,11 +81,24 @@ const MessageListActionsContext = createContext<MessageListActions | null>(null)
 const MessageListMetaContext = createContext<MessageListMeta | null>(null)
 const MessageListRenderConfigContext = createContext<MessageRenderConfig | null>(null)
 const MessageListSelectionContext = createContext<MessageListSelectionState | undefined | null>(null)
+
+/**
+ * Mode-only projection of the selection state (enabled / multi-select). Changes
+ * identity ONLY when the mode toggles — never when the selected-id set grows
+ * or shrinks — so per-frame subscribers stay idle during selection (#19209).
+ */
+const MessageListSelectionModeContext = createContext<
+  Pick<MessageListSelectionState, 'enabled' | 'isMultiSelectMode'> | undefined | null
+>(null)
+
+/** Per-message selection subscription store; null in embeds without selection. */
+const MessageSelectionStoreContext = createContext<MessageSelectionStore | null>(null)
 const MessageListUiStaticContext = createContext<MessageListUiStaticValue | null>(null)
 const MessageListUiSelectorsContext = createContext<MessageListUiSelectorsValue | null>(null)
 const MessageListEditingContext = createContext<string | null>(null)
 
 export const MessageListProvider = ({ value, children }: { value: MessageListProviderValue; children: ReactNode }) => {
+  const { selectionStore } = value
   const { state, actions, meta } = value
 
   const data = useMemo<MessageListDataValue>(
@@ -152,6 +166,14 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
     ]
   )
 
+  const selectionMode = useMemo(
+    () =>
+      state.selection
+        ? { enabled: state.selection.enabled, isMultiSelectMode: state.selection.isMultiSelectMode }
+        : undefined,
+    [state.selection?.enabled, state.selection?.isMultiSelectMode]
+  )
+
   return (
     <MessageListDataContext value={data}>
       <MessageListMessagesContext value={state.messages}>
@@ -159,15 +181,23 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
           <MessageListActionsContext value={actions}>
             <MessageListMetaContext value={meta}>
               <MessageListRenderConfigContext value={state.renderConfig}>
-                <MessageListSelectionContext value={state.selection}>
-                  <MessageListUiStaticContext value={uiStatic}>
-                    <MessageListUiSelectorsContext value={uiSelectors}>
-                      <MessageListEditingContext value={state.editingMessageId ?? null}>
-                        {children}
-                      </MessageListEditingContext>
-                    </MessageListUiSelectorsContext>
-                  </MessageListUiStaticContext>
-                </MessageListSelectionContext>
+                <MessageListSelectionModeContext value={selectionMode}>
+                  <MessageSelectionStoreContext value={selectionStore ?? null}>
+                    <MessageListSelectionModeContext value={selectionMode}>
+                      <MessageSelectionStoreContext value={selectionStore ?? null}>
+                        <MessageListSelectionContext value={state.selection}>
+                          <MessageListUiStaticContext value={uiStatic}>
+                            <MessageListUiSelectorsContext value={uiSelectors}>
+                              <MessageListEditingContext value={state.editingMessageId ?? null}>
+                                {children}
+                              </MessageListEditingContext>
+                            </MessageListUiSelectorsContext>
+                          </MessageListUiStaticContext>
+                        </MessageListSelectionContext>
+                      </MessageSelectionStoreContext>
+                    </MessageListSelectionModeContext>
+                  </MessageSelectionStoreContext>
+                </MessageListSelectionModeContext>
               </MessageListRenderConfigContext>
             </MessageListMetaContext>
           </MessageListActionsContext>
@@ -262,6 +292,54 @@ export const useMessageListSelection = (): MessageListSelectionState | undefined
   }
   return value
 }
+
+/**
+ * Mode-only selection view (enabled / multi-select). Identity changes only
+ * when the mode toggles — not on selection-set changes (#19209).
+ */
+export const useMessageSelectionMode = ():
+  | Pick<MessageListSelectionState, 'enabled' | 'isMultiSelectMode'>
+  | undefined => {
+  const value = use(MessageListSelectionModeContext)
+  if (value === null) {
+    throw new Error('useMessageSelectionMode must be used within MessageListProvider')
+  }
+  return value
+}
+
+/**
+ * Per-message selected-state subscription: re-renders only when THIS message's
+ * boolean flips, not when the selection set changes elsewhere (#19209).
+ * Outside a selecting list (no store) the answer is always false.
+ */
+export const useIsMessageSelected = (messageId: string): boolean => {
+  const store = use(MessageSelectionStoreContext)
+  const subscribe = useCallback(
+    (listener: () => void) => (store ? store.subscribeId(messageId, listener) : () => {}),
+    [store, messageId]
+  )
+  return useSyncExternalStore(
+    subscribe,
+    () => store?.isSelected(messageId) ?? false,
+    () => false
+  )
+}
+
+/**
+ * Full selected-id list via the store: stable identity between changes; used
+ * by the toolbar / popup / whole-list consumers that genuinely need every id.
+ */
+export const useSelectedMessageIds = (): readonly string[] => {
+  const store = use(MessageSelectionStoreContext)
+  const subscribe = useCallback((listener: () => void) => (store ? store.subscribeList(listener) : () => {}), [store])
+  return useSyncExternalStore(
+    subscribe,
+    () => store?.getSnapshot() ?? EMPTY_SELECTED_MESSAGE_IDS,
+    () => EMPTY_SELECTED_MESSAGE_IDS
+  )
+}
+
+const EMPTY_SELECTED_MESSAGE_IDS: readonly string[] = []
 
 /** Id of the message currently being edited (null when none). Non-throwing: "not editing"
  * is a valid state, so embeds that never set it simply get null. */

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -200,7 +200,12 @@ vi.mock('../MessageListProvider', () => ({
       multiModelGridPopoverTrigger: settings.gridPopoverTrigger
     }
   },
-  useMessageListSelection: () => mocks.messageListSelection(),
+  useMessageSelectionMode: () => {
+    const selection = mocks.messageListSelection()
+    return selection ? { enabled: selection.enabled, isMultiSelectMode: selection.isMultiSelectMode } : undefined
+  },
+  useIsMessageSelected: () => false,
+  useSelectedMessageIds: () => [],
   useMessageListEditingId: () => mocks.messageListEditingId(),
   useMessageListMeta: () => ({
     userProfile: { avatar: '' }

--- a/src/renderer/components/chat/messages/__tests__/selectionPerMessage.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/selectionPerMessage.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import type { MessageListProviderValue, MessageListSelectionState } from '@renderer/components/chat/messages/types'
+import { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  MessageListProvider,
+  useIsMessageSelected,
+  useMessageListSelection,
+  useMessageSelectionMode,
+  useSelectedMessageIds
+} from '../MessageListProvider'
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessageSelectionController', () => ({
+  useMessageSelectionController: () => ({ selection: {}, selectionStore: null, actions: {} })
+}))
+
+/** Per-message row: subscribes through the store, like MessageFrame (#19209). */
+function PerIdRow({ messageId }: { messageId: string }) {
+  const selected = useIsMessageSelected(messageId)
+  return <div data-testid={`row-${messageId}`}>{selected ? 'selected' : 'unselected'}</div>
+}
+
+/** Toolbar-shaped consumer: needs the full id list. */
+function Toolbar() {
+  const ids = useSelectedMessageIds()
+  return <div data-testid="toolbar">{ids.length}</div>
+}
+
+/** Mode-only consumer, like the header checkbox visibility. */
+function ModeProbe() {
+  const mode = useMessageSelectionMode()
+  return <div data-testid="mode">{mode?.isMultiSelectMode ? 'multi' : 'single'}</div>
+}
+
+/**
+ * The pre-#19209 shape: reads the whole selection object off the context, so
+ * its render count grows on every selection change while per-id rows do not.
+ */
+function LegacyContextRow() {
+  const selection = useMessageListSelection()
+  return <div data-testid="legacy">{selection?.selectedMessageIds?.length ?? 0}</div>
+}
+
+function buildValue(selection: MessageListSelectionState, store: MessageSelectionStore): MessageListProviderValue {
+  return {
+    state: {
+      topic: { id: 't1', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+      messages: [],
+      partsByMessageId: {},
+      renderConfig: {} as MessageListProviderValue['state']['renderConfig'],
+      messageNavigation: 'none',
+      estimateSize: 0,
+      overscan: 0,
+      loadOlderDelayMs: 0,
+      loadingResetDelayMs: 0,
+      selection
+    },
+    actions: {} as MessageListProviderValue['actions'],
+    meta: {} as MessageListProviderValue['meta'],
+    selectionStore: store
+  }
+}
+
+describe('per-message selection subscriptions (#19209)', () => {
+  it('re-renders only the row whose selection flipped; the context consumer still updates', () => {
+    const store = new MessageSelectionStore()
+    const view = render(
+      <MessageListProvider
+        value={buildValue({ enabled: true, isMultiSelectMode: true, selectedMessageIds: [] }, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+
+    expect(view.getByTestId('row-a').textContent).toBe('unselected')
+    expect(view.getByTestId('row-b').textContent).toBe('unselected')
+
+    // The controller flow: cached state changes (provider rerenders with the new
+    // ids) AND the store mirror is replaced.
+    const withA = { enabled: true, isMultiSelectMode: true, selectedMessageIds: ['a'] as readonly string[] }
+    store.replace(['a'])
+    view.rerender(
+      <MessageListProvider value={buildValue(withA, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+
+    expect(view.getByTestId('row-a').textContent).toBe('selected')
+    expect(view.getByTestId('row-b').textContent).toBe('unselected')
+    expect(view.getByTestId('toolbar').textContent).toBe('1')
+    expect(view.getByTestId('legacy').textContent).toBe('1')
+
+    // Selecting b as well: a's row re-renders only because React rerenders are
+    // not asserted here — the contract under test is the boolean stream. The
+    // decisive assertion is deselect, where b flips back and a's subtree can
+    // stay idle (asserted via the store's per-id notifications below).
+    const both = { enabled: true, isMultiSelectMode: true, selectedMessageIds: ['a', 'b'] as readonly string[] }
+    store.replace(['a', 'b'])
+    view.rerender(
+      <MessageListProvider value={buildValue(both, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+    expect(view.getByTestId('row-b').textContent).toBe('selected')
+
+    // Mode toggle changes the mode probe but leaves per-id booleans untouched.
+    const modeOff = { enabled: true, isMultiSelectMode: false, selectedMessageIds: ['a', 'b'] as readonly string[] }
+    view.rerender(
+      <MessageListProvider value={buildValue(modeOff, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+    expect(view.getByTestId('mode').textContent).toBe('single')
+    expect(view.getByTestId('row-a').textContent).toBe('selected')
+  })
+
+  it('store notifies per-id listeners only for ids whose boolean flipped', () => {
+    const store = new MessageSelectionStore()
+    const aListener = vi.fn()
+    const bListener = vi.fn()
+    const listListener = vi.fn()
+    store.subscribeId('a', aListener)
+    store.subscribeId('b', bListener)
+    store.subscribeList(listListener)
+
+    store.replace(['a'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(bListener).not.toHaveBeenCalled()
+    expect(listListener).toHaveBeenCalledTimes(1)
+
+    // Same content replace: nobody fires, snapshot identity stays stable.
+    const before = store.getSnapshot()
+    store.replace(['a'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(listListener).toHaveBeenCalledTimes(1)
+    expect(store.getSnapshot()).toBe(before)
+
+    store.replace(['a', 'b'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(bListener).toHaveBeenCalledTimes(1)
+    expect(listListener).toHaveBeenCalledTimes(2)
+
+    store.replace([])
+    expect(aListener).toHaveBeenCalledTimes(2)
+    expect(bListener).toHaveBeenCalledTimes(2)
+    expect(store.getSnapshot()).toEqual([])
+  })
+
+  it('unsubscribes cleanly', () => {
+    const store = new MessageSelectionStore()
+    const listener = vi.fn()
+    const unsubscribe = store.subscribeId('a', listener)
+    unsubscribe()
+    store.replace(['a'])
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -18,7 +18,8 @@ import {
   useMessageListActions,
   useMessageListEditingId,
   useMessageListMeta,
-  useMessageListSelection,
+  useIsMessageSelected,
+  useMessageSelectionMode,
   useMessageListUiSelectors,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -68,10 +69,10 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const { t } = useTranslation()
   const actions = useMessageListActions()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
   const messageUi = useMessageListUiSelectors()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-  const isSelected = selection?.selectedMessageIds?.includes(message.id) ?? false
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+  const isSelected = useIsMessageSelected(message.id)
   // Use the message-embedded snapshot rather than re-resolving the live model
   // config: the snapshot is what the message was actually generated with.
   const model = getMessageListItemModel(message)

--- a/src/renderer/components/chat/messages/frame/MessageHeader.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageHeader.tsx
@@ -14,7 +14,8 @@ import { useTranslation } from 'react-i18next'
 import {
   useMessageListActions,
   useMessageListMeta,
-  useMessageListSelection,
+  useIsMessageSelected,
+  useMessageSelectionMode,
   useMessageRenderConfig,
   useOptionalMessageListActions
 } from '../MessageListProvider'
@@ -82,7 +83,7 @@ const MessageHeader: FC<Props> = memo(
     const actions = useMessageListActions()
     const meta = useMessageListMeta()
     const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-    const selection = useMessageListSelection()
+    const selectionMode = useMessageSelectionMode()
     const userName = renderConfig.userName
     const assistantProfile = meta.assistantProfile
     const { t } = useTranslation()
@@ -90,10 +91,8 @@ const MessageHeader: FC<Props> = memo(
     const isBubbleStyle = messageStyle === 'bubble'
     const userAvatar = meta.userProfile?.avatar ?? ''
 
-    const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-    const selectedMessageIds = selection?.selectedMessageIds
-
-    const isSelected = selectedMessageIds?.includes(message.id)
+    const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+    const isSelected = useIsMessageSelected(message.id)
 
     const messageModel = useMemo(() => getMessageListItemModel(message), [message])
     const displayModel = messageModel ?? model

--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { useMessageParts } from '../blocks/MessagePartsContext'
 import {
   useMessageListActions,
-  useMessageListSelection,
+  useMessageSelectionMode,
   useMessageListUi,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -56,7 +56,13 @@ const MessageMenuBar: FC<Props> = (props) => {
   } = props
   const { t } = useTranslation()
   const actions = useMessageListActions()
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
+  // menuBarActions reads only `enabled`; keep the memo dep stable across
+  // selection-set changes by deriving from the mode-only projection (#19209)
+  const selection = useMemo(
+    () => (selectionMode ? { ...selectionMode, selectedMessageIds: undefined } : undefined),
+    [selectionMode]
+  )
   const messageUi = useMessageListUi()
   const renderConfig = useMessageRenderConfig()
   const menuConfig = messageUi.menuConfig ?? defaultMessageMenuConfig

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
@@ -65,7 +65,15 @@ vi.mock('../../MessageListProvider', () => ({
     assistantProfile: undefined,
     userProfile: undefined
   }),
-  useMessageListSelection: () => providerState.selection,
+  useMessageSelectionMode: () =>
+    providerState.selection
+      ? {
+          enabled: true,
+          isMultiSelectMode: providerState.selection.isMultiSelectMode
+        }
+      : undefined,
+  useIsMessageSelected: (id: string) => providerState.selection?.selectedMessageIds?.includes(id) ?? false,
+  useSelectedMessageIds: () => providerState.selection?.selectedMessageIds ?? [],
   useMessageRenderConfig: () => ({
     userName: 'User',
     messageStyle: 'plain'

--- a/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
@@ -15,6 +15,8 @@ import { toast } from '@renderer/services/toast'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+import { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useMessageSelectionController')
@@ -30,6 +32,8 @@ interface UseMessageSelectionControllerParams {
 
 interface MessageSelectionController {
   selection: MessageListSelectionState
+  /** Per-message subscription mirror of `selection.selectedMessageIds` (#19209). */
+  selectionStore: MessageSelectionStore
   actions: Pick<
     MessageListActions,
     | 'selectMessage'
@@ -55,6 +59,18 @@ export function useMessageSelectionController({
   latestExportDataRef.current = { messages, partsByMessageId, copyRichContent }
 
   const selectedIds = useMemo(() => selectedMessageIds ?? [], [selectedMessageIds])
+
+  // Per-message subscription mirror: the controller's cached state stays the
+  // source of truth; the store fans updates out to id-level subscribers so one
+  // toggle does not re-render every frame (#19209).
+  const storeRef = useRef<MessageSelectionStore | null>(null)
+  if (storeRef.current === null) storeRef.current = new MessageSelectionStore()
+  const selectionStore = storeRef.current
+  const selectedIdsRef = useRef(selectedIds)
+  selectedIdsRef.current = selectedIds
+  useEffect(() => {
+    selectionStore.replace(selectedIds)
+  }, [selectedIds, selectionStore])
 
   const toggleMultiSelectMode = useCallback(
     (enabled: boolean) => {
@@ -82,12 +98,12 @@ export function useMessageSelectionController({
     [setSelectedMessageIds]
   )
 
-  const resolveMessageIds = useCallback(
-    (messageIds?: readonly string[]) => {
-      return messageIds?.length ? [...messageIds] : selectedIds
-    },
-    [selectedIds]
-  )
+  // Reads the current selection through a ref: export/delete callbacks keep a
+  // stable identity while the selection changes, so the actions context stops
+  // invalidating on every toggle (#19209).
+  const resolveMessageIds = useCallback((messageIds?: readonly string[]) => {
+    return messageIds?.length ? [...messageIds] : selectedIdsRef.current
+  }, [])
 
   const ensureSelection = useCallback(
     (messageIds?: readonly string[]) => {
@@ -226,5 +242,5 @@ export function useMessageSelectionController({
     ]
   )
 
-  return useMemo(() => ({ selection, actions }), [actions, selection])
+  return useMemo(() => ({ selection, selectionStore, actions }), [actions, selection, selectionStore])
 }

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -13,7 +13,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import MessageItem from '../frame/MessageFrame'
 import {
   useMessageListActions,
-  useMessageListSelection,
+  useMessageSelectionMode,
   useMessageListUiSelectors,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -66,14 +66,14 @@ const MessageGroup = ({
   // Hooks
   const actions = useMessageListActions()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
   const messageUi = useMessageListUiSelectors()
   const multiModelMessageStyleSetting = renderConfig.multiModelMessageStyle
   const gridPopoverTrigger = renderConfig.multiModelGridPopoverTrigger
   const { setTimeoutTimer } = useTimer()
   const currentTabId = useCurrentTabId()
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
   const getMessageUiState = useCallback(
     (messageId: string) => messageUi.getMessageUiState?.(messageId) ?? {},
     [messageUi]

--- a/src/renderer/components/chat/messages/selection/MessageSelectionStore.ts
+++ b/src/renderer/components/chat/messages/selection/MessageSelectionStore.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-message selection subscriptions for the message list (#19209).
+ *
+ * The selection ids used to ride the selection context value: one toggle
+ * changed the context identity and re-rendered every mounted `MessageFrame`
+ * (each recomputing `selectedMessageIds.includes(id)`), plus every consumer of
+ * the actions context the controller's selected-dependent callbacks
+ * invalidated. This store splits the subscription axes:
+ *
+ *  - per-id subscribers (`useIsMessageSelected`) are notified only when THAT
+ *    id's boolean flips;
+ *  - list subscribers (`useSelectedMessageIds`) are notified on any change and
+ *    receive a stable array identity between changes (useSyncExternalStore
+ *    re-render contract);
+ *  - the mode axes (enabled / multi-select) stay on the split mode context,
+ *    which only changes when the mode toggles.
+ *
+ * The store is a mirror, not the source of truth: the controller owns the
+ * persisted selection state and calls `replace()` whenever it changes.
+ */
+export class MessageSelectionStore {
+  private selected = new Set<string>()
+  private snapshot: readonly string[] = []
+  private readonly idListeners = new Map<string, Set<() => void>>()
+  private readonly listListeners = new Set<() => void>()
+
+  /** Replace the full selection; notifies only the listeners whose input changed. */
+  replace(nextIds: readonly string[]): void {
+    const next = new Set(nextIds)
+    let changed = false
+    for (const id of this.selected) {
+      if (!next.has(id)) {
+        changed = true
+        this.selected.delete(id)
+        this.notifyId(id)
+      }
+    }
+    for (const id of next) {
+      if (!this.selected.has(id)) {
+        changed = true
+        this.selected.add(id)
+        this.notifyId(id)
+      }
+    }
+    if (changed) {
+      this.snapshot = [...this.selected]
+      for (const listener of this.listListeners) listener()
+    }
+  }
+
+  isSelected(id: string): boolean {
+    return this.selected.has(id)
+  }
+
+  /** Stable identity between changes — required by useSyncExternalStore. */
+  getSnapshot(): readonly string[] {
+    return this.snapshot
+  }
+
+  subscribeId(id: string, listener: () => void): () => void {
+    let listeners = this.idListeners.get(id)
+    if (!listeners) {
+      listeners = new Set()
+      this.idListeners.set(id, listeners)
+    }
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) this.idListeners.delete(id)
+    }
+  }
+
+  subscribeList(listener: () => void): () => void {
+    this.listListeners.add(listener)
+    return () => this.listListeners.delete(listener)
+  }
+
+  private notifyId(id: string): void {
+    const listeners = this.idListeners.get(id)
+    if (!listeners) return
+    for (const listener of listeners) listener()
+  }
+}

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,4 +1,5 @@
 import type { DeleteMessageOptions, MessageDeleteAvailability } from '@renderer/hooks/chat/ChatWriteContext'
+import type { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import type { SerializedError } from '@renderer/types/error'
 import type { FileMetadata } from '@renderer/types/file'
 import type { Citation, MessageUiState } from '@renderer/types/message'
@@ -416,4 +417,11 @@ export interface MessageListProviderValue {
   state: MessageListState
   actions: MessageListActions
   meta: MessageListMeta
+  /**
+   * Per-message selection subscription store (#19209). Mirrors
+   * `state.selection.selectedMessageIds`; lists that select messages provide
+   * it so frames can subscribe per id instead of per selection change.
+   * Absent in embeds without selection.
+   */
+  selectionStore?: MessageSelectionStore | null
 }

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -909,5 +909,8 @@ export function useHomeMessageListProviderValue({
     [assistant, headerCapabilities.userProfile, topic.name]
   )
 
-  return useMemo(() => ({ state, actions, meta }), [actions, meta, state])
+  return useMemo(
+    () => ({ state, actions, meta, selectionStore: selectionController.selectionStore }),
+    [actions, meta, state, selectionController.selectionStore]
+  )
 }


### PR DESCRIPTION
## What

Implements the per-message selected-state subscription from #19209. `MessageFrame` (and header/group/menubar) read the complete `selectedMessageIds` array off the selection context, so selecting or deselecting **one** message changed the context identity and re-rendered **every** mounted frame — each recomputing `includes(id)` over its Markdown/tool/attachment subtrees. The selection controller's export/delete callbacks also closed over the current id list, so their identities (and with them the actions context for the whole list) churned on every toggle.

## How

The subscription axes are split:

- **`MessageSelectionStore`** (new) mirrors the selection ids and fans updates out per id:
  - `useIsMessageSelected(messageId)` — `useSyncExternalStore` per id; re-renders **only** when that message's boolean flips;
  - `useSelectedMessageIds()` — full list for the toolbar/popup, with a stable snapshot identity between changes;
  - the store is a mirror, not a source of truth: the controller's cached state stays authoritative and calls `replace()` on change.
- **Mode context split**: `useMessageSelectionMode()` exposes `{enabled, isMultiSelectMode}` from a context whose value changes **only** when the mode toggles — never when the id set grows or shrinks.
- **Stable action identities**: `resolveMessageIds` reads the current selection through a ref, so `copySelectedMessages` / `saveSelectedMessages` / `deleteSelectedMessages` (and the actions context) keep their identities across selection changes.
- Consumers switched: `MessageFrame`, `MessageHeader`, `MessageGroup`, `MessageMenuBar` (mode + per-id); `MessageList` toolbar reads the store snapshot. Embeds without a store (`MessageContentProvider`, image-capture host) keep the previous behavior: per-id answers false / empty list.

## Testing

New `selectionPerMessage.test.tsx`:

- provider-level: selecting `a` updates row `a`, the toolbar and the legacy context consumer while row `b`'s boolean stream stays untouched; a mode flip updates the mode probe without disturbing per-id state;
- store-level: per-id listeners fire only for ids whose boolean flipped; a same-content `replace` fires nobody and keeps the snapshot identity; unsubscribe works.

Differential: with `MessageListProvider.tsx` stashed the provider-level case fails (hooks absent). Full `src/renderer/components/chat/messages` + `src/renderer/pages/home` batch: 1303 tests, only my new case fails pre-fix; post-fix green (two unrelated timing-flaky suites — lazy diff boundary, topic rename timers — flap under full-batch load on this machine and pass in isolation on both trees).

Fixes #19209
