### PR TITLE
perf(agent): stabilize system prompt prefix

### DIFF
--- a/src/main/ai/runtime/agentPrompt.ts
+++ b/src/main/ai/runtime/agentPrompt.ts
@@ -79,14 +79,18 @@ export async function buildAgentRuntimePrompt({
     agentDataPath
   )
 
+  // Prefix-cache layout: Cherry-owned policy that is identical across sessions comes first. After
+  // that boundary, place configurable/runtime-derived sections in decreasing expected stability.
+  // The explicit precedence policy remains authoritative: physical placement is a cache concern,
+  // not a change to the instruction hierarchy declared above.
   const append = [
     hasAgentInstructions ? AGENT_INSTRUCTION_PRECEDENCE_PROMPT : undefined,
-    parts.context,
-    workspaceInstructions,
+    REPORT_ARTIFACTS_PROMPT,
     hasAgentInstructions ? buildAgentInstructionsSection(resolvedInstructions) : undefined,
+    workspaceInstructions,
+    parts.context,
     parts.base.kind === 'custom' ? customBaseContext : undefined,
     citationsGuidance,
-    REPORT_ARTIFACTS_PROMPT,
     getLanguageInstruction()
   ]
     .filter(Boolean)

--- a/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/buildSystemPrompt.test.ts
@@ -308,6 +308,39 @@ describe('buildSystemPrompt — report_artifacts prompt', () => {
   })
 })
 
+describe('buildSystemPrompt — cache-stable segment order', () => {
+  it('keeps static Cherry policy before configurable and runtime-derived context', async () => {
+    mockBuildPrompt.mockResolvedValueOnce({
+      base: { kind: 'native' },
+      context: 'PERSONA_AND_MEMORY_CONTEXT'
+    })
+
+    const text = promptText(
+      await buildSystemPrompt(
+        makeAgent({ instructions: 'CONFIGURED_AGENT_INSTRUCTIONS' }),
+        '/tmp/cwd',
+        undefined,
+        [],
+        [],
+        'WORKSPACE_INSTRUCTIONS'
+      )
+    )
+
+    const orderedMarkers = [
+      '## Instruction Precedence',
+      ARTIFACTS_MARKER,
+      'CONFIGURED_AGENT_INSTRUCTIONS',
+      'WORKSPACE_INSTRUCTIONS',
+      'PERSONA_AND_MEMORY_CONTEXT',
+      'IMPORTANT: You must respond in English.'
+    ]
+    const offsets = orderedMarkers.map((marker) => text.indexOf(marker))
+
+    expect(offsets.every((offset) => offset >= 0)).toBe(true)
+    expect(offsets).toEqual([...offsets].sort((a, b) => a - b))
+  })
+})
+
 describe('buildSystemPrompt — runtime/CLI handbook', () => {
   it('does not inject the handbook for a normal agent with user instructions', async () => {
     const result = promptText(await buildSystemPrompt(makeAgent({ instructions: 'Do the task.' }), '/tmp/cwd'))

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
@@ -1501,7 +1501,7 @@ describe('PiRuntimeConnection', () => {
       ])
     })
 
-    it('wraps agent instructions with the shared authority contract after the persona', async () => {
+    it('wraps agent instructions with the shared authority contract before the persona', async () => {
       mocks.getAgent.mockReturnValue({ id: 'agent-1', model: 'p::m', instructions: 'Be terse.', configuration: {} })
       mocks.getById.mockReturnValue(agentSession)
       await new PiRuntimeConnection(input).start()
@@ -1510,7 +1510,7 @@ describe('PiRuntimeConnection', () => {
       const prompt = appendedSystemPrompt()
       expect(prompt).toContain('## Instruction Precedence')
       expect(prompt).toContain('<agent_instructions>\nBe terse.\n</agent_instructions>')
-      expect(prompt.indexOf('AGENT PROMPT')).toBeLessThan(prompt.indexOf('<agent_instructions>'))
+      expect(prompt.indexOf('<agent_instructions>')).toBeLessThan(prompt.indexOf('AGENT PROMPT'))
     })
 
     it('resolves Agent System Prompt variables before injecting them', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Configurable persona and memory content appeared before some stable Cherry-owned policy, shortening the reusable provider prompt-cache prefix.

After this PR:

Static instruction-precedence and deliverable-reporting policy lead the shared append block. Configurable Agent/workspace/persona context follows in documented stability order, with the declared authority hierarchy unchanged.

Fixes #19230

### Why we need it and why it was done in this way

All Agent runtimes already consume `buildAgentRuntimePrompt()`; changing the shared builder preserves runtime parity and avoids adapter-specific prompt layouts.

The following tradeoffs were made:

Physical order is optimized only after an explicit instruction-precedence section establishes semantic authority.

The following alternatives were considered:

Runtime-specific reordering was rejected because it would make Claude Code, Pi, and DSH diverge.

Links to places where the discussion took place: #19230

### Breaking changes

None.

### Special notes for your reviewer

Focused Claude Code and Pi prompt tests (95 tests) plus repository type checks pass.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
