### PR TITLE
feat(code-cli): pin fresh Code CLI installs to verified versions

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -161,6 +161,7 @@ Otherwise, ask the user to confirm before proceeding to Step 6.
        - [ ] Verify stable release notes are preserved in `resources/cherry-studio/release-history.json`
        - [ ] Verify version bump in `package.json`
        - [ ] Verify generated product manifest uses the release version
+       - [ ] Verify each `pinnedVersion` in `src/shared/data/presets/codeCliTools.ts` installs from a clean state and launches with the config Cherry writes for it; bump the pin to the newest version that passes
        - [ ] CI passes
        - [ ] Merge to trigger release build
 3. Report the PR URL and next steps.

--- a/src/main/services/BinaryManager.ts
+++ b/src/main/services/BinaryManager.ts
@@ -216,6 +216,15 @@ const FIXED_CATALOG: ReadonlyMap<string, FixedToolDefinition> = new Map<string, 
     { name: preset.executable, tool: preset.miseTool }
   ])
 ])
+// The verified version a Code CLI installs at when the caller named no version.
+// Resolved here rather than at each call site so every install entry point —
+// the Code page, the lazy first-launch install in CodeCliService, the MCP tool —
+// gets the same protection. Matched on the full recipe so a same-named custom
+// tool can never pick up a Code CLI's pin.
+const pinnedCodeCliVersion = (definition: FixedToolDefinition): string | undefined =>
+  CODE_CLI_TOOL_PRESETS.find((preset) => preset.executable === definition.name && preset.miseTool === definition.tool)
+    ?.pinnedVersion
+
 // Re-exported for main-process callers and tests.
 export { validateBinaryToolDefinition }
 
