### PR TITLE
fix(right-panel): let a maximized branch panel reclaim the composer area

### DIFF
--- a/src/renderer/components/chat/panes/Shell/RightPanel.tsx
+++ b/src/renderer/components/chat/panes/Shell/RightPanel.tsx
@@ -37,6 +37,12 @@ export interface RightPanelInstance {
   headerMode?: 'shell' | 'content'
   /** Whether this panel may enter maximized presentation. */
   canMaximize?: boolean
+  /**
+   * Whether the elevated composer keeps floating above this panel while maximized.
+   * Panels that own the whole area (navigators, canvases) set false so maximizing
+   * actually frees the space the composer would cover.
+   */
+  keepsComposerWhenMaximized?: boolean
 }
 
 /** Resolves one panel slot from domain-owned scope; null means the slot has no identity. */
@@ -264,7 +270,8 @@ export function RightPanelProvider<TScope>({
   const presentationMaximized = presentationOpen && maximized
   // The pane keeps covering the centre until its phase ends, so the composer has to stay lifted
   // past the click that started the restore. `fullWidthActive` lands a commit late, hence the union.
-  const composerElevated = presentationMaximized || fullWidthActive
+  const composerElevated =
+    (presentationMaximized || fullWidthActive) && activeEntry?.keepsComposerWhenMaximized !== false
 
   useLayoutEffect(() => {
     if (!reconciledEntry || reconciledEntry.id === requestedPanelId) return

--- a/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
+++ b/src/renderer/components/chat/panes/Shell/__tests__/RightPanel.test.tsx
@@ -116,6 +116,7 @@ interface TestScope {
   firstKey: string
   firstReadiness: RightPanelReadiness
   firstHeaderMode?: 'shell' | 'content'
+  firstKeepsComposerWhenMaximized?: boolean
   firstShouldThrow?: boolean
   secondReadiness: RightPanelReadiness
 }
@@ -143,7 +144,8 @@ const capabilities = [
       title: 'First',
       readiness: scope.firstReadiness,
       headerMode: scope.firstHeaderMode,
-      canMaximize: true
+      canMaximize: true,
+      keepsComposerWhenMaximized: scope.firstKeepsComposerWhenMaximized
     })
   },
   {
@@ -389,6 +391,35 @@ describe('RightPanel', () => {
     expect(screen.getByTestId('right-pane-host')).toHaveAttribute('data-maximized', 'false')
     expect(screen.getByTestId('presentation-maximized')).toHaveTextContent('false')
     expect(screen.queryByRole('button', { name: 'common.maximize' })).toBeNull()
+  })
+
+  it('drops the composer elevation for a maximized panel that owns the whole area', () => {
+    render(
+      <Harness defaultOpen scope={{ ...readyScope, firstKeepsComposerWhenMaximized: false }}>
+        <RightPanelViewport>
+          <RightPanel />
+        </RightPanelViewport>
+      </Harness>
+    )
+
+    expect(screen.getByTestId('composer-elevated')).toHaveTextContent('false')
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.maximize' }))
+    expect(screen.getByTestId('presentation-maximized')).toHaveTextContent('true')
+    expect(screen.getByTestId('composer-elevated')).toHaveTextContent('false')
+  })
+
+  it('keeps the composer elevated above a maximized panel by default', () => {
+    render(
+      <Harness defaultOpen>
+        <RightPanelViewport>
+          <RightPanel />
+        </RightPanelViewport>
+      </Harness>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'common.maximize' }))
+    expect(screen.getByTestId('composer-elevated')).toHaveTextContent('true')
   })
 
   it('lets a content-composed panel replace the shell header', () => {

--- a/src/renderer/components/chat/shell/ConversationStageCenter.tsx
+++ b/src/renderer/components/chat/shell/ConversationStageCenter.tsx
@@ -15,6 +15,7 @@ export default function ConversationStageCenter(props: ConversationStageCenterPr
       <ConversationComposerStage
         {...props}
         mainVisible={mainVisible && !paneMaximized}
+        composerVisible={paneElevatesComposer || !paneMaximized}
         composerElevated={props.composerElevated || paneElevatesComposer}
       />
     </div>

--- a/src/renderer/components/chat/shell/__tests__/ConversationStageCenter.test.tsx
+++ b/src/renderer/components/chat/shell/__tests__/ConversationStageCenter.test.tsx
@@ -11,15 +11,17 @@ interface MockStageProps {
   main: ReactNode
   composer: ReactNode
   composerElevated?: boolean
+  composerVisible?: boolean
   mainVisible?: boolean
 }
 
 vi.mock('@renderer/components/composer/ConversationComposerStage', () => ({
-  default: ({ placement, main, composer, composerElevated, mainVisible }: MockStageProps) => (
+  default: ({ placement, main, composer, composerElevated, composerVisible, mainVisible }: MockStageProps) => (
     <div
       data-testid="conversation-stage"
       data-placement={placement}
       data-composer-elevated={String(Boolean(composerElevated))}
+      data-composer-visible={String(composerVisible !== false)}
       data-main-visible={String(Boolean(mainVisible))}>
       <div data-testid="stage-main">{main}</div>
       <div data-testid="stage-composer">{composer}</div>
@@ -48,6 +50,18 @@ describe('ConversationStageCenter', () => {
     expect(screen.getByTestId('stage-main')).toHaveTextContent('messages')
     expect(screen.getByTestId('stage-composer')).toHaveTextContent('composer')
     expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-elevated', 'true')
+    expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-visible', 'true')
+    expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-main-visible', 'false')
+  })
+
+  it('yields the whole area to a maximized panel that does not keep the composer', () => {
+    rightPanelPresentationMock.maximized = true
+    rightPanelPresentationMock.elevated = false
+
+    render(<ConversationStageCenter placement="docked" main={<div>messages</div>} composer={<div>composer</div>} />)
+
+    expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-visible', 'false')
+    expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-elevated', 'false')
     expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-main-visible', 'false')
   })
 
@@ -67,6 +81,7 @@ describe('ConversationStageCenter', () => {
     render(<ConversationStageCenter placement="docked" main={<div>messages</div>} composer={<div />} />)
 
     expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-elevated', 'false')
+    expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-composer-visible', 'true')
     expect(screen.getByTestId('conversation-stage')).toHaveAttribute('data-main-visible', 'true')
   })
 })

--- a/src/renderer/components/composer/ComposerDockTransitionFrame.tsx
+++ b/src/renderer/components/composer/ComposerDockTransitionFrame.tsx
@@ -22,6 +22,8 @@ interface ComposerDockTransitionFrameProps {
   mainVisible?: boolean
   /** Lift the composer above a full-area overlay (e.g. a maximized side pane). */
   composerElevated?: boolean
+  /** Hide the composer without unmounting it, so its draft and editor DOM survive. */
+  composerVisible?: boolean
   overlay?: ReactNode
 }
 
@@ -48,6 +50,7 @@ export default function ComposerDockTransitionFrame({
   composer,
   mainVisible = placement === 'docked',
   composerElevated = false,
+  composerVisible = true,
   overlay
 }: ComposerDockTransitionFrameProps) {
   const rootRef = useRef<HTMLDivElement>(null)
@@ -164,14 +167,16 @@ export default function ComposerDockTransitionFrame({
 
       <div
         data-composer-dock-layer=""
-        style={
-          isDocked
+        inert={!composerVisible}
+        style={{
+          ...(isDocked
             ? {
                 paddingInlineStart: composerInlineInsets.left,
                 paddingInlineEnd: composerInlineInsets.right
               }
-            : undefined
-        }
+            : null),
+          opacity: composerVisible ? undefined : 0
+        }}
         className={cn(
           // The whole dock stack stays click-through: the layer, the wrapper, and
           // any width-capped centering inside the composer all span or flank the

--- a/src/renderer/components/composer/ConversationComposerStage.tsx
+++ b/src/renderer/components/composer/ConversationComposerStage.tsx
@@ -10,6 +10,7 @@ interface ConversationComposerStageProps {
   composer: ReactNode
   overlay?: ReactNode
   composerElevated?: boolean
+  composerVisible?: boolean
   mainVisible?: boolean
 }
 
@@ -19,6 +20,7 @@ export default function ConversationComposerStage({
   composer,
   overlay,
   composerElevated,
+  composerVisible,
   mainVisible
 }: ConversationComposerStageProps) {
   const isDocked = placement === 'docked'
@@ -32,6 +34,7 @@ export default function ConversationComposerStage({
       mainVisible={resolvedMainVisible}
       overlay={overlay}
       composerElevated={composerElevated}
+      composerVisible={composerVisible}
     />
   )
 }

--- a/src/renderer/components/composer/__tests__/ComposerDockTransitionFrame.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerDockTransitionFrame.test.tsx
@@ -237,6 +237,25 @@ describe('ComposerDockTransitionFrame', () => {
     expect(container.querySelector('[data-composer-dock-layer]')).toHaveClass('z-50')
   })
 
+  it('hides the composer without unmounting it when the dock yields its area', () => {
+    const baseProps = {
+      placement: 'docked' as const,
+      main: <InsetProbe />,
+      composer: <div data-composer-inputbar="" />,
+      mainVisible: true
+    }
+    const { container, rerender } = render(<ComposerDockTransitionFrame {...baseProps} />)
+    const inputbar = container.querySelector('[data-composer-inputbar]')
+
+    rerender(<ComposerDockTransitionFrame {...baseProps} composerVisible={false} />)
+
+    const dockLayer = container.querySelector<HTMLElement>('[data-composer-dock-layer]')
+    expect(dockLayer).toHaveStyle({ opacity: '0' })
+    expect(dockLayer).toHaveAttribute('inert')
+    // The editor DOM survives so a draft is not lost while the composer is hidden.
+    expect(container.querySelector('[data-composer-inputbar]')).toBe(inputbar)
+  })
+
   it('marks the composer surface when moving from home to docked placement', () => {
     const baseProps = {
       main: <InsetProbe />,

--- a/src/renderer/pages/home/components/TopicRightPane.tsx
+++ b/src/renderer/pages/home/components/TopicRightPane.tsx
@@ -168,7 +168,8 @@ const TOPIC_RIGHT_PANEL_CAPABILITIES = [
       instanceKey: `branch:${scope.topicId ?? 'unavailable'}`,
       title: scope.branchTitle,
       readiness: scope.topicId ? 'ready' : 'unavailable',
-      canMaximize: true
+      canMaximize: true,
+      keepsComposerWhenMaximized: false
     })
   },
   TOPIC_TRACE_PANE_CAPABILITY


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Maximizing the topic branch panel left the composer floating above it, covering the lowest branch node card, the minimap, and the zoom controls — so "maximize" never actually enlarged the usable area of the graph.

After this PR:

A maximized branch panel reclaims the composer area. The composer is hidden rather than unmounted, so an in-progress draft and the editor DOM survive the maximize/restore round trip. Every other panel — including the Agent workspace files pane, where the point is to keep chatting while the panel fills the window — keeps today's floating-composer behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The branch panel is a navigator: maximizing it must expose its whole canvas. Whether the composer keeps floating is therefore a property of the *panel*, not of the maximized state, so `RightPanelInstance` gains `keepsComposerWhenMaximized` (defaulting to `true`, so no existing panel changes) and the branch capability opts out. That flag simply gates the `composerElevated` context the shell and stage already consume, so no new context or consumer is introduced.

The following tradeoffs were made:

The composer is hidden with `opacity: 0` + `inert` instead of being unmounted. That keeps a hidden subtree in the DOM, but unmounting would discard the user's draft and the editor instance on every maximize.

The following alternatives were considered:

Hiding the composer for *every* maximized right panel was rejected: the Agent workspace files pane is intentionally usable while the user continues chatting.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Rebased onto current `main` after the `composerElevated` context landed upstream; this PR now layers the per-panel opt-out onto that context instead of introducing its own, which cut the non-test surface to four files (`RightPanel.tsx`, `ConversationStageCenter.tsx`, `ComposerDockTransitionFrame.tsx` / `ConversationComposerStage.tsx`, `TopicRightPane.tsx`).

Worth confirming: the panel-specific interaction choice, and that the Agent workspace files pane still behaves as before.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix the maximized topic branch panel being obscured by the message composer.
```
