### PR TITLE
fix(claude-code): block image reads for text-only models

### DIFF
--- a/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts
@@ -1,5 +1,5 @@
 import { REASONING_FORMAT_PROFILES } from '@cherrystudio/provider-registry'
-import { ENDPOINT_TYPE, type EndpointType, type Model } from '@shared/data/types/model'
+import { ENDPOINT_TYPE, type EndpointType, type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -227,6 +227,34 @@ describe('buildClaudeCodeQueryRequestForAgentSession resume-token precedence', (
       expect.anything()
     )
     expect(request?.knowledgeBaseIds).toEqual(['kb-selected'])
+  })
+
+  it('passes native image support from the captured connection model into settings', async () => {
+    mocks.getModelByKey.mockReturnValue({
+      id: 'model-1',
+      apiModelId: 'claude-sonnet',
+      capabilities: [MODEL_CAPABILITY.IMAGE_RECOGNITION]
+    })
+
+    await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(mocks.buildSessionSettings).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ supportsImages: true }),
+      expect.anything()
+    )
+
+    mocks.getModelByKey.mockReturnValue({ id: 'model-1', apiModelId: 'text-only', capabilities: [] })
+
+    await buildClaudeCodeQueryRequestForAgentSession('session-1')
+
+    expect(mocks.buildSessionSettings).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ supportsImages: false }),
+      expect.anything()
+    )
   })
 
   it('pins the rebuild baseline to the context window used to materialize settings', async () => {

--- a/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts
@@ -94,6 +94,44 @@ describe('CLAUDE_TOOL_GUARD_RULES', () => {
     })
   })
 
