### PR TITLE
fix(composer): show first picker attachment on unused assistant

### DIFF
--- a/src/renderer/components/composer/ComposerSurface.tsx
+++ b/src/renderer/components/composer/ComposerSurface.tsx
@@ -104,6 +104,7 @@ function DeferredComposerSurface(props: ComposerSurfaceProps) {
   const needsRuntime =
     Boolean(props.editingState) ||
     Boolean(props.draftTokens?.length) ||
+    props.tokens.length > 0 ||
     props.text.trim().length > 0 ||
     Boolean(props.compactWhenSingleLine) ||
     props.isExpanded

--- a/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.lazy.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   onSendDraft: vi.fn(),
   runtimeLoads: 0,
   runtimeIntent: undefined as ComposerDeferredIntent | undefined,
+  runtimeTokens: [] as Array<{ id: string; kind: string; label?: string }>,
   toastError: vi.fn()
 }))
 
@@ -40,13 +41,17 @@ vi.mock('@renderer/components/SendMessageButton', () => ({
 vi.mock('../ComposerSurfaceRuntime', () => {
   mocks.runtimeLoads += 1
   return {
-    default: ({ initialTextSelection, text, deferredIntent }: ComposerSurfaceProps) => {
+    default: ({ initialTextSelection, text, deferredIntent, tokens }: ComposerSurfaceProps) => {
       mocks.runtimeIntent = deferredIntent
+      mocks.runtimeTokens = tokens.map((token) => ({ id: token.id, kind: token.kind, label: token.label }))
       return (
         <div
           data-testid="composer-runtime"
           data-selection={`${initialTextSelection?.start}:${initialTextSelection?.end}`}>
           {text}
+          {tokens.map((token) => (
+            <span key={token.id}>{token.label}</span>
+          ))}
         </div>
       )
     }
@@ -107,6 +112,7 @@ describe('deferred ComposerSurface', () => {
   beforeEach(() => {
     vi.stubGlobal('DataTransfer', FakeDataTransfer)
     mocks.runtimeIntent = undefined
+    mocks.runtimeTokens = []
     mocks.onSendDraft.mockClear()
     mocks.toastError.mockClear()
     MockUsePreferenceUtils.resetMocks()
@@ -246,6 +252,53 @@ describe('deferred ComposerSurface', () => {
       />
     )
     expect(await screen.findByTestId('composer-runtime')).toBeInTheDocument()
+  })
+
+  it('loads the runtime for the first picker file token on an empty unused-assistant fallback', async () => {
+    // Catches: switch to a not-yet-used assistant (empty text/draftTokens), click paperclip,
+    // and the managed file token never becomes visible because the deferred textarea cannot
+    // render chips and needsRuntime used to ignore props.tokens until a drag requested the runtime.
+    // Excluded: drag/paste (they already call requestRuntime), later attachments after the
+    // runtime is warm, and send-time FileEntry creation.
+    const fileToken: ComposerDraftToken = {
+      id: 'file:source-1',
+      kind: 'file',
+      label: 'report.txt'
+    }
+    let actions: ComposerSurfaceActions | undefined
+
+    function FreshAssistantPickerHarness() {
+      const [tokens, setTokens] = useState<ComposerDraftToken[]>([])
+      return (
+        <>
+          <button type="button" onClick={() => setTokens([fileToken])}>
+            Upload attachment
+          </button>
+          <Harness
+            tokens={tokens}
+            onActionsChange={(next) => {
+              actions = next
+            }}
+          />
+        </>
+      )
+    }
+
+    render(<FreshAssistantPickerHarness />)
+
+    expect(screen.getByRole('textbox', { name: 'Message' })).toBeInTheDocument()
+    expect(screen.queryByTestId('composer-runtime')).not.toBeInTheDocument()
+    await waitFor(() => expect(actions).toBeDefined())
+    expect(actions!.getDraft().tokens).toEqual([])
+
+    fireEvent.click(screen.getByRole('button', { name: 'Upload attachment' }))
+
+    expect(actions!.getDraft().tokens).toEqual([
+      expect.objectContaining({ id: 'file:source-1', kind: 'file', label: 'report.txt' })
+    ])
+    const runtime = await screen.findByTestId('composer-runtime')
+    expect(runtime).toHaveTextContent('report.txt')
+    expect(mocks.runtimeTokens).toEqual([{ id: 'file:source-1', kind: 'file', label: 'report.txt' }])
   })
 
   it('loads the runtime for a restored multi-line draft the fixed-height fallback cannot hold', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Switching to a not-yet-used assistant left the composer on the deferred textarea. The paperclip picker only calls `setFiles`, which Chat/Agent map to managed `tokens`. The fallback cannot render file chips, and `needsRuntime` ignored `props.tokens`, so the first attachment chip did not appear until a later drag or paste requested the rich runtime.

After this PR:

`needsRuntime` also becomes true when `props.tokens.length > 0`, so the first picker-managed file token on an unused empty assistant loads the composer runtime and shows the chip immediately. Empty unused composers stay deferred.

N/A — no GitHub issue. Feishu demand `recvstnRlXRdTa`.

### Why we need it and why it was done in this way

The following tradeoffs were made:

Gate on managed `tokens` at the deferred surface (the layer that cannot render chips) instead of teaching the paperclip button to call `requestRuntime`. That keeps the existing files → managed tokens → draft contract and does not add another attachment API or change send/delivery.

The following alternatives were considered:

- Call `requestRuntime` from `AttachmentButton`: couples the picker to the lazy surface and still leaves other token sources (knowledge/skills) invisible.
- Gate on `draftTokens`: picker-managed files arrive on `tokens` first; `draftTokens` update only after the editor serializes, which is why this bug survived.
- Eager-load the runtime for every unused assistant: would regress first-paint deferral already covered by the lazy tests.

Links to places where the discussion took place: Feishu demand `recvstnRlXRdTa`. Independent review PASS with no fixer required.

### Breaking changes

None.

### Special notes for your reviewer

Production change is one predicate in `DeferredComposerSurface`. Regression coverage is `ComposerSurface.lazy.test.tsx` (`loads the runtime for the first picker file token on an empty unused-assistant fallback`).

User-facing testing:

1. Switch to a not-yet-used assistant / empty topic (no draft text).
2. Click the paperclip and attach a file (for example `report.txt`).
3. The composer file token/chip must appear immediately, without needing a later drag or paste.

Electron UI was not exercised in this workspace: `V2MigrationGate` requested a relaunch unsupported in dev (`Legacy userData resolved but migration not needed, relaunching for path consistency`), so no main window was available and the native OS picker cannot be driven via CDP. Confidence is the lazy-gate regression plus the existing files → tokens mapping tests.

Documentation: no user-guide update. This restores expected paperclip behavior; it does not add a new attachment surface.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix first paperclip attachment not appearing immediately after switching to an unused assistant.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI lazy-load predicate plus a unit test; no auth, send, or attachment-delivery changes. Empty composers still stay deferred.
> 
> **Overview**
> Fixes the first paperclip attachment not appearing after switching to an unused, empty assistant.
> 
> The deferred composer cannot render file chips, and `needsRuntime` previously ignored managed `tokens`. Picker files land on `tokens` before `draftTokens`, so the chip stayed invisible until a later drag/paste. `needsRuntime` now also trips when `props.tokens.length > 0`, which loads the rich runtime immediately while still keeping empty unused composers deferred.
> 
> Adds a lazy-surface regression test that injects a picker file token on an empty fallback and asserts the runtime mounts with that chip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fbe1a260f755d886cae250895764df3749ac13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->