### PR TITLE
fix(composer): decouple link chip color from user theme

### DIFF
--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -345,6 +345,42 @@ describe('ComposerToken', () => {
     )
   })
 
+  it('renders link tokens with the fixed link affordance color instead of the theme primary', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'link:1',
+          kind: 'link',
+          label: 'Cherry Studio',
+          promptText: 'https://cherry-ai.com'
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="link"]')
+    expect(token).toBeInTheDocument()
+    expect(token).toHaveClass('text-link')
+    expect(token).not.toHaveClass('text-primary')
+  })
+
+  it('keeps unparseable link tokens on the fixed link affordance color too', () => {
+    const { container } = render(
+      <ComposerToken
+        token={{
+          id: 'link:2',
+          kind: 'link',
+          label: 'Broken Link',
+          promptText: 'not-a-valid-url'
+        }}
+      />
+    )
+
+    const token = container.querySelector('[data-composer-token-kind="link"]')
+    expect(token).toBeInTheDocument()
+    expect(token).toHaveClass('text-link')
+    expect(token).not.toHaveClass('text-primary')
+  })
+
   it('renders folder tokens as compact inline chips with the full path in a tooltip', () => {
     const { container } = render(
       <ComposerToken

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -255,7 +255,8 @@ export function LinkComposerToken(props: ComposerTokenProps) {
   if (!link) {
     return renderActiveComposerTokenElement({
       ...props,
-      icon: tokenIconByKind.link
+      icon: tokenIconByKind.link,
+      colorClassName: 'text-link'
     })
   }
 
@@ -276,6 +277,7 @@ export function LinkComposerToken(props: ComposerTokenProps) {
   // The chip only shows the truncated label; hover must surface the full url the label stands for.
   const chipElement = renderActiveComposerTokenElement({
     ...props,
+    colorClassName: 'text-link',
     className: cn('cursor-pointer rounded-[4px] focus-visible:bg-accent focus-visible:outline-none', props.className),
     icon: props.readOnly ? (
       <span


### PR DESCRIPTION
### What this PR does

Before this PR:

Composer link chips (and the same chips re-rendered in messages) fell through to the shared default `colorClassName = 'text-primary'`, so they rendered in the user-configurable theme color — green (`#00b96b`) by default. The color neither reads as a hyperlink affordance nor stays stable: changing the user theme recolors every link chip.

After this PR:

Both render paths of `LinkComposerToken` (parsed chip and unparseable fallback) pass `colorClassName: 'text-link'`, a fixed semantic role color (blue-600 light / blue-400 dark) that is decoupled from the user's theme color. Chips now match markdown links already rendered in message bodies.

Follow-up addressing review feedback on #19107.

### Why we need it and why it was done in this way

The following tradeoffs were made:

We chose `text-link` over `text-info` — even though `PromptVariableComposerToken` uses `text-info` as an in-file precedent:

1. **Design-system role**: `DESIGN.md` assigns clickable text the dedicated `link` role and explicitly states "Do not treat `primary` as a generic blue"; `info` belongs to the Feedback family, which fits prompt-variable placeholders but not clickable links.
2. **Contrast**: in light mode `--cs-blue-500` (info) is ~3.6:1 against white and fails WCAG AA (4.5:1); `--cs-blue-600` (link) is ~5.3:1 and passes.
3. **Consistency**: message-body markdown links already use `text-link` (markdown/Link.tsx), so chips and adjacent plain links no longer show two different blues side by side.

The following alternatives were considered:

- `text-info` for visual uniformity with prompt-variable chips — rejected per the reasons above; dark mode is unaffected either way since both resolve to blue-400.
- Changing the shared default `'text-primary'` in `renderActiveComposerTokenElement` — rejected because skill/knowledge/reference/quote token kinds intentionally rely on the brand color.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/19107#issuecomment-5406417431

### Breaking changes

None. Visual-only change to link chip color.

### Special notes for your reviewer

- Two contract tests assert the chip carries `text-link` and not `text-primary`, for both the parsed and unparseable URL paths.
- Selected-state highlight still uses `text-primary`; that pre-existing behavior is shared by all token kinds and was intentionally left untouched.
- Affected surfaces: composer editor chips, read-only chips in message rendering, and QueuedFollowupsDock (all consume the same registry).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596909517/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Link chips now use a fixed link-blue instead of following the customizable theme color.
```
