### PR TITLE
fix(image-preview): preserve SVG intrinsic dimensions

### DIFF
--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -15,6 +15,7 @@ import {
   convertToBase64,
   getImageBlobFromSource,
   IMAGE_CAPTURE_ATTRIBUTE,
+  imageInputToPreviewUrl,
   makeSvgSizeAdaptive,
   MAX_ENTITY_IMAGE_UPLOAD_BYTES,
   prepareEntityImageBytes,
@@ -598,6 +599,71 @@ describe('utils/image', () => {
       const result = makeSvgSizeAdaptive(divElement)
 
       expect(result.outerHTML).toBe(originalOuterHTML)
+    })
+  })
+
+  describe('imageInputToPreviewUrl', () => {
+    let previewBlob: Blob | undefined
+    let createObjectUrlDescriptor: PropertyDescriptor | undefined
+    const readBlob = (blob: Blob) =>
+      new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(String(reader.result))
+        reader.onerror = () => reject(reader.error)
+        reader.readAsText(blob)
+      })
+
+    beforeEach(() => {
+      previewBlob = undefined
+      createObjectUrlDescriptor = Object.getOwnPropertyDescriptor(URL, 'createObjectURL')
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: vi.fn((blob: Blob) => {
+          previewBlob = blob
+          return 'blob:svg-preview'
+        })
+      })
+    })
+
+    afterEach(() => {
+      if (createObjectUrlDescriptor) {
+        Object.defineProperty(URL, 'createObjectURL', createObjectUrlDescriptor)
+      } else {
+        Reflect.deleteProperty(URL, 'createObjectURL')
+      }
+    })
+
+    it('restores viewBox dimensions on a responsive SVG preview without mutating the live node', async () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('viewBox', '0 0 960 480')
+      svg.setAttribute('width', '100%')
+      svg.style.maxWidth = '960px'
+      svg.innerHTML = '<text x="20" y="40">First line</text><text x="20" y="80">Second line</text>'
+
+      await expect(imageInputToPreviewUrl(svg, { format: 'svg' })).resolves.toBe('blob:svg-preview')
+
+      expect(svg.getAttribute('width')).toBe('100%')
+      expect(svg.hasAttribute('height')).toBe(false)
+
+      const previewSvg = new DOMParser().parseFromString(await readBlob(previewBlob!), 'image/svg+xml').documentElement
+      expect(previewSvg.getAttribute('width')).toBe('960')
+      expect(previewSvg.getAttribute('height')).toBe('480')
+      expect(previewSvg.getAttribute('viewBox')).toBe('0 0 960 480')
+      expect(previewSvg.textContent).toContain('First line')
+      expect(previewSvg.textContent).toContain('Second line')
+    })
+
+    it('preserves an SVG that already has positive intrinsic dimensions', async () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('viewBox', '0 0 800 400')
+      svg.setAttribute('width', '320px')
+      svg.setAttribute('height', '180px')
+
+      await imageInputToPreviewUrl(svg, { format: 'svg' })
+
+      const previewSvg = new DOMParser().parseFromString(await readBlob(previewBlob!), 'image/svg+xml').documentElement
+      expect(previewSvg.getAttribute('width')).toBe('320px')
+      expect(previewSvg.getAttribute('height')).toBe('180px')
     })
   })
 

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -695,6 +695,24 @@ describe('utils/image', () => {
       expect(previewSvg.getAttribute('width')).toBe('800')
       expect(previewSvg.getAttribute('height')).toBe('400')
     })
