### PR TITLE
fix(agent-runtime): serialize stop and retry teardown

### DIFF
--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -707,6 +707,10 @@ When the idle timer expires, the runtime closes the entry:
 - prewarms Claude Code when a latest resume token is known.
 
 Service stop and destroy close all runtime entries.
+Repeated `closeSession()` calls join the in-flight close; if a replacement entry was created meanwhile,
+its close is chained behind the prior one so callers wait for every connection generation to settle.
+An immediate retry may create its entry while that close is still draining, but it cannot connect until
+the predecessor has closed; the predecessor's observed resume token is handed to that successor directly.
 
 `ClaudeCodeProcessManager` owns every CLI handle this app spawns. Every SDK `Options` object routes
 through its host spawn wrapper, which fixes the stdio contract and records each `ChildProcess`,

--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -710,7 +710,9 @@ Service stop and destroy close all runtime entries.
 Repeated `closeSession()` calls join the in-flight close; if a replacement entry was created meanwhile,
 its close is chained behind the prior one so callers wait for every connection generation to settle.
 An immediate retry may create its entry while that close is still draining, but it cannot connect until
-the predecessor has closed; the predecessor's observed resume token is handed to that successor directly.
+the predecessor has closed. Teardown also joins an in-flight `driver.connect()` and closes any stale
+connection it produces before releasing the successor; the predecessor's observed resume token is handed
+to that successor directly.
 
 `ClaudeCodeProcessManager` owns every CLI handle this app spawns. Every SDK `Options` object routes
 through its host spawn wrapper, which fixes the stdio contract and records each `ChildProcess`,

--- a/docs/references/ai/agent-session-runtime.md
+++ b/docs/references/ai/agent-session-runtime.md
@@ -748,8 +748,9 @@ the last hold's disposal re-kicks it. New-turn admission through `prepareDispatc
 `beginTurn` is gated upstream by `AiStreamManager`. The drain awaits
 `inFlightTurnStarts` — launches admitted before the pause, through their placeholder
 write and `startRuntimeTurn` handoff — plus detached-flow finalizers that may still persist message
-parts after their runtime entry closes. The resulting stream writes belong to `AiStreamManager`'s
-drain. This is distinct from the BaseService lifecycle pause and never touches service state.
+parts and runtime close barriers that may still flush external state after their entry is removed.
+The resulting stream writes belong to `AiStreamManager`'s drain. This is distinct from the BaseService
+lifecycle pause and never touches service state.
 `AgentSessionDeliveryService` suppresses accepted-row kicks while a
 hold is live, tracks validation/claim/send handoffs and deletion orchestration in its drain set,
 rechecks the hold and target busy/live state after asynchronous validation before any transaction, then re-kicks

--- a/docs/references/ai/core-architecture.md
+++ b/docs/references/ai/core-architecture.md
@@ -22,7 +22,8 @@ each subsystem.
 │  useChat({ id: topicId, transport: IpcChatTransport })               │
 │    ├─ sendMessages      → ipcApi.request('ai.stream.open')            │
 │    ├─ reconnectToStream → ipcApi.request('ai.stream.attach')          │
-│    └─ abort signal      → ipcApi.request('ai.stream.abort')           │
+│    ├─ abort signal      → ipcApi.request('ai.stream.abort')           │
+│    └─ stop()            → sdkStop + await ai.stream.abort             │
 │                                                                      │
 │  History:           useQuery('/topics/:topicId/messages') → DataApi   │
 │  Topic-level state: useTopicStreamStatus → shared cache              │
@@ -36,7 +37,7 @@ each subsystem.
 │    ├─ ai.stream.open   → AiStreamManager.dispatch                    │
 │    ├─ ai.stream.attach → AiStreamManager.attach                      │
 │    ├─ ai.stream.detach → AiStreamManager.detach                      │
-│    ├─ ai.stream.abort  → AiStreamManager.abort                       │
+│    ├─ ai.stream.abort  → await AiStreamManager.abortAndDrain         │
 │    └─ ai.tool.respond_approval → AiService.respondToolApproval       │
 │                                                                      │
 │  dispatch (src/main/ai/streamManager/context/dispatch.ts)            │

--- a/docs/references/ai/ipc-transport.md
+++ b/docs/references/ai/ipc-transport.md
@@ -37,6 +37,19 @@ persists the result. Stopping generation is a separate path — the request's
 `abortSignal` requests `ai.stream.abort`. Conflating the two would resurrect the v1
 "unmount → cancel → upstream abort → lost reply" bug class.
 
+## User Stop
+
+`useChatWithHistory.stop()` first calls AI SDK's `stop()` so local stream
+consumption ends immediately, then explicitly sends and awaits
+`ai.stream.abort`. The transport's request `abortSignal` covers a stream opened
+by `sendMessages`, but its abort callback sends IPC without exposing Main's
+completion to the hook; a stream returned by `reconnectToStream()` has no
+original request signal at all. The explicit idempotent IPC therefore covers
+both paths and makes the hook's Stop promise resolve only after Main has crossed
+the topic teardown barrier: terminal persistence is settled and, for an Agent
+session, its runtime generation — including a pending connection attempt — is
+closed before a retry is admitted.
+
 Per-topic chunks arrive through `ipcApi.on('ai.stream.chunk', ...)`, filtered
 by `topicId`.
 

--- a/docs/references/ai/ipc-transport.md
+++ b/docs/references/ai/ipc-transport.md
@@ -39,9 +39,10 @@ persists the result. Stopping generation is a separate path — the request's
 
 ## User Stop
 
-`useChatWithHistory.stop()` first calls AI SDK's `stop()` so local stream
-consumption ends immediately, then explicitly sends and awaits
-`ai.stream.abort`. The transport's request `abortSignal` covers a stream opened
+`useChatWithHistory.stop()` starts `ai.stream.abort` before calling AI SDK's
+`stop()`, then awaits both. This establishes Main's topic admission barrier
+before local stream consumption ends and the UI can retry. The transport's
+request `abortSignal` covers a stream opened
 by `sendMessages`, but its abort callback sends IPC without exposing Main's
 completion to the hook; a stream returned by `reconnectToStream()` has no
 original request signal at all. The explicit idempotent IPC therefore covers

