### PR TITLE
fix(binary-manager): repair incomplete DSH installs

### DIFF
--- a/src/main/services/binaryManager/BinaryManager.ts
+++ b/src/main/services/binaryManager/BinaryManager.ts
@@ -112,7 +112,11 @@ const MISE_PRERELEASE_TOOLS = new Set(
 const MISE_NPM_SHELL_OUT_TOOLS = new Set(
   CODE_CLI_TOOL_PRESETS.filter((preset) => preset.miseNpmShellOut).map((preset) => preset.miseTool)
 )
-const DEEPSEEK_HARNESS_TOOL = 'npm:@deepseek-ai/dsh'
+const MISE_REQUIRED_PEERS = new Map(
+  CODE_CLI_TOOL_PRESETS.flatMap((preset) =>
+    preset.requiredPeer ? [[preset.miseTool, preset.requiredPeer] as const] : []
+  )
+)
 
 // Main-owned session state. Renderer windows receive operations only through
 // snapshots, so this belongs to CacheService's internal tier rather than its
@@ -1123,15 +1127,29 @@ export class BinaryManager extends BaseService {
     )
   }
 
+  /**
+   * Whether a recipe declaring a required peer still has it, resolved the way the
+   * tool's own runtime would. A recipe declaring none passes untouched, so this
+   * costs nothing for the tools that install completely.
+   */
   private hasRequiredRuntimeDependencies(tool: string, entryPath: string): boolean {
-    if (tool !== DEEPSEEK_HARNESS_TOOL) return true
+    const required = MISE_REQUIRED_PEERS.get(tool)
+    if (!required) return true
+    let hostEntry: string
     try {
-      const agentLoopEntry = createRequire(entryPath).resolve('@deepseek-ai/dsh-agent-loop')
-      createRequire(agentLoopEntry).resolve('@deepseek-ai/dsh-scope')
+      hostEntry = createRequire(entryPath).resolve(required.host)
+    } catch {
+      // An absent host means the recipe restructured its packages, which is not
+      // evidence that THIS install lost the peer — never fail a tool closed on it.
+      return true
+    }
+    try {
+      createRequire(hostEntry).resolve(required.peer)
       return true
     } catch (error) {
-      logger.warn('Managed DeepSeek Harness dependency tree is incomplete', {
-        dependency: '@deepseek-ai/dsh-scope',
+      logger.warn('Managed tool dependency tree is incomplete', {
+        tool,
+        ...required,
         error: this.errorMessage(error)
       })
       return false

--- a/src/main/services/binaryManager/BinaryManager.ts
+++ b/src/main/services/binaryManager/BinaryManager.ts
@@ -1,6 +1,7 @@
 import { execFile, execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -111,6 +112,7 @@ const MISE_PRERELEASE_TOOLS = new Set(
 const MISE_NPM_SHELL_OUT_TOOLS = new Set(
   CODE_CLI_TOOL_PRESETS.filter((preset) => preset.miseNpmShellOut).map((preset) => preset.miseTool)
 )
+const DEEPSEEK_HARNESS_TOOL = 'npm:@deepseek-ai/dsh'
 
 // Main-owned session state. Renderer windows receive operations only through
 // snapshots, so this belongs to CacheService's internal tier rather than its
@@ -558,6 +560,9 @@ export class BinaryManager extends BaseService {
         // Update/Uninstall authority over a foreign provider. When mise omits
         // install_path, fall back to the runnable-only check above.
         if (!(await this.isWithinInstall(activeEntry, runnable.canonical))) {
+          return { application: { status: 'broken', ...(version ? { version } : {}) } }
+        }
+        if (!this.hasRequiredRuntimeDependencies(tool, runnable.canonical)) {
           return { application: { status: 'broken', ...(version ? { version } : {}) } }
         }
         return {
@@ -1111,7 +1116,26 @@ export class BinaryManager extends BaseService {
     const activeEntry = entries.find((entry) => entry.active)
     if (!activeEntry) return false
     const runnable = await this.resolveRunnableShim(name, tool)
-    return runnable !== null && (await this.isWithinInstall(activeEntry, runnable.canonical))
+    return (
+      runnable !== null &&
+      (await this.isWithinInstall(activeEntry, runnable.canonical)) &&
+      this.hasRequiredRuntimeDependencies(tool, runnable.canonical)
+    )
+  }
+
+  private hasRequiredRuntimeDependencies(tool: string, entryPath: string): boolean {
+    if (tool !== DEEPSEEK_HARNESS_TOOL) return true
+    try {
+      const agentLoopEntry = createRequire(entryPath).resolve('@deepseek-ai/dsh-agent-loop')
+      createRequire(agentLoopEntry).resolve('@deepseek-ai/dsh-scope')
+      return true
+    } catch (error) {
+      logger.warn('Managed DeepSeek Harness dependency tree is incomplete', {
+        dependency: '@deepseek-ai/dsh-scope',
+        error: this.errorMessage(error)
+      })
+      return false
+    }
   }
 
   private async resolveMiseBinaryForTool(

--- a/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
+++ b/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
@@ -1,8 +1,11 @@
+import type * as NodeModule from 'node:module'
+
 import type * as LifecycleModule from '@main/core/lifecycle'
 import { getPhase } from '@main/core/lifecycle/decorators'
 import { Phase } from '@main/core/lifecycle/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const mockCreateRequire = vi.hoisted(() => vi.fn())
 const { manifestRef, mockExecFileAsync, mockFs, mockFsp, mockPreferenceService, platformMock } = vi.hoisted(() => ({
   manifestRef: { value: [] as Array<{ name: string; tool: string; requestedVersion?: string }> },
   platformMock: { isWin: false },
@@ -37,6 +40,11 @@ const { manifestRef, mockExecFileAsync, mockFs, mockFsp, mockPreferenceService, 
     subscribeMultipleChanges: vi.fn(() => () => {})
   }
 }))
+
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeModule>()
+  return { ...actual, createRequire: mockCreateRequire }
+})
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -154,6 +162,7 @@ describe('BinaryManager', () => {
     vi.clearAllMocks()
     MockMainCacheServiceUtils.resetMocks()
     mockExecFileAsync.mockReset()
+    mockCreateRequire.mockReset().mockReturnValue({ resolve: vi.fn(() => '/mock/resolved-package') })
     platformMock.isWin = false
     mockFs.existsSync.mockReset().mockReturnValue(false)
     mockFs.readFileSync.mockReset()
@@ -558,6 +567,46 @@ describe('BinaryManager', () => {
         name: 'fd',
         availability: { source: 'mise', path: '/mock/feature.binary.data/shims/fd', version: '10.0.0' },
         application: { status: 'applied', version: '10.0.0' }
+      })
+    })
+
+    it('reports managed DeepSeek Harness as broken when its required scope package cannot resolve', async () => {
+      const service = new BinaryManager()
+      ;(service as any).miseBin = '/mock/mise'
+      ;(service as any).isolatedEnv = { env: {}, usesDefaultChinaPipIndex: false }
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'ls') {
+          return {
+            stdout: JSON.stringify({
+              'npm:@deepseek-ai/dsh': [{ version: '0.1.1-rc.2', active: true }]
+            }),
+            stderr: ''
+          }
+        }
+        if (args[0] === 'which') {
+          return { stdout: '/opt/mise/installs/npm-deepseek-ai-dsh/0.1.1-rc.2/lib/bin.js\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      })
+      mockCreateRequire.mockImplementation((filename: string) => ({
+        resolve: (request: string) => {
+          if (request === '@deepseek-ai/dsh-agent-loop') {
+            return '/opt/mise/installs/npm-deepseek-ai-dsh/0.1.1-rc.2/node_modules/@deepseek-ai/dsh-agent-loop/lib/index.js'
+          }
+          if (request === '@deepseek-ai/dsh-scope') {
+            throw Object.assign(new Error(`Cannot find package ${request} from ${filename}`), {
+              code: 'MODULE_NOT_FOUND'
+            })
+          }
+          throw new Error(`Unexpected package resolution: ${request}`)
+        }
+      }))
+
+      await expect(service.getToolSnapshots(['dsh'])).resolves.toMatchObject({
+        dsh: {
+          availability: { source: 'none' },
+          application: { status: 'broken', version: '0.1.1-rc.2' }
+        }
       })
     })
 
@@ -2387,6 +2436,45 @@ describe('BinaryManager', () => {
         '--force',
         'node@22.23.2'
       ])
+    })
+
+    it('repairs an applied DeepSeek Harness whose required scope package is missing', async () => {
+      const service = makeService()
+      let reinstalled = false
+      ;(service as any).isolatedEnv = { env: { PATH: '/mock/mise/shims:/usr/bin' }, usesDefaultChinaPipIndex: false }
+      mockCreateRequire.mockImplementation(() => ({
+        resolve: (request: string) => {
+          if (request === '@deepseek-ai/dsh-agent-loop') return '/mock/dsh-agent-loop/lib/index.js'
+          if (request === '@deepseek-ai/dsh-scope' && !reinstalled) {
+            throw Object.assign(new Error(`Cannot find package ${request}`), { code: 'MODULE_NOT_FOUND' })
+          }
+          if (request === '@deepseek-ai/dsh-scope') return '/mock/dsh-scope/lib/index.js'
+          throw new Error(`Unexpected package resolution: ${request}`)
+        }
+      }))
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'latest') return { stdout: '22.23.2\n', stderr: '' }
+        if (args[0] === 'ls') {
+          return {
+            stdout: JSON.stringify({ 'npm:@deepseek-ai/dsh': [{ version: '0.1.1-rc.2', active: true }] }),
+            stderr: ''
+          }
+        }
+        if (args.includes('npm:@deepseek-ai/dsh@latest')) reinstalled = true
+        if (args[0] === 'which' && args[1] === 'node') {
+          return { stdout: '/mock/mise/installs/node/22.23.2/bin/node\n', stderr: '' }
+        }
+        if (args[0] === 'which' && args[1] === 'npm') {
+          return { stdout: '/mock/mise/installs/node/22.23.2/bin/npm\n', stderr: '' }
+        }
+        if (args[0] === 'which') return { stdout: '/mock/dsh/lib/bin.js\n', stderr: '' }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(service.installByName({ name: 'dsh' })).resolves.toBeUndefined()
+
+      expect(reinstalled).toBe(true)
+      expect(miseArgs()).toContainEqual(['use', '-g', '--minimum-release-age', '0s', 'npm:@deepseek-ai/dsh@latest'])
     })
   })
 

--- a/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
+++ b/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
@@ -610,6 +610,40 @@ describe('BinaryManager', () => {
       })
     })
 
+    it('stays applied when the recipe restructured away the package that hosts its required peer', async () => {
+      // A renamed/absorbed host says the package graph moved on, not that this
+      // install is incomplete — failing closed would strand the tool at broken
+      // with a Retry that can never succeed.
+      const service = new BinaryManager()
+      ;(service as any).miseBin = '/mock/mise'
+      ;(service as any).isolatedEnv = { env: {}, usesDefaultChinaPipIndex: false }
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'ls') {
+          return {
+            stdout: JSON.stringify({
+              'npm:@deepseek-ai/dsh': [{ version: '0.2.0', active: true }]
+            }),
+            stderr: ''
+          }
+        }
+        if (args[0] === 'which') {
+          return { stdout: '/opt/mise/installs/npm-deepseek-ai-dsh/0.2.0/lib/bin.js\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      })
+      mockCreateRequire.mockImplementation((filename: string) => ({
+        resolve: (request: string) => {
+          throw Object.assign(new Error(`Cannot find package ${request} from ${filename}`), {
+            code: 'MODULE_NOT_FOUND'
+          })
+        }
+      }))
+
+      await expect(service.getToolSnapshots(['dsh'])).resolves.toMatchObject({
+        dsh: { application: { status: 'applied', version: '0.2.0' } }
+      })
+    })
+
     it('stays applied for a recipe with no eponymous bin, through a shim it does expose', async () => {
       // core:rust exposes rustc/cargo and no `rust`, so a name-keyed `mise which`
       // reports a working install as unusable (#19075).

--- a/src/shared/data/presets/codeCliTools.ts
+++ b/src/shared/data/presets/codeCliTools.ts
@@ -10,6 +10,11 @@ export interface CodeCliToolPreset {
   misePrerelease?: boolean
   /** Use npm CLI when mise's embedded installer cannot install this package. */
   miseNpmShellOut?: boolean
+  /**
+   * A peer this tool needs at runtime but whose absence an install still reports
+   * as success, named as `peer` resolved from `host`'s own entry point.
+   */
+  requiredPeer?: { host: string; peer: string }
 }
 
 type CodeCliToolDefinition = Omit<CodeCliToolPreset, 'miseTool'>
@@ -47,7 +52,10 @@ export const CODE_CLI_TOOL_PRESETS = Object.freeze([
     install: 'npm',
     misePrerelease: true,
     // mise 2026.7.14 aube exceeds its 16-pass fixed-point limit on DSH's recursive peer graph.
-    miseNpmShellOut: true
+    miseNpmShellOut: true,
+    // dsh-scope is nowhere a real dependency, only a transitive peer, so an install
+    // reports success without it (#19313).
+    requiredPeer: { host: '@deepseek-ai/dsh-agent-loop', peer: '@deepseek-ai/dsh-scope' }
   }),
   defineCodeCliTool({
     id: CodeCli.GEMINI_CLI,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

An active managed DeepSeek Harness recipe was considered applied as soon as its shim resolved, even when `@deepseek-ai/dsh-agent-loop` could not resolve its required `@deepseek-ai/dsh-scope` peer. DSH then exited during startup, while Retry treated the installation as healthy and did nothing.

After this PR:

A recipe may declare a `requiredPeer` in its Code CLI preset. When it does, Binary Manager resolves that peer the way the tool's own runtime would before exposing the managed executable, and marks an install that is missing it as broken instead of applied. That makes the existing Retry action reapply the recipe, and the same check gates the reinstall before the operation reports success. DSH is the only recipe declaring one today; every other tool keeps its existing generic readiness path untouched.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Related to #19313

### Why we need it and why it was done in this way

`@deepseek-ai/dsh-scope` is not a `dependencies` entry of any package in the DSH tree — it exists only as a transitive `peerDependencies` edge (`dsh` → ... → `dsh-agent-loop` → `dsh-scope`, none of them optional). Peer installation is best-effort, so `npm install` can exit 0 with that edge unsatisfied. The install's exit code therefore does not cover this package, and the invariant has to be checked separately from the install.

Resolving it from the managed entry point mirrors Node's real module lookup without launching the runtime. The per-tool fact lives in `CODE_CLI_TOOL_PRESETS` next to `misePrerelease` and `miseNpmShellOut`, and `BinaryManager` derives a lookup from it exactly as it already does for those two, so the generic manager holds no per-tool package names.

The following tradeoffs were made:

- A recipe declaring a `requiredPeer` performs two synchronous module resolutions per snapshot; this is a small local filesystem cost and only applies to recipes that declare one.
- The host package failing to resolve is treated as "the recipe restructured its packages", not "this install is broken". Failing closed there would strand every install at `broken` behind a Retry that can never succeed the first time upstream renames a package — strictly worse than the bug being fixed.
- The repair reuses the existing mise/npm install path instead of introducing a second package manager flow.

The following alternatives were considered:

- Detecting the error only after DSH startup was rejected because it leaves the Toolchain state falsely healthy and gives Retry no work to perform.
- Installing `@deepseek-ai/dsh-scope` separately was rejected because it would couple Cherry Studio to an independently versioned peer instead of repairing the package tree produced by the DSH recipe.
- Reinstalling DSH unconditionally was rejected because it adds network and startup cost for healthy installations.
- Hardcoding the package names in `BinaryManager` was rejected because per-tool acquisition facts already have a home in the shared preset.

Links to places where the discussion took place: #19313

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

This PR closes the detection gap; it does not establish why the tree installs incomplete in the first place, which is why it links #19313 rather than closing it.

Measured against the registry and a local resolve (npm 11.6.2, `legacy-peer-deps=false`):

- `npm install -g @deepseek-ai/dsh@0.1.1-rc.2 --dry-run` resolves 455 packages, 197 of them `@deepseek-ai/*`, and **does** place `dsh-scope`, `dsh-agent-loop`, `dsh-agent`, `dsh-session` and `dsh-invariants`. So npm's peer solver is not what drops the package.
- That dry run — resolution only, no tarball downloads and no disk writes, warm metadata cache — took roughly 12 minutes. `MISE_INSTALL_TIMEOUT_MS` is 15 minutes for the whole install, so a slower or colder machine can plausibly be cut off mid-write and leave a partial tree that the pre-PR classifier still reported as applied. That matches the reported Windows symptom (install succeeds, runtime dies on `ERR_MODULE_NOT_FOUND`) and is tracked separately.

Caveat on that measurement: it used node 24.11.1 / npm 11.6.2, whereas Cherry provisions `node@22` (npm 10.x) for the npm shell-out, so it is indicative rather than an exact reproduction of the production resolver.

Removing the nested scope package from a healthy install reproduces the reported state, and reinstalling the same DSH version restores it, which is why the existing Retry path is used as the repair mechanism.

Validation:

- `pnpm test:main src/main/services/binaryManager/__tests__/BinaryManager.test.ts` (203 tests passed)
- `pnpm lint` (passed; repository-wide ESLint emitted 46 pre-existing warnings and no errors)
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-everything-programmers-should-know/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Managed DeepSeek Harness installations that are missing @deepseek-ai/dsh-scope are now reported as broken in Toolchain instead of appearing healthy and failing at startup, so Retry can reinstall them.
```
