### PR TITLE
feat(wechat-channel): support native iLink media

### DIFF
--- a/src/main/ai/channels/adapters/__tests__/WeChatAdapter.test.ts
+++ b/src/main/ai/channels/adapters/__tests__/WeChatAdapter.test.ts
@@ -38,7 +38,8 @@ const mockBot = {
   reply: vi.fn().mockResolvedValue(undefined),
   sendTyping: vi.fn().mockResolvedValue(undefined),
   stopTyping: vi.fn().mockResolvedValue(undefined),
-  sendImage: vi.fn().mockResolvedValue(undefined)
+  sendImage: vi.fn().mockResolvedValue(undefined),
+  sendFile: vi.fn().mockResolvedValue(undefined)
 }
 
 vi.mock('../wechat/WeChatProtocol', () => ({
@@ -72,6 +73,7 @@ describe('WeChatAdapter', () => {
     mockBot.sendTyping.mockClear().mockResolvedValue(undefined)
     mockBot.stopTyping.mockClear().mockResolvedValue(undefined)
     mockBot.sendImage.mockClear().mockResolvedValue(undefined)
+    mockBot.sendFile.mockClear().mockResolvedValue(undefined)
     vi.mocked(application.get('IpcApiService').broadcastToType).mockClear()
   })
 
@@ -187,19 +189,40 @@ describe('WeChatAdapter', () => {
     expect(buffer.toString()).toBe('png-bytes')
   })
 
-  it('sendFile() rejects non-image files', async () => {
+  it('sendFile() forwards documents and videos with their filename and media type', async () => {
     const adapter = createAdapter()
     await adapter.connect()
 
-    await expect(
-      adapter.sendFile('user-123', {
-        filename: 'report.pdf',
-        data: '',
-        media_type: 'application/pdf',
-        size: 0
-      })
-    ).rejects.toThrow('WeChat can only forward image files')
-    expect(mockBot.sendImage).not.toHaveBeenCalled()
+    await adapter.sendFile('user-123', {
+      filename: 'report.pdf',
+      data: Buffer.from('pdf-bytes').toString('base64'),
+      media_type: 'application/pdf',
+      size: 9
+    })
+    await adapter.sendFile('user-123', {
+      filename: 'demo.mp4',
+      data: Buffer.from('video-bytes').toString('base64'),
+      media_type: 'video/mp4',
+      size: 11
+    })
+
+    expect(mockBot.sendFile).toHaveBeenNthCalledWith(
+      1,
+      'user-123',
+      'report.pdf',
+      Buffer.from('pdf-bytes'),
+      'application/pdf'
+    )
+    expect(mockBot.sendFile).toHaveBeenNthCalledWith(2, 'user-123', 'demo.mp4', Buffer.from('video-bytes'), 'video/mp4')
+  })
+
+  it('sendMessage() clears the typing indicator after delivery', async () => {
+    const adapter = createAdapter()
+    await adapter.connect()
+
+    await adapter.sendMessage('user-123', 'Done')
+
+    expect(mockBot.stopTyping).toHaveBeenCalledWith('user-123')
   })
 
   it('sendTypingIndicator() calls bot.sendTyping()', async () => {

--- a/src/main/ai/channels/adapters/__tests__/WeChatAdapter.test.ts
+++ b/src/main/ai/channels/adapters/__tests__/WeChatAdapter.test.ts
@@ -38,7 +38,6 @@ const mockBot = {
   reply: vi.fn().mockResolvedValue(undefined),
   sendTyping: vi.fn().mockResolvedValue(undefined),
   stopTyping: vi.fn().mockResolvedValue(undefined),
-  sendImage: vi.fn().mockResolvedValue(undefined),
   sendFile: vi.fn().mockResolvedValue(undefined)
 }
 
@@ -72,7 +71,6 @@ describe('WeChatAdapter', () => {
     mockBot.reply.mockClear().mockResolvedValue(undefined)
     mockBot.sendTyping.mockClear().mockResolvedValue(undefined)
     mockBot.stopTyping.mockClear().mockResolvedValue(undefined)
-    mockBot.sendImage.mockClear().mockResolvedValue(undefined)
     mockBot.sendFile.mockClear().mockResolvedValue(undefined)
     vi.mocked(application.get('IpcApiService').broadcastToType).mockClear()
   })
@@ -176,17 +174,18 @@ describe('WeChatAdapter', () => {
     expect(mockBot.send.mock.calls[1][1]).toHaveLength(1000)
   })
 
-  it('sendFile() forwards an image via bot.sendImage()', async () => {
+  it('sendFile() delegates image routing to the protocol', async () => {
     const adapter = createAdapter()
     await adapter.connect()
 
-    const data = Buffer.from('png-bytes').toString('base64')
-    await adapter.sendFile('user-123', { filename: 'chart.png', data, media_type: 'image/png', size: 9 })
+    await adapter.sendFile('user-123', {
+      filename: 'chart.png',
+      data: Buffer.from('png-bytes').toString('base64'),
+      media_type: 'image/png',
+      size: 9
+    })
 
-    expect(mockBot.sendImage).toHaveBeenCalledTimes(1)
-    const [chatId, buffer] = mockBot.sendImage.mock.calls[0]
-    expect(chatId).toBe('user-123')
-    expect(buffer.toString()).toBe('png-bytes')
+    expect(mockBot.sendFile).toHaveBeenCalledWith('user-123', 'chart.png', Buffer.from('png-bytes'), 'image/png')
   })
 
   it('sendFile() forwards documents and videos with their filename and media type', async () => {

--- a/src/main/ai/channels/adapters/wechat/WeChatAdapter.ts
+++ b/src/main/ai/channels/adapters/wechat/WeChatAdapter.ts
@@ -78,7 +78,7 @@ class WeChatAdapter extends ChannelAdapter {
 
   protected override async performDisconnect(): Promise<void> {
     if (this.bot) {
-      this.bot.stop()
+      await this.bot.stop()
       this.bot = null
       this.sendQrToRenderer('', 'disconnected')
       this.log.info('WeChat bot stopped')
@@ -91,14 +91,18 @@ class WeChatAdapter extends ChannelAdapter {
       throw new Error('Bot is not connected')
     }
 
-    const chunks = splitMessage(text, WECHAT_MAX_LENGTH)
+    const bot = this.bot
+    try {
+      const chunks = splitMessage(text, WECHAT_MAX_LENGTH)
+      for (let i = 0; i < chunks.length; i++) {
+        await bot.send(chatId, chunks[i])
 
-    for (let i = 0; i < chunks.length; i++) {
-      await this.bot.send(chatId, chunks[i])
-
-      if (i < chunks.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 100))
+        if (i < chunks.length - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 100))
+        }
       }
+    } finally {
+      bot.stopTyping(chatId).catch(() => {})
     }
   }
 
@@ -106,12 +110,13 @@ class WeChatAdapter extends ChannelAdapter {
     if (!this.bot) {
       throw new Error('Bot is not connected')
     }
-    // The reverse-engineered WeChat protocol only supports outbound images today
-    // (WeixinBot.sendImage). Document upload would need protocol-level CDN work.
-    if (!file.media_type.startsWith('image/')) {
-      throw new Error(`WeChat can only forward image files, not "${file.media_type}" (${file.filename})`)
+
+    const data = Buffer.from(file.data, 'base64')
+    if (file.media_type.startsWith('image/')) {
+      await this.bot.sendImage(chatId, data)
+    } else {
+      await this.bot.sendFile(chatId, file.filename, data, file.media_type)
     }
-    await this.bot.sendImage(chatId, Buffer.from(file.data, 'base64'))
     this.log.info('Sent file', { chatId, filename: file.filename, size: file.size })
   }
 
@@ -175,7 +180,8 @@ class WeChatAdapter extends ChannelAdapter {
             return {
               filename: r.filename,
               data: r.data.toString('base64'),
-              media_type: FILE_EXTENSION_MIME_MAP[ext] || 'application/octet-stream',
+              media_type:
+                r.mediaType === 'application/octet-stream' ? FILE_EXTENSION_MIME_MAP[ext] || r.mediaType : r.mediaType,
               size: r.data.length
             } satisfies FileAttachment
           })

--- a/src/main/ai/channels/adapters/wechat/WeChatAdapter.ts
+++ b/src/main/ai/channels/adapters/wechat/WeChatAdapter.ts
@@ -78,7 +78,7 @@ class WeChatAdapter extends ChannelAdapter {
 
   protected override async performDisconnect(): Promise<void> {
     if (this.bot) {
-      await this.bot.stop()
+      this.bot.stop()
       this.bot = null
       this.sendQrToRenderer('', 'disconnected')
       this.log.info('WeChat bot stopped')
@@ -111,12 +111,7 @@ class WeChatAdapter extends ChannelAdapter {
       throw new Error('Bot is not connected')
     }
 
-    const data = Buffer.from(file.data, 'base64')
-    if (file.media_type.startsWith('image/')) {
-      await this.bot.sendImage(chatId, data)
-    } else {
-      await this.bot.sendFile(chatId, file.filename, data, file.media_type)
-    }
+    await this.bot.sendFile(chatId, file.filename, Buffer.from(file.data, 'base64'), file.media_type)
     this.log.info('Sent file', { chatId, filename: file.filename, size: file.size })
   }
 

--- a/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
+++ b/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
@@ -866,11 +866,16 @@ export class WeixinBot {
 
   /** Send an image to a user by uploading it to the WeChat CDN. */
   async sendImage(userId: string, imageData: Buffer): Promise<void> {
+    const contextToken = this.contextTokenFor(userId)
     const uploaded = await this.uploadMedia(userId, imageData, UploadMediaType.IMAGE)
-    await this.sendMediaMessage(userId, {
-      type: MessageItemType.IMAGE,
-      image_item: { media: this.toCdnMedia(uploaded), mid_size: uploaded.ciphertextSize }
-    })
+    await this.sendMediaMessage(
+      userId,
+      {
+        type: MessageItemType.IMAGE,
+        image_item: { media: this.toCdnMedia(uploaded), mid_size: uploaded.ciphertextSize }
+      },
+      contextToken
+    )
   }
 
   /** Send a video as video media and every other non-image type as a file attachment. */
@@ -880,20 +885,29 @@ export class WeixinBot {
       return
     }
 
+    const contextToken = this.contextTokenFor(userId)
     if (mediaType.startsWith('video/')) {
       const uploaded = await this.uploadMedia(userId, data, UploadMediaType.VIDEO)
-      await this.sendMediaMessage(userId, {
-        type: MessageItemType.VIDEO,
-        video_item: { media: this.toCdnMedia(uploaded), video_size: uploaded.ciphertextSize }
-      })
+      await this.sendMediaMessage(
+        userId,
+        {
+          type: MessageItemType.VIDEO,
+          video_item: { media: this.toCdnMedia(uploaded), video_size: uploaded.ciphertextSize }
+        },
+        contextToken
+      )
       return
     }
 
     const uploaded = await this.uploadMedia(userId, data, UploadMediaType.FILE)
-    await this.sendMediaMessage(userId, {
-      type: MessageItemType.FILE,
-      file_item: { media: this.toCdnMedia(uploaded), file_name: filename, len: String(data.length) }
-    })
+    await this.sendMediaMessage(
+      userId,
+      {
+        type: MessageItemType.FILE,
+        file_item: { media: this.toCdnMedia(uploaded), file_name: filename, len: String(data.length) }
+      },
+      contextToken
+    )
   }
 
   async run(): Promise<void> {
@@ -910,22 +924,11 @@ export class WeixinBot {
     }
   }
 
-  async stop(): Promise<void> {
+  stop(): void {
     this.stopped = true
     this.currentPollController?.abort()
     this.loginAbort?.abort()
-
-    const credentials = this.credentials ?? (this.tokenPath ? await loadCredentials(this.tokenPath) : undefined)
-    if (!credentials) return
-    this.baseUrl = normalizeBaseUrl(credentials.baseUrl)
-
-    try {
-      await apiNotifyLifecycle(this.baseUrl, credentials.token, this.uin, 'stop')
-    } catch (error) {
-      logger.warn('Failed to notify WeChat that the bot stopped', {
-        error: error instanceof Error ? error.message : String(error)
-      })
-    }
+    void this.notifyStop()
   }
 
   private async runLoop(): Promise<void> {
@@ -1016,16 +1019,19 @@ export class WeixinBot {
     await apiSendMessage(this.baseUrl, credentials.token, this.uin, buildTextMessage(userId, contextToken, text))
   }
 
+  private contextTokenFor(userId: string): string {
+    const contextToken = this.contextTokens.get(userId)
+    if (!contextToken) {
+      logger.warn('No cached context token for media, sending without context', { userId })
+    }
+    return contextToken ?? ''
+  }
+
   private async uploadMedia(
     userId: string,
     data: Buffer,
     mediaType: UploadMediaType
   ): Promise<{ downloadEncryptedQueryParam: string; aeskey: Buffer; ciphertextSize: number }> {
-    const contextToken = this.contextTokens.get(userId)
-    if (!contextToken) {
-      logger.warn('No cached context token for media, sending without context', { userId })
-    }
-
     const credentials = await this.ensureCredentials()
     const uploaded = await cdnUploadMedia(this.baseUrl, credentials.token, this.uin, userId, data, mediaType)
     if (!uploaded) throw new Error('Failed to upload media to WeChat CDN')
@@ -1040,7 +1046,7 @@ export class WeixinBot {
     }
   }
 
-  private async sendMediaMessage(userId: string, item: MessageItem): Promise<void> {
+  private async sendMediaMessage(userId: string, item: MessageItem, contextToken: string): Promise<void> {
     const credentials = await this.ensureCredentials()
     await apiSendMessage(this.baseUrl, credentials.token, this.uin, {
       from_user_id: '',
@@ -1048,9 +1054,23 @@ export class WeixinBot {
       client_id: randomUUID(),
       message_type: MessageType.BOT,
       message_state: MessageState.FINISH,
-      context_token: this.contextTokens.get(userId) ?? '',
+      context_token: contextToken,
       item_list: [item]
     })
+  }
+
+  private async notifyStop(): Promise<void> {
+    const credentials = this.credentials ?? (this.tokenPath ? await loadCredentials(this.tokenPath) : undefined)
+    if (!credentials) return
+    this.baseUrl = normalizeBaseUrl(credentials.baseUrl)
+
+    try {
+      await apiNotifyLifecycle(this.baseUrl, credentials.token, this.uin, 'stop')
+    } catch (error) {
+      logger.warn('Failed to notify WeChat that the bot stopped', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 
   private async dispatchMessage(message: IncomingMessage): Promise<void> {

--- a/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
+++ b/src/main/ai/channels/adapters/wechat/WeChatProtocol.ts
@@ -46,6 +46,7 @@ interface CDNMedia {
   encrypt_query_param?: string
   aes_key?: string
   encrypt_type?: number
+  full_url?: string
 }
 
 interface ImageItem {
@@ -60,14 +61,41 @@ interface ImageItem {
   hd_size?: number
 }
 
+interface VoiceItem {
+  media?: CDNMedia
+  aeskey?: string
+  encode_type?: number
+  text?: string
+}
+
+interface FileItem {
+  media?: CDNMedia
+  aeskey?: string
+  file_name?: string
+  len?: string
+}
+
+interface VideoItem {
+  media?: CDNMedia
+  aeskey?: string
+  video_size?: number
+}
+
+type DownloadableFileItem = FileItem | VoiceItem | VideoItem
+
+interface RefMessage {
+  title?: string
+  message_item?: MessageItem
+}
+
 interface MessageItem {
   type: MessageItemType
   text_item?: { text: string }
   image_item?: ImageItem
-  voice_item?: { text?: string }
-  file_item?: { file_name?: string; file_size?: number; media?: CDNMedia; aeskey?: string }
-  video_item?: unknown
-  ref_msg?: unknown
+  voice_item?: VoiceItem
+  file_item?: FileItem
+  video_item?: VideoItem
+  ref_msg?: RefMessage
 }
 
 interface WeixinMessage {
@@ -90,8 +118,8 @@ export interface IncomingMessage {
   timestamp: Date
   /** Raw image items from WeChat CDN (encrypted, need download+decrypt). */
   _imageItems?: ImageItem[]
-  /** Raw file items from WeChat CDN (encrypted, need download+decrypt). */
-  _fileItems?: Array<{ file_name?: string; file_size?: number; media?: CDNMedia; aeskey?: string }>
+  /** Raw non-image media items from WeChat CDN, normalized as workspace files. */
+  _fileItems?: Array<{ filename: string; mediaType: string; item: DownloadableFileItem }>
 }
 
 // --------------- Zod response schemas ---------------
@@ -193,17 +221,31 @@ function resolveImageAesKey(item: ImageItem): Buffer | null {
 
 // --------------- CDN download ---------------
 
+function resolveCdnDownloadUrl(media?: CDNMedia): string | null {
+  const fullUrl = media?.full_url?.trim()
+  if (fullUrl) {
+    try {
+      const url = new URL(fullUrl)
+      if (url.protocol === 'https:' && url.hostname.endsWith('.cdn.weixin.qq.com')) return url.toString()
+      logger.warn('Ignoring an untrusted WeChat CDN URL', { hostname: url.hostname })
+    } catch {
+      logger.warn('Ignoring an invalid WeChat CDN URL')
+    }
+  }
+  if (!media?.encrypt_query_param) return null
+  return `${CDN_BASE_URL}/download?encrypted_query_param=${encodeURIComponent(media.encrypt_query_param)}`
+}
+
 async function cdnDownloadImage(item: ImageItem): Promise<Buffer | null> {
-  const encryptQueryParam = item.media?.encrypt_query_param
-  if (!encryptQueryParam) return null
+  const url = resolveCdnDownloadUrl(item.media)
+  if (!url) return null
 
   const aesKey = resolveImageAesKey(item)
   if (!aesKey) {
-    logger.warn('Image item has encrypt_query_param but no AES key')
+    logger.warn('Image item has CDN media but no AES key')
     return null
   }
 
-  const url = `${CDN_BASE_URL}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam)}`
   const response = await net.fetch(url, { method: 'GET' })
 
   if (!response.ok) {
@@ -223,8 +265,6 @@ async function cdnDownloadImage(item: ImageItem): Promise<Buffer | null> {
   }
   return aesEcbDecrypt(encrypted, aesKey)
 }
-
-type FileItem = NonNullable<MessageItem['file_item']>
 
 /**
  * Parse a CDNMedia.aes_key into a raw 16-byte AES key.
@@ -250,7 +290,7 @@ function parseAesKey(aesKeyBase64: string): Buffer | null {
  * Resolve the 16-byte AES key from a file_item.
  * Priority: file_item.aeskey (hex) > file_item.media.aes_key (base64, with hex re-decode for files)
  */
-function resolveFileAesKey(item: FileItem): Buffer | null {
+function resolveFileAesKey(item: DownloadableFileItem): Buffer | null {
   if (item.aeskey) {
     return Buffer.from(item.aeskey, 'hex')
   }
@@ -260,17 +300,16 @@ function resolveFileAesKey(item: FileItem): Buffer | null {
   return null
 }
 
-async function cdnDownloadFile(item: FileItem): Promise<Buffer | null> {
-  const encryptQueryParam = item.media?.encrypt_query_param
-  if (!encryptQueryParam) return null
+async function cdnDownloadFile(item: DownloadableFileItem): Promise<Buffer | null> {
+  const url = resolveCdnDownloadUrl(item.media)
+  if (!url) return null
 
   const aesKey = resolveFileAesKey(item)
   if (!aesKey) {
-    logger.warn('File item has encrypt_query_param but no AES key')
+    logger.warn('File item has CDN media but no AES key')
     return null
   }
 
-  const url = `${CDN_BASE_URL}/download?encrypted_query_param=${encodeURIComponent(encryptQueryParam)}`
   const response = await net.fetch(url, { method: 'GET' })
 
   if (!response.ok) {
@@ -299,20 +338,25 @@ const GetUploadUrlRespSchema = z.object({
   upload_full_url: z.string().optional()
 })
 
-async function cdnUploadImage(
+enum UploadMediaType {
+  IMAGE = 1,
+  VIDEO = 2,
+  FILE = 3
+}
+
+async function cdnUploadMedia(
   baseUrl: string,
   token: string,
   uin: string,
   toUserId: string,
-  imageData: Buffer
+  data: Buffer,
+  mediaType: UploadMediaType
 ): Promise<{ downloadEncryptedQueryParam: string; aeskey: Buffer; ciphertextSize: number } | null> {
   const aeskey = randomBytes(16)
   const filekey = randomBytes(16).toString('hex')
-  const md5Hash = await import('node:crypto').then((c) => c.createHash('md5').update(imageData).digest('hex'))
-  // 先加密再请求 getuploadurl：官方（Tencent/openclaw-weixin upload.ts）的 filesize 是
-  // PKCS7 密文大小（Math.ceil((rawsize+1)/16)*16），而非明文大小。直接复用 ciphertext.length
-  // 可保证与实际上传的密文严格一致——filesize 与上传体不一致是「文件已过期/已被清理」的最可疑根因。
-  const ciphertext = aesEcbEncrypt(imageData, aeskey)
+  const md5Hash = await import('node:crypto').then((c) => c.createHash('md5').update(data).digest('hex'))
+  // Declare the ciphertext size used by the CDN, so the metadata cannot drift from the upload body.
+  const ciphertext = aesEcbEncrypt(data, aeskey)
 
   // Step 1: get upload URL
   const raw = await apiFetch(
@@ -320,9 +364,9 @@ async function cdnUploadImage(
     '/ilink/bot/getuploadurl',
     {
       filekey,
-      media_type: 1,
+      media_type: mediaType,
       to_user_id: toUserId,
-      rawsize: imageData.length,
+      rawsize: data.length,
       rawfilemd5: md5Hash,
       filesize: ciphertext.length,
       no_need_thumb: true,
@@ -526,6 +570,10 @@ async function apiSendTyping(
     base_info: buildBaseInfo()
   }
   await apiFetch(baseUrl, '/ilink/bot/sendtyping', body, token, uin, 15_000)
+}
+
+async function apiNotifyLifecycle(baseUrl: string, token: string, uin: string, event: 'start' | 'stop'): Promise<void> {
+  await apiFetch(baseUrl, `/ilink/bot/msg/notify${event}`, { base_info: buildBaseInfo() }, token, uin, 15_000)
 }
 
 async function fetchQrCode(baseUrl: string): Promise<QrCodeResponse> {
@@ -802,59 +850,50 @@ export class WeixinBot {
     }
   }
 
-  /**
-   * Download and decrypt a file from WeChat CDN.
-   * Returns { data: Buffer, filename: string } or null on failure.
-   */
-  async downloadFile(fileItem: FileItem): Promise<{ data: Buffer; filename: string } | null> {
+  /** Download and decrypt a non-image media item from WeChat CDN. */
+  async downloadFile(
+    file: NonNullable<IncomingMessage['_fileItems']>[number]
+  ): Promise<{ data: Buffer; filename: string; mediaType: string } | null> {
     try {
-      const data = await cdnDownloadFile(fileItem)
+      const data = await cdnDownloadFile(file.item)
       if (!data) return null
-      return { data, filename: fileItem.file_name ?? 'file' }
+      return { data, filename: file.filename, mediaType: file.mediaType }
     } catch (error) {
       logger.error('Failed to download WeChat file', error instanceof Error ? error : { error: String(error) })
       return null
     }
   }
 
-  /**
-   * Send an image to a user by uploading to WeChat CDN.
-   */
+  /** Send an image to a user by uploading it to the WeChat CDN. */
   async sendImage(userId: string, imageData: Buffer): Promise<void> {
-    const contextToken = this.contextTokens.get(userId)
-    if (!contextToken) {
-      logger.warn('No cached context token for sendImage, sending without context', { userId })
+    const uploaded = await this.uploadMedia(userId, imageData, UploadMediaType.IMAGE)
+    await this.sendMediaMessage(userId, {
+      type: MessageItemType.IMAGE,
+      image_item: { media: this.toCdnMedia(uploaded), mid_size: uploaded.ciphertextSize }
+    })
+  }
+
+  /** Send a video as video media and every other non-image type as a file attachment. */
+  async sendFile(userId: string, filename: string, data: Buffer, mediaType: string): Promise<void> {
+    if (mediaType.startsWith('image/')) {
+      await this.sendImage(userId, data)
+      return
     }
 
-    const credentials = await this.ensureCredentials()
-    const uploaded = await cdnUploadImage(this.baseUrl, credentials.token, this.uin, userId, imageData)
-    if (!uploaded) {
-      throw new Error('Failed to upload image to WeChat CDN')
+    if (mediaType.startsWith('video/')) {
+      const uploaded = await this.uploadMedia(userId, data, UploadMediaType.VIDEO)
+      await this.sendMediaMessage(userId, {
+        type: MessageItemType.VIDEO,
+        video_item: { media: this.toCdnMedia(uploaded), video_size: uploaded.ciphertextSize }
+      })
+      return
     }
 
-    const msg = {
-      from_user_id: '',
-      to_user_id: userId,
-      client_id: randomUUID(),
-      message_type: MessageType.BOT,
-      message_state: MessageState.FINISH,
-      context_token: contextToken ?? '',
-      item_list: [
-        {
-          type: MessageItemType.IMAGE,
-          image_item: {
-            media: {
-              encrypt_query_param: uploaded.downloadEncryptedQueryParam,
-              aes_key: Buffer.from(uploaded.aeskey.toString('hex')).toString('base64'),
-              encrypt_type: 1
-            },
-            mid_size: uploaded.ciphertextSize
-          }
-        }
-      ]
-    }
-
-    await apiSendMessage(this.baseUrl, credentials.token, this.uin, msg)
+    const uploaded = await this.uploadMedia(userId, data, UploadMediaType.FILE)
+    await this.sendMediaMessage(userId, {
+      type: MessageItemType.FILE,
+      file_item: { media: this.toCdnMedia(uploaded), file_name: filename, len: String(data.length) }
+    })
   }
 
   async run(): Promise<void> {
@@ -871,14 +910,33 @@ export class WeixinBot {
     }
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.stopped = true
     this.currentPollController?.abort()
     this.loginAbort?.abort()
+
+    const credentials = this.credentials ?? (this.tokenPath ? await loadCredentials(this.tokenPath) : undefined)
+    if (!credentials) return
+    this.baseUrl = normalizeBaseUrl(credentials.baseUrl)
+
+    try {
+      await apiNotifyLifecycle(this.baseUrl, credentials.token, this.uin, 'stop')
+    } catch (error) {
+      logger.warn('Failed to notify WeChat that the bot stopped', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
   }
 
   private async runLoop(): Promise<void> {
-    await this.ensureCredentials()
+    const credentials = await this.ensureCredentials()
+    try {
+      await apiNotifyLifecycle(this.baseUrl, credentials.token, this.uin, 'start')
+    } catch (error) {
+      logger.warn('Failed to notify WeChat that the bot started', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+    }
     logger.info('Long-poll loop started')
     let retryDelayMs = 1_000
 
@@ -958,6 +1016,43 @@ export class WeixinBot {
     await apiSendMessage(this.baseUrl, credentials.token, this.uin, buildTextMessage(userId, contextToken, text))
   }
 
+  private async uploadMedia(
+    userId: string,
+    data: Buffer,
+    mediaType: UploadMediaType
+  ): Promise<{ downloadEncryptedQueryParam: string; aeskey: Buffer; ciphertextSize: number }> {
+    const contextToken = this.contextTokens.get(userId)
+    if (!contextToken) {
+      logger.warn('No cached context token for media, sending without context', { userId })
+    }
+
+    const credentials = await this.ensureCredentials()
+    const uploaded = await cdnUploadMedia(this.baseUrl, credentials.token, this.uin, userId, data, mediaType)
+    if (!uploaded) throw new Error('Failed to upload media to WeChat CDN')
+    return uploaded
+  }
+
+  private toCdnMedia(uploaded: { downloadEncryptedQueryParam: string; aeskey: Buffer }): CDNMedia {
+    return {
+      encrypt_query_param: uploaded.downloadEncryptedQueryParam,
+      aes_key: Buffer.from(uploaded.aeskey.toString('hex')).toString('base64'),
+      encrypt_type: 1
+    }
+  }
+
+  private async sendMediaMessage(userId: string, item: MessageItem): Promise<void> {
+    const credentials = await this.ensureCredentials()
+    await apiSendMessage(this.baseUrl, credentials.token, this.uin, {
+      from_user_id: '',
+      to_user_id: userId,
+      client_id: randomUUID(),
+      message_type: MessageType.BOT,
+      message_state: MessageState.FINISH,
+      context_token: this.contextTokens.get(userId) ?? '',
+      item_list: [item]
+    })
+  }
+
   private async dispatchMessage(message: IncomingMessage): Promise<void> {
     if (this.handlers.length === 0) return
 
@@ -985,13 +1080,31 @@ export class WeixinBot {
   private toIncomingMessage(message: WeixinMessage): IncomingMessage | null {
     if (message.message_type !== MessageType.USER) return null
 
+    const hasCdnMedia = (media?: CDNMedia) => Boolean(media?.encrypt_query_param || media?.full_url)
     const imageItems = message.item_list
-      .filter((item) => item.type === MessageItemType.IMAGE && item.image_item?.media?.encrypt_query_param)
+      .filter((item) => item.type === MessageItemType.IMAGE && hasCdnMedia(item.image_item?.media))
       .map((item) => item.image_item!)
 
-    const fileItems = message.item_list
-      .filter((item) => item.type === MessageItemType.FILE && item.file_item?.media?.encrypt_query_param)
-      .map((item) => item.file_item!)
+    const fileItems = message.item_list.flatMap((item) => {
+      if (item.type === MessageItemType.FILE && item.file_item && hasCdnMedia(item.file_item.media)) {
+        return [
+          { filename: item.file_item.file_name ?? 'file', mediaType: 'application/octet-stream', item: item.file_item }
+        ]
+      }
+      if (item.type === MessageItemType.VIDEO && item.video_item && hasCdnMedia(item.video_item.media)) {
+        return [{ filename: `video-${message.message_id}.mp4`, mediaType: 'video/mp4', item: item.video_item }]
+      }
+      if (item.type === MessageItemType.VOICE && item.voice_item && hasCdnMedia(item.voice_item.media)) {
+        return [
+          {
+            filename: `voice-${message.message_id}.${voiceExtension(item.voice_item)}`,
+            mediaType: voiceMediaType(item.voice_item),
+            item: item.voice_item
+          }
+        ]
+      }
+      return []
+    })
 
     return {
       userId: message.from_user_id,
@@ -1070,25 +1183,56 @@ function detectType(items: MessageItem[]): IncomingMessage['type'] {
 }
 
 function extractText(items: MessageItem[]): string {
-  return items
-    .map((item) => {
-      switch (item.type) {
-        case MessageItemType.TEXT:
-          return item.text_item?.text ?? ''
-        case MessageItemType.IMAGE:
-          return ''
-        case MessageItemType.VOICE:
-          return item.voice_item?.text ?? '[voice]'
-        case MessageItemType.FILE:
-          return ''
-        case MessageItemType.VIDEO:
-          return '[video]'
-        default:
-          return ''
-      }
-    })
-    .filter(Boolean)
-    .join('\n')
+  return items.map(extractItemText).filter(Boolean).join('\n')
+}
+
+function extractItemText(item: MessageItem): string {
+  let text: string
+  switch (item.type) {
+    case MessageItemType.TEXT:
+      text = item.text_item?.text ?? ''
+      break
+    case MessageItemType.IMAGE:
+    case MessageItemType.FILE:
+      text = ''
+      break
+    case MessageItemType.VOICE:
+      text = item.voice_item?.text ?? '[voice]'
+      break
+    case MessageItemType.VIDEO:
+      text = '[video]'
+      break
+    default:
+      text = ''
+  }
+
+  const quoted = item.ref_msg
+    ? [item.ref_msg.title, item.ref_msg.message_item && extractItemText(item.ref_msg.message_item)]
+    : []
+  const quote = quoted.filter((value): value is string => Boolean(value)).join(' | ')
+  return quote ? `[quote: ${quote}]${text ? `\n${text}` : ''}` : text
+}
+
+function voiceExtension(item: VoiceItem): string {
+  switch (item.encode_type) {
+    case 7:
+      return 'mp3'
+    case 8:
+      return 'ogg'
+    default:
+      return 'silk'
+  }
+}
+
+function voiceMediaType(item: VoiceItem): string {
+  switch (item.encode_type) {
+    case 7:
+      return 'audio/mpeg'
+    case 8:
+      return 'audio/ogg'
+    default:
+      return 'audio/silk'
+  }
 }
 
 function detectImageMime(data: Buffer): string {

--- a/src/main/ai/channels/adapters/wechat/__tests__/WeChatProtocol.test.ts
+++ b/src/main/ai/channels/adapters/wechat/__tests__/WeChatProtocol.test.ts
@@ -1,0 +1,161 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })
+  }
+}))
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+import { WeixinBot } from '../WeChatProtocol'
+
+const BASE_URL = 'https://ilink.example.com'
+let tokenDir: string
+let tokenPath: string
+
+function jsonResponse(body: unknown, headers?: HeadersInit): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers })
+}
+
+function requestBody(callIndex: number): Record<string, unknown> {
+  const options = netFetchMock.mock.calls[callIndex][1] as RequestInit
+  return JSON.parse(options.body as string) as Record<string, unknown>
+}
+
+beforeEach(async () => {
+  tokenDir = await mkdtemp(path.join(tmpdir(), 'wechat-protocol-'))
+  tokenPath = path.join(tokenDir, 'credentials.json')
+  await writeFile(
+    tokenPath,
+    JSON.stringify({ token: 'token', baseUrl: BASE_URL, accountId: 'bot-id', userId: 'bot-user' })
+  )
+  netFetchMock.mockReset()
+})
+
+afterEach(async () => {
+  await rm(tokenDir, { recursive: true, force: true })
+})
+
+describe('WeixinBot media protocol', () => {
+  it('uploads and sends a document as a native FILE item', async () => {
+    netFetchMock
+      .mockResolvedValueOnce(jsonResponse({ upload_param: 'upload-token' }))
+      .mockResolvedValueOnce(new Response('', { status: 200, headers: { 'x-encrypted-param': 'download-token' } }))
+      .mockResolvedValueOnce(jsonResponse({ ret: 0 }))
+
+    const bot = new WeixinBot({ tokenPath })
+    await bot.sendFile('user-1', 'report.pdf', Buffer.from('pdf'), 'application/pdf')
+
+    expect(netFetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/ilink/bot/getuploadurl`)
+    expect(requestBody(0)).toMatchObject({ media_type: 3, rawsize: 3, filesize: 16, to_user_id: 'user-1' })
+    expect(netFetchMock.mock.calls[1][0]).toContain('encrypted_query_param=upload-token')
+
+    const sent = requestBody(2).msg as { item_list: Array<{ type: number; file_item?: Record<string, unknown> }> }
+    expect(sent.item_list).toEqual([
+      {
+        type: 4,
+        file_item: {
+          file_name: 'report.pdf',
+          len: '3',
+          media: expect.objectContaining({ encrypt_query_param: 'download-token' })
+        }
+      }
+    ])
+  })
+
+  it('uploads and sends a video as a native VIDEO item', async () => {
+    netFetchMock
+      .mockResolvedValueOnce(jsonResponse({ upload_full_url: 'https://novac2c.cdn.weixin.qq.com/c2c/upload' }))
+      .mockResolvedValueOnce(new Response('', { status: 200, headers: { 'x-encrypted-param': 'download-token' } }))
+      .mockResolvedValueOnce(jsonResponse({ ret: 0 }))
+
+    const bot = new WeixinBot({ tokenPath })
+    await bot.sendFile('user-1', 'demo.mp4', Buffer.from('video'), 'video/mp4')
+
+    expect(requestBody(0)).toMatchObject({ media_type: 2, rawsize: 5, filesize: 16, to_user_id: 'user-1' })
+    expect(netFetchMock.mock.calls[1][0]).toBe('https://novac2c.cdn.weixin.qq.com/c2c/upload')
+
+    const sent = requestBody(2).msg as { item_list: Array<{ type: number; video_item?: Record<string, unknown> }> }
+    expect(sent.item_list).toEqual([
+      {
+        type: 5,
+        video_item: {
+          video_size: 16,
+          media: expect.objectContaining({ encrypt_query_param: 'download-token' })
+        }
+      }
+    ])
+  })
+
+  it('notifies WeChat when polling starts and stops', async () => {
+    netFetchMock.mockImplementation((url: string, options?: RequestInit) => {
+      if (url.endsWith('/notifystart') || url.endsWith('/notifystop')) return Promise.resolve(jsonResponse({ ret: 0 }))
+      if (url.endsWith('/getupdates')) {
+        return new Promise((_, reject) => {
+          options?.signal?.addEventListener('abort', () =>
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }))
+          )
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    const bot = new WeixinBot({ tokenPath })
+    const run = bot.run()
+    await vi.waitFor(() => expect(netFetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/ilink/bot/msg/notifystart`))
+
+    await bot.stop()
+    await run
+
+    expect(netFetchMock.mock.calls.map(([url]) => url)).toContain(`${BASE_URL}/ilink/bot/msg/notifystop`)
+  })
+
+  it('normalizes inbound file, video, and voice media for the channel adapter', () => {
+    const bot = new WeixinBot({ tokenPath })
+    const toIncomingMessage = bot as unknown as {
+      toIncomingMessage: (message: Record<string, unknown>) => {
+        _fileItems?: Array<{ filename: string; mediaType: string }>
+        text: string
+      }
+    }
+
+    const incoming = toIncomingMessage.toIncomingMessage({
+      message_id: 42,
+      from_user_id: 'user-1',
+      to_user_id: 'bot-user',
+      client_id: 'client-1',
+      create_time_ms: 0,
+      message_type: 1,
+      message_state: 2,
+      context_token: 'context-1',
+      item_list: [
+        { type: 4, file_item: { file_name: 'report.pdf', media: { encrypt_query_param: 'file-token' } } },
+        { type: 5, video_item: { media: { encrypt_query_param: 'video-token' } } },
+        { type: 3, voice_item: { encode_type: 7, text: 'hello', media: { encrypt_query_param: 'voice-token' } } },
+        {
+          type: 1,
+          text_item: { text: 'follow-up' },
+          ref_msg: { title: 'Earlier message', message_item: { type: 1, text_item: { text: 'original message' } } }
+        }
+      ]
+    })
+
+    expect(incoming.text).toContain('[quote: Earlier message | original message]')
+    expect(incoming.text).toContain('hello')
+    expect(incoming.text).toContain('follow-up')
+    expect(incoming._fileItems).toMatchObject([
+      { filename: 'report.pdf', mediaType: 'application/octet-stream' },
+      { filename: 'video-42.mp4', mediaType: 'video/mp4' },
+      { filename: 'voice-42.mp3', mediaType: 'audio/mpeg' }
+    ])
+  })
+})

--- a/src/main/ai/channels/adapters/wechat/__tests__/WeChatProtocol.test.ts
+++ b/src/main/ai/channels/adapters/wechat/__tests__/WeChatProtocol.test.ts
@@ -96,9 +96,31 @@ describe('WeixinBot media protocol', () => {
     ])
   })
 
-  it('notifies WeChat when polling starts and stops', async () => {
+  it('keeps the originating context token while media upload is in flight', async () => {
+    let resolveUploadUrl!: (response: Response) => void
+    netFetchMock
+      .mockImplementationOnce(() => new Promise<Response>((resolve) => (resolveUploadUrl = resolve)))
+      .mockResolvedValueOnce(new Response('', { status: 200, headers: { 'x-encrypted-param': 'download-token' } }))
+      .mockResolvedValueOnce(jsonResponse({ ret: 0 }))
+
+    const bot = new WeixinBot({ tokenPath })
+    const contextTokens = bot as unknown as { contextTokens: Map<string, string> }
+    contextTokens.contextTokens.set('user-1', 'context-before-upload')
+
+    const sending = bot.sendFile('user-1', 'report.pdf', Buffer.from('pdf'), 'application/pdf')
+    await vi.waitFor(() => expect(netFetchMock).toHaveBeenCalledTimes(1))
+    contextTokens.contextTokens.set('user-1', 'context-after-upload')
+    resolveUploadUrl(jsonResponse({ upload_param: 'upload-token' }))
+    await sending
+
+    const sent = requestBody(2).msg as { context_token: string }
+    expect(sent.context_token).toBe('context-before-upload')
+  })
+
+  it('stops polling without waiting for the lifecycle notification', async () => {
     netFetchMock.mockImplementation((url: string, options?: RequestInit) => {
-      if (url.endsWith('/notifystart') || url.endsWith('/notifystop')) return Promise.resolve(jsonResponse({ ret: 0 }))
+      if (url.endsWith('/notifystart')) return Promise.resolve(jsonResponse({ ret: 0 }))
+      if (url.endsWith('/notifystop')) return new Promise(() => {})
       if (url.endsWith('/getupdates')) {
         return new Promise((_, reject) => {
           options?.signal?.addEventListener('abort', () =>
@@ -113,7 +135,7 @@ describe('WeixinBot media protocol', () => {
     const run = bot.run()
     await vi.waitFor(() => expect(netFetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/ilink/bot/msg/notifystart`))
 
-    await bot.stop()
+    expect(bot.stop()).toBeUndefined()
     await run
 
     expect(netFetchMock.mock.calls.map(([url]) => url)).toContain(`${BASE_URL}/ilink/bot/msg/notifystop`)

--- a/src/main/ai/channels/security/__tests__/WorkspaceFileGuard.test.ts
+++ b/src/main/ai/channels/security/__tests__/WorkspaceFileGuard.test.ts
@@ -58,6 +58,12 @@ describe('resolveWorkspaceFile', () => {
     expect(file.media_type).toBe('image/png')
   })
 
+  it('infers video MIME types for native channel delivery', async () => {
+    await writeFile(path.join(workspace, 'clip.mp4'), 'x')
+    const file = await resolveWorkspaceFile(workspace, 'clip.mp4')
+    expect(file.media_type).toBe('video/mp4')
+  })
+
   it('falls back to octet-stream for unknown extensions', async () => {
     await writeFile(path.join(workspace, 'blob.xyz'), 'x')
     const file = await resolveWorkspaceFile(workspace, 'blob.xyz')

--- a/src/main/ai/channels/utils.ts
+++ b/src/main/ai/channels/utils.ts
@@ -47,5 +47,11 @@ export const FILE_EXTENSION_MIME_MAP: Record<string, string> = {
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   gif: 'image/gif',
-  webp: 'image/webp'
+  webp: 'image/webp',
+  mp4: 'video/mp4',
+  m4v: 'video/x-m4v',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  webm: 'video/webm'
 }

--- a/src/main/ai/mcp/servers/cherryAutonomyTools.ts
+++ b/src/main/ai/mcp/servers/cherryAutonomyTools.ts
@@ -133,7 +133,7 @@ const CRON_TOOL: Tool = {
 const NOTIFY_TOOL: Tool = {
   name: NOTIFY_TOOL_NAME,
   description:
-    'Send a notification to the user through connected channels (e.g. Telegram). Provide a message, a file to forward from your workspace, or both. Use this to proactively deliver task results, status updates, or produced files. File support by channel: Telegram/Feishu forward any file; WeChat images only; Discord/Slack/QQ do not support files yet (a file_path to those returns an error).',
+    'Send a notification to the user through connected channels (e.g. Telegram). Provide a message, a file to forward from your workspace, or both. Use this to proactively deliver task results, status updates, or produced files. File support by channel: Telegram/Feishu/WeChat forward any file, and WeChat sends video as native video media; Discord/Slack/QQ do not support files yet (a file_path to those returns an error).',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The WeChat Agent channel could send images but rejected documents, archives, and videos. It also ignored inbound video and voice media, left the typing indicator active after text delivery, and did not send iLink lifecycle notifications.

After this PR:

The channel sends documents and other attachments as native iLink FILE messages, sends video as native VIDEO media, and downloads inbound file, video, and voice media into the Agent workspace. It now preserves quoted-text context, stops typing after delivery, and notifies iLink when polling starts and stops.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # None

### Why we need it and why it was done in this way

The iLink protocol natively supports FILE and VIDEO media through `getuploadurl`, encrypted CDN upload, and `sendmessage`; Cherry's adapter already had the image version of that flow. The implementation generalizes that proven flow rather than adding a dependency or an alternate transport. It keeps WeChat's CDN `full_url` support within HTTPS `*.cdn.weixin.qq.com` hosts before downloading inbound media.

The following tradeoffs were made:

- Audio is sent as a file attachment. Tencent's reference implementation has no verified `voice_item` sending path, so claiming native voice-message output would be speculative.
- Structured `TOOL_CALL_START` / `TOOL_CALL_RESULT` messages are not wired because Cherry's stream listener does not expose the host callback contract they require.

The following alternatives were considered:

- Sending video as a generic file. Rejected because iLink has a native VIDEO message type and clients can render it appropriately.
- Adding Tencent's OpenClaw plugin as a dependency. Rejected because Cherry already owns a compatible protocol implementation and only needs the missing message shapes.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

- Narrow tests verify FILE and VIDEO request shapes, inbound media normalization, lifecycle notifications, adapter routing, and typing cleanup.
- Live WeChat delivery still needs a logged-in account for end-to-end verification.
- `pnpm lint` currently fails in unrelated Web tests because jest-dom matcher types are absent. `pnpm typecheck:node` also has pre-existing OpenRouter `ProviderV3` incompatibilities in `packages/aiCore`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because the existing WeChat channel setup and notify tool are unchanged.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agents can now send documents and videos through WeChat channels, and incoming video and voice messages are available in the agent workspace.
```
