### PR TITLE
fix(api): expose cached tokens in chat completions

### DIFF
--- a/src/main/features/apiGateway/adapters/__tests__/AiSdkToOpenAiSse.test.ts
+++ b/src/main/features/apiGateway/adapters/__tests__/AiSdkToOpenAiSse.test.ts
@@ -14,6 +14,7 @@ const createReasoningDelta = (text: string, id = 'reason_0'): UIMessageChunk => 
 interface GatewayUsage {
   inputTokens?: number
   outputTokens?: number
+  cacheReadTokens?: number
 }
 
 const createFinish = (finishReason: FinishReason | undefined = 'stop', usage?: GatewayUsage): UIMessageChunk => {
@@ -23,7 +24,10 @@ const createFinish = (finishReason: FinishReason | undefined = 'stop', usage?: G
           stats: {
             totalTokens: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
             inputTokens: usage.inputTokens ?? 0,
-            outputTokens: usage.outputTokens ?? 0
+            outputTokens: usage.outputTokens ?? 0,
+            ...(usage.cacheReadTokens !== undefined
+              ? { inputTokenDetails: { cacheReadTokens: usage.cacheReadTokens } }
+              : {})
           }
         }
       : undefined
@@ -146,14 +150,28 @@ describe('AiSdkToOpenAiSse', () => {
   })
 
   describe('Usage Tracking', () => {
-    it('projects prompt/completion tokens onto the terminal usage', async () => {
+    it('projects cached prompt tokens onto the terminal usage without adding them to totals', async () => {
       const adapter = new AiSdkToOpenAiSse({ model: 'openai:gpt-4' })
       const stream = createMockStream([
         createTextDelta('hi'),
-        createFinish('stop', { inputTokens: 12, outputTokens: 7 })
+        createFinish('stop', { inputTokens: 12, outputTokens: 7, cacheReadTokens: 9 })
       ])
       const events = await collectEvents(adapter.transform(stream))
-      expect(events.at(-1)!.usage).toMatchObject({ prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 })
+      expect(events.at(-1)!.usage).toEqual({
+        prompt_tokens: 12,
+        completion_tokens: 7,
+        total_tokens: 19,
+        prompt_tokens_details: { cached_tokens: 9 }
+      })
+    })
+
+    it('omits prompt token details when the provider does not report cache usage', async () => {
+      const adapter = new AiSdkToOpenAiSse({ model: 'openai:gpt-4' })
+      const events = await collectEvents(
+        adapter.transform(createMockStream([createFinish('stop', { inputTokens: 12, outputTokens: 7 })]))
+      )
+
+      expect(events.at(-1)!.usage).toEqual({ prompt_tokens: 12, completion_tokens: 7, total_tokens: 19 })
     })
   })
 
@@ -186,6 +204,26 @@ describe('AiSdkToOpenAiSse', () => {
         function: { name: 'test', arguments: JSON.stringify({ arg: 'value' }) }
       })
       expect(response.usage).toMatchObject({ prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 })
+    })
+
+    it('preserves an explicit zero cached-token count', async () => {
+      const adapter = new AiSdkToOpenAiSse({ model: 'openai:gpt-4' })
+      const stream = createMockStream([
+        createTextDelta('Hello world'),
+        createFinish('stop', { inputTokens: 10, outputTokens: 20, cacheReadTokens: 0 })
+      ])
+      const reader = adapter.transform(stream).getReader()
+      while (!(await reader.read()).done) {
+        /* drain to populate state */
+      }
+      reader.releaseLock()
+
+      expect(adapter.buildNonStreamingResponse().usage).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 20,
+        total_tokens: 30,
+        prompt_tokens_details: { cached_tokens: 0 }
+      })
     })
   })
 

--- a/src/main/features/apiGateway/adapters/interfaces.ts
+++ b/src/main/features/apiGateway/adapters/interfaces.ts
@@ -17,14 +17,17 @@ import type { ToolSet, UIMessageChunk } from 'ai'
  * Token usage carried on `message-metadata` UIMessageChunks emitted by main's
  * `AiService.streamText`: the nested `stats` snapshot (Cherry `MessageStats`,
  * AI SDK v6 names) is the single carrier — the gateway SSE adapters read the
