### PR TITLE
fix(provider-model): reconcile ambiguous delete failures

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelList.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelList.test.tsx
@@ -7,6 +7,7 @@ import { useProviderModelList } from '../useProviderModelList'
 const useModelsMock = vi.fn()
 const deleteModelMock = vi.fn()
 const deleteModelsMock = vi.fn()
+const refetchModelsMock = vi.fn()
 
 const models = [
   {
@@ -38,7 +39,8 @@ describe('useProviderModelList', () => {
     vi.clearAllMocks()
     MockUsePreferenceUtils.resetMocks()
 
-    useModelsMock.mockReturnValue({ models, isLoading: false })
+    refetchModelsMock.mockResolvedValue(models)
+    useModelsMock.mockReturnValue({ models, isLoading: false, refetch: refetchModelsMock })
     deleteModelMock.mockResolvedValue(undefined)
     deleteModelsMock.mockResolvedValue(undefined)
   })
@@ -187,7 +189,7 @@ describe('useProviderModelList', () => {
       rejectDelete = reject
     })
 
-    useModelsMock.mockReturnValue({ models, isLoading: false })
+    useModelsMock.mockReturnValue({ models, isLoading: false, refetch: refetchModelsMock })
     deleteModelMock.mockReturnValueOnce(deletePromise)
 
     const { result } = renderHook(() => useProviderModelList({ providerId: 'openai' }))
@@ -207,11 +209,36 @@ describe('useProviderModelList', () => {
     })
 
     expect(result.current.sections.pendingModelIds.has('openai::model-beta')).toBe(false)
+    expect(refetchModelsMock).toHaveBeenCalledOnce()
     expect(result.current.header.modelCount).toBe(2)
     expect(result.current.sections.displayEnabledModelCount).toBe(2)
     expect(
       result.current.sections.enabledSections.flatMap((section) => section.items).map((item) => item.model.id)
     ).toContain('openai::model-beta')
+  })
+
+  it('keeps a model removed when refresh confirms a rejected delete was committed', async () => {
+    const error = new Error('delete failed')
+    let latestModels = models
+
+    deleteModelMock.mockRejectedValueOnce(error)
+    refetchModelsMock.mockImplementationOnce(async () => {
+      latestModels = models.filter((model) => model.id !== 'openai::model-beta')
+      return latestModels
+    })
+    useModelsMock.mockImplementation(() => ({ models: latestModels, isLoading: false, refetch: refetchModelsMock }))
+
+    const { result, rerender } = renderHook(() => useProviderModelList({ providerId: 'openai' }))
+
+    await act(async () => {
+      await expect(result.current.sections.onDeleteModel(models[1])).resolves.toBeUndefined()
+    })
+    rerender()
+
+    expect(refetchModelsMock).toHaveBeenCalledOnce()
+    expect(
+      result.current.sections.enabledSections.flatMap((section) => section.items).map((item) => item.model.id)
+    ).not.toContain('openai::model-beta')
   })
 
   it('deletes all selected group models and removes them immediately', async () => {
@@ -344,7 +371,8 @@ describe('useProviderModelList', () => {
     ] as any
 
     deleteModelsMock.mockRejectedValueOnce(error)
-    useModelsMock.mockReturnValue({ models: groupedModels, isLoading: false })
+    refetchModelsMock.mockResolvedValueOnce(groupedModels)
+    useModelsMock.mockReturnValue({ models: groupedModels, isLoading: false, refetch: refetchModelsMock })
 
     const { result } = renderHook(() => useProviderModelList({ providerId: 'openai' }))
 
@@ -354,6 +382,7 @@ describe('useProviderModelList', () => {
 
     expect(deleteModelsMock).toHaveBeenCalledWith(['openai::chat-alpha', 'openai::chat-beta'])
     expect(deleteModelMock).not.toHaveBeenCalled()
+    expect(refetchModelsMock).toHaveBeenCalledOnce()
     expect(result.current.header.modelCount).toBe(2)
     expect(
       result.current.sections.enabledSections.flatMap((section) => section.items).map((item) => item.model.id)

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelList.ts
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/useProviderModelList.ts
@@ -83,10 +83,11 @@ const withPrunedModelIds = <T>(entries: Record<string, T>, validIds: Set<string>
 }
 
 export function useProviderModelList({ providerId, disabled = false }: UseProviderModelListArgs) {
-  const { models, isLoading: isModelsLoading } = useModels(
-    { providerId },
-    { swrOptions: PROVIDER_SETTINGS_MODEL_SWR_OPTIONS }
-  )
+  const {
+    models,
+    isLoading: isModelsLoading,
+    refetch: refetchModels
+  } = useModels({ providerId }, { swrOptions: PROVIDER_SETTINGS_MODEL_SWR_OPTIONS })
   const { deleteModel, deleteModels } = useModelMutations()
   const [defaultModelId] = usePreference('chat.default_model_id')
   const [quickAssistantModelId] = usePreference('feature.quick_assistant.model_id')
@@ -151,6 +152,21 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
     setEditingModel(null)
   }, [])
 
+  const confirmModelsDeleted = useCallback(
+    async (modelIds: readonly UniqueModelId[]) => {
+      try {
+        const refreshedModels = (await refetchModels()) as readonly Model[] | undefined
+        if (!refreshedModels) return false
+
+        const refreshedModelIds = new Set(refreshedModels.map((model) => model.id))
+        return modelIds.every((modelId) => !refreshedModelIds.has(modelId))
+      } catch {
+        return false
+      }
+    },
+    [refetchModels]
+  )
+
   const onDeleteModel = useCallback(
     async (model: Model) => {
       if (disabled) return
@@ -166,13 +182,15 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
       try {
         await deleteModel(model.providerId, modelId)
       } catch (error) {
+        const deletionConfirmed = await confirmModelsDeleted([model.id])
+
         setOptimisticDeletedByModelId((current) => {
           const next = { ...current }
           delete next[model.id]
           return next
         })
 
-        throw error
+        if (!deletionConfirmed) throw error
       } finally {
         setPendingModelIdMap((current) => {
           const next = { ...current }
@@ -181,7 +199,7 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
         })
       }
     },
-    [defaultModelIds, deleteModel, disabled]
+    [confirmModelsDeleted, defaultModelIds, deleteModel, disabled]
   )
 
   const onDeleteModels = useCallback(
@@ -191,6 +209,7 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
       if (deletableModels.length === 0) {
         return
       }
+      const deletableModelIds = deletableModels.map((model) => model.id)
 
       setOptimisticDeletedByModelId((current) => {
         const next = { ...current }
@@ -212,19 +231,21 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
       })
 
       try {
-        await deleteModels(deletableModels.map((model) => model.id))
+        await deleteModels(deletableModelIds)
       } catch (error) {
+        const deletionConfirmed = await confirmModelsDeleted(deletableModelIds)
+
         setOptimisticDeletedByModelId((current) => {
           const next = { ...current }
 
-          for (const model of deletableModels) {
-            delete next[model.id]
+          for (const modelId of deletableModelIds) {
+            delete next[modelId]
           }
 
           return next
         })
 
-        throw error
+        if (!deletionConfirmed) throw error
       } finally {
         setPendingModelIdMap((current) => {
           const next = { ...current }
@@ -237,7 +258,7 @@ export function useProviderModelList({ providerId, disabled = false }: UseProvid
         })
       }
     },
-    [defaultModelIds, deleteModels, disabled]
+    [confirmModelsDeleted, defaultModelIds, deleteModels, disabled]
   )
 
   const enabledSections = useMemo(() => toGroupSections(displayState.groups), [displayState.groups])


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Provider model rows were removed optimistically. If a DataApi delete timed out after the main process committed it, a retry could report `NOT_FOUND`; the renderer then restored the stale row and displayed a false failure even though the model no longer existed.

After this PR:

Rejected single and bulk model deletes refetch the provider model list before rolling back. If every requested model is absent from the refreshed result, the operation resolves and the rows stay removed. If any requested model still exists, the original error is rethrown and the authoritative rows are restored.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The provider model list owns the optimistic deletion state, and `useModels` already exposes a provider-scoped refetch. Reconciliation therefore stays local to the failed interaction while successful mutations continue using the existing `/models` cache refresh.

The following tradeoffs were made:

- A rejected delete performs one additional read before deciding whether to restore rows or surface an error.
- Authoritative absence is treated as a successful deletion outcome, preventing a false toast after an ambiguous timeout.

The following alternatives were considered:

- Making ModelService deletion idempotent would address retry-generated `NOT_FOUND`, but it changes the existing single and atomic bulk-delete contracts and cannot resolve cases where every response attempt times out.
- Adding request deduplication or result replay to DataApi would be a cross-cutting infrastructure change.
- Keeping rows optimistically removed after every error could hide genuine deletion failures.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- The explicit refetch runs only after the mutation has exhausted its internal retry path and rejected.
- Focused validation: `pnpm exec vitest run --project renderer src/renderer/pages/settings/ProviderSettings/ModelList/__tests__/ModelList.test.tsx src/renderer/hooks/__tests__/useModel.test.ts` (55 tests passed).
- `pnpm lint` and `pnpm test:lint` passed. The full test suite was not run per the requested narrow verification scope.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Provider model deletion now keeps the model list synchronized when a request reports failure after the model was already removed.
```
