### PR TITLE
fix(oauth): clean up popup message listeners

### DIFF
--- a/src/renderer/services/__tests__/oauth.test.ts
+++ b/src/renderer/services/__tests__/oauth.test.ts
@@ -130,6 +130,18 @@ describe('popup message OAuth flows', () => {
     expect(setSiliconKey).not.toHaveBeenCalled()
   })
 
+  it('keeps the previous flow active when its replacement popup is blocked', async () => {
+    const setSiliconKey = vi.fn()
+    await oauthWithSiliconFlow(setSiliconKey)
+    const siliconPopup = openedPopups[0]
+
+    vi.mocked(window.open).mockReturnValueOnce(null)
+    await oauthWith302AI(vi.fn())
+
+    dispatchPopupMessage(siliconPopup, 'https://account.siliconflow.cn', [{ secretKey: 'silicon-key' }])
+    await vi.waitFor(() => expect(setSiliconKey).toHaveBeenCalledWith('silicon-key'))
+  })
+
   it.each([
     ['charge', providerCharge],
     ['bills', providerBills]
@@ -187,6 +199,30 @@ describe('popup message OAuth flows', () => {
       data: { iv: 'iv', encryptedData: 'ciphertext' }
     })
     expect(mocks.decrypt).not.toHaveBeenCalled()
+  })
+
+  it('finishes processing a valid callback after its popup closes', async () => {
+    let resolveDecryption: (value: string) => void = () => undefined
+    mocks.decrypt.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveDecryption = resolve
+      })
+    )
+    const setKey = vi.fn()
+    await oauthWithAihubmix(setKey)
+    const popup = openedPopups[0]
+
+    dispatchPopupMessage(popup, 'https://console.inferera.com', {
+      key: 'cherry_studio_oauth_callback',
+      data: { iv: 'iv', encryptedData: 'ciphertext' }
+    })
+    await vi.waitFor(() => expect(mocks.decrypt).toHaveBeenCalledOnce())
+
+    popup.closed = true
+    vi.advanceTimersByTime(500)
+    resolveDecryption(JSON.stringify({ api_keys: [{ value: 'callback-key' }] }))
+
+    await vi.waitFor(() => expect(setKey).toHaveBeenCalledWith('callback-key'))
   })
 
   it('preserves successful Aihubmix decryption and AiOnly key handling', async () => {

--- a/src/renderer/services/__tests__/oauth.test.ts
+++ b/src/renderer/services/__tests__/oauth.test.ts
@@ -34,7 +34,14 @@ vi.mock('@renderer/services/toast', () => ({
   toast: { error: mocks.toastError }
 }))
 
-import { oauthWith302AI, oauthWithAihubmix, oauthWithAiOnly, oauthWithSiliconFlow } from '../oauth'
+import {
+  oauthWith302AI,
+  oauthWithAihubmix,
+  oauthWithAiOnly,
+  oauthWithSiliconFlow,
+  providerBills,
+  providerCharge
+} from '../oauth'
 
 interface MockPopup {
   closed: boolean
@@ -62,12 +69,6 @@ function dispatchPopupMessage(popup: MockPopup, origin: string, data: unknown): 
       source: popup as unknown as Window
     })
   )