- * input/output totals from it, plus the reasoning breakdown for dialects that
- * expose one (Gemini's `usageMetadata.thoughtsTokenCount`).
+ * input/output totals from it, plus the cache-read and reasoning breakdowns
+ * for dialects that expose them.
  */
 export interface GatewayUsageMetadata {
   stats?: {
     totalTokens?: number
     inputTokens?: number
     outputTokens?: number
+    inputTokenDetails?: {
+      cacheReadTokens?: number
+    }
     outputTokenDetails?: {
       reasoningTokens?: number
     }
@@ -202,6 +205,7 @@ export interface AdapterState {
   messageId: string
   model: string
   inputTokens: number
+  cacheReadTokens?: number
   outputTokens: number
   currentBlockIndex: number
   blocks: Map<number, ContentBlockState>

--- a/src/main/features/apiGateway/adapters/stream/AiSdkToOpenAiSse.ts
+++ b/src/main/features/apiGateway/adapters/stream/AiSdkToOpenAiSse.ts
@@ -193,7 +193,21 @@ export class AiSdkToOpenAiSse extends BaseStreamAdapter<OpenAiCompatibleChunk> {
   private applyUsageMetadata(metadata: GatewayUsageMetadata | undefined): void {
     if (!metadata) return
     if (metadata.stats?.inputTokens !== undefined) this.state.inputTokens = metadata.stats.inputTokens
+    if (metadata.stats?.inputTokenDetails?.cacheReadTokens !== undefined) {
+      this.state.cacheReadTokens = metadata.stats.inputTokenDetails.cacheReadTokens
+    }
     if (metadata.stats?.outputTokens !== undefined) this.state.outputTokens = metadata.stats.outputTokens
+  }
+
+  private buildUsage(): NonNullable<ChatCompletion['usage']> {
+    return {
+      prompt_tokens: this.state.inputTokens,
+      completion_tokens: this.state.outputTokens,
+      total_tokens: this.state.inputTokens + this.state.outputTokens,
+      ...(this.state.cacheReadTokens !== undefined
+        ? { prompt_tokens_details: { cached_tokens: this.state.cacheReadTokens } }
+        : {})
+    }
   }
 
   private emitContentDelta(content: string): void {
@@ -318,11 +332,7 @@ export class AiSdkToOpenAiSse extends BaseStreamAdapter<OpenAiCompatibleChunk> {
           finish_reason: this.finishReason || 'stop'
         }
       ],
-      usage: {
-        prompt_tokens: this.state.inputTokens,
-        completion_tokens: this.state.outputTokens,
-        total_tokens: this.state.inputTokens + this.state.outputTokens
-      }
+      usage: this.buildUsage()
     }
 
     this.emit(finalChunk)
@@ -379,11 +389,7 @@ export class AiSdkToOpenAiSse extends BaseStreamAdapter<OpenAiCompatibleChunk> {
           logprobs: null
         }
       ],
-      usage: {
-        prompt_tokens: this.state.inputTokens,
-        completion_tokens: this.state.outputTokens,
-        total_tokens: this.state.inputTokens + this.state.outputTokens
-      }
+      usage: this.buildUsage()
     }
   }
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The OpenAI-compatible `/v1/chat/completions` endpoint returned prompt, completion, and total token counts but discarded `inputTokenDetails.cacheReadTokens`. Clients therefore could not observe prompt cache hits.

After this PR:

Streaming and non-streaming chat-completions responses include `prompt_tokens_details.cached_tokens` whenever the provider reports a cache-read value. An explicit zero is preserved, while an unknown value remains omitted. Cached tokens are not added to the existing totals.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19338

### Why we need it and why it was done in this way

Cherry's upstream usage metadata already carries `inputTokenDetails.cacheReadTokens`. This change extends the API Gateway's narrow metadata projection and retains the value while assembling OpenAI-compatible responses.

A shared usage builder is used by both streaming and non-streaming output paths so their token accounting cannot diverge.

The following tradeoffs were made:

- The optional detail is emitted only when the upstream provider reports it.
- This PR changes only the OpenAI chat-completions dialect.
- Existing prompt, completion, and total token calculations remain unchanged.

The following alternatives were considered:

- Deriving cached tokens from totals, which is not possible reliably.
- Always returning zero, which would incorrectly conflate an unknown value with a confirmed cache miss.
- Maintaining separate streaming and non-streaming assembly logic, which would duplicate behavior.

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/issues/19338

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

The response uses the existing OpenAI SDK `CompletionUsage` type, which already defines `prompt_tokens_details.cached_tokens`.

Validation:

- Focused adapter suite: 14 tests passed.
- Node TypeScript typecheck passed.
- Biome and ESLint checks passed.
- Full repository lint completed successfully.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
OpenAI-compatible chat completions now report cached prompt tokens in their usage metadata.
```
