### PR TITLE
feat(data): support JSON Merge Patch for provider settings

### DIFF
--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -46,6 +46,24 @@ import { isRetiredProvider } from '../retiredProviders'
 
 const logger = loggerService.withContext('DataApi:ProviderService')
 
+function applyJsonMergePatch(target: unknown, patch: unknown): unknown {
+  if (patch === null || typeof patch !== 'object' || Array.isArray(patch)) return patch
+
+  const result: Record<string, unknown> =
+    target !== null && typeof target === 'object' && !Array.isArray(target)
+      ? { ...(target as Record<string, unknown>) }
+      : {}
+
+  for (const [key, value] of Object.entries(patch)) {
+    if (value == null) {
+      delete result[key]
+    } else {
+      result[key] = applyJsonMergePatch(result[key], value)
+    }
+  }
+  return result
+}
+
 type NewUserProviderInput = Omit<InsertUserProviderRow, 'orderKey'>
 type ProviderIdentity = Pick<UserProviderRow, 'providerId' | 'presetProviderId'>
 
@@ -453,10 +471,10 @@ class ProviderService {
           dto.defaultChatEndpoint === presetMetadata?.defaultChatEndpoint ? null : dto.defaultChatEndpoint
       }
       if (dto.providerSettings !== undefined) {
-        updates.providerSettings = {
-          ...(current.providerSettings as Partial<ProviderSettings> | null),
-          ...dto.providerSettings
-        }
+        updates.providerSettings = applyJsonMergePatch(
+          current.providerSettings,
+          dto.providerSettings
+        ) as Partial<ProviderSettings>
       }
 
       if (dto.isEnabled === true && !current.isEnabled) {

--- a/src/main/data/services/__tests__/ProviderService.update.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.update.test.ts
@@ -83,6 +83,45 @@ describe('ProviderService.update', () => {
     expect(row.providerSettings).toEqual({ timeout: 30 })
   })
 
+  it('merges nested providerSettings without clobbering sibling keys', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'p-nested',
+      name: 'P',
+      orderKey: 'a0',
+      providerSettings: {
+        cacheControl: { enabled: true, tokenThreshold: 5_000, cacheLastNMessages: 2 }
+      }
+    })
+
+    providerService.update('p-nested', {
+      providerSettings: { cacheControl: { tokenThreshold: 20_000 } }
+    })
+
+    const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, 'p-nested'))
+    expect(row.providerSettings).toEqual({
+      cacheControl: { enabled: true, tokenThreshold: 20_000, cacheLastNMessages: 2 }
+    })
+  })
+
+  it('removes nested and top-level providerSettings keys with null merge-patch values', async () => {
+    await dbh.db.insert(userProviderTable).values({
+      providerId: 'p-delete',
+      name: 'P',
+      orderKey: 'a0',
+      providerSettings: {
+        notes: 'temporary',
+        extraHeaders: { 'X-Keep': 'yes', 'X-Remove': 'no' }
+      }
+    })
+
+    providerService.update('p-delete', {
+      providerSettings: { notes: null, extraHeaders: { 'X-Remove': null } }
+    })
+
+    const [row] = await dbh.db.select().from(userProviderTable).where(eq(userProviderTable.providerId, 'p-delete'))
+    expect(row.providerSettings).toEqual({ extraHeaders: { 'X-Keep': 'yes' } })
+  })
+
   it('drops a key when the patch sets it to undefined (reset-to-default)', async () => {
     await dbh.db.insert(userProviderTable).values({
       providerId: 'p-undef',

--- a/src/shared/data/api/schemas/__tests__/providers.test.ts
+++ b/src/shared/data/api/schemas/__tests__/providers.test.ts
@@ -64,4 +64,12 @@ describe('Provider DTO logo validation', () => {
   it('accepts a non-logo update (e.g. name)', () => {
     expect(UpdateProviderSchema.safeParse({ name: 'Renamed' }).success).toBe(true)
   })
+
+  it('accepts null values in provider settings merge patches', () => {
+    const result = UpdateProviderSchema.safeParse({
+      providerSettings: { notes: null, extraHeaders: { 'X-Remove': null } }
+    })
+
+    expect(result.success).toBe(true)
+  })
 })

--- a/src/shared/data/api/schemas/providers.ts
+++ b/src/shared/data/api/schemas/providers.ts
@@ -46,12 +46,36 @@ const ProviderEndpointConfigsSchema = z.partialRecord(EndpointTypeSchema, Endpoi
   Partial<Record<EndpointType, EndpointConfigOverride>>
 >
 
-/**
- * Provider-settings is a loose bag today (e.g. OAuth tokens, provider-specific
- * knobs); keep `Partial<ProviderSettings>` as the DTO shape for parity with
- * the existing API surface.
- */
-const ProviderSettingsPartialSchema = ProviderSettingsSchema.partial()
+/** Provider settings accepted while creating a provider. */
+const ProviderSettingsCreateSchema = ProviderSettingsSchema.partial()
+
+/** RFC 7396 merge patch accepted while updating an existing provider. */
+const ProviderSettingsMergePatchSchema = z.object({
+  streamOptions: z
+    .object({
+      includeUsage: ProviderSettingsSchema.shape.streamOptions.unwrap().shape.includeUsage.nullable().optional()
+    })
+    .nullable()
+    .optional(),
+  apiVersion: ProviderSettingsSchema.shape.apiVersion.nullable().optional(),
+  cacheControl: z
+    .object({
+      enabled: z.boolean().nullable().optional(),
+      tokenThreshold: z.number().nullable().optional(),
+      cacheSystemMessage: z.boolean().nullable().optional(),
+      cacheLastNMessages: z.number().nullable().optional()
+    })
+    .nullable()
+    .optional(),
+  keepAliveTime: ProviderSettingsSchema.shape.keepAliveTime.nullable().optional(),
+  rateLimit: ProviderSettingsSchema.shape.rateLimit.nullable().optional(),
+  timeout: ProviderSettingsSchema.shape.timeout.nullable().optional(),
+  extraHeaders: z.record(z.string(), z.string().nullable()).nullable().optional(),
+  notes: ProviderSettingsSchema.shape.notes.nullable().optional(),
+  isAuthed: ProviderSettingsSchema.shape.isAuthed.nullable().optional(),
+  oauthUsername: ProviderSettingsSchema.shape.oauthUsername.nullable().optional(),
+  oauthAvatar: ProviderSettingsSchema.shape.oauthAvatar.nullable().optional()
+})
 
 // ============================================================================
 // DTOs
@@ -80,7 +104,7 @@ export const CreateProviderSchema = z.strictObject({
   /** Authentication configuration */
   authConfig: AuthConfigSchema.optional(),
   /** Provider-specific settings */
-  providerSettings: ProviderSettingsPartialSchema.optional()
+  providerSettings: ProviderSettingsCreateSchema.optional()
 })
 export type CreateProviderDto = z.infer<typeof CreateProviderSchema>
 
@@ -94,11 +118,12 @@ const ProviderMutableFieldsSchema = CreateProviderSchema.pick({
   name: true,
   endpointConfigs: true,
   defaultChatEndpoint: true,
-  authConfig: true,
-  providerSettings: true
+  authConfig: true
 })
 
 export const UpdateProviderSchema = ProviderMutableFieldsSchema.partial().extend({
+  /** RFC 7396 merge patch; null removes a stored setting. */
+  providerSettings: ProviderSettingsMergePatchSchema.optional(),
   /**
    * Whether this provider is enabled. A persisted false-to-true transition also
    * moves the provider to the first position atomically; redundant true updates


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Provider settings updates behaved like shallow object merges. Nested changes could replace sibling settings, and `null` could not consistently remove nested or top-level keys.

After this PR:

Provider settings use recursive RFC 7396-style merge-patch semantics. Objects merge recursively, arrays and scalars replace, and `null` deletes keys. Create input remains strict and separate from patch input.

Fixes #19247

### Why we need it and why it was done in this way

The API accepts partial settings documents, so explicit merge-patch behavior is safer and more predictable than a shallow spread. The implementation is a small pure helper covered at both schema and service levels.

The following tradeoffs were made:

Arrays are replaced rather than merged element-by-element, matching JSON Merge Patch semantics.

The following alternatives were considered:

JSON Patch was considered but would require a new operation format and a larger API change.

Links to places where the discussion took place: #19247

### Breaking changes

None.

### Special notes for your reviewer

Focused tests: 19 passed. Main-process typecheck passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Patch and create schemas remain separate and explicit
- [x] Upgrade: Existing stored provider settings require no migration
- [x] Documentation: A user-guide update was considered and is not required for this API bug fix
- [x] Self-review: The focused diff and regression tests were reviewed locally

### Release note

```release-note
Provider settings updates now preserve untouched nested values and support deleting keys with null.
```