### PR TITLE
perf(chat): lazy-load agent tool renderer (#19331)

### DIFF
--- a/src/renderer/components/chat/messages/tools/__tests__/chooseTool.test.tsx
+++ b/src/renderer/components/chat/messages/tools/__tests__/chooseTool.test.tsx
@@ -1,6 +1,6 @@
 import type { NormalToolResponse } from '@renderer/types/mcpTool'
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 // Stub the leaf cards so we can assert ONLY which branch chooseTool routes to.
@@ -14,7 +14,7 @@ vi.mock('../knowledge/MessageKnowledgeSearch', () => ({
 vi.mock('../webSearch/MessageWebSearch', () => ({
   MessageWebSearchToolTitle: () => <div data-testid="web-card" />
 }))
-vi.mock('../agent', () => ({
+vi.mock('../agent/AgentExecutionTimeline', () => ({
   AgentExecutionTimeline: () => <div data-testid="agent-card" />
 }))
 vi.mock('../painting/MessageGenerateImage', () => ({
@@ -30,40 +30,41 @@ function resp(name: string, type?: string): NormalToolResponse {
   return { tool: { name, type } } as unknown as NormalToolResponse
 }
 
-function testIdOf(node: React.ReactNode): string | null {
+async function testIdOf(node: React.ReactNode): Promise<string | null> {
   const { container } = render(<>{node}</>)
+  await act(async () => {})
   return container.querySelector('[data-testid]')?.getAttribute('data-testid') ?? null
 }
 
 describe('chooseTool', () => {
-  it('renders all knowledge-base wire names', () => {
-    expect(testIdOf(chooseTool(resp('kb_search')))).toBe('kb-card')
-    expect(testIdOf(chooseTool(resp('kb_list')))).toBe('agent-card')
-    expect(testIdOf(chooseTool(resp('kb_read')))).toBe('agent-card')
-    expect(testIdOf(chooseTool(resp('kb_manage')))).toBe('agent-card')
+  it('renders all knowledge-base wire names', async () => {
+    expect(await testIdOf(chooseTool(resp('kb_search')))).toBe('kb-card')
+    expect(await testIdOf(chooseTool(resp('kb_list')))).toBe('agent-card')
+    expect(await testIdOf(chooseTool(resp('kb_read')))).toBe('agent-card')
+    expect(await testIdOf(chooseTool(resp('kb_manage')))).toBe('agent-card')
   })
 
-  it('routes the web_search wire name to its title card', () => {
-    expect(testIdOf(chooseTool(resp('web_search')))).toBe('web-card')
+  it('routes the web_search wire name to its title card', async () => {
+    expect(await testIdOf(chooseTool(resp('web_search')))).toBe('web-card')
   })
 
-  it('routes cross-session tools to their dedicated agent cards', () => {
-    expect(testIdOf(chooseTool(resp('session_create')))).toBe('agent-card')
-    expect(testIdOf(chooseTool(resp('session_send')))).toBe('agent-card')
+  it('routes cross-session tools to their dedicated agent cards', async () => {
+    expect(await testIdOf(chooseTool(resp('session_create')))).toBe('agent-card')
+    expect(await testIdOf(chooseTool(resp('session_send')))).toBe('agent-card')
   })
 
-  it('routes provider-executed web search wire names to the web card', () => {
-    expect(testIdOf(chooseTool(resp('web_search', 'provider')))).toBe('web-card')
-    expect(testIdOf(chooseTool(resp('webSearch', 'provider')))).toBe('web-card')
+  it('routes provider-executed web search wire names to the web card', async () => {
+    expect(await testIdOf(chooseTool(resp('web_search', 'provider')))).toBe('web-card')
+    expect(await testIdOf(chooseTool(resp('webSearch', 'provider')))).toBe('web-card')
   })
 
-  it('routes chat and agent generate_image responses to the image card', () => {
-    expect(testIdOf(chooseTool(resp('generate_image')))).toBe('image-card')
-    expect(testIdOf(chooseTool(resp('generate_image', 'mcp')))).toBe('image-card')
-    expect(testIdOf(chooseTool(resp('mcp__cherry-tools__generate_image')))).toBe('image-card')
+  it('routes chat and agent generate_image responses to the image card', async () => {
+    expect(await testIdOf(chooseTool(resp('generate_image')))).toBe('image-card')
+    expect(await testIdOf(chooseTool(resp('generate_image', 'mcp')))).toBe('image-card')
+    expect(await testIdOf(chooseTool(resp('mcp__cherry-tools__generate_image')))).toBe('image-card')
   })
 
-  it('keeps an AI SDK dynamic generate_image part on the builtin image-card path', () => {
+  it('keeps an AI SDK dynamic generate_image part on the builtin image-card path', async () => {
     const part = {
       type: 'dynamic-tool',
       toolCallId: 'image-call',
@@ -75,16 +76,16 @@ describe('chooseTool', () => {
 
     const response = buildToolResponseFromPart(part)
     expect(response?.tool.type).toBe('builtin')
-    expect(testIdOf(chooseTool(response as NormalToolResponse))).toBe('image-card')
+    expect(await testIdOf(chooseTool(response as NormalToolResponse))).toBe('image-card')
   })
 
-  it('routes pi runtime built-ins to the generic agent card', () => {
-    expect(testIdOf(chooseTool(resp('read', 'provider')))).toBe('agent-card')
-    expect(testIdOf(chooseTool(resp('bash', 'provider')))).toBe('agent-card')
+  it('routes pi runtime built-ins to the generic agent card', async () => {
+    expect(await testIdOf(chooseTool(resp('read', 'provider')))).toBe('agent-card')
+    expect(await testIdOf(chooseTool(resp('bash', 'provider')))).toBe('agent-card')
     expect(chooseTool(resp('read', 'builtin'))).toBeNull()
   })
 
-  it('routes actual Pi builtin metadata through the response adapter to the agent card', () => {
+  it('routes actual Pi builtin metadata through the response adapter to the agent card', async () => {
     const part = {
       type: 'dynamic-tool',
       toolCallId: 'pi-read',
@@ -99,10 +100,10 @@ describe('chooseTool', () => {
 
     const response = buildToolResponseFromPart(part)
     expect(response?.tool.type).toBe('provider')
-    expect(testIdOf(chooseTool(response as NormalToolResponse))).toBe('agent-card')
+    expect(await testIdOf(chooseTool(response as NormalToolResponse))).toBe('agent-card')
   })
 
-  it('returns null for an unknown non-Cherry tool', () => {
-    expect(chooseTool(resp('totally_unknown_tool', 'builtin'))).toBeNull()
+  it('returns null for an unknown non-Cherry tool', async () => {
+    expect(await testIdOf(chooseTool(resp('totally_unknown_tool', 'builtin')))).toBeNull()
   })
 })

--- a/src/renderer/components/chat/messages/tools/chooseTool.tsx
+++ b/src/renderer/components/chat/messages/tools/chooseTool.tsx
@@ -11,8 +11,8 @@ import {
   PROVIDER_WEB_SEARCH_TOOL_NAME,
   WEB_SEARCH_TOOL_NAME
 } from '@shared/ai/builtinTools'
+import React, { Suspense } from 'react'
 
-import { AgentExecutionTimeline } from './agent'
 import { MessageKnowledgeSearchToolTitle } from './knowledge/MessageKnowledgeSearch'
 import MessageMetaTool, { isMetaToolName } from './meta/MessageMetaTool'
 import { isGenerateImageToolName } from './painting/generateImageTool'
@@ -23,6 +23,11 @@ import { MessageWebSearchToolTitle } from './webSearch/MessageWebSearch'
 const builtinToolsPrefix = 'builtin_'
 const agentMcpToolsPrefix = 'mcp__'
 const agentTools = new Set<string>(Object.values(AgentToolsType))
+const AgentExecutionTimeline = React.lazy(async () => {
+  // eslint-disable-next-line barrel/closed -- this boundary is intentionally lazy-loaded.
+  const module = await import('./agent/AgentExecutionTimeline')
+  return { default: module.AgentExecutionTimeline }
+})
 /** cherry-tools that carry short wire names rather than the `mcp__` prefix. */
 const CHERRY_AGENT_TOOL_NAMES = new Set([
   'web_fetch',
@@ -65,11 +70,19 @@ export function chooseTool(toolResponse: NormalToolResponse): React.ReactNode | 
   }
   // Short-name tools without a bespoke card render through the standard agent tool-call card.
   if (CHERRY_AGENT_TOOL_NAMES.has(toolName)) {
-    return <AgentExecutionTimeline toolResponse={toolResponse} />
+    return (
+      <Suspense fallback={null}>
+        <AgentExecutionTimeline toolResponse={toolResponse} />
+      </Suspense>
+    )
   }
 
   if (isAskUserQuestionToolName(toolName)) {
-    return <AgentExecutionTimeline toolResponse={toolResponse} />
+    return (
+      <Suspense fallback={null}>
+        <AgentExecutionTimeline toolResponse={toolResponse} />
+      </Suspense>
+    )
   }
 
   // Historical `builtin_*` prefix kept for messages already stored in DB.
@@ -90,7 +103,11 @@ export function chooseTool(toolResponse: NormalToolResponse): React.ReactNode | 
     isAgentTool(toolName) ||
     (toolResponse.tool.type === 'provider' && CHERRY_RUNTIME_BUILTIN_TOOL_NAMES.has(toolName))
   ) {
-    return <AgentExecutionTimeline toolResponse={toolResponse} />
+    return (
+      <Suspense fallback={null}>
+        <AgentExecutionTimeline toolResponse={toolResponse} />
+      </Suspense>
+    )
   }
   return null
 }


### PR DESCRIPTION
## Summary

- lazy-load the Agent execution timeline only when a tool response is routed to the Agent renderer
- keep ordinary chat tool routing and existing fallback behavior unchanged
- update routing tests to await the lazy renderer boundary

## Validation

- `pnpm exec vitest run src/renderer/components/chat/messages/tools/__tests__/chooseTool.test.tsx --project renderer`
- `pnpm exec vitest run src/renderer/components/chat/messages/tools/__tests__/MessageTools.test.tsx src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx --project renderer`
- `pnpm exec eslint src/renderer/components/chat/messages/tools/MessageTools.tsx src/renderer/components/chat/messages/tools/chooseTool.tsx src/renderer/components/chat/messages/blocks/messagePartLayouts.ts src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx --fix`

Refs #19331
