### PR TITLE
fix(app): register the portable Windows launcher at login

### DIFF
--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -1,6 +1,6 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { isDev, isLinux, isMac, isWin } from '@main/core/platform'
+import { isDev, isLinux, isMac, isPortable, isWin } from '@main/core/platform'
 import { app } from 'electron'
 import fs from 'fs'
 import path from 'path'
@@ -12,7 +12,16 @@ export class AppService {
     // Set login item settings for windows and mac
     // linux is not supported because it requires more file operations
     if (isWin || isMac) {
-      app.setLoginItemSettings({ openAtLogin: isLaunchOnBoot })
+      const settings: Parameters<typeof app.setLoginItemSettings>[0] = { openAtLogin: isLaunchOnBoot }
+
+      // electron-builder's portable launcher sets this to its stable source path.
+      // process.execPath points at the extracted Temp payload and becomes stale.
+      if (isWin && isPortable && process.env.PORTABLE_EXECUTABLE_FILE) {
+        settings.path = process.env.PORTABLE_EXECUTABLE_FILE
+        settings.args = []
+      }
+
+      app.setLoginItemSettings(settings)
     } else if (isLinux) {
       try {
         const autostartDir = application.getPath('sys.appdata.autostart')

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   isDev: false,
@@ -9,9 +9,6 @@ const mocks = vi.hoisted(() => ({
   setLoginItemSettings: vi.fn()
 }))
 
-vi.mock('@application', () => ({
-  application: { getPath: vi.fn() }
-}))
 vi.mock('@main/core/platform', () => ({
   get isDev() {
     return mocks.isDev
@@ -36,6 +33,10 @@ vi.mock('electron', () => ({
 import { AppService } from '../AppService'
 
 describe('AppService.setAppLaunchOnBoot', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.stubEnv('PORTABLE_EXECUTABLE_FILE', 'D:\\Apps\\Cherry Studio Portable.exe')

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isDev: false,
+  isLinux: false,
+  isMac: false,
+  isPortable: true,
+  isWin: true,
+  setLoginItemSettings: vi.fn()
+}))
+
+vi.mock('@application', () => ({
+  application: { getPath: vi.fn() }
+}))
+vi.mock('@main/core/platform', () => ({
+  get isDev() {
+    return mocks.isDev
+  },
+  get isLinux() {
+    return mocks.isLinux
+  },
+  get isMac() {
+    return mocks.isMac
+  },
+  get isPortable() {
+    return mocks.isPortable
+  },
+  get isWin() {
+    return mocks.isWin
+  }
+}))
+vi.mock('electron', () => ({
+  app: { setLoginItemSettings: mocks.setLoginItemSettings }
+}))
+
+import { AppService } from '../AppService'
+
+describe('AppService.setAppLaunchOnBoot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('PORTABLE_EXECUTABLE_FILE', 'D:\\Apps\\Cherry Studio Portable.exe')
+    mocks.isLinux = false
+    mocks.isMac = false
+    mocks.isPortable = true
+    mocks.isWin = true
+  })
+
+  it('registers the stable launcher for Windows portable builds', async () => {
+    await new AppService().setAppLaunchOnBoot(true)
+
+    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+      path: 'D:\\Apps\\Cherry Studio Portable.exe',
+      args: []
+    })
+  })
+
+  it('uses Electron defaults for installed Windows builds', async () => {
+    mocks.isPortable = false
+
+    await new AppService().setAppLaunchOnBoot(false)
+
+    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false })
+  })
+
+  it('uses Electron defaults on macOS', async () => {
+    mocks.isMac = true
+    mocks.isPortable = false
+    mocks.isWin = false
+
+    await new AppService().setAppLaunchOnBoot(true)
+
+    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Enabling launch at login from a portable Windows build could register Electron's temporary extracted executable, leaving a stale startup target after the session ended.

After this PR:

Portable Windows builds register `PORTABLE_EXECUTABLE_FILE` as the login-item path. Installed Windows builds and macOS keep their existing behavior.

Fixes #17324

### Why we need it and why it was done in this way

The launcher path supplied by the portable runtime is the stable executable users actually launch. Electron already supports an explicit login-item path, so no custom shortcut management is needed.

The following tradeoffs were made:

The override is guarded by Windows plus the portable-runtime environment variable.

The following alternatives were considered:

Copying the temporary executable or creating a separate shortcut was rejected as more invasive and harder to keep current.

Links to places where the discussion took place: #17324

### Breaking changes

None.

### Special notes for your reviewer

Focused tests: 3 passed. Main-process typecheck passed.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Platform-specific behavior is isolated to the existing login-item path
- [x] Upgrade: Existing installed-build startup behavior is unchanged
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: The focused diff and regression tests were reviewed locally

### Release note

```release-note
Launch at login now uses the stable launcher path for portable Windows builds.
```