@@ -1141,7 +1150,10 @@ export class BinaryManager extends BaseService {
     targetVersion: string | undefined,
     definitions: CustomToolDefinition[]
   ): Promise<string> {
-    const requested = targetVersion ?? definition.requestedVersion ?? 'latest'
+    // The pin is the last fallback before 'latest', so an explicit one-shot target
+    // (upgrade, retry) and a custom definition's own version both still win, and
+    // it never reaches the applied-no-op or prune branches keyed on targetVersion.
+    const requested = targetVersion ?? definition.requestedVersion ?? pinnedCodeCliVersion(definition) ?? 'latest'
     const backend = definition.tool.split(':')[0]
     const defaultRuntime = RUNTIME_DEPS[backend]
     const runtimeName = defaultRuntime?.split('@')[0]

--- a/src/main/services/__tests__/BinaryManager.test.ts
+++ b/src/main/services/__tests__/BinaryManager.test.ts
@@ -1,7 +1,11 @@
 import type * as LifecycleModule from '@main/core/lifecycle'
 import { getPhase } from '@main/core/lifecycle/decorators'
 import { Phase } from '@main/core/lifecycle/types'
+import { CODE_CLI_TOOL_PRESET_MAP } from '@shared/data/presets/codeCliTools'
+import { CodeCli } from '@shared/types/codeCli'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const DSH_PIN = CODE_CLI_TOOL_PRESET_MAP[CodeCli.DEEPSEEK_HARNESS].pinnedVersion
 
 const { manifestRef, mockExecFileAsync, mockFs, mockFsp, mockPreferenceService, platformMock } = vi.hoisted(() => ({
   manifestRef: { value: [] as Array<{ name: string; tool: string; requestedVersion?: string }> },
@@ -2337,19 +2341,17 @@ describe('BinaryManager', () => {
         if (args[0] === 'latest') return { stdout: '22.23.2\n', stderr: '' }
         if (args[0] === 'ls' && args.length === 2) {
           return {
-            stdout: JSON.stringify(
-              installed ? { 'npm:@deepseek-ai/dsh': [{ version: '0.1.0-rc.6', active: true }] } : {}
-            ),
+            stdout: JSON.stringify(installed ? { 'npm:@deepseek-ai/dsh': [{ version: DSH_PIN, active: true }] } : {}),
             stderr: ''
           }
         }
         if (args[0] === 'ls') {
           return {
-            stdout: JSON.stringify({ 'npm:@deepseek-ai/dsh': [{ version: '0.1.0-rc.6', active: true }] }),
+            stdout: JSON.stringify({ 'npm:@deepseek-ai/dsh': [{ version: DSH_PIN, active: true }] }),
             stderr: ''
           }
         }
-        if (args.includes('npm:@deepseek-ai/dsh@latest')) installed = true
+        if (args.includes(`npm:@deepseek-ai/dsh@${DSH_PIN}`)) installed = true
         if (args[0] === 'which' && args[1] === 'node') {
           return { stdout: '/mock/mise/installs/node/22.23.2/bin/node\n', stderr: '' }
         }
@@ -2365,7 +2367,7 @@ describe('BinaryManager', () => {
       const useCalls = mockExecFileAsync.mock.calls.filter((call: any[]) => call[1][0] === 'use')
       expect(useCalls.map((call: any[]) => call[1])).toEqual([
         ['use', '-g', '--pin', 'node@22.23.2'],
-        ['use', '-g', '--minimum-release-age', '0s', 'npm:@deepseek-ai/dsh@latest']
+        ['use', '-g', '--minimum-release-age', '0s', `npm:@deepseek-ai/dsh@${DSH_PIN}`]
       ])
       expect(mockExecFileAsync.mock.calls.map((call: any[]) => call[1])).toContainEqual([
         'latest',
@@ -2768,6 +2770,71 @@ describe('BinaryManager', () => {
       expect(env['XDG_CONFIG_HOME']).toBe('/mock/feature.binary.data/xdg/config')
       expect(env['XDG_CACHE_HOME']).toBe('/mock/feature.binary.data/xdg/cache')
       expect(env['XDG_STATE_HOME']).toBe('/mock/feature.binary.data/xdg/state')
+    })
+  })
+
+  describe('Code CLI version pin', () => {
+    // The pin has to resolve here, not at the call site: CodeCliService.run installs
+    // name-only on first launch, so a renderer-side pin would leave that path on latest.
+    const installSpec = async (
+      definition: { name: string; tool: string; requestedVersion?: string },
+      targetVersion?: string
+    ): Promise<string | undefined> => {
+      const service = new BinaryManager()
+      ;(service as any).miseBin = '/mock/mise'
+      ;(service as any).isolatedEnv = { PATH: '/mock/mise/shims:/usr/bin' }
+      // mise reports back whatever version the install asked for, so the post-install
+      // check in getInstalledVersion passes and the assertion is about the spec sent.
+      let installedVersion = 'latest'
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'latest') return { stdout: '22.23.2\n', stderr: '' }
+        if (args[0] === 'use') {
+          installedVersion = args.at(-1)!.slice(definition.tool.length + 1)
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'ls') {
+          return {
+            stdout: JSON.stringify({ [definition.tool]: [{ version: installedVersion, active: true }] }),
+            stderr: ''
+          }
+        }
+        if (args[0] === 'which') return { stdout: `/mock/mise/shims/${definition.name}\n`, stderr: '' }
+        return { stdout: '', stderr: '' }
+      })
+
+      await (service as any).installWithMise(definition, targetVersion, [])
+
+      // Flattened across every `use` call: a shell-out tool pins its Node runtime
+      // in a separate `use` before the one carrying the tool spec.
+      return mockExecFileAsync.mock.calls
+        .flatMap((call: any[]) => (call[1][0] === 'use' ? call[1] : []))
+        .find((arg: string) => arg.startsWith(`${definition.tool}@`))
+    }
+
+    it('installs a pinned Code CLI at its pin when the caller named no version', async () => {
+      expect(DSH_PIN).toEqual(expect.stringMatching(/^\d+\.\d+\.\d+/))
+
+      await expect(installSpec({ name: 'dsh', tool: 'npm:@deepseek-ai/dsh' })).resolves.toBe(
+        `npm:@deepseek-ai/dsh@${DSH_PIN}`
+      )
+    })
+
+    it('lets an explicit target version override the pin, so an upgrade is never frozen', async () => {
+      await expect(installSpec({ name: 'dsh', tool: 'npm:@deepseek-ai/dsh' }, '0.9.9')).resolves.toBe(
+        'npm:@deepseek-ai/dsh@0.9.9'
+      )
+    })
+
+    it('leaves an unpinned Code CLI on latest', async () => {
+      expect(CODE_CLI_TOOL_PRESET_MAP[CodeCli.OPENAI_CODEX].pinnedVersion).toBeUndefined()
+
+      await expect(installSpec({ name: 'codex', tool: 'codex' })).resolves.toBe('codex@latest')
+    })
+
+    it('never applies a Code CLI pin to a same-named tool with a different recipe', async () => {
+      await expect(installSpec({ name: 'dsh', tool: 'npm:someone-elses-dsh' })).resolves.toBe(
+        'npm:someone-elses-dsh@latest'
+      )
     })
   })
 

--- a/src/renderer/pages/code/hooks/__tests__/useBinaryActions.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useBinaryActions.test.ts
@@ -1,5 +1,4 @@
 import { toast } from '@renderer/services/toast'
-import { CODE_CLI_TOOL_PRESET_MAP } from '@shared/data/presets/codeCliTools'
 import { CodeCli } from '@shared/types/codeCli'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -32,40 +31,15 @@ describe('useBinaryActions', () => {
     ipcRequestMock.mockResolvedValue({ version: '1.0.0' })
   })
 
-  it('installs a pinned CLI tool at its pinned version, not at latest', async () => {
-    const pinnedVersion = CODE_CLI_TOOL_PRESET_MAP[CodeCli.CLAUDE_CODE].pinnedVersion
-    // Guards the assertion below: without a pin it would degrade into asserting
-    // the name-only call and stop catching a dropped pin.
-    expect(pinnedVersion).toEqual(expect.stringMatching(/^\d+\.\d+\.\d+/))
-
+  it('installs a CLI tool by name only, letting main resolve the recipe and its pin', async () => {
     const { result } = renderHook(() => useBinaryActions())
 
     await act(async () => {
       await result.current.install(CodeCli.CLAUDE_CODE)
     })
 
-    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'claude', targetVersion: pinnedVersion })
-    expect(toast.success).toHaveBeenCalledWith('code.install_success')
-  })
-
-  it('installs an unpinned CLI tool by name only, letting main resolve the recipe', async () => {
-    const { result } = renderHook(() => useBinaryActions())
-
-    await act(async () => {
-      await result.current.install(CodeCli.OPENAI_CODEX)
-    })
-
-    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'codex' })
-  })
-
-  it('upgrades a pinned CLI tool without its pin, so the pin never freezes an upgrade', async () => {
-    const { result } = renderHook(() => useBinaryActions())
-
-    await act(async () => {
-      await result.current.upgrade(CodeCli.CLAUDE_CODE)
-    })
-
     expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'claude' })
+    expect(toast.success).toHaveBeenCalledWith('code.install_success')
   })
 
   it('forwards a retry target version so a failed update repeats the same targeted install', async () => {

--- a/src/renderer/pages/code/hooks/__tests__/useBinaryActions.test.ts
+++ b/src/renderer/pages/code/hooks/__tests__/useBinaryActions.test.ts
@@ -1,4 +1,5 @@
 import { toast } from '@renderer/services/toast'
+import { CODE_CLI_TOOL_PRESET_MAP } from '@shared/data/presets/codeCliTools'
 import { CodeCli } from '@shared/types/codeCli'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -31,15 +32,40 @@ describe('useBinaryActions', () => {
     ipcRequestMock.mockResolvedValue({ version: '1.0.0' })
   })
 
-  it('installs a CLI tool by name only, letting main resolve the recipe', async () => {
+  it('installs a pinned CLI tool at its pinned version, not at latest', async () => {
+    const pinnedVersion = CODE_CLI_TOOL_PRESET_MAP[CodeCli.CLAUDE_CODE].pinnedVersion
+    // Guards the assertion below: without a pin it would degrade into asserting
+    // the name-only call and stop catching a dropped pin.
+    expect(pinnedVersion).toEqual(expect.stringMatching(/^\d+\.\d+\.\d+/))
+
     const { result } = renderHook(() => useBinaryActions())
 
     await act(async () => {
       await result.current.install(CodeCli.CLAUDE_CODE)
     })
 
-    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'claude' })
+    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'claude', targetVersion: pinnedVersion })
     expect(toast.success).toHaveBeenCalledWith('code.install_success')
+  })
+
+  it('installs an unpinned CLI tool by name only, letting main resolve the recipe', async () => {
+    const { result } = renderHook(() => useBinaryActions())
+
+    await act(async () => {
+      await result.current.install(CodeCli.OPENAI_CODEX)
+    })
+
+    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'codex' })
+  })
+
+  it('upgrades a pinned CLI tool without its pin, so the pin never freezes an upgrade', async () => {
+    const { result } = renderHook(() => useBinaryActions())
+
+    await act(async () => {
+      await result.current.upgrade(CodeCli.CLAUDE_CODE)
+    })
+
+    expect(ipcRequestMock).toHaveBeenCalledWith('binary.install_tool', { name: 'claude' })
   })
 
   it('forwards a retry target version so a failed update repeats the same targeted install', async () => {

--- a/src/renderer/pages/code/hooks/useBinaryActions.ts
+++ b/src/renderer/pages/code/hooks/useBinaryActions.ts
@@ -52,6 +52,9 @@ export function useBinaryActions() {
 
   // `targetVersion` is only supplied when retrying a failed one-shot update, so
   // the retry repeats the same targeted install instead of a name-only no-op.
+  // Otherwise a fresh install resolves to the tool's pinned version, so a user
+  // never lands on an upstream release this Cherry build was never verified
+  // against. Upgrade deliberately skips the pin — that button means "latest".
   const install = useCallback(
     (toolId: CodeCli, targetVersion?: string) =>
       runInstallTool(
@@ -61,7 +64,7 @@ export function useBinaryActions() {
           successKey: 'code.install_success',
           logLabel: 'Failed to install:'
         },
-        targetVersion
+        targetVersion ?? CODE_CLI_TOOL_PRESET_MAP[toolId].pinnedVersion
       ),
     [runInstallTool]
   )

--- a/src/renderer/pages/code/hooks/useBinaryActions.ts
+++ b/src/renderer/pages/code/hooks/useBinaryActions.ts
@@ -52,9 +52,8 @@ export function useBinaryActions() {
 
   // `targetVersion` is only supplied when retrying a failed one-shot update, so
   // the retry repeats the same targeted install instead of a name-only no-op.
-  // Otherwise a fresh install resolves to the tool's pinned version, so a user
-  // never lands on an upstream release this Cherry build was never verified
-  // against. Upgrade deliberately skips the pin — that button means "latest".
+  // A name-only install resolves to the tool's pinned version in BinaryManager,
+  // which is also where the lazy first-launch install gets it.
   const install = useCallback(
     (toolId: CodeCli, targetVersion?: string) =>
       runInstallTool(
@@ -64,7 +63,7 @@ export function useBinaryActions() {
           successKey: 'code.install_success',
           logLabel: 'Failed to install:'
         },
-        targetVersion ?? CODE_CLI_TOOL_PRESET_MAP[toolId].pinnedVersion
+        targetVersion
       ),
     [runInstallTool]
   )

--- a/src/shared/data/presets/codeCliTools.ts
+++ b/src/shared/data/presets/codeCliTools.ts
@@ -10,6 +10,12 @@ export interface CodeCliToolPreset {
   misePrerelease?: boolean
   /** Use npm CLI when mise's embedded installer cannot install this package. */
   miseNpmShellOut?: boolean
+  /**
+   * Version a fresh install resolves to, verified against this release. Absent
+   * means "latest". Upgrades always go to latest regardless — see
+   * `useBinaryActions`.
+   */
+  pinnedVersion?: string
 }
 
 type CodeCliToolDefinition = Omit<CodeCliToolPreset, 'miseTool'>
@@ -24,21 +30,36 @@ function defineCodeCliTool(definition: CodeCliToolDefinition): Readonly<CodeCliT
 /**
  * Single source of truth for executable names, npm packages, and mise install
  * specs used by both main and renderer processes.
+ *
+ * `pinnedVersion` is carried by the CLIs whose private config files Cherry
+ * writes into: an upstream format change breaks a fresh install on the day it
+ * ships, so new installs resolve to the version verified for this release
+ * instead of whatever is latest. Bumping them is a release-checklist step.
  */
 export const CODE_CLI_TOOL_PRESETS = Object.freeze([
   defineCodeCliTool({
     id: CodeCli.CLAUDE_CODE,
     executable: 'claude',
     packageName: '@anthropic-ai/claude-code',
-    install: 'registry'
+    install: 'registry',
+    pinnedVersion: '2.1.238'
   }),
   defineCodeCliTool({
     id: CodeCli.OPENAI_CODEX,
     executable: 'codex',
     packageName: '@openai/codex',
     install: 'registry'
+    // Unpinnable: mise resolves codex through `aqua:openai/codex`, whose versions
+    // are per-platform tags (`0.144.4-darwin-arm64`). One constant cannot name them
+    // all, and a bare `0.144.4` fails getInstalledVersion's semver equality check.
   }),
-  defineCodeCliTool({ id: CodeCli.OPEN_CODE, executable: 'opencode', packageName: 'opencode-ai', install: 'registry' }),
+  defineCodeCliTool({
+    id: CodeCli.OPEN_CODE,
+    executable: 'opencode',
+    packageName: 'opencode-ai',
+    install: 'registry',
+    pinnedVersion: '1.18.21'
+  }),
   defineCodeCliTool({ id: CodeCli.OPENCLAW, executable: 'openclaw', packageName: 'openclaw', install: 'npm' }),
   defineCodeCliTool({
     id: CodeCli.DEEPSEEK_HARNESS,
@@ -47,20 +68,29 @@ export const CODE_CLI_TOOL_PRESETS = Object.freeze([
     install: 'npm',
     misePrerelease: true,
     // mise 2026.7.14 aube exceeds its 16-pass fixed-point limit on DSH's recursive peer graph.
-    miseNpmShellOut: true
+    miseNpmShellOut: true,
+    pinnedVersion: '0.1.1-rc.2'
   }),
   defineCodeCliTool({
     id: CodeCli.GEMINI_CLI,
     executable: 'gemini',
     packageName: '@google/gemini-cli',
-    install: 'npm'
+    install: 'npm',
+    pinnedVersion: '0.56.0'
   }),
-  defineCodeCliTool({ id: CodeCli.QWEN_CODE, executable: 'qwen', packageName: '@qwen-code/qwen-code', install: 'npm' }),
+  defineCodeCliTool({
+    id: CodeCli.QWEN_CODE,
+    executable: 'qwen',
+    packageName: '@qwen-code/qwen-code',
+    install: 'npm',
+    pinnedVersion: '0.21.15'
+  }),
   defineCodeCliTool({
     id: CodeCli.KIMI_CODE,
     executable: 'kimi',
     packageName: '@moonshot-ai/kimi-code',
-    install: 'npm'
+    install: 'npm',
+    pinnedVersion: '0.38.0'
   }),
   defineCodeCliTool({
     id: CodeCli.QODER_CLI,
@@ -78,7 +108,8 @@ export const CODE_CLI_TOOL_PRESETS = Object.freeze([
     id: CodeCli.PI,
     executable: 'pi',
     packageName: '@earendil-works/pi-coding-agent',
-    install: 'npm'
+    install: 'npm',
+    pinnedVersion: '0.84.2'
   })
 ] as const satisfies readonly Readonly<CodeCliToolPreset>[])
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: installing a Code CLI from the Code page resolved to whatever that CLI had published at that moment, and Cherry writes into 11 private config files across 8 of those CLIs (`src/shared/utils/cliConfig.ts`, `src/main/services/deepSeekHarness/config.ts`). An upstream format change therefore broke a *fresh* install on the day it shipped, with no version in between us and the break — that is exactly #19117, where DSH `0.1.1-rc.1` started rejecting the credentials document Cherry writes and CodeMate died on launch for anyone who installed it that week.

After this PR: `CodeCliToolPreset` carries an optional `pinnedVersion`, and `BinaryManager.installWithMise` falls back to it whenever a caller installs without naming a version, so a new user lands on the version this Cherry build was verified against instead of on this morning's upstream release. Seven CLIs are pinned — claude-code `2.1.238`, opencode `1.18.21`, dsh `0.1.1-rc.2`, gemini-cli `0.56.0`, qwen-code `0.21.15`, kimi-code `0.38.0`, pi `0.84.2`. Upgrade deliberately ignores the pin and still goes to latest, so "give me the newest CLI" stays one click away rather than becoming a new setting. Keeping the pins current is a new `prepare-release` checklist item.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made: (1) the pin resolves inside `installWithMise`, as the last fallback before `latest`, rather than at each call site — there are three install entry points today (the Code page, the lazy first-launch install in `CodeCliService.run`, the MCP tool) and only a central fallback covers a fourth added later; it deliberately sits *below* `targetVersion` so the applied-no-op (`BinaryManager.ts:1456`) and prune (`applyDefinition`) branches stay keyed on an explicit request, which is what keeps an already-installed CLI from being reinstalled or downgraded to the pin; and it is a lookup rather than a `FIXED_CATALOG` field, because `BinaryManager.ts:205` requires fixed definitions to carry no `requestedVersion` (it participates in `sameDefinition` dedupe). (2) The pins are a maintenance obligation rather than a self-updating floor; that is deliberate, because a pin nobody re-verifies buys only reproducibility, so the release checklist entry is part of the change rather than a follow-up. (3) Only the CLIs whose config Cherry writes are pinned — openclaw, qoder and copilot have no config coupling, so pinning them would add release work without removing a failure mode.

The following alternatives were considered: (1) a *minimum* version floor mirroring `BABELDOC_MINIMUM_VERSION`, rejected because a floor only forces an upgrade when we already know the old layout is too old, and does nothing about a *newer* upstream release we have never run; (2) keeping the status quo and adapting the writer each time, rejected because #19131 could shape-detect only the two DSH layouts we had already seen — it does not generalize to a third layout or to the other seven CLIs; (3) pinning plus an explicit "always use latest" opt-in, rejected because the upgrade button already is that opt-in and a second code path would have to be kept honest forever; (4) pinning codex too, blocked (see below).

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19117

### Breaking changes

<!-- optional -->

None. Existing installs are untouched — mise freezes a tool's version at install time and there is no auto-update, so nothing moves under a user who has already installed a CLI. The pin only changes what a new install resolves to, and the upgrade button reaches latest exactly as before.

### Special notes for your reviewer

**Codex is intentionally left unpinned, and this is the one gap in the change.** mise resolves `codex` through `aqua:openai/codex`, whose version namespace is per-platform release tags rather than npm versions:

```
$ mise ls-remote codex | tail -4
0.144.4-linux-x64
0.144.4-win32-arm64
0.144.4-win32-x64
0.145.0-alpha.1-darwin-arm64
```

One constant cannot name all four platform variants, and a bare `0.144.4` would install but then fail `getInstalledVersion`'s semver equality check (`BinaryManager.ts:1186`), since `0.144.4-darwin-arm64 !== 0.144.4`. Pinning codex needs a per-platform pin, which is its own change. The reason is recorded in the preset.

Unrelated pre-existing observation surfaced while verifying the above, **not** addressed here: `mise latest codex` currently returns `0.144.4-win32-x64` while npm has `@openai/codex@0.149.0`, so codex's displayed latest version and its upgrade target are already wrong on macOS and lag npm by several minor versions. Worth a separate issue.

Version namespaces were checked per tool before pinning, because the registry-backed tools do not necessarily share npm's numbering: `mise latest` returns `2.1.238` for claude and `1.18.21` for opencode, both matching npm, so those pins are safe. All seven pins pass `TOOL_KEY_RE` (`binaryTools.ts:6`), which `installByName` validates against.

Verification: `src/main/services/__tests__/BinaryManager.test.ts` (191 tests) and `npx vitest run src/renderer/pages/code src/main/services/codeCli src/main/services/deepSeekHarness src/main/ai/mcp` (75 files, 1077 tests) pass; `pnpm typecheck` passes. A new `Code CLI version pin` block covers the contract in four directions — name-only resolves to the pin, an explicit target overrides it, an unpinned CLI stays on `latest`, and a same-named tool with a different recipe never inherits a pin. The existing DSH shell-out test now asserts `npm:@deepseek-ai/dsh@0.1.1-rc.2` instead of `@latest`, which is the direct proof that the lazy first-launch path is covered.

Note for the reviewer on how much these pins are worth today: only dsh `0.1.1-rc.2` has actually been verified against the config Cherry writes (in #19131, against the published `dsh-credentials-local@0.1.1-rc.2` sources). The other six are the current latest, so right now they buy reproducibility — every new user on one known version — rather than a verified-good combination. The checklist item is what converts them at the next release.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Installing a Code CLI now uses a version verified for this Cherry Studio release instead of the newest one published upstream, so a fresh install no longer breaks when a CLI changes its config format. Use the CLI's upgrade button to move to the latest version.
```

