### PR TITLE
fix(channels): make Feishu inbound failures diagnosable

### DIFF
--- a/src/main/ai/channels/adapters/feishu/FeishuAdapter.ts
+++ b/src/main/ai/channels/adapters/feishu/FeishuAdapter.ts
@@ -15,9 +15,23 @@ import { createFeishuHttpInstance } from './FeishuHttpInstance'
 
 const FEISHU_MAX_LENGTH = 4000
 const FEISHU_PING_TIMEOUT_SECONDS = 10
+/** How long a transparent SDK reconnect may run before the adapter stops reporting connected (#18336). */
+const RECONNECT_GRACE_MS = 5 * 60_000
 const REACTION_THINKING = 'Typing'
 const REACTION_DONE = 'OK'
 const REACTION_ERROR = 'CRY'
+
+/** Inbound message policy — the single source for both the SDK config and the connect log (#18336). */
+const CHANNEL_POLICY = { dmMode: 'open', requireMention: true, respondToMentionAll: false } as const
+
+/** User-facing hints for the SDK's policy-level reject reasons (#18336). */
+const REJECT_HINTS: Record<string, string> = {
+  no_mention: 'group messages must @mention the bot (requireMention is enabled)',
+  group_not_allowed: 'the chat is not in the channel configured allowed_chat_ids',
+  sender_not_allowed: 'the sender is not allowed by the channel policy',
+  dm_disabled: 'direct messages are disabled by the channel policy',
+  mention_all_blocked: '@all mentions are not answered (respondToMentionAll is disabled)'
+}
 
 type ChatReaction = {
   messageId: string
@@ -143,7 +157,7 @@ class FeishuStreamSession {
   }
 }
 
