### PR TITLE
perf(markdown): load the CodeMirror editor stack only when editing

### DIFF
--- a/packages/ui/src/components/__tests__/barrel-code-editor-lazy.test.ts
+++ b/packages/ui/src/components/__tests__/barrel-code-editor-lazy.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Barrel contract for #19208: the ui barrel must NOT re-export the CodeEditor
+ * component. The editor statically pulls the whole CodeMirror stack, so a
+ * barrel re-export would load it into every static graph that touches the
+ * barrel — including read-only chat markdown. The component stays reachable
+ * only through the deep path ('@cherrystudio/ui/components/composites/
+ * code-editor'), which app code imports lazily (LazyCodeEditor).
+ *
+ * Types and the theme getters stay on the barrel: types vanish at build time,
+ * and the theme utils dynamically import the heavy theme bundle themselves.
+ */
+import { describe, expect, it } from 'vitest'
+
+import * as Barrel from '../index'
+
+describe('ui barrel keeps the CodeMirror stack lazy (#19208)', () => {
+  it('does not re-export the CodeEditor component', () => {
+    expect((Barrel as Record<string, unknown>).CodeEditor).toBeUndefined()
+  })
+
+  it('keeps the light editor surface on the barrel: types plus theme getters', () => {
+    // Theme getters are runtime values and must survive the split.
+    expect(typeof Barrel.getCmThemeByName).toBe('function')
+    expect(typeof Barrel.getCmThemeNames).toBe('function')
+  })
+
+  it('still exposes the editor through the deep path for lazy importers', async () => {
+    const mod = await import('../composites/code-editor')
+    // memo-wrapped: a callable-or-memo object, but never undefined
+    expect(mod.default).toBeDefined()
+  })
+})

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -82,7 +82,12 @@ export type { CompoundIcon, IconAvatarProps, IconComponent, IconMeta, IconProps 
 /* Additional Composite Components */
 // CodeEditor
 export {
-  default as CodeEditor,
+  // The CodeEditor component itself is deliberately NOT re-exported from this
+  // barrel: it statically pulls the whole CodeMirror stack, which every barrel
+  // importer would then load. Import it from the deep path
+  // '@cherrystudio/ui/components/composites/code-editor' (lazily on the chat
+  // path) — types and the theme getters stay here because they are light
+  // (the themes bundle is dynamically imported inside utils).
   type CodeEditorHandles,
   type CodeEditorProps,
   type CodeMirrorTheme,

--- a/packages/ui/stories/components/composites/code-editor.stories.tsx
+++ b/packages/ui/stories/components/composites/code-editor.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import * as cmThemes from '@uiw/codemirror-themes-all'
 import { action } from 'storybook/actions'
 
-import { CodeEditor } from '../../../src/components'
+import CodeEditor from '../../../src/components/composites/code-editor'
 import type { CodeMirrorTheme, LanguageConfig } from '../../../src/components/composites/code-editor/types'
 
 // The app-facing getCmThemeNames/getCmThemeByName are async (themes-all loads on

--- a/src/renderer/components/CodeBlockView/CodeBlockView.tsx
+++ b/src/renderer/components/CodeBlockView/CodeBlockView.tsx
@@ -1,4 +1,4 @@
-import { CodeEditor, type CodeEditorHandles } from '@cherrystudio/ui'
+import type { CodeEditorHandles } from '@cherrystudio/ui'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import { Icon } from '@iconify/react'
 import { loggerService } from '@logger'
@@ -15,6 +15,7 @@ import {
   useWrapTool
 } from '@renderer/components/CodeToolbar'
 import CodeViewer from '@renderer/components/CodeViewer'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import ImageViewer from '@renderer/components/ImageViewer'
 import type { BasicPreviewHandles } from '@renderer/components/Preview/types'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
@@ -307,7 +308,7 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
   const sourceView = useMemo(
     () =>
       isEditing ? (
-        <CodeEditor
+        <LazyCodeEditor
           className="source-view"
           ref={sourceViewRef}
           theme={activeCmTheme}

--- a/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
-  CodeEditor,
   type CodeEditorHandles,
+  type CodeEditorProps,
   Dialog,
   DialogContent,
   DialogTitle,
@@ -16,6 +16,7 @@ import {
   SegmentedControl,
   Tooltip
 } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
@@ -39,7 +40,7 @@ const logger = loggerService.withContext('HtmlArtifactsPopup')
 interface CodePanelProps {
   codeEditorRef: React.RefObject<CodeEditorHandles | null>
   html: string
-  theme: React.ComponentProps<typeof CodeEditor>['theme']
+  theme: CodeEditorProps['theme']
   fontSize: number
   onSave?: (html: string) => void
   editable: boolean
@@ -60,7 +61,7 @@ const CodePanel = memo<CodePanelProps>(
 
     return (
       <div className="relative grid h-full w-full grid-rows-[minmax(0,1fr)] overflow-hidden">
-        <CodeEditor
+        <LazyCodeEditor
           ref={codeEditorRef}
           value={html}
           language="html"

--- a/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@cherrystudio/ui', async (importOriginal) => ({
   CodeEditor: mocks.CodeEditor
 }))
 
+vi.mock('@renderer/components/LazyCodeEditor', () => ({
+  LazyCodeEditor: mocks.CodeEditor
+}))
+
 vi.mock('@renderer/components/CodeViewer', () => ({
   default: mocks.CodeViewer
 }))

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@cherrystudio/ui', async (importOriginal) => ({
   CodeEditor: mocks.CodeEditor
 }))
 
+vi.mock('@renderer/components/LazyCodeEditor', () => ({
+  LazyCodeEditor: mocks.CodeEditor
+}))
+
+
+
 vi.mock('@renderer/components/CodeViewer', () => ({
   default: mocks.CodeViewer
 }))

--- a/src/renderer/components/LazyCodeEditor.tsx
+++ b/src/renderer/components/LazyCodeEditor.tsx
@@ -1,0 +1,29 @@
+import { type CodeEditorProps } from '@cherrystudio/ui'
+import { Suspense, lazy } from 'react'
+
+/**
+ * Lazily-loaded CodeMirror editing surface.
+ *
+ * The editor statically pulls the whole CodeMirror stack, and the ui barrel no
+ * longer re-exports it for that reason (#19208): read-only rendering paths
+ * (chat markdown, previews) must not pay for an edit mode they never enter.
+ * The deep import keeps the CodeMirror chunk out of every static graph, and
+ * the Suspense fallback renders the current value as plain source so the
+ * layout does not collapse while the chunk loads.
+ */
+const CodeEditorImpl = lazy(async () => {
+  const mod = await import('@cherrystudio/ui/components/composites/code-editor')
+  return { default: mod.default }
+})
+
+export const LazyCodeEditor = ({ value, ...props }: CodeEditorProps) => (
+  <Suspense
+    fallback={
+      <pre className="source-view lazy-code-editor-fallback" aria-busy="true">
+        {value}
+      </pre>
+    }>
+    {/* `ref` rides along in props: the editor accepts it as a regular prop (React 19) */}
+    <CodeEditorImpl value={value} {...props} />
+  </Suspense>
+)

--- a/src/renderer/components/PromptEditorField.tsx
+++ b/src/renderer/components/PromptEditorField.tsx
@@ -1,6 +1,7 @@
 import '@cherrystudio/ui/components/composites/markdown/styles'
 
-import { Button, CodeEditor, type CodeEditorHandles, Field, FieldContent, FieldError, Markdown } from '@cherrystudio/ui'
+import { Button, type CodeEditorHandles, Field, FieldContent, FieldError, Markdown } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
 import { EditorView } from '@codemirror/view'
 import { usePreference } from '@data/hooks/usePreference'
@@ -187,7 +188,7 @@ export function PromptEditorField({
               <Markdown id={previewId}>{previewValue || value}</Markdown>
             </div>
           ) : (
-            <CodeEditor
+            <LazyCodeEditor
               ref={codeEditorRef}
               theme={promptEditorTheme}
               fontSize={fontSize - 1}

--- a/src/renderer/components/TextFilePreviewPopup.tsx
+++ b/src/renderer/components/TextFilePreviewPopup.tsx
@@ -1,4 +1,5 @@
-import { CodeEditor, Dialog, DialogContent, DialogHeader, DialogTitle } from '@cherrystudio/ui'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { usePreference } from '@data/hooks/usePreference'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
 import { createPopup, type PopupInjectedProps } from '@renderer/services/popup'
@@ -23,7 +24,7 @@ const PopupContainer: React.FC<Props> = ({ text, title, extension, open, resolve
         </DialogHeader>
         <div className="min-h-0 overflow-hidden">
           {extension !== undefined ? (
-            <CodeEditor
+            <LazyCodeEditor
               className="[&_.cm-line]:cursor-text"
               theme={activeCmTheme}
               fontSize={fontSize - 1}

--- a/src/renderer/components/__tests__/PromptEditorField.test.tsx
+++ b/src/renderer/components/__tests__/PromptEditorField.test.tsx
@@ -60,7 +60,11 @@ vi.mock('@cherrystudio/ui', async (importOriginal) => {
         {children}
       </div>
     ),
-    CodeEditor: ({ ref, value, onChange, placeholder, autoFocus, options, theme }: MockCodeEditorProps) => {
+  }
+})
+
+vi.mock('@renderer/components/LazyCodeEditor', () => ({
+  LazyCodeEditor: ({ ref, value, onChange, placeholder, autoFocus, options, theme }: MockCodeEditorProps) => {
       const textareaRef = useRef<HTMLTextAreaElement>(null)
       mocks.codeEditorProps = { options, theme }
       useImperativeHandle(ref, () => ({
@@ -84,8 +88,7 @@ vi.mock('@cherrystudio/ui', async (importOriginal) => {
         </div>
       )
     }
-  }
-})
+}))
 
 describe('PromptEditorField', () => {
   beforeEach(() => {

--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -1,4 +1,5 @@
-import { Button, CodeEditor, ConfirmDialog, Tooltip } from '@cherrystudio/ui'
+import { Button, ConfirmDialog, Tooltip } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { loggerService } from '@logger'
 import { EmptyState, LoadingState } from '@renderer/components/chat/primitives'
@@ -555,7 +556,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
         )}
         <div className="min-h-0 flex-1 overflow-hidden [&:has(.cm-editor)]:pb-[var(--chat-composer-inset,0px)]">
           {canEditSelection && editMode === 'edit' && fileSession?.status === 'ready' ? (
-            <CodeEditor
+            <LazyCodeEditor
               key={previewKey}
               value={fileSession.draft}
               language={getLanguageByFilePath(overlaySelection.filePath)}

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -249,9 +249,33 @@ vi.mock('@renderer/hooks/useCodeStyle', () => ({
   useCodeStyle: () => ({ activeCmTheme: 'light' })
 }))
 
+vi.mock('@renderer/components/LazyCodeEditor', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/components/LazyCodeEditor')>()
+
+  return {
+    LazyCodeEditor: (props: React.ComponentProps<typeof actual.LazyCodeEditor>) => {
+      const ref = useRef<NonNullable<typeof mocks.codeEditorRef>>(null)
+      useEffect(() => {
+        mocks.codeEditorRef = ref.current
+      })
+
+      if (mocks.useRealCodeEditor) return <actual.LazyCodeEditor {...props} ref={ref} />
+
+      return (
+        <textarea
+          data-testid="code-editor"
+          data-font-size={props.fontSize}
+          readOnly={props.editable === false}
+          value={props.value}
+          onChange={(event) => props.onChange?.(event.currentTarget.value)}
+        />
+      )
+    }
+  }
+})
+
 vi.mock('@cherrystudio/ui', async (importActual) => {
-  const actual = await importActual<typeof CherryStudioUi>()
-  const RealCodeEditor = actual.CodeEditor
+  await importActual<typeof CherryStudioUi>()
 
   return {
     Button: ({ children, ...props }: PropsWithChildren<React.ComponentPropsWithoutRef<'button'>>) => (
@@ -266,24 +290,6 @@ vi.mock('@cherrystudio/ui', async (importActual) => {
       const domProps = { ...props }
       delete domProps.attached
       return <div {...domProps}>{children}</div>
-    },
-    CodeEditor: (props: React.ComponentProps<typeof RealCodeEditor>) => {
-      const ref = useRef<NonNullable<typeof mocks.codeEditorRef>>(null)
-      useEffect(() => {
-        mocks.codeEditorRef = ref.current
-      })
-
-      if (mocks.useRealCodeEditor) return <RealCodeEditor {...props} ref={ref} />
-
-      return (
-        <textarea
-          data-testid="code-editor"
-          data-font-size={props.fontSize}
-          readOnly={props.editable === false}
-          value={props.value}
-          onChange={(event) => props.onChange?.(event.currentTarget.value)}
-        />
-      )
     },
     ConfirmDialog: ({
       cancelText,

--- a/src/renderer/pages/code/components/configEditPanel/CliConfigEditor.tsx
+++ b/src/renderer/pages/code/components/configEditPanel/CliConfigEditor.tsx
@@ -1,4 +1,5 @@
-import { Button, CodeEditor, Tabs, TabsContent, TabsList, TabsTrigger, Tooltip } from '@cherrystudio/ui'
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger, Tooltip, type CodeEditorProps } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { usePreference } from '@data/hooks/usePreference'
 import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
 import { type CliConfigFileDraft, formatCliConfigDraftFile } from '@renderer/pages/code/cliConfig'
@@ -97,11 +98,11 @@ export const CliConfigEditor: FC<CliConfigEditorProps> = ({ files, error, onChan
 const EditorBody: FC<{
   file: CliConfigFileDraft
   fontSize: number
-  theme: React.ComponentProps<typeof CodeEditor>['theme']
+  theme: CodeEditorProps['theme']
   onChange: (target: string, content: string) => void
 }> = ({ file, fontSize, theme, onChange }) => (
   <div className={cn('overflow-hidden rounded-lg border border-border-subtle bg-background')}>
-    <CodeEditor
+    <LazyCodeEditor
       theme={theme}
       fontSize={fontSize - 1}
       value={file.content}

--- a/src/renderer/pages/code/components/configEditPanel/__tests__/CliConfigEditor.test.tsx
+++ b/src/renderer/pages/code/components/configEditPanel/__tests__/CliConfigEditor.test.tsx
@@ -9,13 +9,8 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
 }))
 
-vi.mock('@cherrystudio/ui', () => ({
-  Button: ({ children, ...props }: { children: ReactNode }) => (
-    <button type="button" {...props}>
-      {children}
-    </button>
-  ),
-  CodeEditor: ({ value, onChange }: { value: string; onChange?: (value: string) => void }) => (
+vi.mock('@renderer/components/LazyCodeEditor', () => ({
+  LazyCodeEditor: ({ value, onChange }: { value: string; onChange?: (value: string) => void }) => (
     <>
       <textarea readOnly value={value} />
       <button type="button" onClick={() => onChange?.(value)}>
@@ -25,7 +20,16 @@ vi.mock('@cherrystudio/ui', () => ({
         edit value
       </button>
     </>
+  )
+}))
+
+vi.mock('@cherrystudio/ui', () => ({
+  Button: ({ children, ...props }: { children: ReactNode }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
   ),
+
   Tabs: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TabsContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   TabsList: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  CodeEditor,
   Combobox,
   type ComboboxOption,
   EditableNumber,
@@ -15,6 +14,7 @@ import {
   Switch,
   Tooltip
 } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { useMultiplePreferences, usePreference } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import ChatPreferenceSections from '@renderer/components/chat/settings/ChatPreferenceSections'
@@ -541,7 +541,7 @@ const AppearanceSettings: FC = () => {
           <SettingDescription>{t('settings.display.custom.css.migration_notice')}</SettingDescription>
         )}
         <div className="mt-4 overflow-hidden rounded-lg border border-border-subtle">
-          <CodeEditor
+          <LazyCodeEditor
             theme={activeCmTheme}
             fontSize={fontSize - 1}
             value={customCss}

--- a/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
+++ b/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  CodeEditor,
   Dialog,
   DialogContent,
   DialogFooter,
@@ -15,6 +14,7 @@ import {
   FormMessage,
   Label
 } from '@cherrystudio/ui'
+import { LazyCodeEditor } from '@renderer/components/LazyCodeEditor'
 import { dataApiService } from '@data/DataApiService'
 import { usePreference } from '@data/hooks/usePreference'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -385,7 +385,7 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
                   <FormItem>
                     <FormLabel>{t('settings.mcp.addServer.importFrom.tooltip')}</FormLabel>
                     <FormControl>
-                      <CodeEditor
+                      <LazyCodeEditor
                         theme={activeCmTheme}
                         fontSize={fontSize - 1}
                         value={field.value}

--- a/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
@@ -16,12 +16,16 @@ vi.mock('@cherrystudio/ui', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
 
   return {
-    ...actual,
-    CodeEditor: ({ value, onChange }: ComponentProps<'textarea'> & { onChange: (value: string) => void }) => (
-      <textarea aria-label="server config" value={value} onChange={(event) => onChange(event.target.value)} />
-    )
+    ...actual
   }
 })
+
+vi.mock('@renderer/components/LazyCodeEditor', () => ({
+  LazyCodeEditor:     ({ value, onChange }: ComponentProps<'textarea'> & { onChange: (value: string) => void }) => (
+      <textarea aria-label="server config" value={value} onChange={(event) => onChange(event.target.value)} />
+    )
+}))
+
 
 vi.mock('@data/DataApiService', () => ({
   dataApiService: {


### PR DESCRIPTION
## What

Implements #19208. The ui barrel re-exported the `CodeEditor` component, so **every barrel importer — including the read-only chat markdown path — statically loaded `@uiw/react-codemirror` and the CodeMirror core**, even for plain text messages that never enter code-block edit mode.

## How

- **Barrel split**: `packages/ui/src/components/index.ts` now exports only the light editor surface from `composites/code-editor` — types and the theme getters (the theme *bundle* was already dynamically imported inside `utils`). The component stays reachable through the deep path `@cherrystudio/ui/components/composites/code-editor`, which the existing vite alias resolves to source.
- **`LazyCodeEditor`** (new, 1.4KB facade): wraps that deep import in `React.lazy` with a plain `<pre>` fallback rendering the current value, so the layout does not collapse while the chunk loads; `ref` rides along as a regular prop (React 19, matching the editor's contract).
- All eight consumers render the editing surface through it: `CodeBlockView` (chat code blocks), `HtmlArtifactsPopup`, `ArtifactPane`, `PromptEditorField`, `TextFilePreviewPopup`, `AppearanceSettings`, `AddMcpServerModal`, `CliConfigEditor`. Read-only rendering (CodeViewer/shiki) is untouched.

## Verification

**Built output** (electron-vite build, chunk-graph analysis):

- the `@uiw/react-codemirror` wrapper chunk (**120KB**) is referenced statically only by lazy-graph entry chunks; every app-static graph now reaches it **exclusively through dynamic imports** (`LazyCodeEditor` facade; the notes page was already lazy);
- the lazy chain is `LazyCodeEditor` (1.4KB) → `code-editor` entry chunk (12KB) → preload-mapped deps (wrapper 120KB + CodeMirror libs), loaded on first edit-mode mount;
- the `chat-*.js` chunk is **byte-identical** to the pre-change build — its remaining codemirror base-lib dependency comes from `streamdown` (pre-existing, out of scope here), proving the chat-path change is exactly the editor extraction.

**Tests**: new barrel-contract test (component absent from barrel; light getters present; deep path still exposes the editor) + consumer test mocks moved from the barrel's `CodeEditor` to `LazyCodeEditor` — 202/202 across the affected suites, 3/3 in the ui package.

Fixes #19208
