### PR TITLE
feat(translate): make single-direction translation target-only

### DIFF
--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Übersetzung stoppen",
   "translate.target_language": "Zielsprache",
   "translate.title": "Übersetzen",
+  "translate.translate_to": "Übersetzen nach",
   "update.install": "Jetzt installieren",
   "update.later": "Später",
   "update.message": "Neue Version {{version}} gefunden. Jetzt installieren?",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Σταματήστε τη μετάφραση",
   "translate.target_language": "Γλώσσα προορισμού",
   "translate.title": "Μετάφραση",
+  "translate.translate_to": "Μετάφραση σε",
   "update.install": "Εγκατάσταση",
   "update.later": "Μετά",
   "update.message": "Νέα έκδοση {{version}} είναι έτοιμη, θέλετε να την εγκαταστήσετε τώρα;",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Stop Translation",
   "translate.target_language": "Target Language",
   "translate.title": "Translation",
+  "translate.translate_to": "Translate to",
   "update.install": "Install",
   "update.later": "Later",
   "update.message": "New version {{version}} is ready, do you want to install it now?",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Detener Traducción",
   "translate.target_language": "Idioma de destino",
   "translate.title": "Traducción",
+  "translate.translate_to": "Traducir a",
   "update.install": "Instalar",
   "update.later": "Más tarde",
   "update.message": "Nueva versión {{version}} disponible, ¿desea instalarla ahora?",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Arrêter la traduction",
   "translate.target_language": "Langue cible",
   "translate.title": "traduction",
+  "translate.translate_to": "Traduire en",
   "update.install": "Installer",
   "update.later": "Plus tard",
   "update.message": "Nouvelle version {{version}} disponible, voulez-vous l'installer maintenant ?",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "翻訳を停止",
   "translate.target_language": "目標言語",
   "translate.title": "翻訳",
+  "translate.translate_to": "翻訳先",
   "update.install": "今すぐインストール",
   "update.later": "後で",
   "update.message": "新バージョン {{version}} が利用可能です。今すぐインストールしますか？",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Parar Tradução",
   "translate.target_language": "Idioma de destino",
   "translate.title": "Tradução",
+  "translate.translate_to": "Traduzir para",
   "update.install": "Instalar",
   "update.later": "Mais tarde",
   "update.message": "Nova versão {{version}} disponível, deseja instalar agora?",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Oprește traducerea",
   "translate.target_language": "Limbă țintă",
   "translate.title": "Traducere",
+  "translate.translate_to": "Tradu în",
   "update.install": "Instalează",
   "update.later": "Mai târziu",
   "update.message": "Noua versiune {{version}} este gata, vrei să o instalezi acum?",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Остановить перевод",
   "translate.target_language": "Целевой язык",
   "translate.title": "Перевод",
+  "translate.translate_to": "Перевести на",
   "update.install": "Установить",
   "update.later": "Позже",
   "update.message": "Новая версия {{version}} готова, установить сейчас?",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "Dừng Dịch",
   "translate.target_language": "Ngôn ngữ đích",
   "translate.title": "Dịch",
+  "translate.translate_to": "Dịch sang",
   "update.install": "Cài đặt",
   "update.later": "Sau đó",
   "update.message": "Phiên bản mới {{version}} đã sẵn sàng, bạn có muốn cài đặt ngay bây giờ không?",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "停止翻译",
   "translate.target_language": "目标语言",
   "translate.title": "翻译",
+  "translate.translate_to": "译为",
   "update.install": "立即安装",
   "update.later": "稍后",
   "update.message": "发现新版本 {{version}}，是否立即安装？",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -5179,6 +5179,7 @@
   "translate.stop": "停止翻譯",
   "translate.target_language": "目標語言",
   "translate.title": "翻譯",
