### PR TITLE
feat(settings): add searchable settings navigation

### DIFF
--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -1,6 +1,4 @@
-import { MenuDivider, MenuItem, MenuList, PageHeader } from '@cherrystudio/ui'
-import { GatewayIcon } from '@renderer/components/icons/GatewayIcon'
-import { McpLogo } from '@renderer/components/icons/SvgIcon'
+import { MenuDivider, MenuItem, MenuList, PageHeader, SearchInput } from '@cherrystudio/ui'
 import Scrollbar from '@renderer/components/Scrollbar'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
 import {
@@ -12,41 +10,46 @@ import {
 } from '@renderer/pages/settings/settingsStyles'
 import { cn } from '@renderer/utils/style'
 import { Outlet, useLocation, useNavigate } from '@tanstack/react-router'
-import {
-  Activity,
-  Bell,
-  CalendarClock,
-  Cloud,
-  Command,
-  Crop,
-  FileBox,
-  FileCode,
-  HardDrive,
-  Info,
-  Package,
-  Palette,
-  PictureInPicture2,
-  Radio,
-  ScanText,
-  Search,
-  Settings2,
-  Terminal,
-  TextCursorInput,
-  ToolCase,
-  Zap
-} from 'lucide-react'
 import type { CSSProperties, FC } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
+import { settingsNavigationSections, type SettingsPath } from './settingsNavigation'
+import { buildSettingsSearchEntries, filterSettingsSearchEntries } from './settingsSearch'
 
 const SettingsPage: FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
   const { pathname } = location
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const isMacTransparentWindow = useMacTransparentWindow()
+  const [searchText, setSearchText] = useState('')
+
+  const searchEntries = useMemo(
+    () =>
+      buildSettingsSearchEntries(
+        settingsNavigationSections,
+        i18n.getResourceBundle('en-US', 'translation') as Record<string, string>,
+        t
+      ),
+    [i18n, t]
+  )
+  const matchingPaths = useMemo(
+    () => new Set(filterSettingsSearchEntries(searchEntries, searchText).map((entry) => entry.path)),
+    [searchEntries, searchText]
+  )
+  const isSearching = searchText.trim().length > 0
+  const visibleSections = isSearching
+    ? settingsNavigationSections
+        .map((section) => ({ ...section, items: section.items.filter((item) => matchingPaths.has(item.path)) }))
+        .filter((section) => section.items.length > 0)
+    : settingsNavigationSections
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`)
-  const go = (path: string) => navigate({ to: path })
+  const go = (path: SettingsPath) => {
+    setSearchText('')
+    void navigate({ to: path })
+  }
 
   return (
     <div
@@ -61,201 +64,51 @@ const SettingsPage: FC = () => {
           data-ui="settings.navigation"
           className="flex min-h-0 w-(--settings-width) min-w-(--settings-width) flex-col border-border border-r-[0.5px]">
           <PageHeader title={t('title.settings')} className="mb-1" />
+          <div className="px-2.5 pb-2">
+            <SearchInput
+              size="sm"
+              value={searchText}
+              onChange={(event) => setSearchText(event.target.value)}
+              onClear={() => setSearchText('')}
+              clearLabel={t('common.clear')}
+              placeholder={t('common.search')}
+              aria-label={t('common.search')}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape' && searchText) {
+                  event.stopPropagation()
+                  setSearchText('')
+                }
+              }}
+            />
+          </div>
           <Scrollbar className="min-h-0 flex-1 select-none">
-            <MenuList className={settingsSubmenuListClassName}>
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Cloud />}
-                label={t('settings.provider.title')}
-                active={isActive('/settings/provider')}
-                onClick={() => go('/settings/provider')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Package />}
-                label={t('settings.model')}
-                active={isActive('/settings/model')}
-                onClick={() => go('/settings/model')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<FileBox />}
-                label={t('settings.dependencies.localModels.title')}
-                active={isActive('/settings/local-models')}
-                onClick={() => go('/settings/local-models')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<GatewayIcon />}
-                label={t('apiGateway.title')}
-                active={isActive('/settings/api-gateway')}
-                onClick={() => go('/settings/api-gateway')}
-              />
-              <MenuDivider className={settingsSubmenuDividerClassName} />
-              <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.capabilities')}</div>
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<McpLogo width={16} height={16} className="text-foreground" />}
-                label={t('agent.settings.toolsMcp.mcp.tab')}
-                active={isActive('/settings/mcp')}
-                onClick={() => go('/settings/mcp')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<ToolCase />}
-                label={t('settings.skills.title')}
-                active={isActive('/settings/skills')}
-                onClick={() => go('/settings/skills')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Zap />}
-                label={t('settings.prompts.title')}
-                active={isActive('/settings/prompts')}
-                onClick={() => go('/settings/prompts')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Search />}
-                label={t('settings.tool.websearch.title')}
-                active={isActive('/settings/websearch')}
-                onClick={() => go('/settings/websearch')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<FileCode />}
-                label={t('settings.tool.file_processing.features.document_to_markdown.title')}
-                active={isActive('/settings/file-processing')}
-                onClick={() => go('/settings/file-processing')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<ScanText />}
-                label={t('settings.tool.file_processing.features.image_to_text.title')}
-                active={isActive('/settings/ocr')}
-                onClick={() => go('/settings/ocr')}
-              />
-              <MenuDivider className={settingsSubmenuDividerClassName} />
-              <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.personal')}</div>
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Settings2 />}
-                label={t('settings.general.common.title')}
-                active={isActive('/settings/general')}
-                onClick={() => go('/settings/general')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Palette />}
-                label={t('settings.appearance.title')}
-                active={isActive('/settings/appearance')}
-                onClick={() => go('/settings/appearance')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Bell />}
-                label={t('settings.notification.title')}
-                active={isActive('/settings/notifications')}
-                onClick={() => go('/settings/notifications')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<HardDrive />}
-                label={t('settings.data.title')}
-                active={isActive('/settings/data')}
-                onClick={() => go('/settings/data')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Activity />}
-                label={t('settings.usage.title')}
-                active={isActive('/settings/usage')}
-                onClick={() => go('/settings/usage')}
-              />
-              <MenuDivider className={settingsSubmenuDividerClassName} />
-              <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.automation')}</div>
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Radio />}
-                label={t('settings.channels.title')}
-                active={isActive('/settings/channels')}
-                onClick={() => go('/settings/channels')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<CalendarClock />}
-                label={t('settings.scheduledTasks.title')}
-                active={isActive('/settings/scheduled-tasks')}
-                onClick={() => go('/settings/scheduled-tasks')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Command />}
-                label={t('settings.shortcuts.title')}
-                active={isActive('/settings/shortcut')}
-                onClick={() => go('/settings/shortcut')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<PictureInPicture2 />}
-                label={t('settings.quickAssistant.title')}
-                active={isActive('/settings/quick-assistant')}
-                onClick={() => go('/settings/quick-assistant')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<TextCursorInput />}
-                label={t('selection.name')}
-                active={isActive('/settings/selection-assistant')}
-                onClick={() => go('/settings/selection-assistant')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Crop />}
-                label={t('settings.screenshot.title')}
-                active={isActive('/settings/screenshot')}
-                onClick={() => go('/settings/screenshot')}
-              />
-              <MenuDivider className={settingsSubmenuDividerClassName} />
-              <div className={settingsSubmenuSectionTitleClassName}>{t('settings.menuGroups.system')}</div>
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Terminal />}
-                label={t('settings.dependencies.title')}
-                active={isActive('/settings/dependencies')}
-                onClick={() => go('/settings/dependencies')}
-              />
-              <MenuItem
-                className={settingsSubmenuItemClassName}
-                labelClassName={settingsSubmenuItemLabelClassName}
-                icon={<Info />}
-                label={t('settings.about.label')}
-                active={isActive('/settings/about')}
-                onClick={() => go('/settings/about')}
-              />
-            </MenuList>
+            {visibleSections.length > 0 ? (
+              <MenuList className={settingsSubmenuListClassName}>
+                {visibleSections.map((section, sectionIndex) => (
+                  <Fragment key={section.labelKey ?? 'primary'}>
+                    {sectionIndex > 0 && <MenuDivider className={settingsSubmenuDividerClassName} />}
+                    {section.labelKey && (
+                      <div className={settingsSubmenuSectionTitleClassName}>{t(section.labelKey)}</div>
+                    )}
+                    {section.items.map((item) => (
+                      <MenuItem
+                        key={item.path}
+                        className={settingsSubmenuItemClassName}
+                        labelClassName={settingsSubmenuItemLabelClassName}
+                        icon={item.icon}
+                        label={t(item.labelKey)}
+                        active={isActive(item.path)}
+                        onClick={() => go(item.path)}
+                      />
+                    ))}
+                  </Fragment>
+                ))}
+              </MenuList>
+            ) : (
+              <div role="status" className="px-5 py-3 text-muted-foreground text-xs">
+                {t('common.no_results')}
+              </div>
+            )}
           </Scrollbar>
         </div>
         <div className="flex h-full min-h-0 min-w-0 flex-1">

--- a/src/renderer/pages/settings/__tests__/SettingsPage.test.tsx
+++ b/src/renderer/pages/settings/__tests__/SettingsPage.test.tsx
@@ -1,6 +1,8 @@
+import enUS from '@renderer/i18n/locales/en-us.json'
 import zhCN from '@renderer/i18n/locales/zh-cn.json'
-import { fireEvent, render, screen } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ChangeEventHandler, KeyboardEventHandler, ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SettingsPage from '../SettingsPage'
@@ -11,9 +13,9 @@ const { isMacTransparentWindowMock, navigateMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
-  MenuDivider: () => <hr data-testid="menu-divider" />,
+  MenuDivider: () => <hr />,
   MenuItem: ({ icon, label, onClick }: { icon?: ReactNode; label: string; onClick?: () => void }) => (
-    <button type="button" data-testid="menu-item" onClick={onClick}>
+    <button type="button" onClick={onClick}>
       {icon}
       {label}
     </button>
@@ -21,6 +23,30 @@ vi.mock('@cherrystudio/ui', () => ({
   MenuList: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   PageHeader: ({ className, title }: { className?: string; title: string }) => (
     <header className={className}>{title}</header>
+  ),
+  SearchInput: ({
+    value,
+    onChange,
+    onKeyDown,
+    onClear,
+    clearLabel,
+    ...props
+  }: {
+    value: string
+    onChange: ChangeEventHandler<HTMLInputElement>
+    onKeyDown?: KeyboardEventHandler<HTMLInputElement>
+    onClear?: () => void
+    clearLabel?: string
+    'aria-label'?: string
+  }) => (
+    <div>
+      <input type="search" value={value} onChange={onChange} onKeyDown={onKeyDown} {...props} />
+      {value && onClear && (
+        <button type="button" aria-label={clearLabel} onClick={onClear}>
+          clear
+        </button>
+      )}
+    </div>
   )
 }))
 
@@ -39,33 +65,13 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 vi.mock('react-i18next', () => ({
-  initReactI18next: { type: '3rdParty', init: vi.fn() },
   useTranslation: () => ({
-    t: (key: string) =>
-      ({
-        'agent.settings.toolsMcp.mcp.tab': 'MCP',
-        'selection.name': '划词助手',
-        'settings.appearance.title': '外观',
-        'settings.channels.title': '频道',
-        'settings.dependencies.title': '环境依赖',
-        'settings.dependencies.localModels.title': '本地模型',
-        'settings.general.common.title': zhCN['settings.general.common.title'],
-        'settings.menuGroups.automation': '效率',
-        'settings.menuGroups.capabilities': '工具',
-        'settings.menuGroups.personal': '偏好',
-        'settings.menuGroups.quickAccess': '快捷入口',
-        'settings.menuGroups.system': '系统',
-        'settings.model': '默认模型',
-        'settings.prompts.title': '提示词',
-        'settings.quickAssistant.title': '快捷助手',
-        'settings.scheduledTasks.title': '定时任务',
-        'settings.screenshot.title': '截图',
-        'settings.shortcuts.title': '快捷键',
-        'settings.skills.title': '技能',
-        'settings.system.title': '系统',
-        'settings.tool.file_processing.features.image_to_text.title': 'OCR',
-        'settings.tool.file_processing.features.document_to_markdown.title': '文档处理'
-      })[key] ?? key
+    i18n: {
+      language: 'zh-CN',
+      resolvedLanguage: 'zh-CN',
+      getResourceBundle: () => enUS
+    },
+    t: (key: string) => zhCN[key as keyof typeof zhCN] ?? enUS[key as keyof typeof enUS] ?? key
   })
 }))
 
@@ -75,74 +81,35 @@ describe('SettingsPage', () => {
     navigateMock.mockReset()
   })
 
-  it('places General directly above Appearance and local models directly below the default model', () => {
-    const { container } = render(<SettingsPage />)
+  it('finds a localized setting by pinyin and navigates to its owning page', async () => {
+    const user = userEvent.setup()
+    render(<SettingsPage />)
 
-    expect(container.querySelector('[data-ui="settings.view"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-ui="settings.navigation"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-ui="settings.content"]')).toBeInTheDocument()
-    expect(screen.getByText('偏好')).toBeInTheDocument()
+    const searchbox = screen.getByRole('searchbox', { name: '搜索' })
+    await user.type(searchbox, 'xitongdaili')
 
-    const generalItem = screen.getByRole('button', { name: '通用' })
-    const appearanceItem = screen.getByRole('button', { name: '外观' })
-    const defaultModelItem = screen.getByRole('button', { name: '默认模型' })
-    const localModelsItem = screen.getByRole('button', { name: '本地模型' })
+    expect(screen.getByRole('button', { name: '通用' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '模型服务' })).not.toBeInTheDocument()
 
-    expect(generalItem.nextElementSibling).toBe(appearanceItem)
-    expect(defaultModelItem.nextElementSibling).toBe(localModelsItem)
-    fireEvent.click(generalItem)
+    await user.click(screen.getByRole('button', { name: '通用' }))
+
     expect(navigateMock).toHaveBeenCalledWith({ to: '/settings/general' })
-    fireEvent.click(localModelsItem)
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/settings/local-models' })
+    expect(searchbox).toHaveValue('')
+    expect(screen.getByRole('button', { name: '模型服务' })).toBeInTheDocument()
   })
 
-  it('keeps document processing and OCR together in tools and dependencies in the system group', () => {
+  it('announces an empty result and restores navigation with Escape', async () => {
+    const user = userEvent.setup()
     render(<SettingsPage />)
 
-    expect(screen.getByText('工具')).toBeInTheDocument()
+    const searchbox = screen.getByRole('searchbox', { name: '搜索' })
+    await user.type(searchbox, 'no-such-setting-value')
 
-    const documentProcessingItem = screen.getByRole('button', { name: '文档处理' })
-    const ocrItem = screen.getByRole('button', { name: 'OCR' })
-    expect(documentProcessingItem.nextElementSibling).toBe(ocrItem)
-    expect(ocrItem.nextElementSibling).toHaveAttribute('data-testid', 'menu-divider')
+    expect(screen.getByRole('status')).toHaveTextContent('无结果')
 
-    const dependenciesItem = screen.getByRole('button', { name: '环境依赖' })
-    expect(screen.queryByRole('button', { name: '系统' })).not.toBeInTheDocument()
-    expect(screen.getByText('系统').nextElementSibling).toBe(dependenciesItem)
-    fireEvent.click(dependenciesItem)
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/settings/dependencies' })
-  })
+    await user.keyboard('{Escape}')
 
-  it('places Skills below MCP and prompt management directly below Skills', () => {
-    render(<SettingsPage />)
-
-    const mcpItem = screen.getByText('MCP').closest('button')
-    const skillsItem = screen.getByRole('button', { name: '技能' })
-
-    expect(mcpItem).not.toBeNull()
-    expect(mcpItem?.nextElementSibling).toBe(skillsItem)
-    fireEvent.click(skillsItem)
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/settings/skills' })
-
-    const promptsItem = screen.getByRole('button', { name: '提示词' })
-    expect(skillsItem.nextElementSibling).toBe(promptsItem)
-    fireEvent.click(promptsItem)
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/settings/prompts' })
-  })
-
-  it('merges quick access into efficiency and places both assistants last', () => {
-    render(<SettingsPage />)
-
-    expect(screen.getByText('效率')).toBeInTheDocument()
-    expect(screen.queryByText('快捷入口')).not.toBeInTheDocument()
-
-    const efficiencyItems = ['频道', '定时任务', '快捷键', '快捷助手', '划词助手', '截图'].map((name) =>
-      screen.getByRole('button', { name })
-    )
-    const menuItems = screen.getAllByTestId('menu-item')
-    const efficiencyStart = menuItems.indexOf(efficiencyItems[0])
-
-    expect(menuItems.slice(efficiencyStart, efficiencyStart + efficiencyItems.length)).toEqual(efficiencyItems)
-    expect(efficiencyItems.at(-1)?.nextElementSibling).toHaveAttribute('data-testid', 'menu-divider')
+    expect(searchbox).toHaveValue('')
+    expect(screen.getByRole('button', { name: '模型服务' })).toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/settings/__tests__/settingsSearch.test.ts
+++ b/src/renderer/pages/settings/__tests__/settingsSearch.test.ts
@@ -67,6 +67,30 @@ describe('settings search', () => {
     }
   })
 
+  it('matches labels without requiring their display whitespace in the query', () => {
+    const sections = createSections([
+      {
+        path: '/settings/api-gateway',
+        labelKey: 'apiGateway.title',
+        icon: null,
+        search: { prefixes: ['apiGateway'] }
+      }
+    ])
+    const catalog = {
+      'apiGateway.apiKey': 'API Key',
+      'apiGateway.title': 'API Gateway'
+    }
+    const translations: Record<string, string> = {
+      'apiGateway.apiKey': 'API 密钥',
+      'apiGateway.title': 'API 网关'
+    }
+    const entries = buildSettingsSearchEntries(sections, catalog, (key) => translations[key] ?? key)
+
+    expect(filterSettingsSearchEntries(entries, 'API密钥').map((entry) => entry.path)).toEqual([
+      '/settings/api-gateway'
+    ])
+  })
+
   it('requires every word in a query to match the same setting', () => {
     const sections = createSections([
       {

--- a/src/renderer/pages/settings/__tests__/settingsSearch.test.ts
+++ b/src/renderer/pages/settings/__tests__/settingsSearch.test.ts
@@ -1,0 +1,139 @@
+import enUS from '@renderer/i18n/locales/en-us.json'
+import { describe, expect, it } from 'vitest'
+
+import type { SettingsNavigationSection } from '../settingsNavigation'
+import { buildSettingsSearchEntries, filterSettingsSearchEntries } from '../settingsSearch'
+
+const createSections = (items: SettingsNavigationSection['items']): readonly SettingsNavigationSection[] => [{ items }]
+
+describe('settings search', () => {
+  it('assigns catalog keys to the longest dot-boundary prefix', () => {
+    const sections = createSections([
+      {
+        path: '/settings/provider',
+        labelKey: 'provider.title',
+        icon: null,
+        search: { prefixes: ['settings.models'] }
+      },
+      {
+        path: '/settings/model',
+        labelKey: 'model.title',
+        icon: null,
+        search: { prefixes: ['settings.model'] }
+      },
+      {
+        path: '/settings/general',
+        labelKey: 'general.title',
+        icon: null,
+        search: { prefixes: ['settings.models.context_management'] }
+      }
+    ])
+    const catalog = {
+      'general.title': 'General',
+      'model.title': 'Default model',
+      'provider.title': 'Model provider',
+      'settings.model': 'Default model',
+      'settings.models.add': 'Add model',
+      'settings.models.context_management.title': 'Context management'
+    }
+    const entries = buildSettingsSearchEntries(sections, catalog, (key) => catalog[key] ?? key)
+
+    expect(filterSettingsSearchEntries(entries, 'add').map((entry) => entry.path)).toEqual(['/settings/provider'])
+    expect(filterSettingsSearchEntries(entries, 'default').map((entry) => entry.path)).toEqual(['/settings/model'])
+    expect(filterSettingsSearchEntries(entries, 'context').map((entry) => entry.path)).toEqual(['/settings/general'])
+  })
+
+  it('matches the current language, English fallback, full pinyin, and pinyin initials', () => {
+    const sections = createSections([
+      {
+        path: '/settings/general',
+        labelKey: 'settings.general.common.title',
+        icon: null,
+        search: { prefixes: ['settings.proxy'] }
+      }
+    ])
+    const catalog = {
+      'settings.general.common.title': 'General',
+      'settings.proxy.mode.system': 'System Proxy'
+    }
+    const translations: Record<string, string> = {
+      'settings.general.common.title': '通用',
+      'settings.proxy.mode.system': '系统代理'
+    }
+    const entries = buildSettingsSearchEntries(sections, catalog, (key) => translations[key] ?? key)
+
+    for (const query of ['系统代理', 'system proxy', 'xitongdaili', 'xtdl']) {
+      expect(filterSettingsSearchEntries(entries, query).map((entry) => entry.path)).toEqual(['/settings/general'])
+    }
+  })
+
+  it('requires every word in a query to match the same setting', () => {
+    const sections = createSections([
+      {
+        path: '/settings/dependencies',
+        labelKey: 'settings.dependencies.title',
+        icon: null,
+        search: { prefixes: ['settings.dependencies'] }
+      }
+    ])
+    const catalog = {
+      'settings.dependencies.proxy': 'Download proxy',
+      'settings.dependencies.source.system': 'System',
+      'settings.dependencies.title': 'Dependencies'
+    }
+    const entries = buildSettingsSearchEntries(sections, catalog, (key) => catalog[key] ?? key)
+
+    expect(filterSettingsSearchEntries(entries, 'system proxy')).toEqual([])
+  })
+
+  it('adds exact legacy keys without stealing their prefix-owned page', () => {
+    const sections = createSections([
+      {
+        path: '/settings/provider',
+        labelKey: 'provider.title',
+        icon: null,
+        search: { prefixes: ['settings.provider'] }
+      },
+      {
+        path: '/settings/websearch',
+        labelKey: 'websearch.title',
+        icon: null,
+        search: { prefixes: ['settings.tool.websearch'], exactKeys: ['settings.provider.api_key'] }
+      }
+    ])
+    const catalog = {
+      'provider.title': 'Provider',
+      'settings.provider.api_key': 'API Key',
+      'websearch.title': 'Web Search'
+    }
+    const entries = buildSettingsSearchEntries(sections, catalog, (key) => catalog[key] ?? key)
+
+    expect(filterSettingsSearchEntries(entries, 'api key').map((entry) => entry.path)).toEqual([
+      '/settings/provider',
+      '/settings/websearch'
+    ])
+  })
+
+  it('keeps the checked-in navigation search scopes valid against the source catalog', async () => {
+    const { settingsNavigationSections } = await import('../settingsNavigation')
+    const sections: readonly SettingsNavigationSection[] = settingsNavigationSections
+    const items = sections.flatMap((section) => section.items)
+    const prefixes = items.flatMap((item) => item.search.prefixes)
+
+    expect(new Set(items.map((item) => item.path)).size).toBe(items.length)
+    expect(new Set(prefixes).size).toBe(prefixes.length)
+
+    for (const item of items) {
+      expect(enUS).toHaveProperty(item.labelKey)
+      for (const prefix of item.search.prefixes) {
+        expect(
+          Object.keys(enUS).some((key) => key === prefix || key.startsWith(`${prefix}.`)),
+          `Missing catalog prefix: ${prefix}`
+        ).toBe(true)
+      }
+      for (const key of item.search.exactKeys ?? []) {
+        expect(enUS).toHaveProperty(key)
+      }
+    }
+  })
+})

--- a/src/renderer/pages/settings/settingsNavigation.tsx
+++ b/src/renderer/pages/settings/settingsNavigation.tsx
@@ -1,0 +1,296 @@
+import { GatewayIcon } from '@renderer/components/icons/GatewayIcon'
+import { McpLogo } from '@renderer/components/icons/SvgIcon'
+import {
+  Activity,
+  Bell,
+  CalendarClock,
+  Cloud,
+  Command,
+  Crop,
+  FileBox,
+  FileCode,
+  HardDrive,
+  Info,
+  Package,
+  Palette,
+  PictureInPicture2,
+  Radio,
+  ScanText,
+  Search,
+  Settings2,
+  Terminal,
+  TextCursorInput,
+  ToolCase,
+  Zap
+} from 'lucide-react'
+import type { ReactNode } from 'react'
+
+interface SettingsSearchScope {
+  prefixes: readonly string[]
+  exactKeys?: readonly string[]
+}
+
+export interface SettingsNavigationItem {
+  path: string
+  labelKey: string
+  icon: ReactNode
+  search: SettingsSearchScope
+}
+
+export interface SettingsNavigationSection {
+  labelKey?: string
+  items: readonly SettingsNavigationItem[]
+}
+
+export const settingsNavigationSections = [
+  {
+    items: [
+      {
+        path: '/settings/provider',
+        labelKey: 'settings.provider.title',
+        icon: <Cloud />,
+        search: {
+          prefixes: ['settings.provider', 'settings.models', 'models', 'ovms', 'lmstudio', 'gpustack']
+        }
+      },
+      {
+        path: '/settings/model',
+        labelKey: 'settings.model',
+        icon: <Package />,
+        search: {
+          prefixes: [
+            'settings.model',
+            'settings.models.default_assistant_model',
+            'settings.models.painting_model',
+            'settings.models.quick_model',
+            'settings.models.retry',
+            'settings.models.topic_naming',
+            'settings.models.translate_model',
+            'settings.translate'
+          ]
+        }
+      },
+      {
+        path: '/settings/local-models',
+        labelKey: 'settings.dependencies.localModels.title',
+        icon: <FileBox />,
+        search: { prefixes: ['settings.dependencies.localModels'] }
+      },
+      {
+        path: '/settings/api-gateway',
+        labelKey: 'apiGateway.title',
+        icon: <GatewayIcon />,
+        search: { prefixes: ['apiGateway'] }
+      }
+    ]
+  },
+  {
+    labelKey: 'settings.menuGroups.capabilities',
+    items: [
+      {
+        path: '/settings/mcp',
+        labelKey: 'agent.settings.toolsMcp.mcp.tab',
+        icon: <McpLogo width={16} height={16} className="text-foreground" />,
+        search: { prefixes: ['settings.mcp', 'agent.settings.toolsMcp.mcp'] }
+      },
+      {
+        path: '/settings/skills',
+        labelKey: 'settings.skills.title',
+        icon: <ToolCase />,
+        search: { prefixes: ['settings.skills'] }
+      },
+      {
+        path: '/settings/prompts',
+        labelKey: 'settings.prompts.title',
+        icon: <Zap />,
+        search: { prefixes: ['settings.prompts'] }
+      },
+      {
+        path: '/settings/websearch',
+        labelKey: 'settings.tool.websearch.title',
+        icon: <Search />,
+        search: {
+          prefixes: ['settings.provider.basic_auth', 'settings.tool.websearch'],
+          exactKeys: [
+            'settings.general.label',
+            'settings.provider.api_host',
+            'settings.provider.api_key.label',
+            'settings.provider.api_key.tip'
+          ]
+        }
+      },
+      {
+        path: '/settings/file-processing',
+        labelKey: 'settings.tool.file_processing.features.document_to_markdown.title',
+        icon: <FileCode />,
+        search: {
+          prefixes: [
+            'settings.tool.file_processing',
+            'settings.tool.file_processing.features.document_to_markdown',
+            'settings.tool.file_processing.processors.doc2x',
+            'settings.tool.file_processing.processors.local_document',
+            'settings.tool.file_processing.processors.mineru',
+            'settings.tool.file_processing.processors.mistral',
+            'settings.tool.file_processing.processors.open_mineru'
+          ],
+          exactKeys: [
+            'settings.provider.api.key.list.title',
+            'settings.provider.api_host',
+            'settings.provider.api_key.tip',
+            'settings.provider.get_api_key'
+          ]
+        }
+      },
+      {
+        path: '/settings/ocr',
+        labelKey: 'settings.tool.file_processing.features.image_to_text.title',
+        icon: <ScanText />,
+        search: {
+          prefixes: [
+            'settings.tool.file_processing.features.image_to_text',
+            'settings.tool.file_processing.processors.local_paddleocr',
+            'settings.tool.file_processing.processors.ovocr',
+            'settings.tool.file_processing.processors.paddleocr',
+            'settings.tool.file_processing.processors.system',
+            'settings.tool.file_processing.processors.tesseract'
+          ],
+          exactKeys: [
+            'settings.provider.api.key.list.title',
+            'settings.provider.api_host',
+            'settings.provider.api_key.tip',
+            'settings.provider.get_api_key'
+          ]
+        }
+      }
+    ]
+  },
+  {
+    labelKey: 'settings.menuGroups.personal',
+    items: [
+      {
+        path: '/settings/general',
+        labelKey: 'settings.general.common.title',
+        icon: <Settings2 />,
+        search: {
+          prefixes: [
+            'settings.developer',
+            'settings.fetch',
+            'settings.hardware_acceleration',
+            'settings.launch',
+            'settings.models.context_management',
+            'settings.power',
+            'settings.proxy',
+            'settings.tray'
+          ]
+        }
+      },
+      {
+        path: '/settings/appearance',
+        labelKey: 'settings.appearance.title',
+        icon: <Palette />,
+        search: {
+          prefixes: [
+            'chat.settings.code_execution',
+            'chat.settings.code_image_tools',
+            'settings.appearance',
+            'settings.display',
+            'settings.general.common',
+            'settings.theme',
+            'settings.topic',
+            'settings.use_system_title_bar',
+            'settings.zoom'
+          ],
+          exactKeys: ['common.language']
+        }
+      },
+      {
+        path: '/settings/notifications',
+        labelKey: 'settings.notification.title',
+        icon: <Bell />,
+        search: { prefixes: ['settings.notification'], exactKeys: ['notification.tip'] }
+      },
+      {
+        path: '/settings/data',
+        labelKey: 'settings.data.title',
+        icon: <HardDrive />,
+        search: { prefixes: ['settings.data', 'settings.general.backup', 'settings.privacy'] }
+      },
+      {
+        path: '/settings/usage',
+        labelKey: 'settings.usage.title',
+        icon: <Activity />,
+        search: { prefixes: ['settings.usage'] }
+      }
+    ]
+  },
+  {
+    labelKey: 'settings.menuGroups.automation',
+    items: [
+      {
+        path: '/settings/channels',
+        labelKey: 'settings.channels.title',
+        icon: <Radio />,
+        search: { prefixes: ['agent.channels', 'settings.channels'] }
+      },
+      {
+        path: '/settings/scheduled-tasks',
+        labelKey: 'settings.scheduledTasks.title',
+        icon: <CalendarClock />,
+        search: { prefixes: ['agent.tasks', 'settings.scheduledTasks'] }
+      },
+      {
+        path: '/settings/shortcut',
+        labelKey: 'settings.shortcuts.title',
+        icon: <Command />,
+        search: { prefixes: ['settings.shortcuts'] }
+      },
+      {
+        path: '/settings/quick-assistant',
+        labelKey: 'settings.quickAssistant.title',
+        icon: <PictureInPicture2 />,
+        search: {
+          prefixes: ['settings.quickAssistant', 'selection.settings.user_modal'],
+          exactKeys: [
+            'settings.models.quick_assistant_default_tag',
+            'settings.models.quick_assistant_response_settings',
+            'settings.models.quick_assistant_selection',
+            'settings.models.quick_assistant_usage_method'
+          ]
+        }
+      },
+      {
+        path: '/settings/selection-assistant',
+        labelKey: 'selection.name',
+        icon: <TextCursorInput />,
+        search: { prefixes: ['selection.settings'] }
+      },
+      {
+        path: '/settings/screenshot',
+        labelKey: 'settings.screenshot.title',
+        icon: <Crop />,
+        search: { prefixes: ['settings.screenshot'] }
+      }
+    ]
+  },
+  {
+    labelKey: 'settings.menuGroups.system',
+    items: [
+      {
+        path: '/settings/dependencies',
+        labelKey: 'settings.dependencies.title',
+        icon: <Terminal />,
+        search: { prefixes: ['settings.dependencies'] }
+      },
+      {
+        path: '/settings/about',
+        labelKey: 'settings.about.label',
+        icon: <Info />,
+        search: {
+          prefixes: ['settings.about', 'settings.general.auto_check_update', 'settings.general.test_plan']
+        }
+      }
+    ]
+  }
+] as const satisfies readonly SettingsNavigationSection[]
+
+export type SettingsPath = (typeof settingsNavigationSections)[number]['items'][number]['path']

--- a/src/renderer/pages/settings/settingsSearch.ts
+++ b/src/renderer/pages/settings/settingsSearch.ts
@@ -12,6 +12,7 @@ export interface SettingsSearchEntry {
 
 interface SettingsSearchHaystack {
   searchText: string
+  whitespaceFreeText: string
   pinyinText: string
 }
 
@@ -63,7 +64,11 @@ export function buildSettingsSearchEntries(
       haystacks: Array.from(keysByPath.get(item.path) ?? [], (key) => {
         const texts = new Set([translate(key).trim(), englishCatalog[key]?.trim()].filter(Boolean))
         const searchText = Array.from(texts).join(' ').toLowerCase()
-        return { searchText, pinyinText: buildPinyinText(searchText) }
+        return {
+          searchText,
+          whitespaceFreeText: searchText.replace(/\s+/g, ''),
+          pinyinText: buildPinyinText(searchText)
+        }
       })
     }
   })
@@ -78,7 +83,12 @@ export function filterSettingsSearchEntries(
 
   return entries.filter((entry) =>
     entry.haystacks.some((haystack) =>
-      keywords.every((keyword) => haystack.searchText.includes(keyword) || haystack.pinyinText.includes(keyword))
+      keywords.every(
+        (keyword) =>
+          haystack.searchText.includes(keyword) ||
+          haystack.whitespaceFreeText.includes(keyword) ||
+          haystack.pinyinText.includes(keyword)
+      )
     )
   )
 }

--- a/src/renderer/pages/settings/settingsSearch.ts
+++ b/src/renderer/pages/settings/settingsSearch.ts
@@ -1,0 +1,84 @@
+import * as tinyPinyin from 'tiny-pinyin'
+
+import type { SettingsNavigationSection } from './settingsNavigation'
+
+type SettingsCatalog = Record<string, string>
+type Translate = (key: string) => string
+
+export interface SettingsSearchEntry {
+  path: string
+  haystacks: readonly SettingsSearchHaystack[]
+}
+
+interface SettingsSearchHaystack {
+  searchText: string
+  pinyinText: string
+}
+
+function matchesPrefix(key: string, prefix: string): boolean {
+  return key === prefix || key.startsWith(`${prefix}.`)
+}
+
+function buildPinyinText(text: string): string {
+  if (!tinyPinyin.isSupported() || !/[\u4e00-\u9fa5]/.test(text)) return ''
+
+  const words = tinyPinyin.convertToPinyin(text, ' ', true).toLowerCase().split(/\s+/).filter(Boolean)
+  return `${words.join('')} ${words.map((word) => word[0] ?? '').join('')}`
+}
+
+export function buildSettingsSearchEntries(
+  sections: readonly SettingsNavigationSection[],
+  englishCatalog: SettingsCatalog,
+  translate: Translate
+): SettingsSearchEntry[] {
+  const items = sections.flatMap((section) => section.items)
+  const keysByPath = new Map(
+    items.map((item) => [item.path, new Set([item.labelKey, ...(item.search.exactKeys ?? [])])])
+  )
+
+  for (const key of Object.keys(englishCatalog)) {
+    let longestPrefixLength = -1
+    let owners: typeof items = []
+
+    for (const item of items) {
+      const prefixLength = Math.max(
+        -1,
+        ...item.search.prefixes.filter((prefix) => matchesPrefix(key, prefix)).map((prefix) => prefix.length)
+      )
+      if (prefixLength < longestPrefixLength) continue
+
+      if (prefixLength > longestPrefixLength) {
+        longestPrefixLength = prefixLength
+        owners = []
+      }
+      if (prefixLength >= 0) owners.push(item)
+    }
+
+    for (const owner of owners) keysByPath.get(owner.path)?.add(key)
+  }
+
+  return items.map((item) => {
+    return {
+      path: item.path,
+      haystacks: Array.from(keysByPath.get(item.path) ?? [], (key) => {
+        const texts = new Set([translate(key).trim(), englishCatalog[key]?.trim()].filter(Boolean))
+        const searchText = Array.from(texts).join(' ').toLowerCase()
+        return { searchText, pinyinText: buildPinyinText(searchText) }
+      })
+    }
+  })
+}
+
+export function filterSettingsSearchEntries(
+  entries: readonly SettingsSearchEntry[],
+  query: string
+): SettingsSearchEntry[] {
+  const keywords = query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  if (keywords.length === 0) return [...entries]
+
+  return entries.filter((entry) =>
+    entry.haystacks.some((haystack) =>
+      keywords.every((keyword) => haystack.searchText.includes(keyword) || haystack.pinyinText.includes(keyword))
+    )
+  )
+}


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Users had to browse settings pages manually because the settings navigation did not support search.

After this PR:

The settings sidebar can filter pages by localized setting text, the English fallback, Chinese pinyin, or pinyin initials. The navigation registry is also the single source of truth for menu rendering and search scopes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Settings pages are lazily mounted, so search needs a static mapping from translation-key scopes to their owning routes. A shared navigation registry keeps that mapping aligned with the visible menu, while longest-prefix ownership handles the existing multi-prefix translation catalog without renaming stable i18n keys.

The following tradeoffs were made:

- Results navigate to the owning settings page; item-level scrolling and highlighting are intentionally deferred.
- Dynamic provider, MCP server, and task names are excluded from the static index.
- Multi-word queries must match one setting entry to avoid combining unrelated labels from the same page.

The following alternatives were considered:

- Mounting every settings page and searching the DOM was rejected because pages have data-loading and IPC side effects.
- Renaming existing i18n keys by page was rejected because it would couple stable translation identifiers to UI layout and create a large locale migration.
- Searching the entire catalog without route scopes was rejected because it cannot resolve navigation ownership and produces unrelated matches.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validated with focused renderer tests and a tracked, isolated Electron instance in both English and Simplified Chinese. No user-guide update is required because the search field is self-discoverable within the existing settings navigation.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Adds localized settings search with English fallback and Chinese pinyin support.
```
