### PR TITLE
fix(composer): preserve pasted screenshots with text flavors

### DIFF
--- a/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
@@ -168,6 +168,44 @@ describe('pasteHandling', () => {
     })
   })
 
+  it('attaches a supported screenshot when the clipboard also exposes a text flavor', async () => {
+    const tempImageFile: FileMetadata = {
+      ...selectedFile,
+      name: 'temp_file_123_image.png',
+      origin_name: 'temp_file_123_image.png',
+      path: '/tmp/temp_file_123_image.png',
+      ext: '.png',
+      type: FILE_TYPE.IMAGE
+    }
+    const clipboardImage = {
+      name: 'image.png',
+      type: 'image/png',
+      arrayBuffer: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
+    } as unknown as File
+    vi.mocked(window.api.file.createTempFile).mockResolvedValue(tempImageFile.path)
+    vi.mocked(window.api.file.get).mockResolvedValue(tempImageFile)
+
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: (type: string) => (type === 'text' ? 'clipboard image' : ''),
+        files: [clipboardImage]
+      }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(event, ['.png'], setFiles)
+
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalledOnce()
+    expect(window.api.file.write).toHaveBeenCalledWith(tempImageFile.path, new Uint8Array([1, 2, 3]))
+    expect(files).toHaveLength(1)
+    expect(files[0]).toMatchObject({ path: tempImageFile.path, ext: '.png', type: FILE_TYPE.IMAGE })
+  })
+
   describe('handler registration and lifecycle', () => {
     it('registers a handler and allows manual unregistration', () => {
       const handler = vi.fn().mockResolvedValue(true)

--- a/src/renderer/components/composer/paste/pasteHandling.ts
+++ b/src/renderer/components/composer/paste/pasteHandling.ts
@@ -38,9 +38,17 @@ export const handlePaste = async (
   t?: (key: string) => string
 ): Promise<boolean> => {
   try {
-    // 优先处理文本粘贴
+    const clipboardFiles = Array.from(event.clipboardData?.files ?? [])
+    // Windows screenshot clipboards can expose both a text flavor and image bytes. Prefer the
+    // supported image in that case; letting the editor handle the text flavor can render a preview
+    // without ever adding an attachment to composer state.
+    const hasSupportedClipboardImage = clipboardFiles.some(
+      (file) => file.type.startsWith('image/') && supportExts.includes(getFileExtension(file.name))
+    )
+
+    // 优先处理文本粘贴，除非剪贴板同时包含当前会话支持的图像。
     const clipboardText = event.clipboardData?.getData('text')
-    if (clipboardText) {
+    if (clipboardText && !hasSupportedClipboardImage) {
       // 1. 文本粘贴
       if (clipboardText.length > LONG_TEXT_PASTE_THRESHOLD) {
         if (!supportExts.includes(PASTED_TEXT_FILE_EXTENSION)) return false
@@ -67,11 +75,11 @@ export const handlePaste = async (
       return false
     }
     // 2. 文件/图片粘贴（仅在无文本时处理）
-    if (event.clipboardData?.files && event.clipboardData.files.length > 0) {
+    if (clipboardFiles.length > 0) {
       event.preventDefault()
       const extensionSet = new Set(supportExts)
       try {
-        for (const file of event.clipboardData.files) {
+        for (const file of clipboardFiles) {
           // 使用新的API获取文件路径
           const filePath = window.api.file.getPathForFile(file)
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

When the Windows clipboard exposed both an image file and a text flavor, paste handling selected the text path first. The image could appear in the editor but never enter the composer attachment state sent to the model.

After this PR:

Supported clipboard images take precedence over accompanying text flavors and are written to the temporary attachment path before being added to composer state. Text-only paste behavior remains unchanged.

Fixes #19248

### Why we need it and why it was done in this way

Windows screenshot tools can expose several clipboard representations for the same screenshot. The attachment pipeline already works correctly once it receives the image bytes, so the fix belongs at clipboard-format selection rather than in message serialization.

The following tradeoffs were made:

For mixed clipboard payloads containing a supported image, the image is prioritized. Text-only payloads and unsupported file formats continue through their existing paths.

The following alternatives were considered:

Changing the downstream Agent message format was rejected because uploaded attachments already prove that path works. Sending both clipboard representations was avoided because the accompanying text flavor can be metadata rather than intentional user content.

Links to places where the discussion took place: #19248

### Breaking changes

None.

### Special notes for your reviewer

Added a Windows-style regression test where clipboard data exposes both text and image formats. It verifies that the image bytes are persisted and added as a composer attachment.

Validated with:

- 8 focused paste-handling tests
- Renderer type checking
- Biome formatting and diff checks

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fixed pasted Windows screenshots not being delivered to models when the clipboard also contains a text flavor.
```
