### PR TITLE
fix(logger): keep source metadata on file log lines with data arguments

### DIFF
--- a/src/main/core/logger/LoggerService.ts
+++ b/src/main/core/logger/LoggerService.ts
@@ -248,28 +248,56 @@ export class LoggerService {
       }
     }
 
-    // add source information to meta
+    // Winston merges only the first splat object into the logged line (no
+    // `format.splat()` configured), so collapse caller data + source into one meta.
+    const entry: Record<string, unknown> = {}
+    const rest: unknown[] = []
+    let fileMessage = message
+
+    const [first, ...others] = meta
+    if (first instanceof Error) {
+      Object.assign(entry, first)
+      entry.stack = first.stack
+      fileMessage = `${message} ${first.message}`
+    } else if (first !== null && typeof first === 'object') {
+      Object.assign(entry, first)
+    } else if (first !== undefined) {
+      rest.push(first)
+    }
+    for (const item of others) {
+      rest.push(item instanceof Error ? { name: item.name, message: item.message, stack: item.stack } : item)
+    }
+    if (rest.length > 0) {
+      entry.data = rest
+    }
+
+    // source fields assigned last so caller data can never clobber them
     // renderer process has its own module and context, do not use this.module and this.context
-    const sourceWithContext: LogSourceWithContext = source
+    entry.process = source.process
     if (source.process === 'main') {
-      sourceWithContext.module = this.module
+      entry.module = this.module
       if (Object.keys(this.context).length > 0) {
-        sourceWithContext.context = this.context
+        entry.context = this.context
+      }
+    } else {
+      if (source.window !== undefined) {
+        entry.window = source.window
+      }
+      if (source.module !== undefined) {
+        entry.module = source.module
+      }
+      if (source.context !== undefined) {
+        entry.context = source.context
       }
     }
-    meta.push(sourceWithContext)
 
     // add extra system information for error and warn levels
     if (level === LEVEL.ERROR || level === LEVEL.WARN) {
-      const extra = {
-        sys: SYSTEM_INFO,
-        appver: APP_VERSION
-      }
-
-      meta.push(extra)
+      entry.sys = SYSTEM_INFO
+      entry.appver = APP_VERSION
     }
 
