### PR TITLE
fix(analytics): update SDK and filter token usage reports

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@cherrystudio/ai-core": "workspace:*",
-    "@cherrystudio/analytics-client": "^1.3.0",
+    "@cherrystudio/analytics-client": "^1.3.1",
     "@cherrystudio/extension-table-plus": "workspace:^",
     "@cherrystudio/openai": "6.15.0",
     "@cherrystudio/provider-registry": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,8 +313,8 @@ importers:
         specifier: workspace:*
         version: link:packages/aiCore
       '@cherrystudio/analytics-client':
-        specifier: ^1.3.0
-        version: 1.3.0(typescript@5.8.3)
+        specifier: ^1.3.1
+        version: 1.3.1(typescript@5.8.3)
       '@cherrystudio/extension-table-plus':
         specifier: workspace:^
         version: link:packages/extension-table-plus
@@ -2928,8 +2928,8 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@cherrystudio/analytics-client@1.3.0':
-    resolution: {integrity: sha512-/dzKNngoAsNOGd1BpTqH4AgqGWKMkUIL48bxo13MAfZjubAeRpomiCv3F9I5CcJlte/3pZggtThC4Zs3hSYZAg==}
+  '@cherrystudio/analytics-client@1.3.1':
+    resolution: {integrity: sha512-TS15TqnzHCZygJvyy+YLnPbJP6AhtizLZG/sJOOZXW0YvdJkUTb4V9T0IPMD1W9hC5xcsH36jTHmeK8ip5glEg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       typescript: '>=4.7.0'
@@ -17360,7 +17360,7 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
-  '@cherrystudio/analytics-client@1.3.0(typescript@5.8.3)':
+  '@cherrystudio/analytics-client@1.3.1(typescript@5.8.3)':
     optionalDependencies:
       typescript: 5.8.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -221,3 +221,4 @@ minimumReleaseAgeExclude:
   - '@deepseek-ai/dsh-tool-subagent-report@0.1.0-rc.7'
   - '@deepseek-ai/dsh-tool-subagent@0.1.0-rc.7'
   - '@deepseek-ai/dsh-user-questions@0.1.0-rc.7'
+  - '@cherrystudio/analytics-client@1.3.1'

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -7,6 +7,7 @@ import {
   type RuntimeProviderCallEvent,
   type RuntimeProviderCallHandler
 } from '@cherrystudio/ai-core'
+import type { TokenUsageSource } from '@cherrystudio/analytics-client'
 import { endpointImpliedCapability, type ParamValues } from '@cherrystudio/provider-registry'
 import {
   type AiUsageCaptureContext,
@@ -208,6 +209,8 @@ export interface AiRequestOptions extends AiTransportOptions {
 export type AsInProcess<T extends AiBaseRequest> = Omit<T, 'requestOptions'> & {
   requestOptions?: AiRequestOptions
   usageContext?: InProcessUsageContext
+  /** Trusted in-process classification for remote token analytics. */
+  tokenUsageSource?: TokenUsageSource
   runtimeTimingSink?: MessageRuntimeTimingSink
   /**
    * Emits compaction lifecycle events as `data-compaction-anchor` chunks.
@@ -617,7 +620,7 @@ export class AiService extends BaseService {
       system,
       options: wrapModel ? { ...options, maxRetries: 0 } : options,
       hookParts: [
-        this.analyticsHookPart(model),
+        this.analyticsHookPart(model, request.tokenUsageSource ?? 'chat'),
         ...(request.runtimeTimingSink
           ? [
               {
@@ -639,8 +642,8 @@ export class AiService extends BaseService {
     return agent.stream(preparedMessages, signal)
   }
 
-  private analyticsHookPart(model: Model): Partial<AgentLoopHooks> {
-    return createAnalyticsHook(model, (trackedModel, usage) => this.trackUsage(trackedModel, usage))
+  private analyticsHookPart(model: Model, source: TokenUsageSource = 'chat'): Partial<AgentLoopHooks> {
+    return createAnalyticsHook(model, (trackedModel, usage) => this.trackUsage(trackedModel, usage, source))
   }
 
   // ── Non-streaming text generation (agent.generate) ──
@@ -710,7 +713,7 @@ export class AiService extends BaseService {
       tools,
       system: request.system ?? system,
       options: wrapModel ? { ...options, maxRetries: 0 } : options,
-      hookParts: [this.analyticsHookPart(model), ...hookParts],
+      hookParts: [this.analyticsHookPart(model, request.tokenUsageSource ?? 'chat'), ...hookParts],
       mediaCapabilities,
       toolResultMediaCapabilities: resolveToolResultMediaCapabilities(
         mediaCapabilities,
@@ -1008,7 +1011,11 @@ export class AiService extends BaseService {
       ...(signal ? { abortSignal: signal } : {})
     })
 
-    this.trackUsage(model, { inputTokens: result.usage?.tokens ?? 0, outputTokens: 0 })
+    this.trackUsage(
+      model,
+      { inputTokens: result.usage?.tokens ?? 0, outputTokens: 0 },
+      request.tokenUsageSource ?? 'chat'
+    )
 
     return { embeddings: result.embeddings, usage: result.usage }
   }
@@ -1200,11 +1207,14 @@ export class AiService extends BaseService {
 
   // ── Token usage tracking ──
 
-  private trackUsage(model: Model, usage?: { inputTokens?: number; outputTokens?: number }): void {
-    if (!usage || !model.providerId || !model.apiModelId || model.providerId === 'local-provider') return
+  private trackUsage(
+    model: Model,
+    usage?: { inputTokens?: number; outputTokens?: number },
+    source: TokenUsageSource = 'chat'
+  ): void {
+    if (!usage || !model.providerId || !model.apiModelId) return
     const inputTokens = usage.inputTokens ?? 0
     const outputTokens = usage.outputTokens ?? 0
-    if (inputTokens === 0 && outputTokens === 0) return
 
     try {
       const analyticsService = application.get('AnalyticsService')
@@ -1212,7 +1222,8 @@ export class AiService extends BaseService {
         provider: model.providerId,
         model: model.apiModelId ?? model.id,
         input_tokens: inputTokens,
-        output_tokens: outputTokens
+        output_tokens: outputTokens,
+        source
       })
     } catch {
       // AnalyticsService may not be activated (data collection disabled)

--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -1201,7 +1201,7 @@ export class AiService extends BaseService {
   // ── Token usage tracking ──
 
   private trackUsage(model: Model, usage?: { inputTokens?: number; outputTokens?: number }): void {
-    if (!usage || !model.providerId || !model.apiModelId) return
+    if (!usage || !model.providerId || !model.apiModelId || model.providerId === 'local-provider') return
     const inputTokens = usage.inputTokens ?? 0
     const outputTokens = usage.outputTokens ?? 0
     if (inputTokens === 0 && outputTokens === 0) return

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -339,7 +339,8 @@ describe('AiService', () => {
       provider: 'test-provider',
       model: 'test-api-model',
       input_tokens: 3,
-      output_tokens: 5
+      output_tokens: 5,
+      source: 'chat'
     })
   })
 
@@ -371,39 +372,23 @@ describe('AiService', () => {
       provider: 'test-provider',
       model: 'test-api-model',
       input_tokens: 3,
-      output_tokens: 5
+      output_tokens: 5,
+      source: 'chat'
     })
   })
 
-  it('does not report token analytics when all token counts are zero', async () => {
+  it('reports explicitly classified token analytics as agent usage', async () => {
     const service = createService()
-    const hooks = (service as any).analyticsHookPart({
-      id: 'test-model',
-      providerId: 'test-provider',
-      apiModelId: 'test-api-model'
-    })
-
-    await hooks.onStepFinish({
-      usage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        totalTokens: 0,
-        inputTokenDetails: {},
-        outputTokenDetails: {}
-      }
-    })
-    await hooks.onFinish()
-
-    expect(mockApplicationGet).not.toHaveBeenCalled()
-  })
-
-  it('does not report token analytics for local-provider', async () => {
-    const service = createService()
-    const hooks = (service as any).analyticsHookPart({
-      id: 'test-model',
-      providerId: 'local-provider',
-      apiModelId: 'test-api-model'
-    })
+    const trackTokenUsage = vi.fn()
+    mockApplicationGet.mockReturnValue({ trackTokenUsage })
+    const hooks = (service as any).analyticsHookPart(
+      {
+        id: 'test-model',
+        providerId: 'test-provider',
+        apiModelId: 'test-api-model'
+      },
+      'agent'
+    )
 
     await hooks.onStepFinish({
       usage: {
@@ -416,7 +401,13 @@ describe('AiService', () => {
     })
     await hooks.onFinish()
 
-    expect(mockApplicationGet).not.toHaveBeenCalled()
+    expect(trackTokenUsage).toHaveBeenCalledWith({
+      provider: 'test-provider',
+      model: 'test-api-model',
+      input_tokens: 3,
+      output_tokens: 5,
+      source: 'agent'
+    })
   })
 
   it('normalizes base64 and url images from ai-core generateImage', async () => {

--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -375,6 +375,50 @@ describe('AiService', () => {
     })
   })
 
+  it('does not report token analytics when all token counts are zero', async () => {
+    const service = createService()
+    const hooks = (service as any).analyticsHookPart({
+      id: 'test-model',
+      providerId: 'test-provider',
+      apiModelId: 'test-api-model'
+    })
+
+    await hooks.onStepFinish({
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        inputTokenDetails: {},
+        outputTokenDetails: {}
+      }
+    })
+    await hooks.onFinish()
+
+    expect(mockApplicationGet).not.toHaveBeenCalled()
+  })
+
+  it('does not report token analytics for local-provider', async () => {
+    const service = createService()
+    const hooks = (service as any).analyticsHookPart({
+      id: 'test-model',
+      providerId: 'local-provider',
+      apiModelId: 'test-api-model'
+    })
+
+    await hooks.onStepFinish({
+      usage: {
+        inputTokens: 3,
+        outputTokens: 5,
+        totalTokens: 8,
+        inputTokenDetails: {},
+        outputTokenDetails: {}
+      }
+    })
+    await hooks.onFinish()
+
+    expect(mockApplicationGet).not.toHaveBeenCalled()
+  })
+
   it('normalizes base64 and url images from ai-core generateImage', async () => {
     const service = createService()
     vi.spyOn(service as never, 'buildAgentParamsFor').mockResolvedValue({

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1809,6 +1809,7 @@ export class AgentSessionRuntimeService extends BaseService {
       candidate.aliases.some((alias) => normalizeAgentSdkModelAlias(alias) === normalizedModel)
     )
     const modelId = frozenModel?.modelId ?? normalizedModel
+    const apiModelId = frozenModel?.apiModelId ?? normalizedModel
     aiUsageRecordService.recordInvocation({
       requestId: invocation.requestId,
       context: createAiUsageCaptureContext({
@@ -1831,7 +1832,7 @@ export class AgentSessionRuntimeService extends BaseService {
     try {
       application.get('AnalyticsService').trackTokenUsage({
         provider: capture.providerId,
-        model: modelId,
+        model: apiModelId,
         input_tokens: invocation.usage.inputTokens,
         output_tokens: invocation.usage.outputTokens,
         source: 'agent'

--- a/src/main/ai/agentSession/AgentSessionRuntimeService.ts
+++ b/src/main/ai/agentSession/AgentSessionRuntimeService.ts
@@ -1826,6 +1826,19 @@ export class AgentSessionRuntimeService extends BaseService {
       metrics: invocation.metrics,
       completedAt: Date.now()
     })
+
+    if (!invocation.usage) return
+    try {
+      application.get('AnalyticsService').trackTokenUsage({
+        provider: capture.providerId,
+        model: modelId,
+        input_tokens: invocation.usage.inputTokens,
+        output_tokens: invocation.usage.outputTokens,
+        source: 'agent'
+      })
+    } catch {
+      // Telemetry must never affect Agent runtime delivery.
+    }
   }
 
   private handleCompactionComplete(entry: AgentSessionRuntimeEntry, anchor?: AgentSessionCompactionAnchorData): void {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -36,7 +36,8 @@ const mocks = vi.hoisted(() => ({
   getSessionById: vi.fn(),
   getAgent: vi.fn(),
   ensureTraceId: vi.fn(),
-  recordUsage: vi.fn()
+  recordUsage: vi.fn(),
+  trackTokenUsage: vi.fn()
 }))
 
 vi.mock('@data/services/AgentSessionService', () => ({
@@ -285,6 +286,7 @@ describe('AgentSessionRuntimeService', () => {
         }
       if (name === 'ClaudeCodeWarmQueryManager')
         return { closeAll: mocks.closeWarmQueries, closeAgentSessionWarm: mocks.closeAgentSessionWarm }
+      if (name === 'AnalyticsService') return { trackTokenUsage: mocks.trackTokenUsage }
       throw new Error(`Unexpected application.get(${name})`)
     })
   })
@@ -630,6 +632,13 @@ describe('AgentSessionRuntimeService', () => {
         })
       )
     )
+    expect(mocks.trackTokenUsage).toHaveBeenCalledWith({
+      provider: 'claude-code',
+      model: 'claude-sonnet-4-5',
+      input_tokens: 10,
+      output_tokens: 5,
+      source: 'agent'
+    })
 
     events.push({ type: 'turn-complete' })
     await expect(reader.read()).resolves.toMatchObject({ done: true })
@@ -666,6 +675,13 @@ describe('AgentSessionRuntimeService', () => {
         })
       )
     )
+    expect(mocks.trackTokenUsage).toHaveBeenLastCalledWith({
+      provider: 'claude-code',
+      model: 'claude-sonnet-4-5',
+      input_tokens: 4,
+      output_tokens: 2,
+      source: 'agent'
+    })
     void service.closeSession('session-1')
   })
 
@@ -682,6 +698,7 @@ describe('AgentSessionRuntimeService', () => {
     })
 
     expect(mocks.recordUsage).not.toHaveBeenCalled()
+    expect(mocks.trackTokenUsage).not.toHaveBeenCalled()
   })
 
   describe('api_retry ephemeral status', () => {

--- a/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
+++ b/src/main/ai/agentSession/__tests__/AgentSessionRuntimeService.test.ts
@@ -544,10 +544,11 @@ describe('AgentSessionRuntimeService', () => {
         },
         frozenModels: [
           {
-            modelId: 'claude-sonnet-4-5',
+            modelId: 'configured-sonnet',
+            apiModelId: 'claude-sonnet-4-5',
             modelName: 'Claude Sonnet',
             pricingSnapshot: null,
-            aliases: ['claude-sonnet-4-5']
+            aliases: ['configured-sonnet', 'claude-sonnet-4-5']
           }
         ]
       },
@@ -606,7 +607,7 @@ describe('AgentSessionRuntimeService', () => {
           context: {
             providerId: 'claude-code',
             providerName: 'Claude Code',
-            modelId: 'claude-sonnet-4-5',
+            modelId: 'configured-sonnet',
             modelName: 'Claude Sonnet',
             pricingSnapshot: null,
             credentialReceipt: { attribution: 'explicit', id: 'key-a', masked: 'key-***' },
@@ -4739,6 +4740,7 @@ describe('AgentSessionRuntimeService', () => {
           frozenModels: [
             {
               modelId: 'claude-sonnet-4-5',
+              apiModelId: 'claude-sonnet-4-5',
               modelName: 'Claude Sonnet',
               pricingSnapshot: null,
               aliases: ['claude-sonnet-4-5']

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeRuntimeDriver.test.ts
@@ -395,7 +395,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
     mocks.consumeWarmQuery.mockResolvedValue({
@@ -406,7 +414,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
 
@@ -1463,8 +1479,20 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerName: 'Anthropic',
         source: null,
         frozenModels: [
-          { modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] },
-          { modelId: 'haiku', modelName: 'Haiku', pricingSnapshot: null, aliases: ['haiku-sdk'] }
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          },
+          {
+            modelId: 'haiku',
+            apiModelId: 'haiku-sdk',
+            modelName: 'Haiku',
+            pricingSnapshot: null,
+            aliases: ['haiku-sdk']
+          }
         ]
       }
     })
@@ -1626,7 +1654,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
     const connection = await new ClaudeCodeRuntimeDriver().connect({
@@ -1692,7 +1728,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
     const connection = await new ClaudeCodeRuntimeDriver().connect({
@@ -1768,7 +1812,13 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerName: 'LongCat',
         source: null,
         frozenModels: [
-          { modelId: 'LongCat-2.0', modelName: 'LongCat 2.0', pricingSnapshot: null, aliases: ['LongCat-2.0'] }
+          {
+            modelId: 'LongCat-2.0',
+            apiModelId: 'LongCat-2.0',
+            modelName: 'LongCat 2.0',
+            pricingSnapshot: null,
+            aliases: ['LongCat-2.0']
+          }
         ]
       }
     })
@@ -1881,7 +1931,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
     const connection = await new ClaudeCodeRuntimeDriver().connect({
@@ -1985,7 +2043,15 @@ describe('ClaudeCodeRuntimeDriver', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: { type: 'agent', id: 'agent-1', name: 'Frozen Agent', icon: null },
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet-sdk'] }]
+        frozenModels: [
+          {
+            modelId: 'sonnet',
+            apiModelId: 'sonnet-sdk',
+            modelName: 'Sonnet',
+            pricingSnapshot: null,
+            aliases: ['sonnet-sdk']
+          }
+        ]
       }
     })
     const connection = await new ClaudeCodeRuntimeDriver().connect({

--- a/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeWarmQueryManager.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/ClaudeCodeWarmQueryManager.test.ts
@@ -326,7 +326,9 @@ describe('ClaudeCodeWarmQueryManager', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet'] }]
+        frozenModels: [
+          { modelId: 'sonnet', apiModelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet'] }
+        ]
       }
     })
     const consumed = await manager.consume({
@@ -339,7 +341,9 @@ describe('ClaudeCodeWarmQueryManager', () => {
         providerId: 'anthropic',
         providerName: 'Anthropic',
         source: null,
-        frozenModels: [{ modelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet'] }]
+        frozenModels: [
+          { modelId: 'sonnet', apiModelId: 'sonnet', modelName: 'Sonnet', pricingSnapshot: null, aliases: ['sonnet'] }
+        ]
       }
     })
 

--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -580,6 +580,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       frozenModels: [
         {
           modelId: 'model-1',
+          apiModelId: 'claude-sonnet',
           modelName: 'model-1',
           pricingSnapshot: null,
           aliases: ['claude-sonnet', 'model-1']
@@ -698,9 +699,9 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
     expect(request?.usageCapture).toMatchObject({
       owner: 'agent-sdk',
       frozenModels: [
-        { modelId: 'model-1', aliases: ['model-1-api', 'model-1'] },
-        { modelId: 'model-2', aliases: ['model-2-api', 'model-2'] },
-        { modelId: 'model-3', aliases: ['model-3-api', 'model-3'] }
+        { modelId: 'model-1', apiModelId: 'model-1-api', aliases: ['model-1-api', 'model-1'] },
+        { modelId: 'model-2', apiModelId: 'model-2-api', aliases: ['model-2-api', 'model-2'] },
+        { modelId: 'model-3', apiModelId: 'model-3-api', aliases: ['model-3-api', 'model-3'] }
       ]
     })
   })
@@ -1003,6 +1004,7 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       frozenModels: [
         {
           modelId: 'sonnet',
+          apiModelId: 'sonnet-api',
           modelName: 'sonnet',
           pricingSnapshot: null,
           aliases: ['sonnet-api', 'sonnet']

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -181,6 +181,7 @@ function buildUsageModels(
   const byModelId = new Map<
     string,
     {
+      apiModelId: string
       modelName: string | null
       pricingSnapshot: ReturnType<typeof createAiUsagePricingSnapshot>
       aliases: Set<string>
@@ -188,6 +189,7 @@ function buildUsageModels(
   >()
   for (const { sdkModelId, ref } of entries) {
     const current = byModelId.get(ref.modelId) ?? {
+      apiModelId: ref.apiModelId,
       modelName: ref.model?.name ?? ref.modelId,
       pricingSnapshot: createAiUsagePricingSnapshot(ref.model?.pricing),
       aliases: new Set<string>()
@@ -199,6 +201,7 @@ function buildUsageModels(
   }
   return [...byModelId].map(([modelId, snapshot]) => ({
     modelId,
+    apiModelId: snapshot.apiModelId,
     modelName: snapshot.modelName,
     pricingSnapshot: snapshot.pricingSnapshot,
     aliases: [...snapshot.aliases]

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -246,6 +246,7 @@ export function buildDshProviderInjection(
       frozenModels: [
         {
           modelId: model.id,
+          apiModelId: modelId,
           modelName: model.name ?? model.id,
           aliases: [...new Set([model.id, modelId])],
           pricingSnapshot: createAiUsagePricingSnapshot(model.pricing)

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.test.ts
@@ -346,7 +346,9 @@ beforeEach(() => {
       providerId: 'p',
       providerName: 'P',
       source: null,
-      frozenModels: [{ modelId: 'p::m', modelName: 'M', aliases: ['p::m', 'm'], pricingSnapshot: null }]
+      frozenModels: [
+        { modelId: 'p::m', apiModelId: 'm', modelName: 'M', aliases: ['p::m', 'm'], pricingSnapshot: null }
+      ]
     }
   })
   mocks.getPath.mockImplementation((key: string) => (key === 'feature.agents.pi.root' ? PI_ROOT : PI_SESSIONS))

--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -341,6 +341,7 @@ describe('buildPiProviderInjection', () => {
       frozenModels: [
         {
           modelId: 'anthropic::claude',
+          apiModelId: 'claude-sonnet-4',
           modelName: 'Sonnet',
           aliases: ['anthropic::claude', 'claude-sonnet-4'],
           pricingSnapshot: null

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -196,6 +196,7 @@ export function buildPiProviderInjection(
       frozenModels: [
         {
           modelId: model.id,
+          apiModelId: modelId,
           modelName: model.name ?? model.id,
           aliases: [...new Set([model.id, modelId])],
           pricingSnapshot: createAiUsagePricingSnapshot(model.pricing)

--- a/src/main/ai/runtime/types.ts
+++ b/src/main/ai/runtime/types.ts
@@ -31,6 +31,7 @@ export type AgentSessionUsageCapture =
       source: SourceSnapshot | null
       frozenModels: ReadonlyArray<{
         modelId: string
+        apiModelId: string
         modelName: string | null
         aliases: readonly string[]
         pricingSnapshot: AiUsagePricingSnapshot | null

--- a/src/main/ai/streamManager/AiStreamManager.ts
+++ b/src/main/ai/streamManager/AiStreamManager.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 
 import { application } from '@application'
+import type { TokenUsageSource } from '@cherrystudio/analytics-client'
 import { loggerService } from '@logger'
 import { DEFAULT_TIMEOUT } from '@main/ai/constants'
 import { serializeError } from '@main/ai/utils/serializeError'
@@ -70,7 +71,10 @@ import type {
 import { withReasoningTimingMetadata } from './withReasoningTimingMetadata'
 
 const logger = loggerService.withContext('AiStreamManager')
-type ManagedAiStreamRequest = AiStreamRequest & { usageContext?: InProcessUsageContext }
+type ManagedAiStreamRequest = AiStreamRequest & {
+  usageContext?: InProcessUsageContext
+  tokenUsageSource?: TokenUsageSource
+}
 
 // Renderer→main stream requests (open/attach/detach/abort) are validated by the IpcApi
 // router against `aiRequestSchemas` (src/shared/ipc/schemas/ai.ts) before reaching the
@@ -882,6 +886,8 @@ export class AiStreamManager extends BaseService {
     idleTimeoutMs?: number
     /** In-process agent correlation for gateway-owned provider-request records. */
     usageContext?: InProcessUsageContext
+    /** Trusted in-process classification for remote token analytics. */
+    tokenUsageSource?: TokenUsageSource
   }): SendResult {
     const messages: CherryUIMessage[] =
       input.messages && input.messages.length > 0
@@ -898,6 +904,7 @@ export class AiStreamManager extends BaseService {
       contextOwner: input.contextOwner,
       reasoningEffort: input.reasoningEffort,
       ...(input.usageContext ? { usageContext: input.usageContext } : {}),
+      ...(input.tokenUsageSource ? { tokenUsageSource: input.tokenUsageSource } : {}),
       ...(input.idleTimeoutMs !== undefined ? { requestOptions: { timeout: input.idleTimeoutMs } } : {})
     }
     return this.send({

--- a/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
+++ b/src/main/ai/streamManager/__tests__/AiStreamManager.test.ts
@@ -302,6 +302,7 @@ describe('AiStreamManager', () => {
         messages: [{ id: 'user-1', role: 'user', parts: [{ type: 'text', text: 'hello' }] }],
         listener: new FakeListener('gateway:request-1'),
         contextOwner: 'caller',
+        tokenUsageSource: 'agent',
         usageContext: {
           agentSessionId: 'session-1',
           assistantMessageId: 'message-1',
@@ -309,7 +310,9 @@ describe('AiStreamManager', () => {
         }
       })
 
-      expect(mockStreamText).toHaveBeenCalledWith(expect.objectContaining({ chatId: 'session-1' }))
+      expect(mockStreamText).toHaveBeenCalledWith(
+        expect.objectContaining({ chatId: 'session-1', tokenUsageSource: 'agent' })
+      )
     })
   })
 

--- a/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
+++ b/src/main/features/apiGateway/__tests__/proxyStream.stream.test.ts
@@ -570,6 +570,7 @@ describe('processMessage (streaming)', () => {
       agentSessionId: 'session-1',
       source: { type: 'agent', id: 'agent-1', name: 'Original Agent', icon: '🧠' }
     }
+    mockIsInternalAgentRequest.mockReturnValue(true)
     mockResolveAgentSessionUsage.mockReturnValue(usageContext)
     const requestHeaders = new Headers({ 'x-cherry-internal-usage-token': 'proof' })
     const response = processMessage({
@@ -581,7 +582,26 @@ describe('processMessage (streaming)', () => {
     await vi.waitFor(() => expect(captured.listener).toBeDefined())
 
     expect(mockResolveAgentSessionUsage).toHaveBeenCalledWith(requestHeaders)
-    expect(mockStreamPrompt).toHaveBeenCalledWith(expect.objectContaining({ usageContext }))
+    expect(mockStreamPrompt).toHaveBeenCalledWith(expect.objectContaining({ tokenUsageSource: 'agent', usageContext }))
+
+    commit(captured.listener!)
+    await captured.listener!.onDone({} as any)
+    await response
+  })
+
+  it('marks internal Agent usage when no active turn correlation is available', async () => {
+    mockIsInternalAgentRequest.mockReturnValue(true)
+    const response = processMessage({
+      params: { model: 'openai:gpt-4', stream: true, messages: [] } as any,
+      inputFormat: 'openai',
+      outputFormat: 'openai',
+      requestHeaders: new Headers({ 'x-cherry-internal-usage-token': 'proof' })
+    })
+    await vi.waitFor(() => expect(captured.listener).toBeDefined())
+
+    const streamPromptInput = mockStreamPrompt.mock.calls[0][0]
+    expect(streamPromptInput).toEqual(expect.objectContaining({ tokenUsageSource: 'agent' }))
+    expect(streamPromptInput).not.toHaveProperty('usageContext')
 
     commit(captured.listener!)
     await captured.listener!.onDone({} as any)
@@ -690,6 +710,21 @@ describe('processMessage (streaming)', () => {
     const res = await resPromise
     expect(res.headers.get('Content-Type')).toBe('application/json')
     await expect(res.json()).resolves.toEqual({ done: true })
+  })
+
+  it('marks non-streaming internal Agent usage as agent usage', async () => {
+    mockIsInternalAgentRequest.mockReturnValue(true)
+    const resPromise = processMessage({
+      params: { model: 'openai:gpt-4', messages: [] } as any,
+      inputFormat: 'openai',
+      outputFormat: 'openai',
+      requestHeaders: new Headers({ 'x-cherry-internal-usage-token': 'proof' })
+    })
+
+    await vi.waitFor(() => expect(captured.listener).toBeDefined())
+    expect(mockStreamPrompt).toHaveBeenCalledWith(expect.objectContaining({ tokenUsageSource: 'agent' }))
+    await captured.listener!.onDone({} as any)
+    await resPromise
   })
 })
 

--- a/src/main/features/apiGateway/proxyStream.ts
+++ b/src/main/features/apiGateway/proxyStream.ts
@@ -384,6 +384,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
             callOverrides,
             contextOwner: 'caller',
             ...(usageContext ? { usageContext } : {}),
+            ...(isInternalAgentRequest ? { tokenUsageSource: 'agent' as const } : {}),
             idleTimeoutMs: GATEWAY_STREAM_IDLE_TIMEOUT_MS
           })
         } catch (error) {
@@ -467,6 +468,7 @@ export async function processMessage(config: MessageConfig): Promise<Response> {
       callOverrides,
       contextOwner: 'caller',
       ...(usageContext ? { usageContext } : {}),
+      ...(isInternalAgentRequest ? { tokenUsageSource: 'agent' as const } : {}),
       idleTimeoutMs: GATEWAY_STREAM_IDLE_TIMEOUT_MS
     })
 

--- a/src/main/services/AnalyticsService.ts
+++ b/src/main/services/AnalyticsService.ts
@@ -100,13 +100,7 @@ export class AnalyticsService extends BaseService implements Activatable {
   }
 
   public trackTokenUsage(data: TokenUsageData): void {
-    if (
-      !this.isActivated ||
-      !this.desiredEnabled ||
-      data.provider === 'local-provider' ||
-      (data.input_tokens === 0 && data.output_tokens === 0)
-    )
-      return
+    if (!this.isActivated || !this.desiredEnabled || (data.input_tokens === 0 && data.output_tokens === 0)) return
     this.client!.trackTokenUsage(data)
   }
 

--- a/src/main/services/AnalyticsService.ts
+++ b/src/main/services/AnalyticsService.ts
@@ -100,7 +100,13 @@ export class AnalyticsService extends BaseService implements Activatable {
   }
 
   public trackTokenUsage(data: TokenUsageData): void {
-    if (!this.isActivated || !this.desiredEnabled) return
+    if (
+      !this.isActivated ||
+      !this.desiredEnabled ||
+      data.provider === 'local-provider' ||
+      (data.input_tokens === 0 && data.output_tokens === 0)
+    )
+      return
     this.client!.trackTokenUsage(data)
   }
 

--- a/src/main/services/__tests__/AnalyticsService.test.ts
+++ b/src/main/services/__tests__/AnalyticsService.test.ts
@@ -147,3 +147,59 @@ describe('AnalyticsService data collection preference', () => {
     expect(service.isActivated).toBe(true)
   })
 })
+
+describe('AnalyticsService token usage', () => {
+  it('forwards reportable usage without changing its source', async () => {
+    const service = new AnalyticsService()
+    await service._doInit()
+    await vi.waitFor(() => expect(service.isActivated).toBe(true))
+
+    service.trackTokenUsage({
+      provider: 'test-provider',
+      model: 'test-model',
+      input_tokens: 3,
+      output_tokens: 5,
+      source: 'agent'
+    })
+
+    expect(mockTrackTokenUsage).toHaveBeenCalledWith({
+      provider: 'test-provider',
+      model: 'test-model',
+      input_tokens: 3,
+      output_tokens: 5,
+      source: 'agent'
+    })
+  })
+
+  it('does not forward usage when all token counts are zero', async () => {
+    const service = new AnalyticsService()
+    await service._doInit()
+    await vi.waitFor(() => expect(service.isActivated).toBe(true))
+
+    service.trackTokenUsage({
+      provider: 'test-provider',
+      model: 'test-model',
+      input_tokens: 0,
+      output_tokens: 0,
+      source: 'agent'
+    })
+
+    expect(mockTrackTokenUsage).not.toHaveBeenCalled()
+  })
+
+  it('does not forward local-provider usage', async () => {
+    const service = new AnalyticsService()
+    await service._doInit()
+    await vi.waitFor(() => expect(service.isActivated).toBe(true))
+
+    service.trackTokenUsage({
+      provider: 'local-provider',
+      model: 'test-model',
+      input_tokens: 3,
+      output_tokens: 5,
+      source: 'agent'
+    })
+
+    expect(mockTrackTokenUsage).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/services/__tests__/AnalyticsService.test.ts
+++ b/src/main/services/__tests__/AnalyticsService.test.ts
@@ -186,20 +186,4 @@ describe('AnalyticsService token usage', () => {
 
     expect(mockTrackTokenUsage).not.toHaveBeenCalled()
   })
-
-  it('does not forward local-provider usage', async () => {
-    const service = new AnalyticsService()
-    await service._doInit()
-    await vi.waitFor(() => expect(service.isActivated).toBe(true))
-
-    service.trackTokenUsage({
-      provider: 'local-provider',
-      model: 'test-model',
-      input_tokens: 3,
-      output_tokens: 5,
-      source: 'agent'
-    })
-
-    expect(mockTrackTokenUsage).not.toHaveBeenCalled()
-  })
 })

--- a/src/main/services/__tests__/AnalyticsService.test.ts
+++ b/src/main/services/__tests__/AnalyticsService.test.ts
@@ -171,6 +171,28 @@ describe('AnalyticsService token usage', () => {
     })
   })
 
+  it('forwards embedding usage when output tokens are zero', async () => {
+    const service = new AnalyticsService()
+    await service._doInit()
+    await vi.waitFor(() => expect(service.isActivated).toBe(true))
+
+    service.trackTokenUsage({
+      provider: 'test-provider',
+      model: 'test-embedding-model',
+      input_tokens: 42,
+      output_tokens: 0,
+      source: 'chat'
+    })
+
+    expect(mockTrackTokenUsage).toHaveBeenCalledWith({
+      provider: 'test-provider',
+      model: 'test-embedding-model',
+      input_tokens: 42,
+      output_tokens: 0,
+      source: 'chat'
+    })
+  })
+
   it('does not forward usage when all token counts are zero', async () => {
     const service = new AnalyticsService()
     await service._doInit()


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: token telemetry could include `local-provider` usage, while the analytics client remained on 1.3.0.

After this PR: the client is updated to 1.3.1, and all-zero or `local-provider` token usage is excluded from reporting with regression coverage.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: filtering stays at the existing centralized `AiService.trackUsage` boundary.

The following alternatives were considered: filtering only in `AnalyticsService`; this was not chosen because `AiService` already owns token normalization and the all-zero guard.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validation: focused token analytics tests (4 passed), `pnpm lint`, and `git diff --check`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