--- a/docs/references/ai/stream-manager.md
+++ b/docs/references/ai/stream-manager.md
@@ -470,6 +470,7 @@ class AiStreamManager {
 
   // ── Control ───────────────────────────────────────────────────────
   abort(topicId: string, reason: string): void
+  abortAndDrain(topicId: string, reason: string): Promise<void>
   hasLiveStream(topicId: string): boolean
   // Queue a steer user row persisted while a turn was live; the running turn
   // yields and `onExecutionDone` chains a `steer-continuation` to answer it.
@@ -739,7 +740,7 @@ duplicated; the rest are stream-manager-specific.
 | Agent-session follow-up | `ai.stream.open` on a live `agent-session:*` topic | provider persists the user row, `enqueueUserMessage` steers via `connection.redirect()` (no abort) or queues on `pendingTurns`; `manager.send` upserts the subscriber → `{ mode: 'injected' }` | steer folds into the current turn (rolled at a `steer-boundary`), else the next turn starts from `pendingTurns` — see [Agent Session Runtime](./agent-session-runtime.md#live-follow-up) |
 | Tool-approval pause+resume | approval-request chunk → `awaiting-approval` | decision via `ai.tool.respond_approval`; a live agent runtime resolves its registry entry, while MCP dispatches `continue-conversation` | card clears when the resumed stream broadcasts `pending` — see [Tool Approval](./tool-approval.md) |
 | Reconnect | `ai.stream.attach` on mount | `manager.attach`: `not-found` / streaming (register listener + compact replay) / done-paused (`finalMessage(s)`) / error | live chunks resume, or the final row is returned; attach never changes runtime state |
-| Abort — user stop | `ai.stream.abort` | per exec: `abortController.abort` → loop `signal` aborts → broadcast reader `cancel` → read loop `done` | partial persisted as **`paused`**; topic status → `aborted` (or `awaiting-approval` if an exec had it set) |
+| Abort — user stop | `ai.stream.abort` | `abortAndDrain` holds the topic dispatch lock; per exec: `abortController.abort` → loop `signal` aborts → broadcast reader `cancel` → read loop `done`; then Agent runtime close settles | partial persists as **`paused`** and the request resolves before the next same-topic dispatch is admitted |
 | Abort — no subscribers | last `WebContentsListener` dies + `backgroundMode === 'abort'` | `onChunk` prunes dead listeners; `listeners.size === 0` → auto `abort(topicId, 'no-subscribers')` | partial persisted as **`paused`** — never silently `success` or leaked |
 | Multi-window | window B opens a live topic | B sends `ai.stream.attach` → compact replay + its own `WebContentsListener`; each chunk fans out to A and B | both windows render the same chunks in sync |
 | Channel / Agent | `AiStreamManager.send` in-process (no IPC) | scenario differs only by listener composition (table below) | per-listener effect |
@@ -773,7 +774,7 @@ listener composition:
 | `ai.stream.open` | `AiStreamOpenRequest` (`submit-message` \| `regenerate-message`) | `{ mode, activeExecutions?, reservedMessages?, preserveActiveNode? }` | Open / inject; provider routes by topicId |
 | `ai.stream.attach` | `{ topicId }` | `AiStreamAttachResponse` | Subscribe; returns compact replay when streaming |
 | `ai.stream.detach` | `{ topicId }` | void | Unsubscribe (stream continues) |
-| `ai.stream.abort` | `{ topicId }` | void | Stop current generation |
+| `ai.stream.abort` | `{ topicId }` | void | Stop current generation; resolves after terminal persistence and Agent runtime close settle |
 
 > Topic status snapshots need no dedicated IPC: a new window pulls every
 > `topic.stream.statuses.${topicId}` entry via `Cache_GetAllShared` on

--- a/docs/references/ai/stream-manager.md
+++ b/docs/references/ai/stream-manager.md
@@ -935,11 +935,15 @@ entry is evicted; subsequent `attach` returns `not-found` and the
 renderer reads from the DB through `useQuery` (PersistenceListener has
 already written by then).
 
-If the user stops and immediately retries on the same topic, `send`
-takes the start branch: `evictStream` first clears the grace-period
-remnant (cancels the cleanup timer and drops the entry from
-`activeStreams`), then the new stream is created — the old never blocks
-the new.
+After a naturally terminal stream, or after an awaited user Stop has crossed its
+teardown barrier, a same-topic retry takes the start branch: `evictStream` first
+clears the grace-period remnant (cancels the cleanup timer and drops the entry
+from `activeStreams`), then creates the new stream. The grace-period entry never
+blocks the new generation; an in-progress user Stop intentionally does, through
+the topic dispatch lock, until terminal persistence and, for Agent sessions,
+runtime teardown settle. See [IPC Transport → User Stop](./ipc-transport.md#user-stop) for why the
+Renderer sends and awaits an explicit abort request even after calling AI SDK's
+`stop()`.
 
 ## Edge case cheat sheet
 

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1089,6 +1089,7 @@ export class AgentSessionRuntimeService extends BaseService {
 
   /** Whether any agent session can still mutate its DB row or external runtime files. */
   hasBusySessions(): boolean {
+    if (this.closingSessions.size > 0) return true
     if (this.inFlightBackgroundFlowFlushes.size > 0) return true
     for (const sessionId of this.entries.keys()) {
       if (this.isSessionBusy(sessionId)) return true
@@ -1171,8 +1172,9 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   /**
-   * Await in-flight turn-start launches (placeholder write + `startRuntimeTurn` handoff) and
-   * detached-flow finalizers, bounded by timeoutMs. Never rejects; stragglers are NOT aborted.
+   * Await in-flight turn-start launches (placeholder write + `startRuntimeTurn` handoff),
+   * detached-flow finalizers, and runtime close barriers, bounded by timeoutMs. Never rejects;
+   * stragglers are NOT aborted.
    * The resulting stream writes are AiStreamManager's drain — this only covers the windows this
    * service writes in.
    * The set can grow one step while draining (a settling turn schedules the next start
@@ -1204,6 +1206,13 @@ export class AgentSessionRuntimeService extends BaseService {
         const remove = () => pending.delete(flush)
         flush.then(remove, remove)
       }
+      for (const [sessionId, closing] of this.closingSessions) {
+        if (seen.has(closing.promise)) continue
+        seen.add(closing.promise)
+        pending.set(closing.promise, sessionId)
+        const remove = () => pending.delete(closing.promise)
+        closing.promise.then(remove, remove)
+      }
     }
 
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined
@@ -1232,13 +1241,18 @@ export class AgentSessionRuntimeService extends BaseService {
   /** Advisory pre-flight enumeration for the restore orchestrator. Read-only, in-memory. */
   listActiveWork(): Array<{ id: string; summary: string }> {
     const work: Array<{ id: string; summary: string }> = []
+    const activeSessionIds = new Set<string>()
     for (const [sessionId, entry] of this.entries) {
       if (!this.isSessionBusy(sessionId)) continue
+      activeSessionIds.add(sessionId)
       const turn = this.liveTurn(entry) ? 'live' : '-'
       work.push({
         id: sessionId,
         summary: `turn=${turn} pending=${entry.runtimeState.queue.length} execution=${entry.runtimeState.execution.kind} compacting=${isAgentSessionRuntimeCompacting(entry.runtimeState)} launch=${entry.runtimeState.launch.kind}`
       })
+    }
+    for (const sessionId of this.closingSessions.keys()) {
+      if (!activeSessionIds.has(sessionId)) work.push({ id: sessionId, summary: 'closing=true' })
     }
     return work
   }

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -931,12 +931,15 @@ export class AgentSessionRuntimeService extends BaseService {
     const entry = this.entries.get(sessionId)
     if (!entry) return priorClosing?.promise ?? Promise.resolve()
     const fallbackConnection = this.currentConnection(entry)
+    const connectionAttempt = this.connectionAttempts.get(sessionId)?.promise
     let closing: Promise<void>
     try {
       closing = this.closeEntry(entry)
     } catch (error) {
       logger.warn('Agent runtime entry close failed', { sessionId, error })
-      closing = this.closeRuntimeConnection(fallbackConnection, sessionId)
+      const fallbackClosings: Promise<unknown>[] = [this.closeRuntimeConnection(fallbackConnection, sessionId)]
+      if (connectionAttempt) fallbackClosings.push(connectionAttempt)
+      closing = Promise.allSettled(fallbackClosings).then(() => undefined)
     }
     const combinedClosing = Promise.allSettled(priorClosing ? [priorClosing.promise, closing] : [closing]).then(
       () => undefined

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -323,6 +323,7 @@ export class AgentSessionRuntimeService extends BaseService {
   private readonly _onRuntimeIdle = new Emitter<{ sessionId: string }>()
   readonly onRuntimeIdle: Event<{ sessionId: string }> = this._onRuntimeIdle.event
   private readonly entries = new Map<string, AgentSessionRuntimeEntry>()
+  private readonly closingSessions = new Map<string, { promise: Promise<void>; resumeToken?: string }>()
   /** Write-quiesce holds (backup restore). Quiesced ⇔ non-empty. Distinct from the BaseService
    *  lifecycle pause — this never touches service state. See `pause()`. */
   private readonly pauseHolds = new Set<symbol>()
@@ -926,8 +927,9 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   closeSession(sessionId: string): Promise<void> {
+    const priorClosing = this.closingSessions.get(sessionId)
     const entry = this.entries.get(sessionId)
-    if (!entry) return Promise.resolve()
+    if (!entry) return priorClosing?.promise ?? Promise.resolve()
     const fallbackConnection = this.currentConnection(entry)
     let closing: Promise<void>
     try {
@@ -936,11 +938,21 @@ export class AgentSessionRuntimeService extends BaseService {
       logger.warn('Agent runtime entry close failed', { sessionId, error })
       closing = this.closeRuntimeConnection(fallbackConnection, sessionId)
     }
+    const combinedClosing = Promise.allSettled(priorClosing ? [priorClosing.promise, closing] : [closing]).then(
+      () => undefined
+    )
+    const barrier = {
+      promise: combinedClosing.finally(() => {
+        if (this.closingSessions.get(sessionId) === barrier) this.closingSessions.delete(sessionId)
+      }),
+      resumeToken: entry.lastResumeToken ?? priorClosing?.resumeToken
+    }
+    this.closingSessions.set(sessionId, barrier)
     if (this.entries.get(sessionId) === entry) {
       this.entries.delete(sessionId)
       this._onRuntimeIdle.fire({ sessionId })
     }
-    return closing
+    return barrier.promise
   }
 
   /**
@@ -1417,6 +1429,15 @@ export class AgentSessionRuntimeService extends BaseService {
 
   private async ensureConnection(entry: AgentSessionRuntimeEntry): Promise<boolean> {
     while (this.isCurrentEntry(entry)) {
+      const closing = this.closingSessions.get(entry.sessionId)
+      if (closing) {
+        await closing.promise
+        if (this.isCurrentEntry(entry) && !entry.lastResumeToken && closing.resumeToken) {
+          entry.lastResumeToken = closing.resumeToken
+        }
+        continue
+      }
+
       const target = this.connectionTarget(entry)
       const connection = this.currentConnection(entry)
       if (connection) {
@@ -3045,7 +3066,8 @@ export class AgentSessionRuntimeService extends BaseService {
   }
 
   private closeAll(): Promise<void> {
-    const closings = [...this.entries.keys()].map((sessionId) => this.closeSession(sessionId))
+    const sessionIds = new Set([...this.entries.keys(), ...this.closingSessions.keys()])
+    const closings = [...sessionIds].map((sessionId) => this.closeSession(sessionId))
     return Promise.allSettled(closings).then(() => undefined)
   }
 

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1571,13 +1571,13 @@ export class AgentSessionRuntimeService extends BaseService {
       onSteerInjected: (inputs) => this.reserveSteerContinuation(entry, inputs)
     })
     if (!this.isCurrentEntry(entry) || !this.connectionTargetEquals(entry, target)) {
-      void this.closeRuntimeConnection(connection, entry.sessionId)
+      await this.closeRuntimeConnection(connection, entry.sessionId)
       return false
     }
 
     this.applyRuntimeStateEvent(entry, { type: 'connection-connected', attemptId, connection })
     if (this.currentConnection(entry) !== connection) {
-      void this.closeRuntimeConnection(connection, entry.sessionId)
+      await this.closeRuntimeConnection(connection, entry.sessionId)
       return false
     }
     entry.usageCapture = connection.usageCapture
@@ -3100,14 +3100,14 @@ export class AgentSessionRuntimeService extends BaseService {
     application.get('CacheService').deleteShared(AGENT_SESSION_BACKGROUND_TASKS_CACHE_KEY(entry.sessionId))
     application.get('CacheService').deleteShared(AGENT_SESSION_TASK_EVENTS_CACHE_KEY(entry.sessionId))
 
+    const connectionAttempt = this.connectionAttempts.get(entry.sessionId)?.promise
     const connection = this.closeConnection(entry, false)
     this.applyRuntimeStateEvent(entry, { type: 'reset' })
-    this.connectionAttempts.delete(entry.sessionId)
     this.inFlightTurnStarts.delete(entry.sessionId)
 
-    return Promise.all([backgroundFlowFlush, this.closeRuntimeConnection(connection, entry.sessionId)]).then(
-      () => undefined
-    )
+    const closings: Promise<unknown>[] = [backgroundFlowFlush, this.closeRuntimeConnection(connection, entry.sessionId)]
+    if (connectionAttempt) closings.push(connectionAttempt)
+    return Promise.allSettled(closings).then(() => undefined)
   }
 
   private closeFailedPolicyUpdateConnection(entry: AgentSessionRuntimeEntry, connection: AgentRuntimeConnection): void {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.pause.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.pause.test.ts
@@ -118,6 +118,19 @@ function seedQueuedFollowUp(service: Service) {
   return entryOf(service)
 }
 
+function beginClosingConnection(service: Service) {
+  service.beginTurn(baseTurnInput)
+  const gate = createDeferred<void>()
+  const close = vi.fn(() => gate.promise)
+  entryOf(service).runtimeState.connection = {
+    kind: 'connected',
+    connection: { close },
+    occupancy: {}
+  }
+  const closing = service.closeSession('session-1')
+  return { close, closing, gate }
+}
+
 function stubLaunch(service: Service, target: LaunchTarget, implementation: () => Promise<void> | void) {
   const runtime = internals(service)
   switch (target) {
@@ -308,6 +321,40 @@ describe('AgentSessionRuntimeService pause / drainInFlight', () => {
     })
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(drained).toBe(false)
+
+    gate.resolve()
+    await closing
+    await expect(drain).resolves.toEqual({ stragglerIds: [] })
+    hold.dispose()
+  })
+
+  it('reports a closing connection as active work after its runtime entry is removed', async () => {
+    const service = new AgentSessionRuntimeService()
+    const { close, closing, gate } = beginClosingConnection(service)
+
+    expect(service.inspect('session-1')).toBeUndefined()
+    expect(close).toHaveBeenCalledOnce()
+    expect(service.hasBusySessions()).toBe(true)
+    expect(service.listActiveWork()).toEqual([{ id: 'session-1', summary: 'closing=true' }])
+
+    gate.resolve()
+    await closing
+    expect(service.hasBusySessions()).toBe(false)
+    expect(service.listActiveWork()).toEqual([])
+  })
+
+  it('drains a closing connection after its runtime entry is removed', async () => {
+    const service = new AgentSessionRuntimeService()
+    const hold = service.pause('restore')
+    const { closing, gate } = beginClosingConnection(service)
+
+    let settled = false
+    const drain = service.drainInFlight({ timeoutMs: 5_000 }).then((result) => {
+      settled = true
+      return result
+    })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    expect(settled).toBe(false)
 
     gate.resolve()
     await closing

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -4046,15 +4046,20 @@ describe('AgentSessionRuntimeService', () => {
     await reader.cancel().catch(() => undefined)
   })
 
-  it('closes a late runtime connection when the user aborts before connect resolves', async () => {
-    const events = createAsyncQueue<any>()
-    const connection = {
-      events: events.iterable,
+  it('waits for a late aborted connection to close before connecting an immediate retry', async () => {
+    const firstConnectionClose = createDeferred<void>()
+    const firstConnection = {
+      events: createAsyncQueue<any>().iterable,
+      send: vi.fn(),
+      close: vi.fn(() => firstConnectionClose.promise)
+    }
+    const secondConnection = {
+      events: createAsyncQueue<any>().iterable,
       send: vi.fn(),
       close: vi.fn()
     }
-    const pendingConnection = createDeferred<typeof connection>()
-    const connect = vi.fn().mockReturnValue(pendingConnection.promise)
+    const pendingConnection = createDeferred<typeof firstConnection>()
+    const connect = vi.fn().mockReturnValueOnce(pendingConnection.promise).mockResolvedValueOnce(secondConnection)
     runtimeDriverRegistry.register({
       type: 'test-runtime',
       capabilities: ['agent-session'],
@@ -4078,11 +4083,37 @@ describe('AgentSessionRuntimeService', () => {
     controller.abort('user-requested')
     expect(service.inspect('session-1')).toBeUndefined()
 
-    pendingConnection.resolve(connection)
+    const retry = service.beginTurn({
+      ...baseTurnInput,
+      assistantMessageId: 'assistant-2',
+      userMessage: userMessage('user-2')
+    })
+    const retryReader = service
+      .openTurnStream({
+        sessionId: 'session-1',
+        turnId: retry.turnId,
+        signal: new AbortController().signal
+      })
+      .getReader()
 
-    await vi.waitFor(() => expect(connection.close).toHaveBeenCalledOnce())
-    expect(connection.send).not.toHaveBeenCalled()
+    await expect(retryReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(connect).toHaveBeenCalledOnce()
+
+    pendingConnection.resolve(firstConnection)
+    await vi.waitFor(() => expect(firstConnection.close).toHaveBeenCalledOnce())
+    expect(connect).toHaveBeenCalledOnce()
+
+    firstConnectionClose.resolve()
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() =>
+      expect(secondConnection.send).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: false })
+    )
+    expect(firstConnection.send).not.toHaveBeenCalled()
+    void service.closeSession('session-1')
     await reader.cancel().catch(() => undefined)
+    await retryReader.cancel().catch(() => undefined)
   })
 
   describe('steer soft-queue — live follow-up (pure streaming-input, no interrupt)', () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3119,6 +3119,51 @@ describe('AgentSessionRuntimeService', () => {
     }
   })
 
+  it('waits for the same in-flight connection close when closeSession is called again', async () => {
+    const service = new AgentSessionRuntimeService()
+    service.beginTurn(baseTurnInput)
+    const connectionClose = createDeferred<void>()
+    const connection = { close: vi.fn(() => connectionClose.promise), send: vi.fn(), events: [] }
+    getEntry(service).connection = connection
+
+    const firstClose = service.closeSession('session-1')
+    const repeatedClose = service.closeSession('session-1')
+    let repeatedCloseSettled = false
+    void repeatedClose.then(() => {
+      repeatedCloseSettled = true
+    })
+    await Promise.resolve()
+
+    expect(repeatedCloseSettled).toBe(false)
+
+    connectionClose.resolve()
+    await expect(Promise.all([firstClose, repeatedClose])).resolves.toBeDefined()
+    expect(connection.close).toHaveBeenCalledOnce()
+  })
+
+  it('also closes a replacement entry created while the prior entry is still closing', async () => {
+    const service = new AgentSessionRuntimeService()
+    service.beginTurn(baseTurnInput)
+    const firstConnectionClose = createDeferred<void>()
+    const firstConnection = { close: vi.fn(() => firstConnectionClose.promise), send: vi.fn(), events: [] }
+    getEntry(service).connection = firstConnection
+    const firstClose = service.closeSession('session-1')
+
+    service.beginTurn({ ...baseTurnInput, assistantMessageId: 'assistant-2' })
+    const secondConnectionClose = createDeferred<void>()
+    const secondConnection = { close: vi.fn(() => secondConnectionClose.promise), send: vi.fn(), events: [] }
+    getEntry(service).connection = secondConnection
+
+    const secondClose = service.closeSession('session-1')
+
+    expect(secondConnection.close).toHaveBeenCalledOnce()
+    expect(service.inspect('session-1')).toBeUndefined()
+
+    firstConnectionClose.resolve()
+    secondConnectionClose.resolve()
+    await expect(Promise.all([firstClose, secondClose])).resolves.toBeDefined()
+  })
+
   it('does not throw and logs a warning when the connection close rejects on closeSession (REGRESSION agent-session-5)', async () => {
     const service = new AgentSessionRuntimeService()
     service.beginTurn(baseTurnInput)
@@ -3900,6 +3945,69 @@ describe('AgentSessionRuntimeService', () => {
     expect(service.inspect('session-1')).toMatchObject({ resumeToken: 'resume-db' })
     void service.closeSession('session-1')
     await reader.cancel().catch(() => undefined)
+  })
+
+  it('waits for the aborted connection to close before connecting an immediate retry', async () => {
+    const firstEvents = createAsyncQueue<any>()
+    const secondEvents = createAsyncQueue<any>()
+    const firstClose = createDeferred<void>()
+    const firstConnection = {
+      events: firstEvents.iterable,
+      send: vi.fn(),
+      close: vi.fn(() => firstClose.promise)
+    }
+    const secondConnection = {
+      events: secondEvents.iterable,
+      send: vi.fn(),
+      close: vi.fn()
+    }
+    const connect = vi.fn().mockResolvedValueOnce(firstConnection).mockResolvedValueOnce(secondConnection)
+    runtimeDriverRegistry.register({
+      type: 'test-runtime',
+      capabilities: ['agent-session'],
+      connect,
+      validateSession: vi.fn(),
+      listAvailableTools: vi.fn().mockResolvedValue([])
+    })
+    const service = new AgentSessionRuntimeService()
+    const first = service.beginTurn({ ...baseTurnInput, userMessage: userMessage('user-1') })
+    const firstAbort = new AbortController()
+    const firstReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: first.turnId, signal: firstAbort.signal })
+      .getReader()
+
+    await expect(firstReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await vi.waitFor(() => expect(firstConnection.send).toHaveBeenCalledOnce())
+    firstEvents.push({ type: 'resume-token', token: 'resume-before-stop' })
+    await vi.waitFor(() => expect(service.inspect('session-1')).toMatchObject({ resumeToken: 'resume-before-stop' }))
+
+    firstAbort.abort('user-requested')
+    await vi.waitFor(() => expect(firstConnection.close).toHaveBeenCalledOnce())
+
+    const second = service.beginTurn({
+      ...baseTurnInput,
+      assistantMessageId: 'assistant-2',
+      userMessage: userMessage('user-2')
+    })
+    const secondReader = service
+      .openTurnStream({ sessionId: 'session-1', turnId: second.turnId, signal: new AbortController().signal })
+      .getReader()
+
+    await expect(secondReader.read()).resolves.toMatchObject({ value: { type: 'start' }, done: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(connect).toHaveBeenCalledOnce()
+    expect(secondConnection.send).not.toHaveBeenCalled()
+
+    firstClose.resolve()
+
+    await vi.waitFor(() => expect(connect).toHaveBeenCalledTimes(2))
+    expect(connect).toHaveBeenLastCalledWith(expect.objectContaining({ resumeToken: 'resume-before-stop' }))
+    await vi.waitFor(() =>
+      expect(secondConnection.send).toHaveBeenCalledWith({ message: userMessage('user-2'), systemReminder: false })
+    )
+    void service.closeSession('session-1')
+    await firstReader.cancel().catch(() => undefined)
+    await secondReader.cancel().catch(() => undefined)
   })
 
   it('closes the runtime session when the active turn is aborted by the user', async () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -3141,6 +3141,27 @@ describe('AgentSessionRuntimeService', () => {
     expect(connection.close).toHaveBeenCalledOnce()
   })
 
+  it('waits for a pending connection attempt when synchronous close cleanup falls back', async () => {
+    const service = new AgentSessionRuntimeService()
+    service.beginTurn(baseTurnInput)
+    const connectionAttempt = createDeferred<void>()
+    ;(service as any).connectionAttempts.set('session-1', { promise: connectionAttempt.promise })
+    mocks.cacheDeleteShared.mockImplementationOnce(() => {
+      throw new Error('cache cleanup failed')
+    })
+
+    let settled = false
+    const closing = service.closeSession('session-1').then(() => {
+      settled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(settled).toBe(false)
+
+    connectionAttempt.resolve()
+    await expect(closing).resolves.toBeUndefined()
+  })
+
   it('also closes a replacement entry created while the prior entry is still closing', async () => {
     const service = new AgentSessionRuntimeService()
     service.beginTurn(baseTurnInput)

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -1183,12 +1183,34 @@ export class AiStreamManager extends BaseService {
     await this.withDispatchLock(topicId, async () => {
       const stream = this.activeStreams.get(topicId)
       const loopPromises = stream ? [...stream.executions.values()].map((execution) => execution.loopPromise) : []
+      const drainedLoops = new Set(loopPromises)
 
       this.abort(topicId, reason)
       await Promise.allSettled(loopPromises)
 
       if (isAgentSessionTopic(topicId)) {
-        await application.get('AgentSessionRuntimeService').closeSession(extractAgentSessionId(topicId))
+        const runtimeClosing = application
+          .get('AgentSessionRuntimeService')
+          .closeSession(extractAgentSessionId(topicId))
+        const drainReplacementLoops = async (): Promise<void> => {
+          for (;;) {
+            const replacement = this.activeStreams.get(topicId)
+            const replacementLoops = replacement
+              ? [...replacement.executions.values()]
+                  .map((execution) => execution.loopPromise)
+                  .filter((loopPromise) => !drainedLoops.has(loopPromise))
+              : []
+            if (replacementLoops.length === 0) return
+
+            replacementLoops.forEach((loopPromise) => drainedLoops.add(loopPromise))
+            this.abort(topicId, reason)
+            await Promise.allSettled(replacementLoops)
+          }
+        }
+
+        await drainReplacementLoops()
+        await runtimeClosing
+        await drainReplacementLoops()
       }
     })
   }

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -1178,6 +1178,21 @@ export class AiStreamManager extends BaseService {
     stream.status = 'aborted'
   }
 
+  /** Abort a user-visible topic and hold same-topic admission until its durable teardown settles. */
+  async abortAndDrain(topicId: string, reason: string): Promise<void> {
+    await this.withDispatchLock(topicId, async () => {
+      const stream = this.activeStreams.get(topicId)
+      const loopPromises = stream ? [...stream.executions.values()].map((execution) => execution.loopPromise) : []
+
+      this.abort(topicId, reason)
+      await Promise.allSettled(loopPromises)
+
+      if (isAgentSessionTopic(topicId)) {
+        await application.get('AgentSessionRuntimeService').closeSession(extractAgentSessionId(topicId))
+      }
+    })
+  }
+
   // ── Execution loop callbacks ──────────────────────────────────────
   // Driven internally by `createAndLaunchExecution`. Public because
   // tests invoke them directly to simulate chunk/done/error.

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -1602,6 +1602,46 @@ describe('AiStreamManager', () => {
       await expect(nextTurn).resolves.toBeUndefined()
       expect(nextTurnAdmitted).toBe(true)
     })
+
+    it('drains an agent continuation launched during terminal handling before releasing admission', async () => {
+      vi.useRealTimers()
+      const continuationListener = new FakeListener('persistence:continuation', 'persistence')
+      let releaseContinuationPersistence!: () => void
+      continuationListener.onPausedImpl = () =>
+        new Promise<void>((resolve) => {
+          releaseContinuationPersistence = resolve
+        })
+      const runtimeListener = new FakeListener('agent-runtime:session-1')
+      runtimeListener.onPausedImpl = () => {
+        mgr.startRuntimeTurn({
+          topicId: 'agent-session:session-1',
+          modelId: 'provider-a::model-a',
+          request: req('agent-session:session-1'),
+          listeners: [continuationListener]
+        })
+      }
+      startSingle(mgr, {
+        topicId: 'agent-session:session-1',
+        modelId: 'provider-a::model-a',
+        request: req('agent-session:session-1'),
+        listeners: [new FakeListener('persistence:initial', 'persistence'), runtimeListener]
+      })
+
+      const stopping = mgr.abortAndDrain('agent-session:session-1', 'user-requested')
+      let nextTurnAdmitted = false
+      const nextTurn = mgr.withDispatchLock('agent-session:session-1', async () => {
+        nextTurnAdmitted = true
+      })
+
+      await flushUntil(() => mockCloseSession.mock.calls.length === 1)
+      await flushUntil(() => continuationListener.pausedResults.length === 1)
+      expect(nextTurnAdmitted).toBe(false)
+
+      releaseContinuationPersistence()
+      await expect(stopping).resolves.toBeUndefined()
+      await expect(nextTurn).resolves.toBeUndefined()
+      expect(nextTurnAdmitted).toBe(true)
+    })
   })
 
   // ── listener management ─────────────────────────────────────────

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -130,6 +130,7 @@ const fakeCacheService = {
 }
 const mockSaveSpans = vi.fn<(topicId: string) => Promise<void>>(async () => undefined)
 const mockWillContinueTopic = vi.fn<(topicId: string) => boolean>(() => false)
+const mockCloseSession = vi.fn<(sessionId: string) => Promise<void>>(async () => undefined)
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -142,7 +143,11 @@ vi.mock('@application', async () => {
     AiService: { streamText: mockStreamText },
     CacheService: fakeCacheService,
     TraceStorageService: { saveSpans: mockSaveSpans },
-    AgentSessionRuntimeService: { willContinueTopic: mockWillContinueTopic, abortPendingTurn: mockAbortPendingTurn }
+    AgentSessionRuntimeService: {
+      willContinueTopic: mockWillContinueTopic,
+      abortPendingTurn: mockAbortPendingTurn,
+      closeSession: mockCloseSession
+    }
   } as Parameters<typeof mockApplicationFactory>[0])
 })
 
@@ -1555,6 +1560,47 @@ describe('AiStreamManager', () => {
       // Abort on a finished stream → no-op (status stays 'done')
       mgr.abort('a', 'late')
       expect(mgr.inspect('a')!.status).toBe('done')
+    })
+
+    it('holds same-topic admission until paused persistence and runtime close settle', async () => {
+      vi.useRealTimers()
+      const listener = new FakeListener('persistence:agent')
+      let releasePersistence!: () => void
+      listener.onPausedImpl = () =>
+        new Promise<void>((resolve) => {
+          releasePersistence = resolve
+        })
+      let releaseRuntimeClose!: () => void
+      mockCloseSession.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseRuntimeClose = resolve
+          })
+      )
+      startSingle(mgr, {
+        topicId: 'agent-session:session-1',
+        modelId: 'provider-a::model-a',
+        request: req('agent-session:session-1'),
+        listeners: [listener]
+      })
+
+      const stopping = mgr.abortAndDrain('agent-session:session-1', 'user-requested')
+      let nextTurnAdmitted = false
+      const nextTurn = mgr.withDispatchLock('agent-session:session-1', async () => {
+        nextTurnAdmitted = true
+      })
+
+      await flushUntil(() => listener.pausedResults.length === 1)
+      expect(nextTurnAdmitted).toBe(false)
+
+      releasePersistence()
+      await flushUntil(() => mockCloseSession.mock.calls.length === 1)
+      expect(nextTurnAdmitted).toBe(false)
+
+      releaseRuntimeClose()
+      await expect(stopping).resolves.toBeUndefined()
+      await expect(nextTurn).resolves.toBeUndefined()
+      expect(nextTurnAdmitted).toBe(true)
     })
   })
 

--- a/src/main/ipc/handlers/__tests__/ai.test.ts
+++ b/src/main/ipc/handlers/__tests__/ai.test.ts
@@ -43,6 +43,7 @@ const aiStreamManager = {
   attach: vi.fn(),
   detach: vi.fn(),
   abort: vi.fn(),
+  abortAndDrain: vi.fn(),
   getDeferredToolOutput: vi.fn()
 }
 
@@ -337,10 +338,27 @@ describe('aiHandlers — streaming', () => {
     expect(aiStreamManager.detach).not.toHaveBeenCalled()
   })
 
-  it('stream_abort aborts the topic without resolving a WebContents', async () => {
-    await aiHandlers['ai.stream.abort']({ topicId: 't' }, { senderId: null })
-    expect(aiStreamManager.abort).toHaveBeenCalledWith('t', 'user-requested')
+  it('stream_abort resolves only after the topic has drained without resolving a WebContents', async () => {
+    let finishDrain!: () => void
+    aiStreamManager.abortAndDrain.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishDrain = resolve
+      })
+    )
+
+    const aborting = aiHandlers['ai.stream.abort']({ topicId: 't' }, { senderId: null })
+    let settled = false
+    void aborting.then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+    expect(aiStreamManager.abortAndDrain).toHaveBeenCalledWith('t', 'user-requested')
     expect(windowManager.getWindow).not.toHaveBeenCalled()
+
+    finishDrain()
+    await expect(aborting).resolves.toBeUndefined()
   })
 
   it('get_tool_result prefers the active stream over the persisted copy', async () => {

--- a/src/main/ipc/handlers/ai.ts
+++ b/src/main/ipc/handlers/ai.ts
@@ -190,7 +190,7 @@ export const aiHandlers: IpcHandlersFor<typeof aiRequestSchemas> = {
     if (wc) application.get('AiStreamManager').detach(wc, request)
   },
   'ai.stream.abort': async ({ topicId }) => {
-    application.get('AiStreamManager').abort(topicId, 'user-requested')
+    await application.get('AiStreamManager').abortAndDrain(topicId, 'user-requested')
   },
 
   // ── Tool calls — deferred output lookup + approval decisions. ──

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -1203,7 +1203,11 @@ const AgentComposerInner = ({
 
   const abortAgentSession = useCallback(async () => {
     logger.info('Aborting agent session', { sessionTopicId })
-    await chatStop()
+    try {
+      await chatStop()
+    } catch (error) {
+      logger.error('Failed to abort agent session', { sessionTopicId, error })
+    }
   }, [chatStop, sessionTopicId])
 
   const handleAgentChange = useCallback(

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -14,6 +14,7 @@ import { IpcChannel } from '@shared/IpcChannel'
 import type { AbsoluteFilePath } from '@shared/types/file'
 import type { LocalSkill } from '@shared/types/skill'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
+import { mockRendererLoggerService } from '@test-mocks/RendererLoggerService'
 import { act, fireEvent, render, renderHook, screen, waitFor, within } from '@testing-library/react'
 import { type ComponentProps, type ReactNode, useEffect, useRef } from 'react'
 import type * as ReactI18nextModule from 'react-i18next'
@@ -4511,6 +4512,30 @@ describe('AgentComposer', () => {
     fireEvent.click(screen.getByText('pause'))
 
     expect(mocks.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a failed active stream stop at the composer boundary', async () => {
+    const stopError = new Error('main abort failed')
+    mocks.stop.mockRejectedValueOnce(stopError)
+    const loggerError = vi.spyOn(mockRendererLoggerService, 'error').mockImplementation(() => {})
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming
+      />
+    )
+
+    fireEvent.click(screen.getByText('pause'))
+
+    await waitFor(() =>
+      expect(loggerError).toHaveBeenCalledWith('Failed to abort agent session', {
+        sessionTopicId: 'agent-session:session-1',
+        error: stopError
+      })
+    )
   })
 
   it('queues a follow-up while the agent session is streaming (does not send directly)', () => {

--- a/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
+++ b/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
@@ -83,6 +83,8 @@ describe('useChatWithHistory', () => {
     }))
 
     resumeStream.mockClear()
+    streamAbortMock.mockReset()
+    streamAbortMock.mockResolvedValue(undefined)
     setMessages.mockClear()
     stop.mockClear()
     sendMessage.mockClear()
@@ -310,6 +312,30 @@ describe('useChatWithHistory', () => {
 
     expect(streamAbortMock).toHaveBeenCalledWith({ topicId: 'topic-abort' })
     expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resolve stop() until the main-process stream has drained', async () => {
+    let finishDrain!: () => void
+    streamAbortMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishDrain = resolve
+      })
+    )
+    const refresh = vi.fn().mockResolvedValue(refreshedMessages)
+    const { result } = renderHook(() => useChatWithHistory('topic-abort', [], refresh))
+
+    const stopping = result.current.stop()
+    let settled = false
+    void stopping.then(() => {
+      settled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(stop).toHaveBeenCalledTimes(1)
+    expect(settled).toBe(false)
+
+    finishDrain()
+    await expect(stopping).resolves.toBeUndefined()
   })
 
   it('does not refresh on streaming → aborted/error because page handoff owns final refresh', async () => {

--- a/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
+++ b/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
@@ -338,6 +338,16 @@ describe('useChatWithHistory', () => {
     await expect(stopping).resolves.toBeUndefined()
   })
 
+  it('rejects stop() when the main-process stream cannot be aborted', async () => {
+    const abortError = new Error('main abort failed')
+    streamAbortMock.mockRejectedValueOnce(abortError)
+    const refresh = vi.fn().mockResolvedValue(refreshedMessages)
+    const { result } = renderHook(() => useChatWithHistory('topic-abort', [], refresh))
+
+    await expect(result.current.stop()).rejects.toBe(abortError)
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
   it('does not refresh on streaming → aborted/error because page handoff owns final refresh', async () => {
     for (const terminal of ['aborted', 'error'] as const) {
       const refresh = vi.fn().mockResolvedValue(refreshedMessages)

--- a/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
+++ b/src/renderer/hooks/__tests__/useChatWithHistory.test.ts
@@ -314,6 +314,24 @@ describe('useChatWithHistory', () => {
     expect(stop).toHaveBeenCalledTimes(1)
   })
 
+  it('starts the main-process abort before stopping the local SDK stream', async () => {
+    const calls: string[] = []
+    streamAbortMock.mockImplementationOnce(async () => {
+      calls.push('main-abort')
+    })
+    stop.mockImplementationOnce(async () => {
+      calls.push('sdk-stop')
+    })
+    const refresh = vi.fn().mockResolvedValue(refreshedMessages)
+    const { result } = renderHook(() => useChatWithHistory('topic-abort', [], refresh))
+
+    await act(async () => {
+      await result.current.stop()
+    })
+
+    expect(calls).toEqual(['main-abort', 'sdk-stop'])
+  })
+
   it('does not resolve stop() until the main-process stream has drained', async () => {
     let finishDrain!: () => void
     streamAbortMock.mockReturnValueOnce(
@@ -336,6 +354,31 @@ describe('useChatWithHistory', () => {
 
     finishDrain()
     await expect(stopping).resolves.toBeUndefined()
+  })
+
+  it('waits for the main-process drain before rejecting a local stop failure', async () => {
+    let finishDrain!: () => void
+    streamAbortMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishDrain = resolve
+      })
+    )
+    const stopError = new Error('local stop failed')
+    stop.mockRejectedValueOnce(stopError)
+    const refresh = vi.fn().mockResolvedValue(refreshedMessages)
+    const { result } = renderHook(() => useChatWithHistory('topic-abort', [], refresh))
+
+    const stopping = result.current.stop()
+    let settled = false
+    void stopping.catch(() => {
+      settled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(settled).toBe(false)
+
+    finishDrain()
+    await expect(stopping).rejects.toBe(stopError)
   })
 
   it('rejects stop() when the main-process stream cannot be aborted', async () => {

--- a/src/renderer/hooks/useChatWithHistory.ts
+++ b/src/renderer/hooks/useChatWithHistory.ts
@@ -69,9 +69,7 @@ export function useChatWithHistory(
   const stop = useCallback(async () => {
     await sdkStop()
     if (enabled) {
-      await ipcApi.request('ai.stream.abort', { topicId }).catch((err) => {
-        logger.warn('streamAbort failed', { topicId, err })
-      })
+      await ipcApi.request('ai.stream.abort', { topicId })
     }
   }, [enabled, sdkStop, topicId])
 

--- a/src/renderer/hooks/useChatWithHistory.ts
+++ b/src/renderer/hooks/useChatWithHistory.ts
@@ -67,10 +67,10 @@ export function useChatWithHistory(
   })
 
   const stop = useCallback(async () => {
-    await sdkStop()
-    if (enabled) {
-      await ipcApi.request('ai.stream.abort', { topicId })
-    }
+    const mainAbort = enabled ? ipcApi.request('ai.stream.abort', { topicId }) : Promise.resolve()
+    const [mainAbortResult, sdkStopResult] = await Promise.allSettled([mainAbort, sdkStop()])
+    if (mainAbortResult.status === 'rejected') throw mainAbortResult.reason
+    if (sdkStopResult.status === 'rejected') throw sdkStopResult.reason
   }, [enabled, sdkStop, topicId])
 
   const refreshRef = useRef(refresh)

--- a/src/renderer/hooks/useChatWithHistory.ts
+++ b/src/renderer/hooks/useChatWithHistory.ts
@@ -67,12 +67,12 @@ export function useChatWithHistory(
   })
 
   const stop = useCallback(async () => {
+    await sdkStop()
     if (enabled) {
-      void ipcApi.request('ai.stream.abort', { topicId }).catch((err) => {
+      await ipcApi.request('ai.stream.abort', { topicId }).catch((err) => {
         logger.warn('streamAbort failed', { topicId, err })
       })
     }
-    await sdkStop()
   }, [enabled, sdkStop, topicId])
 
   const refreshRef = useRef(refresh)

--- a/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
+++ b/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
@@ -1,14 +1,15 @@
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { invalidateMessages, streamOpen } = vi.hoisted(() => ({
+const { invalidateMessages, loggerError, streamOpen } = vi.hoisted(() => ({
   invalidateMessages: vi.fn(),
+  loggerError: vi.fn(),
   streamOpen: vi.fn()
 }))
 
 vi.mock('@data/DataApiService', () => ({ dataApiService: { get: vi.fn(), patch: vi.fn() } }))
 vi.mock('@logger', () => ({
-  loggerService: { withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }
+  loggerService: { withContext: () => ({ info: vi.fn(), warn: vi.fn(), error: loggerError }) }
 }))
 vi.mock('@renderer/ipc', () => ({
   ipcApi: { request: (_route: string, input: unknown) => streamOpen(input) }
@@ -57,7 +58,8 @@ function renderActions(
   uiMessages: ReturnType<typeof uiMsg>[],
   cache = makeCache(),
   activeNodeId = uiMessages.at(-1)?.id ?? null,
-  startNewContextBlocked = false
+  startNewContextBlocked = false,
+  stop: () => Promise<void> = vi.fn(async () => {})
 ) {
   const scrollToBottom = vi.fn()
   const regenerate = vi.fn(async () => {})
@@ -70,7 +72,7 @@ function renderActions(
       activeNodeId,
       regenerate,
       setMessages,
-      stop: vi.fn(async () => {}),
+      stop,
       refresh: vi.fn(async () => []),
       cache,
       seedReservedMessages,
@@ -87,6 +89,24 @@ function renderActions(
     seedReservedMessages
   }
 }
+
+describe('useChatWriteActions — pause', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('logs a failed stream stop instead of exposing a rejected pause callback', async () => {
+    const stopError = new Error('abort failed')
+    const stop = vi.fn<() => Promise<void>>().mockRejectedValueOnce(stopError)
+    const { actions } = renderActions([uiMsg('u1', 'user', 'vroot')], makeCache(), 'u1', false, stop)
+
+    const pauseResult = actions.pause() as unknown
+    if (pauseResult instanceof Promise) await expect(pauseResult).rejects.toBe(stopError)
+
+    expect(pauseResult).toBeUndefined()
+    await vi.waitFor(() =>
+      expect(loggerError).toHaveBeenCalledWith('Failed to pause chat stream', { topicId: 't1', error: stopError })
+    )
+  })
+})
 
 function clearMessage() {
   return {

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -519,6 +519,12 @@ export function useChatWriteActions(params: Params): Result {
     [setActiveNodeTrigger, topic.id]
   )
 
+  const handlePause = useCallback<ChatWriteActions['pause']>(() => {
+    void stop().catch((error) => {
+      logger.error('Failed to pause chat stream', { topicId: topic.id, error })
+    })
+  }, [stop, topic.id])
+
   const actions = useMemo<ChatWriteActions>(
     () => ({
       canStartNewContext,
@@ -528,7 +534,7 @@ export function useChatWriteActions(params: Params): Result {
       getMessageDeleteAvailability,
       deleteMessage: handleDeleteMessage,
       deleteMessageGroup: handleDeleteMessageGroup,
-      pause: stop,
+      pause: handlePause,
       editMessage: handleEditMessage,
       forkAndResend: handleForkAndResend,
       setActiveNode: handleSetActiveNode,
@@ -543,7 +549,7 @@ export function useChatWriteActions(params: Params): Result {
       getMessageDeleteAvailability,
       handleDeleteMessage,
       handleDeleteMessageGroup,
-      stop,
+      handlePause,
       handleEditMessage,
       handleForkAndResend,
       handleSetActiveNode,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Stopping an Agent Session could resolve before Main finished terminal persistence and runtime teardown. An immediate same-topic retry could start a replacement connection while the previous connection, or an in-flight `driver.connect()`, was still alive. That overlap could produce an empty or stalled retry reported as `AgentRuntimeError: No response`. It could also lose the Claude Code resume handoff and start a new CLI session, causing the SDK-owned Git status snapshot to be regenerated mid-conversation. Renderer Stop swallowed Main abort failures, and runtime close barriers removed from the active-entry map were invisible to write-quiesce drains.

After this PR:

Renderer Stop ends local stream consumption immediately and then awaits Main's abort-and-drain contract. Main holds the same-topic dispatch lock until terminal persistence, the current Agent runtime connection, and any pending connection attempt have settled. A per-session close barrier carries teardown and resume-token handoff across entry replacement, closes stale connections produced by late attempts, remains visible to backup/restore drains, and does not block unrelated topics or sessions. The retried turn is admitted only after this teardown completes, preventing empty or stalled retry streams. Main abort failures propagate to the composer boundary for centralized logging instead of being reported as a successful Stop.

Claude Code's Git status snapshot remains owned by the Claude Code SDK. Normal Stop/Continue keeps the same CLI session; if the SDK resume history is genuinely unavailable, the runtime starts a new CLI session only with the existing explicit conversation-reset notice.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19040, fixes #19119

### Why we need it and why it was done in this way

#19040 and #19119 are two symptoms of the same Stop/Retry lifecycle race. A replacement connection could overlap the aborted Claude SDK query, returning an empty or stalled stream; losing the resume token across that boundary could also restart the Claude Code CLI conversation and refresh its Git status snapshot. The smallest correct fix is to preserve session identity and serialize teardown across Stop/Continue rather than duplicate Git state inside Cherry Studio.

Main owns active streams, persistence, runtime connections, resume tokens, and cross-window coordination, making it the authoritative teardown boundary. Renderer keeps local Stop responsive through AI SDK's `stop()`, then awaits that Main-owned boundary through IPC.

The keyed `closingSessions` barrier is intentionally narrow: it joins concurrent closes, survives runtime-entry replacement, transfers the last known resume token, and releases only after all connection work has drained. Backup/restore quiescing observes the same barrier so external runtime writes cannot outlive its drain verdict.

The following tradeoffs were made:

- The Stop promise now includes real persistence and runtime teardown latency. Local consumption still stops immediately, but an immediate retry intentionally waits for correctness.
- The runtime service keeps a small per-session closing registry to bridge connection generations. In exchange, unrelated sessions and topics remain concurrent.
- Teardown uses `Promise.allSettled` so every owned resource gets a close opportunity before the barrier releases, even if one cleanup rejects.
- A genuinely unrecoverable Claude Code resume still creates a new SDK session and therefore a new SDK snapshot, but the existing conversation-reset notice makes that boundary explicit instead of silently presenting it as the same conversation.

The following alternatives were considered:

- Maintaining a Cherry-owned frozen Git snapshot was rejected because it would duplicate Claude Code SDK responsibility and could diverge from the SDK's actual session lifecycle.
- Renderer-only stopping state was rejected because it cannot coordinate other windows or observe Main-owned resources.
- Waiting only for the current connection was rejected because an unresolved `driver.connect()` can later produce another live connection.
- A global teardown barrier was rejected because it would serialize unrelated sessions.
- A broader session lifecycle/state-machine rewrite was deferred because the keyed barrier fixes the concrete ownership race with a smaller contract change.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

- https://github.com/CherryHQ/cherry-studio/issues/19040
- https://github.com/CherryHQ/cherry-studio/issues/19119
- Supersedes https://github.com/CherryHQ/cherry-studio/pull/19183

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This PR includes and extends the lifecycle fix proposed in #19183. Regression coverage uses deferred connect and close promises to prove that an immediate retry cannot issue its second `driver.connect()` until the late stale connection has finished closing, and that the previous resume token reaches the successor. Additional tests cover repeated and replacement-entry closes, same-topic admission through terminal persistence, continuation loops launched during terminal handling, write-quiesce drains for detached runtime-close barriers, and Main abort failure propagation through the renderer boundary. The canonical Agent Session runtime documentation is synchronized with the awaited Stop and drain contracts.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed an issue where stopping and immediately retrying an Agent Session could return an empty or stalled response, or restart Claude Code without its previous resume state and refresh the SDK-owned Git status snapshot.
```
