### PR TITLE
fix(sortable): prevent nested inputs from starting keyboard drag

### DIFF
--- a/packages/ui/src/components/composites/sortable/__tests__/sortable-keyboard.test.tsx
+++ b/packages/ui/src/components/composites/sortable/__tests__/sortable-keyboard.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest'
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import Sortable from '../sortable'
+
+const items = [{ id: 'alpha', label: 'Alpha' }]
+
+describe('Sortable keyboard activation', () => {
+  it('does not start dragging when IME completion keys originate from a nested input', () => {
+    const onDragStart = vi.fn()
+
+    render(
+      <Sortable
+        items={items}
+        itemKey="id"
+        onDragStart={onDragStart}
+        onSortEnd={() => {}}
+        renderItem={(item) => <input aria-label={`Rename ${item.label}`} />}
+      />
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Rename Alpha' })
+    // userEvent does not expose composition-state keyboard events.
+    fireEvent.keyDown(input, { code: 'Space', isComposing: true, key: ' ' })
+    fireEvent.keyDown(input, { code: 'Enter', isComposing: true, key: 'Enter' })
+
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  it('starts dragging when Enter originates from the sortable row', async () => {
+    const onDragStart = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <Sortable
+        items={items}
+        itemKey="id"
+        onDragStart={onDragStart}
+        onSortEnd={() => {}}
+        renderItem={(item) => <span>{item.label}</span>}
+      />
+    )
+
+    screen.getByRole('button', { name: 'Alpha' }).focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(onDragStart).toHaveBeenCalledTimes(1))
+  })
+})

--- a/packages/ui/src/components/composites/sortable/__tests__/sortable.test.tsx
+++ b/packages/ui/src/components/composites/sortable/__tests__/sortable.test.tsx
@@ -119,27 +119,6 @@ describe('Sortable', () => {
     expect(states.some((state) => state.overlay === true)).toBe(true)
   })
 
-  it('binds the drag activator to the whole row in default mode', () => {
-    const states: Array<{ dragHandleProps?: unknown }> = []
-
-    render(
-      <Sortable
-        items={[{ id: 'a' }]}
-        itemKey="id"
-        onSortEnd={() => {}}
-        renderItem={(item, state) => {
-          states.push(state)
-          return <div>{item.id}</div>
-        }}
-      />
-    )
-
-    // No handle props are handed to renderItem; the activator attributes/listeners
-    // land on the sortable row itself.
-    expect(states.every((state) => state.dragHandleProps === undefined)).toBe(true)
-    expect(document.querySelector('[aria-roledescription="sortable"]')).not.toBeNull()
-  })
-
   it('routes the drag activator to a handle in dragHandle mode, leaving the row inert', () => {
     let captured: any
 

--- a/packages/ui/src/components/composites/sortable/item-renderer.tsx
+++ b/packages/ui/src/components/composites/sortable/item-renderer.tsx
@@ -7,6 +7,7 @@ import type { RenderItemType, SortableDragHandleProps } from './types'
 
 interface ItemRendererProps<T> {
   ref?: React.Ref<HTMLDivElement>
+  activatorRef?: React.Ref<HTMLDivElement>
   index?: number
   item: T
   renderItem: RenderItemType<T>
@@ -22,6 +23,7 @@ interface ItemRendererProps<T> {
 
 export function ItemRenderer<T>({
   ref,
+  activatorRef,
   index,
   item,
   renderItem,
@@ -63,6 +65,7 @@ export function ItemRenderer<T>({
         ...(dragOverlay ? ({ '--scale': 1.02, zIndex: 999, position: 'relative' } as React.CSSProperties) : {})
       }}>
       <div
+        ref={activatorRef}
         style={
           {
             position: 'relative',

--- a/packages/ui/src/components/composites/sortable/sortable-item.tsx
+++ b/packages/ui/src/components/composites/sortable/sortable-item.tsx
@@ -39,6 +39,7 @@ export function SortableItem<T>({
   return (
     <ItemRenderer
       ref={setNodeRef}
+      activatorRef={dragHandle ? undefined : setActivatorNodeRef}
       item={item}
       index={index}
       renderItem={renderItem}

--- a/src/renderer/components/VirtualList/GroupedSortableVirtualList.tsx
+++ b/src/renderer/components/VirtualList/GroupedSortableVirtualList.tsx
@@ -2,7 +2,7 @@ import { BlurCancelPointerSensor } from '@cherrystudio/ui'
 import type { DragEndEvent, DragOverEvent, DragStartEvent, UniqueIdentifier } from '@dnd-kit/core'
 import { DndContext, DragOverlay, KeyboardSensor, useDroppable, useSensor, useSensors } from '@dnd-kit/core'
 import { SortableContext, type SortingStrategy, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { CSS, useCombinedRefs } from '@dnd-kit/utilities'
 import type React from 'react'
 import { memo, useCallback, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -578,7 +578,7 @@ function SortableItemRow<TGroup, TItem>({
     activeDragState?.active !== undefined &&
     isItemDragData(activeDragState.active) &&
     activeDragState.active.itemId === data.itemId
-  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+  const { attributes, isDragging, listeners, setActivatorNodeRef, setNodeRef, transform, transition } = useSortable({
     id: toItemSortableId(data.itemId),
     data,
     disabled: {
@@ -586,10 +586,11 @@ function SortableItemRow<TGroup, TItem>({
       droppable: disabled || (dropTargetRowState.isBlocked && !isActiveItem)
     }
   })
+  const setSortableNodeRef = useCombinedRefs(setNodeRef, setActivatorNodeRef)
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setSortableNodeRef}
       data-dragging={isDragging || undefined}
       {...dropTargetRowState.props}
       className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}
@@ -674,15 +675,16 @@ function SortableGroupHeaderRow<TGroup, TItem>({
     rowId: data.groupId,
     rowType: 'group'
   })
-  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
+  const { attributes, isDragging, listeners, setActivatorNodeRef, setNodeRef, transform, transition } = useSortable({
     id: toGroupSortableId(data.groupId),
     data,
     disabled: disabled || dropTargetRowState.isBlocked
   })
+  const setSortableNodeRef = useCombinedRefs(setNodeRef, setActivatorNodeRef)
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setSortableNodeRef}
       data-dragging={isDragging || undefined}
       {...dropTargetRowState.props}
       className={joinClassNames(dropTargetRowState.props.className, dropIndicatorPosition ? 'relative' : undefined)}

--- a/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.keyboard.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.keyboard.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollIntoView = vi.fn()
+})
+
+afterAll(() => {
+  if (originalScrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
+  }
+})
+
+const virtualMocks = vi.hoisted(() => ({
+  useVirtualizer: vi.fn((options: { count: number; estimateSize: (index: number) => number }) => ({
+    getTotalSize: () => options.count * 40,
+    getVirtualIndexes: () => Array.from({ length: options.count }, (_, index) => index),
+    getVirtualItems: () =>
+      Array.from({ length: options.count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        size: options.estimateSize(index),
+        start: index * 40
+      })),
+    measure: vi.fn(),
+    measureElement: vi.fn(),
+    resizeItem: vi.fn(),
+    scrollElement: null,
+    scrollToIndex: vi.fn(),
+    scrollToOffset: vi.fn()
+  }))
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  defaultRangeExtractor: vi.fn((range) =>
+    Array.from({ length: range.endIndex - range.startIndex + 1 }, (_, index) => range.startIndex + index)
+  ),
+  useVirtualizer: virtualMocks.useVirtualizer
+}))
+
+import { GroupedSortableVirtualList } from '..'
+
+const groups = [{ group: { id: 'first' }, header: 'First', items: [{ id: 'alpha', label: 'Alpha' }] }]
+
+type RenderListOptions = {
+  draggableGroups?: boolean
+  renderGroupHeader?: (header: string) => ReactNode
+}
+
+function renderList(
+  renderItem: (item: { id: string; label: string }) => ReactNode,
+  onDragStart = vi.fn(),
+  { draggableGroups = false, renderGroupHeader }: RenderListOptions = {}
+) {
+  render(
+    <GroupedSortableVirtualList
+      groups={groups}
+      getGroupId={(group) => group.id}
+      getItemId={(item) => item.id}
+      dragCapabilities={{ groups: draggableGroups }}
+      estimateItemSize={() => 40}
+      renderGroupHeader={renderGroupHeader}
+      renderItem={renderItem}
+      onDragEnd={() => {}}
+      onDragStart={onDragStart}
+    />
+  )
+
+  return onDragStart
+}
+
+describe('GroupedSortableVirtualList keyboard activation', () => {
+  it('does not start dragging when IME completion keys originate from a nested input', () => {
+    const onDragStart = renderList((item) => <input aria-label={`Rename ${item.label}`} />)
+
+    const input = screen.getByRole('textbox', { name: 'Rename Alpha' })
+    // userEvent does not expose composition-state keyboard events.
+    fireEvent.keyDown(input, { code: 'Space', isComposing: true, key: ' ' })
+    fireEvent.keyDown(input, { code: 'Enter', isComposing: true, key: 'Enter' })
+
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  it('starts dragging when Enter originates from the sortable row', async () => {
+    const onDragStart = renderList((item) => <span>{item.label}</span>)
+    const user = userEvent.setup()
+
+    screen.getByRole('button', { name: 'Alpha' }).focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(onDragStart).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not start group dragging when IME completion keys originate from a nested input', () => {
+    const onDragStart = renderList((item) => <span>{item.label}</span>, vi.fn(), {
+      draggableGroups: true,
+      renderGroupHeader: (header) => <input aria-label={`Rename ${header}`} />
+    })
+
+    const input = screen.getByRole('textbox', { name: 'Rename First' })
+    // userEvent does not expose composition-state keyboard events.
+    fireEvent.keyDown(input, { code: 'Space', isComposing: true, key: ' ' })
+    fireEvent.keyDown(input, { code: 'Enter', isComposing: true, key: 'Enter' })
+
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  it('starts group dragging when Enter originates from the group row', async () => {
+    const onDragStart = renderList((item) => <span>{item.label}</span>, vi.fn(), {
+      draggableGroups: true,
+      renderGroupHeader: (header) => <span>{header}</span>
+    })
+    const user = userEvent.setup()
+
+    screen.getByRole('button', { name: 'First' }).focus()
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => expect(onDragStart).toHaveBeenCalledTimes(1))
+  })
+})

--- a/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
@@ -1,3 +1,4 @@
+import type * as DndKitUtilities from '@dnd-kit/utilities'
 import { act, render, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -113,7 +114,7 @@ vi.mock('@dnd-kit/sortable', () => {
 })
 
 vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
+  ...(await importOriginal<typeof DndKitUtilities>()),
   CSS: {
     Transform: {
       toString: (transform: unknown) => (transform ? 'translate3d(0px, 12px, 0px)' : undefined)

--- a/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
+++ b/src/renderer/components/VirtualList/__tests__/GroupedSortableVirtualList.test.tsx
@@ -102,6 +102,7 @@ vi.mock('@dnd-kit/sortable', () => {
         attributes: {},
         isDragging: dndMocks.activeSortableId === id,
         listeners: {},
+        setActivatorNodeRef: vi.fn(),
         setNodeRef: vi.fn(),
         transform: { scaleX: 1, scaleY: 1, x: 0, y: 12 },
         transition: 'transform 200ms ease'
@@ -111,7 +112,8 @@ vi.mock('@dnd-kit/sortable', () => {
   }
 })
 
-vi.mock('@dnd-kit/utilities', () => ({
+vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
   CSS: {
     Transform: {
       toString: (transform: unknown) => (transform ? 'translate3d(0px, 12px, 0px)' : undefined)

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -1,3 +1,4 @@
+import type * as DndKitUtilities from '@dnd-kit/utilities'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { type ReactNode, useMemo, useState } from 'react'
@@ -109,7 +110,7 @@ vi.mock('@dnd-kit/sortable', () => {
 })
 
 vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
+  ...(await importOriginal<typeof DndKitUtilities>()),
   CSS: {
     Transform: {
       toString: () => undefined

--- a/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
+++ b/src/renderer/components/chat/resourceList/base/__tests__/ResourceList.test.tsx
@@ -97,6 +97,7 @@ vi.mock('@dnd-kit/sortable', () => {
       return {
         attributes: { 'data-sortable-id': id },
         listeners: {},
+        setActivatorNodeRef: vi.fn(),
         setNodeRef: vi.fn(),
         transform: null,
         transition: undefined,
@@ -107,7 +108,8 @@ vi.mock('@dnd-kit/sortable', () => {
   }
 })
 
-vi.mock('@dnd-kit/utilities', () => ({
+vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
   CSS: {
     Transform: {
       toString: () => undefined

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -211,6 +211,7 @@ vi.mock('@dnd-kit/sortable', () => {
       return {
         attributes: { 'data-sortable-id': id },
         listeners: {},
+        setActivatorNodeRef: vi.fn(),
         setNodeRef: vi.fn(),
         transform: null,
         transition: undefined,
@@ -221,7 +222,8 @@ vi.mock('@dnd-kit/sortable', () => {
   }
 })
 
-vi.mock('@dnd-kit/utilities', () => ({
+vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
   CSS: {
     Transform: {
       toString: () => undefined

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -1,4 +1,5 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
+import type * as DndKitUtilities from '@dnd-kit/utilities'
 import type * as ImageCaptureTargetsHook from '@renderer/hooks/useImageCaptureTargets'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
@@ -223,7 +224,7 @@ vi.mock('@dnd-kit/sortable', () => {
 })
 
 vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
+  ...(await importOriginal<typeof DndKitUtilities>()),
   CSS: {
     Transform: {
       toString: () => undefined

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -76,6 +76,7 @@ vi.mock('@dnd-kit/sortable', () => {
       return {
         attributes: { 'data-sortable-id': id },
         listeners: {},
+        setActivatorNodeRef: vi.fn(),
         setNodeRef: vi.fn(),
         transform: null,
         transition: undefined,
@@ -86,7 +87,8 @@ vi.mock('@dnd-kit/sortable', () => {
   }
 })
 
-vi.mock('@dnd-kit/utilities', () => ({
+vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
   CSS: {
     Transform: {
       toString: () => undefined

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -1,3 +1,4 @@
+import type * as DndKitUtilities from '@dnd-kit/utilities'
 import type * as UseCacheModule from '@renderer/data/hooks/useCache'
 import type * as TopicMenuActionsHook from '@renderer/hooks/chat/useTopicMenuActions'
 import { type AssistantTopicsSource, deriveAssistantTopicsView } from '@renderer/hooks/resourceViewSources'
@@ -88,7 +89,7 @@ vi.mock('@dnd-kit/sortable', () => {
 })
 
 vi.mock('@dnd-kit/utilities', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@dnd-kit/utilities')>()),
+  ...(await importOriginal<typeof DndKitUtilities>()),
   CSS: {
     Transform: {
       toString: () => undefined


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Sortable rows attached dnd-kit keyboard listeners without registering the listener host as the activator node. Keyboard events from nested controls, including Space or Enter used while completing Chinese IME input in the conversation rename dialog, could therefore start a drag and leave a stuck `DragOverlay`.
<img width="1466" height="486" alt="image" src="https://github.com/user-attachments/assets/17e2e6a9-0ee3-4f80-b1ed-2c7535f86fc4" />

After this PR:

Listener-bearing sortable rows register their activator nodes through dnd-kit's ref APIs. Keyboard drag activation is scoped to the row itself, while direct Enter activation on a focused row continues to work. Real dnd-kit regression tests cover shared sortable rows and virtualized item and group rows.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19197

### Why we need it and why it was done in this way

This fixes the drag lifecycle at the shared sortable ownership boundary. dnd-kit's `KeyboardSensor` already uses the registered activator node to reject keyboard events from nested elements, so supplying that contract prevents unintended activation without adding dialog-specific IME behavior.

The following tradeoffs were made:

Nested interactive elements no longer initiate whole-row keyboard dragging. The sortable row itself remains keyboard-accessible, and explicit drag handles keep their existing behavior.

The following alternatives were considered:

- Adding another composition or blur guard to the rename dialog was rejected because composing Enter is already guarded and dialog-local handling would not fix keyboard activation for other sortable consumers.
- Cancelling a stuck overlay after activation was rejected because it treats the visible symptom instead of preventing the invalid drag.
- A custom keyboard sensor was rejected because dnd-kit already provides the required activator-node contract.

Links to places where the discussion took place: #19197, #18456, #19224

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- Regression tests exercise real dnd-kit keyboard behavior rather than mocked sensor implementation details.
- Related UI and renderer suites pass 319 tests.
- `pnpm typecheck`, targeted Biome/ESLint checks, i18n validation, and diff checks pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix an issue where completing Chinese IME input while renaming a conversation could leave a stuck drag preview and block subsequent dragging.
```
