### PR TITLE
feat(pi-icon): use official Pi mark

### DIFF
--- a/packages/ui/icons/general/pi-cli.svg
+++ b/packages/ui/icons/general/pi-cli.svg
@@ -1,3 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-  <path d="M5.25 4a1.25 1.25 0 0 0 0 2.5H7.5v12.25a1.25 1.25 0 0 0 2.5 0V6.5h4v12.25a1.25 1.25 0 0 0 2.5 0V6.5h2.25a1.25 1.25 0 0 0 0-2.5H5.25Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor" fill-rule="evenodd">
+  <path clip-rule="evenodd" d="M1 1h16.5v11H12v5.5H6.5V23H1V1Zm5.5 5.5V12H12V6.5H6.5Z"/>
+  <path d="M17.5 12H23v11h-5.5V12Z"/>
 </svg>

--- a/packages/ui/src/components/icons/general/pi-cli.tsx
+++ b/packages/ui/src/components/icons/general/pi-cli.tsx
@@ -2,8 +2,16 @@ import type { SVGProps } from 'react'
 
 import type { IconComponent } from '../types'
 const PiCli: IconComponent = (props: SVGProps<SVGSVGElement>) => (
-  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" fill="currentColor" viewBox="0 0 24 24" {...props}>
-    <path d="M5.25 4a1.25 1.25 0 0 0 0 2.5H7.5v12.25a1.25 1.25 0 0 0 2.5 0V6.5h4v12.25a1.25 1.25 0 0 0 2.5 0V6.5h2.25a1.25 1.25 0 0 0 0-2.5H5.25Z" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="1em"
+    height="1em"
+    fill="currentColor"
+    fillRule="evenodd"
+    viewBox="0 0 24 24"
+    {...props}>
+    <path d="M1 1h16.5v11H12v5.5H6.5V23H1V1Zm5.5 5.5V12H12V6.5H6.5Z" clipRule="evenodd" />
+    <path d="M17.5 12H23v11h-5.5V12Z" />
   </svg>
 )
 export { PiCli }

--- a/src/renderer/components/AgentRuntimeOption.tsx
+++ b/src/renderer/components/AgentRuntimeOption.tsx
@@ -9,12 +9,13 @@ import {
   RadioGroup,
   RadioGroupItem
 } from '@cherrystudio/ui'
+import { PiCli } from '@cherrystudio/ui/icons'
 import { Deepseek } from '@cherrystudio/ui/icons/providers'
 import { cn } from '@cherrystudio/ui/lib/utils'
 import { AGENT_RUNTIME_CAPABILITIES } from '@shared/ai/agentRuntimeCapabilities'
 import type { AgentType } from '@shared/data/types/agent'
 import type { TFunction } from 'i18next'
-import { Check, Sparkles, Zap } from 'lucide-react'
+import { Check, Sparkles } from 'lucide-react'
 import { type ElementType, useId } from 'react'
 
 /**
@@ -27,7 +28,7 @@ import { type ElementType, useId } from 'react'
 
 const RUNTIME_ICONS = {
   'claude-code': Sparkles,
-  pi: Zap,
+  pi: PiCli,
   dsh: Deepseek
 } satisfies Record<AgentType, ElementType>
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Pi used a generic pi glyph in Code Mate and a lightning icon in the Agent runtime selector.

After this PR:

Pi uses its official pixel mark consistently in Code Mate and the Agent runtime selector. The icon inherits `currentColor` for light and dark themes.

<img width="319" height="121" alt="image" src="https://github.com/user-attachments/assets/3f3afca2-ef12-41e4-8779-7cf0dc99dd6e" />

<img width="343" height="160" alt="image" src="https://github.com/user-attachments/assets/8665c745-ee95-4625-a239-5e207a654b90" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The official mark makes Pi recognizable and removes inconsistent branding between the two product surfaces. Reusing the generated `PiCli` component keeps one SVG source of truth.

The following tradeoffs were made:

The icon remains monochrome so it follows the existing semantic foreground color in every theme.

The following alternatives were considered:

Keeping the generic pi glyph or the Agent selector's lightning icon was rejected because neither matches the supplied Pi mark.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation:

- `pnpm lint`
- `pnpm test:pkg:ui packages/ui/src/components/icons/__tests__ packages/ui/scripts/__tests__/icons-generate.test.ts` (104 tests)
- Electron visual verification in Code Mate and the Agent selector in light and dark themes

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Update Pi branding across Code Mate and Agent runtime selectors.
```
