### PR TITLE
fix(web-search): anchor relative dates to runtime

### DIFF
--- a/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
+++ b/src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts
@@ -166,4 +166,28 @@ describe('assembleSystemPrompt', () => {
     })
     expect(out).toBe('base')
   })
+
+  it('anchors relative dates to the runtime local date when web search is enabled', async () => {
+    const out = await assembleSystemPrompt({
+      assistant: makeAssistant({ prompt: 'base' }),
+      model,
+      webSearchEnabled: true,
+      now: new Date(2026, 7, 20, 23, 59)
+    })
+
+    expect(out).toContain('<current-date>2026-08-20</current-date>')
+    expect(out).toContain('this month')
+    expect(out).toContain('Do not substitute dates remembered from training')
+  })
+
+  it('does not add volatile date context when web search is unavailable', async () => {
+    const out = await assembleSystemPrompt({
+      assistant: makeAssistant({ prompt: 'base' }),
+      model,
+      webSearchEnabled: false,
+      now: new Date(2026, 7, 20)
+    })
+
+    expect(out).toBe('base')
+  })
 })

--- a/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
+++ b/src/main/ai/runtime/aiSdk/params/assembleSystemPrompt.ts
@@ -21,10 +21,14 @@ export interface AssembleSystemPromptInput {
   deferredEntries?: readonly ToolEntry[]
   /** True only when a selected first-party lookup tool with the citation-id contract remains available. */
   hasCitableTools?: boolean
+  /** Add a volatile local-date anchor when this request can execute web search. */
+  webSearchEnabled?: boolean
+  /** Injectable clock for deterministic tests. */
+  now?: Date
 }
 
 export async function assembleSystemPrompt(input: AssembleSystemPromptInput): Promise<string | undefined> {
-  const { assistant, model, tools, deferredEntries, hasCitableTools = false } = input
+  const { assistant, model, tools, deferredEntries, hasCitableTools = false, webSearchEnabled = false } = input
 
   const sections: string[] = []
 
@@ -47,6 +51,17 @@ export async function assembleSystemPrompt(input: AssembleSystemPromptInput): Pr
     sections.push(CITATIONS_SYSTEM_PROMPT)
   }
 
+  if (webSearchEnabled) {
+    sections.push(buildWebSearchDateContext(input.now ?? new Date()))
+  }
+
   if (sections.length === 0) return undefined
   return sections.join('\n\n')
+}
+
+export function buildWebSearchDateContext(now: Date): string {
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  return `<current-date>${year}-${month}-${day}</current-date>\nInterpret relative dates such as today, this month, and the last 30 days from this date. Do not substitute dates remembered from training or earlier conversation turns.`
 }

--- a/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
+++ b/src/main/ai/runtime/aiSdk/params/buildAgentParams.ts
@@ -287,7 +287,14 @@ export async function buildAgentParams(input: BuildAgentParamsInput): Promise<Bu
   const features = extraFeatures?.length ? [...INTERNAL_FEATURES, ...extraFeatures] : INTERNAL_FEATURES
   const contributions = collectFromFeatures(scope, features)
 
-  const system = await assembleSystemPrompt({ assistant, model, tools, deferredEntries, hasCitableTools })
+  const system = await assembleSystemPrompt({
+    assistant,
+    model,
+    tools,
+    deferredEntries,
+    hasCitableTools,
+    webSearchEnabled: finalWebToolRoutes.webSearch !== 'none'
+  })
   const options = buildAgentOptions(
     scope,
     contributions.stopConditions,


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Web-search requests had no runtime date anchor in their shared system prompt. Models could therefore resolve relative phrases such as "this month" from stale training or conversation context and generate searches for the wrong month.

After this PR:

Requests with an active web-search route receive the app's local calendar date plus an explicit instruction to resolve relative dates from it. Non-web requests remain unchanged, avoiding unnecessary daily prompt-prefix churn.

Fixes #19032

### Why we need it and why it was done in this way

The date is injected at the common AI SDK prompt assembly boundary, after the final web-tool route is known. This keeps behavior consistent across client and server web-search implementations and across providers.

The following tradeoffs were made:

- The prompt guides query generation rather than filtering provider results after retrieval; providers expose different date-filter capabilities, while every route shares this prompt boundary.
- The date uses the application's local calendar because relative dates should match the user's system day.

The following alternatives were considered:

- Adding provider-specific date parameters was rejected because it would not cover all public web-search routes consistently.
- Adding the date to every request was rejected because it would make otherwise stable prompt prefixes change every day.

Links to places where the discussion took place: #19032

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage uses an injectable clock and verifies both enabled and disabled web-search paths. `pnpm vitest run --project main src/main/ai/runtime/aiSdk/params/__tests__/assembleSystemPrompt.test.ts`, `pnpm typecheck`, targeted oxlint, and targeted ESLint pass.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Web Search now uses the current local date when interpreting requests such as "this month" or "the last 30 days", preventing stale-month queries across providers.
```
