### PR TITLE
fix(artifact-pane): pad composer inset inside code surfaces

### DIFF
--- a/src/renderer/components/FilePreview/FilePreviewLayout.tsx
+++ b/src/renderer/components/FilePreview/FilePreviewLayout.tsx
@@ -1,4 +1,5 @@
 import { Scrollbar } from '@cherrystudio/ui'
+import { cn } from '@renderer/utils/style'
 import type { ReactNode } from 'react'
 
 interface FilePreviewFrameProps {
@@ -15,17 +16,19 @@ function FilePreviewFrame({ children }: FilePreviewFrameProps) {
   )
 }
 
-function FilePreviewContent({ children }: { children: ReactNode }) {
+function FilePreviewContent({ children, composerInset = true }: { children: ReactNode; composerInset?: boolean }) {
   return (
     // Themed auto-hiding scrollbar (consistent with the rest of the app) for the text-like
     // previews that scroll here (markdown/text/html source). `scrollbar-gutter:auto` overrides
     // Scrollbar's default `stable` so document-viewer plugins (image/pdf/word/pptx), whose
     // full-height child never overflows Content, don't reserve an empty gutter strip. A maximized
     // pane runs full height under the elevated composer, so the scroll end also needs its height
-    // as trailing room to clear it.
+    // as trailing room to clear it. A plugin whose content paints its own opaque surface passes
+    // composerInset={false} and pads inside that surface instead — padding here would show the
+    // pane background as a band between the surface and the floating composer.
     <Scrollbar
       data-testid="file-preview-content"
-      className="min-h-0 flex-1 pb-[var(--chat-composer-inset,0px)] [scrollbar-gutter:auto]">
+      className={cn('min-h-0 flex-1 [scrollbar-gutter:auto]', composerInset && 'pb-[var(--chat-composer-inset,0px)]')}>
       {children}
     </Scrollbar>
   )

--- a/src/renderer/components/FilePreview/plugins/text/TextFilePreview.tsx
+++ b/src/renderer/components/FilePreview/plugins/text/TextFilePreview.tsx
@@ -91,10 +91,12 @@ function TextPreviewContent({ filePath, loadState }: TextPreviewContentProps): R
 
   return (
     <div className="flex min-h-full w-full">
+      {/* The composer inset pads inside the viewer, whose shiki theme paints an opaque
+          background — the code surface then runs to the container bottom under the composer. */}
       <CodeViewer
         value={loadState.content}
         language={getLanguageByFilePath(filePath)}
-        className="min-w-0 flex-1 overflow-hidden"
+        className="min-w-0 flex-1 overflow-hidden pb-[var(--chat-composer-inset,0px)]"
       />
     </div>
   )
@@ -136,7 +138,7 @@ export default function TextFilePreview({ filePath, metadata, refreshKey }: File
 
   return (
     <FilePreviewLayout.Frame>
-      <FilePreviewLayout.Content>
+      <FilePreviewLayout.Content composerInset={loadState.status !== 'ready'}>
         <TextPreviewContent filePath={filePath} loadState={loadState} />
       </FilePreviewLayout.Content>
     </FilePreviewLayout.Frame>

--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -598,7 +598,9 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
             </Button>
           </div>
         )}
-        <div className="min-h-0 flex-1 overflow-hidden [&:has(.cm-editor)]:pb-[var(--chat-composer-inset,0px)]">
+        {/* The inset pads inside the editor's scroll container (not this wrapper) so the
+            editor runs full height under the elevated composer with trailing scroll room. */}
+        <div className="min-h-0 flex-1 overflow-hidden [&_.cm-scroller]:pb-[var(--chat-composer-inset,0px)]">
           {canEditSelection && editMode === 'edit' && fileSession?.status === 'ready' ? (
             <CodeEditor
               key={previewKey}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

In a maximized artifact pane, the composer inset (`--chat-composer-inset`) was applied outside the code surfaces:

- **Edit mode**: the inset was `padding-bottom` on the `overflow-hidden` wrapper around the CodeMirror editor, shrinking the editor so it (and its scrollbars) ended above the floating composer, leaving an empty band below.
- **Text preview**: the inset padded the outer `Scrollbar` of `FilePreviewLayout.Content`, outside the shiki-themed viewer that paints the opaque code background — the code surface cut off above the composer with a `bg-card` band showing through.

After this PR:

Both code surfaces run full height under the floating composer, with the inset as trailing room *inside* the surface so the last lines can scroll clear of it:

- Edit mode pads the CodeMirror `.cm-scroller` instead of the wrapper.
- `FilePreviewLayout.Content` gains an optional `composerInset` flag (default `true`, other plugins unchanged); the text plugin turns it off once content is ready and pads the shiki viewer root, which owns the opaque background. Loading/empty/error states keep the outer inset.

<table>
<tr>
 <td>
 Before
 <td>
 After

<tr>
 <td>
 
<img width="1413" height="638" alt="image" src="https://github.com/user-attachments/assets/3ffd9ca5-538e-4d4f-a903-3f56cd6e24ad" />

 <td>
<img width="2770" height="622" alt="CleanShot 2026-08-25 at 16 54 29@2x" src="https://github.com/user-attachments/assets/62089cb3-98fd-48d2-ac69-9e398bfb4883" />

<tr>
 <td>
 
<img width="1426" height="532" alt="image" src="https://github.com/user-attachments/assets/809a7f46-011e-4b73-a348-0a29eaf7593d" />

 <td>
<img width="2768" height="432" alt="CleanShot 2026-08-25 at 16 32 32@2x" src="https://github.com/user-attachments/assets/9a2fd9fa-6eab-4c2e-af21-d57fe4dd0b3c" />

</table>

Fixes #

### Why we need it and why it was done in this way

The composer is a floating overlay by design; reserving space outside the content surface breaks that illusion and produces a visible seam/band. Padding inside the surface keeps the surface continuous to the container bottom while still preventing the composer from covering the last lines.

The following tradeoffs were made:

- With the editor at full height, the horizontal scrollbar of an unwrapped editor sits at the container bottom edge, partially behind the centered composer (same behavior as the message list under the composer).
- `composerInset` is a per-plugin opt-out rather than a global relocation of the padding, because only opaque-surface content needs to own the inset; transparent surfaces (markdown etc.) are seamless with the existing container padding.

The following alternatives were considered:

- Padding an inner full-height wrapper inside `Content` for all plugins — still shows the band, since children cannot cover a scroll container's own padding area, and it would disturb the layout assumptions of all eight plugins.
- Making the shiki background transparent so `bg-card` shows everywhere — would break code-theme contrast chosen by the user's code style preference.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

- Shiki's inline pre style only sets `background-color`/`color`, so the Tailwind `pb-[var(--chat-composer-inset,0px)]` class on the viewer root is not overridden.
- Document-viewer plugins (pdf/word/pptx/spreadsheet) with internally scrolling full-height children may show a similar band from the same container padding; left out of scope here and noted in the `Content` comment.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the maximized file pane in agent sessions: code preview and edit surfaces now extend full height under the floating message input instead of cutting off above it, and the last lines scroll clear of the input.
```
