### PR TITLE
fix(topics): keep pinned chats inside assistant groups

### DIFF
--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -79,7 +79,6 @@ import {
   sortTopicsForDisplayGroups,
   TOPIC_ASSISTANT_SECTION_ID,
   TOPIC_PINNED_GROUP_ID,
-  TOPIC_PINNED_SECTION_ID,
   TOPIC_UNLINKED_ASSISTANT_GROUP_ID,
   type TopicDisplayMode
 } from '@renderer/utils/chat/topicsHelpers'
@@ -740,19 +739,15 @@ export function Topics({
           }
         },
         now: groupNow,
-        pinnedAsSection: isAssistantDisplayMode
+        pinnedAsSection: false
       }),
-    [assistantById, displayMode, groupNow, isAssistantDisplayMode, t]
+    [assistantById, displayMode, groupNow, t]
   )
 
   const topicSectionBy = useMemo(() => {
     if (!isAssistantDisplayMode) return undefined
 
     return (topic: Topic): ResourceListSection => {
-      if (topic.pinned) {
-        return { id: TOPIC_PINNED_SECTION_ID, label: t('selector.common.pinned_title') }
-      }
-
       if (isGroupGrouping) {
         const assistant = topic.assistantId ? assistantById.get(topic.assistantId) : undefined
         const group = assistant?.groupId ? assistantGroupById.get(assistant.groupId) : undefined
@@ -884,13 +879,13 @@ export function Topics({
     (topic: Topic) => {
       conversationNav.openConversationTab(topic.id, topic.name, { forceNew: true })
     },
-    [conversationNav, t]
+    [conversationNav]
   )
   const openTopicInNewWindow = useCallback(
     (topic: Topic) => {
       conversationNav.openConversationWindow(topic.id, topic.name)
     },
-    [conversationNav, t]
+    [conversationNav]
   )
 
   const handleToggleAssistantPin = useCallback(
@@ -1380,6 +1375,9 @@ export function Topics({
 
       const topic = topics.find((candidate) => candidate.id === payload.activeId)
       if (!topic || topic.pinned) return
+      const overTopic =
+        payload.overType === 'item' ? topics.find((candidate) => candidate.id === payload.overId) : undefined
+      if (overTopic?.pinned) return
 
       const targetAssistantId = resolveAssistantIdForTopicGroup(payload.targetGroupId, assistantById)
       if (targetAssistantId === undefined) return

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -738,8 +738,7 @@ export function Topics({
             unlinked: t('chat.topics.group.unknown_assistant')
           }
         },
-        now: groupNow,
-        pinnedAsSection: false
+        now: groupNow
       }),
     [assistantById, displayMode, groupNow, t]
   )
@@ -1238,8 +1237,9 @@ export function Topics({
   )
 
   const canDropTopicItem = useCallback(
-    ({ targetGroupId }: { targetGroupId: string }) =>
+    ({ overItem, targetGroupId }: { overItem?: Topic; targetGroupId: string }) =>
       isAssistantDisplayMode &&
+      !overItem?.pinned &&
       targetGroupId !== TOPIC_PINNED_GROUP_ID &&
       targetGroupId !== TOPIC_UNLINKED_ASSISTANT_GROUP_ID &&
       resolveAssistantIdForTopicGroup(targetGroupId, assistantById) !== undefined,

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -454,7 +454,6 @@ import {
   applyOptimisticTopicDisplayMove,
   TOPIC_ASSISTANT_SECTION_ID,
   TOPIC_PINNED_GROUP_ID,
-  TOPIC_PINNED_SECTION_ID,
   TOPIC_UNLINKED_ASSISTANT_GROUP_ID
 } from '@renderer/utils/chat/topicsHelpers'
 import type { Pin } from '@shared/data/types/pin'
@@ -3126,7 +3125,6 @@ describe('Topics', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Alpha Assistant' }))
 
     // Sections stay expanded; expanding Alpha removes it from the collapsed list.
-    expect(getTopicGroupExpansionCache().assistant).not.toContain(TOPIC_PINNED_SECTION_ID)
     expect(getTopicGroupExpansionCache().assistant).not.toContain(TOPIC_ASSISTANT_SECTION_ID)
     expect(getTopicGroupExpansionCache().assistant).not.toContain('topic:assistant:assistant-1')
     expect(getTopicGroupExpansionCache().assistant).toContain('topic:assistant:assistant-2')

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1364,6 +1364,7 @@ describe('Topics', () => {
   })
 
   it('moves a topic into the pinned group immediately after pinning without refreshing topics', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'time')
     pinMutationMocks.createPin.mockResolvedValue(createTopicPin())
 
     const { getByText, rerenderTopicList } = renderTopicList()
@@ -2618,7 +2619,7 @@ describe('Topics', () => {
     ])
   })
 
-  it('re-selects the active topic from an assistant group while history records are active', () => {
+  it('selects the pinned topic first from an assistant group while history records are active', () => {
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     setTopicGroupExpansionCache({
       ...createExpandedTopicGroupExpansionFixture(),
@@ -2631,7 +2632,7 @@ describe('Topics', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Alpha Assistant' }))
 
-    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a' }))
+    expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-b' }))
   })
 
   it('does not show the assistant section toggle action in time display mode', () => {
@@ -3081,7 +3082,7 @@ describe('Topics', () => {
 
     const { onNewTopic, rerenderTopicList } = renderTopicList()
 
-    expect(screen.getByRole('button', { name: 'Pinned' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Pinned' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Unlinked Assistant' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Alpha Assistant' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Beta Assistant' })).toBeInTheDocument()
@@ -3103,11 +3104,6 @@ describe('Topics', () => {
       'true'
     )
     expect(screen.getByText('No conversations')).toBeInTheDocument()
-    const assistantSectionButton = screen
-      .getAllByRole('button', { name: 'Assistant' })
-      .find((button) => button.hasAttribute('aria-expanded'))
-    expect(screen.getByRole('button', { name: 'Pinned' })).toHaveAttribute('aria-expanded', 'true')
-    expect(assistantSectionButton).toHaveAttribute('aria-expanded', 'true')
     expect(groupChevron(screen.getByRole('button', { name: 'Alpha Assistant' }))).toHaveAttribute(
       'aria-expanded',
       'false'
@@ -3120,7 +3116,7 @@ describe('Topics', () => {
       'aria-expanded',
       'false'
     )
-    expect(screen.getByText('Pinned unknown')).toBeInTheDocument()
+    expect(screen.queryByText('Pinned unknown')).not.toBeInTheDocument()
     expect(screen.queryByText('Known alpha')).not.toBeInTheDocument()
     expect(screen.queryByText('Known beta')).not.toBeInTheDocument()
     expect(screen.queryByText('Default topic')).not.toBeInTheDocument()
@@ -3139,7 +3135,7 @@ describe('Topics', () => {
     fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'chat.conversation.new' }))
     expect(onNewTopic).toHaveBeenCalledWith({ assistantId: 'assistant-1' })
 
-    for (const groupName of ['Pinned', 'Unlinked Assistant'] as const) {
+    for (const groupName of ['Unlinked Assistant'] as const) {
       const header = screen.getByRole('button', { name: groupName }).closest('div')
       expect(header).toBeInTheDocument()
       expect(
@@ -3826,7 +3822,7 @@ describe('Topics', () => {
     expect(patchSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('does not allow pinned or unknown groups to participate in assistant group reorder', () => {
+  it('does not allow the unknown group to participate in assistant group reorder', () => {
     const patchSpy = vi.spyOn(dataApiService, 'patch').mockResolvedValue(undefined as never)
     MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
     mockUseInfiniteQuery.mockReturnValue({
@@ -3856,23 +3852,8 @@ describe('Topics', () => {
 
     renderTopicList()
 
-    expect(screen.getByRole('button', { name: 'Pinned' })).toBeInTheDocument()
-    expect(
-      screen
-        .getAllByRole('button', { name: 'Assistant' })
-        .some((button) => button.getAttribute('aria-expanded') === 'true')
-    ).toBe(true)
-    expect(dndMocks.sortableData.has('group:topic:pinned')).toBe(false)
-    expect(dndMocks.sortableData.has('group:topic:section:pinned')).toBe(false)
+    expect(screen.queryByRole('button', { name: 'Pinned' })).not.toBeInTheDocument()
     expect(dndMocks.sortableData.has('group:topic:assistant:unknown')).toBe(false)
-
-    dndMocks.onDragEnd?.({
-      active: {
-        data: sortableData('group:topic:assistant:assistant-1'),
-        id: 'group:topic:assistant:assistant-1'
-      },
-      over: { data: droppableData('group:topic:section:pinned'), id: 'group:topic:section:pinned' }
-    })
     dndMocks.onDragEnd?.({
       active: {
         data: sortableData('group:topic:assistant:assistant-1'),

--- a/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/topicsHelpers.test.ts
@@ -222,7 +222,7 @@ describe('Topics helpers', () => {
     ])
   })
 
-  it('builds assistant display groups with pinned/known/unlinked buckets', () => {
+  it('keeps pinned topics inside their assistant display group', () => {
     const groupTopic = createTopicDisplayGroupResolver({
       assistantById: new Map([
         ['assistant-1', { id: 'assistant-1', name: 'Research' }],
@@ -232,9 +232,9 @@ describe('Topics helpers', () => {
       mode: 'assistant'
     })
 
-    expect(groupTopic(createTopic({ id: 'pinned', pinned: true, assistantId: undefined }))).toEqual({
-      id: 'topic:pinned',
-      label: 'Pinned'
+    expect(groupTopic(createTopic({ id: 'pinned', pinned: true, assistantId: 'assistant-1' }))).toEqual({
+      id: 'topic:assistant:assistant-1',
+      label: 'Research'
     })
     expect(groupTopic(createTopic({ id: 'unlinked', assistantId: undefined }))).toEqual({
       id: TOPIC_UNLINKED_ASSISTANT_GROUP_ID,
@@ -250,13 +250,15 @@ describe('Topics helpers', () => {
     })
   })
 
-  it('sorts assistant display groups by pinned, assistant rank, then unknown while preserving group order', () => {
+  it('sorts assistant groups by rank with pinned topics first inside each assistant', () => {
     const topics = [
       createTopic({ id: 'assistant-b-1', assistantId: 'assistant-b' }),
       createTopic({ id: 'unknown-1', assistantId: 'missing-assistant' }),
       createTopic({ id: 'default-1', assistantId: undefined }),
       createTopic({ id: 'assistant-a-1', assistantId: 'assistant-a' }),
-      createTopic({ id: 'pinned-1', assistantId: 'missing-assistant', pinned: true }),
+      createTopic({ id: 'pinned-a', assistantId: 'assistant-a', pinned: true }),
+      createTopic({ id: 'pinned-b', assistantId: 'assistant-b', pinned: true }),
+      createTopic({ id: 'pinned-unknown', assistantId: 'missing-assistant', pinned: true }),
       createTopic({ id: 'assistant-b-2', assistantId: 'assistant-b' })
     ]
 
@@ -268,7 +270,16 @@ describe('Topics helpers', () => {
         ]),
         mode: 'assistant'
       }).map((topic) => topic.id)
-    ).toEqual(['pinned-1', 'assistant-a-1', 'assistant-b-1', 'assistant-b-2', 'unknown-1', 'default-1'])
+    ).toEqual([
+      'pinned-a',
+      'assistant-a-1',
+      'pinned-b',
+      'assistant-b-1',
+      'assistant-b-2',
+      'pinned-unknown',
+      'unknown-1',
+      'default-1'
+    ])
   })
 
   it('sorts assistant group topics by raw persisted orderKey ascending when available', () => {

--- a/src/renderer/utils/chat/topicsHelpers.ts
+++ b/src/renderer/utils/chat/topicsHelpers.ts
@@ -43,7 +43,6 @@ export type TopicDisplayGroupOptions = {
   labels: TopicDisplayGroupLabels
   mode: TopicDisplayMode
   now?: Parameters<typeof getResourceTimeBucket>[1]
-  pinnedAsSection?: boolean
 }
 
 export type TopicDisplaySortOptions = {
@@ -65,7 +64,6 @@ const TOPIC_TIME_BUCKET_RANK: Record<ResourceListTimeBucket, number> = {
 }
 
 export const TOPIC_PINNED_GROUP_ID = 'topic:pinned'
-export const TOPIC_PINNED_SECTION_ID = 'topic:section:pinned'
 export const TOPIC_ASSISTANT_SECTION_ID = 'topic:section:assistant'
 export const TOPIC_UNLINKED_ASSISTANT_GROUP_ID = 'topic:assistant:unknown'
 
@@ -193,12 +191,11 @@ export function createTopicDisplayGroupResolver<T extends Pick<Topic, 'assistant
   assistantById,
   labels,
   mode,
-  now,
-  pinnedAsSection = false
+  now
 }: TopicDisplayGroupOptions): ResourceListGroupResolver<T> {
   const pinnedResolver = createPinnedGroupResolver<T>({
     isPinned: (topic) => topic.pinned === true,
-    group: { id: 'pinned', label: mode === 'time' || !pinnedAsSection ? labels.pinned : '' } satisfies ResourceListGroup
+    group: { id: 'pinned', label: labels.pinned } satisfies ResourceListGroup
   })
 
   if (mode === 'time') {

--- a/src/renderer/utils/chat/topicsHelpers.ts
+++ b/src/renderer/utils/chat/topicsHelpers.ts
@@ -214,35 +214,29 @@ export function createTopicDisplayGroupResolver<T extends Pick<Topic, 'assistant
     )
   }
 
-  return withTopicGroupIdPrefix(
-    composeResourceListGroupResolvers(pinnedResolver, (topic) => {
-      const assistantId = topic.assistantId
+  return withTopicGroupIdPrefix((topic) => {
+    const assistantId = topic.assistantId
 
-      if (!assistantId) {
-        return { id: 'assistant:unknown', label: labels.assistant.unlinked }
-      }
-
-      const assistant = assistantById?.get(assistantId)
-      if (assistant) {
-        return { id: `assistant:${assistant.id}`, label: assistant.name }
-      }
-
+    if (!assistantId) {
       return { id: 'assistant:unknown', label: labels.assistant.unlinked }
-    })
-  )
+    }
+
+    const assistant = assistantById?.get(assistantId)
+    if (assistant) {
+      return { id: `assistant:${assistant.id}`, label: assistant.name }
+    }
+
+    return { id: 'assistant:unknown', label: labels.assistant.unlinked }
+  })
 }
 
-function getAssistantGroupRank<T extends Pick<Topic, 'assistantId' | 'pinned'>>(
+function getAssistantGroupRank<T extends Pick<Topic, 'assistantId'>>(
   topic: T,
   assistantRankById?: ReadonlyMap<string, number>
 ) {
-  if (topic.pinned === true) {
-    return 0
-  }
-
   const assistantRank = topic.assistantId ? assistantRankById?.get(topic.assistantId) : undefined
   if (assistantRank !== undefined) {
-    return assistantRank + 1
+    return assistantRank
   }
 
   return TOPIC_UNLINKED_ASSISTANT_RANK
@@ -259,11 +253,17 @@ export function sortTopicsForDisplayGroups<T extends Pick<Topic, 'assistantId' |
   const isPinned = (topic: T) => topic.pinned === true
 
   if (options.mode === 'assistant') {
-    return sortRankedResourceItems(topics, {
-      getRank: (topic) => getAssistantGroupRank(topic, options.assistantRankById),
-      isPinned,
-      compareWithinGroup: (a, b) => compareResourceOrderKey(readOptionalOrderKey(a), readOptionalOrderKey(b))
-    })
+    return topics
+      .map((topic, index) => ({ topic, index, rank: getAssistantGroupRank(topic, options.assistantRankById) }))
+      .sort((a, b) => {
+        if (a.rank !== b.rank) return a.rank - b.rank
+        if (a.topic.pinned !== b.topic.pinned) return a.topic.pinned ? -1 : 1
+        if (a.topic.pinned && b.topic.pinned) return a.index - b.index
+        return (
+          compareResourceOrderKey(readOptionalOrderKey(a.topic), readOptionalOrderKey(b.topic)) || a.index - b.index
+        )
+      })
+      .map(({ topic }) => topic)
   }
 
   return sortRankedResourceItems(topics, {


### PR DESCRIPTION
### What this PR does

Before this PR:

When conversations were grouped by assistant, pinning a conversation moved it into a global pinned group and detached it visually from its assistant.

After this PR:

Pinned conversations remain in their assistant group and sort before unpinned conversations in that same group. Time grouping keeps the existing global pinned section.

Fixes #19081

### Why we need it and why it was done in this way

Assistant grouping communicates ownership, so pinning should affect ordering inside that ownership boundary rather than replace it. The grouping resolver now treats assistant identity as authoritative in assistant mode, while the sorter applies pinned-first ordering within each assistant rank.

The following tradeoffs were made:

Pinned conversations are not draggable, and unpinned conversations cannot be dropped relative to a pinned row. This preserves the pinned-first invariant without changing the persisted topic order model.

The following alternatives were considered:

Adding a second persisted pin scope was considered, but it would require a data migration and more UI for a behavior that can be derived from the existing display mode. Keeping global pinning in time mode and assistant-local pinning in assistant mode is deterministic and backward compatible.

Links to places where the discussion took place: #19081

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage verifies group resolution, assistant-rank ordering, pinned-first ordering within each assistant, pinning behavior in time mode, and drag/drop boundaries. All 117 targeted tests and the full typecheck pass locally.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Keep pinned conversations inside their assistant group when conversations are grouped by assistant.
```
