### PR TITLE
fix(chat-messages): stop reading-mode freeze from fighting middle-click autoscroll

### DIFF
--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -29,9 +29,6 @@ import {
 export const MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX = 6
 export const MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX = 12
 const MESSAGE_SCROLL_TO_BOTTOM_BUTTON_DEFAULT_BOTTOM_OFFSET_PX = 24
-// Suppression decays after this much scroller stillness; the next movement
-// re-confirms in capture phase before virtua can fight the resumed tick.
-const AUTOSCROLL_IDLE_MS = 250
 const KEYBOARD_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])
 const KEYBOARD_SCROLL_OWNER_SELECTOR =
   'input,textarea,select,[contenteditable]:not([contenteditable="false"]),[role="textbox"],[role="combobox"],[role="listbox"],[role="slider"],[role="spinbutton"]'
@@ -159,7 +156,7 @@ export function MessageVirtualList<T>({
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
   const { beginScrollbarDrag, endScrollbarDrag, scrollToBottom, markUserInput, takeUserControl } = runtime
   const { onWheel } = runtime.scrollerProps
-  const { beginAutoscroll, endAutoscroll } = runtime
+  const { armAutoscrollCandidate, confirmAutoscroll, dismissAutoscroll } = runtime
   // Latch the captured node like TabRouter does: a background tab detaches the
   // ref (element === null) while its DOM node lives on, and clearing this state
   // would unmount the virtualizer below — discarding virtua's measurements and
@@ -278,38 +275,13 @@ export function MessageVirtualList<T>({
     scrollerElement.addEventListener('focusin', onFocusIn)
     scrollerElement.addEventListener('focusout', onFocusOut)
     scrollerElement.addEventListener('keydown', onKeyDown)
-    // Chromium middle-click autoscroll synthesizes scrollTop directly without wheel
-    // or pointer drag events; the freeze logic would otherwise snap every step
-    // back. A middle press only arms the gesture — it cannot prove autoscroll
-    // engaged (it never does on macOS/Linux) — so the scroller's own movement
-    // confirms, in capture phase so the first tick isn't fought, and stillness
-    // decays the yield. Dismissal stays on gestures: mouseup would cut Windows'
-    // press-and-hold entry.
-    let armed = false
-    let yieldingFreeze = false
-    let idleTimer: ReturnType<typeof setTimeout> | null = null
-    const stopFreezeYield = () => {
-      if (!yieldingFreeze) return
-      yieldingFreeze = false
-      endAutoscroll()
-    }
-    const dismissAutoscroll = () => {
-      if (!armed) return
-      armed = false
-      if (idleTimer) {
-        clearTimeout(idleTimer)
-        idleTimer = null
-      }
-      stopFreezeYield()
-    }
+    // Chromium middle-click autoscroll synthesizes scrollTop without wheel or
+    // pointer drag events. The runtime owns the candidate/confirmed lifecycle
+    // so freeze suppression is time-bounded and not latched on a swallowed
+    // dismissal click.
     const onCapturedScroll = (event: Event) => {
-      if (!armed || event.target !== scrollerElement) return
-      if (!yieldingFreeze) {
-        yieldingFreeze = true
-        beginAutoscroll()
-      }
-      if (idleTimer) clearTimeout(idleTimer)
-      idleTimer = setTimeout(stopFreezeYield, AUTOSCROLL_IDLE_MS)
+      if (event.target !== scrollerElement) return
+      confirmAutoscroll()
     }
     const onAutoscrollMouseDown = (event: MouseEvent) => {
       const isMiddle = event.button === 1
@@ -317,20 +289,13 @@ export function MessageVirtualList<T>({
       if (isMiddle && insideScroller) {
         const target = event.target instanceof Element ? event.target : null
         if (target?.closest('a,button,[role="button"]')) return
-        // Toggle: second middle press exits autoscroll (Chromium's dismiss gesture).
-        if (armed) {
-          dismissAutoscroll()
-          return
-        }
-        armed = true
+        armAutoscrollCandidate()
         return
       }
-      // Non-middle click or click outside scroller while autoscroll is active
-      // dismisses it (Chromium parity).
       dismissAutoscroll()
     }
     const onKeyDownAutoscrollDismiss = (event: KeyboardEvent) => {
-      if (armed && event.key === 'Escape') dismissAutoscroll()
+      if (event.key === 'Escape') dismissAutoscroll()
     }
     const onWindowBlur = () => dismissAutoscroll()
     // Single document-level listener covers both inside and outside clicks;
@@ -354,7 +319,15 @@ export function MessageVirtualList<T>({
       ownerDocument.removeEventListener('scroll', onCapturedScroll, { capture: true })
       ownerDocument.defaultView?.removeEventListener('blur', onWindowBlur)
     }
-  }, [beginAutoscroll, beginScrollbarDrag, endAutoscroll, endScrollbarDrag, markUserInput, scrollerElement])
+  }, [
+    armAutoscrollCandidate,
+    beginScrollbarDrag,
+    confirmAutoscroll,
+    dismissAutoscroll,
+    endScrollbarDrag,
+    markUserInput,
+    scrollerElement
+  ])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom()

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -29,6 +29,9 @@ import {
 export const MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX = 6
 export const MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX = 12
 const MESSAGE_SCROLL_TO_BOTTOM_BUTTON_DEFAULT_BOTTOM_OFFSET_PX = 24
+// Suppression decays after this much scroller stillness; the next movement
+// re-confirms in capture phase before virtua can fight the resumed tick.
+const AUTOSCROLL_IDLE_MS = 250
 const KEYBOARD_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])
 const KEYBOARD_SCROLL_OWNER_SELECTOR =
   'input,textarea,select,[contenteditable]:not([contenteditable="false"]),[role="textbox"],[role="combobox"],[role="listbox"],[role="slider"],[role="spinbutton"]'
@@ -276,11 +279,38 @@ export function MessageVirtualList<T>({
     scrollerElement.addEventListener('focusout', onFocusOut)
     scrollerElement.addEventListener('keydown', onKeyDown)
     // Chromium middle-click autoscroll synthesizes scrollTop directly without wheel
-    // or pointer drag events. The freeze logic would otherwise snap it back every
-    // frame. Track the middle-button autoscroll lifecycle: on Windows a quick
-    // press+release enters autoscroll mode and a second middle press (or Esc /
-    // any other click) exits it — so ending on mouseup would be too early.
-    let autoscrollArmed = false
+    // or pointer drag events; the freeze logic would otherwise snap every step
+    // back. A middle press only arms the gesture — it cannot prove autoscroll
+    // engaged (it never does on macOS/Linux) — so the scroller's own movement
+    // confirms, in capture phase so the first tick isn't fought, and stillness
+    // decays the yield. Dismissal stays on gestures: mouseup would cut Windows'
+    // press-and-hold entry.
+    let armed = false
+    let yieldingFreeze = false
+    let idleTimer: ReturnType<typeof setTimeout> | null = null
+    const stopFreezeYield = () => {
+      if (!yieldingFreeze) return
+      yieldingFreeze = false
+      endAutoscroll()
+    }
+    const dismissAutoscroll = () => {
+      if (!armed) return
+      armed = false
+      if (idleTimer) {
+        clearTimeout(idleTimer)
+        idleTimer = null
+      }
+      stopFreezeYield()
+    }
+    const onCapturedScroll = (event: Event) => {
+      if (!armed || event.target !== scrollerElement) return
+      if (!yieldingFreeze) {
+        yieldingFreeze = true
+        beginAutoscroll()
+      }
+      if (idleTimer) clearTimeout(idleTimer)
+      idleTimer = setTimeout(stopFreezeYield, AUTOSCROLL_IDLE_MS)
+    }
     const onAutoscrollMouseDown = (event: MouseEvent) => {
       const isMiddle = event.button === 1
       const insideScroller = scrollerElement.contains(event.target as Node)
@@ -288,44 +318,29 @@ export function MessageVirtualList<T>({
         const target = event.target instanceof Element ? event.target : null
         if (target?.closest('a,button,[role="button"]')) return
         // Toggle: second middle press exits autoscroll (Chromium's dismiss gesture).
-        if (autoscrollArmed) {
-          autoscrollArmed = false
-          endAutoscroll()
+        if (armed) {
+          dismissAutoscroll()
           return
         }
-        autoscrollArmed = true
-        beginAutoscroll()
+        armed = true
         return
       }
       // Non-middle click or click outside scroller while autoscroll is active
       // dismisses it (Chromium parity).
-      if (autoscrollArmed) {
-        autoscrollArmed = false
-        endAutoscroll()
-      }
+      dismissAutoscroll()
     }
     const onKeyDownAutoscrollDismiss = (event: KeyboardEvent) => {
-      if (autoscrollArmed && event.key === 'Escape') {
-        autoscrollArmed = false
-        endAutoscroll()
-      }
+      if (armed && event.key === 'Escape') dismissAutoscroll()
     }
-    const onWindowBlur = () => {
-      if (autoscrollArmed) {
-        autoscrollArmed = false
-        endAutoscroll()
-      }
-    }
+    const onWindowBlur = () => dismissAutoscroll()
     // Single document-level listener covers both inside and outside clicks;
     // a separate scroller listener would double-fire for inside clicks.
     ownerDocument.addEventListener('mousedown', onAutoscrollMouseDown, { passive: true })
     ownerDocument.addEventListener('keydown', onKeyDownAutoscrollDismiss)
+    ownerDocument.addEventListener('scroll', onCapturedScroll, { capture: true, passive: true })
     ownerDocument.defaultView?.addEventListener('blur', onWindowBlur)
     return () => {
-      if (autoscrollArmed) {
-        autoscrollArmed = false
-        endAutoscroll()
-      }
+      dismissAutoscroll()
       focusOwnerObserver.disconnect()
       scrollerElement.removeEventListener('pointerdown', onPointerDown)
       scrollerElement.removeEventListener('pointermove', onPointerMove)
@@ -336,6 +351,7 @@ export function MessageVirtualList<T>({
       scrollerElement.removeEventListener('keydown', onKeyDown)
       ownerDocument.removeEventListener('mousedown', onAutoscrollMouseDown)
       ownerDocument.removeEventListener('keydown', onKeyDownAutoscrollDismiss)
+      ownerDocument.removeEventListener('scroll', onCapturedScroll, { capture: true })
       ownerDocument.defaultView?.removeEventListener('blur', onWindowBlur)
     }
   }, [beginAutoscroll, beginScrollbarDrag, endAutoscroll, endScrollbarDrag, markUserInput, scrollerElement])

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -156,6 +156,7 @@ export function MessageVirtualList<T>({
   const [scrollerElement, setScrollerElement] = useState<HTMLDivElement | null>(null)
   const { beginScrollbarDrag, endScrollbarDrag, scrollToBottom, markUserInput, takeUserControl } = runtime
   const { onWheel } = runtime.scrollerProps
+  const { beginAutoscroll, endAutoscroll } = runtime
   // Latch the captured node like TabRouter does: a background tab detaches the
   // ref (element === null) while its DOM node lives on, and clearing this state
   // would unmount the virtualizer below — discarding virtua's measurements and
@@ -274,7 +275,57 @@ export function MessageVirtualList<T>({
     scrollerElement.addEventListener('focusin', onFocusIn)
     scrollerElement.addEventListener('focusout', onFocusOut)
     scrollerElement.addEventListener('keydown', onKeyDown)
+    // Chromium middle-click autoscroll synthesizes scrollTop directly without wheel
+    // or pointer drag events. The freeze logic would otherwise snap it back every
+    // frame. Track the middle-button autoscroll lifecycle: on Windows a quick
+    // press+release enters autoscroll mode and a second middle press (or Esc /
+    // any other click) exits it — so ending on mouseup would be too early.
+    let autoscrollArmed = false
+    const onAutoscrollMouseDown = (event: MouseEvent) => {
+      const isMiddle = event.button === 1
+      const insideScroller = scrollerElement.contains(event.target as Node)
+      if (isMiddle && insideScroller) {
+        const target = event.target instanceof Element ? event.target : null
+        if (target?.closest('a,button,[role="button"]')) return
+        // Toggle: second middle press exits autoscroll (Chromium's dismiss gesture).
+        if (autoscrollArmed) {
+          autoscrollArmed = false
+          endAutoscroll()
+          return
+        }
+        autoscrollArmed = true
+        beginAutoscroll()
+        return
+      }
+      // Non-middle click or click outside scroller while autoscroll is active
+      // dismisses it (Chromium parity).
+      if (autoscrollArmed) {
+        autoscrollArmed = false
+        endAutoscroll()
+      }
+    }
+    const onKeyDownAutoscrollDismiss = (event: KeyboardEvent) => {
+      if (autoscrollArmed && event.key === 'Escape') {
+        autoscrollArmed = false
+        endAutoscroll()
+      }
+    }
+    const onWindowBlur = () => {
+      if (autoscrollArmed) {
+        autoscrollArmed = false
+        endAutoscroll()
+      }
+    }
+    // Single document-level listener covers both inside and outside clicks;
+    // a separate scroller listener would double-fire for inside clicks.
+    ownerDocument.addEventListener('mousedown', onAutoscrollMouseDown, { passive: true })
+    ownerDocument.addEventListener('keydown', onKeyDownAutoscrollDismiss)
+    ownerDocument.defaultView?.addEventListener('blur', onWindowBlur)
     return () => {
+      if (autoscrollArmed) {
+        autoscrollArmed = false
+        endAutoscroll()
+      }
       focusOwnerObserver.disconnect()
       scrollerElement.removeEventListener('pointerdown', onPointerDown)
       scrollerElement.removeEventListener('pointermove', onPointerMove)
@@ -283,8 +334,11 @@ export function MessageVirtualList<T>({
       scrollerElement.removeEventListener('focusin', onFocusIn)
       scrollerElement.removeEventListener('focusout', onFocusOut)
       scrollerElement.removeEventListener('keydown', onKeyDown)
+      ownerDocument.removeEventListener('mousedown', onAutoscrollMouseDown)
+      ownerDocument.removeEventListener('keydown', onKeyDownAutoscrollDismiss)
+      ownerDocument.defaultView?.removeEventListener('blur', onWindowBlur)
     }
-  }, [beginScrollbarDrag, endScrollbarDrag, markUserInput, scrollerElement])
+  }, [beginAutoscroll, beginScrollbarDrag, endAutoscroll, endScrollbarDrag, markUserInput, scrollerElement])
 
   const handleScrollToBottom = useCallback(() => {
     scrollToBottom()

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -17,8 +17,6 @@ const runtimeMockState = vi.hoisted(() => ({
   armAutoscrollCandidate: vi.fn(),
   confirmAutoscroll: vi.fn(),
   dismissAutoscroll: vi.fn(),
-  beginAutoscroll: vi.fn(),
-  endAutoscroll: vi.fn(),
   onWheel: vi.fn(),
   shift: false,
   scrollerRef: { current: null as HTMLDivElement | null }
@@ -96,8 +94,6 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       markUserInput: runtimeMockState.markUserInput,
       beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
-      beginAutoscroll: runtimeMockState.beginAutoscroll,
-      endAutoscroll: runtimeMockState.endAutoscroll,
       armAutoscrollCandidate: runtimeMockState.armAutoscrollCandidate,
       confirmAutoscroll: runtimeMockState.confirmAutoscroll,
       dismissAutoscroll: runtimeMockState.dismissAutoscroll,
@@ -138,8 +134,6 @@ describe('MessageVirtualList', () => {
     runtimeMockState.markUserInput.mockClear()
     runtimeMockState.beginScrollbarDrag.mockClear()
     runtimeMockState.endScrollbarDrag.mockClear()
-    runtimeMockState.beginAutoscroll.mockClear()
-    runtimeMockState.endAutoscroll.mockClear()
     runtimeMockState.armAutoscrollCandidate.mockClear()
     runtimeMockState.confirmAutoscroll.mockClear()
     runtimeMockState.dismissAutoscroll.mockClear()

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -146,7 +146,6 @@ describe('MessageVirtualList', () => {
     runtimeMockState.onWheel.mockClear()
     runtimeMockState.shift = false
     runtimeMockState.scrollerRef.current = null
-    runtimeMockState._resetAutoscrollState()
     virtuaMockState.scrollRefReadyAtMount.length = 0
   })
 

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -5,95 +5,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageVirtualList } from '../MessageVirtualList'
 import { useScrollRuntimeBoundary } from '../ScrollOwnershipContext'
 
-const runtimeMockState = vi.hoisted(() => {
-  let armed = false
-  let active = false
-  let candidateTimer: ReturnType<typeof setTimeout> | null = null
-  let idleTimer: ReturnType<typeof setTimeout> | null = null
-  const clearCandidate = () => {
-    if (candidateTimer) {
-      clearTimeout(candidateTimer)
-      candidateTimer = null
-    }
-  }
-  const clearIdle = () => {
-    if (idleTimer) {
-      clearTimeout(idleTimer)
-      idleTimer = null
-    }
-  }
-  const beginAutoscrollImpl = vi.fn(() => {
-    active = true
-    armed = false
-    clearCandidate()
-    clearIdle()
-    idleTimer = setTimeout(() => {
-      active = false
-      idleTimer = null
-      endAutoscrollImpl()
-    }, 250)
-  })
-  const endAutoscrollImpl = vi.fn(() => {
-    if (!active && !armed) return
-    active = false
-    armed = false
-    clearCandidate()
-    clearIdle()
-  })
-  const armAutoscrollCandidateImpl = vi.fn(() => {
-    if (armed || active) {
-      endAutoscrollImpl()
-      return
-    }
-    armed = true
-    clearCandidate()
-    candidateTimer = setTimeout(() => {
-      armed = false
-      candidateTimer = null
-    }, 400)
-  })
-  const confirmAutoscrollImpl = vi.fn(() => {
-    if (!armed && !active) return
-    if (active) {
-      clearIdle()
-      idleTimer = setTimeout(() => {
-        active = false
-        idleTimer = null
-        endAutoscrollImpl()
-      }, 250)
-      return
-    }
-    beginAutoscrollImpl()
-  })
-  const dismissAutoscrollImpl = vi.fn(() => {
-    if (!armed && !active) return
-    endAutoscrollImpl()
-  })
-  return {
-    isScrollToBottomButtonVisible: false,
-    takeUserControl: vi.fn(),
-    scrollToBottom: vi.fn(),
-    notifyWheelIntent: vi.fn(),
-    scrollByWheel: vi.fn(() => true),
-    markUserInput: vi.fn(),
-    beginScrollbarDrag: vi.fn(),
-    endScrollbarDrag: vi.fn(),
-    beginAutoscroll: beginAutoscrollImpl,
-    endAutoscroll: endAutoscrollImpl,
-    armAutoscrollCandidate: armAutoscrollCandidateImpl,
-    confirmAutoscroll: confirmAutoscrollImpl,
-    dismissAutoscroll: dismissAutoscrollImpl,
-    onWheel: vi.fn(),
-    shift: false,
-    scrollerRef: { current: null as HTMLDivElement | null },
-    _resetAutoscrollState: () => {
-      armed = false
-      active = false
-      clearCandidate()
-      clearIdle()
-    }
-  }
-})
+const runtimeMockState = vi.hoisted(() => ({
+  isScrollToBottomButtonVisible: false,
+  takeUserControl: vi.fn(),
+  scrollToBottom: vi.fn(),
+  notifyWheelIntent: vi.fn(),
+  scrollByWheel: vi.fn(() => true),
+  markUserInput: vi.fn(),
+  beginScrollbarDrag: vi.fn(),
+  endScrollbarDrag: vi.fn(),
+  armAutoscrollCandidate: vi.fn(),
+  confirmAutoscroll: vi.fn(),
+  dismissAutoscroll: vi.fn(),
+  beginAutoscroll: vi.fn(),
+  endAutoscroll: vi.fn(),
+  onWheel: vi.fn(),
+  shift: false,
+  scrollerRef: { current: null as HTMLDivElement | null }
+}))
 
 const virtuaMockState = vi.hoisted(() => ({
   scrollRefReadyAtMount: [] as boolean[]
@@ -644,10 +573,7 @@ describe('MessageVirtualList', () => {
     expect(runtimeMockState.endScrollbarDrag).toHaveBeenCalledTimes(1)
   })
 
-  it('does not yield the reading freeze on a bare middle press', () => {
-    // A middle press does not prove Chromium entered autoscroll (macOS, Linux
-    // middle-click paste); the freeze must keep holding until the scroller
-    // really moves (#19225 review).
+  it('arms candidate on middle press and confirms only after outer scroller moves', () => {
     render(
       <MessageVirtualList
         items={['message-1']}
@@ -658,53 +584,15 @@ describe('MessageVirtualList', () => {
 
     const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
     fireEvent.mouseDown(scroller, { button: 1 })
-    fireEvent.mouseUp(document)
-
-    expect(runtimeMockState.beginAutoscroll).not.toHaveBeenCalled()
+    expect(runtimeMockState.armAutoscrollCandidate).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.confirmAutoscroll).not.toHaveBeenCalled()
 
     scroller.scrollTop = 100
     fireEvent.scroll(scroller)
-    expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.confirmAutoscroll).toHaveBeenCalledTimes(1)
   })
 
-  it('decays the autoscroll yield after stillness and requires fresh arming to re-confirm', () => {
-    vi.useFakeTimers()
-    try {
-      render(
-        <MessageVirtualList
-          items={['message-1']}
-          getItemKey={(item) => item}
-          renderItem={(item) => <span>{item}</span>}
-        />
-      )
-
-      const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
-      fireEvent.mouseDown(scroller, { button: 1 })
-      scroller.scrollTop = 100
-      fireEvent.scroll(scroller)
-      expect(runtimeMockState.endAutoscroll).not.toHaveBeenCalled()
-
-      // Cursor resting in the autoscroll dead zone must hand the freeze back.
-      vi.advanceTimersByTime(250)
-      expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
-
-      // After decay, a stale scroll without fresh middle press must NOT re-yield
-      // — otherwise programmatic drift could be misclassified as autoscroll.
-      scroller.scrollTop = 150
-      fireEvent.scroll(scroller)
-      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
-
-      // Fresh middle press re-arms and next movement re-confirms.
-      fireEvent.mouseDown(scroller, { button: 1 })
-      scroller.scrollTop = 200
-      fireEvent.scroll(scroller)
-      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(2)
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it('dismisses an active autoscroll gesture on second middle press, other clicks, Escape and blur', () => {
+  it('forwards dismiss on other clicks, Escape, blur and unmount', () => {
     const { unmount } = render(
       <MessageVirtualList
         items={['message-1']}
@@ -714,35 +602,28 @@ describe('MessageVirtualList', () => {
     )
 
     const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
-    const startGesture = () => {
-      fireEvent.mouseDown(scroller, { button: 1 })
-      scroller.scrollTop += 10
-      fireEvent.scroll(scroller)
-      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalled()
-      runtimeMockState.beginAutoscroll.mockClear()
-      runtimeMockState.endAutoscroll.mockClear()
-    }
-
-    startGesture()
     fireEvent.mouseDown(scroller, { button: 1 })
-    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.armAutoscrollCandidate).toHaveBeenCalledTimes(1)
 
-    startGesture()
+    runtimeMockState.dismissAutoscroll.mockClear()
+    fireEvent.mouseDown(scroller, { button: 1 })
+    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
+
+    runtimeMockState.dismissAutoscroll.mockClear()
     fireEvent.mouseDown(document.body, { button: 0 })
-    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
 
-    startGesture()
+    runtimeMockState.dismissAutoscroll.mockClear()
     fireEvent.keyDown(document, { key: 'Escape' })
-    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
 
-    startGesture()
+    runtimeMockState.dismissAutoscroll.mockClear()
     fireEvent.blur(window)
-    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
 
-    // Unmount while yielding must release the freeze too.
-    startGesture()
+    runtimeMockState.dismissAutoscroll.mockClear()
     unmount()
-    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
   })
 
   it('confirms autoscroll only from the outer scroller, not nested regions', () => {
@@ -765,12 +646,12 @@ describe('MessageVirtualList', () => {
     fireEvent.mouseDown(screen.getByTestId('nested-scroll-content'), { button: 1 })
     region.scrollTop = 50
     fireEvent.scroll(region)
-    expect(runtimeMockState.beginAutoscroll).not.toHaveBeenCalled()
+    expect(runtimeMockState.confirmAutoscroll).not.toHaveBeenCalled()
 
     const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
     scroller.scrollTop = 20
     fireEvent.scroll(scroller)
-    expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.confirmAutoscroll).toHaveBeenCalledTimes(1)
   })
 
   it('records only scroll intent from ordinary input and removes the listeners on unmount', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -5,21 +5,95 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { MessageVirtualList } from '../MessageVirtualList'
 import { useScrollRuntimeBoundary } from '../ScrollOwnershipContext'
 
-const runtimeMockState = vi.hoisted(() => ({
-  isScrollToBottomButtonVisible: false,
-  takeUserControl: vi.fn(),
-  scrollToBottom: vi.fn(),
-  notifyWheelIntent: vi.fn(),
-  scrollByWheel: vi.fn(() => true),
-  markUserInput: vi.fn(),
-  beginScrollbarDrag: vi.fn(),
-  endScrollbarDrag: vi.fn(),
-  beginAutoscroll: vi.fn(),
-  endAutoscroll: vi.fn(),
-  onWheel: vi.fn(),
-  shift: false,
-  scrollerRef: { current: null as HTMLDivElement | null }
-}))
+const runtimeMockState = vi.hoisted(() => {
+  let armed = false
+  let active = false
+  let candidateTimer: ReturnType<typeof setTimeout> | null = null
+  let idleTimer: ReturnType<typeof setTimeout> | null = null
+  const clearCandidate = () => {
+    if (candidateTimer) {
+      clearTimeout(candidateTimer)
+      candidateTimer = null
+    }
+  }
+  const clearIdle = () => {
+    if (idleTimer) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+  }
+  const beginAutoscrollImpl = vi.fn(() => {
+    active = true
+    armed = false
+    clearCandidate()
+    clearIdle()
+    idleTimer = setTimeout(() => {
+      active = false
+      idleTimer = null
+      endAutoscrollImpl()
+    }, 250)
+  })
+  const endAutoscrollImpl = vi.fn(() => {
+    if (!active && !armed) return
+    active = false
+    armed = false
+    clearCandidate()
+    clearIdle()
+  })
+  const armAutoscrollCandidateImpl = vi.fn(() => {
+    if (armed || active) {
+      endAutoscrollImpl()
+      return
+    }
+    armed = true
+    clearCandidate()
+    candidateTimer = setTimeout(() => {
+      armed = false
+      candidateTimer = null
+    }, 400)
+  })
+  const confirmAutoscrollImpl = vi.fn(() => {
+    if (!armed && !active) return
+    if (active) {
+      clearIdle()
+      idleTimer = setTimeout(() => {
+        active = false
+        idleTimer = null
+        endAutoscrollImpl()
+      }, 250)
+      return
+    }
+    beginAutoscrollImpl()
+  })
+  const dismissAutoscrollImpl = vi.fn(() => {
+    if (!armed && !active) return
+    endAutoscrollImpl()
+  })
+  return {
+    isScrollToBottomButtonVisible: false,
+    takeUserControl: vi.fn(),
+    scrollToBottom: vi.fn(),
+    notifyWheelIntent: vi.fn(),
+    scrollByWheel: vi.fn(() => true),
+    markUserInput: vi.fn(),
+    beginScrollbarDrag: vi.fn(),
+    endScrollbarDrag: vi.fn(),
+    beginAutoscroll: beginAutoscrollImpl,
+    endAutoscroll: endAutoscrollImpl,
+    armAutoscrollCandidate: armAutoscrollCandidateImpl,
+    confirmAutoscroll: confirmAutoscrollImpl,
+    dismissAutoscroll: dismissAutoscrollImpl,
+    onWheel: vi.fn(),
+    shift: false,
+    scrollerRef: { current: null as HTMLDivElement | null },
+    _resetAutoscrollState: () => {
+      armed = false
+      active = false
+      clearCandidate()
+      clearIdle()
+    }
+  }
+})
 
 const virtuaMockState = vi.hoisted(() => ({
   scrollRefReadyAtMount: [] as boolean[]
@@ -95,6 +169,9 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
       beginAutoscroll: runtimeMockState.beginAutoscroll,
       endAutoscroll: runtimeMockState.endAutoscroll,
+      armAutoscrollCandidate: runtimeMockState.armAutoscrollCandidate,
+      confirmAutoscroll: runtimeMockState.confirmAutoscroll,
+      dismissAutoscroll: runtimeMockState.dismissAutoscroll,
       shift: runtimeMockState.shift,
       wrappedItems: items,
       wrappedRenderItem: (item: unknown, index: number) =>
@@ -134,9 +211,13 @@ describe('MessageVirtualList', () => {
     runtimeMockState.endScrollbarDrag.mockClear()
     runtimeMockState.beginAutoscroll.mockClear()
     runtimeMockState.endAutoscroll.mockClear()
+    runtimeMockState.armAutoscrollCandidate.mockClear()
+    runtimeMockState.confirmAutoscroll.mockClear()
+    runtimeMockState.dismissAutoscroll.mockClear()
     runtimeMockState.onWheel.mockClear()
     runtimeMockState.shift = false
     runtimeMockState.scrollerRef.current = null
+    runtimeMockState._resetAutoscrollState()
     virtuaMockState.scrollRefReadyAtMount.length = 0
   })
 
@@ -586,7 +667,7 @@ describe('MessageVirtualList', () => {
     expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
   })
 
-  it('decays the autoscroll yield after stillness and re-confirms on the next movement', () => {
+  it('decays the autoscroll yield after stillness and requires fresh arming to re-confirm', () => {
     vi.useFakeTimers()
     try {
       render(
@@ -607,9 +688,15 @@ describe('MessageVirtualList', () => {
       vi.advanceTimersByTime(250)
       expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
 
-      // Resuming (cursor pushed past the dead zone again) re-yields without a
-      // new middle press, before the next tick can be snapped back.
+      // After decay, a stale scroll without fresh middle press must NOT re-yield
+      // — otherwise programmatic drift could be misclassified as autoscroll.
       scroller.scrollTop = 150
+      fireEvent.scroll(scroller)
+      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
+
+      // Fresh middle press re-arms and next movement re-confirms.
+      fireEvent.mouseDown(scroller, { button: 1 })
+      scroller.scrollTop = 200
       fireEvent.scroll(scroller)
       expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(2)
     } finally {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -14,6 +14,8 @@ const runtimeMockState = vi.hoisted(() => ({
   markUserInput: vi.fn(),
   beginScrollbarDrag: vi.fn(),
   endScrollbarDrag: vi.fn(),
+  beginAutoscroll: vi.fn(),
+  endAutoscroll: vi.fn(),
   onWheel: vi.fn(),
   shift: false,
   scrollerRef: { current: null as HTMLDivElement | null }
@@ -91,6 +93,8 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       markUserInput: runtimeMockState.markUserInput,
       beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
+      beginAutoscroll: runtimeMockState.beginAutoscroll,
+      endAutoscroll: runtimeMockState.endAutoscroll,
       shift: runtimeMockState.shift,
       wrappedItems: items,
       wrappedRenderItem: (item: unknown, index: number) =>
@@ -128,6 +132,8 @@ describe('MessageVirtualList', () => {
     runtimeMockState.markUserInput.mockClear()
     runtimeMockState.beginScrollbarDrag.mockClear()
     runtimeMockState.endScrollbarDrag.mockClear()
+    runtimeMockState.beginAutoscroll.mockClear()
+    runtimeMockState.endAutoscroll.mockClear()
     runtimeMockState.onWheel.mockClear()
     runtimeMockState.shift = false
     runtimeMockState.scrollerRef.current = null
@@ -555,6 +561,129 @@ describe('MessageVirtualList', () => {
 
     fireEvent.pointerUp(document)
     expect(runtimeMockState.endScrollbarDrag).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not yield the reading freeze on a bare middle press', () => {
+    // A middle press does not prove Chromium entered autoscroll (macOS, Linux
+    // middle-click paste); the freeze must keep holding until the scroller
+    // really moves (#19225 review).
+    render(
+      <MessageVirtualList
+        items={['message-1']}
+        getItemKey={(item) => item}
+        renderItem={(item) => <span>{item}</span>}
+      />
+    )
+
+    const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+    fireEvent.mouseDown(scroller, { button: 1 })
+    fireEvent.mouseUp(document)
+
+    expect(runtimeMockState.beginAutoscroll).not.toHaveBeenCalled()
+
+    scroller.scrollTop = 100
+    fireEvent.scroll(scroller)
+    expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('decays the autoscroll yield after stillness and re-confirms on the next movement', () => {
+    vi.useFakeTimers()
+    try {
+      render(
+        <MessageVirtualList
+          items={['message-1']}
+          getItemKey={(item) => item}
+          renderItem={(item) => <span>{item}</span>}
+        />
+      )
+
+      const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+      fireEvent.mouseDown(scroller, { button: 1 })
+      scroller.scrollTop = 100
+      fireEvent.scroll(scroller)
+      expect(runtimeMockState.endAutoscroll).not.toHaveBeenCalled()
+
+      // Cursor resting in the autoscroll dead zone must hand the freeze back.
+      vi.advanceTimersByTime(250)
+      expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+
+      // Resuming (cursor pushed past the dead zone again) re-yields without a
+      // new middle press, before the next tick can be snapped back.
+      scroller.scrollTop = 150
+      fireEvent.scroll(scroller)
+      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('dismisses an active autoscroll gesture on second middle press, other clicks, Escape and blur', () => {
+    const { unmount } = render(
+      <MessageVirtualList
+        items={['message-1']}
+        getItemKey={(item) => item}
+        renderItem={(item) => <span>{item}</span>}
+      />
+    )
+
+    const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+    const startGesture = () => {
+      fireEvent.mouseDown(scroller, { button: 1 })
+      scroller.scrollTop += 10
+      fireEvent.scroll(scroller)
+      expect(runtimeMockState.beginAutoscroll).toHaveBeenCalled()
+      runtimeMockState.beginAutoscroll.mockClear()
+      runtimeMockState.endAutoscroll.mockClear()
+    }
+
+    startGesture()
+    fireEvent.mouseDown(scroller, { button: 1 })
+    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+
+    startGesture()
+    fireEvent.mouseDown(document.body, { button: 0 })
+    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+
+    startGesture()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+
+    startGesture()
+    fireEvent.blur(window)
+    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+
+    // Unmount while yielding must release the freeze too.
+    startGesture()
+    unmount()
+    expect(runtimeMockState.endAutoscroll).toHaveBeenCalledTimes(1)
+  })
+
+  it('confirms autoscroll only from the outer scroller, not nested regions', () => {
+    render(
+      <MessageVirtualList
+        items={['message-1']}
+        getItemKey={(item) => item}
+        renderItem={() => (
+          <div data-testid="nested-scroll-region" style={{ overflowY: 'auto' }}>
+            <span data-testid="nested-scroll-content">content</span>
+          </div>
+        )}
+      />
+    )
+
+    const region = screen.getByTestId('nested-scroll-region')
+    Object.defineProperty(region, 'clientHeight', { configurable: true, value: 100 })
+    Object.defineProperty(region, 'scrollHeight', { configurable: true, value: 300 })
+
+    fireEvent.mouseDown(screen.getByTestId('nested-scroll-content'), { button: 1 })
+    region.scrollTop = 50
+    fireEvent.scroll(region)
+    expect(runtimeMockState.beginAutoscroll).not.toHaveBeenCalled()
+
+    const scroller = document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+    scroller.scrollTop = 20
+    fireEvent.scroll(scroller)
+    expect(runtimeMockState.beginAutoscroll).toHaveBeenCalledTimes(1)
   })
 
   it('records only scroll intent from ordinary input and removes the listeners on unmount', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -604,9 +604,9 @@ describe('MessageVirtualList', () => {
     fireEvent.mouseDown(scroller, { button: 1 })
     expect(runtimeMockState.armAutoscrollCandidate).toHaveBeenCalledTimes(1)
 
-    runtimeMockState.dismissAutoscroll.mockClear()
+    runtimeMockState.armAutoscrollCandidate.mockClear()
     fireEvent.mouseDown(scroller, { button: 1 })
-    expect(runtimeMockState.dismissAutoscroll).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.armAutoscrollCandidate).toHaveBeenCalledTimes(1)
 
     runtimeMockState.dismissAutoscroll.mockClear()
     fireEvent.mouseDown(document.body, { button: 0 })

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3741,8 +3741,6 @@ describe('useChatVirtualizerRuntime', () => {
       // A later programmatic nudge (virtua compensation, streaming layout)
       // must NOT be mistaken for autoscroll and must NOT suppress the freeze,
       // and must NOT resume following at the live bottom.
-      const handle = { isFollowing: () => false } as MessageVirtualListHandle
-      void handle
       scrollTop = 560
       act(() => callbacks[0]?.([], {} as ResizeObserver))
       expect(scrollTop).toBe(500)

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3691,7 +3691,7 @@ describe('useChatVirtualizerRuntime', () => {
       expect(scrollTop).toBe(560)
 
       // Stillness beyond the idle window hands control back to the freeze.
-      act(() => vi.advanceTimersByTime(300))
+      void act(() => vi.advanceTimersByTime(300))
       scrollTop = 570
       act(() => callbacks[0]?.([], {} as ResizeObserver))
       expect(scrollTop).toBe(500)
@@ -3716,7 +3716,7 @@ describe('useChatVirtualizerRuntime', () => {
       vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
       let runtime: ChatVirtualizerRuntime<string> | undefined
       let scrollTop = 500
-      let scrollHeight = 2000
+      const scrollHeight = 2000
       render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
       const scroller = runtime!.scrollerRef.current!
       Object.defineProperty(scroller, 'scrollTop', {
@@ -3736,7 +3736,7 @@ describe('useChatVirtualizerRuntime', () => {
 
       // Candidate expires without ever confirming — e.g. macOS middle-click
       // where Chromium never entered autoscroll.
-      act(() => vi.advanceTimersByTime(500))
+      void act(() => vi.advanceTimersByTime(500))
 
       // A later programmatic nudge (virtua compensation, streaming layout)
       // must NOT be mistaken for autoscroll and must NOT suppress the freeze,

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3736,7 +3736,7 @@ describe('useChatVirtualizerRuntime', () => {
 
       // Candidate expires without ever confirming — e.g. macOS middle-click
       // where Chromium never entered autoscroll.
-      void act(() => vi.advanceTimersByTime(500))
+      void act(() => vi.advanceTimersByTime(1600))
 
       // A later programmatic nudge (virtua compensation, streaming layout)
       // must NOT be mistaken for autoscroll and must NOT suppress the freeze,

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3607,4 +3607,160 @@ describe('useChatVirtualizerRuntime', () => {
       raf.restore()
     }
   })
+
+  it('does not reassert the reading anchor during confirmed middle-click autoscroll', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000_000)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => 2000 })
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 400 })
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+
+      // Candidate without movement must NOT suppress freeze — streaming growth
+      // while armed still snaps back.
+      act(() => runtime!.armAutoscrollCandidate())
+      scrollTop = 560
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(500)
+
+      // Fresh confirmed autoscroll via real outer-scroller movement.
+      act(() => runtime!.dismissAutoscroll())
+      scrollTop = 500
+      act(() => runtime!.armAutoscrollCandidate())
+      act(() => runtime!.confirmAutoscroll())
+
+      // During active autoscroll, a programmatic drift must NOT be snapped back
+      // — otherwise each Chromium tick would vibrate.
+      scrollTop = 560
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(560)
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
+
+  it('resumes the reading freeze after the autoscroll idle window expires', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000_000)
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => 2000 })
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 400 })
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+      act(() => runtime!.armAutoscrollCandidate())
+      act(() => runtime!.confirmAutoscroll())
+
+      scrollTop = 560
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(560)
+
+      // Stillness beyond the idle window hands control back to the freeze.
+      act(() => vi.advanceTimersByTime(300))
+      scrollTop = 570
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(500)
+      vi.useRealTimers()
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+      try {
+        vi.useRealTimers()
+      } catch {}
+    }
+  })
+
+  it('does not treat a stale candidate plus programmatic scroll as autoscroll', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1_000_000)
+
+    try {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      let scrollHeight = 2000
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      Object.defineProperty(scroller, 'scrollHeight', { configurable: true, get: () => scrollHeight })
+      Object.defineProperty(scroller, 'clientHeight', { configurable: true, get: () => 400 })
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+      act(() => runtime!.armAutoscrollCandidate())
+
+      // Candidate expires without ever confirming — e.g. macOS middle-click
+      // where Chromium never entered autoscroll.
+      act(() => vi.advanceTimersByTime(500))
+
+      // A later programmatic nudge (virtua compensation, streaming layout)
+      // must NOT be mistaken for autoscroll and must NOT suppress the freeze,
+      // and must NOT resume following at the live bottom.
+      const handle = { isFollowing: () => false } as MessageVirtualListHandle
+      void handle
+      scrollTop = 560
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(500)
+
+      // Even if a scroll event arrives late, without a fresh candidate it must
+      // not re-enter autoscroll and must not enter following.
+      act(() => runtime!.confirmAutoscroll())
+      scrollTop = 570
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(500)
+      vi.useRealTimers()
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+      try {
+        vi.useRealTimers()
+      } catch {}
+    }
+  })
 })

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -168,6 +168,8 @@ const USER_SCROLL_INPUT_WINDOW_MS = 250
 // confirm it before freeze logic yields. Both candidate and confirmed states
 // are time-bounded so a swallowed dismissal click cannot latch suppression.
 const AUTOSCROLL_CANDIDATE_MS = 1500
+// Must stay above virtua's 150ms scroll-end debounce: onScrollEnd settles the
+// user-scroll gesture first, so this timer only has to release the autoscroll latch.
 const AUTOSCROLL_IDLE_MS = 250
 // While the user holds the viewport frozen, snap scrollTop back to the freeze
 // anchor when a layout change drifts it by more than this. Kept above
@@ -223,7 +225,6 @@ export function useChatVirtualizerRuntime<T>({
   const autoscrollCandidateRef = useRef(false)
   const autoscrollCandidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoscrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const autoscrollCandidateScrollTopRef = useRef<number | null>(null)
   const autoscrollSuppressConfirmRef = useRef(false)
   const autoscrollSuppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const readNavigationActiveRef = useRef(false)
@@ -538,7 +539,6 @@ export function useChatVirtualizerRuntime<T>({
     autoscrollActiveRef.current = false
     clearAutoscrollIdleTimer()
     clearAutoscrollSuppressTimer()
-    autoscrollCandidateScrollTopRef.current = null
     pendingUserInputRef.current = null
     if (wheelTimeoutRef.current) {
       clearTimeout(wheelTimeoutRef.current)
@@ -553,7 +553,6 @@ export function useChatVirtualizerRuntime<T>({
     const wasActive = autoscrollActiveRef.current
     if (!wasCandidate && !wasActive) return
     autoscrollCandidateRef.current = false
-    autoscrollCandidateScrollTopRef.current = null
     clearAutoscrollCandidateTimer()
     clearAutoscrollSuppressTimer()
     if (wasActive) {
@@ -563,7 +562,6 @@ export function useChatVirtualizerRuntime<T>({
 
   const beginAutoscroll = useCallback(() => {
     autoscrollCandidateRef.current = false
-    autoscrollCandidateScrollTopRef.current = null
     clearAutoscrollCandidateTimer()
     clearAutoscrollSuppressTimer()
     if (autoscrollActiveRef.current) {
@@ -583,11 +581,9 @@ export function useChatVirtualizerRuntime<T>({
       if (!autoscrollActiveRef.current) return
       autoscrollActiveRef.current = false
       autoscrollCandidateRef.current = true
-      autoscrollCandidateScrollTopRef.current = scrollerRef.current?.scrollTop ?? null
       clearAutoscrollCandidateTimer()
       autoscrollCandidateTimerRef.current = setTimeout(() => {
         autoscrollCandidateRef.current = false
-        autoscrollCandidateScrollTopRef.current = null
         autoscrollCandidateTimerRef.current = null
         clearAutoscrollSuppressTimer()
         pendingUserInputRef.current = null
@@ -619,11 +615,9 @@ export function useChatVirtualizerRuntime<T>({
       return
     }
     autoscrollCandidateRef.current = true
-    autoscrollCandidateScrollTopRef.current = scrollerRef.current?.scrollTop ?? null
     clearAutoscrollCandidateTimer()
     autoscrollCandidateTimerRef.current = setTimeout(() => {
       autoscrollCandidateRef.current = false
-      autoscrollCandidateScrollTopRef.current = null
       autoscrollCandidateTimerRef.current = null
     }, AUTOSCROLL_CANDIDATE_MS)
   }, [clearAutoscrollCandidateTimer, dismissAutoscroll])

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -144,10 +144,6 @@ export interface ChatVirtualizerRuntime<T> {
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */
   endScrollbarDrag(): void
-  /** Mark Chromium middle-click autoscroll as active so freeze logic yields. */
-  beginAutoscroll(): void
-  /** Clear the autoscroll flag and re-anchor the viewport. */
-  endAutoscroll(): void
   /** Arm a candidate middle-click autoscroll; freeze still holds until scroll confirms it. */
   armAutoscrollCandidate(): void
   /** Confirm a candidate via real outer-scroller movement; starts freeze suppression. */
@@ -227,11 +223,31 @@ export function useChatVirtualizerRuntime<T>({
   const autoscrollCandidateRef = useRef(false)
   const autoscrollCandidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoscrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const autoscrollCandidateScrollTopRef = useRef<number | null>(null)
+  const autoscrollSuppressConfirmRef = useRef(false)
+  const autoscrollSuppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const readNavigationActiveRef = useRef(false)
   const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
   const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastWheelDirRef = useRef<ScrollDirection>('none')
+  const clearAutoscrollSuppressTimer = useCallback(() => {
+    if (autoscrollSuppressTimerRef.current) {
+      clearTimeout(autoscrollSuppressTimerRef.current)
+      autoscrollSuppressTimerRef.current = null
+    }
+    autoscrollSuppressConfirmRef.current = false
+  }, [])
+  const suppressNextAutoscrollConfirm = useCallback(() => {
+    autoscrollSuppressConfirmRef.current = true
+    if (autoscrollSuppressTimerRef.current) {
+      clearTimeout(autoscrollSuppressTimerRef.current)
+    }
+    autoscrollSuppressTimerRef.current = setTimeout(() => {
+      autoscrollSuppressConfirmRef.current = false
+      autoscrollSuppressTimerRef.current = null
+    }, 50)
+  }, [])
   const markUserInput = useCallback((direction: ScrollDirection = 'none') => {
     pendingUserInputRef.current = { at: performance.now(), direction }
   }, [])
@@ -319,10 +335,13 @@ export function useChatVirtualizerRuntime<T>({
     if (!el) return
     smoothScroll.cancel()
     const target = getRealBottom(el, bottomFollowInsetRef.current)
+    if (Math.abs(el.scrollTop - target) > FREEZE_REASSERT_TOLERANCE_PX) {
+      suppressNextAutoscrollConfirm()
+    }
     el.scrollTop = target
     lastScrollOffsetRef.current = target
     hideScrollToBottomButton()
-  }, [hideScrollToBottomButton, smoothScroll])
+  }, [hideScrollToBottomButton, smoothScroll, suppressNextAutoscrollConfirm])
 
   const autoStick = useAutoStickToBottom({
     isFollowing: viewportFollow.isFollowing,
@@ -426,6 +445,7 @@ export function useChatVirtualizerRuntime<T>({
       const currentTop = frozen.element.getBoundingClientRect().top - el.getBoundingClientRect().top
       const drift = currentTop - frozen.elementViewportTop
       if (Math.abs(drift) > FREEZE_REASSERT_TOLERANCE_PX) {
+        suppressNextAutoscrollConfirm()
         el.scrollTop += drift
       }
       return
@@ -433,9 +453,10 @@ export function useChatVirtualizerRuntime<T>({
 
     const target = Math.max(0, topPadding) + handle.getItemOffset(itemIndex) + frozen.offsetInItem
     if (Math.abs(el.scrollTop - target) > FREEZE_REASSERT_TOLERANCE_PX) {
+      suppressNextAutoscrollConfirm()
       el.scrollTop = target
     }
-  }, [findDataIndexByKey, smoothScroll, topPadding])
+  }, [findDataIndexByKey, smoothScroll, suppressNextAutoscrollConfirm, topPadding])
 
   // Explicit reading actions freeze the current semantic anchor. Passive DOM
   // events, ordinary clicks and virtualizer compensation never call this path.
@@ -516,6 +537,8 @@ export function useChatVirtualizerRuntime<T>({
     if (!autoscrollActiveRef.current) return
     autoscrollActiveRef.current = false
     clearAutoscrollIdleTimer()
+    clearAutoscrollSuppressTimer()
+    autoscrollCandidateScrollTopRef.current = null
     pendingUserInputRef.current = null
     if (wheelTimeoutRef.current) {
       clearTimeout(wheelTimeoutRef.current)
@@ -523,22 +546,26 @@ export function useChatVirtualizerRuntime<T>({
     }
     lastWheelDirRef.current = 'none'
     settleUserScrollGesture()
-  }, [clearAutoscrollIdleTimer, settleUserScrollGesture])
+  }, [clearAutoscrollIdleTimer, clearAutoscrollSuppressTimer, settleUserScrollGesture])
 
   const dismissAutoscroll = useCallback(() => {
     const wasCandidate = autoscrollCandidateRef.current
     const wasActive = autoscrollActiveRef.current
     if (!wasCandidate && !wasActive) return
     autoscrollCandidateRef.current = false
+    autoscrollCandidateScrollTopRef.current = null
     clearAutoscrollCandidateTimer()
+    clearAutoscrollSuppressTimer()
     if (wasActive) {
       endAutoscrollInternal()
     }
-  }, [clearAutoscrollCandidateTimer, endAutoscrollInternal])
+  }, [clearAutoscrollCandidateTimer, clearAutoscrollSuppressTimer, endAutoscrollInternal])
 
   const beginAutoscroll = useCallback(() => {
     autoscrollCandidateRef.current = false
+    autoscrollCandidateScrollTopRef.current = null
     clearAutoscrollCandidateTimer()
+    clearAutoscrollSuppressTimer()
     if (autoscrollActiveRef.current) {
       clearAutoscrollIdleTimer()
     } else {
@@ -553,13 +580,38 @@ export function useChatVirtualizerRuntime<T>({
     clearAutoscrollIdleTimer()
     autoscrollIdleTimerRef.current = setTimeout(() => {
       autoscrollIdleTimerRef.current = null
-      endAutoscrollInternal()
+      if (!autoscrollActiveRef.current) return
+      autoscrollActiveRef.current = false
+      autoscrollCandidateRef.current = true
+      autoscrollCandidateScrollTopRef.current = scrollerRef.current?.scrollTop ?? null
+      clearAutoscrollCandidateTimer()
+      autoscrollCandidateTimerRef.current = setTimeout(() => {
+        autoscrollCandidateRef.current = false
+        autoscrollCandidateScrollTopRef.current = null
+        autoscrollCandidateTimerRef.current = null
+        clearAutoscrollSuppressTimer()
+        pendingUserInputRef.current = null
+        if (wheelTimeoutRef.current) {
+          clearTimeout(wheelTimeoutRef.current)
+          wheelTimeoutRef.current = null
+        }
+        lastWheelDirRef.current = 'none'
+        settleUserScrollGesture()
+      }, AUTOSCROLL_CANDIDATE_MS)
+      pendingUserInputRef.current = null
+      if (wheelTimeoutRef.current) {
+        clearTimeout(wheelTimeoutRef.current)
+        wheelTimeoutRef.current = null
+      }
+      lastWheelDirRef.current = 'none'
     }, AUTOSCROLL_IDLE_MS)
-  }, [clearAutoscrollCandidateTimer, clearAutoscrollIdleTimer, endAutoscrollInternal, markUserInput])
-
-  const endAutoscroll = useCallback(() => {
-    dismissAutoscroll()
-  }, [dismissAutoscroll])
+  }, [
+    clearAutoscrollCandidateTimer,
+    clearAutoscrollIdleTimer,
+    clearAutoscrollSuppressTimer,
+    markUserInput,
+    settleUserScrollGesture
+  ])
 
   const armAutoscrollCandidate = useCallback(() => {
     if (autoscrollCandidateRef.current || autoscrollActiveRef.current) {
@@ -567,14 +619,17 @@ export function useChatVirtualizerRuntime<T>({
       return
     }
     autoscrollCandidateRef.current = true
+    autoscrollCandidateScrollTopRef.current = scrollerRef.current?.scrollTop ?? null
     clearAutoscrollCandidateTimer()
     autoscrollCandidateTimerRef.current = setTimeout(() => {
       autoscrollCandidateRef.current = false
+      autoscrollCandidateScrollTopRef.current = null
       autoscrollCandidateTimerRef.current = null
     }, AUTOSCROLL_CANDIDATE_MS)
   }, [clearAutoscrollCandidateTimer, dismissAutoscroll])
 
   const confirmAutoscroll = useCallback(() => {
+    if (autoscrollSuppressConfirmRef.current) return
     if (!autoscrollCandidateRef.current && !autoscrollActiveRef.current) return
     beginAutoscroll()
   }, [beginAutoscroll])
@@ -583,8 +638,9 @@ export function useChatVirtualizerRuntime<T>({
     return () => {
       clearAutoscrollCandidateTimer()
       clearAutoscrollIdleTimer()
+      clearAutoscrollSuppressTimer()
     }
-  }, [clearAutoscrollCandidateTimer, clearAutoscrollIdleTimer])
+  }, [clearAutoscrollCandidateTimer, clearAutoscrollIdleTimer, clearAutoscrollSuppressTimer])
 
   const enterFollowingMode = useCallback(
     (reason: FollowingReason) => {
@@ -1000,11 +1056,15 @@ export function useChatVirtualizerRuntime<T>({
         readNavigationActiveRef.current = true
         smoothScroll.scrollTo(resolveTarget, { onComplete: finish })
       } else {
-        el.scrollTop = resolveTarget()
+        const target = resolveTarget()
+        if (Math.abs(el.scrollTop - target) > FREEZE_REASSERT_TOLERANCE_PX) {
+          suppressNextAutoscrollConfirm()
+        }
+        el.scrollTop = target
         takeUserControl('navigation', getPreferredAnchor?.() ?? null)
       }
     },
-    [clampToReachable, prepareReadingNavigation, smoothScroll, takeUserControl]
+    [clampToReachable, prepareReadingNavigation, smoothScroll, suppressNextAutoscrollConfirm, takeUserControl]
   )
 
   const scrollToBottom = useCallback(() => {
@@ -1151,8 +1211,6 @@ export function useChatVirtualizerRuntime<T>({
     markUserInput,
     beginScrollbarDrag,
     endScrollbarDrag,
-    beginAutoscroll,
-    endAutoscroll,
     armAutoscrollCandidate,
     confirmAutoscroll,
     dismissAutoscroll

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -148,6 +148,12 @@ export interface ChatVirtualizerRuntime<T> {
   beginAutoscroll(): void
   /** Clear the autoscroll flag and re-anchor the viewport. */
   endAutoscroll(): void
+  /** Arm a candidate middle-click autoscroll; freeze still holds until scroll confirms it. */
+  armAutoscrollCandidate(): void
+  /** Confirm a candidate via real outer-scroller movement; starts freeze suppression. */
+  confirmAutoscroll(): void
+  /** Dismiss any candidate or confirmed autoscroll and re-anchor the viewport. */
+  dismissAutoscroll(): void
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
@@ -161,6 +167,12 @@ const LONG_JUMP_VIEWPORTS = 3
 // non-scrollbar gestures stay active until onScrollEnd, so trackpad momentum is
 // not cut off by a timer. Native scrollbar drags use the pointer lifecycle below.
 const USER_SCROLL_INPUT_WINDOW_MS = 250
+// Middle-click autoscroll synthesizes scrollTop without wheel/pointer events.
+// A middle press only arms a candidate; real outer-scroller movement must
+// confirm it before freeze logic yields. Both candidate and confirmed states
+// are time-bounded so a swallowed dismissal click cannot latch suppression.
+const AUTOSCROLL_CANDIDATE_MS = 400
+const AUTOSCROLL_IDLE_MS = 250
 // While the user holds the viewport frozen, snap scrollTop back to the freeze
 // anchor when a layout change drifts it by more than this. Kept above
 // subpixel/rounding noise so an already-stable viewport never churns.
@@ -212,6 +224,9 @@ export function useChatVirtualizerRuntime<T>({
   const userScrollGestureRef = useRef(false)
   const scrollbarDragActiveRef = useRef(false)
   const autoscrollActiveRef = useRef(false)
+  const autoscrollCandidateRef = useRef(false)
+  const autoscrollCandidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const autoscrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const readNavigationActiveRef = useRef(false)
   const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
@@ -481,16 +496,82 @@ export function useChatVirtualizerRuntime<T>({
     settleUserScrollGesture()
   }, [settleUserScrollGesture])
 
-  const beginAutoscroll = useCallback(() => {
-    autoscrollActiveRef.current = true
-    markUserInput()
-  }, [markUserInput])
+  const clearAutoscrollCandidateTimer = useCallback(() => {
+    if (autoscrollCandidateTimerRef.current) {
+      clearTimeout(autoscrollCandidateTimerRef.current)
+      autoscrollCandidateTimerRef.current = null
+    }
+  }, [])
 
-  const endAutoscroll = useCallback(() => {
+  const clearAutoscrollIdleTimer = useCallback(() => {
+    if (autoscrollIdleTimerRef.current) {
+      clearTimeout(autoscrollIdleTimerRef.current)
+      autoscrollIdleTimerRef.current = null
+    }
+  }, [])
+
+  const endAutoscrollInternal = useCallback(() => {
     if (!autoscrollActiveRef.current) return
     autoscrollActiveRef.current = false
+    clearAutoscrollIdleTimer()
     settleUserScrollGesture()
-  }, [settleUserScrollGesture])
+  }, [clearAutoscrollIdleTimer, settleUserScrollGesture])
+
+  const dismissAutoscroll = useCallback(() => {
+    const wasCandidate = autoscrollCandidateRef.current
+    const wasActive = autoscrollActiveRef.current
+    if (!wasCandidate && !wasActive) return
+    autoscrollCandidateRef.current = false
+    clearAutoscrollCandidateTimer()
+    if (wasActive) {
+      endAutoscrollInternal()
+    }
+  }, [clearAutoscrollCandidateTimer, endAutoscrollInternal])
+
+  const beginAutoscroll = useCallback(() => {
+    autoscrollCandidateRef.current = false
+    clearAutoscrollCandidateTimer()
+    if (autoscrollActiveRef.current) {
+      clearAutoscrollIdleTimer()
+    } else {
+      autoscrollActiveRef.current = true
+    }
+    markUserInput()
+    clearAutoscrollIdleTimer()
+    autoscrollIdleTimerRef.current = setTimeout(() => {
+      autoscrollIdleTimerRef.current = null
+      endAutoscrollInternal()
+    }, AUTOSCROLL_IDLE_MS)
+  }, [clearAutoscrollCandidateTimer, clearAutoscrollIdleTimer, endAutoscrollInternal, markUserInput])
+
+  const endAutoscroll = useCallback(() => {
+    dismissAutoscroll()
+  }, [dismissAutoscroll])
+
+  const armAutoscrollCandidate = useCallback(() => {
+    if (autoscrollCandidateRef.current || autoscrollActiveRef.current) {
+      dismissAutoscroll()
+      return
+    }
+    autoscrollCandidateRef.current = true
+    clearAutoscrollCandidateTimer()
+    autoscrollCandidateTimerRef.current = setTimeout(() => {
+      autoscrollCandidateRef.current = false
+      autoscrollCandidateTimerRef.current = null
+    }, AUTOSCROLL_CANDIDATE_MS)
+  }, [clearAutoscrollCandidateTimer, dismissAutoscroll])
+
+  const confirmAutoscroll = useCallback(() => {
+    if (!autoscrollCandidateRef.current && !autoscrollActiveRef.current) return
+    beginAutoscroll()
+  }, [beginAutoscroll])
+
+  useEffect(() => {
+    return () => {
+      clearAutoscrollCandidateTimer()
+      clearAutoscrollIdleTimer()
+    }
+  }, [clearAutoscrollCandidateTimer, clearAutoscrollIdleTimer])
 
   const enterFollowingMode = useCallback(
     (reason: FollowingReason) => {
@@ -1061,7 +1142,10 @@ export function useChatVirtualizerRuntime<T>({
     beginScrollbarDrag,
     endScrollbarDrag,
     beginAutoscroll,
-    endAutoscroll
+    endAutoscroll,
+    armAutoscrollCandidate,
+    confirmAutoscroll,
+    dismissAutoscroll
   }
 }
 

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -821,11 +821,7 @@ export function useChatVirtualizerRuntime<T>({
       userScrollGestureRef.current ||
       hasRecentUserScrollIntent
     const wheelDir = lastWheelDirRef.current
-    const direction = autoscrollActiveRef.current
-      ? deltaDirection
-      : wheelDir !== 'none'
-        ? wheelDir
-        : deltaDirection
+    const direction = autoscrollActiveRef.current ? deltaDirection : wheelDir !== 'none' ? wheelDir : deltaDirection
     if (hasRecentUserScrollIntent && pendingUserInput?.direction === 'none' && direction !== 'none') {
       pendingUserInput.direction = direction
     }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -514,6 +514,7 @@ export function useChatVirtualizerRuntime<T>({
     if (!autoscrollActiveRef.current) return
     autoscrollActiveRef.current = false
     clearAutoscrollIdleTimer()
+    lastUserInputAtRef.current = 0
     settleUserScrollGesture()
   }, [clearAutoscrollIdleTimer, settleUserScrollGesture])
 

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -171,7 +171,7 @@ const USER_SCROLL_INPUT_WINDOW_MS = 250
 // A middle press only arms a candidate; real outer-scroller movement must
 // confirm it before freeze logic yields. Both candidate and confirmed states
 // are time-bounded so a swallowed dismissal click cannot latch suppression.
-const AUTOSCROLL_CANDIDATE_MS = 400
+const AUTOSCROLL_CANDIDATE_MS = 1500
 const AUTOSCROLL_IDLE_MS = 250
 // While the user holds the viewport frozen, snap scrollTop back to the freeze
 // anchor when a layout change drifts it by more than this. Kept above
@@ -230,6 +230,8 @@ export function useChatVirtualizerRuntime<T>({
   const readNavigationActiveRef = useRef(false)
   const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
+  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastWheelDirRef = useRef<ScrollDirection>('none')
   const markUserInput = useCallback((direction: ScrollDirection = 'none') => {
     pendingUserInputRef.current = { at: performance.now(), direction }
   }, [])
@@ -514,7 +516,12 @@ export function useChatVirtualizerRuntime<T>({
     if (!autoscrollActiveRef.current) return
     autoscrollActiveRef.current = false
     clearAutoscrollIdleTimer()
-    lastUserInputAtRef.current = 0
+    pendingUserInputRef.current = null
+    if (wheelTimeoutRef.current) {
+      clearTimeout(wheelTimeoutRef.current)
+      wheelTimeoutRef.current = null
+    }
+    lastWheelDirRef.current = 'none'
     settleUserScrollGesture()
   }, [clearAutoscrollIdleTimer, settleUserScrollGesture])
 
@@ -537,6 +544,11 @@ export function useChatVirtualizerRuntime<T>({
     } else {
       autoscrollActiveRef.current = true
     }
+    if (wheelTimeoutRef.current) {
+      clearTimeout(wheelTimeoutRef.current)
+      wheelTimeoutRef.current = null
+    }
+    lastWheelDirRef.current = 'none'
     markUserInput()
     clearAutoscrollIdleTimer()
     autoscrollIdleTimerRef.current = setTimeout(() => {
@@ -733,9 +745,6 @@ export function useChatVirtualizerRuntime<T>({
 
   // ---- scroll / wheel handlers ---------------------------------------
 
-  const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lastWheelDirRef = useRef<ScrollDirection>('none')
-
   const notifyWheelIntent = useCallback(
     (deltaY: number) => {
       const dir = getScrollDirection(deltaY)
@@ -812,7 +821,11 @@ export function useChatVirtualizerRuntime<T>({
       userScrollGestureRef.current ||
       hasRecentUserScrollIntent
     const wheelDir = lastWheelDirRef.current
-    const direction = wheelDir !== 'none' ? wheelDir : deltaDirection
+    const direction = autoscrollActiveRef.current
+      ? deltaDirection
+      : wheelDir !== 'none'
+        ? wheelDir
+        : deltaDirection
     if (hasRecentUserScrollIntent && pendingUserInput?.direction === 'none' && direction !== 'none') {
       pendingUserInput.direction = direction
     }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -144,6 +144,10 @@ export interface ChatVirtualizerRuntime<T> {
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */
   endScrollbarDrag(): void
+  /** Mark Chromium middle-click autoscroll as active so freeze logic yields. */
+  beginAutoscroll(): void
+  /** Clear the autoscroll flag and re-anchor the viewport. */
+  endAutoscroll(): void
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
@@ -207,6 +211,7 @@ export function useChatVirtualizerRuntime<T>({
   const pendingUserInputRef = useRef<PendingUserInput | null>(null)
   const userScrollGestureRef = useRef(false)
   const scrollbarDragActiveRef = useRef(false)
+  const autoscrollActiveRef = useRef(false)
   const readNavigationActiveRef = useRef(false)
   const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
@@ -214,6 +219,7 @@ export function useChatVirtualizerRuntime<T>({
     pendingUserInputRef.current = { at: performance.now(), direction }
   }, [])
   const isUserScrollIntentPending = useCallback((direction: ScrollDirection = 'none') => {
+    if (autoscrollActiveRef.current) return true
     const input = pendingUserInputRef.current
     if (!input) return false
     const directionMatches = input.direction === 'none' || direction === 'none' || input.direction === direction
@@ -377,7 +383,13 @@ export function useChatVirtualizerRuntime<T>({
     const content = contentRef.current
     const handle = vlistHandleRef.current
     if (!frozen || !el || !handle) return
-    if (smoothScroll.isAnimating() || userScrollGestureRef.current || scrollbarDragActiveRef.current) return
+    if (
+      smoothScroll.isAnimating() ||
+      userScrollGestureRef.current ||
+      scrollbarDragActiveRef.current ||
+      autoscrollActiveRef.current
+    )
+      return
 
     const itemIndex = findDataIndexByKey(frozen.itemKey)
     if (itemIndex < 0) {
@@ -466,6 +478,17 @@ export function useChatVirtualizerRuntime<T>({
   const endScrollbarDrag = useCallback(() => {
     if (!scrollbarDragActiveRef.current) return
     scrollbarDragActiveRef.current = false
+    settleUserScrollGesture()
+  }, [settleUserScrollGesture])
+
+  const beginAutoscroll = useCallback(() => {
+    autoscrollActiveRef.current = true
+    markUserInput()
+  }, [markUserInput])
+
+  const endAutoscroll = useCallback(() => {
+    if (!autoscrollActiveRef.current) return
+    autoscrollActiveRef.current = false
     settleUserScrollGesture()
   }, [settleUserScrollGesture])
 
@@ -573,7 +596,8 @@ export function useChatVirtualizerRuntime<T>({
     if (!content || typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(() => {
       const isReading = !viewportFollow.isFollowing()
-      const shouldHoldRestingViewport = isReading && !userScrollGestureRef.current && !scrollbarDragActiveRef.current
+      const shouldHoldRestingViewport =
+        isReading && !userScrollGestureRef.current && !scrollbarDragActiveRef.current && !autoscrollActiveRef.current
       if (shouldHoldRestingViewport) {
         // Restore range from the currently committed DOM before re-asserting
         // scrollTop. Disclosure collapse may already have let the browser clamp
@@ -700,7 +724,11 @@ export function useChatVirtualizerRuntime<T>({
     ) {
       pendingUserInputRef.current = null
     }
-    const isUserInitiated = scrollbarDragActiveRef.current || userScrollGestureRef.current || hasRecentUserScrollIntent
+    const isUserInitiated =
+      scrollbarDragActiveRef.current ||
+      autoscrollActiveRef.current ||
+      userScrollGestureRef.current ||
+      hasRecentUserScrollIntent
     const wheelDir = lastWheelDirRef.current
     const direction = wheelDir !== 'none' ? wheelDir : deltaDirection
     if (hasRecentUserScrollIntent && pendingUserInput?.direction === 'none' && direction !== 'none') {
@@ -1031,7 +1059,9 @@ export function useChatVirtualizerRuntime<T>({
     scrollByWheel,
     markUserInput,
     beginScrollbarDrag,
-    endScrollbarDrag
+    endScrollbarDrag,
+    beginAutoscroll,
+    endAutoscroll
   }
 }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

Middle-click autoscroll in the chat message list vibrated at high frequency and jumped when the cursor left the window. The bug report (#19194) also noted it usually only scrolled in one direction and that collapsed code blocks vibrated too.

After this PR:

Middle-click autoscroll scrolls smoothly in both directions. The cursor-leaving-window jump is gone.

Fixes #19194

### Why we need it and why it was done in this way

Root cause: the virtual list's reading-mode freeze (ResizeObserver reassert + `onScroll` snap-back + `hasRecentUserScrollIntent` window) treats any `scrollTop` change without a preceding `wheel`/`pointer`/`keyboard` signal as programmatic drift and snaps it back. Chromium's autoscroll synthesizes `scrollTop` directly with no wheel event, so every tick was fought — the classic vibration loop. Direction tracking also required the scroll delta to match the last wheel direction, so reversing direction briefly lost the "user intent" flag.

The following tradeoffs were made:

- Added a minimal `autoscrollActiveRef` lifecycle (`beginAutoscroll`/`endAutoscroll`) to `useChatVirtualizerRuntime` that yields all three freeze paths for the duration of the gesture. No changes to virtua, no CSS changes, no Electron prefs.
- The list wires it to a document-level middle-button toggle matching Chromium's UX. A middle press only *arms* the gesture (it cannot prove autoscroll engaged — on macOS/Linux it never does), and the freeze yields from the scroller's own first movement onward, confirmed by a capture-phase scroll listener so the first tick isn't fought. The yield decays after 250ms of scroller stillness so a never-started or paused autoscroll hands control back to the freeze; dismissal stays gesture-based (second middle-press / any other click / Esc / blur) because ending on mouseup would cut Windows' press-and-hold entry. Dismiss on any click matches Chromium's own dismiss behavior and avoids the case where a quick press+release would be ended too early by mouseup. Scrolls originating in nested scrollers do not confirm the outer list's yield.

The following alternatives were considered:

- Extending `USER_SCROLL_INPUT_WINDOW_MS` or removing direction gating — would help but still leaves the ResizeObserver snap-back fighting autoscroll.
- Disabling autoscroll entirely — rejected, the reporter explicitly wants it.
- Latching suppression on the bare middle press alone — rejected after review: platforms where the gesture doesn't engage would keep the freeze suppressed until an unrelated click.

### Release note

```release-note
Fix middle-click (autoscroll) scrolling in the chat message list so it no longer vibrates or jumps.
```

### Checklist

- [x] Branch: This PR targets `main`
- [x] Self-review: reviewed via `git diff` + `pnpm lint` + `tsc --noEmit`