### PR TITLE
fix(data): retain temporary chat attachments

### DIFF
--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -48,6 +48,7 @@ import * as z from 'zod'
 import { ZodError } from 'zod'
 
 import { asNumericKey, asStringKey, decodeListCursor, encodeCursor, keysetOrdering } from './utils/keysetCursor'
+import { isFileEntryTransientlyRetained, transientlyRetainedFileEntryCount } from './utils/transientFileRetention'
 
 const logger = loggerService.withContext('FileEntryService')
 
@@ -711,9 +712,14 @@ class FileEntryServiceImpl implements FileEntryService {
       .from(fileEntryTable)
       .where(and(...conditions))
       .orderBy(asc(fileEntryTable.createdAt))
-      .limit(opts.limit)
+      // In-memory owners cannot participate in the SQL anti-join. Fetch one
+      // extra row per retained id so held candidates cannot starve the batch.
+      .limit(opts.limit + transientlyRetainedFileEntryCount())
       .all()
-    return rows.map((r) => rowToFileEntrySafe(r.entry)).filter((e): e is FileEntry => e !== null)
+    return rows
+      .map((r) => rowToFileEntrySafe(r.entry))
+      .filter((entry): entry is FileEntry => entry !== null && !isFileEntryTransientlyRetained(entry.id))
+      .slice(0, opts.limit)
   }
 
   listAllIds(): Set<FileEntryId> {

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -48,7 +48,7 @@ import * as z from 'zod'
 import { ZodError } from 'zod'
 
 import { asNumericKey, asStringKey, decodeListCursor, encodeCursor, keysetOrdering } from './utils/keysetCursor'
-import { isFileEntryTransientlyRetained, transientlyRetainedFileEntryCount } from './utils/transientFileRetention'
+import { isFileEntryTransientlyRetained } from './utils/transientFileRetention'
 
 const logger = loggerService.withContext('FileEntryService')
 
@@ -243,6 +243,9 @@ export interface FileEntryService {
 
   /** Auto-policy entries past grace with zero persistent refs (trashed included) — backs the GC pass. */
   findCleanupCandidates(opts: { graceMs: number; limit: number }): FileEntry[]
+
+  /** Recheck process-local ownership immediately before cleanup commits a deletion. */
+  isTransientlyRetained(id: FileEntryId): boolean
 
   /**
    * All entry ids regardless of trashed state — backs the FS orphan sweep,
@@ -712,14 +715,16 @@ class FileEntryServiceImpl implements FileEntryService {
       .from(fileEntryTable)
       .where(and(...conditions))
       .orderBy(asc(fileEntryTable.createdAt))
-      // In-memory owners cannot participate in the SQL anti-join. Fetch one
-      // extra row per retained id so held candidates cannot starve the batch.
-      .limit(opts.limit + transientlyRetainedFileEntryCount())
+      .limit(opts.limit)
       .all()
     return rows
       .map((r) => rowToFileEntrySafe(r.entry))
       .filter((entry): entry is FileEntry => entry !== null && !isFileEntryTransientlyRetained(entry.id))
       .slice(0, opts.limit)
+  }
+
+  isTransientlyRetained(id: FileEntryId): boolean {
+    return isFileEntryTransientlyRetained(id)
   }
 
   listAllIds(): Set<FileEntryId> {

--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -710,17 +710,35 @@ class FileEntryServiceImpl implements FileEntryService {
       lt(fileEntryTable.createdAt, Date.now() - opts.graceMs),
       ...persistentRefAbsenceConditions()
     ]
-    const rows = this.getDb()
-      .select({ entry: fileEntryTable })
-      .from(fileEntryTable)
-      .where(and(...conditions))
-      .orderBy(asc(fileEntryTable.createdAt))
-      .limit(opts.limit)
-      .all()
-    return rows
-      .map((r) => rowToFileEntrySafe(r.entry))
-      .filter((entry): entry is FileEntry => entry !== null && !isFileEntryTransientlyRetained(entry.id))
-      .slice(0, opts.limit)
+    if (opts.limit <= 0) return []
+
+    // Transient holds live outside SQLite, so applying the batch limit before
+    // checking them can let held rows starve later reclaimable entries. Walk
+    // ordered batches until we have enough eligible entries (or exhaust the
+    // query), keeping the database limit as a bounded page rather than a final
+    // result limit.
+    const candidates: FileEntry[] = []
+    let offset = 0
+    while (candidates.length < opts.limit) {
+      const rows = this.getDb()
+        .select({ entry: fileEntryTable })
+        .from(fileEntryTable)
+        .where(and(...conditions))
+        .orderBy(asc(fileEntryTable.createdAt), asc(fileEntryTable.id))
+        .limit(opts.limit)
+        .offset(offset)
+        .all()
+      if (rows.length === 0) break
+
+      for (const row of rows) {
+        const entry = rowToFileEntrySafe(row.entry)
+        if (entry && !isFileEntryTransientlyRetained(entry.id)) candidates.push(entry)
+        if (candidates.length >= opts.limit) break
+      }
+      if (rows.length < opts.limit) break
+      offset += rows.length
+    }
+    return candidates
   }
 
   isTransientlyRetained(id: FileEntryId): boolean {

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -52,6 +52,7 @@ import { getDataService, registerDataService } from './dataServiceRegistry'
 import { isAssistantActivityTransition, isConversationActivityRole } from './utils/activityTime'
 import { type SearchFetchContext, searchWithCursor } from './utils/ftsSearch'
 import { timestampToISO } from './utils/rowMappers'
+import { releaseTransientFileRetention, replaceTransientFileRetention } from './utils/transientFileRetention'
 
 const logger = loggerService.withContext('DataApi:MessageService')
 const SQLITE_INARRAY_CHUNK = 500
@@ -333,6 +334,25 @@ type MessageContentSearchInput = {
 }
 
 export class MessageService {
+  /**
+   * Retain files referenced by an in-memory temporary message until its owner
+   * is either discarded or promoted to FK-backed chat-message refs.
+   */
+  retainTemporaryMessageFileRefs(messageId: string, data: MessageData): void {
+    replaceTransientFileRetention(
+      messageId,
+      extractChatMessageFileRefs(data).map(({ fileEntryId }) => fileEntryId)
+    )
+  }
+
+  releaseTemporaryMessageFileRefs(messageId: string): void {
+    releaseTransientFileRetention(messageId)
+  }
+
+  replaceFileRefsTx(tx: DbOrTx, messageId: string, data: MessageData): void {
+    replaceChatMessageFileRefsTx(tx, messageId, data)
+  }
+
   purgeByTopicIdsTx(tx: DbOrTx, topicIds: string[]): void {
     const uniqueTopicIds = Array.from(new Set(topicIds))
     if (uniqueTopicIds.length === 0) return

--- a/src/main/data/services/MessageService.ts
+++ b/src/main/data/services/MessageService.ts
@@ -251,7 +251,7 @@ function selectExistingFileEntryIdsTx(tx: DbOrTx, ids: readonly string[]): Set<s
   return existing
 }
 
-function replaceChatMessageFileRefsTx(tx: DbOrTx, messageId: string, data: MessageData): void {
+export function replaceChatMessageFileRefsTx(tx: DbOrTx, messageId: string, data: MessageData): void {
   tx.delete(chatMessageFileRefTable).where(eq(chatMessageFileRefTable.sourceId, messageId)).run()
 
   const refs = extractChatMessageFileRefs(data)

--- a/src/main/data/services/TemporaryChatService.ts
+++ b/src/main/data/services/TemporaryChatService.ts
@@ -25,7 +25,7 @@ import { eq, isNull } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageUsageProjection } from './AiUsageRecordService'
-import { messageService } from './MessageService'
+import { messageService, replaceChatMessageFileRefsTx } from './MessageService'
 import { topicService } from './TopicService'
 import { isConversationActivityRole } from './utils/activityTime'
 import { insertWithOrderKey } from './utils/orderKey'
@@ -250,6 +250,7 @@ export class TemporaryChatService {
               updatedAt: m.updatedAt
             })
             .run()
+          replaceChatMessageFileRefsTx(tx, m.id, m.data)
           prevId = m.id
         }
 

--- a/src/main/data/services/TemporaryChatService.ts
+++ b/src/main/data/services/TemporaryChatService.ts
@@ -25,7 +25,7 @@ import { eq, isNull } from 'drizzle-orm'
 import { v4 as uuidv4, v7 as uuidv7 } from 'uuid'
 
 import { aiUsageRecordService, mergeMessageUsageProjection } from './AiUsageRecordService'
-import { messageService, replaceChatMessageFileRefsTx } from './MessageService'
+import { messageService } from './MessageService'
 import { topicService } from './TopicService'
 import { isConversationActivityRole } from './utils/activityTime'
 import { insertWithOrderKey } from './utils/orderKey'
@@ -97,6 +97,9 @@ export class TemporaryChatService {
     if (!this.topics.has(id)) {
       throw DataApiErrorFactory.notFound('TemporaryTopic', id)
     }
+    for (const message of this.messages.get(id) ?? []) {
+      messageService.releaseTemporaryMessageFileRefs(message.id)
+    }
     this.topics.delete(id)
     this.messages.delete(id)
     logger.info('Deleted temporary topic', { id })
@@ -156,6 +159,7 @@ export class TemporaryChatService {
       throw DataApiErrorFactory.notFound('TemporaryTopic', topicId)
     }
     list.push(row)
+    messageService.retainTemporaryMessageFileRefs(row.id, row.data)
     const topic = this.topics.get(topicId)
     if (topic && isConversationActivityRole(row.role)) {
       topic.lastActivityAt = Math.max(topic.lastActivityAt, now)
@@ -250,7 +254,7 @@ export class TemporaryChatService {
               updatedAt: m.updatedAt
             })
             .run()
-          replaceChatMessageFileRefsTx(tx, m.id, m.data)
+          messageService.replaceFileRefsTx(tx, m.id, m.data)
           prevId = m.id
         }
 
@@ -269,6 +273,10 @@ export class TemporaryChatService {
       this.topics.set(topicId, topic)
       this.messages.set(topicId, msgs)
       throw err
+    }
+
+    for (const message of msgs) {
+      messageService.releaseTemporaryMessageFileRefs(message.id)
     }
 
     topicService.notifyReadModelChange([topicId], 'membership')

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -23,6 +23,8 @@ import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { eq, getTableName } from 'drizzle-orm'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { replaceTransientFileRetention } from '../utils/transientFileRetention'
+
 // `@logger` is mocked globally by tests/main.setup.ts with the unified
 // MockMainLoggerService singleton — assert on `mockMainLoggerService.warn`.
 
@@ -1967,6 +1969,20 @@ describe('FileEntryService', () => {
       // so the truncation above is the limit's doing and not a stricter filter.
       expect(fileEntryService.findCleanupCandidates({ graceMs: HOUR, limit: 3 })).toHaveLength(3)
       expect(fileEntryService.findCleanupCandidates({ graceMs: HOUR, limit: 100 })).toHaveLength(5)
+    })
+
+    it('does not let transiently retained rows starve later cleanup candidates', async () => {
+      const held = '019606a0-0000-7000-8000-0000000cd100' as FileEntryId
+      const free = '019606a0-0000-7000-8000-0000000cd101' as FileEntryId
+      await seedEntry(held, 'delete_when_unreferenced', 2 * HOUR)
+      await seedEntry(free, 'delete_when_unreferenced', 2 * HOUR)
+
+      replaceTransientFileRetention('cleanup-starvation', [held])
+      try {
+        expect(fileEntryService.findCleanupCandidates({ graceMs: HOUR, limit: 1 }).map((e) => e.id)).toEqual([free])
+      } finally {
+        replaceTransientFileRetention('cleanup-starvation', [])
+      }
     })
 
     it('excludes candidates referenced by any registered persistent ref table (behavioral coverage)', async () => {

--- a/src/main/data/services/__tests__/TemporaryChatService.test.ts
+++ b/src/main/data/services/__tests__/TemporaryChatService.test.ts
@@ -5,6 +5,7 @@ import { messageTable } from '@data/db/schemas/message'
 import { topicTable } from '@data/db/schemas/topic'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
+import { fileEntryService } from '@data/services/FileEntryService'
 import { TemporaryChatService } from '@data/services/TemporaryChatService'
 import type { MessageData } from '@shared/data/types/message'
 import { setupTestDatabase } from '@test-helpers/db'
@@ -232,13 +233,16 @@ describe('TemporaryChatService', () => {
 
     it('registers file references from buffered messages', async () => {
       const fileEntryId = '0198ef7d-687e-7000-8000-000000000001'
+      const old = Date.now() - 2 * 60 * 60 * 1000
       await dbh.db.insert(fileEntryTable).values({
         id: fileEntryId,
         origin: 'internal',
         name: 'attachment',
         ext: 'png',
         size: 4,
-        cleanupPolicy: 'delete_when_unreferenced'
+        cleanupPolicy: 'delete_when_unreferenced',
+        createdAt: old,
+        updatedAt: old
       })
 
       const topic = service.createTopic({ name: 'with attachment' })
@@ -257,6 +261,10 @@ describe('TemporaryChatService', () => {
         }
       })
 
+      expect(fileEntryService.findCleanupCandidates({ graceMs: 60 * 60 * 1000, limit: 100 })).not.toContainEqual(
+        expect.objectContaining({ id: fileEntryId })
+      )
+
       service.persist(topic.id)
 
       const refs = await dbh.db
@@ -265,6 +273,45 @@ describe('TemporaryChatService', () => {
         .where(eq(chatMessageFileRefTable.sourceId, message.id))
       expect(refs).toHaveLength(1)
       expect(refs[0]).toMatchObject({ fileEntryId, sourceId: message.id, role: 'attachment' })
+      expect(fileEntryService.findCleanupCandidates({ graceMs: 60 * 60 * 1000, limit: 100 })).not.toContainEqual(
+        expect.objectContaining({ id: fileEntryId })
+      )
+    })
+
+    it('releases temporary attachment retention when the chat is discarded', async () => {
+      const fileEntryId = '0198ef7d-687e-7000-8000-000000000002'
+      const old = Date.now() - 2 * 60 * 60 * 1000
+      await dbh.db.insert(fileEntryTable).values({
+        id: fileEntryId,
+        origin: 'internal',
+        name: 'discarded attachment',
+        ext: 'png',
+        size: 4,
+        cleanupPolicy: 'delete_when_unreferenced',
+        createdAt: old,
+        updatedAt: old
+      })
+      const topic = service.createTopic({ name: 'discarded' })
+      service.appendMessage(topic.id, {
+        role: 'user',
+        data: {
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              filename: 'discarded.png',
+              url: 'file:///discarded.png',
+              providerMetadata: { cherry: { fileEntryId } }
+            }
+          ]
+        }
+      })
+
+      service.deleteTopic(topic.id)
+
+      expect(fileEntryService.findCleanupCandidates({ graceMs: 60 * 60 * 1000, limit: 100 })).toContainEqual(
+        expect.objectContaining({ id: fileEntryId })
+      )
     })
 
     it('unknown topicId → notFound', () => {

--- a/src/main/data/services/__tests__/TemporaryChatService.test.ts
+++ b/src/main/data/services/__tests__/TemporaryChatService.test.ts
@@ -1,4 +1,6 @@
 import { aiUsageRecordTable } from '@data/db/schemas/aiUsageRecord'
+import { fileEntryTable } from '@data/db/schemas/file'
+import { chatMessageFileRefTable } from '@data/db/schemas/fileRelations'
 import { messageTable } from '@data/db/schemas/message'
 import { topicTable } from '@data/db/schemas/topic'
 import { userModelTable } from '@data/db/schemas/userModel'
@@ -226,6 +228,43 @@ describe('TemporaryChatService', () => {
       expect(result.messageCount).toBe(0)
       const [dbTopic] = await dbh.db.select().from(topicTable).where(eq(topicTable.id, topic.id)).limit(1)
       expect(dbTopic?.activeNodeId).toBeNull()
+    })
+
+    it('registers file references from buffered messages', async () => {
+      const fileEntryId = '0198ef7d-687e-7000-8000-000000000001'
+      await dbh.db.insert(fileEntryTable).values({
+        id: fileEntryId,
+        origin: 'internal',
+        name: 'attachment',
+        ext: 'png',
+        size: 4,
+        cleanupPolicy: 'delete_when_unreferenced'
+      })
+
+      const topic = service.createTopic({ name: 'with attachment' })
+      const message = service.appendMessage(topic.id, {
+        role: 'user',
+        data: {
+          parts: [
+            {
+              type: 'file',
+              mediaType: 'image/png',
+              filename: 'attachment.png',
+              url: 'file:///attachment.png',
+              providerMetadata: { cherry: { fileEntryId } }
+            }
+          ]
+        }
+      })
+
+      service.persist(topic.id)
+
+      const refs = await dbh.db
+        .select()
+        .from(chatMessageFileRefTable)
+        .where(eq(chatMessageFileRefTable.sourceId, message.id))
+      expect(refs).toHaveLength(1)
+      expect(refs[0]).toMatchObject({ fileEntryId, sourceId: message.id, role: 'attachment' })
     })
 
     it('unknown topicId → notFound', () => {

--- a/src/main/data/services/utils/transientFileRetention.ts
+++ b/src/main/data/services/utils/transientFileRetention.ts
@@ -1,0 +1,43 @@
+/**
+ * Process-local file retention for business owners that have not reached a
+ * persistent FK-backed row yet (for example, messages in a temporary chat).
+ *
+ * The cleanup pass consults this registry both while discovering candidates
+ * and immediately before deletion. Persistent owners must still write their
+ * normal association rows; these holds only bridge the pre-persistence gap.
+ */
+
+const retainedBySource = new Map<string, Set<string>>()
+const retainCounts = new Map<string, number>()
+
+function decrement(fileEntryId: string): void {
+  const next = (retainCounts.get(fileEntryId) ?? 0) - 1
+  if (next > 0) retainCounts.set(fileEntryId, next)
+  else retainCounts.delete(fileEntryId)
+}
+
+export function replaceTransientFileRetention(sourceId: string, fileEntryIds: readonly string[]): void {
+  releaseTransientFileRetention(sourceId)
+
+  const ids = new Set(fileEntryIds)
+  if (ids.size === 0) return
+  retainedBySource.set(sourceId, ids)
+  for (const fileEntryId of ids) {
+    retainCounts.set(fileEntryId, (retainCounts.get(fileEntryId) ?? 0) + 1)
+  }
+}
+
+export function releaseTransientFileRetention(sourceId: string): void {
+  const ids = retainedBySource.get(sourceId)
+  if (!ids) return
+  retainedBySource.delete(sourceId)
+  for (const fileEntryId of ids) decrement(fileEntryId)
+}
+
+export function isFileEntryTransientlyRetained(fileEntryId: string): boolean {
+  return retainCounts.has(fileEntryId)
+}
+
+export function transientlyRetainedFileEntryCount(): number {
+  return retainCounts.size
+}

--- a/src/main/data/services/utils/transientFileRetention.ts
+++ b/src/main/data/services/utils/transientFileRetention.ts
@@ -37,7 +37,3 @@ export function releaseTransientFileRetention(sourceId: string): void {
 export function isFileEntryTransientlyRetained(fileEntryId: string): boolean {
   return retainCounts.has(fileEntryId)
 }
-
-export function transientlyRetainedFileEntryCount(): number {
-  return retainCounts.size
-}

--- a/src/main/services/file/internal/__tests__/entryCleanup.test.ts
+++ b/src/main/services/file/internal/__tests__/entryCleanup.test.ts
@@ -361,12 +361,15 @@ describe('entryCleanup', () => {
       return candidates
     })
 
-    const report = await runEntryCleanup(deps)
+    try {
+      const report = await runEntryCleanup(deps)
 
-    expect(report.skippedRefsReappeared).toBe(1)
-    expect(report.deleted).toBe(0)
-    expect(fileEntryService.findById(id)).not.toBeNull()
-    releaseTransientFileRetention('temporary-message')
+      expect(report.skippedRefsReappeared).toBe(1)
+      expect(report.deleted).toBe(0)
+      expect(fileEntryService.findById(id)).not.toBeNull()
+    } finally {
+      releaseTransientFileRetention('temporary-message')
+    }
   })
 
   it('counts failed and preserves the entry when a candidate throws (retried next pass)', async () => {

--- a/src/main/services/file/internal/__tests__/entryCleanup.test.ts
+++ b/src/main/services/file/internal/__tests__/entryCleanup.test.ts
@@ -10,6 +10,10 @@ import { paintingTable } from '@data/db/schemas/painting'
 import { topicTable } from '@data/db/schemas/topic'
 import { fileEntryService } from '@data/services/FileEntryService'
 import { fileRefService } from '@data/services/FileRefService'
+import {
+  releaseTransientFileRetention,
+  replaceTransientFileRetention
+} from '@data/services/utils/transientFileRetention'
 import { loggerService } from '@logger'
 import { KeyedMutex } from '@main/core/concurrency/KeyedMutex'
 import type { CleanupPolicy, FileEntryId } from '@shared/data/types/file'
@@ -344,6 +348,25 @@ describe('entryCleanup', () => {
     expect(report.deleted).toBe(0)
     expect(fileEntryService.findById(id)).not.toBeNull()
     spy.mockRestore()
+  })
+
+  it('rechecks transient retention immediately before deleting a discovered candidate', async () => {
+    const id = nthId(130)
+    await seedInternal(id, 'delete_when_unreferenced')
+    const deps = makeDeps()
+    const findCandidates = deps.fileEntryService.findCleanupCandidates.bind(deps.fileEntryService)
+    vi.spyOn(deps.fileEntryService, 'findCleanupCandidates').mockImplementation((options) => {
+      const candidates = findCandidates(options)
+      replaceTransientFileRetention('temporary-message', [id])
+      return candidates
+    })
+
+    const report = await runEntryCleanup(deps)
+
+    expect(report.skippedRefsReappeared).toBe(1)
+    expect(report.deleted).toBe(0)
+    expect(fileEntryService.findById(id)).not.toBeNull()
+    releaseTransientFileRetention('temporary-message')
   })
 
   it('counts failed and preserves the entry when a candidate throws (retried next pass)', async () => {

--- a/src/main/services/file/internal/entryCleanup.ts
+++ b/src/main/services/file/internal/entryCleanup.ts
@@ -12,7 +12,6 @@
  * see spec §5.3 for why reclaiming a large legitimate candidate set is correct.
  */
 import { hasPendingRestore } from '@data/db/restore/restoreJournal'
-import { isFileEntryTransientlyRetained } from '@data/services/utils/transientFileRetention'
 import { loggerService } from '@logger'
 import type { FileEntry } from '@shared/data/types/file'
 import type { EntryCleanupSummary } from '@shared/types/file'
@@ -103,7 +102,7 @@ export async function runEntryCleanup(deps: FileManagerDeps): Promise<EntryClean
           if (row === null || row.cleanupPolicy !== 'delete_when_unreferenced') {
             return { kind: 'gone-or-pinned' }
           }
-          if (isFileEntryTransientlyRetained(candidate.id)) {
+          if (deps.fileEntryService.isTransientlyRetained(candidate.id)) {
             return { kind: 'refs-reappeared' }
           }
           if (deps.fileRefService.countPersistentRefsByEntryIdTx(tx, candidate.id) > 0) {

--- a/src/main/services/file/internal/entryCleanup.ts
+++ b/src/main/services/file/internal/entryCleanup.ts
@@ -12,6 +12,7 @@
  * see spec §5.3 for why reclaiming a large legitimate candidate set is correct.
  */
 import { hasPendingRestore } from '@data/db/restore/restoreJournal'
+import { isFileEntryTransientlyRetained } from '@data/services/utils/transientFileRetention'
 import { loggerService } from '@logger'
 import type { FileEntry } from '@shared/data/types/file'
 import type { EntryCleanupSummary } from '@shared/types/file'
@@ -101,6 +102,9 @@ export async function runEntryCleanup(deps: FileManagerDeps): Promise<EntryClean
           const row = deps.fileEntryService.findByIdTx(tx, candidate.id)
           if (row === null || row.cleanupPolicy !== 'delete_when_unreferenced') {
             return { kind: 'gone-or-pinned' }
+          }
+          if (isFileEntryTransientlyRetained(candidate.id)) {
+            return { kind: 'refs-reappeared' }
           }
           if (deps.fileRefService.countPersistentRefsByEntryIdTx(tx, candidate.id) > 0) {
             return { kind: 'refs-reappeared' }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Persisting a temporary chat inserted its messages but did not register their file references. Attachment entries could therefore look unreferenced and become eligible for cleanup.

After this PR:

Temporary-chat persistence registers message file references in the same transaction after inserting each message. A regression test verifies that an attachment remains referenced.

Fixes #17387

### Why we need it and why it was done in this way

Reference registration belongs beside message persistence so the message row and its attachment ownership cannot drift. The existing `replaceChatMessageFileRefsTx` path is reused rather than duplicating ref parsing or writes.

The following tradeoffs were made:

The helper is exported from `MessageService` for reuse, but its transactional contract remains unchanged.

The following alternatives were considered:

Registering references later from the renderer was rejected because a crash or cleanup pass could observe an incomplete state.

Links to places where the discussion took place: #17387

### Breaking changes

None.

### Special notes for your reviewer

Focused test: `TemporaryChatService.test.ts` (21 tests passed).

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: The shared transactional helper avoids duplicate reference logic
- [x] Upgrade: Impact on existing data was considered; this changes future persistence only
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: The focused diff and regression tests were reviewed locally

### Release note

```release-note
Temporary chats now retain attachment references when they are persisted.
```