### PR TITLE
fix(mini-app): realign tab pool current state from consistent snapshots

### DIFF
--- a/src/renderer/components/MiniApp/MiniAppTabsPool.tsx
+++ b/src/renderer/components/MiniApp/MiniAppTabsPool.tsx
@@ -45,6 +45,7 @@ const MiniAppTabsPool: React.FC = () => {
     currentMiniAppId,
     splitOpen,
     splitMiniAppId,
+    openedOneOffMiniApp,
     setOpenedKeepAliveMiniApps,
     setCurrentMiniAppId,
     setMiniAppShow
@@ -140,15 +141,20 @@ const MiniAppTabsPool: React.FC = () => {
     const orphanedApps = openedKeepAliveMiniApps.filter((app) => !isReferenced(app.appId))
     if (orphanedApps.length === 0) return
 
-    const kept = openedKeepAliveMiniApps.filter((app) => isReferenced(app.appId))
+    // The updater filters the latest stored pool, which can hold apps this render never
+    // saw — current/show must not be derived here; the realign effect below owns that.
     setOpenedKeepAliveMiniApps((prev) => prev.filter((app) => isReferenced(app.appId)))
     for (const app of orphanedApps) clearWebviewState(app.appId)
+  }, [openedKeepAliveMiniApps, setOpenedKeepAliveMiniApps, splitMiniAppId, splitOpen, tabMiniAppIds])
 
