### PR TITLE
perf(backup): parallelize device metadata reads

### DIFF
--- a/src/renderer/components/LocalBackupModals.tsx
+++ b/src/renderer/components/LocalBackupModals.tsx
@@ -1,8 +1,7 @@
 import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Input } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
-import { ipcApi } from '@renderer/ipc'
 import { backupToLocal } from '@renderer/services/BackupService'
-import dayjs from 'dayjs'
+import { createDefaultBackupFileName } from '@renderer/utils/backupFileName'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -63,12 +62,7 @@ export function useLocalBackupModal(localBackupDir: string | undefined) {
   }
 
   const showBackupModal = useCallback(async () => {
-    // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
-    const timestamp = dayjs().format('YYYYMMDDHHmmss')
-    const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
-    setCustomFileName(defaultFileName)
+    setCustomFileName(await createDefaultBackupFileName())
     setIsModalVisible(true)
   }, [])
 

--- a/src/renderer/components/S3Modals.tsx
+++ b/src/renderer/components/S3Modals.tsx
@@ -10,11 +10,11 @@ import {
   Input,
   Spinner
 } from '@cherrystudio/ui'
-import { ipcApi } from '@renderer/ipc'
 import { backupToS3 } from '@renderer/services/BackupService'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import { getLocalizedBackupErrorMessage } from '@renderer/utils/backup'
+import { createDefaultBackupFileName } from '@renderer/utils/backupFileName'
 import { formatFileSize } from '@renderer/utils/file'
 import dayjs from 'dayjs'
 import { useCallback, useState } from 'react'
@@ -46,12 +46,7 @@ export function useS3BackupModal() {
   }
 
   const showBackupModal = useCallback(async () => {
-    // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
-    const timestamp = dayjs().format('YYYYMMDDHHmmss')
-    const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
-    setCustomFileName(defaultFileName)
+    setCustomFileName(await createDefaultBackupFileName())
     setIsModalVisible(true)
   }, [])
 

--- a/src/renderer/components/WebdavModals.tsx
+++ b/src/renderer/components/WebdavModals.tsx
@@ -1,7 +1,6 @@
 import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Input } from '@cherrystudio/ui'
-import { ipcApi } from '@renderer/ipc'
 import { backupToWebdav } from '@renderer/services/BackupService'
-import dayjs from 'dayjs'
+import { createDefaultBackupFileName } from '@renderer/utils/backupFileName'
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -38,12 +37,7 @@ export function useWebdavBackupModal({ backupMethod }: { backupMethod?: typeof b
   }
 
   const showBackupModal = useCallback(async () => {
-    // 获取默认文件名
-    const deviceType = await ipcApi.request('system.get_device_type')
-    const hostname = await window.api.system.getHostname()
-    const timestamp = dayjs().format('YYYYMMDDHHmmss')
-    const defaultFileName = `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
-    setCustomFileName(defaultFileName)
+    setCustomFileName(await createDefaultBackupFileName())
     setIsModalVisible(true)
   }, [])
 

--- a/src/renderer/utils/__tests__/backupFileName.test.ts
+++ b/src/renderer/utils/__tests__/backupFileName.test.ts
@@ -1,0 +1,38 @@
+import { ipcApi } from '@renderer/ipc'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createDefaultBackupFileName } from '../backupFileName'
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: vi.fn() }
+}))
+
+describe('createDefaultBackupFileName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts independent device metadata reads concurrently', async () => {
+    let resolveDeviceType!: (value: string) => void
+    let resolveHostname!: (value: string) => void
+    const deviceType = new Promise<string>((resolve) => {
+      resolveDeviceType = resolve
+    })
+    const hostname = new Promise<string>((resolve) => {
+      resolveHostname = resolve
+    })
+
+    vi.mocked(ipcApi.request).mockReturnValue(deviceType as never)
+    vi.stubGlobal('window', { api: { system: { getHostname: vi.fn(() => hostname) } } })
+
+    const fileName = createDefaultBackupFileName()
+
+    expect(ipcApi.request).toHaveBeenCalledWith('system.get_device_type')
+    expect(window.api.system.getHostname).toHaveBeenCalledOnce()
+
+    resolveHostname('macbook')
+    resolveDeviceType('desktop')
+
+    await expect(fileName).resolves.toMatch(/^cherry-studio\.\d{14}\.macbook\.desktop\.zip$/)
+  })
+})

--- a/src/renderer/utils/__tests__/backupFileName.test.ts
+++ b/src/renderer/utils/__tests__/backupFileName.test.ts
@@ -1,5 +1,5 @@
 import { ipcApi } from '@renderer/ipc'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createDefaultBackupFileName } from '../backupFileName'
 
@@ -8,6 +8,10 @@ vi.mock('@renderer/ipc', () => ({
 }))
 
 describe('createDefaultBackupFileName', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -23,7 +27,13 @@ describe('createDefaultBackupFileName', () => {
     })
 
     vi.mocked(ipcApi.request).mockReturnValue(deviceType as never)
-    vi.stubGlobal('window', { api: { system: { getHostname: vi.fn(() => hostname) } } })
+    vi.stubGlobal('window', {
+      ...window,
+      api: {
+        ...window.api,
+        system: { ...window.api.system, getHostname: vi.fn(() => hostname) }
+      }
+    })
 
     const fileName = createDefaultBackupFileName()
 

--- a/src/renderer/utils/backupFileName.ts
+++ b/src/renderer/utils/backupFileName.ts
@@ -1,0 +1,12 @@
+import { ipcApi } from '@renderer/ipc'
+import dayjs from 'dayjs'
+
+export async function createDefaultBackupFileName(): Promise<string> {
+  const [deviceType, hostname] = await Promise.all([
+    ipcApi.request('system.get_device_type'),
+    window.api.system.getHostname()
+  ])
+  const timestamp = dayjs().format('YYYYMMDDHHmmss')
+
+  return `cherry-studio.${timestamp}.${hostname}.${deviceType}.zip`
+}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Backup filename preparation fetched independent device type and hostname metadata serially in multiple backup dialogs.

After this PR:

A shared helper reads both values concurrently and produces the same default backup filename for local, S3, and WebDAV flows.

Fixes #17286

### Why we need it and why it was done in this way

The two IPC reads have no dependency. A shared helper removes duplicated sequencing and makes the concurrency invariant directly testable.

The following tradeoffs were made:

Only metadata reads are parallelized; backup I/O behavior is unchanged.

The following alternatives were considered:

Caching system metadata globally was considered unnecessary for this small, on-demand path.

Links to places where the discussion took place: #17286

### Breaking changes

None.

### Special notes for your reviewer

Focused concurrency test passed. Renderer typecheck passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Duplicate filename preparation was consolidated
- [x] Upgrade: No stored data or migration impact
- [x] Documentation: A user-guide update was considered and is not required for this performance change
- [x] Self-review: The focused diff and regression test were reviewed locally

### Release note

```release-note
Backup filename preparation no longer serializes independent system metadata reads.
```