### PR TITLE
fix(agent): polish subagent flow and running status

### DIFF
--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -43,6 +43,7 @@ import type { ResourceListRevealRequest } from '@renderer/components/chat/resour
 import ComposerFloatingCapsule from '@renderer/components/composer/ComposerFloatingCapsule'
 import Scrollbar from '@renderer/components/Scrollbar'
 import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useAgentSessionBackgroundTasks } from '@renderer/hooks/agent/useAgentSessionBackgroundTasks'
 import { useAgentSessionCompaction } from '@renderer/hooks/agent/useAgentSessionCompaction'
 import { useAgentSessionContextUsage } from '@renderer/hooks/agent/useAgentSessionContextUsage'
 import { useAgentSessionTaskEvents } from '@renderer/hooks/agent/useAgentSessionTaskEvents'
@@ -55,7 +56,7 @@ import { type Topic, TopicType, type TopicType as TopicTypeEnum } from '@rendere
 import { buildAgentFileWorkspaceKey, buildAgentSessionTopicId } from '@renderer/utils/agentSession'
 import { resolveInlineFilePath } from '@renderer/utils/filePath'
 import { cn } from '@renderer/utils/style'
-import type { AgentSessionTaskEvents } from '@shared/ai/agentSessionBackgroundTasks'
+import type { AgentSessionBackgroundTasks } from '@shared/ai/agentSessionBackgroundTasks'
 import { isDeferredToolOutput } from '@shared/ai/transport'
 import { AGENT_WORKSPACE_TYPE, type AgentWorkspaceType } from '@shared/data/api/schemas/agentWorkspaces'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
@@ -758,7 +759,8 @@ const AgentToolFlowMessageList = memo(function AgentToolFlowMessageList({
         selection: undefined,
         renderConfig: {
           ...providerValue.state.renderConfig,
-          collapseCompletedToolHistory: false
+          collapseCompletedToolHistory: true,
+          messageStyle: 'bubble' as const
         }
       }
     }),
