### PR TITLE
fix(ai-provider): tolerate missing annotations in OpenAI Responses replies

### DIFF
--- a/patches/@ai-sdk__openai@3.0.53.patch
+++ b/patches/@ai-sdk__openai@3.0.53.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..2e4f1a303666d5dde57f7eee1aed7bd90193a84e 100644
+index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..9489a0c2b109af4865e2c76ac80fb7b9af5b4c95 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -737,7 +737,7 @@ var OpenAIChatLanguageModel = class {
@@ -111,6 +111,15 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..2e4f1a303666d5dde57f7eee1aed7bd9
        import_v421.z.object({
          type: import_v421.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v421.z.string(),
+@@ -3878,7 +3903,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils26.lazySchema)(
+                       index: import_v421.z.number()
+                     })
+                   ])
+-                )
++                ).nullish().transform((v) => v ?? [])
+               })
+             )
+           }),
 @@ -4812,7 +4837,7 @@ var OpenAIResponsesLanguageModel = class {
          }
        }
@@ -139,7 +148,7 @@ index 1c78d6f13caed5cbfa034d86f5e51729d540a1ba..2e4f1a303666d5dde57f7eee1aed7bd9
                if (store) {
                  controller.enqueue({
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..0f9e7c9d4055f92619e7389799bc227c080ce008 100644
+index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..4536cc06d7026fa76b9af104fc652335c1deac09 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
 @@ -728,7 +728,7 @@ var OpenAIChatLanguageModel = class {
@@ -251,6 +260,15 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..0f9e7c9d4055f92619e7389799bc227c
        z21.object({
          type: z21.literal("response.reasoning_summary_part.done"),
          item_id: z21.string(),
+@@ -3955,7 +3980,7 @@ var openaiResponsesResponseSchema = lazySchema19(
+                       index: z21.number()
+                     })
+                   ])
+-                )
++                ).nullish().transform((v) => v ?? [])
+               })
+             )
+           }),
 @@ -4891,7 +4916,7 @@ var OpenAIResponsesLanguageModel = class {
          }
        }
@@ -279,7 +297,7 @@ index 3dee8855a0cff4c2d5bef4ff1cb2a92a48bd8c4f..0f9e7c9d4055f92619e7389799bc227c
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..fb4082853ddb20ce66c7ae7e5b2581e4a8cba40a 100644
+index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..b05a907baa10ed0323d6b5abc48e613025a06a07 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
 @@ -764,7 +764,7 @@ var OpenAIChatLanguageModel = class {
@@ -391,6 +409,15 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..fb4082853ddb20ce66c7ae7e5b2581e4
        import_v417.z.object({
          type: import_v417.z.literal("response.reasoning_summary_part.done"),
          item_id: import_v417.z.string(),
+@@ -3820,7 +3845,7 @@ var openaiResponsesResponseSchema = (0, import_provider_utils24.lazySchema)(
+                       index: import_v417.z.number()
+                     })
+                   ])
+-                )
++                ).nullish().transform((v) => v ?? [])
+               })
+             )
+           }),
 @@ -5073,7 +5098,7 @@ var OpenAIResponsesLanguageModel = class {
          }
        }
@@ -419,7 +446,7 @@ index 27527ce4b6c232e26c4bed988292d8fdd5dbbb5f..fb4082853ddb20ce66c7ae7e5b2581e4
                if (store) {
                  controller.enqueue({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index db50beda01459008c836cd5648e024340fe31e90..8944669a00acc033bbd2c2faa04c04a2d32bbef9 100644
+index db50beda01459008c836cd5648e024340fe31e90..412e91203d5a79b44cf5570a66d831fe9cd7493b 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
 @@ -720,7 +720,7 @@ var OpenAIChatLanguageModel = class {
@@ -531,6 +558,15 @@ index db50beda01459008c836cd5648e024340fe31e90..8944669a00acc033bbd2c2faa04c04a2
        z17.object({
          type: z17.literal("response.reasoning_summary_part.done"),
          item_id: z17.string(),
+@@ -3846,7 +3871,7 @@ var openaiResponsesResponseSchema = lazySchema15(
+                       index: z17.number()
+                     })
+                   ])
+-                )
++                ).nullish().transform((v) => v ?? [])
+               })
+             )
+           }),
 @@ -5129,7 +5154,7 @@ var OpenAIResponsesLanguageModel = class {
          }
        }