+  describe('unsupported-image-read', () => {
+    it.each(['default', 'acceptEdits', 'bypassPermissions'] as const)(
+      'denies image reads for a text-only model under %s',
+      async (mode) => {
+        const decision = await evaluate(
+          makeCtx({
+            toolName: 'Read',
+            input: { file_path: '/ws/assets/Preview.PNG' },
+            permissionMode: mode,
+            supportsImages: false
+          })
+        )
+
+        expect(decision).toEqual({
+          effect: 'deny',
+          reason:
+            'The selected model does not support image input, so Read cannot open /ws/assets/Preview.PNG. Use a vision-capable model or inspect the file through a text-only alternative.',
+          ruleId: 'unsupported-image-read'
+        })
+      }
+    )
+
+    it('allows image reads for vision models and non-image reads for text-only models', async () => {
+      await expect(
+        evaluate(
+          makeCtx({
+            toolName: 'Read',
+            input: { file_path: '/ws/assets/Preview.png' },
+            supportsImages: true
+          })
+        )
+      ).resolves.toBeUndefined()
+      await expect(
+        evaluate(makeCtx({ toolName: 'Read', input: { file_path: '/ws/src/Game.cs' }, supportsImages: false }))
+      ).resolves.toBeUndefined()
+    })
+  })
+
   describe('builtin-destructive', () => {
     it('denies destructive Bash for protected built-in agents in every mode', async () => {
       for (const mode of ['default', 'bypassPermissions'] as const) {

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -973,6 +973,48 @@ describe('buildClaudeCodeSessionSettings', () => {
     ).toBe(true)
   })
 
+  it('denies image Read calls before text-only model sessions can persist image tool results', async () => {
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never,
+      { supportsImages: false }
+    )
+    const hooks = settings.hooks?.PreToolUse?.[0]?.hooks ?? []
+    const runHooks = (filePath: string) =>
+      Promise.all(
+        hooks.map((hook) =>
+          hook(
+            { hook_event_name: 'PreToolUse', tool_name: 'Read', tool_input: { file_path: filePath } } as never,
+            'tool-use-1',
+            {} as never
+          )
+        )
+      )
+
+    const imageRead = await runHooks('/workspace/project/assets/Preview.png')
+    expect(imageRead).toContainEqual(
+      expect.objectContaining({
+        hookSpecificOutput: expect.objectContaining({
+          permissionDecision: 'deny',
+          permissionDecisionReason: expect.stringContaining('does not support image input')
+        })
+      })
+    )
+
+    const sourceRead = await runHooks('/workspace/project/src/Game.cs')
+    expect(
+      sourceRead.every(
+        (out) =>
+          (out as { hookSpecificOutput?: { permissionDecision?: string } })?.hookSpecificOutput?.permissionDecision !==
+          'deny'
+      )
+    ).toBe(true)
+  })
+
   it('blocks permanent deletion and destructive Bash for protected built-in Agents', async () => {
     mocks.getAgent.mockReturnValue({
       id: 'agent-1',

--- a/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
+++ b/src/main/ai/runtime/claudeCode/agentSessionWarmup.ts
@@ -28,7 +28,7 @@ import type { Provider } from '@shared/data/types/provider'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
 import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
 import { formatGatewayModelId } from '@shared/utils/apiGateway'
-import { supportsDynamicallyLoadedTools } from '@shared/utils/model'
+import { isVisionModel, supportsDynamicallyLoadedTools } from '@shared/utils/model'
 import {
   isExternalCliProvider,
   isOllamaProvider,
@@ -519,6 +519,7 @@ export async function buildClaudeCodeQueryRequestForAgentSession(
         mcpServerSnapshots,
         linkedChannelSnapshot,
         knowledgeBaseIds: selectedKnowledgeBaseIds,
+        supportsImages: Array.isArray(model.capabilities) && isVisionModel(model),
         thinkingOptions,
         fastMode: fastModeTransport === 'claude-code'
       },

--- a/src/main/ai/runtime/claudeCode/guardRules.ts
+++ b/src/main/ai/runtime/claudeCode/guardRules.ts
@@ -12,6 +12,8 @@
  * denial declares no `bypassBehavior`; there is no effect for bypass to skip.
  */
 
+import path from 'node:path'
+
 import { BUILTIN_AGENT_TOOL_GUARD_RULES } from '@main/ai/agents/builtin/builtinAgentGuardRules'
 import {
   findBuiltinToolPolicy,
@@ -23,6 +25,7 @@ import { detectGlobalInstall } from '@main/ai/toolApproval/dependencyGuard'
 import type { GuardHit, ToolGuardContext, ToolGuardRule } from '@main/ai/toolApproval/toolGuards'
 import { CONFIG_TOOL_NAME } from '@shared/ai/builtinTools'
 import { claudeToolRequiresUserInteraction } from '@shared/ai/claudecode/toolRegistry'
+import { imageExts } from '@shared/utils/file'
 
 import { isPathWithinAllowedRoots } from './pathContainment'
 import { checkSkillRuntimeDependencies, SKILL_TOOL_NAME } from './skillDependencies'
@@ -73,6 +76,13 @@ const mutatingConfigAction = (ctx: ToolGuardContext): GuardHit | null => {
   return HEADLESS_CONFIG_MUTATION_ACTIONS.has(action) ? {} : null
 }
 
+const unsupportedImageRead = (ctx: ToolGuardContext): GuardHit | null => {
+  if (ctx.supportsImages !== false) return null
+  const requestedPath = ctx.input?.file_path
+  if (typeof requestedPath !== 'string' || !imageExts.includes(path.extname(requestedPath).toLowerCase())) return null
+  return { evidence: requestedPath }
+}
+
 const pathOutsideAllowedRoots = async (ctx: ToolGuardContext): Promise<GuardHit | null> => {
   const pathField = WORKSPACE_PATH_FIELDS[ctx.toolName as keyof typeof WORKSPACE_PATH_FIELDS]
   if (!pathField) return null
@@ -103,6 +113,14 @@ const CROSS_CUTTING_TOOL_GUARD_RULES: readonly ToolGuardRule[] = [
     match: { when: (ctx) => (ctx.toolName && ctx.isDisabled(ctx.toolName) ? {} : null) },
     effect: 'deny',
     reason: (_hit, ctx) => `The ${ctx.toolName} tool is disabled for this agent.`
+  },
+  {
+    id: 'unsupported-image-read',
+    bypassBehavior: 'enforce',
+    match: { tool: 'Read', when: unsupportedImageRead },
+    effect: 'deny',
+    reason: (hit) =>
+      `The selected model does not support image input, so Read cannot open ${hit.evidence}. Use a vision-capable model or inspect the file through a text-only alternative.`
   },
   {
     // Global/shared installs leak into ~/.bun, ~/.local/share/uv, … shared by every agent, so this

--- a/src/main/ai/runtime/claudeCode/hooks.ts
+++ b/src/main/ai/runtime/claudeCode/hooks.ts
@@ -60,6 +60,7 @@ export interface ClaudeCodeHookContext {
   mountedServers: ReadonlySet<string>
   /** Loaded plugin directories by manifest name; indexed once per session. */
   pluginDirectories: ReadonlyMap<string, string>
+  supportsImages: boolean
   agentsMdLoader: AgentsMdLoader
 }
 
@@ -87,6 +88,7 @@ export function buildClaudeCodeHooks(ctx: ClaudeCodeHookContext): ClaudeCodeSett
       pluginDirectories: ctx.pluginDirectories,
       cwd,
       agentDataPath,
+      supportsImages: ctx.supportsImages,
       interaction: application.get('AgentSessionRuntimeService').getInteractionState(sessionId),
       isDisabled: (name) => snapshot?.isDisabled(name) ?? false
     })

--- a/src/main/ai/runtime/claudeCode/settingsBuilder.ts
+++ b/src/main/ai/runtime/claudeCode/settingsBuilder.ts
@@ -106,6 +106,8 @@ export function registerMcpSessionCatalogSync(
 
 export interface ClaudeCodeSessionOptions {
   lastAgentSessionId?: string
+  /** Whether the connection model accepts native image input. */
+  supportsImages?: boolean
   /** Model-declared context window used to align Claude Code's automatic compaction threshold. */
   contextWindow?: number
   /** Model-declared output cap; pinned as the per-request limit and reserved out of the budget. */
@@ -201,7 +203,8 @@ export async function buildClaudeCodeSessionSettings(
     mountedServers,
     agentDataPath,
     agentsMdLoader,
-    await buildPluginDirectoryIndex(plugins?.map((plugin) => plugin.path) ?? [])
+    await buildPluginDirectoryIndex(plugins?.map((plugin) => plugin.path) ?? []),
+    options?.supportsImages !== false
   )
 
   // 5. System prompt. The citation guidance is gated on the same resolved scope that decides whether
@@ -412,7 +415,8 @@ async function buildToolPermissions(
   mountedServers: ReadonlySet<string>,
   agentDataPath: string,
   agentsMdLoader: AgentsMdLoader,
-  pluginDirectories: ReadonlyMap<string, string>
+  pluginDirectories: ReadonlyMap<string, string>,
+  supportsImages: boolean
 ): Promise<{
   canUseTool: CanUseTool
   hooks: ClaudeCodeSettings['hooks']
@@ -551,6 +555,7 @@ async function buildToolPermissions(
     builtinRole,
     mountedServers,
     pluginDirectories,
+    supportsImages,
     agentsMdLoader
   })
 

--- a/src/main/ai/toolApproval/toolGuards.ts
+++ b/src/main/ai/toolApproval/toolGuards.ts
@@ -36,6 +36,8 @@ export interface ToolGuardContext {
   readonly pluginDirectories: ReadonlyMap<string, string>
   readonly cwd: string
   readonly agentDataPath: string
+  /** Whether the connection model accepts native image input. Undefined preserves legacy behavior. */
+  readonly supportsImages?: boolean
   readonly interaction: ToolGuardInteractionState
   /** Live disabled predicate; returns false when no snapshot is bound (canUseTool fails closed). */
   readonly isDisabled: (toolName: string) => boolean


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Claude Code Agent could execute the built-in `Read` tool on image files even when the selected model was text-only. The SDK then persisted the image tool result in its transcript, causing the current request and every resumed turn to fail with a 400 multimodal-model error.

After this PR:

Cherry passes the connection model's image-input capability into the Claude Code `PreToolUse` guard. Image `Read` calls are denied before execution for text-only models, while vision-model image reads and ordinary text-file reads remain unchanged.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

The `PreToolUse` hook runs before a tool result can enter Claude Code's persisted transcript and remains authoritative under all permission modes. The guard uses the already captured connection model rather than model-name inference, and reuses Cherry's shared image-extension list.

The following tradeoffs were made:

- The guard targets image paths recognized by Cherry and only activates when the model is explicitly known to lack image input. Unknown capability state preserves the previous behavior.
- Existing sessions whose Claude Code transcripts already contain image tool results are not rewritten automatically; users must start a new session or clean the affected transcript.

The following alternatives were considered:

- Filtering image blocks while serializing or resuming a conversation. This mutates conversation history and can hide tool results after they have already been persisted.
- Resetting the resume token after a provider 400. This discards unrelated context and treats many different provider errors as transcript corruption.

Links to places where the discussion took place: Related issue #10177 covers multimedia returned by MCP tools; this PR addresses the built-in Claude Code `Read` path.

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The regression was reproduced on Cherry Studio v2.0.8 with a text-only DeepSeek V4 Flash connection. The persisted Claude transcript contained a PNG `Read` result immediately before the provider began returning 400 errors.

Verification:

- `pnpm lint`
- `pnpm test:lint`
- `pnpm exec vitest run --project main src/main/ai/runtime/claudeCode/__tests__/agentSessionWarmup.test.ts src/main/ai/runtime/claudeCode/__tests__/guardRules.test.ts src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts` (`228 passed`, `1 skipped`)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Prevent Claude Code Agent sessions using text-only models from becoming unusable after the Read tool opens an image file.
```
