### PR TITLE
fix(provider-registry): distinguish integer image ranges

### DIFF
--- a/packages/provider-registry/data/models.json
+++ b/packages/provider-registry/data/models.json
@@ -1784,7 +1784,7 @@
       "pricing": {
         "cacheRead": {
           "currency": "USD",
-          "perMillionTokens": 0.04
+          "perMillionTokens": 0.055
         },
         "cacheWrite": {
           "currency": "USD",
@@ -3111,7 +3111,7 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.13
+          "perMillionTokens": 0.14
         },
         "output": {
           "currency": "USD",
@@ -7718,11 +7718,11 @@
       "pricing": {
         "input": {
           "currency": "USD",
-          "perMillionTokens": 0.055
+          "perMillionTokens": 0.04
         },
         "output": {
           "currency": "USD",
-          "perMillionTokens": 0.14
+          "perMillionTokens": 0.13
         }
       },
       "reasoning": {
@@ -11111,6 +11111,7 @@
                 "default": 4.5,
                 "max": 20,
                 "min": 1,
+                "step": 0.1,
                 "type": "range"
               },
               "negativePrompt": {
@@ -21698,5 +21699,5 @@
       "ownedBy": "zhipu"
     }
   ],
-  "version": "7a8ec69b5981aea8"
+  "version": "0a900dcf6dab1f85"
 }

--- a/packages/provider-registry/src/__tests__/imageGenerationSupport.test.ts
+++ b/packages/provider-registry/src/__tests__/imageGenerationSupport.test.ts
@@ -72,7 +72,13 @@ describe('ImageGenerationSupportSchema', () => {
         }
       }
     })
-    expect(parsed.modes?.generate?.supports.numImages).toEqual({ type: 'range', min: 1, max: 1, default: 1 })
+    expect(parsed.modes?.generate?.supports.numImages).toEqual({
+      type: 'range',
+      min: 1,
+      max: 1,
+      default: 1,
+      step: 1
+    })
   })
 
   it('FLUX.1-Kontext-pro: safetyTolerance range with default 6', () => {
@@ -91,7 +97,52 @@ describe('ImageGenerationSupportSchema', () => {
       type: 'range',
       min: 0,
       max: 6,
-      default: 6
+      default: 6,
+      step: 1
+    })
+  })
+
+  it('defaults count ranges to an integer step and rejects fractional counts', () => {
+    const parsed = ImageGenerationSupportSchema.parse({
+      modes: {
+        generate: {
+          supports: { numImages: { type: 'range', min: 1, max: 4, default: 1 } }
+        }
+      }
+    })
+    expect(parsed.modes?.generate?.supports.numImages).toEqual({
+      type: 'range',
+      min: 1,
+      max: 4,
+      default: 1,
+      step: 1
+    })
+
+    expect(() =>
+      ImageGenerationSupportSchema.parse({
+        modes: {
+          generate: {
+            supports: { numImages: { type: 'range', min: 1, max: 4, default: 2.5 } }
+          }
+        }
+      })
+    ).toThrow()
+  })
+
+  it('preserves fractional continuous ranges', () => {
+    const parsed = ImageGenerationSupportSchema.parse({
+      modes: {
+        generate: {
+          supports: { guidanceScale: { type: 'range', min: 1, max: 20, default: 4.5, step: 0.1 } }
+        }
+      }
+    })
+    expect(parsed.modes?.generate?.supports.guidanceScale).toEqual({
+      type: 'range',
+      min: 1,
+      max: 20,
+      default: 4.5,
+      step: 0.1
     })
   })
 

