### PR TITLE
perf(painting): parallelize history file hydration

### DIFF
--- a/src/renderer/pages/paintings/model/mappers/__tests__/paintingMappers.test.ts
+++ b/src/renderer/pages/paintings/model/mappers/__tests__/paintingMappers.test.ts
@@ -106,6 +106,48 @@ describe('paintingMappers', () => {
     })
   })
 
+  it('starts output and input file-entry batches concurrently', async () => {
+    let resolveOutput!: (value: unknown) => void
+    let resolveInput!: (value: unknown) => void
+    const outputEntry = new Promise((resolve) => {
+      resolveOutput = resolve
+    })
+    const inputEntry = new Promise((resolve) => {
+      resolveInput = resolve
+    })
+    mockDataApiGet.mockImplementation((path: string) => (path.endsWith('/output-file') ? outputEntry : inputEntry))
+
+    const hydration = recordToPaintingData({
+      ...record,
+      files: { output: ['output-file'], input: ['input-file'] }
+    })
+
+    expect(mockDataApiGet).toHaveBeenCalledTimes(2)
+    expect(mockDataApiGet).toHaveBeenNthCalledWith(1, '/files/entries/output-file')
+    expect(mockDataApiGet).toHaveBeenNthCalledWith(2, '/files/entries/input-file')
+
+    resolveOutput({
+      id: 'output-file',
+      origin: 'internal',
+      name: 'output-file',
+      ext: 'png',
+      size: 10,
+      createdAt: 0,
+      updatedAt: 0
+    })
+    resolveInput({
+      id: 'input-file',
+      origin: 'internal',
+      name: 'input-file',
+      ext: 'png',
+      size: 10,
+      createdAt: 0,
+      updatedAt: 0
+    })
+
+    await hydration
+  })
+
   it('round-trips painting through create DTO carrying only the frozen-receipt fields', async () => {
     const paintingDataList = await recordsToPaintingDataList([record])
     const paintingData = paintingDataList[0]

--- a/src/renderer/pages/paintings/model/mappers/recordToPaintingData.ts
+++ b/src/renderer/pages/paintings/model/mappers/recordToPaintingData.ts
@@ -63,8 +63,10 @@ async function resolveEntries(ids: string[]): Promise<FileEntry[]> {
  * a different tab.
  */
 export async function recordToPaintingData(record: PaintingRecord): Promise<PaintingData> {
-  const outputEntries = await resolveEntries(record.files.output)
-  const inputFiles = await resolveEntries(record.files.input)
+  const [outputEntries, inputFiles] = await Promise.all([
+    resolveEntries(record.files.output),
+    resolveEntries(record.files.input)
+  ])
   const files = await Promise.all(outputEntries.map(fileEntryToMetadata))
 
   const model = normalizeStoredPaintingModel(record.modelId)


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Painting history hydrated output and input file entries one at a time, creating avoidable latency proportional to the number of files.

After this PR:

Independent file-entry lookups run concurrently while preserving input/output order and the existing best-effort behavior for missing entries.

Fixes #17289

### Why we need it and why it was done in this way

Each lookup is independent. `Promise.all` removes serial wait time without changing mapping semantics, result order, or error isolation.

The following tradeoffs were made:

Concurrency is limited to the files already present in one painting record; no global worker pool was introduced.

The following alternatives were considered:

A persistent hydration cache was avoided because invalidation would add complexity beyond this issue.

Links to places where the discussion took place: #17289

### Breaking changes

None.

### Special notes for your reviewer

Focused mapper tests: 5 passed. Renderer typecheck passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Existing missing-entry behavior and ordering are preserved
- [x] Upgrade: No stored data or migration impact
- [x] Documentation: A user-guide update was considered and is not required for this performance change
- [x] Self-review: The focused diff and regression tests were reviewed locally

### Release note

```release-note
Painting history loads independent file metadata concurrently.
```