### PR TITLE
fix(agent): add back navigation to subagent flows

### DIFF
--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -64,6 +64,7 @@ import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { createFilePathHandle, type TreeDirRoot } from '@shared/utils/file'
 import {
   Activity,
+  ArrowLeft,
   Bot,
   CheckCircle,
   Circle,
@@ -110,6 +111,7 @@ const logger = loggerService.withContext('AgentRightPane')
 // ── Agent-specific composition over the generic right panel ─────────────────
 
 const FLOW_TAB_PREFIX = 'flow:'
+const STATUS_PANE_ID = 'status'
 const FALLBACK_TIMESTAMP = '1970-01-01T00:00:00.000Z'
 
 const TracePane = lazy(() =>
@@ -812,6 +814,28 @@ function AgentFlowRightPanel({ active, panelId, scope }: RightPanelComponentProp
   )
 }
 
+function AgentFlowPanelTitle({ title }: { title: string }) {
+  const panelActions = useRightPanelActions()
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-w-0 items-center gap-0.5">
+      <Tooltip content={t('common.back')} delay={800}>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label={t('common.back')}
+          onClick={() => panelActions.tryOpen(STATUS_PANE_ID)}>
+          <ArrowLeft size={16} />
+        </Button>
+      </Tooltip>
+      <span className="min-w-0 flex-1 truncate px-1">{title}</span>
+    </div>
+  )
+}
+
 /**
  * Stops one background task without touching the turn. The runtime answers with a task notification
  * carrying status `stopped`, so the row updates from that rather than from optimistic local state;
@@ -1194,7 +1218,7 @@ const AGENT_RIGHT_PANEL_CAPABILITIES = [
   {
     component: AgentStatusRightPanel,
     resolve: (scope) => ({
-      id: 'status',
+      id: STATUS_PANE_ID,
       instanceKey: `session:${scope.meta.sessionId ?? ''}`,
       title: scope.statusTitle,
       readiness: scope.meta.conversationState
@@ -1209,7 +1233,7 @@ const AGENT_RIGHT_PANEL_CAPABILITIES = [
       return {
         id: getFlowTabValue(tab.toolCallId),
         instanceKey: `session:${scope.meta.sessionId ?? ''}:flow:${tab.toolCallId}`,
-        title: tab.title,
+        title: <AgentFlowPanelTitle title={tab.title} />,
         readiness: scope.meta.conversationState
       }
     }
@@ -1355,11 +1379,11 @@ function AgentRightPaneStatusShortcut({ disabled }: { disabled?: boolean }) {
   const panelState = useRightPanelState()
   const panelActions = useRightPanelActions()
   const { t } = useTranslation()
-  if (disabled || panelState.presentationMaximized || !panelActions.canOpen('status')) return null
+  if (disabled || panelState.presentationMaximized || !panelActions.canOpen(STATUS_PANE_ID)) return null
 
   const shortcut = (
     <RightPanelShortcut
-      tab="status"
+      tab={STATUS_PANE_ID}
       label={t('agent.right_pane.tabs.status')}
       icon={<Activity className="size-3.5" />}
       tooltip={false}

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -1153,6 +1153,30 @@ describe('AgentRightPane', () => {
     expect(screen.getByTestId('shell-tab-title')).toHaveTextContent('Inspect task state')
   })
 
+  it('returns from a subagent flow to the status panel', async () => {
+    const user = userEvent.setup()
+
+    renderStatusTasks([
+      {
+        id: 'subagent-1',
+        status: 'in_progress',
+        title: 'Inspect task state',
+        taskType: 'local_agent',
+        toolUseId: 'tool-use-1'
+      }
+    ])
+
+    const rightPane = screen.getByTestId('right-pane')
+    await user.click(within(rightPane).getByRole('button', { name: /Inspect task state/ }))
+
+    expect(screen.getByTestId('shell-tab-title')).toHaveTextContent('Inspect task state')
+
+    await user.click(screen.getByRole('button', { name: 'common.back' }))
+
+    expect(screen.getByTestId('shell-tab-title')).toHaveTextContent('agent.right_pane.tabs.status')
+    expect(screen.getByText('agent.right_pane.info.subagents')).toBeInTheDocument()
+  })
+
   it('shows a dsh todo_write snapshot in the floating task capsule', () => {
     const todoPart = {
       type: 'dynamic-tool',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Subagent flow details in the Agent right pane did not provide an in-panel way to return to the task status list.

<img width="804" height="391" alt="image" src="https://github.com/user-attachments/assets/d16ee702-e0c0-4858-b2c0-954b0896eaf9" />

After this PR:

Subagent flow headers include an accessible Back action that returns to the Agent status panel. A regression test covers the drill-down and return path.
<img width="804" height="518" alt="image" src="https://github.com/user-attachments/assets/d7a6055e-03c3-45ee-b199-5efd17d28810" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The flow detail is a structural child of the task status list, so Back returns to that canonical parent while the existing Close action continues to control the right pane itself.

The following tradeoffs were made:

Back always targets the Agent status panel instead of recording entry-source history.

The following alternatives were considered:

Tracking arbitrary previous panels, closed state, or nested flow history was rejected because it would turn a local drill-down into a history stack without a product requirement.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This reuses the existing `common.back` translation and shared UI primitives; no locale additions are required.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added a back button to subagent flow details so users can return to the Agent status panel.
```
