### PR TITLE
feat(settings): index remaining settings sections for search

### DIFF
--- a/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
+++ b/src/renderer/components/chat/settings/ChatPreferenceSections.tsx
@@ -296,7 +296,7 @@ const ChatPreferenceSections: FC<ChatPreferenceSectionsProps> = ({ sectionClassN
             />
           </SettingRow>
           <SettingDivider />
-          <SettingRow id="setting-appearance-confirm-delete-message" className="scroll-mt-6">
+          <SettingRow className="scroll-mt-6">
             <SettingSwitch
               checked={pasteLongTextAsFile}
               onCheckedChange={setPasteLongTextAsFile}
@@ -322,7 +322,7 @@ const ChatPreferenceSections: FC<ChatPreferenceSectionsProps> = ({ sectionClassN
             </>
           )}
           <SettingDivider />
-          <SettingRow>
+          <SettingRow id="setting-appearance-confirm-delete-message" className="scroll-mt-6">
             <SettingSwitch
               checked={confirmDeleteMessage}
               onCheckedChange={setConfirmDeleteMessage}

--- a/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
@@ -274,7 +274,7 @@ const AboutSettings: FC = () => {
         {!isPortable && (
           <>
             <Divider className="my-3" />
-            <SettingRow className="gap-3">
+            <SettingRow id="setting-about-auto-check-update" className="scroll-mt-6 gap-3">
               <SettingRowTitle>{t('settings.general.auto_check_update.title')}</SettingRowTitle>
               <Switch checked={autoCheckUpdate} onCheckedChange={(v) => setAutoCheckUpdate(v)} />
             </SettingRow>
@@ -375,6 +375,7 @@ const AboutSettings: FC = () => {
         />
         <Divider className="my-3" />
         <AboutActionRow
+          id="setting-about-diagnostics"
           icon={<FileArchive className="size-4.5" />}
           title={t('settings.about.diagnostics.entry.title')}
           actionLabel={t('settings.about.diagnostics.entry.button')}
@@ -382,6 +383,7 @@ const AboutSettings: FC = () => {
         />
         <Divider className="my-3" />
         <AboutActionRow
+          id="setting-about-debug-tools"
           icon={<Bug className="size-4.5" />}
           title={t('settings.about.debug.title')}
           actionLabel={t('settings.about.debug.open')}
@@ -401,16 +403,18 @@ const AboutSettings: FC = () => {
 function AboutActionRow({
   actionLabel,
   icon,
+  id,
   onAction,
   title
 }: {
   actionLabel: string
   icon: ReactNode
+  id?: string
   onAction: () => void | Promise<void>
   title: string
 }) {
   return (
-    <SettingRow className="gap-3">
+    <SettingRow id={id} className={id ? 'scroll-mt-6 gap-3' : 'gap-3'}>
       <SettingRowTitle className="gap-2.5">
         {icon}
         {title}

--- a/src/renderer/pages/settings/AboutSettings/about.search.ts
+++ b/src/renderer/pages/settings/AboutSettings/about.search.ts
@@ -2,7 +2,9 @@ import type { SettingsSearchEntry } from '../settingsSearch/types'
 
 export const route = '/settings/about'
 
-// Actionable rows only: version info lines stay out per D8
+// Actionable rows only: version info lines stay out per D8. The update rows
+// sit inside `!isPortable` (portable builds hide them) — acceptable declared
+// exception: normal builds always render them, portable jumps degrade silently.
 export const entries: SettingsSearchEntry[] = [
   {
     anchorId: 'auto-check-update',

--- a/src/renderer/pages/settings/AboutSettings/about.search.ts
+++ b/src/renderer/pages/settings/AboutSettings/about.search.ts
@@ -1,0 +1,24 @@
+import type { SettingsSearchEntry } from '../settingsSearch/types'
+
+export const route = '/settings/about'
+
+// Actionable rows only: version info lines stay out per D8
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'auto-check-update',
+    titleKey: 'settings.general.auto_check_update.title',
+    groupKey: 'settings.about.label',
+    aliases: ['update', '更新']
+  },
+  {
+    anchorId: 'diagnostics',
+    titleKey: 'settings.about.diagnostics.entry.title',
+    groupKey: 'settings.about.label',
+    aliases: ['diagnostics', '诊断']
+  },
+  {
+    anchorId: 'debug-tools',
+    titleKey: 'settings.about.debug.title',
+    groupKey: 'settings.about.label'
+  }
+]

--- a/src/renderer/pages/settings/McpSettings/McpSettingsPage.tsx
+++ b/src/renderer/pages/settings/McpSettings/McpSettingsPage.tsx
@@ -50,6 +50,7 @@ const McpSettings: FC = () => {
           <Scrollbar className="min-h-0 flex-1">
             <MenuList className={settingsSubmenuListClassName}>
               <MenuItem
+                id="setting-mcp-servers-tab-servers"
                 label={t('settings.mcp.title')}
                 active={activeView === 'servers'}
                 onClick={() => navigate({ to: '/settings/mcp/servers' })}
@@ -60,6 +61,7 @@ const McpSettings: FC = () => {
               <MenuDivider className={settingsSubmenuDividerClassName} />
               <div className={settingsSubmenuSectionTitleClassName}>{t('settings.mcp.discover', 'Discover')}</div>
               <MenuItem
+                id="setting-mcp-builtin-tab-builtin"
                 label={t('settings.mcp.builtinServers', 'Built-in Servers')}
                 active={activeView === 'builtin'}
                 onClick={() => navigate({ to: '/settings/mcp/builtin' })}
@@ -68,6 +70,7 @@ const McpSettings: FC = () => {
                 labelClassName={settingsSubmenuItemLabelClassName}
               />
               <MenuItem
+                id="setting-mcp-marketplaces-tab-marketplaces"
                 label={t('settings.mcp.marketplaces', 'Marketplaces')}
                 active={activeView === 'marketplaces'}
                 onClick={() => navigate({ to: '/settings/mcp/marketplaces' })}

--- a/src/renderer/pages/settings/McpSettings/mcp.search.ts
+++ b/src/renderer/pages/settings/McpSettings/mcp.search.ts
@@ -1,0 +1,26 @@
+import type { SettingsSearchEntry } from '../settingsSearch/types'
+
+// The MCP section's static tabs are real sub-routes: entries override the
+// route to land directly on the tab; anchors point at the tab menu items in
+// McpSettingsPage's sidebar. Server entries themselves are dynamic entities
+// and stay unindexed per D8 (baseline section title still matches).
+export const route = '/settings/mcp'
+
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'tab-servers',
+    titleKey: 'settings.mcp.title',
+    route: '/settings/mcp/servers',
+    aliases: ['mcp']
+  },
+  {
+    anchorId: 'tab-builtin',
+    titleKey: 'settings.mcp.builtinServers',
+    route: '/settings/mcp/builtin'
+  },
+  {
+    anchorId: 'tab-marketplaces',
+    titleKey: 'settings.mcp.marketplaces',
+    route: '/settings/mcp/marketplaces'
+  }
+]

--- a/src/renderer/pages/settings/NotificationSettings/NotificationSettings.tsx
+++ b/src/renderer/pages/settings/NotificationSettings/NotificationSettings.tsx
@@ -34,7 +34,7 @@ const NotificationSettings: FC = () => {
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.notification.title')}</SettingTitle>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-notifications-assistant-notification" className="scroll-mt-6">
           <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <span>{t('settings.notification.assistant')}</span>
             <InfoTooltip
@@ -49,7 +49,7 @@ const NotificationSettings: FC = () => {
           />
         </SettingRow>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-notifications-backup-notification" className="scroll-mt-6">
           <SettingRowTitle>{t('settings.notification.backup')}</SettingRowTitle>
           <Switch
             checked={notificationSettings.backup}
@@ -57,7 +57,7 @@ const NotificationSettings: FC = () => {
           />
         </SettingRow>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-notifications-knowledge-embed-notification" className="scroll-mt-6">
           <SettingRowTitle>{t('settings.notification.knowledge_embed')}</SettingRowTitle>
           <Switch
             checked={notificationSettings.knowledge}
@@ -65,7 +65,7 @@ const NotificationSettings: FC = () => {
           />
         </SettingRow>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-notifications-update-notification" className="scroll-mt-6">
           <SettingRowTitle>{t('settings.notification.update')}</SettingRowTitle>
           <Switch
             aria-label={t('settings.notification.update')}

--- a/src/renderer/pages/settings/NotificationSettings/NotificationSettings.tsx
+++ b/src/renderer/pages/settings/NotificationSettings/NotificationSettings.tsx
@@ -74,7 +74,7 @@ const NotificationSettings: FC = () => {
           />
         </SettingRow>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-notifications-mini-app-notification" className="scroll-mt-6">
           <SettingRowTitle>{t('settings.notification.mini_app')}</SettingRowTitle>
           <Switch
             aria-label={t('settings.notification.mini_app')}

--- a/src/renderer/pages/settings/NotificationSettings/notification.search.ts
+++ b/src/renderer/pages/settings/NotificationSettings/notification.search.ts
@@ -1,0 +1,26 @@
+import type { SettingsSearchEntry } from '../settingsSearch/types'
+
+export const route = '/settings/notifications'
+
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'assistant-notification',
+    titleKey: 'settings.notification.assistant',
+    groupKey: 'settings.notification.title'
+  },
+  {
+    anchorId: 'backup-notification',
+    titleKey: 'settings.notification.backup',
+    groupKey: 'settings.notification.title'
+  },
+  {
+    anchorId: 'knowledge-embed-notification',
+    titleKey: 'settings.notification.knowledge_embed',
+    groupKey: 'settings.notification.title'
+  },
+  {
+    anchorId: 'update-notification',
+    titleKey: 'settings.notification.update',
+    groupKey: 'settings.notification.title'
+  }
+]

--- a/src/renderer/pages/settings/NotificationSettings/notification.search.ts
+++ b/src/renderer/pages/settings/NotificationSettings/notification.search.ts
@@ -22,5 +22,10 @@ export const entries: SettingsSearchEntry[] = [
     anchorId: 'update-notification',
     titleKey: 'settings.notification.update',
     groupKey: 'settings.notification.title'
+  },
+  {
+    anchorId: 'mini-app-notification',
+    titleKey: 'settings.notification.mini_app',
+    groupKey: 'settings.notification.title'
   }
 ]

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHost.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHost.tsx
@@ -90,7 +90,7 @@ export default function ApiHost({ providerId, onRequestModelPullGuide }: ApiHost
 
   return (
     <>
-      <ApiHostSection>
+      <ApiHostSection id="setting-provider-api-host">
         {!isAnthropicPrimaryEndpoint ? (
           <ApiHostField
             providerIdForSettings={provider.id}

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHostFields.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiHostFields.tsx
@@ -259,6 +259,6 @@ export function AnthropicApiHostField({
   )
 }
 
-export function ApiHostSection({ children }: { children: React.ReactNode }) {
-  return <ProviderSection>{children}</ProviderSection>
+export function ApiHostSection({ children, id }: { children: React.ReactNode; id?: string }) {
+  return <ProviderSection id={id}>{children}</ProviderSection>
 }

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
@@ -82,7 +82,7 @@ export default function ApiKey({
 
   return (
     <>
-      <ProviderSection id={provider.id === 'cherryin' ? 'cherryin-api-key-section' : 'setting-provider-api-key'}>
+      <ProviderSection id="setting-provider-api-key">
         <ProviderField
           className="space-y-2"
           title={

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ApiKey.tsx
@@ -82,7 +82,7 @@ export default function ApiKey({
 
   return (
     <>
-      <ProviderSection id={provider.id === 'cherryin' ? 'cherryin-api-key-section' : undefined}>
+      <ProviderSection id={provider.id === 'cherryin' ? 'cherryin-api-key-section' : 'setting-provider-api-key'}>
         <ProviderField
           className="space-y-2"
           title={

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthConnectionSlotsLayout.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/AuthConnectionSlotsLayout.tsx
@@ -17,7 +17,7 @@ export default function AuthConnectionSlotsLayout({ providerId, children }: Auth
   const isLoginBased = provider ? isLoginBasedProvider(provider) : false
 
   return (
-    <section className="shrink-0 space-y-4">
+    <section id={`setting-provider-auth-${providerId}`} className="shrink-0 space-y-4">
       <ProviderSpecificSettings providerId={providerId} placement="beforeAuth" />
       {!isLoginBased && (
         <div className="flex flex-col gap-3">

--- a/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListHeader.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ModelList/ModelListHeader.tsx
@@ -55,7 +55,9 @@ const ModelListHeader: React.FC<ModelListHeaderProps> = ({
     <>
       <div className={modelListClasses.headerInlineRow}>
         <div className={modelListClasses.sectionTitleLine}>
-          <h2 className={modelListClasses.sectionTitle}>{t('settings.models.list_title')}</h2>
+          <h2 id="setting-provider-model-list" className={modelListClasses.sectionTitle}>
+            {t('settings.models.list_title')}
+          </h2>
           {docsLink ? (
             <div className={modelListClasses.titleHelpRow}>
               <Tooltip content={t('settings.models.docs')}>

--- a/src/renderer/pages/settings/ProviderSettings/provider.search.ts
+++ b/src/renderer/pages/settings/ProviderSettings/provider.search.ts
@@ -1,0 +1,25 @@
+import type { SettingsSearchEntry } from '../settingsSearch/types'
+
+// Indexed rows = the provider detail column, which always mounts for the
+// selected provider (persisted last selection, else the first visible one).
+// Login-based providers (claude-code/codex/grok OAuth) render no key/host rows
+// and registry meta can hide either field — declared exception: the focus
+// scroll gives up silently by design and the jump still lands on the page.
+export const route = '/settings/provider'
+
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'api-key',
+    titleKey: 'settings.provider.api_key.label',
+    aliases: ['api key', 'key', 'secret']
+  },
+  {
+    anchorId: 'api-host',
+    titleKey: 'settings.provider.api_host',
+    aliases: ['endpoint', 'base url', '端点', '接口地址']
+  },
+  {
+    anchorId: 'model-list',
+    titleKey: 'settings.models.list_title'
+  }
+]

--- a/src/renderer/pages/settings/ProviderSettings/provider.search.ts
+++ b/src/renderer/pages/settings/ProviderSettings/provider.search.ts
@@ -2,9 +2,11 @@ import type { SettingsSearchEntry } from '../settingsSearch/types'
 
 // Indexed rows = the provider detail column, which always mounts for the
 // selected provider (persisted last selection, else the first visible one).
-// Login-based providers (claude-code/codex/grok OAuth) render no key/host rows
-// and registry meta can hide either field — declared exception: the focus
-// scroll gives up silently by design and the jump still lands on the page.
+// The login-flow entries carry providerId so the jump selects the provider
+// via ?id= and flashes its auth section (setting-provider-auth-<id>, rendered
+// by AuthConnectionSlotsLayout). Registry meta can still hide the key/host
+// fields per provider — declared exception: the focus scroll gives up
+// silently by design and the jump still lands on the page.
 export const route = '/settings/provider'
 
 export const entries: SettingsSearchEntry[] = [
@@ -21,5 +23,30 @@ export const entries: SettingsSearchEntry[] = [
   {
     anchorId: 'model-list',
     titleKey: 'settings.models.list_title'
+  },
+  {
+    anchorId: 'auth-claude-code',
+    titleKey: 'provider.claude-code',
+    providerId: 'claude-code',
+    aliases: ['claude code', 'cli', 'oauth', '登录']
+  },
+  {
+    anchorId: 'auth-openai-codex',
+    titleKey: 'provider.openai-codex',
+    descriptionKey: 'settings.provider.codex.description',
+    providerId: 'openai-codex',
+    aliases: ['codex', 'chatgpt', 'oauth', '登录']
+  },
+  {
+    anchorId: 'auth-github-copilot',
+    titleKey: 'provider.copilot',
+    providerId: 'copilot',
+    aliases: ['copilot', 'github copilot', 'oauth', '登录']
+  },
+  {
+    anchorId: 'auth-grok-cli',
+    titleKey: 'provider.grok-cli',
+    providerId: 'grok-cli',
+    aliases: ['grok', 'cli', 'oauth', '登录']
   }
 ]

--- a/src/renderer/pages/settings/ProviderSettings/provider.search.ts
+++ b/src/renderer/pages/settings/ProviderSettings/provider.search.ts
@@ -38,7 +38,7 @@ export const entries: SettingsSearchEntry[] = [
     aliases: ['codex', 'chatgpt', 'oauth', '登录']
   },
   {
-    anchorId: 'auth-github-copilot',
+    anchorId: 'auth-copilot',
     titleKey: 'provider.copilot',
     providerId: 'copilot',
     aliases: ['copilot', 'github copilot', 'oauth', '登录']

--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -133,7 +133,7 @@ const QuickAssistantSettings: FC = () => {
         {enableQuickAssistant && (
           <>
             <SettingDivider />
-            <SettingRow id="setting-quick-assistant-read-clipboard-at-startup" className="scroll-mt-6">
+            <SettingRow>
               <SettingRowTitle>{t('settings.quickAssistant.read_clipboard_at_startup')}</SettingRowTitle>
               <Switch checked={readClipboardAtStartup} onCheckedChange={handleClickReadClipboardAtStartup} />
             </SettingRow>
@@ -144,11 +144,7 @@ const QuickAssistantSettings: FC = () => {
         <SettingGroup theme={theme}>
           <SettingTitle>{t('settings.models.quick_assistant_response_settings')}</SettingTitle>
           <SettingDivider />
-          <SettingRow
-            id="setting-quick-assistant-usage-method"
-            role="group"
-            aria-labelledby={usageMethodTitleId}
-            className="min-h-8.5 scroll-mt-6 gap-3">
+          <SettingRow role="group" aria-labelledby={usageMethodTitleId} className="min-h-8.5 gap-3">
             <SettingRowTitle id={usageMethodTitleId}>
               {t('settings.models.quick_assistant_usage_method')}
             </SettingRowTitle>

--- a/src/renderer/pages/settings/QuickAssistantSettings.tsx
+++ b/src/renderer/pages/settings/QuickAssistantSettings.tsx
@@ -110,7 +110,7 @@ const QuickAssistantSettings: FC = () => {
       <SettingGroup theme={theme}>
         <SettingTitle>{t('settings.quickAssistant.title')}</SettingTitle>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-quick-assistant-enable-quick-assistant" className="scroll-mt-6">
           <SettingRowTitle style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
             <span>{t('settings.quickAssistant.enable_quick_assistant')}</span>
             <InfoTooltip
@@ -133,7 +133,7 @@ const QuickAssistantSettings: FC = () => {
         {enableQuickAssistant && (
           <>
             <SettingDivider />
-            <SettingRow>
+            <SettingRow id="setting-quick-assistant-read-clipboard-at-startup" className="scroll-mt-6">
               <SettingRowTitle>{t('settings.quickAssistant.read_clipboard_at_startup')}</SettingRowTitle>
               <Switch checked={readClipboardAtStartup} onCheckedChange={handleClickReadClipboardAtStartup} />
             </SettingRow>
@@ -144,7 +144,11 @@ const QuickAssistantSettings: FC = () => {
         <SettingGroup theme={theme}>
           <SettingTitle>{t('settings.models.quick_assistant_response_settings')}</SettingTitle>
           <SettingDivider />
-          <SettingRow role="group" aria-labelledby={usageMethodTitleId} className="min-h-8.5 gap-3">
+          <SettingRow
+            id="setting-quick-assistant-usage-method"
+            role="group"
+            aria-labelledby={usageMethodTitleId}
+            className="min-h-8.5 scroll-mt-6 gap-3">
             <SettingRowTitle id={usageMethodTitleId}>
               {t('settings.models.quick_assistant_usage_method')}
             </SettingRowTitle>

--- a/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
@@ -300,7 +300,7 @@ const SelectionAssistantSettings: FC = () => {
           <SettingGroup theme={theme}>
             <SettingTitle>{t('selection.settings.advanced.title')}</SettingTitle>
             <SettingDivider />
-            <SettingRow id="setting-selection-assistant-filter-mode" className="scroll-mt-6">
+            <SettingRow>
               <SettingLabel>
                 <SettingRowTitle>
                   {t('selection.settings.advanced.filter_mode.title')}
@@ -335,7 +335,7 @@ const SelectionAssistantSettings: FC = () => {
             {filterMode && filterMode !== 'default' && (
               <>
                 <SettingDivider />
-                <SettingRow id="setting-selection-assistant-filter-list" className="scroll-mt-6">
+                <SettingRow>
                   <SettingLabel>
                     <SettingRowTitle>{t('selection.settings.advanced.filter_list.title')}</SettingRowTitle>
                     <SettingDescription>{t('selection.settings.advanced.filter_list.description')}</SettingDescription>

--- a/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/SelectionAssistantSettings.tsx
@@ -109,7 +109,7 @@ const SelectionAssistantSettings: FC = () => {
           </div>
         </SettingTitle>
         <SettingDivider />
-        <SettingRow>
+        <SettingRow id="setting-selection-assistant-enable-selection-assistant" className="scroll-mt-6">
           <SettingLabel>
             <SettingRowTitle>{t('selection.settings.enable.title')}</SettingRowTitle>
             {!isSupportedOS && <SettingDescription>{t('selection.settings.enable.description')}</SettingDescription>}
@@ -300,7 +300,7 @@ const SelectionAssistantSettings: FC = () => {
           <SettingGroup theme={theme}>
             <SettingTitle>{t('selection.settings.advanced.title')}</SettingTitle>
             <SettingDivider />
-            <SettingRow>
+            <SettingRow id="setting-selection-assistant-filter-mode" className="scroll-mt-6">
               <SettingLabel>
                 <SettingRowTitle>
                   {t('selection.settings.advanced.filter_mode.title')}
@@ -335,7 +335,7 @@ const SelectionAssistantSettings: FC = () => {
             {filterMode && filterMode !== 'default' && (
               <>
                 <SettingDivider />
-                <SettingRow>
+                <SettingRow id="setting-selection-assistant-filter-list" className="scroll-mt-6">
                   <SettingLabel>
                     <SettingRowTitle>{t('selection.settings.advanced.filter_list.title')}</SettingRowTitle>
                     <SettingDescription>{t('selection.settings.advanced.filter_list.description')}</SettingDescription>

--- a/src/renderer/pages/settings/SelectionAssistantSettings/selectionAssistant.search.ts
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/selectionAssistant.search.ts
@@ -8,15 +8,7 @@ export const entries: SettingsSearchEntry[] = [
     titleKey: 'selection.settings.enable.title',
     groupKey: 'selection.name',
     aliases: ['selection assistant', '划词']
-  },
-  {
-    anchorId: 'filter-mode',
-    titleKey: 'selection.settings.advanced.filter_mode.title',
-    groupKey: 'selection.settings.advanced.title'
-  },
-  {
-    anchorId: 'filter-list',
-    titleKey: 'selection.settings.advanced.filter_list.title',
-    groupKey: 'selection.settings.advanced.title'
   }
+  // rows behind the selectionEnabled master switch (filter mode/list, off by
+  // default) stay out per D8 — their anchors may not exist on jump
 ]

--- a/src/renderer/pages/settings/SelectionAssistantSettings/selectionAssistant.search.ts
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/selectionAssistant.search.ts
@@ -1,0 +1,22 @@
+import type { SettingsSearchEntry } from '../settingsSearch/types'
+
+export const route = '/settings/selection-assistant'
+
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'enable-selection-assistant',
+    titleKey: 'selection.settings.enable.title',
+    groupKey: 'selection.name',
+    aliases: ['selection assistant', '划词']
+  },
+  {
+    anchorId: 'filter-mode',
+    titleKey: 'selection.settings.advanced.filter_mode.title',
+    groupKey: 'selection.settings.advanced.title'
+  },
+  {
+    anchorId: 'filter-list',
+    titleKey: 'selection.settings.advanced.filter_list.title',
+    groupKey: 'selection.settings.advanced.title'
+  }
+]

--- a/src/renderer/pages/settings/quickAssistant.search.ts
+++ b/src/renderer/pages/settings/quickAssistant.search.ts
@@ -1,0 +1,25 @@
+import type { SettingsSearchEntry } from './settingsSearch/types'
+
+export const route = '/settings/quick-assistant'
+
+const group = 'settings.quickAssistant.title'
+
+export const entries: SettingsSearchEntry[] = [
+  {
+    anchorId: 'enable-quick-assistant',
+    titleKey: 'settings.quickAssistant.enable_quick_assistant',
+    groupKey: group,
+    aliases: ['quick assistant']
+  },
+  {
+    anchorId: 'read-clipboard-at-startup',
+    titleKey: 'settings.quickAssistant.read_clipboard_at_startup',
+    groupKey: group,
+    aliases: ['clipboard', '剪贴板']
+  },
+  {
+    anchorId: 'usage-method',
+    titleKey: 'settings.models.quick_assistant_usage_method',
+    groupKey: 'settings.models.quick_assistant_response_settings'
+  }
+]

--- a/src/renderer/pages/settings/quickAssistant.search.ts
+++ b/src/renderer/pages/settings/quickAssistant.search.ts
@@ -10,16 +10,7 @@ export const entries: SettingsSearchEntry[] = [
     titleKey: 'settings.quickAssistant.enable_quick_assistant',
     groupKey: group,
     aliases: ['quick assistant']
-  },
-  {
-    anchorId: 'read-clipboard-at-startup',
-    titleKey: 'settings.quickAssistant.read_clipboard_at_startup',
-    groupKey: group,
-    aliases: ['clipboard', '剪贴板']
-  },
-  {
-    anchorId: 'usage-method',
-    titleKey: 'settings.models.quick_assistant_usage_method',
-    groupKey: 'settings.models.quick_assistant_response_settings'
   }
+  // feature-gated rows (clipboard, usage method behind the master switch,
+  // off by default) stay out per D8 — their anchors may not exist on jump
 ]

--- a/src/renderer/pages/settings/settingsSearch/SearchResultsPage.tsx
+++ b/src/renderer/pages/settings/settingsSearch/SearchResultsPage.tsx
@@ -47,7 +47,10 @@ const SearchResultsPage = () => {
       const result = results[index]
       if (!result) return
       setPendingFocus(result.focusId)
-      void navigate({ to: result.route, search: result.panel ? { panel: result.panel } : undefined })
+      const search: Record<string, string> = {}
+      if (result.panel) search.panel = result.panel
+      if (result.providerId) search.id = result.providerId
+      void navigate({ to: result.route, search: Object.keys(search).length ? search : undefined })
     },
     [results, navigate]
   )

--- a/src/renderer/pages/settings/settingsSearch/__tests__/settingsSearchIndex.test.ts
+++ b/src/renderer/pages/settings/settingsSearch/__tests__/settingsSearchIndex.test.ts
@@ -89,6 +89,12 @@ describe('settings search index', () => {
           expect(lookup(enUS, key), `en-us missing ${key}`).toBeTruthy()
         }
         const domId = getSettingDomId(entry.route ?? section.route, entry.anchorId)
+        // auth- entries flash the provider page's dynamic section
+        // setting-provider-auth-<providerId> — a mismatched tail (e.g. a brand
+        // name diverging from the real provider id) silently kills the scroll.
+        if (entry.anchorId.startsWith('auth-') && entry.providerId) {
+          expect(entry.anchorId, `${entry.anchorId} must end with its providerId`).toBe(`auth-${entry.providerId}`)
+        }
         expect(domIds.has(domId), `duplicate dom id ${domId}`).toBe(false)
         domIds.add(domId)
       }

--- a/src/renderer/pages/settings/settingsSearch/searchEngine.ts
+++ b/src/renderer/pages/settings/settingsSearch/searchEngine.ts
@@ -139,6 +139,7 @@ export function rankEntries(
         result: {
           route,
           panel: entry.panel,
+          providerId: entry.providerId,
           focusId: getSettingDomId(route, entry.anchorId),
           title,
           description,

--- a/src/renderer/pages/settings/settingsSearch/types.ts
+++ b/src/renderer/pages/settings/settingsSearch/types.ts
@@ -17,6 +17,12 @@ export interface SettingsSearchEntry {
    * panel mounts before the anchor lookup.
    */
   panel?: string
+  /**
+   * Provider id for provider-page entries that must select a specific provider
+   * on arrival: carried as ?id= (the page consumes it, selects the provider and
+   * strips the param).
+   */
+  providerId?: string
 }
 
 export interface SettingsSearchSection {
@@ -38,6 +44,8 @@ export interface SettingsSearchResult {
   route: string
   /** In-page panel key (?panel=) for state-switched sections like Data */
   panel?: string
+  /** Provider id (?id=) for provider-page entries that select a provider */
+  providerId?: string
   /** DOM id to scroll to and flash; undefined when the result is the section itself */
   focusId?: string
   /** Resolved title text for display and highlighting */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The settings search (stacked on #19345) indexes the five high-traffic sections; searching anything owned by the remaining sections only ever matches section titles via the menu baseline.

After this PR:

Leaf indexes cover every section that has statically visible, actionable rows:

- **Notifications** (4 rows), **Quick Assistant** (enable row), **Selection Assistant** (enable row), **About** (auto-update, diagnostics, debug tools) — plain `.search.ts` files + anchor ids on the rows.
- **MCP** — the three static tabs are real sub-routes, so entries use the entry-level route override to land directly on `/settings/mcp/servers|builtin|marketplaces`, anchored at the tab menu items. Dynamic server rows stay unindexed by design.
- **Provider (Model Services)** — the detail column always mounts for the selected provider, so its API key / API host / model list rows are indexed with `端点` / `endpoint` / `base url` aliases; login-based providers (no key/host fields) are a declared exception.
- Sections whose rows are dynamic entity lists (Channels, Skills, Prompts, Tasks, Local Models, WebSearch providers, FileProcessing processors) or that contain no static actionable settings rows (Usage, Screenshot, Dependencies, API Gateway) intentionally remain on the section-title baseline — their searchable surface is the section itself (in-page search owns deeper filtering).

Rows behind default-off master switches were deliberately dropped during review (anchors would not exist on a default install); the About `!isPortable` case is a declared exception.

### Why we need it and why it was done this way

The following tradeoffs were made:

- Static-row indexing only: dynamic entity rows cannot be statically declared, and jump anchors for them would be dead on most installs.
- Feature-gated rows dropped rather than indexed with graceful degradation: a hit that jumps correctly but shows no target row reads as a broken search on a default install.

The following alternatives were considered:

- Indexing gated rows and relying on the focus-scroll's silent give-up (rejected: correct-looking search results that highlight nothing feel broken).

Links to places where the discussion took place: internal design review (D8 index-scope decision) + external architecture review round.

### Breaking changes

None.

### Special notes for your reviewer

- This PR is stacked: base is `feat/settings-search-core` (#19345); GitHub will retarget it to `main` automatically once the parent merges. Review the increment only (`gh pr diff` shows just this PR's files).
- All new anchor ids are enforced by the reconciliation test added in #19345 (a missing JSX anchor fails CI).

### Checklist

- [x] Branch: This PR targets `main` (via stacked parent `feat/settings-search-core`, auto-retargeted on parent merge)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#codeforhumans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior. — not required: extends #19345's search coverage, no new UI concepts
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Settings search now covers all sections with static settings rows, including MCP tabs (see #19345 for the search itself).
```

