### PR TITLE
fix(agent): discover workspace .agents skills

### DIFF
--- a/src/main/ai/runtime/dsh/dshConnectionSignature.test.ts
+++ b/src/main/ai/runtime/dsh/dshConnectionSignature.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getModel: vi.fn(),
   getApiKeys: vi.fn(),
   listSkills: vi.fn(),
+  listLocalSkillPaths: vi.fn(),
   getSkillDirectory: vi.fn(),
   findMcp: vi.fn(),
   listTools: vi.fn(),
@@ -26,7 +27,11 @@ vi.mock('@data/services/AgentChannelService', () => ({
   agentChannelService: { findBySessionId: mocks.findBySessionId }
 }))
 vi.mock('@main/ai/skills/SkillService', () => ({
-  skillService: { list: mocks.listSkills, getSkillDirectory: mocks.getSkillDirectory }
+  skillService: {
+    list: mocks.listSkills,
+    listLocalSkillPaths: mocks.listLocalSkillPaths,
+    getSkillDirectory: mocks.getSkillDirectory
+  }
 }))
 
 vi.mock('@main/ai/runtime/dsh/modelInjection', () => ({ resolveDshInjectionApi: vi.fn(() => undefined) }))
@@ -55,6 +60,7 @@ beforeEach(() => {
   mocks.getModel.mockResolvedValue({ id: 'provider::model', updatedAt: 1 })
   mocks.getApiKeys.mockReturnValue([{ id: 'key-1', key: 'secret', enabled: true }])
   mocks.listSkills.mockResolvedValue([{ id: 'skill-1', isEnabled: true, updatedAt: 1 }])
+  mocks.listLocalSkillPaths.mockResolvedValue([])
   mocks.getSkillDirectory.mockImplementation((folderName: string) => `/skills/${folderName}`)
   mocks.findMcp.mockReturnValue({ id: 'mcp-1', name: 'server', updatedAt: 1 })
   mocks.listTools.mockReturnValue([{ name: 'search', inputSchema: { type: 'object' } }])
@@ -85,6 +91,7 @@ describe('captureDshConnectionSnapshot', () => {
       () => mocks.getModel.mockResolvedValueOnce({ id: 'provider::model', updatedAt: 2 }),
       () => mocks.getApiKeys.mockReturnValueOnce([{ id: 'key-2', key: 'rotated', enabled: true }]),
       () => mocks.listSkills.mockResolvedValueOnce([{ id: 'skill-2', isEnabled: true, updatedAt: 1 }]),
+      () => mocks.listLocalSkillPaths.mockResolvedValueOnce(['/workspace/.agents/skills/review']),
       () => mocks.findMcp.mockReturnValueOnce({ id: 'mcp-1', name: 'server', updatedAt: 2 }),
       () => mocks.listTools.mockReturnValueOnce([{ name: 'changed' }]),
       () => mocks.findBySessionId.mockReturnValueOnce({ id: 'channel-1', agentId: agent.id })
@@ -100,6 +107,7 @@ describe('captureDshConnectionSnapshot', () => {
 
   it('returns the exact provider, model, skills, MCP, and channel facts signed by the snapshot', async () => {
     mocks.listSkills.mockResolvedValue([{ id: 'skill-1', folderName: 'pdf', isEnabled: true }])
+    mocks.listLocalSkillPaths.mockResolvedValue(['/workspace/.agents/skills/review'])
     mocks.findBySessionId.mockReturnValue({ id: 'channel-1', agentId: agent.id })
 
     const snapshot = await captureDshConnectionSnapshot('session-1', agent.id, 'provider::model')
@@ -108,7 +116,7 @@ describe('captureDshConnectionSnapshot', () => {
       provider: { id: 'provider' },
       model: { id: 'provider::model' },
       enabledApiKeys: [{ id: 'key-1', key: 'secret', enabled: true }],
-      additionalSkillPaths: ['/skills/pdf'],
+      additionalSkillPaths: ['/skills/pdf', '/workspace/.agents/skills/review'],
       linkedChannel: { id: 'channel-1' }
     })
     expect(snapshot.mcpServerSnapshots.get('mcp-1')).toMatchObject({ id: 'mcp-1', name: 'server' })

--- a/src/main/ai/runtime/dsh/dshConnectionSignature.ts
+++ b/src/main/ai/runtime/dsh/dshConnectionSignature.ts
@@ -64,10 +64,11 @@ export async function captureDshConnectionSnapshot(
 
   const modelId = requestedModelId ?? agent.model
   const parsed = parseUniqueModelId(modelId)
-  const [provider, model, skills] = await Promise.all([
+  const [provider, model, skills, workspaceSkillPaths] = await Promise.all([
     providerService.getByProviderId(parsed.providerId),
     modelService.getByKey(parsed.providerId, parsed.modelId),
-    skillService.list({ agentId: agent.id })
+    skillService.list({ agentId: agent.id }),
+    skillService.listLocalSkillPaths(session.workspace.path)
   ])
   const enabledSkills = skills.filter((skill) => skill.isEnabled)
   const mcpServerSnapshots = new Map<string, ReturnType<typeof mcpServerService.findByIdOrName>>()
@@ -96,6 +97,7 @@ export async function captureDshConnectionSnapshot(
           model,
           apiKeys,
           enabledSkills,
+          workspaceSkillPaths,
           mcpServers,
           mcpTools,
           linkedChannelId: linkedChannel?.id ?? null,
@@ -115,7 +117,10 @@ export async function captureDshConnectionSnapshot(
     provider,
     model,
     enabledApiKeys: apiKeys,
-    additionalSkillPaths: enabledSkills.map((skill) => skillService.getSkillDirectory(skill.folderName)),
+    additionalSkillPaths: [
+      ...enabledSkills.map((skill) => skillService.getSkillDirectory(skill.folderName)),
+      ...workspaceSkillPaths
+    ],
     mcpServerSnapshots,
     linkedChannel: linkedChannel ? { id: linkedChannel.id } : null,
     signature

--- a/src/main/ai/runtime/pi/piConnectionSignature.test.ts
+++ b/src/main/ai/runtime/pi/piConnectionSignature.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getModel: vi.fn(),
   getApiKeys: vi.fn(),
   listSkills: vi.fn(),
+  listLocalSkillPaths: vi.fn(),
   getSkillDirectory: vi.fn(),
   findMcp: vi.fn(),
   listTools: vi.fn(),
@@ -26,7 +27,11 @@ vi.mock('@data/services/AgentChannelService', () => ({
   agentChannelService: { findBySessionId: mocks.findBySessionId }
 }))
 vi.mock('@main/ai/skills/SkillService', () => ({
-  skillService: { list: mocks.listSkills, getSkillDirectory: mocks.getSkillDirectory }
+  skillService: {
+    list: mocks.listSkills,
+    listLocalSkillPaths: mocks.listLocalSkillPaths,
+    getSkillDirectory: mocks.getSkillDirectory
+  }
 }))
 
 const { capturePiConnectionSnapshot } = await import('./piConnectionSignature')
@@ -52,6 +57,7 @@ beforeEach(() => {
   mocks.getModel.mockResolvedValue({ id: 'provider::model', updatedAt: 1 })
   mocks.getApiKeys.mockReturnValue([{ id: 'key-1', key: 'secret', enabled: true }])
   mocks.listSkills.mockResolvedValue([{ id: 'skill-1', isEnabled: true, updatedAt: 1 }])
+  mocks.listLocalSkillPaths.mockResolvedValue([])
   mocks.getSkillDirectory.mockImplementation((folderName: string) => `/skills/${folderName}`)
   mocks.findMcp.mockReturnValue({ id: 'mcp-1', name: 'server', updatedAt: 1 })
   mocks.listTools.mockReturnValue([{ name: 'search', inputSchema: { type: 'object' } }])
@@ -81,6 +87,7 @@ describe('capturePiConnectionSnapshot', () => {
       () => mocks.getModel.mockResolvedValueOnce({ id: 'provider::model', updatedAt: 2 }),
       () => mocks.getApiKeys.mockReturnValueOnce([{ id: 'key-2', key: 'rotated', enabled: true }]),
       () => mocks.listSkills.mockResolvedValueOnce([{ id: 'skill-2', isEnabled: true, updatedAt: 1 }]),
+      () => mocks.listLocalSkillPaths.mockResolvedValueOnce(['/workspace/.agents/skills/review']),
       () => mocks.findMcp.mockReturnValueOnce({ id: 'mcp-1', name: 'server', updatedAt: 2 }),
       () => mocks.listTools.mockReturnValueOnce([{ name: 'changed' }]),
       () => mocks.findBySessionId.mockReturnValueOnce({ id: 'channel-1', agentId: agent.id })
@@ -96,6 +103,7 @@ describe('capturePiConnectionSnapshot', () => {
 
   it('returns the exact provider, model, skills, MCP, and channel facts signed by the snapshot', async () => {
     mocks.listSkills.mockResolvedValue([{ id: 'skill-1', folderName: 'pdf', isEnabled: true }])
+    mocks.listLocalSkillPaths.mockResolvedValue(['/workspace/.agents/skills/review'])
     mocks.findBySessionId.mockReturnValue({ id: 'channel-1', agentId: agent.id })
 
     const snapshot = await capturePiConnectionSnapshot('session-1', agent.id, 'provider::model')
@@ -104,7 +112,7 @@ describe('capturePiConnectionSnapshot', () => {
       provider: { id: 'provider' },
       model: { id: 'provider::model' },
       enabledApiKeys: [{ id: 'key-1', key: 'secret', enabled: true }],
-      additionalSkillPaths: ['/skills/pdf'],
+      additionalSkillPaths: ['/skills/pdf', '/workspace/.agents/skills/review'],
       linkedChannel: { id: 'channel-1' }
     })
     expect(snapshot.mcpServerSnapshots.get('mcp-1')).toMatchObject({ id: 'mcp-1', name: 'server' })

--- a/src/main/ai/runtime/pi/piConnectionSignature.ts
+++ b/src/main/ai/runtime/pi/piConnectionSignature.ts
@@ -60,10 +60,11 @@ export async function capturePiConnectionSnapshot(
 
   const modelId = requestedModelId ?? agent.model
   const parsed = parseUniqueModelId(modelId)
-  const [provider, model, skills] = await Promise.all([
+  const [provider, model, skills, workspaceSkillPaths] = await Promise.all([
     providerService.getByProviderId(parsed.providerId),
     modelService.getByKey(parsed.providerId, parsed.modelId),
-    skillService.list({ agentId: agent.id })
+    skillService.list({ agentId: agent.id }),
+    skillService.listLocalSkillPaths(session.workspace.path)
   ])
   const enabledSkills = skills.filter((skill) => skill.isEnabled)
   const mcpServerSnapshots = new Map<string, ReturnType<typeof mcpServerService.findByIdOrName>>()
@@ -92,6 +93,7 @@ export async function capturePiConnectionSnapshot(
           model,
           apiKeys,
           enabledSkills,
+          workspaceSkillPaths,
           mcpServers,
           mcpTools,
           linkedChannelId: linkedChannel?.id ?? null,
@@ -107,7 +109,10 @@ export async function capturePiConnectionSnapshot(
     provider,
     model,
     enabledApiKeys: apiKeys,
-    additionalSkillPaths: enabledSkills.map((skill) => skillService.getSkillDirectory(skill.folderName)),
+    additionalSkillPaths: [
+      ...enabledSkills.map((skill) => skillService.getSkillDirectory(skill.folderName)),
+      ...workspaceSkillPaths
+    ],
     mcpServerSnapshots,
     linkedChannel: linkedChannel ? { id: linkedChannel.id } : null,
     signature

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -218,9 +218,7 @@ export class SkillService {
     return this.installSkillDir(canonicalPath, 'local', pathToFileURL(canonicalPath).href)
   }
 
-  /**
-   * List local skills from an agent workdir's .claude/skills/ directory.
-   */
+  /** List user-owned workspace skills from supported project skill roots. */
   async listLocal(workdir: string): Promise<Array<{ name: string; description?: string; filename: string }>> {
     const results: Array<{ name: string; description?: string; filename: string }> = []
 
@@ -256,22 +254,35 @@ export class SkillService {
     return names
   }
 
-  private async listLocalSkillDirectories(workdir: string): Promise<Array<{ name: string; path: string }>> {
-    const skillsDir = path.join(workdir, '.claude', 'skills')
-    const results: Array<{ name: string; path: string }> = []
+  /** Resolve workspace skill directories for runtimes that accept explicit skill paths. */
+  async listLocalSkillPaths(workdir: string): Promise<string[]> {
+    const paths: string[] = []
+    for (const skill of await this.listLocalSkillDirectories(workdir)) {
+      if (await findSkillMdPath(skill.path)) paths.push(skill.path)
+    }
+    return paths
+  }
 
-    try {
-      const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true })
-      for (const entry of entries) {
-        if (!(await this.isLocalSkillDirectoryEntry(skillsDir, entry))) continue
-        results.push({ name: entry.name, path: path.join(skillsDir, entry.name) })
+  private async listLocalSkillDirectories(workdir: string): Promise<Array<{ name: string; path: string }>> {
+    const results: Array<{ name: string; path: string }> = []
+    const seenNames = new Set<string>()
+
+    // Keep the existing Claude-specific root first when duplicate folder names exist.
+    for (const skillsDir of [path.join(workdir, '.claude', 'skills'), path.join(workdir, '.agents', 'skills')]) {
+      try {
+        const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true })
+        for (const entry of entries) {
+          if (seenNames.has(entry.name) || !(await this.isLocalSkillDirectoryEntry(skillsDir, entry))) continue
+          seenNames.add(entry.name)
+          results.push({ name: entry.name, path: path.join(skillsDir, entry.name) })
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue
+        logger.warn('Failed to enumerate skills directory', {
+          skillsDir,
+          error: error instanceof Error ? error.message : String(error)
+        })
       }
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return results
-      logger.warn('Failed to enumerate skills directory', {
-        skillsDir,
-        error: error instanceof Error ? error.message : String(error)
-      })
     }
 
     return results
@@ -380,7 +391,7 @@ export class SkillService {
 
   /**
    * `listLocal` is only for user/project-owned workspace skills that already
-   * live under `.claude/skills/`. Those entries can be real directories or
+   * live under `.claude/skills/` or `.agents/skills/`. Those entries can be real directories or
    * user-created symlinks to directories.
    *
    * Cherry-managed skills also appear under `.claude/skills/` as app-owned mirror

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -334,6 +334,37 @@ describe('SkillService', () => {
       })
     })
 
+    it('discovers .agents skills and keeps .claude precedence for duplicate folder names', async () => {
+      const skillService = new SkillService()
+      const workdir = await createTempDir('skill-local-workdir-')
+      const claudeSkill = path.join(workdir, '.claude', 'skills', 'shared-skill')
+      const agentSharedSkill = path.join(workdir, '.agents', 'skills', 'shared-skill')
+      const agentOnlySkill = path.join(workdir, '.agents', 'skills', 'agent-only')
+      await Promise.all([
+        fs.promises.mkdir(claudeSkill, { recursive: true }),
+        fs.promises.mkdir(agentSharedSkill, { recursive: true }),
+        fs.promises.mkdir(agentOnlySkill, { recursive: true })
+      ])
+      await Promise.all([
+        fs.promises.writeFile(path.join(claudeSkill, 'SKILL.md'), '# Claude skill'),
+        fs.promises.writeFile(path.join(agentSharedSkill, 'SKILL.md'), '# Agent shared skill'),
+        fs.promises.writeFile(path.join(agentOnlySkill, 'SKILL.md'), '# Agent-only skill')
+      ])
+
+      const result = await skillService.listLocal(workdir)
+
+      expect(result.map((skill) => skill.filename).sort()).toEqual(['agent-only', 'shared-skill'])
+      expect(parseSkillMetadata).toHaveBeenCalledWith(claudeSkill, 'shared-skill', 'skills', {
+        calculateSize: false
+      })
+      expect(parseSkillMetadata).not.toHaveBeenCalledWith(
+        agentSharedSkill,
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      )
+    })
+
     it('skips Cherry-managed skill symlinks that point to the global skill storage', async () => {
       const skillService = new SkillService()
       const workdir = await createTempDir('skill-local-workdir-')
@@ -401,6 +432,22 @@ describe('SkillService', () => {
 
       expect(result).toEqual(['valid-skill'])
       expect(parseSkillMetadata).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('listLocalSkillPaths', () => {
+    it('returns valid skill directories from both workspace roots', async () => {
+      const skillService = new SkillService()
+      const workdir = await createTempDir('skill-local-paths-workdir-')
+      const claudeSkill = path.join(workdir, '.claude', 'skills', 'claude-skill')
+      const agentSkill = path.join(workdir, '.agents', 'skills', 'agent-skill')
+      await Promise.all([
+        fs.promises.mkdir(claudeSkill, { recursive: true }),
+        fs.promises.mkdir(agentSkill, { recursive: true })
+      ])
+      vi.mocked(findSkillMdPath).mockImplementation(async (skillPath) => path.join(skillPath, 'SKILL.md'))
+
+      await expect(skillService.listLocalSkillPaths(workdir)).resolves.toEqual([claudeSkill, agentSkill])
     })
   })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Agent sessions automatically discovered workspace skills under `.claude/skills`, but ignored compatible skills stored under `.agents/skills`.

After this PR:

Workspace skills are discovered from both `.claude/skills` and `.agents/skills`. Duplicate skill folder names preserve `.claude/skills` precedence, and discovered paths are included in Pi and DSH connection signatures.

Fixes #19241

### Why we need it and why it was done in this way

Supporting both conventional workspace roots makes repository-provided skills available without manual file discovery. Reusing `SkillService` keeps symlink validation and directory checks centralized.

The following tradeoffs were made:

Skills are deduplicated by folder name, with the existing `.claude/skills` location taking precedence for compatibility.

The following alternatives were considered:

Scanning arbitrary workspace directories was rejected because it would be unpredictable and unnecessarily broad. Handling discovery independently in each runtime was rejected to avoid divergent behavior.

Links to places where the discussion took place: #19241

### Breaking changes

None.

### Special notes for your reviewer

Connection signatures include workspace skill paths so runtime connections are recreated when the discovered skill set changes.

Validated with:

- 99 SkillService and Pi/DSH signature tests
- Main-process type checking
- Biome formatting and diff checks

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Agent sessions now automatically discover workspace skills stored under .agents/skills.
```