-class FeishuAdapter extends ChannelAdapter {
+export class FeishuAdapter extends ChannelAdapter {
   private channel: Lark.LarkChannel | null = null
   private appId: string
   private appSecret: string
@@ -151,6 +165,10 @@ class FeishuAdapter extends ChannelAdapter {
   private readonly verificationToken: string
   private readonly allowedChatIds: string[]
   private readonly domain: FeishuDomain
+  private acceptedCount = 0
+  private rejectedCount = 0
+  private reconnectGraceTimer: ReturnType<typeof setTimeout> | null = null
+
   private readonly streams = new Map<string, FeishuStreamSession>()
   private readonly chatReactions = new Map<string, ChatReaction>()
 
@@ -199,11 +217,7 @@ class FeishuAdapter extends ChannelAdapter {
       logger: sdkLogger,
       loggerLevel: Lark.LoggerLevel.info,
       httpInstance: createFeishuHttpInstance(),
-      policy: {
-        dmMode: 'open',
-        requireMention: true,
-        respondToMentionAll: false
-      },
+      policy: CHANNEL_POLICY,
       safety: { batch: { text: { delayMs: 0 } } },
       outbound: { textChunkLimit: FEISHU_MAX_LENGTH },
       wsConfig: { pingTimeout: FEISHU_PING_TIMEOUT_SECONDS }
@@ -212,6 +226,7 @@ class FeishuAdapter extends ChannelAdapter {
 
     channel.on({
       message: (message) => {
+        this.acceptedCount += 1
         void this.handleMessage(message).catch((error) => {
           this.log.error('Failed to handle Feishu message', {
             chatId: message.chatId,
@@ -221,14 +236,34 @@ class FeishuAdapter extends ChannelAdapter {
         })
       },
       reconnecting: () => {
+        // The SDK retries transparently and in-flight streams stay alive, so
+        // the status deliberately remains connected during the grace window.
+        // If reconnection never completes, stop reporting a live connection —
+        // that is the 'connected but nothing arrives' trap of #18336.
         this.log.warn('Feishu WebSocket reconnecting')
+        this.armReconnectGrace(channel)
       },
       reconnected: () => {
+        this.clearReconnectGrace()
         this.markConnected()
         this.log.info('Feishu WebSocket reconnected')
       },
       reject: (event) => {
-        this.log.debug('Feishu message rejected', { chatId: event.chatId, reason: event.reason })
+        // Policy rejections (e.g. a group message without @mention under
+        // requireMention) were invisible at debug level: the bot looked
+        // connected while quietly ignoring every message (#18336).
+        this.rejectedCount += 1
+        const hint = REJECT_HINTS[event.reason] ?? 'check the channel policy configuration'
+        this.log.warn(
+          `Feishu message rejected: ${event.reason} (${hint}; rejected=${this.rejectedCount} accepted=${this.acceptedCount})`,
+          {
+            chatId: event.chatId,
+            reason: event.reason,
+            hint,
+            rejectedTotal: this.rejectedCount,
+            acceptedTotal: this.acceptedCount
+          }
+        )
       },
       error: (error) => {
         this.log.error('Feishu channel error', { error: error.message, code: error.code })
@@ -250,7 +285,12 @@ class FeishuAdapter extends ChannelAdapter {
     }
 
     this.markConnected()
-    this.log.info('Feishu bot connected (WebSocket)')
+    // Make the active inbound policy visible in logs: 'connected but messages
+    // never arrive' reports are usually policy rejections, not dead sockets (#18336).
+    this.log.info(
+      `Feishu bot connected (WebSocket; dmMode=${CHANNEL_POLICY.dmMode} requireMention=${CHANNEL_POLICY.requireMention} allowedChatIds=${this.allowedChatIds.length})`,
+      { ...CHANNEL_POLICY, allowedChatIds: this.allowedChatIds.length }
+    )
   }
 
   private startRegistrationInBackground(signal: AbortSignal): void {
@@ -296,6 +336,7 @@ class FeishuAdapter extends ChannelAdapter {
   }
 
   protected override async performDisconnect(): Promise<void> {
+    this.clearReconnectGrace()
     for (const stream of this.streams.values()) stream.dispose()
     this.streams.clear()
     this.chatReactions.clear()
@@ -529,6 +570,23 @@ class FeishuAdapter extends ChannelAdapter {
     }
 
     return { images, files }
+  }
+
+  private armReconnectGrace(channel: Lark.LarkChannel): void {
+    this.clearReconnectGrace()
+    this.reconnectGraceTimer = setTimeout(() => {
+      this.reconnectGraceTimer = null
+      if (this.channel !== channel || !this.connected) return
+      this.markDisconnected('Feishu WebSocket did not reconnect within the grace window')
+      this.log.error('Feishu WebSocket reconnect grace window elapsed; marking disconnected')
+    }, RECONNECT_GRACE_MS)
+  }
+
+  private clearReconnectGrace(): void {
+    if (this.reconnectGraceTimer !== null) {
+      clearTimeout(this.reconnectGraceTimer)
+      this.reconnectGraceTimer = null
+    }
   }
 
   private getChannel(): Lark.LarkChannel {

--- a/src/main/ai/channels/adapters/feishu/__tests__/FeishuAdapter.diagnostics.test.ts
+++ b/src/main/ai/channels/adapters/feishu/__tests__/FeishuAdapter.diagnostics.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Diagnostics contract for the Feishu adapter (#18336): policy rejections must
+ * surface as warn-level channel logs with an actionable hint, the connect log
+ * must state the active inbound policy, and the adapter must not report
+ * "connected" while the SDK is reconnecting a dead socket.
+ *
+ * The Lark SDK is mocked at module level with a controllable fake channel; the
+ * adapter under test is the real one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fake = vi.hoisted(() => {
+  const handlers: Record<string, ((...args: unknown[]) => void) | undefined> = {}
+  const channel = {
+    on(map: Record<string, (...args: unknown[]) => void>) {
+      Object.assign(handlers, map)
+    },
+    async connect() {},
+    async disconnect() {},
+    rawWsClient: null
+  }
+  return { handlers, channel, createdWith: null as unknown as Record<string, unknown> }
+})
+
+vi.mock('@larksuiteoapi/node-sdk', () => ({
+  Domain: { Lark: 'https://open.larksuite.com', Feishu: 'https://open.feishu.cn' },
+  LoggerLevel: { info: 'info' },
+  createLarkChannel: (config: Record<string, unknown>) => {
+    fake.createdWith = config
+    return fake.channel
+  }
+}))
+
+vi.mock('file-type', () => ({ fileTypeFromBuffer: async () => undefined }))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({
+    IpcApiService: { broadcastToType: vi.fn() }
+  } as never)
+})
+
+import { FeishuAdapter } from '../FeishuAdapter'
+import type { ChannelLogEntry } from '../../../types'
+import type { ChannelStatusEvent } from '../../../types'
+
+function buildAdapter(): FeishuAdapter {
+  return new FeishuAdapter({
+    channelId: 'channel-1',
+    channelType: 'feishu',
+    agentId: 'agent-1',
+    channelConfig: {
+      app_id: 'app',
+      app_secret: 'secret',
+      encrypt_key: '',
+      verification_token: '',
+      allowed_chat_ids: [],
+      domain: 'feishu'
+    }
+  })
+}
+
+describe('Feishu adapter diagnostics (#18336)', () => {
+  let adapter: FeishuAdapter
+  let logs: ChannelLogEntry[]
+  let statuses: ChannelStatusEvent[]
+
+  beforeEach(async () => {
+    fake.handlers.message = undefined
+    fake.handlers.reject = undefined
+    fake.handlers.reconnecting = undefined
+    fake.handlers.reconnected = undefined
+    adapter = buildAdapter()
+    logs = []
+    statuses = []
+    adapter.on('log', (event) => logs.push(event))
+    adapter.on('statusChange', (event) => statuses.push(event))
+    await adapter.connect()
+  })
+
+  afterEach(async () => {
+    await adapter.disconnect()
+  })
+
+  it('logs the active inbound policy on connect', () => {
+    expect(adapter.connected).toBe(true)
+    const connectLog = logs.find((event) => event.message.includes('Feishu bot connected'))
+    expect(connectLog).toBeDefined()
+    expect(connectLog?.message).toContain('requireMention')
+    expect(fake.createdWith?.policy).toMatchObject({ dmMode: 'open', requireMention: true })
+  })
+
+  it('surfaces policy rejections as warn logs with hint and counters', () => {
+    fake.handlers.reject!({ messageId: 'm1', chatId: 'c1', senderId: 'u1', reason: 'no_mention' })
+
+    const rejectLog = logs.find((event) => event.message.includes('Feishu message rejected'))
+    expect(rejectLog?.level).toBe('warn')
+    expect(rejectLog?.message).toContain('no_mention')
+    // the hint makes the silent failure actionable (#18336's core complaint)
+    expect(rejectLog?.message).toContain('@mention')
+
+    fake.handlers.reject!({ messageId: 'm2', chatId: 'c1', senderId: 'u1', reason: 'dm_disabled' })
+    const second = logs.filter((event) => event.message.includes('Feishu message rejected'))
+    expect(second).toHaveLength(2)
+    expect(second[1].message).toContain('direct messages are disabled')
+  })
+
+  it('stays connected during a transparent reconnect, but stops reporting connected past the grace window', async () => {
+    vi.useFakeTimers()
+    try {
+      expect(adapter.connected).toBe(true)
+
+      // Deliberate design: streams stay alive while the SDK retries.
+      fake.handlers.reconnecting!()
+      expect(adapter.connected).toBe(true)
+
+      // Grace window elapses without a successful reconnect.
+      vi.advanceTimersByTime(5 * 60_000 + 1000)
+      expect(adapter.connected).toBe(false)
+      expect(statuses.at(-1)?.connected).toBe(false)
+
+      // A late reconnect still recovers the status.
+      fake.handlers.reconnected!()
+      expect(adapter.connected).toBe(true)
+      expect(statuses.at(-1)?.connected).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still counts accepted messages separately from rejections', () => {
+    // an accepted (but content-empty) message first, then a rejection: the
+    // running counters must appear in the reject log
+    fake.handlers.message!({
+      messageId: 'm2',
+      chatId: 'c1',
+      senderId: 'u1',
+      content: '   ',
+      resources: []
+    })
+    fake.handlers.reject!({ messageId: 'm1', chatId: 'c1', senderId: 'u1', reason: 'no_mention' })
+
+    const rejectLog = logs.find((event) => event.message.includes('Feishu message rejected'))
+    expect(rejectLog?.message).toContain('accepted=1')
+  })
+})


### PR DESCRIPTION
## What

#18336's report — Feishu WebSocket "connected" but inbound messages never arrive, **no error logged anywhere** — describes two invisible failure modes this PR makes diagnosable:

1. **Policy rejections were silent.** The adapter runs the SDK with `requireMention: true`, so every group message that does not @mention the bot (plus four other policy reasons) is delivered to the `reject` handler — which logged at **debug** level with no reason. At the default log level a bot ignoring every message produced no output at all. The connect log also said nothing about the active inbound policy, so "why is my message ignored" was unanswerable from logs.
2. **A stuck reconnect masqueraded as healthy.** The SDK reconnects transparently and the existing design (kept — there is a test pinning it) keeps `connected` true and streams alive during the retry. But if reconnection never completes, the adapter reports connected forever.

## How

- `reject` now logs at **warn** with the reject reason, a user-facing hint per reason (`no_mention` → "group messages must @mention the bot (requireMention is enabled)", etc. — all five SDK reject reasons mapped), and running `accepted`/`rejected` counters. The connect log states the active policy (`dmMode`, `requireMention`, allowed-chat count) sourced from one shared `CHANNEL_POLICY` constant that also feeds `createLarkChannel`, so config and log cannot drift.
- A **5-minute reconnect grace window**: `reconnecting` still keeps the status connected (transparent retry, streams alive); if `reconnected` has not landed by the deadline the adapter marks itself disconnected with the reason, and a late reconnect still recovers. Timer is cleared on reconnect/disconnect.

## Testing

New `FeishuAdapter.diagnostics.test.ts` (real adapter over a module-mocked Lark SDK): policy-in-connect-log, reject → warn with hint + counters, the grace-window lifecycle (connected during retry → disconnected after the window → recovers on a late reconnect, via fake timers), and accepted/rejected counting. The pre-existing "keeps active stream listeners alive while the WebSocket reconnects" test still passes — the transparent-retry design is preserved. Full `src/main/ai/channels` suite: 220/223 (3 pre-existing Windows symlink failures, identical on the unpatched tree).

Fixes #18336