-    this.logger.log(level, message, ...meta)
+    this.logger.log(level, fileMessage, entry)
   }
 
   /**

--- a/src/main/core/logger/__tests__/LoggerService.test.ts
+++ b/src/main/core/logger/__tests__/LoggerService.test.ts
@@ -1,0 +1,140 @@
+import { Writable } from 'node:stream'
+
+import { IpcChannel } from '@shared/IpcChannel'
+import type { LogSourceWithContext } from '@shared/types/logger'
+import { ipcMain } from 'electron'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import winston from 'winston'
+
+const tmpLogsDir = vi.hoisted(() => {
+  const { mkdtempSync } = require('node:fs')
+  const { tmpdir } = require('node:os')
+  const { join } = require('node:path')
+  return mkdtempSync(join(tmpdir(), 'logger-service-test-')) as string
+})
+
+const flags = vi.hoisted(() => ({ dev: false }))
+
+// the global setup mocks '@logger' (this very file) and winston — undo both to test the real implementation
+vi.unmock('@logger')
+vi.unmock('winston')
+vi.unmock('winston-daily-rotate-file')
+vi.mock('@main/core/paths/constants', () => ({ LOGS_DIR: tmpLogsDir }))
+vi.mock('@main/core/platform', () => ({
+  get isDev() {
+    return flags.dev
+  }
+}))
+
+/**
+ * Loads a fresh module graph so DEV_LOGGING (computed at import time) reflects
+ * the current `flags.dev`, and swaps the file transports for an in-memory sink.
+ */
+async function loadLogger() {
+  vi.resetModules()
+  const { loggerService } = await import('../LoggerService')
+  const lines: string[] = []
+  const base = loggerService.getBaseLogger()
+  base.clear()
+  base.add(
+    new winston.transports.Stream({
+      stream: new Writable({
+        write(chunk, _encoding, callback) {
+          lines.push(String(chunk))
+          callback()
+        }
+      })
+    })
+  )
+  const readLine = async (index = 0): Promise<Record<string, unknown>> => {
+    await new Promise((resolve) => setImmediate(resolve))
+    return JSON.parse(lines[index])
+  }
+  return { loggerService, lines, readLine }
+}
+
+describe('LoggerService file output', () => {
+  beforeEach(() => {
+    flags.dev = false
+  })
+
+  it('keeps module/process when the call carries data arguments', async () => {
+    const { loggerService, lines, readLine } = await loadLogger()
+    const error = Object.assign(new Error('io fail'), { code: 'EFAKE' })
+    loggerService.withContext('ScanTest').error('boom', error, { requestId: 'r1' })
+
+    const line = await readLine()
+    expect(line.module).toBe('ScanTest')
+    expect(line.process).toBe('main')
+    expect(line.level).toBe('error')
+    expect(String(line.message)).toContain('boom')
+    expect(String(line.stack)).toContain('io fail')
+    // caller data must survive to disk, wherever it nests
+    expect(lines[0]).toContain('r1')
+    expect(lines[0]).toContain('EFAKE')
+  })
+
+  it('adds sys/appver on warn and error but not on info', async () => {
+    const { loggerService, readLine } = await loadLogger()
+    const logger = loggerService.withContext('SysTest')
+    logger.error('e1')
+    logger.info('i1')
+
+    const errorLine = await readLine(0)
+    expect(errorLine.sys).toBeDefined()
+    expect(typeof errorLine.appver).toBe('string')
+    expect(errorLine.appver).not.toBe('')
+
+    const infoLine = await readLine(1)
+    expect(infoLine.module).toBe('SysTest')
+    expect(infoLine).not.toHaveProperty('sys')
+    expect(infoLine).not.toHaveProperty('appver')
+  })
+
+  it('writes timestamps that diagnostic collectors can parse', async () => {
+    const { loggerService, readLine } = await loadLogger()
+    loggerService.withContext('TsTest').warn('w1')
+
+    const line = await readLine()
+    // sourceCollector.parseLineTimestamp parses via `timestamp.replace(' ', 'T')`
+    const parsed = Date.parse(String(line.timestamp).replace(' ', 'T'))
+    expect(Number.isFinite(parsed)).toBe(true)
+  })
+
+  it('preserves renderer window/module when the forwarded log carries data', async () => {
+    const { readLine, lines } = await loadLogger()
+    const calls = vi.mocked(ipcMain.handle).mock.calls
+    const handler = calls.filter(([channel]) => channel === IpcChannel.App_LogToMain).at(-1)?.[1] as (
+      event: unknown,
+      source: LogSourceWithContext,
+      level: string,
+      message: string,
+      data: unknown[]
+    ) => void
+    expect(handler).toBeDefined()
+
+    handler(null, { process: 'renderer', window: 'w1', module: 'RM' }, 'error', 'renderer boom', [{ topicId: 't1' }])
+
+    const line = await readLine()
+    expect(line.process).toBe('renderer')
+    expect(line.window).toBe('w1')
+    expect(line.module).toBe('RM')
+    expect(lines[0]).toContain('t1')
+  })
+
+  it('keeps dev console output limited to caller data', async () => {
+    flags.dev = true
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const { loggerService } = await loadLogger()
+      loggerService.withContext('ConsoleTest').error('boom', { secret: 's1' })
+
+      const call = consoleError.mock.calls.at(-1)
+      expect(call).toBeDefined()
+      const [, ...metaArgs] = call!
+      expect(metaArgs).toEqual([{ secret: 's1' }])
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

**Before this PR:** `processLog` handed the source metadata and the `sys`/`appver` extras to winston as *additional splat arguments*:

```ts
meta.push(sourceWithContext)
meta.push({ sys: SYSTEM_INFO, appver: APP_VERSION })
this.logger.log(level, message, ...meta)
```

The main-process format chain never installs `format.splat()`, so winston merges only the **first** meta object into the persisted line and drops the rest. Two consequences:

- Any call carrying data — `logger.error('msg', someObject)` — lost `module`, `process`, `window` and `context` in `app.log` / `app-error.log`.
- `sys` and `appver` were **never** persisted, on any line, at any level.

Calls with no data argument happened to serialize correctly, which is why this stayed invisible.

**After this PR:** caller data and source fields are collapsed into a single meta object, source fields assigned last. Data arguments beyond the first are preserved under a `data` key; an `Error` first argument keeps its `stack` and appends its message to the file message.

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Build one entry object in `processLog`, rather than adding `format.splat()`.** Enabling splat is a one-line change, but it alters how *every* log line in the repo is serialized and brings `%s`-style message interpolation into play. Collapsing at the single call site is contained and reviewable.
- **Source fields are assigned last, so caller data cannot clobber them.** Merging caller data last would be friendlier to callers, but it lets any call forge its own `module`/`process` and makes the metadata untrustworthy for anything reading logs mechanically.
- **Extra arguments land under `data` as an array** instead of being spread into the entry, so caller keys cannot collide with each other or with reserved fields.

The following alternatives were considered:

- `format.splat()` — see above.
- Leaving it and having consumers tolerate missing metadata — rejected: these fields are read by hand during support triage, and the next PR in this stack uses `module` as a matching dimension.

### Breaking changes

None for callers. The **shape of persisted log lines changes**: lines that previously lost metadata now carry it, and `sys`/`appver` now appear on `warn`/`error` lines. Anything parsing these files sees strictly more fields, never fewer.

### Special notes for your reviewer

The 5 new tests `vi.unmock` `@logger`, `winston` and `winston-daily-rotate-file` so they drive the real service writing a real file. Mocking winston here would assert against the mock rather than the splat behaviour that caused the bug.

Each test pins a concrete failure mode instead of snapshotting output:

| Test | Bug it catches |
|---|---|
| keeps module/process when the call carries data arguments | the reported defect |
| adds sys/appver on warn and error but not on info | `sys`/`appver` never persisted |
| writes timestamps that diagnostic collectors can parse | timestamp-format contract with `sourceCollector` |
| preserves renderer window/module when the forwarded log carries data | renderer path losing its own source fields |
| keeps dev console output limited to caller data | console path must not gain the file-only extras |

`pnpm exec vitest run --project main src/main/core/logger` — 5 passed. `pnpm lint` clean.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: not required — no user-facing feature or behavior change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
