### PR TITLE
fix(selection-assistant): keep custom action footer visible

### DIFF
--- a/src/renderer/pages/settings/SelectionAssistantSettings/components/SelectionActionUserModal.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/components/SelectionActionUserModal.tsx
@@ -110,7 +110,10 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
 
   return (
     <Dialog open={isModalOpen} onOpenChange={(next) => !next && onCancel()}>
-      <DialogContent aria-describedby={undefined} closeOnOverlayClick={false} className="sm:max-w-130">
+      <DialogContent
+        aria-describedby={undefined}
+        closeOnOverlayClick={false}
+        className="max-h-[calc(100vh-2rem)] grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-130">
         <DialogHeader>
           <DialogTitle>
             {editingAction
@@ -118,7 +121,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
               : t('selection.settings.user_modal.title.add')}
           </DialogTitle>
         </DialogHeader>
-        <div className="flex w-full min-w-0 flex-col gap-4">
+        <div className="flex min-h-0 w-full min-w-0 flex-col gap-4 overflow-y-auto pr-1">
           <ModalSection>
             <div className="flex flex-row">
               <div className="w-[70%] flex-auto pr-4">
@@ -265,7 +268,7 @@ const SelectionActionUserModal: FC<SelectionActionUserModalProps> = ({
               value={formData.prompt || ''}
               onChange={(e) => handleInputChange('prompt', e.target.value)}
               rows={4}
-              className="resize-none"
+              className="max-h-40 resize-none overflow-y-auto"
             />
           </ModalSection>
         </div>

--- a/src/renderer/pages/settings/SelectionAssistantSettings/components/__tests__/SelectionActionUserModal.test.tsx
+++ b/src/renderer/pages/settings/SelectionAssistantSettings/components/__tests__/SelectionActionUserModal.test.tsx
@@ -1,0 +1,61 @@
+import type { SelectionActionItem } from '@shared/data/preference/preferenceTypes'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import SelectionActionUserModal from '../SelectionActionUserModal'
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: () => null
+}))
+
+vi.mock('@renderer/components/CopyButton', () => ({
+  default: () => null
+}))
+
+vi.mock('@renderer/hooks/useAssistant', () => ({
+  useAssistants: () => ({ assistants: [] })
+}))
+
+vi.mock('@renderer/hooks/useModel', () => ({
+  useDefaultModel: () => ({ defaultModel: undefined })
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+describe('SelectionActionUserModal', () => {
+  it('keeps the footer accessible when editing a long prompt', () => {
+    const longPrompt = 'Keep the prompt inside the dialog.\n'.repeat(200)
+    const onOk = vi.fn()
+    const editingAction: SelectionActionItem = {
+      id: 'user-long-prompt',
+      name: 'Long prompt',
+      enabled: true,
+      isBuiltIn: false,
+      prompt: longPrompt
+    }
+
+    render(<SelectionActionUserModal isModalOpen editingAction={editingAction} onOk={onOk} onCancel={vi.fn()} />)
+
+    const prompt = screen.getByPlaceholderText('selection.settings.user_modal.prompt.placeholder')
+    const dialogContent = screen.getByTestId('dialog-content')
+    const scrollableBody = dialogContent.children[1]
+
+    expect(prompt).toHaveValue(longPrompt)
+    // These layout utilities are the viewport/scroll contract that prevents issue #19358.
+    expect(dialogContent).toHaveClass(
+      'max-h-[calc(100vh-2rem)]',
+      'grid-rows-[auto_minmax(0,1fr)_auto]',
+      'overflow-hidden'
+    )
+    expect(scrollableBody).toHaveClass('min-h-0', 'overflow-y-auto')
+    expect(prompt).toHaveClass('max-h-40', 'overflow-y-auto', 'resize-none')
+    const confirmButton = screen.getByRole('button', { name: 'common.confirm' })
+    expect(confirmButton).toBeVisible()
+
+    fireEvent.click(confirmButton)
+
+    expect(onOk).toHaveBeenCalledWith(editingAction)
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Long custom-action prompts in Selection Assistant expanded the content-sized textarea beyond the available viewport and could push the dialog footer, including the Confirm button, off screen.

After this PR:

The dialog is bounded to the viewport, its form body can scroll independently, and long prompts scroll inside a capped textarea while the footer remains accessible. Short prompts keep their normal content-sized behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19358

### Why we need it and why it was done in this way

The shared textarea uses content-based field sizing, so `rows={4}` alone does not constrain a long prompt. A three-row dialog layout keeps the header and footer intrinsic while allowing the middle form area to shrink and scroll. The prompt itself receives a small maximum height and internal scrolling so the other fields remain usable.

The following tradeoffs were made:

Long prompts require scrolling inside the prompt field, and the whole form body may also scroll on small viewports. This preserves all content without increasing the dialog beyond the viewport.

The following alternatives were considered:

Changing the shared textarea sizing behavior was avoided because it would affect unrelated forms. Truncating prompt content was rejected because it would change saved user data.

Links to places where the discussion took place: #19358

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

- Added focused regression coverage for the viewport, scroll-container, footer, and long-prompt submission contracts.
- Verified the affected Selection Assistant component tests (4 tests), lint checks, type checks, and production build.
- Manually verified the modal in Electron at a 960 × 650 viewport with a 200-line prompt; the prompt scrolls internally and the Confirm button remains visible.
- No user-guide update is required because this restores the intended modal layout without changing the workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Selection Assistant custom-action dialogs now keep confirmation controls accessible when prompts are very long.
```