-    // Realign whenever the current id no longer resolves to a pooled app — the stale id may
-    // predate this cleanup rather than be part of it.
-    if (kept.some((app) => app.appId === currentMiniAppId)) return
+  // Realign a current id that resolves to no shown app. Always-on, not gated behind orphan
+  // cleanup: a stale-snapshot decision then self-heals on the fresh-pool re-run.
+  useEffect(() => {
+    // One-off apps live outside the keep-alive pool but legitimately own the current id.
+    if (currentMiniAppId === openedOneOffMiniApp?.appId) return
+    if (openedKeepAliveMiniApps.some((app) => app.appId === currentMiniAppId)) return
 
-    if (activeMiniAppId && kept.some((app) => app.appId === activeMiniAppId)) {
+    if (activeMiniAppId && openedKeepAliveMiniApps.some((app) => app.appId === activeMiniAppId)) {
       setCurrentMiniAppId(activeMiniAppId)
       setMiniAppShow(true)
       return
@@ -160,12 +166,9 @@ const MiniAppTabsPool: React.FC = () => {
     activeMiniAppId,
     currentMiniAppId,
     openedKeepAliveMiniApps,
+    openedOneOffMiniApp,
     setCurrentMiniAppId,
-    setMiniAppShow,
-    setOpenedKeepAliveMiniApps,
-    splitMiniAppId,
-    splitOpen,
-    tabMiniAppIds
+    setMiniAppShow
   ])
 
   /** 设置 ref 回调 */

--- a/src/renderer/components/MiniApp/__tests__/MiniAppTabsPool.test.tsx
+++ b/src/renderer/components/MiniApp/__tests__/MiniAppTabsPool.test.tsx
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   currentMiniAppId: '',
   splitOpen: false,
   splitMiniAppId: '',
+  openedOneOffMiniApp: null as MiniApp | null,
   maxKeepAliveMiniApps: 10,
   setOpenedKeepAliveMiniApps: vi.fn(),
   setCurrentMiniAppId: vi.fn(),
@@ -73,6 +74,7 @@ vi.mock('@renderer/hooks/useMiniApps', () => ({
     currentMiniAppId: mocks.currentMiniAppId,
     splitOpen: mocks.splitOpen,
     splitMiniAppId: mocks.splitMiniAppId,
+    openedOneOffMiniApp: mocks.openedOneOffMiniApp,
     setOpenedKeepAliveMiniApps: mocks.setOpenedKeepAliveMiniApps,
     setCurrentMiniAppId: mocks.setCurrentMiniAppId,
     setMiniAppShow: mocks.setMiniAppShow
@@ -127,6 +129,7 @@ describe('MiniAppTabsPool', () => {
     mocks.currentMiniAppId = ''
     mocks.splitOpen = false
     mocks.splitMiniAppId = ''
+    mocks.openedOneOffMiniApp = null
     mocks.maxKeepAliveMiniApps = 10
     mocks.setOpenedKeepAliveMiniApps.mockReset()
     mocks.tabs = []
@@ -273,10 +276,14 @@ describe('MiniAppTabsPool', () => {
     ]
     mocks.activeTabId = 'home'
 
-    render(<MiniAppTabsPool />)
+    const { rerender } = render(<MiniAppTabsPool />)
 
     await waitFor(() => expect(mocks.openedKeepAliveMiniApps.map((app) => app.appId)).toEqual(['alpha']))
     expect(clearWebviewState).toHaveBeenCalledWith('bravo')
+    // The reactive cache re-renders the pool; realign observes the fresh pool there.
+    act(() => {
+      rerender(<MiniAppTabsPool />)
+    })
     expect(mocks.setCurrentMiniAppId).toHaveBeenCalledWith('')
     expect(mocks.setMiniAppShow).toHaveBeenCalledWith(false)
   })
@@ -287,10 +294,13 @@ describe('MiniAppTabsPool', () => {
     mocks.tabs = [{ id: 't1', url: '/app/mini-app/alpha' }]
     mocks.activeTabId = 't1'
 
-    render(<MiniAppTabsPool />)
+    const { rerender } = render(<MiniAppTabsPool />)
 
     await waitFor(() => expect(mocks.openedKeepAliveMiniApps.map((app) => app.appId)).toEqual(['alpha']))
     expect(clearWebviewState).toHaveBeenCalledWith('bravo')
+    act(() => {
+      rerender(<MiniAppTabsPool />)
+    })
     expect(mocks.setCurrentMiniAppId).toHaveBeenCalledWith('alpha')
     expect(mocks.setMiniAppShow).toHaveBeenCalledWith(true)
   })
@@ -301,10 +311,13 @@ describe('MiniAppTabsPool', () => {
     mocks.tabs = [{ id: 't1', url: '/app/mini-app/alpha' }]
     mocks.activeTabId = 't1'
 
-    render(<MiniAppTabsPool />)
+    const { rerender } = render(<MiniAppTabsPool />)
 
     await waitFor(() => expect(mocks.openedKeepAliveMiniApps).toEqual([]))
     expect(clearWebviewState).toHaveBeenCalledWith('bravo')
+    act(() => {
+      rerender(<MiniAppTabsPool />)
+    })
     expect(mocks.setCurrentMiniAppId).toHaveBeenCalledWith('')
     expect(mocks.setMiniAppShow).toHaveBeenCalledWith(false)
   })
@@ -354,6 +367,70 @@ describe('MiniAppTabsPool', () => {
     await waitFor(() => expect(mocks.openedKeepAliveMiniApps.map((app) => app.appId)).toEqual(['alpha']))
     expect(mocks.setCurrentMiniAppId).toHaveBeenCalledWith('alpha')
     expect(mocks.setMiniAppShow).toHaveBeenCalledWith(true)
+  })
+
+  it('keeps an app current when it joins the pool between render and orphan cleanup (in-place tab switch)', async () => {
+    mocks.openedKeepAliveMiniApps = [stubApp('alpha')]
+    mocks.currentMiniAppId = 'alpha'
+    mocks.tabs = [{ id: 't1', url: '/app/mini-app/bravo' }]
+    mocks.activeTabId = 't1'
+
+    // MiniAppPage's passive effect commits bravo to the store before the pool's
+    // cleanup effect runs — the pool's closures still hold the pre-bravo snapshot.
+    const { rerender } = render(
+      <>
+        <PassiveEffectProbe
+          onEffect={() => {
+            mocks.openedKeepAliveMiniApps = [stubApp('alpha'), stubApp('bravo')]
+            mocks.currentMiniAppId = 'bravo'
+          }}
+        />
+        <MiniAppTabsPool />
+      </>
+    )
+    await waitFor(() => expect(mocks.openedKeepAliveMiniApps.map((app) => app.appId)).toEqual(['bravo']))
+    expect(clearWebviewState).toHaveBeenCalledWith('alpha')
+
+    // The store update re-renders the pool; realign must not have hidden bravo meanwhile.
+    act(() => {
+      rerender(
+        <>
+          <PassiveEffectProbe onEffect={() => undefined} />
+          <MiniAppTabsPool />
+        </>
+      )
+    })
+
+    expect(mocks.currentMiniAppId).toBe('bravo')
+    expect(mocks.setMiniAppShow).not.toHaveBeenCalledWith(false)
+  })
+
+  it('realigns a dangling current id even when no orphan cleanup runs', () => {
+    mocks.openedKeepAliveMiniApps = [stubApp('alpha')]
+    mocks.currentMiniAppId = 'ghost'
+    mocks.tabs = [{ id: 't1', url: '/app/mini-app/alpha' }]
+    mocks.activeTabId = 't1'
+
+    render(<MiniAppTabsPool />)
+
+    expect(mocks.setOpenedKeepAliveMiniApps).not.toHaveBeenCalled()
+    expect(mocks.setCurrentMiniAppId).toHaveBeenCalledWith('alpha')
+    expect(mocks.setMiniAppShow).toHaveBeenCalledWith(true)
+  })
+
+  it('leaves a one-off current app untouched while orphan cleanup evicts pooled apps', async () => {
+    mocks.openedKeepAliveMiniApps = [stubApp('alpha')]
+    mocks.openedOneOffMiniApp = stubApp('solo')
+    mocks.currentMiniAppId = 'solo'
+    mocks.tabs = [{ id: 'home', url: '/app/translate' }]
+    mocks.activeTabId = 'home'
+
+    render(<MiniAppTabsPool />)
+
+    await waitFor(() => expect(mocks.openedKeepAliveMiniApps).toEqual([]))
+    expect(clearWebviewState).toHaveBeenCalledWith('alpha')
+    expect(mocks.setCurrentMiniAppId).not.toHaveBeenCalled()
+    expect(mocks.setMiniAppShow).not.toHaveBeenCalledWith(false)
   })
 
   it('ignores a load callback that lands after the app was evicted', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The orphan-cleanup effect in `MiniAppTabsPool` mixed two views of the same state: the pool was filtered with a functional updater (resolved against the **latest** cache value), while the `currentMiniAppId`/`miniAppShow` realignment was derived from the **render-time** snapshot (`kept`). If a sibling effect committed a new app to the pool in the same commit (the only such writer is `MiniAppPage`'s mount effect), the app could be kept in the pool yet hidden — and the next effect run early-returned on "no orphans", so the state never self-corrected.

After this PR:

The effect is split in two. Cleanup only filters the pool and clears webview state for orphans. Realignment is its own always-on effect that re-runs against each fresh snapshot, so a decision made against a stale snapshot self-heals on the next run instead of sticking. A `currentMiniAppId` owned by the one-off popup (`openMiniApp(app, false)`) is treated as resolved and left untouched.

Fixes: N/A (found by code inspection, no tracking issue)

### Why we need it and why it was done in this way

The old code was only correct because every current caller happens to sequence its writes favorably — `TabRouter` syncs routes in an effect one commit after the tab-url change, so `MiniAppPage`'s pool registration never lands in the same commit as the pool's cleanup. That is correctness by coincidence: any future entry point that registers a pool entry from an effect (or a synchronous router sync) would silently reintroduce a stuck-blank webview. This change makes the reconciliation correct by construction and pins it with deterministic regression tests.

The following tradeoffs were made:

- Realignment now converges on the store-driven re-render (one commit after cleanup) instead of eagerly inside the cleanup pass. The observable end state on all reachable paths is unchanged; three existing eviction tests gained a `rerender` to model the reactive-cache re-render the module-level mocks don't emit.
- Making the realign always-on required exempting the one-off popup's current id, which legitimately lives outside the keep-alive pool.

The following alternatives were considered:

- Reading the post-filter pool synchronously via `cacheService.get('mini_app.opened_keep_alive')` inside the cleanup effect. Rejected: `useCache`'s contract explicitly forbids driving post-write work from values smuggled out of the store ("derive it in a `useEffect` that watches the value instead"), and it leaks the cache internals into the component.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The damaging interleave is **not reachable through current UI paths** — this is a latent-inconsistency fix, not a live user-facing bug. The three new regression tests construct the interleave directly (a sibling passive effect writing the store between the pool's render and its cleanup effect) and fail deterministically on the old implementation; all 25 tests pass on the new one.
- Verified locally with `vitest run` on the test file, `tsgo --noEmit -p tsconfig.web.json`, scoped `oxlint --deny-warnings`, `biome check`, and `eslint` on the touched files. The full repo gate is left to CI.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