+  "translate.translate_to": "譯為",
   "update.install": "立即安裝",
   "update.later": "稍後",
   "update.message": "新版本 {{version}} 已準備就緒，是否立即安裝？",

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -215,9 +215,7 @@ const TranslatePage: FC = () => {
   const [translateModelId, setTranslateModelId] = usePreference('feature.translate.model_id')
   const { models } = useModels({ enabled: true })
   const detectLanguage = useDetectLang()
-  const { add: addHistory } = useTranslateHistory({
-    update: { showErrorToast: false, rethrowError: false }
-  })
+  const { add: addHistory } = useTranslateHistory()
   const { notesPath } = useNotesSettings()
   const { shikiMarkdownIt } = useCodeStyle()
   const { onSelectFile, selecting, clearFiles } = useFiles({ extensions: [...imageExts, ...textExts, ...documentExts] })
@@ -377,7 +375,7 @@ const TranslatePage: FC = () => {
       rawText: string,
       actualSourceLanguage: TranslateLangCode | null,
       actualTargetLanguage: TranslateLangCode
-    ): Promise<TranslateHistory | undefined> => {
+    ): Promise<void> => {
       if (isTranslating) return
 
       smoothReset('')
@@ -402,7 +400,7 @@ const TranslatePage: FC = () => {
         )
       }
 
-      return addHistory({
+      await addHistory({
         sourceText: rawText,
         targetText: translated,
         sourceLanguage: actualSourceLanguage,

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -215,7 +215,7 @@ const TranslatePage: FC = () => {
   const [translateModelId, setTranslateModelId] = usePreference('feature.translate.model_id')
   const { models } = useModels({ enabled: true })
   const detectLanguage = useDetectLang()
-  const { add: addHistory, update: updateHistory } = useTranslateHistory({
+  const { add: addHistory } = useTranslateHistory({
     update: { showErrorToast: false, rethrowError: false }
   })
   const { notesPath } = useNotesSettings()
@@ -418,15 +418,7 @@ const TranslatePage: FC = () => {
 
       if (allowBidirectional && !isBidirectional) {
         setDetectedLanguage(null)
-        const history = await translate(rawText, null, targetLanguage)
-        if (history) {
-          void detectLanguageOrUnknown(rawText, detectLanguage, () => undefined)
-            .then((language) => {
-              if (language === UNKNOWN_LANG_CODE) return
-              return updateHistory(history.id, { sourceLanguage: language })
-            })
-            .catch(() => undefined)
-        }
+        await translate(rawText, null, targetLanguage)
         return
       }
 
@@ -475,8 +467,7 @@ const TranslatePage: FC = () => {
       sourceLanguage,
       t,
       targetLanguage,
-      translate,
-      updateHistory
+      translate
     ]
   )
 

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -215,7 +215,9 @@ const TranslatePage: FC = () => {
   const [translateModelId, setTranslateModelId] = usePreference('feature.translate.model_id')
   const { models } = useModels({ enabled: true })
   const detectLanguage = useDetectLang()
-  const { add: addHistory } = useTranslateHistory()
+  const { add: addHistory, update: updateHistory } = useTranslateHistory({
+    update: { showErrorToast: false, rethrowError: false }
+  })
   const { notesPath } = useNotesSettings()
   const { shikiMarkdownIt } = useCodeStyle()
   const { onSelectFile, selecting, clearFiles } = useFiles({ extensions: [...imageExts, ...textExts, ...documentExts] })
@@ -375,7 +377,7 @@ const TranslatePage: FC = () => {
       rawText: string,
       actualSourceLanguage: TranslateLangCode | null,
       actualTargetLanguage: TranslateLangCode
-    ): Promise<void> => {
+    ): Promise<TranslateHistory | undefined> => {
       if (isTranslating) return
 
       smoothReset('')
@@ -400,7 +402,7 @@ const TranslatePage: FC = () => {
         )
       }
 
-      await addHistory({
+      return addHistory({
         sourceText: rawText,
         targetText: translated,
         sourceLanguage: actualSourceLanguage,
@@ -410,13 +412,33 @@ const TranslatePage: FC = () => {
     [addHistory, autoCopy, copy, isTranslating, runTranslate, setTimeoutTimer, smoothReset, t]
   )
 
+  // Off the translation critical path: a failed detection or patch just leaves
+  // the stored source language unset, so every outcome stays silent.
+  //
+  // Backfills for different history ids can overlap on this one template-path
+  // mutation, which shares `isMutating`/`error` across them (see
+  // docs/references/data/data-api-in-renderer.md). Harmless today because
+  // nothing here reads that state — revisit if this call site ever does.
+  const backfillHistorySourceLanguage = useCallback(
+    (historyId: string, rawText: string) => {
+      void detectLanguageOrUnknown(rawText, detectLanguage, () => undefined)
+        .then((language) => {
+          if (language === UNKNOWN_LANG_CODE) return
+          return updateHistory(historyId, { sourceLanguage: language })
+        })
+        .catch(() => undefined)
+    },
+    [detectLanguage, updateHistory]
+  )
+
   const translateTextContent = useCallback(
     async (rawText: string, allowBidirectional: boolean, isCurrent?: () => boolean): Promise<void> => {
       if (!rawText.trim() || !selectedModelId || isDetecting || isTranslating) return
 
       if (allowBidirectional && !isBidirectional) {
         setDetectedLanguage(null)
-        await translate(rawText, null, targetLanguage)
+        const history = await translate(rawText, null, targetLanguage)
+        if (history) backfillHistorySourceLanguage(history.id, rawText)
         return
       }
 
@@ -455,6 +477,7 @@ const TranslatePage: FC = () => {
       await translate(rawText, actualSourceLanguage, targetResult.language)
     },
     [
+      backfillHistorySourceLanguage,
       bidirectionalPair,
       detectLanguage,
       isBidirectional,

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -373,7 +373,7 @@ const TranslatePage: FC = () => {
   const translate = useCallback(
     async (
       rawText: string,
-      actualSourceLanguage: TranslateLangCode,
+      actualSourceLanguage: TranslateLangCode | null,
       actualTargetLanguage: TranslateLangCode
     ): Promise<void> => {
       if (isTranslating) return
@@ -414,8 +414,14 @@ const TranslatePage: FC = () => {
     async (rawText: string, allowBidirectional: boolean, isCurrent?: () => boolean): Promise<void> => {
       if (!rawText.trim() || !selectedModelId || isDetecting || isTranslating) return
 
+      if (allowBidirectional && !isBidirectional) {
+        setDetectedLanguage(null)
+        await translate(rawText, null, targetLanguage)
+        return
+      }
+
       let actualSourceLanguage = sourceLanguage
-      if (sourceLanguage === 'auto') {
+      if ((allowBidirectional && isBidirectional) || sourceLanguage === 'auto') {
         setIsDetecting(true)
         try {
           actualSourceLanguage = await detectLanguageOrUnknown(rawText, detectLanguage, (error) => {
@@ -935,6 +941,7 @@ const TranslatePage: FC = () => {
             onTargetChange={(language) => void safePersist(setTargetLanguage(language), 'translate target language')}
             detectedLanguage={detectedLanguage}
             isBidirectional={isPdfMode ? false : isBidirectional}
+            showSourceControls={isPdfMode}
             bidirectionalPair={bidirectionalPair}
             couldExchange={couldExchange}
             onExchange={handleExchange}

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -215,7 +215,9 @@ const TranslatePage: FC = () => {
   const [translateModelId, setTranslateModelId] = usePreference('feature.translate.model_id')
   const { models } = useModels({ enabled: true })
   const detectLanguage = useDetectLang()
-  const { add: addHistory } = useTranslateHistory()
+  const { add: addHistory, update: updateHistory } = useTranslateHistory({
+    update: { showErrorToast: false, rethrowError: false }
+  })
   const { notesPath } = useNotesSettings()
   const { shikiMarkdownIt } = useCodeStyle()
   const { onSelectFile, selecting, clearFiles } = useFiles({ extensions: [...imageExts, ...textExts, ...documentExts] })
@@ -375,7 +377,7 @@ const TranslatePage: FC = () => {
       rawText: string,
       actualSourceLanguage: TranslateLangCode | null,
       actualTargetLanguage: TranslateLangCode
-    ): Promise<void> => {
+    ): Promise<TranslateHistory | undefined> => {
       if (isTranslating) return
 
       smoothReset('')
@@ -400,7 +402,7 @@ const TranslatePage: FC = () => {
         )
       }
 
-      await addHistory({
+      return addHistory({
         sourceText: rawText,
         targetText: translated,
         sourceLanguage: actualSourceLanguage,
@@ -416,7 +418,15 @@ const TranslatePage: FC = () => {
 
       if (allowBidirectional && !isBidirectional) {
         setDetectedLanguage(null)
-        await translate(rawText, null, targetLanguage)
+        const history = await translate(rawText, null, targetLanguage)
+        if (history) {
+          void detectLanguageOrUnknown(rawText, detectLanguage, () => undefined)
+            .then((language) => {
+              if (language === UNKNOWN_LANG_CODE) return
+              return updateHistory(history.id, { sourceLanguage: language })
+            })
+            .catch(() => undefined)
+        }
         return
       }
 
@@ -465,7 +475,8 @@ const TranslatePage: FC = () => {
       sourceLanguage,
       t,
       targetLanguage,
-      translate
+      translate,
+      updateHistory
     ]
   )
 
@@ -602,7 +613,9 @@ const TranslatePage: FC = () => {
         setTranslateOutput(history.targetText)
       }
 
-      void safePersist(setSourceLanguage(history.sourceLanguage ?? 'auto'), 'translate source language')
+      if (history.sourceLanguage) {
+        void safePersist(setSourceLanguage(history.sourceLanguage), 'translate source language')
+      }
       void safePersist(setTargetLanguage(nextTargetLanguage), 'translate target language')
       setHistoryOpen(false)
     },

--- a/src/renderer/pages/translate/TranslatePage.tsx
+++ b/src/renderer/pages/translate/TranslatePage.tsx
@@ -613,8 +613,8 @@ const TranslatePage: FC = () => {
         setTranslateOutput(history.targetText)
       }
 
-      if (history.sourceLanguage) {
-        void safePersist(setSourceLanguage(history.sourceLanguage), 'translate source language')
+      if (history.kind === 'file' || history.sourceLanguage) {
+        void safePersist(setSourceLanguage(history.sourceLanguage ?? 'auto'), 'translate source language')
       }
       void safePersist(setTargetLanguage(nextTargetLanguage), 'translate target language')
       setHistoryOpen(false)

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -357,7 +357,7 @@ vi.mock('../components/TranslateInputPane', () => ({
 }))
 
 vi.mock('../components/TranslateLanguageBar', () => ({
-  default: (props: { isBidirectional: boolean }) => {
+  default: (props: { isBidirectional: boolean; showSourceControls: boolean }) => {
     languageBarMock(props)
     return null
   }
@@ -1028,7 +1028,9 @@ describe('TranslatePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'translate.files.upload' }))
 
     await waitFor(() => expect(screen.getByTestId('pdf-translation-view')).toBeInTheDocument())
-    expect(languageBarMock).toHaveBeenLastCalledWith(expect.objectContaining({ isBidirectional: false }))
+    expect(languageBarMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isBidirectional: false, showSourceControls: true })
+    )
     expect(screen.getByRole('button', { name: 'translate.button.translate' })).toBeDisabled()
     expect(pdfHandleMock.start).not.toHaveBeenCalled()
   })
@@ -1206,7 +1208,7 @@ describe('TranslatePage', () => {
     await waitFor(() => expect(translateCoreMock.translateText).toHaveBeenCalledTimes(1))
   })
 
-  it('shows warning and skips translate when source and target language are the same', async () => {
+  it('translates to the selected target without blocking on a matching stored source language', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'zh-cn',
@@ -1218,51 +1220,31 @@ describe('TranslatePage', () => {
     rerender(<TranslatePage />)
     fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
 
-    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith('translate.language.same'))
-    expect(translateCoreMock.translateText).not.toHaveBeenCalled()
-  })
-
-  it('continues translating with the selected target when auto detection returns unknown', async () => {
-    MockUsePreferenceUtils.setMultiplePreferenceValues({
-      'feature.translate.model_id': 'openai::gpt-4.1',
-      'feature.translate.page.source_language': 'auto',
-      'feature.translate.page.target_language': 'en-us'
-    })
-    translateCoreMock.detectLanguage.mockResolvedValueOnce('unknown')
-
-    const { rerender } = render(<TranslatePage />)
-    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
-    rerender(<TranslatePage />)
-    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
-
     await waitFor(() =>
       expect(translateCoreMock.translateText).toHaveBeenCalledWith(
         'hello',
-        'en-us',
+        'zh-cn',
         expect.any(Function),
         expect.any(AbortSignal)
       )
     )
-    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.warning).not.toHaveBeenCalledWith('translate.language.same')
     await waitFor(() =>
       expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
         sourceText: 'hello',
         targetText: 'translated text',
-        sourceLanguage: 'unknown',
-        targetLanguage: 'en-us'
+        sourceLanguage: null,
+        targetLanguage: 'zh-cn'
       })
     )
   })
 
-  it('continues translating with the selected target when auto detection throws', async () => {
+  it('skips source detection and stores no source language for single-direction translation', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'auto',
       'feature.translate.page.target_language': 'en-us'
     })
-    const detectError = new Error('detect failed')
-    translateCoreMock.detectLanguage.mockRejectedValueOnce(detectError)
-
     const { rerender } = render(<TranslatePage />)
     fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
     rerender(<TranslatePage />)
@@ -1276,12 +1258,13 @@ describe('TranslatePage', () => {
         expect.any(AbortSignal)
       )
     )
+    expect(translateCoreMock.detectLanguage).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
     await waitFor(() =>
       expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
         sourceText: 'hello',
         targetText: 'translated text',
-        sourceLanguage: 'unknown',
+        sourceLanguage: null,
         targetLanguage: 'en-us'
       })
     )
@@ -1321,10 +1304,10 @@ describe('TranslatePage', () => {
     )
   })
 
-  it('uses the detected source language to choose the opposite bidirectional target', async () => {
+  it('detects the source language to choose the opposite bidirectional target', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
-      'feature.translate.page.source_language': 'auto',
+      'feature.translate.page.source_language': 'en-us',
       'feature.translate.page.bidirectional_enabled': true,
       'feature.translate.page.bidirectional_pair': ['en-us', 'zh-cn']
     })
@@ -1581,7 +1564,7 @@ describe('TranslatePage', () => {
       expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
         sourceText: 'hello',
         targetText: 'translated text',
-        sourceLanguage: 'zh-cn',
+        sourceLanguage: null,
         targetLanguage: 'en-us'
       })
     )

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -54,6 +54,7 @@ const translateCoreMock = vi.hoisted(() => ({
   detectLanguage: vi.fn(),
   setTimeoutTimer: vi.fn(),
   translateText: vi.fn(),
+  updateHistory: vi.fn(),
   isAbortError: vi.fn(),
   formatErrorMessageWithPrefix: vi.fn((_: unknown, prefix: string) => prefix)
 }))
@@ -132,7 +133,7 @@ vi.mock('@renderer/hooks/translate', async (importOriginal) => ({
       return 'unknown'
     }
   },
-  useTranslateHistory: () => ({ add: translateCoreMock.addHistory })
+  useTranslateHistory: () => ({ add: translateCoreMock.addHistory, update: translateCoreMock.updateHistory })
 }))
 
 vi.mock('@renderer/hooks/translate/useDetectLang', () => ({
@@ -496,6 +497,8 @@ describe('TranslatePage', () => {
     translateCoreMock.setTimeoutTimer.mockReset()
     translateCoreMock.translateText.mockReset()
     translateCoreMock.translateText.mockResolvedValue('translated text')
+    translateCoreMock.updateHistory.mockReset()
+    translateCoreMock.updateHistory.mockResolvedValue(undefined)
     translateCoreMock.isAbortError.mockReset()
     translateCoreMock.isAbortError.mockReturnValue(false)
     translateCoreMock.formatErrorMessageWithPrefix.mockReset()
@@ -1239,12 +1242,20 @@ describe('TranslatePage', () => {
     )
   })
 
-  it('skips source detection and stores no source language for single-direction translation', async () => {
+  it('stores single-direction history before detecting and backfills its source language', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'auto',
       'feature.translate.page.target_language': 'en-us'
     })
+    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
+    let resolveDetection!: (language: string) => void
+    translateCoreMock.detectLanguage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDetection = resolve
+      })
+    )
+
     const { rerender } = render(<TranslatePage />)
     fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
     rerender(<TranslatePage />)
@@ -1258,7 +1269,6 @@ describe('TranslatePage', () => {
         expect.any(AbortSignal)
       )
     )
-    expect(translateCoreMock.detectLanguage).not.toHaveBeenCalled()
     expect(toast.error).not.toHaveBeenCalled()
     await waitFor(() =>
       expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
@@ -1268,6 +1278,59 @@ describe('TranslatePage', () => {
         targetLanguage: 'en-us'
       })
     )
+    await waitFor(() => expect(translateCoreMock.detectLanguage).toHaveBeenCalledWith('hello'))
+    expect(translateCoreMock.addHistory.mock.invocationCallOrder[0]).toBeLessThan(
+      translateCoreMock.detectLanguage.mock.invocationCallOrder[0]
+    )
+    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
+
+    await act(async () => resolveDetection('zh-cn'))
+
+    await waitFor(() =>
+      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-1', { sourceLanguage: 'zh-cn' })
+    )
+  })
+
+  it.each([
+    ['unknown detection', () => Promise.resolve('unknown')],
+    ['failed detection', () => Promise.reject(new Error('detect failed'))]
+  ])('leaves single-direction history unchanged after %s', async (_caseName, detectResult) => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
+    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
+    translateCoreMock.detectLanguage.mockImplementationOnce(detectResult)
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+
+    await waitFor(() => expect(translateCoreMock.detectLanguage).toHaveBeenCalledWith('hello'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('ignores a deleted history row during source-language backfill', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
+    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-deleted' })
+    translateCoreMock.updateHistory.mockRejectedValueOnce(new Error('history not found'))
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+
+    await waitFor(() =>
+      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-deleted', { sourceLanguage: 'en-us' })
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('continues translating with the selected target when auto detection returns unknown in bidirectional mode', async () => {
@@ -1593,6 +1656,17 @@ describe('TranslatePage', () => {
     expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.source_language')).toBe('auto')
     expect(MockUseCacheUtils.getCacheValue('translate.input')).toBe('hello')
     expect(MockUseCacheUtils.getCacheValue('translate.output')).toBe('你好')
+  })
+
+  it('does not reset the shared source preference when text history has no source language', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.page.source_language', 'zh-cn')
+
+    render(<TranslatePage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'translate.history.title' }))
+    fireEvent.click(screen.getByRole('button', { name: 'reuse-null-target-history' }))
+
+    expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.source_language')).toBe('zh-cn')
   })
 
   it('falls back to a concrete target language when reusing history with a null target and current unknown target', async () => {

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -51,10 +51,11 @@ const dropMock = vi.hoisted(() => ({
 
 const translateCoreMock = vi.hoisted(() => ({
   addHistory: vi.fn(),
+  updateHistory: vi.fn(),
+  historyHookOptions: vi.fn(),
   detectLanguage: vi.fn(),
   setTimeoutTimer: vi.fn(),
   translateText: vi.fn(),
-  updateHistory: vi.fn(),
   isAbortError: vi.fn(),
   formatErrorMessageWithPrefix: vi.fn((_: unknown, prefix: string) => prefix)
 }))
@@ -133,7 +134,10 @@ vi.mock('@renderer/hooks/translate', async (importOriginal) => ({
       return 'unknown'
     }
   },
-  useTranslateHistory: () => ({ add: translateCoreMock.addHistory, update: translateCoreMock.updateHistory })
+  useTranslateHistory: (options?: unknown) => {
+    translateCoreMock.historyHookOptions(options)
+    return { add: translateCoreMock.addHistory, update: translateCoreMock.updateHistory }
+  }
 }))
 
 vi.mock('@renderer/hooks/translate/useDetectLang', () => ({
@@ -511,6 +515,7 @@ describe('TranslatePage', () => {
     translateCoreMock.translateText.mockResolvedValue('translated text')
     translateCoreMock.updateHistory.mockReset()
     translateCoreMock.updateHistory.mockResolvedValue(undefined)
+    translateCoreMock.historyHookOptions.mockClear()
     translateCoreMock.isAbortError.mockReset()
     translateCoreMock.isAbortError.mockReturnValue(false)
     translateCoreMock.formatErrorMessageWithPrefix.mockReset()
@@ -1256,13 +1261,72 @@ describe('TranslatePage', () => {
     )
   })
 
-  it('keeps single-direction history target-only without detecting a source language', async () => {
+  it('stores single-direction history before detecting and backfills its source language', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'auto',
       'feature.translate.page.target_language': 'en-us'
     })
     translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
+    let resolveDetection!: (language: string) => void
+    translateCoreMock.detectLanguage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveDetection = resolve
+      })
+    )
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+
+    // The user-visible translation completes while detection is still pending.
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('translate.complete'))
+    expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
+      sourceText: 'hello',
+      targetText: 'translated text',
+      sourceLanguage: null,
+      targetLanguage: 'en-us'
+    })
+    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
+    // Backfill must not flip the page into the detecting state.
+    expect(screen.getByRole('button', { name: 'translate.button.translate' })).not.toBeDisabled()
+
+    await act(async () => resolveDetection('zh-cn'))
+
+    await waitFor(() =>
+      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-1', { sourceLanguage: 'zh-cn' })
+    )
+    expect(screen.getByRole('button', { name: 'translate.button.translate' })).not.toBeDisabled()
+  })
+
+  it.each([
+    ['unknown detection', () => Promise.resolve('unknown')],
+    ['failed detection', () => Promise.reject(new Error('detect failed'))]
+  ])('leaves single-direction history source unset after %s', async (_caseName, detectResult) => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
+    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
+    translateCoreMock.detectLanguage.mockImplementationOnce(detectResult)
+
+    const { rerender } = render(<TranslatePage />)
+    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
+    rerender(<TranslatePage />)
+    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
+
+    await waitFor(() => expect(translateCoreMock.detectLanguage).toHaveBeenCalledWith('hello'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores a deleted history row during source-language backfill', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
+    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-deleted' })
+    translateCoreMock.updateHistory.mockRejectedValueOnce(new Error('history not found'))
 
     const { rerender } = render(<TranslatePage />)
     fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
@@ -1270,25 +1334,21 @@ describe('TranslatePage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
 
     await waitFor(() =>
-      expect(translateCoreMock.translateText).toHaveBeenCalledWith(
-        'hello',
-        'en-us',
-        expect.any(Function),
-        expect.any(AbortSignal)
-      )
-    )
-    expect(toast.error).not.toHaveBeenCalled()
-    await waitFor(() =>
-      expect(translateCoreMock.addHistory).toHaveBeenCalledWith({
-        sourceText: 'hello',
-        targetText: 'translated text',
-        sourceLanguage: null,
-        targetLanguage: 'en-us'
+      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-deleted', {
+        sourceLanguage: 'en-us'
       })
     )
-    expect(translateCoreMock.detectLanguage).not.toHaveBeenCalled()
-    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
     expect(toast.error).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'translate.button.translate' })).not.toBeDisabled()
+    // The mocked hook cannot enforce its own feedback options, so assert the
+    // page asks for the silent behavior the backfill relies on.
+    expect(translateCoreMock.historyHookOptions).toHaveBeenCalledWith({
+      update: { showErrorToast: false, rethrowError: false }
+    })
   })
 
   it('continues translating with the selected target when auto detection returns unknown in bidirectional mode', async () => {

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -1683,6 +1683,8 @@ describe('TranslatePage', () => {
   })
 
   it('restores the side-by-side preview when reusing a PDF history entry', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('feature.translate.page.source_language', 'zh-cn')
+
     render(<TranslatePage />)
 
     fireEvent.click(screen.getByRole('button', { name: 'translate.history.title' }))
@@ -1691,6 +1693,9 @@ describe('TranslatePage', () => {
     const view = await screen.findByTestId('pdf-translation-view')
     expect(view).toHaveAttribute('data-file-path', '/tmp/paper.pdf')
     expect(view).toHaveAttribute('data-restored-output', '/tmp/files/entry-target.pdf')
+    await waitFor(() => {
+      expect(MockUsePreferenceUtils.getPreferenceValue('feature.translate.page.source_language')).toBe('auto')
+    })
     // A PDF row's texts are file names — they must not land in the text panes.
     expect(MockUseCacheUtils.getCacheValue('translate.input')).not.toBe('paper.pdf')
   })

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -358,9 +358,21 @@ vi.mock('../components/TranslateInputPane', () => ({
 }))
 
 vi.mock('../components/TranslateLanguageBar', () => ({
-  default: (props: { isBidirectional: boolean; showSourceControls: boolean }) => {
+  default: (props: {
+    isBidirectional: boolean
+    showSourceControls: boolean
+    onSourceChange: (language: string) => void
+    onTargetChange: (language: string) => void
+  }) => {
     languageBarMock(props)
-    return null
+    return (
+      <div>
+        {!props.isBidirectional && props.showSourceControls && (
+          <button type="button" aria-label="translate.source_language" onClick={() => props.onSourceChange('zh-cn')} />
+        )}
+        <button type="button" aria-label="translate.target_language" onClick={() => props.onTargetChange('en-us')} />
+      </div>
+    )
   }
 }))
 
@@ -1028,12 +1040,14 @@ describe('TranslatePage', () => {
     fileMock.onSelectFile.mockResolvedValue([{ name: 'input.pdf', path: '/tmp/input.pdf', size: 10, type: 'document' }])
 
     render(<TranslatePage />)
+    expect(screen.queryByRole('button', { name: 'translate.source_language' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'translate.target_language' })).toBeInTheDocument()
+
     fireEvent.click(screen.getByRole('button', { name: 'translate.files.upload' }))
 
     await waitFor(() => expect(screen.getByTestId('pdf-translation-view')).toBeInTheDocument())
-    expect(languageBarMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({ isBidirectional: false, showSourceControls: true })
-    )
+    expect(screen.getByRole('button', { name: 'translate.source_language' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'translate.target_language' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'translate.button.translate' })).toBeDisabled()
     expect(pdfHandleMock.start).not.toHaveBeenCalled()
   })

--- a/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
+++ b/src/renderer/pages/translate/__tests__/TranslatePage.test.tsx
@@ -1242,19 +1242,13 @@ describe('TranslatePage', () => {
     )
   })
 
-  it('stores single-direction history before detecting and backfills its source language', async () => {
+  it('keeps single-direction history target-only without detecting a source language', async () => {
     MockUsePreferenceUtils.setMultiplePreferenceValues({
       'feature.translate.model_id': 'openai::gpt-4.1',
       'feature.translate.page.source_language': 'auto',
       'feature.translate.page.target_language': 'en-us'
     })
     translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
-    let resolveDetection!: (language: string) => void
-    translateCoreMock.detectLanguage.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveDetection = resolve
-      })
-    )
 
     const { rerender } = render(<TranslatePage />)
     fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
@@ -1278,58 +1272,8 @@ describe('TranslatePage', () => {
         targetLanguage: 'en-us'
       })
     )
-    await waitFor(() => expect(translateCoreMock.detectLanguage).toHaveBeenCalledWith('hello'))
-    expect(translateCoreMock.addHistory.mock.invocationCallOrder[0]).toBeLessThan(
-      translateCoreMock.detectLanguage.mock.invocationCallOrder[0]
-    )
+    expect(translateCoreMock.detectLanguage).not.toHaveBeenCalled()
     expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
-
-    await act(async () => resolveDetection('zh-cn'))
-
-    await waitFor(() =>
-      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-1', { sourceLanguage: 'zh-cn' })
-    )
-  })
-
-  it.each([
-    ['unknown detection', () => Promise.resolve('unknown')],
-    ['failed detection', () => Promise.reject(new Error('detect failed'))]
-  ])('leaves single-direction history unchanged after %s', async (_caseName, detectResult) => {
-    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
-    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-1' })
-    translateCoreMock.detectLanguage.mockImplementationOnce(detectResult)
-
-    const { rerender } = render(<TranslatePage />)
-    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
-    rerender(<TranslatePage />)
-    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
-
-    await waitFor(() => expect(translateCoreMock.detectLanguage).toHaveBeenCalledWith('hello'))
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    expect(translateCoreMock.updateHistory).not.toHaveBeenCalled()
-    expect(toast.error).not.toHaveBeenCalled()
-  })
-
-  it('ignores a deleted history row during source-language backfill', async () => {
-    MockUsePreferenceUtils.setPreferenceValue('feature.translate.model_id', 'openai::gpt-4.1')
-    translateCoreMock.addHistory.mockResolvedValueOnce({ id: 'history-deleted' })
-    translateCoreMock.updateHistory.mockRejectedValueOnce(new Error('history not found'))
-
-    const { rerender } = render(<TranslatePage />)
-    fireEvent.change(screen.getByLabelText('translate.input.placeholder'), { target: { value: 'hello' } })
-    rerender(<TranslatePage />)
-    fireEvent.click(screen.getByRole('button', { name: 'translate.button.translate' }))
-
-    await waitFor(() =>
-      expect(translateCoreMock.updateHistory).toHaveBeenCalledWith('history-deleted', { sourceLanguage: 'en-us' })
-    )
-    await act(async () => {
-      await Promise.resolve()
-    })
-
     expect(toast.error).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
+++ b/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
@@ -21,6 +21,7 @@ type Props = {
   onTargetChange: (language: TranslateLangCode) => void
   detectedLanguage: TranslateLangCode | null
   isBidirectional: boolean
+  showSourceControls: boolean
   bidirectionalPair: TranslateBidirectionalPair
   couldExchange: boolean
   onExchange: () => void
@@ -45,6 +46,7 @@ const TranslateLanguageBar: FC<Props> = ({
   onTargetChange,
   detectedLanguage,
   isBidirectional,
+  showSourceControls,
   bidirectionalPair,
   couldExchange,
   onExchange
@@ -147,7 +149,7 @@ const TranslateLanguageBar: FC<Props> = ({
 
   return (
     <div className={cn('flex shrink-0 items-center gap-3 px-4 py-4 lg:px-6', className)}>
-      {!isBidirectional && (
+      {!isBidirectional && showSourceControls && (
         <>
           <Combobox
             size="default"

--- a/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
+++ b/src/renderer/pages/translate/components/TranslateLanguageBar.tsx
@@ -207,27 +207,34 @@ const TranslateLanguageBar: FC<Props> = ({
           </span>
         </Button>
       ) : (
-        <Combobox
-          size="default"
-          options={targetOptions}
-          value={targetLanguage}
-          onChange={(value) => handleTargetSelect(Array.isArray(value) ? value[0] : value)}
-          placeholder={t('translate.target_language')}
-          searchable={false}
-          emptyText={t('common.no_results')}
-          width={targetSelectWidth}
-          popoverClassName="w-(--radix-popover-trigger-width)"
-          renderValue={(value, options) => {
-            const option = options.find((item) => item.value === value)
-            return (
-              <div className="flex min-w-0 flex-1 items-center gap-2 truncate">
-                <span className="sr-only">{t('translate.target_language')}</span>
-                {option?.icon ?? languageIcon(target?.emoji ?? UNKNOWN_EMOJI)}
-                <span className="truncate">{option?.label ?? targetLabel}</span>
-              </div>
-            )
-          }}
-        />
+        <>
+          {!showSourceControls && (
+            <span aria-hidden="true" className="shrink-0 text-muted-foreground text-sm">
+              {t('translate.translate_to')}
+            </span>
+          )}
+          <Combobox
+            size="default"
+            options={targetOptions}
+            value={targetLanguage}
+            onChange={(value) => handleTargetSelect(Array.isArray(value) ? value[0] : value)}
+            placeholder={t('translate.target_language')}
+            searchable={false}
+            emptyText={t('common.no_results')}
+            width={targetSelectWidth}
+            popoverClassName="w-(--radix-popover-trigger-width)"
+            renderValue={(value, options) => {
+              const option = options.find((item) => item.value === value)
+              return (
+                <div className="flex min-w-0 flex-1 items-center gap-2 truncate">
+                  <span className="sr-only">{t('translate.target_language')}</span>
+                  {option?.icon ?? languageIcon(target?.emoji ?? UNKNOWN_EMOJI)}
+                  <span className="truncate">{option?.label ?? targetLabel}</span>
+                </div>
+              )
+            }}
+          />
+        </>
       )}
     </div>
   )

--- a/src/renderer/pages/translate/components/__tests__/TranslateLanguageBar.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateLanguageBar.test.tsx
@@ -95,6 +95,7 @@ const baseProps = (): BarProps => ({
   onTargetChange: vi.fn(),
   detectedLanguage: null,
   isBidirectional: false,
+  showSourceControls: true,
   bidirectionalPair: [english.langCode, chinese.langCode],
   couldExchange: true,
   onExchange: vi.fn()
@@ -126,6 +127,17 @@ describe('TranslateLanguageBar', () => {
     expect(screen.getByText('translate.source_language')).toBeInTheDocument()
     expect(screen.getByText('translate.target_language')).toBeInTheDocument()
     expect(screen.getByText('English')).toBeInTheDocument()
+  })
+
+  it('renders only the target language control for single-direction text translation', () => {
+    const props = baseProps()
+    props.showSourceControls = false
+
+    render(<TranslateLanguageBar {...props} />)
+
+    expect(screen.queryByRole('button', { name: sourceLanguageButtonName })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'translate.exchange.label' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: targetLanguageButtonName })).toBeInTheDocument()
   })
 
   it('opens source dropdown and calls onSourceChange on select', () => {

--- a/src/renderer/pages/translate/components/__tests__/TranslateLanguageBar.test.tsx
+++ b/src/renderer/pages/translate/components/__tests__/TranslateLanguageBar.test.tsx
@@ -140,6 +140,33 @@ describe('TranslateLanguageBar', () => {
     expect(screen.getByRole('button', { name: targetLanguageButtonName })).toBeInTheDocument()
   })
 
+  it('labels the lone target control so it explains what is being selected', () => {
+    const props = baseProps()
+    props.showSourceControls = false
+
+    render(<TranslateLanguageBar {...props} />)
+
+    expect(screen.getByText('translate.translate_to')).toBeInTheDocument()
+    // The visible label is decorative: the control keeps its own accessible name.
+    expect(screen.getByRole('button', { name: 'translate.target_language 🇬🇧 English' })).toBeInTheDocument()
+  })
+
+  it('omits the target label when the source control already provides context', () => {
+    render(<TranslateLanguageBar {...baseProps()} />)
+
+    expect(screen.queryByText('translate.translate_to')).not.toBeInTheDocument()
+  })
+
+  it('omits the target label in bidirectional mode', () => {
+    const props = baseProps()
+    props.isBidirectional = true
+    props.showSourceControls = false
+
+    render(<TranslateLanguageBar {...props} />)
+
+    expect(screen.queryByText('translate.translate_to')).not.toBeInTheDocument()
+  })
+
   it('opens source dropdown and calls onSourceChange on select', () => {
     const props = baseProps()
     render(<TranslateLanguageBar {...props} />)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Ordinary single-direction text translation exposed a source-language control and could run source detection before translating, even though only the selected target language affects the result. It could also block when the stored source matched the target.

After this PR:

Single-direction text translation shows only the target-language control, translates immediately without source detection, does not apply source/target equality blocking, and stores `null` source-language history metadata. Bidirectional translation still detects the source to choose direction, and PDF translation keeps its source-language controls and existing behavior.

Fixes #18899

### Why we need it and why it was done in this way

The common text path now exits early with the selected target when bidirectional mode is disabled. This keeps the change local to translation orchestration and avoids altering detection utilities or the PDF pipeline.

The following tradeoffs were made:

- Single-direction history no longer records a guessed source language.
- Existing stored source preferences remain available for PDF and bidirectional workflows.

The following alternatives were considered:

Keeping Auto/offline detection only for metadata was rejected because it preserves work that does not affect the translation result. Adding another “unspecified source” option was rejected because target-only is the simpler default for the common flow.

Links to places where the discussion took place: #18899

### Breaking changes

None.

### Special notes for your reviewer

Validation on current `main`:

- 134 renderer tests across `src/renderer/pages/translate`
- Full `pnpm typecheck`
- Biome and ESLint on all changed files
- `git diff --check`

Commit `a4f40d642` is signed and GitHub Verified.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: The touched translation flow is left simpler
- [x] Upgrade: No persisted-data migration is required; nullable source history is already supported
- [x] Documentation: User-facing documentation was considered; the existing translation guide does not document the removed source-only text behavior
- [x] Self-review: Reviewed the final diff and reran focused and static checks

### Release note

```release-note
Single-direction text translation now requires only a target language and starts without source-language detection.
```