@@ -661,7 +697,7 @@ index ad42deeedaf1a9c3fdb578aadb0e295a5499ec39..56ed9e241cbdeb327878345b3852159d
  
  export type OpenAIResponsesReasoningProviderOptions = z.infer<
 diff --git a/src/responses/openai-responses-api.ts b/src/responses/openai-responses-api.ts
-index 53a3f242d81d0b52d9126b0f4580a30778373606..715f51cb5d5cc3a2f5cbd537e8d508936d7cb2df 100644
+index 53a3f242d81d0b52d9126b0f4580a30778373606..b478c2cd2af3112592255d010f67b61187cb4f2b 100644
 --- a/src/responses/openai-responses-api.ts
 +++ b/src/responses/openai-responses-api.ts
 @@ -985,6 +985,11 @@ export const openaiResponsesChunkSchema = lazySchema(() =>
@@ -676,6 +712,15 @@ index 53a3f242d81d0b52d9126b0f4580a30778373606..715f51cb5d5cc3a2f5cbd537e8d50893
        z.object({
          type: z.literal('response.reasoning_summary_part.done'),
          item_id: z.string(),
+@@ -1111,7 +1116,7 @@ export const openaiResponsesResponseSchema = lazySchema(() =>
+                         index: z.number(),
+                       }),
+                     ]),
+-                  ),
++                  ).nullish().transform((v) => v ?? []),
+                 }),
+               ),
+             }),
 diff --git a/src/responses/openai-responses-language-model.ts b/src/responses/openai-responses-language-model.ts
 index fe9616c8119e0d81750b4b367115aa1e58c9bc3d..ee29c4bf14104ceb2e5ce1dafe816828b14018cb 100644
 --- a/src/responses/openai-responses-language-model.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ patchedDependencies:
   '@ai-sdk/google@3.0.64': aa5ab9dff5281d7b3c163e6724fc727980aee1b3f921e504ae4b266be7c5912a
   '@ai-sdk/open-responses@1.0.34': 7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648
   '@ai-sdk/openai-compatible@2.0.62': 7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966
-  '@ai-sdk/openai@3.0.53': 50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee
+  '@ai-sdk/openai@3.0.53': 9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c
   '@ai-sdk/react@3.0.187': 8182f09c37c2d080e4794d30401712c0605e986e985380ea76699758f2ed7230
   '@ai-sdk/xai@3.0.111': 14ac373f04d53e60b277485bdcc1e590b2a2e17dfbe28575f5098c108a32977e
   '@napi-rs/system-ocr@1.1.0': aa1a73e445ee644774745b620589bb99d85bee6c95cc2a91fe9137e580da5bde
@@ -260,7 +260,7 @@ importers:
         version: 1.0.34(patch_hash=7a7a5a05a06775293425dfb63c279d62fded2d6ac0667ba64664cc43bfef0648)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)
+        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: 2.0.62
         version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
@@ -1434,7 +1434,7 @@ importers:
         version: 3.0.64(patch_hash=aa5ab9dff5281d7b3c163e6724fc727980aee1b3f921e504ae4b266be7c5912a)(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.4.3)
+        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.4.3)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.4.3)
@@ -1471,7 +1471,7 @@ importers:
         version: 3.0.64(patch_hash=aa5ab9dff5281d7b3c163e6724fc727980aee1b3f921e504ae4b266be7c5912a)(zod@4.3.4)
       '@ai-sdk/openai':
         specifier: ^3.0.53
-        version: 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)
+        version: 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.62
         version: 2.0.62(patch_hash=7130c492d179d6e18e356f38e8c8d5a3a12ef14c253743842dfe61b9f61e0966)(zod@4.3.4)
@@ -16001,7 +16001,7 @@ snapshots:
 
   '@ai-sdk/azure@3.0.54(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/openai': 3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)