+
+    it.each(['NaN 0 800 400', '0 Infinity 800 400'])(
+      'does not derive intrinsic dimensions from an invalid viewBox origin: %s',
+      async (viewBox) => {
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+        svg.setAttribute('viewBox', viewBox)
+        svg.setAttribute('width', '100%')
+
+        await imageInputToPreviewUrl(svg, { format: 'svg' })
+
+        const previewSvg = new DOMParser().parseFromString(
+          await readBlob(previewBlob!),
+          'image/svg+xml'
+        ).documentElement
+        expect(previewSvg.hasAttribute('width')).toBe(false)
+        expect(previewSvg.hasAttribute('height')).toBe(false)
+      }
+    )
   })
 
   describe('getImageBlobFromSource', () => {

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -709,7 +709,7 @@ describe('utils/image', () => {
           await readBlob(previewBlob!),
           'image/svg+xml'
         ).documentElement
-        expect(previewSvg.hasAttribute('width')).toBe(false)
+        expect(previewSvg.getAttribute('width')).toBe('100%')
         expect(previewSvg.hasAttribute('height')).toBe(false)
       }
     )

--- a/src/renderer/utils/__tests__/image.test.ts
+++ b/src/renderer/utils/__tests__/image.test.ts
@@ -665,6 +665,36 @@ describe('utils/image', () => {
       expect(previewSvg.getAttribute('width')).toBe('320px')
       expect(previewSvg.getAttribute('height')).toBe('180px')
     })
+
+    it.each([
+      ['width only', '1600', null],
+      ['height only', null, '900'],
+      ['relative width', '20em', null],
+      ['signed and trailing-decimal lengths', '+320', '180.']
+    ])('preserves valid %s SVG sizing', async (_label, width, height) => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('viewBox', '0 0 16 9')
+      if (width !== null) svg.setAttribute('width', width)
+      if (height !== null) svg.setAttribute('height', height)
+
+      await imageInputToPreviewUrl(svg, { format: 'svg' })
+
+      const previewSvg = new DOMParser().parseFromString(await readBlob(previewBlob!), 'image/svg+xml').documentElement
+      expect(previewSvg.getAttribute('width')).toBe(width)
+      expect(previewSvg.getAttribute('height')).toBe(height)
+    })
+
+    it('replaces a non-finite SVG length with finite viewBox dimensions', async () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      svg.setAttribute('viewBox', '0 0 800 400')
+      svg.setAttribute('width', '1e309px')
+
+      await imageInputToPreviewUrl(svg, { format: 'svg' })
+
+      const previewSvg = new DOMParser().parseFromString(await readBlob(previewBlob!), 'image/svg+xml').documentElement
+      expect(previewSvg.getAttribute('width')).toBe('800')
+      expect(previewSvg.getAttribute('height')).toBe('400')
+    })
   })
 
   describe('getImageBlobFromSource', () => {

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -602,10 +602,13 @@ export const svgToSvgBlob = (svgElement: SVGElement): Blob => {
   return new Blob([svgData], { type: 'image/svg+xml' })
 }
 
-const ABSOLUTE_SVG_LENGTH = /^\s*(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?(?:px|pt|pc|mm|cm|in|q)?\s*$/i
+const INTRINSIC_SVG_LENGTH = /^\s*\+?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?(?:px|pt|pc|mm|cm|in|q|em|ex)?\s*$/i
 
-const hasPositiveAbsoluteSvgLength = (value: string | null): boolean =>
-  value !== null && ABSOLUTE_SVG_LENGTH.test(value) && Number.parseFloat(value) > 0
+const hasPositiveIntrinsicSvgLength = (value: string | null): boolean => {
+  if (value === null || !INTRINSIC_SVG_LENGTH.test(value)) return false
+  const length = Number.parseFloat(value)
+  return Number.isFinite(length) && length > 0
+}
 
 /**
  * An SVG embedded in the conversation is responsive (`width="100%"`, usually no
@@ -617,8 +620,8 @@ const hasPositiveAbsoluteSvgLength = (value: string | null): boolean =>
 const createStandaloneSvgPreview = (svgElement: SVGElement): SVGElement => {
   const clone = svgElement.cloneNode(true) as SVGElement
   if (
-    hasPositiveAbsoluteSvgLength(clone.getAttribute('width')) &&
-    hasPositiveAbsoluteSvgLength(clone.getAttribute('height'))
+    hasPositiveIntrinsicSvgLength(clone.getAttribute('width')) ||
+    hasPositiveIntrinsicSvgLength(clone.getAttribute('height'))
   ) {
     return clone
   }

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -631,13 +631,7 @@ const createStandaloneSvgPreview = (svgElement: SVGElement): SVGElement => {
     ?.trim()
     .split(/[\s,]+/)
     .map(Number)
-  if (
-    viewBox?.length === 4 &&
-    Number.isFinite(viewBox[2]) &&
-    Number.isFinite(viewBox[3]) &&
-    viewBox[2] > 0 &&
-    viewBox[3] > 0
-  ) {
+  if (viewBox?.length === 4 && viewBox.every(Number.isFinite) && viewBox[2] > 0 && viewBox[3] > 0) {
     clone.setAttribute('width', String(viewBox[2]))
     clone.setAttribute('height', String(viewBox[3]))
   }

--- a/src/renderer/utils/image.ts
+++ b/src/renderer/utils/image.ts
@@ -602,6 +602,46 @@ export const svgToSvgBlob = (svgElement: SVGElement): Blob => {
   return new Blob([svgData], { type: 'image/svg+xml' })
 }
 
+const ABSOLUTE_SVG_LENGTH = /^\s*(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?(?:px|pt|pc|mm|cm|in|q)?\s*$/i
+
+const hasPositiveAbsoluteSvgLength = (value: string | null): boolean =>
+  value !== null && ABSOLUTE_SVG_LENGTH.test(value) && Number.parseFloat(value) > 0
+
+/**
+ * An SVG embedded in the conversation is responsive (`width="100%"`, usually no
+ * height), but the same node becomes a replaced image in the full-screen preview.
+ * Percentage/missing dimensions give that standalone image the browser's small
+ * default intrinsic size, so the viewer's fit and zoom geometry starts from the
+ * wrong box. Give only the preview clone an intrinsic vector size.
+ */
+const createStandaloneSvgPreview = (svgElement: SVGElement): SVGElement => {
+  const clone = svgElement.cloneNode(true) as SVGElement
+  if (
+    hasPositiveAbsoluteSvgLength(clone.getAttribute('width')) &&
+    hasPositiveAbsoluteSvgLength(clone.getAttribute('height'))
+  ) {
+    return clone
+  }
+
+  const viewBox = clone
+    .getAttribute('viewBox')
+    ?.trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  if (
+    viewBox?.length === 4 &&
+    Number.isFinite(viewBox[2]) &&
+    Number.isFinite(viewBox[3]) &&
+    viewBox[2] > 0 &&
+    viewBox[3] > 0
+  ) {
+    clone.setAttribute('width', String(viewBox[2]))
+    clone.setAttribute('height', String(viewBox[3]))
+  }
+
+  return clone
+}
+
 export type ImageInput = SVGElement | HTMLImageElement | string | Blob
 
 export interface ImagePreviewOptions {
@@ -616,7 +656,10 @@ export interface ImagePreviewOptions {
  */
 export const imageInputToPreviewUrl = async (input: ImageInput, options: ImagePreviewOptions = {}): Promise<string> => {
   if (input instanceof SVGElement) {
-    const blob = options.format === 'svg' ? svgToSvgBlob(input) : await svgToPngBlob(input, options.scale || 3)
+    const blob =
+      options.format === 'svg'
+        ? svgToSvgBlob(createStandaloneSvgPreview(input))
+        : await svgToPngBlob(input, options.scale || 3)
     return URL.createObjectURL(blob)
   }
 


### PR DESCRIPTION
## Summary

- keep Mermaid/Graphviz/PlantUML/inline-SVG full-screen previews on the SVG path;
- clone responsive SVG roots and restore positive intrinsic `width`/`height` from a valid `viewBox` before creating the preview blob;
- preserve the live responsive node and the existing SVG download source;
- add regression coverage for multiline Mermaid-style content and already intrinsic-sized SVGs.

## Root cause

The in-message renderer intentionally makes SVG roots responsive (`width="100%"`, usually without `height`). Reusing that node as a standalone `<img>` source leaves Chromium without absolute intrinsic dimensions, so it falls back to a small replaced-element box and the image viewer performs fit/zoom geometry from the wrong size.

The fix applies only to the cloned standalone preview. If both dimensions are already positive absolute SVG lengths, they are preserved. Otherwise, a finite positive `viewBox` supplies the intrinsic dimensions. The source remains SVG rather than being rasterized.

## Validation

- `pnpm exec vitest run src/renderer/utils/__tests__/image.test.ts src/renderer/services/__tests__/ImagePreviewService.test.ts src/renderer/components/ActionTools/__tests__/useImageTools.test.tsx src/renderer/components/Preview/__tests__/MermaidPreview.test.tsx packages/ui/src/components/composites/image-preview/__tests__/image-preview.test.tsx` — 72 passed
- `pnpm lint` — passed (46 pre-existing warnings, 0 errors)
- `git diff --check` — passed

Closes #19355