-}
-
-async function flushPromises(): Promise<void> {
-  for (let index = 0; index < 10; index += 1) {
-    await Promise.resolve()
-  }
 }
 
 describe('popup message OAuth flows', () => {
@@ -104,14 +105,12 @@ describe('popup message OAuth flows', () => {
     expect(setKey).not.toHaveBeenCalled()
 
     dispatchPopupMessage(popup, 'https://account.siliconflow.cn', payload)
-    await flushPromises()
+    await vi.waitFor(() => expect(setKey).toHaveBeenCalledWith('silicon-key'))
 
     expect(setKey).toHaveBeenCalledOnce()
-    expect(setKey).toHaveBeenCalledWith('silicon-key')
     expect(popup.close).toHaveBeenCalledOnce()
 
     dispatchPopupMessage(popup, 'https://account.siliconflow.cn', payload)
-    await flushPromises()
     expect(setKey).toHaveBeenCalledOnce()
   })
 
@@ -126,10 +125,23 @@ describe('popup message OAuth flows', () => {
 
     dispatchPopupMessage(siliconPopup, 'https://account.siliconflow.cn', [{ secretKey: 'stale-key' }])
     dispatchPopupMessage(popup302, 'https://dash.302.ai', { data: { apikey: '302-key' } })
-    await flushPromises()
+    await vi.waitFor(() => expect(set302Key).toHaveBeenCalledWith('302-key'))
 
     expect(setSiliconKey).not.toHaveBeenCalled()
-    expect(set302Key).toHaveBeenCalledWith('302-key')
+  })
+
+  it.each([
+    ['charge', providerCharge],
+    ['bills', providerBills]
+  ] as const)('retires the OAuth handler when the named popup is reused for %s', async (_label, openPage) => {
+    const setKey = vi.fn()
+    await oauthWithSiliconFlow(setKey)
+    const oauthPopup = openedPopups[0]
+
+    await openPage('silicon')
+    dispatchPopupMessage(oauthPopup, 'https://account.siliconflow.cn', [{ secretKey: 'stale-key' }])
+
+    expect(setKey).not.toHaveBeenCalled()
   })
 
   it('removes a handler when its popup closes', async () => {
@@ -140,7 +152,6 @@ describe('popup message OAuth flows', () => {
     popup.closed = true
     vi.advanceTimersByTime(500)
     dispatchPopupMessage(popup, 'https://dash.302.ai', { data: { apikey: 'late-key' } })
-    await flushPromises()
 
     expect(setKey).not.toHaveBeenCalled()
   })
@@ -152,7 +163,6 @@ describe('popup message OAuth flows', () => {
 
     vi.advanceTimersByTime(10 * 60 * 1000)
     dispatchPopupMessage(popup, 'https://dash.302.ai', { data: { apikey: 'late-key' } })
-    await flushPromises()
 
     expect(setKey).not.toHaveBeenCalled()
   })
@@ -166,18 +176,16 @@ describe('popup message OAuth flows', () => {
       key: 'cherry_studio_oauth_callback',
       data: { iv: 42 }
     })
-    await flushPromises()
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith('settings.provider.oauth.error'))
 
     expect(mocks.decrypt).not.toHaveBeenCalled()
     expect(setKey).not.toHaveBeenCalled()
-    expect(mocks.toastError).toHaveBeenCalledWith('settings.provider.oauth.error')
     expect(popup.close).toHaveBeenCalledOnce()
 
     dispatchPopupMessage(popup, 'https://console.inferera.com', {
       key: 'cherry_studio_oauth_callback',
       data: { iv: 'iv', encryptedData: 'ciphertext' }
     })
-    await flushPromises()
     expect(mocks.decrypt).not.toHaveBeenCalled()
   })
 
@@ -190,18 +198,16 @@ describe('popup message OAuth flows', () => {
       key: 'cherry_studio_oauth_callback',
       data: { iv: 'iv', encryptedData: 'ciphertext' }
     })
-    await flushPromises()
+    await vi.waitFor(() => expect(setAihubmixKey).toHaveBeenCalledWith('aihubmix-key'))
 
     expect(mocks.decrypt).toHaveBeenCalledWith('ciphertext', 'iv', '')
-    expect(setAihubmixKey).toHaveBeenCalledWith('aihubmix-key')
 
     const setAiOnlyKey = vi.fn()
     await oauthWithAiOnly(setAiOnlyKey)
     const aiOnlyPopup = openedPopups[1]
     dispatchPopupMessage(aiOnlyPopup, 'https://maas.aiionly.com', [{ secretKey: 'aionly-key' }])
-    await flushPromises()
+    await vi.waitFor(() => expect(setAiOnlyKey).toHaveBeenCalledWith('aionly-key'))
 
-    expect(setAiOnlyKey).toHaveBeenCalledWith('aionly-key')
     expect(aiOnlyPopup.close).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/services/__tests__/oauth.test.ts
+++ b/src/renderer/services/__tests__/oauth.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  decrypt: vi.fn(),
+  getLanguageCode: vi.fn(async () => 'en-US'),
+  loggerError: vi.fn(),
+  toastError: vi.fn(),
+  translate: vi.fn((key: string) => key)
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => ({
+      debug: vi.fn(),
+      error: mocks.loggerError,
+      warn: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@renderer/i18n/resolver', () => ({
+  default: { t: mocks.translate },
+  getLanguageCode: mocks.getLanguageCode
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    on: vi.fn(),
+    request: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: mocks.toastError }
+}))
+
+import { oauthWith302AI, oauthWithAihubmix, oauthWithAiOnly, oauthWithSiliconFlow } from '../oauth'
+
+interface MockPopup {
+  closed: boolean
+  close: ReturnType<typeof vi.fn>
+}
+
+const openedPopups: MockPopup[] = []
+
+function createPopup(): MockPopup {
+  const popup: MockPopup = {
+    closed: false,
+    close: vi.fn(() => {
+      popup.closed = true
+    })
+  }
+  openedPopups.push(popup)
+  return popup
+}
+
+function dispatchPopupMessage(popup: MockPopup, origin: string, data: unknown): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data,
+      origin,
+      source: popup as unknown as Window
+    })
+  )
+}
+
+async function flushPromises(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('popup message OAuth flows', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    openedPopups.length = 0
+    mocks.getLanguageCode.mockResolvedValue('en-US')
+    mocks.decrypt.mockResolvedValue(JSON.stringify({ api_keys: [{ value: 'aihubmix-key' }] }))
+
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { aes: { decrypt: mocks.decrypt } }
+    })
+    vi.spyOn(window, 'open').mockImplementation(() => createPopup() as unknown as Window)
+  })
+
+  afterEach(() => {
+    for (const popup of openedPopups) popup.closed = true
+    vi.advanceTimersByTime(500)
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('accepts only the expected Silicon popup and origin, then removes the listener', async () => {
+    const setKey = vi.fn()
+    await oauthWithSiliconFlow(setKey)
+    const popup = openedPopups[0]
+    const otherPopup = createPopup()
+    const payload = [{ secretKey: 'silicon-key' }]
+
+    dispatchPopupMessage(popup, 'https://attacker.example', payload)
+    dispatchPopupMessage(otherPopup, 'https://account.siliconflow.cn', payload)
+    expect(setKey).not.toHaveBeenCalled()
+
+    dispatchPopupMessage(popup, 'https://account.siliconflow.cn', payload)
+    await flushPromises()
+
+    expect(setKey).toHaveBeenCalledOnce()
+    expect(setKey).toHaveBeenCalledWith('silicon-key')
+    expect(popup.close).toHaveBeenCalledOnce()
+
+    dispatchPopupMessage(popup, 'https://account.siliconflow.cn', payload)
+    await flushPromises()
+    expect(setKey).toHaveBeenCalledOnce()
+  })
+
+  it('retires the previous handler when another flow reuses the oauth popup name', async () => {
+    const setSiliconKey = vi.fn()
+    const set302Key = vi.fn()
+    await oauthWithSiliconFlow(setSiliconKey)
+    const siliconPopup = openedPopups[0]
+
+    await oauthWith302AI(set302Key)
+    const popup302 = openedPopups[1]
+
+    dispatchPopupMessage(siliconPopup, 'https://account.siliconflow.cn', [{ secretKey: 'stale-key' }])
+    dispatchPopupMessage(popup302, 'https://dash.302.ai', { data: { apikey: '302-key' } })
+    await flushPromises()
+
+    expect(setSiliconKey).not.toHaveBeenCalled()
+    expect(set302Key).toHaveBeenCalledWith('302-key')
+  })
+
+  it('removes a handler when its popup closes', async () => {
+    const setKey = vi.fn()
+    await oauthWith302AI(setKey)
+    const popup = openedPopups[0]
+
+    popup.closed = true
+    vi.advanceTimersByTime(500)
+    dispatchPopupMessage(popup, 'https://dash.302.ai', { data: { apikey: 'late-key' } })
+    await flushPromises()
+
+    expect(setKey).not.toHaveBeenCalled()
+  })
+
+  it('removes a handler when the flow times out', async () => {
+    const setKey = vi.fn()
+    await oauthWith302AI(setKey)
+    const popup = openedPopups[0]
+
+    vi.advanceTimersByTime(10 * 60 * 1000)
+    dispatchPopupMessage(popup, 'https://dash.302.ai', { data: { apikey: 'late-key' } })
+    await flushPromises()
+
+    expect(setKey).not.toHaveBeenCalled()
+  })
+
+  it('cleans up a recognized malformed Aihubmix callback', async () => {
+    const setKey = vi.fn()
+    await oauthWithAihubmix(setKey)
+    const popup = openedPopups[0]
+
+    dispatchPopupMessage(popup, 'https://console.inferera.com', {
+      key: 'cherry_studio_oauth_callback',
+      data: { iv: 42 }
+    })
+    await flushPromises()
+
+    expect(mocks.decrypt).not.toHaveBeenCalled()
+    expect(setKey).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('settings.provider.oauth.error')
+    expect(popup.close).toHaveBeenCalledOnce()
+
+    dispatchPopupMessage(popup, 'https://console.inferera.com', {
+      key: 'cherry_studio_oauth_callback',
+      data: { iv: 'iv', encryptedData: 'ciphertext' }
+    })
+    await flushPromises()
+    expect(mocks.decrypt).not.toHaveBeenCalled()
+  })
+
+  it('preserves successful Aihubmix decryption and AiOnly key handling', async () => {
+    const setAihubmixKey = vi.fn()
+    await oauthWithAihubmix(setAihubmixKey)
+    const aihubmixPopup = openedPopups[0]
+
+    dispatchPopupMessage(aihubmixPopup, 'https://console.inferera.com', {
+      key: 'cherry_studio_oauth_callback',
+      data: { iv: 'iv', encryptedData: 'ciphertext' }
+    })
+    await flushPromises()
+
+    expect(mocks.decrypt).toHaveBeenCalledWith('ciphertext', 'iv', '')
+    expect(setAihubmixKey).toHaveBeenCalledWith('aihubmix-key')
+
+    const setAiOnlyKey = vi.fn()
+    await oauthWithAiOnly(setAiOnlyKey)
+    const aiOnlyPopup = openedPopups[1]
+    dispatchPopupMessage(aiOnlyPopup, 'https://maas.aiionly.com', [{ secretKey: 'aionly-key' }])
+    await flushPromises()
+
+    expect(setAiOnlyKey).toHaveBeenCalledWith('aionly-key')
+    expect(aiOnlyPopup.close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/services/oauth.ts
+++ b/src/renderer/services/oauth.ts
@@ -35,7 +35,30 @@ interface PopupMessageOAuthOptions<T> {
   onError?: (error: unknown) => void
 }
 
-const activePopupFlowCleanups = new Map<string, () => void>()
+class PopupFlowRegistry {
+  readonly #cleanups = new Map<string, () => void>()
+
+  retire(popupName: string): void {
+    this.#cleanups.get(popupName)?.()
+  }
+
+  register(popupName: string, cleanup: () => void): void {
+    this.retire(popupName)
+    this.#cleanups.set(popupName, cleanup)
+  }
+
+  release(popupName: string, cleanup: () => void): void {
+    if (this.#cleanups.get(popupName) === cleanup) this.#cleanups.delete(popupName)
+  }
+}
+
+const popupFlowRegistry = new PopupFlowRegistry()
+
+function openNamedPopup(authUrl: string, popupName: string, features: string): Window | null {
+  // Reusing a named window is terminal for any message flow that owned it.
+  popupFlowRegistry.retire(popupName)
+  return window.open(authUrl, popupName, features)
+}
 
 function isSecretKeyOAuthPayload(data: unknown): data is SecretKeyOAuthPayload {
   return (
@@ -69,11 +92,9 @@ function startPopupMessageOAuth<T>({
   setKey,
   onError
 }: PopupMessageOAuthOptions<T>): void {
-  const popup = window.open(authUrl, popupName, OAUTH_POPUP_FEATURES)
+  const popup = openNamedPopup(authUrl, popupName, OAUTH_POPUP_FEATURES)
   if (!popup) return
   const openedPopup = popup
-
-  activePopupFlowCleanups.get(popupName)?.()
 
   const expectedOrigin = new URL(authUrl.trim()).origin
   let active = true
@@ -91,9 +112,7 @@ function startPopupMessageOAuth<T>({
     stopListening()
     window.clearInterval(closePollId)
     window.clearTimeout(timeoutId)
-    if (activePopupFlowCleanups.get(popupName) === finish) {
-      activePopupFlowCleanups.delete(popupName)
-    }
+    popupFlowRegistry.release(popupName, finish)
   }
 
   function messageHandler(event: MessageEvent): void {
@@ -126,7 +145,7 @@ function startPopupMessageOAuth<T>({
   }, OAUTH_POPUP_CLOSE_POLL_MS)
   const timeoutId = window.setTimeout(finish, OAUTH_POPUP_TIMEOUT_MS)
 
-  activePopupFlowCleanups.set(popupName, finish)
+  popupFlowRegistry.register(popupName, finish)
   window.addEventListener('message', messageHandler)
 }
 
@@ -178,7 +197,7 @@ export const oauthWithPPIO = async (setKey) => {
   const redirectUri = 'cherrystudio://'
   const authUrl = `https://ppio.com/oauth/authorize?invited_by=JYT9GD&client_id=${PPIO_CLIENT_ID}&scope=api%20openid&response_type=code&redirect_uri=${encodeURIComponent(redirectUri)}`
 
-  window.open(
+  openNamedPopup(
     authUrl,
     'oauth',
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
@@ -302,7 +321,7 @@ export const oauthWithCherryIn = async (
 
   logger.debug('Opening authorization URL')
 
-  window.open(
+  openNamedPopup(
     authUrl,
     'oauth',
     'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
@@ -391,7 +410,7 @@ export const providerCharge = async (provider: string) => {
 
   const { url, width, height } = chargeUrlMap[provider]
 
-  window.open(
+  openNamedPopup(
     url,
     'oauth',
     `width=${width},height=${height},toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes`
@@ -430,7 +449,7 @@ export const providerBills = async (provider: string) => {
 
   const { url, width, height } = billsUrlMap[provider]
 
-  window.open(
+  openNamedPopup(
     url,
     'oauth',
     `width=${width},height=${height},toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes`

--- a/src/renderer/services/oauth.ts
+++ b/src/renderer/services/oauth.ts
@@ -35,7 +35,8 @@ interface PopupMessageOAuthOptions<T> {
   onError?: (error: unknown) => void
 }
 
-class PopupFlowRegistry {
+/** Owns the active popup flows so replacement and teardown stay lifecycle-safe. */
+class OAuthPopupFlowManager {
   readonly #cleanups = new Map<string, () => void>()
 
   retire(popupName: string): void {
@@ -52,12 +53,12 @@ class PopupFlowRegistry {
   }
 }
 
-const popupFlowRegistry = new PopupFlowRegistry()
+const oauthPopupFlowManager = new OAuthPopupFlowManager()
 
 function openNamedPopup(authUrl: string, popupName: string, features: string): Window | null {
   const popup = window.open(authUrl, popupName, features)
   // Only retire the current flow once its replacement actually opens.
-  if (popup) popupFlowRegistry.retire(popupName)
+  if (popup) oauthPopupFlowManager.retire(popupName)
   return popup
 }
 
@@ -114,7 +115,7 @@ function startPopupMessageOAuth<T>({
     stopListening()
     window.clearInterval(closePollId)
     window.clearTimeout(timeoutId)
-    popupFlowRegistry.release(popupName, finish)
+    oauthPopupFlowManager.release(popupName, finish)
   }
 
   function messageHandler(event: MessageEvent): void {
@@ -148,7 +149,7 @@ function startPopupMessageOAuth<T>({
   }, OAUTH_POPUP_CLOSE_POLL_MS)
   const timeoutId = window.setTimeout(finish, OAUTH_POPUP_TIMEOUT_MS)
 
-  popupFlowRegistry.register(popupName, finish)
+  oauthPopupFlowManager.register(popupName, finish)
   window.addEventListener('message', messageHandler)
 }
 

--- a/src/renderer/services/oauth.ts
+++ b/src/renderer/services/oauth.ts
@@ -55,9 +55,10 @@ class PopupFlowRegistry {
 const popupFlowRegistry = new PopupFlowRegistry()
 
 function openNamedPopup(authUrl: string, popupName: string, features: string): Window | null {
-  // Reusing a named window is terminal for any message flow that owned it.
-  popupFlowRegistry.retire(popupName)
-  return window.open(authUrl, popupName, features)
+  const popup = window.open(authUrl, popupName, features)
+  // Only retire the current flow once its replacement actually opens.
+  if (popup) popupFlowRegistry.retire(popupName)
+  return popup
 }
 
 function isSecretKeyOAuthPayload(data: unknown): data is SecretKeyOAuthPayload {
@@ -99,6 +100,7 @@ function startPopupMessageOAuth<T>({
   const expectedOrigin = new URL(authUrl.trim()).origin
   let active = true
   let listening = true
+  let processingCallback = false
 
   const stopListening = () => {
     if (!listening) return
@@ -120,7 +122,8 @@ function startPopupMessageOAuth<T>({
     if (!active || event.source !== openedPopup || event.origin !== expectedOrigin || !matches(data)) return
 
     // A recognized callback is terminal. Stop accepting duplicate messages,
-    // but keep the close/timeout guards alive while async payload work runs.
+    // but let its async payload work finish even when the callback page closes.
+    processingCallback = true
     stopListening()
 
     void Promise.resolve()
@@ -141,7 +144,7 @@ function startPopupMessageOAuth<T>({
   }
 
   const closePollId = window.setInterval(() => {
-    if (openedPopup.closed) finish()
+    if (openedPopup.closed && !processingCallback) finish()
   }, OAUTH_POPUP_CLOSE_POLL_MS)
   const timeoutId = window.setTimeout(finish, OAUTH_POPUP_TIMEOUT_MS)
 

--- a/src/renderer/services/oauth.ts
+++ b/src/renderer/services/oauth.ts
@@ -10,61 +10,168 @@ const SILICON_CLIENT_ID = 'SFaJLLq0y6CAMoyDm81aMu'
 const PPIO_CLIENT_ID = '37d0828c96b34936a600b62c'
 const PPIO_APP_SECRET = import.meta.env.RENDERER_VITE_PPIO_APP_SECRET || ''
 
-export const oauthWithSiliconFlow = async (setKey) => {
-  const authUrl = `https://account.siliconflow.cn/oauth?client_id=${SILICON_CLIENT_ID}`
+const OAUTH_POPUP_TIMEOUT_MS = 10 * 60 * 1000
+const OAUTH_POPUP_CLOSE_POLL_MS = 500
+const OAUTH_POPUP_FEATURES =
+  'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
 
-  const popup = window.open(
-    authUrl,
-    'oauth',
-    'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
+type SecretKeyOAuthPayload = [{ secretKey: string }, ...unknown[]]
+
+interface AihubmixOAuthPayload {
+  key: 'cherry_studio_oauth_callback'
+  data?: unknown
+}
+
+interface NestedApiKeyOAuthPayload {
+  data: { apikey: string }
+}
+
+interface PopupMessageOAuthOptions<T> {
+  authUrl: string
+  popupName: string
+  matches: (data: unknown) => data is T
+  getKey: (data: T) => string | Promise<string>
+  setKey: (key: string) => void | Promise<void>
+  onError?: (error: unknown) => void
+}
+
+const activePopupFlowCleanups = new Map<string, () => void>()
+
+function isSecretKeyOAuthPayload(data: unknown): data is SecretKeyOAuthPayload {
+  return (
+    Array.isArray(data) &&
+    data.length > 0 &&
+    typeof data[0] === 'object' &&
+    data[0] !== null &&
+    typeof (data[0] as { secretKey?: unknown }).secretKey === 'string'
   )
+}
 
-  const messageHandler = (event) => {
-    if (event.data.length > 0 && event.data[0]['secretKey'] !== undefined) {
-      setKey(event.data[0]['secretKey'])
-      popup?.close()
-      window.removeEventListener('message', messageHandler)
+function isAihubmixOAuthPayload(data: unknown): data is AihubmixOAuthPayload {
+  return typeof data === 'object' && data !== null && (data as { key?: unknown }).key === 'cherry_studio_oauth_callback'
+}
+
+function isNestedApiKeyOAuthPayload(data: unknown): data is NestedApiKeyOAuthPayload {
+  if (typeof data !== 'object' || data === null) return false
+  const nestedData = (data as { data?: unknown }).data
+  return (
+    typeof nestedData === 'object' &&
+    nestedData !== null &&
+    typeof (nestedData as { apikey?: unknown }).apikey === 'string'
+  )
+}
+
+function startPopupMessageOAuth<T>({
+  authUrl,
+  popupName,
+  matches,
+  getKey,
+  setKey,
+  onError
+}: PopupMessageOAuthOptions<T>): void {
+  const popup = window.open(authUrl, popupName, OAUTH_POPUP_FEATURES)
+  if (!popup) return
+  const openedPopup = popup
+
+  activePopupFlowCleanups.get(popupName)?.()
+
+  const expectedOrigin = new URL(authUrl.trim()).origin
+  let active = true
+  let listening = true
+
+  const stopListening = () => {
+    if (!listening) return
+    listening = false
+    window.removeEventListener('message', messageHandler)
+  }
+
+  const finish = () => {
+    if (!active) return
+    active = false
+    stopListening()
+    window.clearInterval(closePollId)
+    window.clearTimeout(timeoutId)
+    if (activePopupFlowCleanups.get(popupName) === finish) {
+      activePopupFlowCleanups.delete(popupName)
     }
   }
 
-  window.removeEventListener('message', messageHandler)
+  function messageHandler(event: MessageEvent): void {
+    const data: unknown = event.data
+    if (!active || event.source !== openedPopup || event.origin !== expectedOrigin || !matches(data)) return
+
+    // A recognized callback is terminal. Stop accepting duplicate messages,
+    // but keep the close/timeout guards alive while async payload work runs.
+    stopListening()
+
+    void Promise.resolve()
+      .then(() => getKey(data))
+      .then(async (key) => {
+        if (!active) return
+        await setKey(key)
+        if (!active) return
+        openedPopup.close()
+        finish()
+      })
+      .catch((error) => {
+        if (!active) return
+        openedPopup.close()
+        onError?.(error)
+        finish()
+      })
+  }
+
+  const closePollId = window.setInterval(() => {
+    if (openedPopup.closed) finish()
+  }, OAUTH_POPUP_CLOSE_POLL_MS)
+  const timeoutId = window.setTimeout(finish, OAUTH_POPUP_TIMEOUT_MS)
+
+  activePopupFlowCleanups.set(popupName, finish)
   window.addEventListener('message', messageHandler)
 }
 
-export const oauthWithAihubmix = async (setKey) => {
-  const authUrl = ` https://console.inferera.com/token?client_id=cherry_studio_oauth&lang=${await getLanguageCode()}&aff=SJyh`
+export const oauthWithSiliconFlow = async (setKey) => {
+  const authUrl = `https://account.siliconflow.cn/oauth?client_id=${SILICON_CLIENT_ID}`
 
-  const popup = window.open(
+  startPopupMessageOAuth({
     authUrl,
-    'oauth',
-    'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
-  )
+    popupName: 'oauth',
+    matches: isSecretKeyOAuthPayload,
+    getKey: (data) => data[0].secretKey,
+    setKey,
+    onError: (error) => logger.error('[oauthWithSiliconFlow] error', error as Error)
+  })
+}
 
-  const messageHandler = async (event) => {
-    const data = event.data
+export const oauthWithAihubmix = async (setKey) => {
+  const authUrl = `https://console.inferera.com/token?client_id=cherry_studio_oauth&lang=${await getLanguageCode()}&aff=SJyh`
 
-    if (data && data.key === 'cherry_studio_oauth_callback') {
-      const { iv, encryptedData } = data.data
-
-      try {
-        const secret = import.meta.env.RENDERER_VITE_AIHUBMIX_SECRET || ''
-        const decryptedData: any = await window.api.aes.decrypt(encryptedData, iv, secret)
-        const { api_keys } = JSON.parse(decryptedData)
-        if (api_keys && api_keys.length > 0) {
-          setKey(api_keys[0].value)
-          popup?.close()
-          window.removeEventListener('message', messageHandler)
-        }
-      } catch (error) {
-        logger.error('[oauthWithAihubmix] error', error as Error)
-        popup?.close()
-        toast.error(i18n.t('settings.provider.oauth.error'))
+  startPopupMessageOAuth({
+    authUrl,
+    popupName: 'oauth',
+    matches: isAihubmixOAuthPayload,
+    getKey: async (data) => {
+      const callbackData = typeof data.data === 'object' && data.data !== null ? data.data : {}
+      const { iv, encryptedData } = callbackData as { iv?: unknown; encryptedData?: unknown }
+      if (typeof iv !== 'string' || typeof encryptedData !== 'string') {
+        throw new Error('Invalid OAuth callback payload')
       }
-    }
-  }
 
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+      const secret = import.meta.env.RENDERER_VITE_AIHUBMIX_SECRET || ''
+      const decryptedData: any = await window.api.aes.decrypt(encryptedData, iv, secret)
+      const { api_keys } = JSON.parse(decryptedData)
+      const key = api_keys?.[0]?.value
+      if (typeof key !== 'string' || key.length === 0) {
+        throw new Error('No API key received')
+      }
+      return key
+    },
+    setKey,
+    onError: (error) => {
+      logger.error('[oauthWithAihubmix] error', error as Error)
+      toast.error(i18n.t('settings.provider.oauth.error'))
+    }
+  })
 }
 
 export const oauthWithPPIO = async (setKey) => {
@@ -145,43 +252,27 @@ export const oauthWithPPIO = async (setKey) => {
 export const oauthWith302AI = async (setKey) => {
   const authUrl = 'https://dash.302.ai/sso/login?app=cherry-ai.com&name=Cherry%20Studio'
 
-  const popup = window.open(
+  startPopupMessageOAuth({
     authUrl,
-    'oauth',
-    'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
-  )
-
-  const messageHandler = (event) => {
-    if (event.data && event.data.data.apikey !== undefined) {
-      setKey(event.data.data.apikey)
-      popup?.close()
-      window.removeEventListener('message', messageHandler)
-    }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+    popupName: 'oauth',
+    matches: isNestedApiKeyOAuthPayload,
+    getKey: (data) => data.data.apikey,
+    setKey,
+    onError: (error) => logger.error('[oauthWith302AI] error', error as Error)
+  })
 }
 
 export const oauthWithAiOnly = async (setKey) => {
   const authUrl = `https://maas.aiionly.com/login?inviteCode=1755481173663DrZBBOC0&cherryCode=01`
 
-  const popup = window.open(
+  startPopupMessageOAuth({
     authUrl,
-    'login',
-    'width=720,height=720,toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,alwaysOnTop=yes,alwaysRaised=yes'
-  )
-
-  const messageHandler = (event) => {
-    if (event.data.length > 0 && event.data[0]['secretKey'] !== undefined) {
-      setKey(event.data[0]['secretKey'])
-      popup?.close()
-      window.removeEventListener('message', messageHandler)
-    }
-  }
-
-  window.removeEventListener('message', messageHandler)
-  window.addEventListener('message', messageHandler)
+    popupName: 'login',
+    matches: isSecretKeyOAuthPayload,
+    getKey: (data) => data[0].secretKey,
+    setKey,
+    onError: (error) => logger.error('[oauthWithAiOnly] error', error as Error)
+  })
 }
 
 export interface NewApiOAuthConfig {


### PR DESCRIPTION
## Summary

- give the SiliconFlow, Aihubmix, 302.AI, and AiOnly popup-message OAuth flows one shared listener lifecycle
- remove the exact registered handler after success, recognized callback failure, popup closure, timeout, or replacement by a newer flow using the same popup name
- accept credentials only from the opened popup, the expected provider origin, and a provider-specific payload shape
- keep the existing PPIO and CherryIN deep-link IPC flows unchanged

## Why

Each popup OAuth attempt previously created its own `message` handler. Calling `removeEventListener` with the new attempt's handler could not retire a handler left by an earlier attempt, while closing or abandoning the popup had no cleanup path. Aihubmix also retained its listener when decryption or callback parsing failed.

Repeated attempts could therefore accumulate closures and let a later `message` reach stale settings state. The shared lifecycle keeps one active listener per named popup and retains close/timeout guards while asynchronous callback processing is in flight.

## Tests

- `pnpm exec vitest run src/renderer/services/__tests__/oauth.test.ts` (6 passed)
- `pnpm lint`
- `git diff --check`

The regression suite covers source/origin filtering, successful one-shot cleanup, replacement of a stale attempt, popup closure, timeout, malformed Aihubmix callbacks, decryption, and the existing AiOnly key path.

Closes #19210