+      '@ai-sdk/openai': 3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
@@ -16124,13 +16124,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.3.4)':
+  '@ai-sdk/openai@3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/openai@3.0.53(patch_hash=50619577d7cf96a09abeecda737973c96a6322848afd76a778923d094e2d07ee)(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.53(patch_hash=9d370fa143fdb495dc3e197872be775853e61aa51fc2d3b3e1afd8279883e55c)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)

--- a/src/main/ai/provider/__tests__/openaiResponsesAnnotationsPatch.test.ts
+++ b/src/main/ai/provider/__tests__/openaiResponsesAnnotationsPatch.test.ts
@@ -1,0 +1,46 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { describe, expect, it } from 'vitest'
+
+// Guards patches/@ai-sdk__openai@3.0.53.patch. The upstream non-streaming Responses schema
+// requires `annotations` on every output_text part, but third-party Responses implementations
+// (Volcano Ark's Agent plan, #19337) omit it entirely — a valid HTTP 200 that, unpatched, fails
+// schema validation (AI_TypeValidationError) and breaks every non-streaming call. The patch
+// defaults the field to []. If an SDK upgrade drops the patch, this test fails loudly.
+describe('patched @ai-sdk/openai responses schema tolerates a missing annotations field', () => {
+  it('parses a 200 whose output_text part omits annotations', async () => {
+    const body = {
+      id: 'resp_1',
+      created_at: 1787598519,
+      model: 'deepseek-v4-pro',
+      object: 'response',
+      status: 'completed',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          id: 'msg_1',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'Hello! How can I help you today?' }]
+        }
+      ],
+      usage: { input_tokens: 6, output_tokens: 9, total_tokens: 15 }
+    }
+    const model = createOpenAI({
+      apiKey: 'test',
+      fetch: async () =>
+        new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } })
+    }).responses('deepseek-v4-pro')
+
+    const result = await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]
+    })
+
+    expect(result.content).toEqual([
+      {
+        type: 'text',
+        text: 'Hello! How can I help you today?',
+        providerMetadata: { openai: { itemId: 'msg_1' } }
+      }
+    ])
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: with the `OpenAI Responses` chat protocol, any non-streaming call to a third-party provider that omits `annotations` on an `output_text` part (Volcano Ark "Agent plan") failed with `AI_TypeValidationError` — a valid HTTP 200 rejected by schema validation, so every chat against those models was broken.

After this PR: `patches/@ai-sdk__openai@3.0.53.patch` gains one hunk making `output[].content[].annotations` in `openaiResponsesResponseSchema` `.nullish()` and defaulting it to `[]`, so such replies parse and render normally.

Fixes #19337

### Why we need it and why it was done in this way

The following tradeoffs were made: the fix lives in the vendored patch rather than app code because the strict schema is inside `@ai-sdk/openai`; `.nullish().transform((v) => v ?? [])` is used instead of `.default([])` because `openai-responses-language-model.ts` reads `contentPart.annotations.length` directly and some providers send an explicit `null`. Only the non-streaming schema needed relaxing — the streaming chunk schema already types `annotations` as optional, and Chat Completions is already `.nullish()` upstream, which is why switching protocols back worked.

The following alternatives were considered: migrating third-party Responses providers to `@ai-sdk/open-responses` (issue #13462) was rejected — that package parses far fewer stream events and drops annotations entirely, i.e. it would silently lose built-in-search citations and image/file outputs to fix a missing-field problem.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19337

### Breaking changes

None.

### Special notes for your reviewer

`src/main/ai/provider/__tests__/openaiResponsesAnnotationsPatch.test.ts` guards the hunk the same way `anthropicThinkingSignaturePatch.test.ts` does — if an SDK upgrade drops the patch, the test fails loudly. `pnpm-lock.yaml` only changes the `@ai-sdk/openai` patch hash.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the OpenAI Responses protocol failing with AI_TypeValidationError against third-party providers (e.g. Volcano Ark Agent plan) that omit the `annotations` field in their replies.
```