--- a/packages/provider-registry/src/creators/kling.ts
+++ b/packages/provider-registry/src/creators/kling.ts
@@ -78,6 +78,7 @@ export default defineCreator({
                 default: 4.5,
                 max: 20,
                 min: 1,
+                step: 0.1,
                 type: 'range'
               },
               negativePrompt: {

--- a/packages/provider-registry/src/schemas/model.ts
+++ b/packages/provider-registry/src/schemas/model.ts
@@ -254,7 +254,19 @@ const RangeSpecSchema = z
     min: z.number(),
     max: z.number(),
     default: z.number().optional(),
+    /** Omitted means the numeric input accepts any precision; renderers may
+     *  still choose an interaction step for controls such as sliders. */
     step: z.number().optional()
+  })
+  .refine((r) => r.min <= r.max, { message: 'min must be ≤ max' })
+
+export const RangeIntSpecSchema = z
+  .object({
+    type: z.literal('range'),
+    min: z.number().int(),
+    max: z.number().int(),
+    default: z.number().int().optional(),
+    step: z.number().int().positive().default(1)
   })
   .refine((r) => r.min <= r.max, { message: 'min must be ≤ max' })
 
@@ -282,6 +294,29 @@ export const SupportSpecSchema = z.discriminatedUnion('type', [
   TextSpecSchema
 ])
 
+const INTEGER_RANGE_PARAM_KEYS = [
+  CANONICAL_PARAM_KEY.NUM_IMAGES,
+  CANONICAL_PARAM_KEY.MAX_IMAGES,
+  CANONICAL_PARAM_KEY.NUM_INFERENCE_STEPS,
+  CANONICAL_PARAM_KEY.SAFETY_TOLERANCE,
+  CANONICAL_PARAM_KEY.OUTPUT_COMPRESSION
+] as const
+
+const ImageSupportsSchema = z.partialRecord(CanonicalParamKeySchema, SupportSpecSchema).transform((supports, ctx) => {
+  const normalized = { ...supports }
+  for (const key of INTEGER_RANGE_PARAM_KEYS) {
+    const spec = supports[key]
+    if (spec === undefined) continue
+    const result = RangeIntSpecSchema.safeParse(spec)
+    if (result.success) {
+      normalized[key] = result.data
+    } else {
+      for (const issue of result.error.issues) ctx.addIssue({ ...issue, path: [key, ...issue.path] })
+    }
+  }
+  return normalized
+})
+
 /**
  * Per-mode model capability declaration. The renderer iterates `supports`
  * and dispatches `specToField` by `spec.type`; no per-vendor logic. `supports`
@@ -299,7 +334,7 @@ export const SupportSpecSchema = z.discriminatedUnion('type', [
  * instead of a hand-maintained routing table.
  */
 const ImageModeDefSchema = z.object({
-  supports: z.partialRecord(CanonicalParamKeySchema, SupportSpecSchema),
+  supports: ImageSupportsSchema,
   maxInputImages: z.number().int().positive().optional(),
   vendorTransport: z
     .object({


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Image count parameters and continuous parameters shared the same range schema. Fractional values such as `numImages: 2.5` could therefore pass registry validation.

After this PR:

Count-like image parameters use an integer range schema with a default step of `1`, while continuous parameters retain decimal support. Kolors `guidanceScale` explicitly uses a `0.1` step.

Fixes #19249

### Why we need it and why it was done in this way

The registry is the earliest reliable enforcement point and is already validated by catalog invariant tests. The existing `type: "range"` wire format remains unchanged, avoiding a registry schema-version change.

The following tradeoffs were made:

Integer semantics are selected by canonical parameter key. This keeps existing provider entries compatible and avoids modifying every count entry.

The following alternatives were considered:

Adding a new `rangeInt` wire type was rejected because it would break older catalog consumers. Restricting only the painting number input was rejected because it would leave invalid registry data possible and would break legitimate continuous values.

Links to places where the discussion took place: #19249

### Breaking changes

None. The registry wire format remains unchanged.

### Special notes for your reviewer

Validated with:

- Provider Registry build
- Registry compatibility check
- All 326 Provider Registry tests
- Generated catalog validation

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Image-generation count parameters now reject fractional values while continuous controls retain decimal precision.
```