@@ -767,7 +769,9 @@ const AgentToolFlowMessageList = memo(function AgentToolFlowMessageList({
 
   return (
     <MessageListProvider value={flowProviderValue}>
-      <div className="h-full min-h-0 [&_.MessageFooter]:hidden [&_.group-menu-bar]:hidden [&_.message-avatar]:hidden">
+      <div
+        className="h-full min-h-0 bg-muted/15 [&_.MessageFooter]:hidden [&_.group-menu-bar]:hidden [&_.message-avatar]:hidden"
+        data-testid="agent-flow-message-list">
         <MessageList />
       </div>
     </MessageListProvider>
@@ -1014,29 +1018,29 @@ function TaskStatusIcon({ status }: { status: AgentStatusTask['status'] | AgentR
   return <span className="flex size-5 shrink-0 items-center justify-center">{icon}</span>
 }
 
-/** Foreground runs belong to one assistant row; detached runs use the SDK's per-task edge state. */
-function useAgentRunLiveness(messages: CherryUIMessage[], taskEvents: AgentSessionTaskEvents): AgentRunLiveness {
+/** Foreground runs belong to one assistant row; detached runs use the runtime's current membership snapshot. */
+function useAgentRunLiveness(
+  messages: CherryUIMessage[],
+  backgroundTasks: AgentSessionBackgroundTasks
+): AgentRunLiveness {
   return useMemo(() => {
     const activeMessageIds = new Set(
       messages
         .filter((message) => message.role === 'assistant' && message.metadata?.status === 'pending')
         .map((message) => message.id)
     )
-    const liveBackgroundTaskIds = new Set(
-      Object.values(taskEvents)
-        .filter((event) => event.isBackgrounded === true && event.status !== 'completed' && event.status !== 'error')
-        .map((event) => event.taskId)
-    )
+    const liveBackgroundTaskIds = new Set(backgroundTasks.map((task) => task.id))
     return { activeMessageIds, liveBackgroundTaskIds }
-  }, [messages, taskEvents])
+  }, [backgroundTasks, messages])
 }
 
 function useAgentRightPaneStatus(active = true): AgentRightPaneStatus {
   const runtime = useAgentRightPaneRuntime()
   const meta = useAgentRightPaneMeta()
+  const backgroundTasks = useAgentSessionBackgroundTasks(meta.sessionId)
   // Current-process per-task lifecycle edges.
   const lateTaskEvents = useAgentSessionTaskEvents(meta.sessionId)
-  const liveness = useAgentRunLiveness(runtime.messages, lateTaskEvents)
+  const liveness = useAgentRunLiveness(runtime.messages, backgroundTasks)
   const retainedStatusRef = useRef<AgentRightPaneStatus | null>(null)
   const status = useMemo(
     () =>

--- a/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/AgentRightPane.tsx
@@ -769,9 +769,7 @@ const AgentToolFlowMessageList = memo(function AgentToolFlowMessageList({
 
   return (
     <MessageListProvider value={flowProviderValue}>
-      <div
-        className="h-full min-h-0 bg-muted/15 [&_.MessageFooter]:hidden [&_.group-menu-bar]:hidden [&_.message-avatar]:hidden"
-        data-testid="agent-flow-message-list">
+      <div className="h-full min-h-0 bg-muted/15 [&_.MessageFooter]:hidden [&_.group-menu-bar]:hidden [&_.message-avatar]:hidden">
         <MessageList />
       </div>
     </MessageListProvider>

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -999,7 +999,6 @@ describe('AgentRightPane', () => {
 
     expect(screen.getByTestId('message-list-provider')).toHaveAttribute('data-collapse-completed-tool-history', 'true')
     expect(screen.getByTestId('message-list-provider')).toHaveAttribute('data-message-style', 'bubble')
-    expect(screen.getByTestId('agent-flow-message-list')).toHaveClass('bg-muted/15')
   })
 
   it('marks direct artifact opening as user initiated', async () => {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/AgentRightPane.test.tsx
@@ -6,6 +6,7 @@ import {
 import type * as ArtifactPanePath from '@renderer/components/chat/panes/artifactPanePath'
 import { useRightPanelState } from '@renderer/components/chat/panes/Shell'
 import type * as ChatPrimitives from '@renderer/components/chat/primitives'
+import type { AgentSessionBackgroundTask } from '@shared/ai/agentSessionBackgroundTasks'
 import type { CherryMessagePart, CherryUIMessage } from '@shared/data/types/message'
 import type { PhysicalFileMetadata } from '@shared/types/file'
 import { TreeDir, TreeDirRoot, TreeFile } from '@shared/utils/file'
@@ -25,6 +26,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as AgentRightPaneProjection from '../agentRightPaneProjection'
 
 const {
+  backgroundTasksState,
   buildAgentToolFlowProjectionMock,
   getToolResultMock,
   fileSessionDiscardMock,
@@ -42,6 +44,7 @@ const {
   toastErrorMock,
   uiMockState
 } = vi.hoisted(() => ({
+  backgroundTasksState: { value: [] as AgentSessionBackgroundTask[] },
   buildAgentToolFlowProjectionMock: vi.fn(),
   getToolResultMock: vi.fn(),
   fileSessionDiscardMock: vi.fn(),
@@ -200,7 +203,19 @@ vi.mock('@renderer/components/chat/messages/MessageList', () => ({
 }))
 
 vi.mock('@renderer/components/chat/messages/MessageListProvider', () => ({
-  MessageListProvider: ({ children }: PropsWithChildren) => <>{children}</>
+  MessageListProvider: ({
+    children,
+    value
+  }: PropsWithChildren<{
+    value: { state: { renderConfig: { collapseCompletedToolHistory: boolean; messageStyle: string } } }
+  }>) => (
+    <div
+      data-testid="message-list-provider"
+      data-collapse-completed-tool-history={String(value.state.renderConfig.collapseCompletedToolHistory)}
+      data-message-style={value.state.renderConfig.messageStyle}>
+      {children}
+    </div>
+  )
 }))
 
 vi.mock('@renderer/hooks/useToolResult', () => ({
@@ -355,6 +370,10 @@ vi.mock('@renderer/hooks/agent/useAgentSessionCompaction', () => ({
 
 vi.mock('@renderer/hooks/agent/useAgentSessionContextUsage', () => ({
   useAgentSessionContextUsage: () => ({ percentage: null, usage: null })
+}))
+
+vi.mock('@renderer/hooks/agent/useAgentSessionBackgroundTasks', () => ({
+  useAgentSessionBackgroundTasks: () => backgroundTasksState.value
 }))
 
 // A live turn: run-task rows render the status their events report. Staleness is covered where the
@@ -564,6 +583,7 @@ describe('AgentRightPane', () => {
     resolveArtifactPaneFileSelectionMock.mockReturnValue(null)
     systemFileTreeState.root = new TreeDirRoot('/system-workspace')
     systemFileTreeState.version = 0
+    backgroundTasksState.value = []
     useDirectoryTreeMock.mockImplementation(() => systemFileTreeState)
     useArtifactFileTreeModelMock.mockImplementation(() => ({
       hasLoaded: fileTreeModelState.hasLoaded,
@@ -953,6 +973,35 @@ describe('AgentRightPane', () => {
     )
   })
 
+  it('presents flow prompts as bubbles and keeps completed process history collapsed', () => {
+    const flowPart = {
+      type: 'dynamic-tool',
+      toolCallId: 'flow-1',
+      toolName: 'Agent',
+      state: 'output-available',
+      input: { prompt: 'Inspect the workspace' },
+      output: 'Inspection complete'
+    } as unknown as CherryMessagePart
+    const messages = [{ id: 'm1', role: 'assistant', parts: [flowPart], metadata: {} }] as CherryUIMessage[]
+
+    render(
+      <TestAgentRightPane
+        sessionId="session-a"
+        workspacePath="/workspace"
+        messages={messages}
+        partsByMessageId={{ m1: [flowPart] }}>
+        <OpenFlowButton />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'open flow' }))
+
+    expect(screen.getByTestId('message-list-provider')).toHaveAttribute('data-collapse-completed-tool-history', 'true')
+    expect(screen.getByTestId('message-list-provider')).toHaveAttribute('data-message-style', 'bubble')
+    expect(screen.getByTestId('agent-flow-message-list')).toHaveClass('bg-muted/15')
+  })
+
   it('marks direct artifact opening as user initiated', async () => {
     resolveArtifactPaneFileSelectionMock.mockReturnValue({
       workspacePath: '/workspace',
@@ -1151,6 +1200,35 @@ describe('AgentRightPane', () => {
 
     expect(screen.getByTestId('right-pane')).toHaveAttribute('data-open', 'true')
     expect(screen.getByTestId('shell-tab-title')).toHaveTextContent('Inspect task state')
+  })
+
+  it('keeps a detached subagent spinning while it remains in the background task snapshot', () => {
+    const taskEvent = {
+      event: 'started' as const,
+      taskId: 'subagent-1',
+      toolUseId: 'tool-use-1',
+      status: 'in_progress' as const,
+      title: 'Run a detached subagent',
+      taskType: 'subagent'
+    }
+    const taskPart = { type: 'data-agent-task-event', data: taskEvent } as unknown as CherryMessagePart
+    const messages = [
+      { id: 'm1', role: 'assistant', parts: [taskPart], metadata: { status: 'success' } }
+    ] as CherryUIMessage[]
+    backgroundTasksState.value = [
+      { id: 'subagent-1', type: 'subagent', description: 'Run a detached subagent', toolCallId: 'tool-use-1' }
+    ]
+    render(
+      <TestAgentRightPane sessionId="session-a" messages={messages} partsByMessageId={{ m1: [taskPart] }}>
+        <AgentRightPane.Shortcuts />
+        <AgentRightPane.Viewport />
+      </TestAgentRightPane>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'agent.right_pane.tabs.status' }))
+
+    const taskButton = screen.getByRole('button', { name: /Run a detached subagent/ })
+    expect(taskButton.querySelector('.animate-spin')).not.toBeNull()
   })
 
   it('returns from a subagent flow to the status panel', async () => {

--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
@@ -131,6 +131,74 @@ describe('agent right pane projections', () => {
     ])
   })
 
+  it('keeps a foreground task result when its lifecycle event is present', () => {
+    const selected = toolPart(
+      'root',
+      'Agent',
+      undefined,
+      'output-available',
+      { prompt: 'Explore the repo' },
+      'Repository review complete'
+    )
+    const started = {
+      type: 'data-agent-task-event',
+      data: {
+        event: 'started',
+        taskId: 'task-1',
+        toolUseId: 'root',
+        status: 'in_progress',
+        title: 'Explore the repo'
+      }
+    } as unknown as CherryMessagePart
+    const parts = [selected, started]
+
+    const projection = buildAgentToolFlowProjection([message('m1', parts)], { m1: parts }, 'root')
+
+    expect(projection.partsByMessageId['root:agent-flow-assistant']).toEqual([
+      { type: 'text', text: 'Repository review complete' }
+    ])
+  })
+
+  it('hides a legacy background launch receipt without borrowing task status', () => {
+    const selected = toolPart(
+      'root',
+      'Agent',
+      undefined,
+      'output-available',
+      { prompt: 'Explore the repo' },
+      'Async agent launched successfully. Internal id: task-1; output_file: /tmp/task-1.output'
+    )
+    const parts = [selected, textPart('child agent text', 'root')]
+
+    const projection = buildAgentToolFlowProjection([message('m1', parts)], { m1: parts }, 'root')
+    const assistantParts = projection.partsByMessageId['root:agent-flow-assistant'] as Array<{ text?: string }>
+
+    expect(assistantParts.map((part) => part.text).filter(Boolean)).toEqual(['child agent text'])
+    expect(JSON.stringify(assistantParts)).not.toContain('Async agent launched successfully')
+    expect(JSON.stringify(assistantParts)).not.toContain('/tmp/task-1.output')
+  })
+
+  it.each(['async_launched', 'remote_launched'] as const)(
+    'hides a structured %s receipt without borrowing task status',
+    (status) => {
+      const selected = toolPart(
+        'root',
+        'Agent',
+        undefined,
+        'output-available',
+        { prompt: 'Explore the repo' },
+        { status, agentId: 'internal-agent-id' }
+      )
+      const parts = [selected, textPart('child agent text', 'root')]
+
+      const projection = buildAgentToolFlowProjection([message('m1', parts)], { m1: parts }, 'root')
+      const assistantParts = projection.partsByMessageId['root:agent-flow-assistant']
+
+      expect(assistantParts).toEqual([expect.objectContaining({ type: 'text', text: 'child agent text' })])
+      expect(JSON.stringify(assistantParts)).not.toContain('internal-agent-id')
+    }
+  )
+
   it('degrades to the selected tool prompt when child metadata is missing', () => {
     const parts = [
       toolPart('root', 'Agent', undefined, 'output-available', { prompt: 'Run the subagent' }),

--- a/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
@@ -94,7 +94,7 @@ export interface AgentArtifactFile {
 export interface AgentRunLiveness {
   /** Assistant message ids whose own turn is still pending. */
   activeMessageIds: ReadonlySet<string>
-  /** Task ids whose per-task lifecycle edge says they detached into the background. */
+  /** Task ids currently present in the runtime's background-task membership snapshot. */
   liveBackgroundTaskIds: ReadonlySet<string>
 }
 
@@ -588,7 +588,7 @@ export function buildAgentRightPaneStatus(
 
   // A run only settles if its completion event arrives; an interrupted turn, a crashed CLI or an
   // app restart means it never will. Foreground liveness belongs to the originating assistant row,
-  // while background liveness comes only from the SDK's per-task edge surface.
+  // while background liveness comes only from the runtime's current background-task membership snapshot.
   if (liveness) {
     for (const [id, task] of runTaskMap) {
       if (RUN_TASK_TERMINAL_STATUSES.has(task.status)) continue

--- a/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
@@ -5,7 +5,11 @@ import {
   isTaskRecord,
   normalizeTaskStatus
 } from '@renderer/components/chat/messages/tools/agent'
-import { AgentToolsType } from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
+import {
+  type AgentToolOutput,
+  AgentToolsType,
+  isBackgroundAgentOutput
+} from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
 import {
   getPartParentToolCallId,
   stripPartParentToolMetadata
@@ -177,10 +181,13 @@ function getToolPromptText(part: CherryMessagePart | undefined): string | undefi
   return textFromContent(input.prompt) ?? textFromContent(input.description)
 }
 
-function getToolOutputText(part: CherryMessagePart | undefined, resolvedOutput?: unknown): string | undefined {
-  if (resolvedOutput !== undefined) return textFromContent(resolvedOutput)
-  if (!part) return undefined
-  return textFromContent(getToolPartOutput(part))
+const LEGACY_ASYNC_AGENT_LAUNCH_RECEIPT_PREFIX = 'Async agent launched successfully.'
+
+function isBackgroundAgentLaunchReceipt(output: unknown, text: string | undefined): boolean {
+  return (
+    isBackgroundAgentOutput(output as AgentToolOutput | undefined) ||
+    (text?.startsWith(LEGACY_ASYNC_AGENT_LAUNCH_RECEIPT_PREFIX) ?? false)
+  )
 }
 
 function createFlowTextMessage(
@@ -324,7 +331,18 @@ export function buildAgentToolFlowProjection(
       }
     }
 
-    const outputText = getToolOutputText(selectedToolPart, selectedToolOutput)
+    const selectedOutput =
+      selectedToolOutput !== undefined
+        ? selectedToolOutput
+        : selectedToolPart
+          ? getToolPartOutput(selectedToolPart)
+          : undefined
+    const selectedOutputText = textFromContent(selectedOutput)
+    // A detached Agent result is only a control receipt and may expose internal ids or paths. Its
+    // actual conversation already arrives through the child flow parts collected above.
+    const outputText = isBackgroundAgentLaunchReceipt(selectedOutput, selectedOutputText)
+      ? undefined
+      : selectedOutputText
     if (outputText) assistantParts.push({ type: 'text', text: outputText } as CherryMessagePart)
     const isFlowActive = toolNodes.some(
       (node) => selectedToolCallIds.has(node.toolCallId) && !isTerminalToolState(node.state)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Subagent flow details rendered as a flat process transcript and could expose background-launch receipts containing internal task identifiers and output paths.
- A detached subagent could lose its running indicator in the right sidebar after the parent assistant turn completed, even while the task was still active.

https://github.com/user-attachments/assets/38e71948-9f96-4d7c-8e33-89f77160026f

After this PR:

- Subagent flow details use chat bubbles, collapse completed tool history, and omit both structured and legacy background-launch receipts.
- Detached subagents use the runtime's authoritative background-task membership snapshot for liveness, so the existing spinner and stop action remain visible until the task settles.

https://github.com/user-attachments/assets/9eb8ec71-b435-4bfb-9685-62707e6a0190

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The right pane should present the child conversation rather than transport metadata, and task liveness must remain accurate when background work outlives the assistant turn that launched it. The projection therefore filters control receipts at the display boundary, while the status view reads liveness from the existing main-owned background-task snapshot and continues using lifecycle events for task history and terminal details.

The following tradeoffs were made:

- The shared structured-output predicate handles current launch receipts; a narrow prefix check remains for legacy string receipts already stored in transcripts.
- Background-task membership is used only as the live-state authority, keeping the existing task event model responsible for descriptive and terminal metadata.

The following alternatives were considered:

- Inferring liveness from the parent assistant message was rejected because detached work can continue after that message succeeds.
- Treating the latest task event as permanent live state was rejected because interrupted sessions can leave stale `in_progress` edges.
- Streaming additional internal thinking state into the detail pane was intentionally left out to keep the change focused.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- Focused renderer tests cover legacy and structured receipt filtering, bubble/collapse presentation, and detached-task liveness.
- The behavior was also verified in the development app: the chat and sidebar showed the running state together, then transitioned to completion.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Improved subagent flow readability and fixed the sidebar running indicator for detached subagents.
```
