### PR TITLE
fix(screenshot): keep overlays on the active macOS Space

### DIFF
--- a/src/main/core/window/__tests__/windowRegistry.invariants.test.ts
+++ b/src/main/core/window/__tests__/windowRegistry.invariants.test.ts
@@ -27,6 +27,14 @@ describe('WINDOW_TYPE_REGISTRY behavior invariants', () => {
       ).toBe(true)
     }
   })
+
+  it('keeps screenshot overlays on their capture Space while allowing fullscreen coverage', () => {
+    expect(WINDOW_TYPE_REGISTRY[WindowType.Screenshot]?.behavior?.visibleOnAllWorkspaces).toEqual({
+      enabled: false,
+      visibleOnFullScreen: true,
+      skipTransformProcessType: true
+    })
+  })
 })
 
 // The shared preload bundle is code-split, and Electron's sandbox blocks a preload from

--- a/src/main/core/window/windowRegistry.ts
+++ b/src/main/core/window/windowRegistry.ts
@@ -574,9 +574,9 @@ export const WINDOW_TYPE_REGISTRY: Partial<Record<WindowType, WindowTypeMetadata
     behavior: {
       // screen-saver level puts the overlay above the Dock and menu bar.
       alwaysOnTop: { level: 'screen-saver' },
-      // visibleOnFullScreen lets the overlay cover macOS fullscreen apps; skipTransformProcessType
-      // stops the process-type change that would flash the Dock icon and disturb focus.
-      visibleOnAllWorkspaces: { enabled: true, visibleOnFullScreen: true, skipTransformProcessType: true },
+      // Keep the overlay on the Space where capture started while still allowing it
+      // above fullscreen apps. skipTransformProcessType avoids Dock/focus churn.
+      visibleOnAllWorkspaces: { enabled: false, visibleOnFullScreen: true, skipTransformProcessType: true },
       macShowInDock: false
     },
     quirks: {

--- a/src/main/services/screenshot/ScreenshotOverlayService.ts
+++ b/src/main/services/screenshot/ScreenshotOverlayService.ts
@@ -328,10 +328,10 @@ export class ScreenshotOverlayService extends BaseService {
 
           // Transparent first so the OS show animation is never visible.
           window.setOpacity(0)
-          // macOS drops this flag on hide(), and closing a pooled overlay only hides it —
-          // a recycled window would otherwise fail to cover a fullscreen Space.
+          // macOS drops the fullscreen-auxiliary collection behavior on hide(). Reapply it
+          // without joining every Space, so a stale capture cannot follow Space switches.
           if (isMac) {
-            window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true })
+            window.setVisibleOnAllWorkspaces(false, { visibleOnFullScreen: true, skipTransformProcessType: true })
           }
           // showMode 'manual' means nothing else ever shows this window, and setOpacity()
           // on a hidden one is a no-op. Inactive: only the cursor's overlay takes focus.
@@ -791,9 +791,10 @@ export class ScreenshotOverlayService extends BaseService {
     for (const windowId of this.overlayWindowIds) {
       const window = windowManager.getWindow(windowId)
       if (!window || window.isDestroyed()) continue
-      // macOS drops the all-workspaces flag on hide(); the alwaysOnTop level is
-      // restored declaratively by the window type's reapplyAlwaysOnTop quirk.
-      window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true, skipTransformProcessType: true })
+      // Restore fullscreen coverage after hide() without making the stale capture
+      // follow the user to another Space. The always-on-top level is restored by
+      // the window type's reapplyAlwaysOnTop quirk.
+      window.setVisibleOnAllWorkspaces(false, { visibleOnFullScreen: true, skipTransformProcessType: true })
       window.setOpacity(0)
       // The active overlay must become the key window again or Esc and the next drag
       // land nowhere; the others stay unfocused, as at session start.

--- a/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
+++ b/src/main/services/screenshot/__tests__/ScreenshotOverlayService.test.ts
@@ -847,7 +847,7 @@ describe('ScreenshotOverlayService', () => {
       expect(initDataOf('overlay-0-0').imageUrl).toContain(secondMediaId)
     })
 
-    it('re-applies the all-workspaces flag when a pooled overlay is reused on macOS', async () => {
+    it('re-applies fullscreen coverage without joining all Spaces when a pooled overlay is reused on macOS', async () => {
       singleDisplaySetup()
       await service.startCapture()
       service.dismiss()
@@ -856,9 +856,9 @@ describe('ScreenshotOverlayService', () => {
 
       await service.startCapture()
 
-      // The window behavior applies this only at creation and macOS drops the flag when a pooled
-      // overlay is hidden, so from the second capture on it neither covers a fullscreen Space nor takes Esc.
-      expect(window.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(true, {
+      // macOS drops the fullscreen-auxiliary behavior when a pooled overlay is hidden.
+      // Reapply it without canJoinAllSpaces so the frozen image cannot follow a Space switch.
+      expect(window.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(false, {
         visibleOnFullScreen: true,
         skipTransformProcessType: true
       })
@@ -1087,7 +1087,10 @@ describe('ScreenshotOverlayService', () => {
       // re-entrance guard still blocks every new capture.
       const window = fakeWindow('overlay-0-0')
       expect(window.show).toHaveBeenCalled()
-      expect(window.setVisibleOnAllWorkspaces).toHaveBeenCalled()
+      expect(window.setVisibleOnAllWorkspaces).toHaveBeenCalledWith(false, {
+        visibleOnFullScreen: true,
+        skipTransformProcessType: true
+      })
       expect(service.isSessionOverlay('overlay-0-0')).toBe(true)
     })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Screenshot overlay windows were marked visible on all macOS workspaces, which could pull or duplicate overlays across Spaces during capture.

After this PR:

Screenshot overlays stay attached to the Space where capture starts while retaining full-screen visibility. All overlay creation and registry paths use the same setting.

Fixes #19240

### Why we need it and why it was done in this way

Electron treats all-workspace visibility and full-screen visibility as independent settings. Disabling the former fixes Space affinity without removing the latter.

The following tradeoffs were made:

The fix deliberately changes only screenshot overlays, not general application-window workspace behavior.

The following alternatives were considered:

Moving windows after creation was rejected because it is timing-sensitive and can visibly flash on another Space.

Links to places where the discussion took place: #19240

### Breaking changes

None.

### Special notes for your reviewer

Focused tests: 71 passed. Main-process typecheck passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: All screenshot overlay call sites now share the same invariant
- [x] Upgrade: No stored data or migration impact
- [x] Documentation: A user-guide update was considered and is not required for this platform bug fix
- [x] Self-review: The focused diff and regression tests were reviewed locally

### Release note

```release-note
Screenshot overlays now remain on the active macOS Space during capture.
```