### PR TITLE
docs(cherry-electron-dev): fix broken diagnostics link

### DIFF
--- a/.agents/skills/cherry-electron-dev/references/performance-debugging.md
+++ b/.agents/skills/cherry-electron-dev/references/performance-debugging.md
@@ -243,7 +243,7 @@ owns the CPU or memory.
 ### Prefer the built-in main-process diagnostics
 
 For startup, lifecycle, database, DataApi, or IPC latency, first read
-[Performance Diagnostics](../../../../docs/guides/diagnostics.md). Restart the
+[Performance Diagnostics](../../../../docs/references/diagnostics/README.md). Restart the
 tracked instance with `CS_DIAGNOSTICS=1` prepended to its existing launch
 command only when the restart is justified by the question. The opt-in path
 provides:


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`main` CI (`basic-checks` → Read-only Checks) fails on `pnpm docs:check`: `.agents/skills/cherry-electron-dev/references/performance-debugging.md` links to `docs/guides/diagnostics.md`, which does not exist.

After this PR:

The link points at the real doc, `docs/references/diagnostics/README.md`, and `pnpm docs:check` passes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: None — one-character-class link retarget, no content rewritten.

The following alternatives were considered: Creating `docs/guides/diagnostics.md`; rejected because the diagnostics doc already exists under `docs/references/diagnostics/` and `docs/guides/` is not part of the docs structure closed set.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/32808589501/job/97683469582

### Breaking changes

None.

### Special notes for your reviewer

Broken link was introduced by e5da21ef7e (`docs(cherry-electron-dev): expand performance diagnostics`). Every other sub-check in the failing job already exited 0; this was the only failure.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
