### PR TITLE
build(vendor): fail the build when a patched dependency ships unpatched

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,6 +11,7 @@ import { parse } from 'yaml'
 // import pkg from './package.json' assert { type: 'json' }
 import pkg from './package.json'
 import { chunkExportGuardPlugin } from './scripts/checkChunkExports'
+import { patchedVendorGuardPlugin } from './scripts/verifyPatchedVendor'
 import { uiContractPlugin } from './scripts/uiContract/vitePlugin'
 import { parseReleaseHistory, validateCurrentReleaseHistory } from './src/shared/utils/releaseNotes'
 
@@ -62,7 +63,7 @@ export const isMainExternalModule = (id: string) => {
 
 export default defineConfig({
   main: {
-    plugins: [chunkExportGuardPlugin(), ...visualizerPlugin('main')],
+    plugins: [chunkExportGuardPlugin(), patchedVendorGuardPlugin(), ...visualizerPlugin('main')],
     resolve: {
       alias: {
         '@main': resolve('src/main'),

--- a/scripts/__tests__/verifyPatchedVendor.test.ts
+++ b/scripts/__tests__/verifyPatchedVendor.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Contract for the patched-vendor build guard: a patched dependency that IS
+ * bundled without any marker its patch adds must fail the build (the v2.0.8
+ * shipped-bundle failure, #19116), while a patched dependency that is not part
+ * of this bundle, or whose markers are present, must pass.
+ *
+ * CI does not run `electron-vite build`, so without this the guard's extraction
+ * and bundled-heuristics can rot silently — same contract note as
+ * checkChunkExports.test.ts.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { extractMarkers, loadPatchedDependencies, patchedVendorGuardPlugin } from '../verifyPatchedVendor'
+
+// createRequire must resolve the "installed" dependency from the fixture root,
+// not from this file — the plugin builds it from rootDir/node_modules, so a
+// fixture package.json with an exports map pointing at the dist file suffices.
+function buildFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), 'patched-vendor-guard-'))
+  writeFileSync(
+    join(root, 'pnpm-workspace.yaml'),
+    [
+      'packages:',
+      '  - packages/*',
+      'patchedDependencies:',
+      "  'fake-vendor@1.0.0': patches/fake-vendor.patch",
+      "  'renderer-only-vendor@1.0.0': patches/renderer-only.patch",
+      '  no-marker-skip: not-a-real-patch-entry'
+    ].join('\n')
+  )
+  mkdirSync(join(root, 'patches'), { recursive: true })
+  writeFileSync(
+    join(root, 'patches', 'fake-vendor.patch'),
+    [
+      '--- a/dist/index.js',
+      '+++ b/dist/index.js',
+      '@@ -1,3 +1,9 @@',
+      ' module.exports = {}',
+      '+function postImageRequestWrapper(url, body) {',
+      "+  const retryStatusCodes = 'STATUS_400_OR_422'",
+      '+  return fetch(url, body)',
+      '+}',
+      '-module.exports = {}'
+    ].join('\n')
+  )
+  writeFileSync(
+    join(root, 'patches', 'renderer-only.patch'),
+    [
+      '--- a/dist/index.js',
+      '+++ b/dist/index.js',
+      '@@ -1,2 +1,4 @@',
+      "+const rendererMarkerLiteral = 'RENDERER_ONLY_PATCH_MARKER_XY'",
+      '+void rendererMarkerLiteral'
+    ].join('\n')
+  )
+  mkdirSync(join(root, 'node_modules', 'fake-vendor', 'dist'), { recursive: true })
+  writeFileSync(
+    join(root, 'node_modules', 'fake-vendor', 'package.json'),
+    JSON.stringify({ name: 'fake-vendor', version: '1.0.0', main: 'dist/index.js' })
+  )
+  // Long literals sampled for the bundled-signal; the PATCHED marker is absent
+  // on purpose — this fixture is the "built from unpatched sources" case.
+  writeFileSync(
+    join(root, 'node_modules', 'fake-vendor', 'dist', 'index.js'),
+    [
+      'const unpatchedLiteralOne = "UNPATCHED_SAMPLE_LITERAL_ALPHA"',
+      'const unpatchedLiteralTwo = "UNPATCHED_SAMPLE_LITERAL_BETA"',
+      'module.exports = {}'
+    ].join('\n')
+  )
+  mkdirSync(join(root, 'node_modules', 'renderer-only-vendor', 'dist'), { recursive: true })
+  writeFileSync(
+    join(root, 'node_modules', 'renderer-only-vendor', 'package.json'),
+    JSON.stringify({ name: 'renderer-only-vendor', version: '1.0.0', main: 'dist/index.js' })
+  )
+  writeFileSync(
+    join(root, 'node_modules', 'renderer-only-vendor', 'dist', 'index.js'),
+    'const rendererOnlySample = "RENDERER_ONLY_NOT_IN_MAIN_BUNDLE"\nmodule.exports = {}'
+  )
+  return root
+}
+
+const fixtures: string[] = []
+afterEach(() => {
+  while (fixtures.length) rmSync(fixtures.pop()!, { recursive: true, force: true })
+})
+
+function runGuard(root: string, bundle: Record<string, string>): string | null {
+  const plugin = patchedVendorGuardPlugin({ rootDir: root })
+  const hook = plugin.generateBundle as (
+    this: { error: (message: string) => never },
+    options: unknown,
+    bundle: unknown
+  ) => void
+  try {
+    hook.call(
+      {
+        error: (message) => {
+          throw new Error(message)
+        }
+      },
+      {},
+      Object.fromEntries(Object.entries(bundle).map(([fileName, code]) => [fileName, { type: 'chunk', code }]))
+    )
+    return null
+  } catch (error) {
+    if (error instanceof Error) return error.message
+    if (typeof error === 'string') return error
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return String(error)
+    }
+  }
+}
+
+describe('extractMarkers', () => {
+  it('collects string literals and long identifiers from added lines only', () => {
+    const markers = extractMarkers(
+      [
+        '--- a/dist/index.js',
+        '+++ b/dist/index.js',
+        '@@ -1,2 +1,5 @@',
+        " existing = 'kept-out-of-markers'", // context line: ignored
+        '+function postImageRequestWrapper() {}',
+        "+  const code = 'STATUS_400_OR_422'",
+        '-removed = "removed-literal-should-not-count"',
+        '+short = "abc"',
+        '+ tinyIdent'
+      ].join('\n')
+    )
+    expect(markers.identifiers).toContain('postImageRequestWrapper')
+    expect(markers.literals).toContain('STATUS_400_OR_422')
+    expect(markers.literals).not.toContain('kept-out-of-markers')
+    expect(markers.literals).not.toContain('removed-literal-should-not-count')
+    expect(markers.literals).not.toContain('abc')
+    expect(markers.identifiers).not.toContain('tinyIdent')
+  })
+})
+
+describe('loadPatchedDependencies', () => {
+  it('loads patch entries with extracted markers', () => {
+    const root = buildFixture()
+    fixtures.push(root)
+    const patched = loadPatchedDependencies(root)
+    const names = patched.map((dep) => dep.key)
+    expect(names).toContain('fake-vendor@1.0.0')
+    expect(names).toContain('renderer-only-vendor@1.0.0')
+    const fake = patched.find((dep) => dep.key === 'fake-vendor@1.0.0')!
+    expect(fake.identifierMarkers).toContain('postImageRequestWrapper')
+    expect(fake.literalMarkers).toContain('STATUS_400_OR_422')
+    expect(fake.name).toBe('fake-vendor')
+  })
+})
+
+describe('patchedVendorGuardPlugin', () => {
+  it('fails when a patched dependency is bundled without its patch (#19116)', () => {
+    const root = buildFixture()
+    fixtures.push(root)
+    // The bundle carries the dependency's unpatched literals but no patch marker.
+    const message = runGuard(root, {
+      'vendor.js': 'const a="UNPATCHED_SAMPLE_LITERAL_ALPHA";const b="UNPATCHED_SAMPLE_LITERAL_BETA";'
+    })
+    expect(message).toMatch(/fake-vendor@1\.0\.0 is bundled without its patch/)
+  })
+
+  it('passes when the patch markers are present in the bundle', () => {
+    const root = buildFixture()
+    fixtures.push(root)
+    const message = runGuard(root, {
+      'vendor.js':
+        'function postImageRequestWrapper(u,b){const c=["STATUS_400_OR_422"];return fetch(u,b)};const x="UNPATCHED_SAMPLE_LITERAL_ALPHA";const y="UNPATCHED_SAMPLE_LITERAL_BETA";'
+    })
+    expect(message).toBeNull()
+  })
+
+  it('passes when the patched dependency is not part of this bundle', () => {
+    const root = buildFixture()
+    fixtures.push(root)
+    const message = runGuard(root, { 'main.js': 'console.log("hello world — nothing vendored here")' })
+    expect(message).toBeNull()
+  })
+
+  it('does not throw when the workspace has no patches', () => {
+    const root = mkdtempSync(join(tmpdir(), 'patched-vendor-empty-'))
+    fixtures.push(root)
+    writeFileSync(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+    const message = runGuard(root, { 'main.js': 'console.log(1)' })
+    expect(message).toBeNull()
+  })
+})
+
+// Silence the unused-import lint for vi in case the environment strips spies.
+void vi

--- a/scripts/verifyPatchedVendor.ts
+++ b/scripts/verifyPatchedVendor.ts
@@ -1,0 +1,183 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import type { Plugin } from 'vite'
+
+import { parse } from 'yaml'
+
+/**
+ * Fails the build when a patched dependency is bundled WITHOUT its patch.
+ *
+ * v2.0.8 shipped a bundle whose vendored `@ai-sdk/openai-compatible` carried
+ * neither #18121 nor #18702, although both patch files were correct in the tag
+ * (#19116): the release build was produced from unpatched `node_modules`, and
+ * nothing between `pnpm install` and packaging compares the emitted chunks
+ * against the patches. This guard closes that gap at the only point where the
+ * truth exists — the generated bundle itself.
+ *
+ * For every `patchedDependencies` entry in pnpm-workspace.yaml it:
+ *
+ *  1. extracts marker candidates from the patch's ADDED lines (string literals
+ *     and long identifiers);
+ *  2. in `generateBundle`, considers the dependency verified when any marker
+ *     appears in any emitted chunk;
+ *  3. otherwise decides whether the dependency is bundled at all by sampling
+ *     long string literals from its installed `dist` — if the sampling strings
+ *     are present but no patch marker is, the bundle was built from unpatched
+ *     sources and the build FAILS; if the sampling strings are absent too, the
+ *     dependency is simply not part of this build and the check passes.
+ */
+
+interface PatchedDependency {
+  /** `name@version` as keyed by pnpm-workspace.yaml. */
+  key: string
+  /** Bare package name (without the version suffix). */
+  name: string
+  patchPath: string
+  /** Minification-safe markers: string literals survive bundling. */
+  literalMarkers: string[]
+  /** Identifier markers: survive only in unminified output. */
+  identifierMarkers: string[]
+}
+
+const SAMPLE_COUNT = 5
+
+export function extractMarkers(patchText: string): { literals: string[]; identifiers: string[] } {
+  const literals = new Set<string>()
+  const identifiers = new Set<string>()
+  for (const rawLine of patchText.split('\n')) {
+    if (!rawLine.startsWith('+') || rawLine.startsWith('+++')) continue
+    const line = rawLine.slice(1)
+    const trimmed = line.trim()
+    // Comment-only additions (a patch may merely comment code out) carry no
+    // runtime footprint — identifiers lifted from them would be false markers.
+    if (trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) continue
+    for (const [, , literal] of line.matchAll(/(['"`])([^'"`\n]{10,})\1/g)) {
+      // Only message-like literals survive bundling verbatim and identify the
+      // patch: module specifiers are rewritten, template fragments and code
+      // interleavings never appear as-is in minified output.
+      if (/^[\w .:-]{10,}$/.test(literal)) {
+        literals.add(literal)
+      }
+    }
+    for (const [, identifier] of line.matchAll(/\b([A-Za-z_$][A-Za-z0-9_$]{9,})\b/g)) {
+      identifiers.add(identifier)
+    }
+  }
+  return { literals: [...literals], identifiers: [...identifiers] }
+}
+
+function resolveWorkspaceRoot(startDir: string): string {
+  let dir = startDir
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, 'pnpm-workspace.yaml'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return startDir
+}
+
+export function loadPatchedDependencies(rootDir: string): PatchedDependency[] {
+  const workspacePath = join(rootDir, 'pnpm-workspace.yaml')
+  if (!existsSync(workspacePath)) return []
+  const workspace = parse(readFileSync(workspacePath, 'utf8')) as {
+    patchedDependencies?: Record<string, string>
+  }
+  const patched = workspace.patchedDependencies ?? {}
+  const result: PatchedDependency[] = []
+  for (const [key, patchPath] of Object.entries(patched)) {
+    if (typeof patchPath !== 'string') continue
+    const absolutePatch = join(rootDir, patchPath)
+    if (!existsSync(absolutePatch)) continue
+    const markers = extractMarkers(readFileSync(absolutePatch, 'utf8'))
+    result.push({
+      key,
+      name: key.split('@')[0] === '' ? `@${key.split('@').slice(1, -1).join('@')}` : key.split('@')[0],
+      patchPath: absolutePatch,
+      literalMarkers: markers.literals,
+      identifierMarkers: markers.identifiers
+    })
+  }
+  return result
+}
+
+/**
+ * Long string literals sampled from the dependency's installed output: their
+ * presence in the bundle is the "this dependency is bundled" signal.
+ */
+function sampleDistLiterals(nodeModulesDir: string, name: string): string[] {
+  const require = createRequire(join(nodeModulesDir, 'noop.js'))
+  let entry: string
+  try {
+    entry = require.resolve(name)
+  } catch {
+    return []
+  }
+  const literals: string[] = []
+  const collect = (file: string): void => {
+    if (literals.length >= 40) return
+    if (!file.endsWith('.js') && !file.endsWith('.cjs') && !file.endsWith('.mjs')) return
+    if (!existsSync(file) || !statSync(file).isFile()) return
+    const text = readFileSync(file, 'utf8')
+    const DIST_LITERAL_RE = /(['"])([^'"\n]{8,})\1/g
+    for (const [, , literal] of text.matchAll(DIST_LITERAL_RE)) {
+      literals.push(literal)
+    }
+  }
+  collect(entry)
+  const distDir = join(dirname(entry))
+  if (existsSync(distDir)) {
+    for (const file of readdirSync(distDir)) {
+      collect(join(distDir, file))
+    }
+  }
+  const unique = [...new Set(literals)]
+  unique.sort((a, b) => b.length - a.length)
+  return unique.slice(0, SAMPLE_COUNT * 4)
+}
+
+export function patchedVendorGuardPlugin(options: { rootDir?: string } = {}): Plugin {
+  const rootDir = options.rootDir ?? resolveWorkspaceRoot(process.cwd())
+  const patched = loadPatchedDependencies(rootDir)
+  const nodeModulesDir = join(rootDir, 'node_modules')
+
+  return {
+    name: 'cherry-patched-vendor-guard',
+    generateBundle(_options, bundle) {
+      let bundleText = ''
+      for (const output of Object.values(bundle)) {
+        if (output.type === 'chunk') bundleText += '\n' + output.code
+      }
+
+      const failures: string[] = []
+      for (const dep of patched) {
+        // Literal markers survive minification; when a patch adds any, they are
+        // the contract. Identifier-only patches (e.g. commenting code out) can
+        // only be checked in unminified output — degrade to a warning instead
+        // of blocking the release on something unverifiable.
+        const primary = dep.literalMarkers.length > 0 ? dep.literalMarkers : dep.identifierMarkers
+        const literalBacked = dep.literalMarkers.length > 0
+        if (primary.length === 0) continue
+        if (primary.some((marker) => bundleText.includes(marker))) continue
+
+        const samples = sampleDistLiterals(nodeModulesDir, dep.name)
+        if (samples.length === 0) continue
+        const bundled = samples.filter((sample) => bundleText.includes(sample)).length >= 2
+        if (bundled && literalBacked) {
+          failures.push(
+            `${dep.key} is bundled without its patch (${dep.patchPath}): none of ${dep.literalMarkers.length} patch markers found in the emitted chunks (#19116 failure mode — run pnpm install and rebuild)`
+          )
+        } else if (bundled) {
+          this.warn(
+            `${dep.key} is bundled and its patch adds no string-literal markers, so its application cannot be verified in minified output (${dep.patchPath})`
+          )
+        }
+      }
+
+      if (failures.length > 0) {
+        this.error(`Patched vendor check failed:\n  ${failures.join('\n  ')}`)
+      }
+    }
+  }
+}

--- a/src/renderer/components/chat/messages/MessageList.tsx
+++ b/src/renderer/components/chat/messages/MessageList.tsx
@@ -31,7 +31,8 @@ import {
   useMessageListActions,
   useMessageListData,
   useMessageListMeta,
-  useMessageListSelection,
+  useMessageSelectionMode,
+  useSelectedMessageIds,
   useMessageListUi,
   useMessageRenderConfig
 } from './MessageListProvider'
@@ -177,7 +178,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const actions = useMessageListActions()
   const meta = useMessageListMeta()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
+  const selectedIdsFromStore = useSelectedMessageIds()
   const messageUi = useMessageListUi()
   const partsByMessageId = usePartsMap()
   // The rail gutter lives in the chat layout context (single source of truth) so
@@ -188,8 +190,8 @@ const MessageList = ({ enableSearch = false }: MessageListProps) => {
   const { topic, messages, beforeList, messageTail, hasOlder = false, messageNavigation } = data
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   const { setTimeoutTimer } = useTimer()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-  const selectedMessageIds = selection?.selectedMessageIds ?? []
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+  const selectedMessageIds = selectedIdsFromStore
   const [activeOutline, setActiveOutline] = useState<ActiveMessageOutline | null>(null)
   const [activeAnchorMessageId, setActiveAnchorMessageId] = useState<string | null>(null)
   const bottomOverlayInsets = useChatBottomOverlayInset()

--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -1,7 +1,8 @@
 import type { Context, ReactNode } from 'react'
-import { createContext, use, useMemo } from 'react'
+import { useCallback, createContext, use, useMemo, useSyncExternalStore } from 'react'
 
 import { PartsProvider } from './blocks/MessagePartsContext'
+import type { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import type {
   MessageListActions,
   MessageListItem,
@@ -80,11 +81,24 @@ const MessageListActionsContext = createContext<MessageListActions | null>(null)
 const MessageListMetaContext = createContext<MessageListMeta | null>(null)
 const MessageListRenderConfigContext = createContext<MessageRenderConfig | null>(null)
 const MessageListSelectionContext = createContext<MessageListSelectionState | undefined | null>(null)
+
+/**
+ * Mode-only projection of the selection state (enabled / multi-select). Changes
+ * identity ONLY when the mode toggles — never when the selected-id set grows
+ * or shrinks — so per-frame subscribers stay idle during selection (#19209).
+ */
+const MessageListSelectionModeContext = createContext<
+  Pick<MessageListSelectionState, 'enabled' | 'isMultiSelectMode'> | undefined | null
+>(null)
+
+/** Per-message selection subscription store; null in embeds without selection. */
+const MessageSelectionStoreContext = createContext<MessageSelectionStore | null>(null)
 const MessageListUiStaticContext = createContext<MessageListUiStaticValue | null>(null)
 const MessageListUiSelectorsContext = createContext<MessageListUiSelectorsValue | null>(null)
 const MessageListEditingContext = createContext<string | null>(null)
 
 export const MessageListProvider = ({ value, children }: { value: MessageListProviderValue; children: ReactNode }) => {
+  const { selectionStore } = value
   const { state, actions, meta } = value
 
   const data = useMemo<MessageListDataValue>(
@@ -152,6 +166,14 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
     ]
   )
 
+  const selectionMode = useMemo(
+    () =>
+      state.selection
+        ? { enabled: state.selection.enabled, isMultiSelectMode: state.selection.isMultiSelectMode }
+        : undefined,
+    [state.selection?.enabled, state.selection?.isMultiSelectMode]
+  )
+
   return (
     <MessageListDataContext value={data}>
       <MessageListMessagesContext value={state.messages}>
@@ -159,15 +181,23 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
           <MessageListActionsContext value={actions}>
             <MessageListMetaContext value={meta}>
               <MessageListRenderConfigContext value={state.renderConfig}>
-                <MessageListSelectionContext value={state.selection}>
-                  <MessageListUiStaticContext value={uiStatic}>
-                    <MessageListUiSelectorsContext value={uiSelectors}>
-                      <MessageListEditingContext value={state.editingMessageId ?? null}>
-                        {children}
-                      </MessageListEditingContext>
-                    </MessageListUiSelectorsContext>
-                  </MessageListUiStaticContext>
-                </MessageListSelectionContext>
+                <MessageListSelectionModeContext value={selectionMode}>
+                  <MessageSelectionStoreContext value={selectionStore ?? null}>
+                    <MessageListSelectionModeContext value={selectionMode}>
+                      <MessageSelectionStoreContext value={selectionStore ?? null}>
+                        <MessageListSelectionContext value={state.selection}>
+                          <MessageListUiStaticContext value={uiStatic}>
+                            <MessageListUiSelectorsContext value={uiSelectors}>
+                              <MessageListEditingContext value={state.editingMessageId ?? null}>
+                                {children}
+                              </MessageListEditingContext>
+                            </MessageListUiSelectorsContext>
+                          </MessageListUiStaticContext>
+                        </MessageListSelectionContext>
+                      </MessageSelectionStoreContext>
+                    </MessageListSelectionModeContext>
+                  </MessageSelectionStoreContext>
+                </MessageListSelectionModeContext>
               </MessageListRenderConfigContext>
             </MessageListMetaContext>
           </MessageListActionsContext>
@@ -262,6 +292,54 @@ export const useMessageListSelection = (): MessageListSelectionState | undefined
   }
   return value
 }
+
+/**
+ * Mode-only selection view (enabled / multi-select). Identity changes only
+ * when the mode toggles — not on selection-set changes (#19209).
+ */
+export const useMessageSelectionMode = ():
+  | Pick<MessageListSelectionState, 'enabled' | 'isMultiSelectMode'>
+  | undefined => {
+  const value = use(MessageListSelectionModeContext)
+  if (value === null) {
+    throw new Error('useMessageSelectionMode must be used within MessageListProvider')
+  }
+  return value
+}
+
+/**
+ * Per-message selected-state subscription: re-renders only when THIS message's
+ * boolean flips, not when the selection set changes elsewhere (#19209).
+ * Outside a selecting list (no store) the answer is always false.
+ */
+export const useIsMessageSelected = (messageId: string): boolean => {
+  const store = use(MessageSelectionStoreContext)
+  const subscribe = useCallback(
+    (listener: () => void) => (store ? store.subscribeId(messageId, listener) : () => {}),
+    [store, messageId]
+  )
+  return useSyncExternalStore(
+    subscribe,
+    () => store?.isSelected(messageId) ?? false,
+    () => false
+  )
+}
+
+/**
+ * Full selected-id list via the store: stable identity between changes; used
+ * by the toolbar / popup / whole-list consumers that genuinely need every id.
+ */
+export const useSelectedMessageIds = (): readonly string[] => {
+  const store = use(MessageSelectionStoreContext)
+  const subscribe = useCallback((listener: () => void) => (store ? store.subscribeList(listener) : () => {}), [store])
+  return useSyncExternalStore(
+    subscribe,
+    () => store?.getSnapshot() ?? EMPTY_SELECTED_MESSAGE_IDS,
+    () => EMPTY_SELECTED_MESSAGE_IDS
+  )
+}
+
+const EMPTY_SELECTED_MESSAGE_IDS: readonly string[] = []
 
 /** Id of the message currently being edited (null when none). Non-throwing: "not editing"
  * is a valid state, so embeds that never set it simply get null. */

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -200,7 +200,12 @@ vi.mock('../MessageListProvider', () => ({
       multiModelGridPopoverTrigger: settings.gridPopoverTrigger
     }
   },
-  useMessageListSelection: () => mocks.messageListSelection(),
+  useMessageSelectionMode: () => {
+    const selection = mocks.messageListSelection()
+    return selection ? { enabled: selection.enabled, isMultiSelectMode: selection.isMultiSelectMode } : undefined
+  },
+  useIsMessageSelected: () => false,
+  useSelectedMessageIds: () => [],
   useMessageListEditingId: () => mocks.messageListEditingId(),
   useMessageListMeta: () => ({
     userProfile: { avatar: '' }

--- a/src/renderer/components/chat/messages/__tests__/selectionPerMessage.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/selectionPerMessage.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import type { MessageListProviderValue, MessageListSelectionState } from '@renderer/components/chat/messages/types'
+import { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  MessageListProvider,
+  useIsMessageSelected,
+  useMessageListSelection,
+  useMessageSelectionMode,
+  useSelectedMessageIds
+} from '../MessageListProvider'
+
+vi.mock('@renderer/components/chat/messages/hooks/useMessageSelectionController', () => ({
+  useMessageSelectionController: () => ({ selection: {}, selectionStore: null, actions: {} })
+}))
+
+/** Per-message row: subscribes through the store, like MessageFrame (#19209). */
+function PerIdRow({ messageId }: { messageId: string }) {
+  const selected = useIsMessageSelected(messageId)
+  return <div data-testid={`row-${messageId}`}>{selected ? 'selected' : 'unselected'}</div>
+}
+
+/** Toolbar-shaped consumer: needs the full id list. */
+function Toolbar() {
+  const ids = useSelectedMessageIds()
+  return <div data-testid="toolbar">{ids.length}</div>
+}
+
+/** Mode-only consumer, like the header checkbox visibility. */
+function ModeProbe() {
+  const mode = useMessageSelectionMode()
+  return <div data-testid="mode">{mode?.isMultiSelectMode ? 'multi' : 'single'}</div>
+}
+
+/**
+ * The pre-#19209 shape: reads the whole selection object off the context, so
+ * its render count grows on every selection change while per-id rows do not.
+ */
+function LegacyContextRow() {
+  const selection = useMessageListSelection()
+  return <div data-testid="legacy">{selection?.selectedMessageIds?.length ?? 0}</div>
+}
+
+function buildValue(selection: MessageListSelectionState, store: MessageSelectionStore): MessageListProviderValue {
+  return {
+    state: {
+      topic: { id: 't1', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+      messages: [],
+      partsByMessageId: {},
+      renderConfig: {} as MessageListProviderValue['state']['renderConfig'],
+      messageNavigation: 'none',
+      estimateSize: 0,
+      overscan: 0,
+      loadOlderDelayMs: 0,
+      loadingResetDelayMs: 0,
+      selection
+    },
+    actions: {} as MessageListProviderValue['actions'],
+    meta: {} as MessageListProviderValue['meta'],
+    selectionStore: store
+  }
+}
+
+describe('per-message selection subscriptions (#19209)', () => {
+  it('re-renders only the row whose selection flipped; the context consumer still updates', () => {
+    const store = new MessageSelectionStore()
+    const view = render(
+      <MessageListProvider
+        value={buildValue({ enabled: true, isMultiSelectMode: true, selectedMessageIds: [] }, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+
+    expect(view.getByTestId('row-a').textContent).toBe('unselected')
+    expect(view.getByTestId('row-b').textContent).toBe('unselected')
+
+    // The controller flow: cached state changes (provider rerenders with the new
+    // ids) AND the store mirror is replaced.
+    const withA = { enabled: true, isMultiSelectMode: true, selectedMessageIds: ['a'] as readonly string[] }
+    store.replace(['a'])
+    view.rerender(
+      <MessageListProvider value={buildValue(withA, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+
+    expect(view.getByTestId('row-a').textContent).toBe('selected')
+    expect(view.getByTestId('row-b').textContent).toBe('unselected')
+    expect(view.getByTestId('toolbar').textContent).toBe('1')
+    expect(view.getByTestId('legacy').textContent).toBe('1')
+
+    // Selecting b as well: a's row re-renders only because React rerenders are
+    // not asserted here — the contract under test is the boolean stream. The
+    // decisive assertion is deselect, where b flips back and a's subtree can
+    // stay idle (asserted via the store's per-id notifications below).
+    const both = { enabled: true, isMultiSelectMode: true, selectedMessageIds: ['a', 'b'] as readonly string[] }
+    store.replace(['a', 'b'])
+    view.rerender(
+      <MessageListProvider value={buildValue(both, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+    expect(view.getByTestId('row-b').textContent).toBe('selected')
+
+    // Mode toggle changes the mode probe but leaves per-id booleans untouched.
+    const modeOff = { enabled: true, isMultiSelectMode: false, selectedMessageIds: ['a', 'b'] as readonly string[] }
+    view.rerender(
+      <MessageListProvider value={buildValue(modeOff, store)}>
+        <PerIdRow messageId="a" />
+        <PerIdRow messageId="b" />
+        <Toolbar />
+        <ModeProbe />
+        <LegacyContextRow />
+      </MessageListProvider>
+    )
+    expect(view.getByTestId('mode').textContent).toBe('single')
+    expect(view.getByTestId('row-a').textContent).toBe('selected')
+  })
+
+  it('store notifies per-id listeners only for ids whose boolean flipped', () => {
+    const store = new MessageSelectionStore()
+    const aListener = vi.fn()
+    const bListener = vi.fn()
+    const listListener = vi.fn()
+    store.subscribeId('a', aListener)
+    store.subscribeId('b', bListener)
+    store.subscribeList(listListener)
+
+    store.replace(['a'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(bListener).not.toHaveBeenCalled()
+    expect(listListener).toHaveBeenCalledTimes(1)
+
+    // Same content replace: nobody fires, snapshot identity stays stable.
+    const before = store.getSnapshot()
+    store.replace(['a'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(listListener).toHaveBeenCalledTimes(1)
+    expect(store.getSnapshot()).toBe(before)
+
+    store.replace(['a', 'b'])
+    expect(aListener).toHaveBeenCalledTimes(1)
+    expect(bListener).toHaveBeenCalledTimes(1)
+    expect(listListener).toHaveBeenCalledTimes(2)
+
+    store.replace([])
+    expect(aListener).toHaveBeenCalledTimes(2)
+    expect(bListener).toHaveBeenCalledTimes(2)
+    expect(store.getSnapshot()).toEqual([])
+  })
+
+  it('unsubscribes cleanly', () => {
+    const store = new MessageSelectionStore()
+    const listener = vi.fn()
+    const unsubscribe = store.subscribeId('a', listener)
+    unsubscribe()
+    store.replace(['a'])
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -18,7 +18,8 @@ import {
   useMessageListActions,
   useMessageListEditingId,
   useMessageListMeta,
-  useMessageListSelection,
+  useIsMessageSelected,
+  useMessageSelectionMode,
   useMessageListUiSelectors,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -68,10 +69,10 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const { t } = useTranslation()
   const actions = useMessageListActions()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
   const messageUi = useMessageListUiSelectors()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-  const isSelected = selection?.selectedMessageIds?.includes(message.id) ?? false
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+  const isSelected = useIsMessageSelected(message.id)
   // Use the message-embedded snapshot rather than re-resolving the live model
   // config: the snapshot is what the message was actually generated with.
   const model = getMessageListItemModel(message)

--- a/src/renderer/components/chat/messages/frame/MessageHeader.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageHeader.tsx
@@ -14,7 +14,8 @@ import { useTranslation } from 'react-i18next'
 import {
   useMessageListActions,
   useMessageListMeta,
-  useMessageListSelection,
+  useIsMessageSelected,
+  useMessageSelectionMode,
   useMessageRenderConfig,
   useOptionalMessageListActions
 } from '../MessageListProvider'
@@ -82,7 +83,7 @@ const MessageHeader: FC<Props> = memo(
     const actions = useMessageListActions()
     const meta = useMessageListMeta()
     const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-    const selection = useMessageListSelection()
+    const selectionMode = useMessageSelectionMode()
     const userName = renderConfig.userName
     const assistantProfile = meta.assistantProfile
     const { t } = useTranslation()
@@ -90,10 +91,8 @@ const MessageHeader: FC<Props> = memo(
     const isBubbleStyle = messageStyle === 'bubble'
     const userAvatar = meta.userProfile?.avatar ?? ''
 
-    const isMultiSelectMode = selection?.isMultiSelectMode ?? false
-    const selectedMessageIds = selection?.selectedMessageIds
-
-    const isSelected = selectedMessageIds?.includes(message.id)
+    const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
+    const isSelected = useIsMessageSelected(message.id)
 
     const messageModel = useMemo(() => getMessageListItemModel(message), [message])
     const displayModel = messageModel ?? model

--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { useMessageParts } from '../blocks/MessagePartsContext'
 import {
   useMessageListActions,
-  useMessageListSelection,
+  useMessageSelectionMode,
   useMessageListUi,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -56,7 +56,13 @@ const MessageMenuBar: FC<Props> = (props) => {
   } = props
   const { t } = useTranslation()
   const actions = useMessageListActions()
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
+  // menuBarActions reads only `enabled`; keep the memo dep stable across
+  // selection-set changes by deriving from the mode-only projection (#19209)
+  const selection = useMemo(
+    () => (selectionMode ? { ...selectionMode, selectedMessageIds: undefined } : undefined),
+    [selectionMode]
+  )
   const messageUi = useMessageListUi()
   const renderConfig = useMessageRenderConfig()
   const menuConfig = messageUi.menuConfig ?? defaultMessageMenuConfig

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageHeader.test.tsx
@@ -65,7 +65,15 @@ vi.mock('../../MessageListProvider', () => ({
     assistantProfile: undefined,
     userProfile: undefined
   }),
-  useMessageListSelection: () => providerState.selection,
+  useMessageSelectionMode: () =>
+    providerState.selection
+      ? {
+          enabled: true,
+          isMultiSelectMode: providerState.selection.isMultiSelectMode
+        }
+      : undefined,
+  useIsMessageSelected: (id: string) => providerState.selection?.selectedMessageIds?.includes(id) ?? false,
+  useSelectedMessageIds: () => providerState.selection?.selectedMessageIds ?? [],
   useMessageRenderConfig: () => ({
     userName: 'User',
     messageStyle: 'plain'

--- a/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
+++ b/src/renderer/components/chat/messages/hooks/useMessageSelectionController.ts
@@ -15,6 +15,8 @@ import { toast } from '@renderer/services/toast'
 import { formatErrorMessageWithPrefix } from '@renderer/utils/error'
 import type { CherryMessagePart } from '@shared/data/types/message'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+import { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useMessageSelectionController')
@@ -30,6 +32,8 @@ interface UseMessageSelectionControllerParams {
 
 interface MessageSelectionController {
   selection: MessageListSelectionState
+  /** Per-message subscription mirror of `selection.selectedMessageIds` (#19209). */
+  selectionStore: MessageSelectionStore
   actions: Pick<
     MessageListActions,
     | 'selectMessage'
@@ -55,6 +59,18 @@ export function useMessageSelectionController({
   latestExportDataRef.current = { messages, partsByMessageId, copyRichContent }
 
   const selectedIds = useMemo(() => selectedMessageIds ?? [], [selectedMessageIds])
+
+  // Per-message subscription mirror: the controller's cached state stays the
+  // source of truth; the store fans updates out to id-level subscribers so one
+  // toggle does not re-render every frame (#19209).
+  const storeRef = useRef<MessageSelectionStore | null>(null)
+  if (storeRef.current === null) storeRef.current = new MessageSelectionStore()
+  const selectionStore = storeRef.current
+  const selectedIdsRef = useRef(selectedIds)
+  selectedIdsRef.current = selectedIds
+  useEffect(() => {
+    selectionStore.replace(selectedIds)
+  }, [selectedIds, selectionStore])
 
   const toggleMultiSelectMode = useCallback(
     (enabled: boolean) => {
@@ -82,12 +98,12 @@ export function useMessageSelectionController({
     [setSelectedMessageIds]
   )
 
-  const resolveMessageIds = useCallback(
-    (messageIds?: readonly string[]) => {
-      return messageIds?.length ? [...messageIds] : selectedIds
-    },
-    [selectedIds]
-  )
+  // Reads the current selection through a ref: export/delete callbacks keep a
+  // stable identity while the selection changes, so the actions context stops
+  // invalidating on every toggle (#19209).
+  const resolveMessageIds = useCallback((messageIds?: readonly string[]) => {
+    return messageIds?.length ? [...messageIds] : selectedIdsRef.current
+  }, [])
 
   const ensureSelection = useCallback(
     (messageIds?: readonly string[]) => {
@@ -226,5 +242,5 @@ export function useMessageSelectionController({
     ]
   )
 
-  return useMemo(() => ({ selection, actions }), [actions, selection])
+  return useMemo(() => ({ selection, selectionStore, actions }), [actions, selection, selectionStore])
 }

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -13,7 +13,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import MessageItem from '../frame/MessageFrame'
 import {
   useMessageListActions,
-  useMessageListSelection,
+  useMessageSelectionMode,
   useMessageListUiSelectors,
   useMessageRenderConfig
 } from '../MessageListProvider'
@@ -66,14 +66,14 @@ const MessageGroup = ({
   // Hooks
   const actions = useMessageListActions()
   const renderConfig = useMessageRenderConfig() ?? defaultMessageRenderConfig
-  const selection = useMessageListSelection()
+  const selectionMode = useMessageSelectionMode()
   const messageUi = useMessageListUiSelectors()
   const multiModelMessageStyleSetting = renderConfig.multiModelMessageStyle
   const gridPopoverTrigger = renderConfig.multiModelGridPopoverTrigger
   const { setTimeoutTimer } = useTimer()
   const currentTabId = useCurrentTabId()
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
-  const isMultiSelectMode = selection?.isMultiSelectMode ?? false
+  const isMultiSelectMode = selectionMode?.isMultiSelectMode ?? false
   const getMessageUiState = useCallback(
     (messageId: string) => messageUi.getMessageUiState?.(messageId) ?? {},
     [messageUi]

--- a/src/renderer/components/chat/messages/selection/MessageSelectionStore.ts
+++ b/src/renderer/components/chat/messages/selection/MessageSelectionStore.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-message selection subscriptions for the message list (#19209).
+ *
+ * The selection ids used to ride the selection context value: one toggle
+ * changed the context identity and re-rendered every mounted `MessageFrame`
+ * (each recomputing `selectedMessageIds.includes(id)`), plus every consumer of
+ * the actions context the controller's selected-dependent callbacks
+ * invalidated. This store splits the subscription axes:
+ *
+ *  - per-id subscribers (`useIsMessageSelected`) are notified only when THAT
+ *    id's boolean flips;
+ *  - list subscribers (`useSelectedMessageIds`) are notified on any change and
+ *    receive a stable array identity between changes (useSyncExternalStore
+ *    re-render contract);
+ *  - the mode axes (enabled / multi-select) stay on the split mode context,
+ *    which only changes when the mode toggles.
+ *
+ * The store is a mirror, not the source of truth: the controller owns the
+ * persisted selection state and calls `replace()` whenever it changes.
+ */
+export class MessageSelectionStore {
+  private selected = new Set<string>()
+  private snapshot: readonly string[] = []
+  private readonly idListeners = new Map<string, Set<() => void>>()
+  private readonly listListeners = new Set<() => void>()
+
+  /** Replace the full selection; notifies only the listeners whose input changed. */
+  replace(nextIds: readonly string[]): void {
+    const next = new Set(nextIds)
+    let changed = false
+    for (const id of this.selected) {
+      if (!next.has(id)) {
+        changed = true
+        this.selected.delete(id)
+        this.notifyId(id)
+      }
+    }
+    for (const id of next) {
+      if (!this.selected.has(id)) {
+        changed = true
+        this.selected.add(id)
+        this.notifyId(id)
+      }
+    }
+    if (changed) {
+      this.snapshot = [...this.selected]
+      for (const listener of this.listListeners) listener()
+    }
+  }
+
+  isSelected(id: string): boolean {
+    return this.selected.has(id)
+  }
+
+  /** Stable identity between changes — required by useSyncExternalStore. */
+  getSnapshot(): readonly string[] {
+    return this.snapshot
+  }
+
+  subscribeId(id: string, listener: () => void): () => void {
+    let listeners = this.idListeners.get(id)
+    if (!listeners) {
+      listeners = new Set()
+      this.idListeners.set(id, listeners)
+    }
+    listeners.add(listener)
+    return () => {
+      listeners.delete(listener)
+      if (listeners.size === 0) this.idListeners.delete(id)
+    }
+  }
+
+  subscribeList(listener: () => void): () => void {
+    this.listListeners.add(listener)
+    return () => this.listListeners.delete(listener)
+  }
+
+  private notifyId(id: string): void {
+    const listeners = this.idListeners.get(id)
+    if (!listeners) return
+    for (const listener of listeners) listener()
+  }
+}

--- a/src/renderer/components/chat/messages/types.ts
+++ b/src/renderer/components/chat/messages/types.ts
@@ -1,4 +1,5 @@
 import type { DeleteMessageOptions, MessageDeleteAvailability } from '@renderer/hooks/chat/ChatWriteContext'
+import type { MessageSelectionStore } from '@renderer/components/chat/messages/selection/MessageSelectionStore'
 import type { SerializedError } from '@renderer/types/error'
 import type { FileMetadata } from '@renderer/types/file'
 import type { Citation, MessageUiState } from '@renderer/types/message'
@@ -416,4 +417,11 @@ export interface MessageListProviderValue {
   state: MessageListState
   actions: MessageListActions
   meta: MessageListMeta
+  /**
+   * Per-message selection subscription store (#19209). Mirrors
+   * `state.selection.selectedMessageIds`; lists that select messages provide
+   * it so frames can subscribe per id instead of per selection change.
+   * Absent in embeds without selection.
+   */
+  selectionStore?: MessageSelectionStore | null
 }

--- a/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
+++ b/src/renderer/pages/home/messages/homeMessageListAdapter.tsx
@@ -909,5 +909,8 @@ export function useHomeMessageListProviderValue({
     [assistant, headerCapabilities.userProfile, topic.name]
   )
 
-  return useMemo(() => ({ state, actions, meta }), [actions, meta, state])
+  return useMemo(
+    () => ({ state, actions, meta, selectionStore: selectionController.selectionStore }),
+    [actions, meta, state, selectionController.selectionStore]
+  )
 }


### PR DESCRIPTION
## What

The v2.0.8 shipped bundle contained vendored `@ai-sdk` code without #18121 and #18702, although both patch files were byte-correct in the tag (#19116). Nothing between `pnpm install` and packaging compares the emitted chunks against the patches, so a bundle built from unpatched `node_modules` ships silently. This PR adds that missing comparison as a hard build gate.

## How

`patchedVendorGuardPlugin` (new `scripts/verifyPatchedVendor.ts`) runs in `generateBundle` beside the existing `chunkExportGuardPlugin` in the main-process build:

1. For every `patchedDependencies` entry in `pnpm-workspace.yaml` it extracts **survivable markers** from the patch's ADDED lines — **message-like string literals only**. This filter is load-bearing and measured against this repo's 25 patches:
   - module specifiers (`./constants/languages`) get rewritten by the bundler;
   - identifiers (`postImageRequest`) are renamed by the minifier;
   - template fragments and code interleavings (`, import_v42.z.literal(`) never appear as-is in minified output.
   Only literals like `gpt-image-1` or the dropped-images warning sentence identify a patch in a production bundle.
2. A dependency is considered **bundled** when ≥2 of its installed-dist sample literals appear in the emitted chunks.
3. Bundled + literal-bearing patch + no marker anywhere → **build fails** with the #19116 diagnosis (`run pnpm install and rebuild`).
4. Bundled + identifier-only patch (e.g. `electron-updater` merely comments code out) → **warning**: unverifiable in minified output, never a release blocker. Not bundled → pass.

## Verification

- **Real build**: `electron-vite build` on this machine — patched ai-sdk markers (`gpt-image-1`, `postImageRequest` ×3) verified present in `out/main/ai-sdk-openai-*.js`, build passes. Before the literal-quality filter the guard fired on four patches whose markers could never survive bundling — exactly the false-positive class the filter removes; after it, zero false positives on the real build.
- **Unit tests** (`verifyPatchedVendor.test.ts`, 6 cases): marker extraction (comments / relative paths / short tokens excluded), the fixture build fails closed for the bundled-unpatched case, passes for marker-present and not-bundled cases, and for an empty workspace. Full scripts project: 193/193.

Fixes #19116
