### PR TITLE
fix(knowledge): batch Gitee AI rerank requests

### DIFF
--- a/src/main/features/knowledge/pipeline/indexing/__tests__/rerank.test.ts
+++ b/src/main/features/knowledge/pipeline/indexing/__tests__/rerank.test.ts
@@ -99,6 +99,14 @@ function createSearchResults(): KnowledgeSearchResult[] {
   ]
 }
 
+function createSearchResultBatch(count: number): KnowledgeSearchResult[] {
+  return Array.from({ length: count }, (_, index) => ({
+    ...createSearchResults()[0],
+    pageContent: `document-${index}`,
+    chunkId: `chunk-${index}`
+  }))
+}
+
 describe('knowledge rerank runtime', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -185,6 +193,73 @@ describe('knowledge rerank runtime', () => {
     )
 
     expect(mocks.aiRerankMock).toHaveBeenCalledWith(expect.objectContaining({ topN: DEFAULT_DOCUMENT_COUNT }))
+  })
+
+  it('batches Gitee AI rerank requests at 25 documents and restores global indexes', async () => {
+    const searchResults = createSearchResultBatch(27)
+    mocks.aiRerankMock
+      .mockResolvedValueOnce({
+        ranking: [
+          { originalIndex: 0, score: 0.4, document: 'document-0' },
+          { originalIndex: 24, score: 0.8, document: 'document-24' }
+        ]
+      })
+      .mockResolvedValueOnce({
+        ranking: [
+          { originalIndex: 0, score: 0.9, document: 'document-25' },
+          { originalIndex: 1, score: 0.2, document: 'document-26' }
+        ]
+      })
+
+    const result = await rerankKnowledgeSearchResults(
+      createKnowledgeBase({ rerankModelId: 'gitee-ai::bge-reranker-v2-m3', documentCount: 3 }),
+      'hello',
+      searchResults
+    )
+
+    expect(mocks.aiRerankMock).toHaveBeenNthCalledWith(1, {
+      uniqueModelId: 'gitee-ai::bge-reranker-v2-m3',
+      query: 'hello',
+      documents: searchResults.slice(0, 25).map((item) => item.pageContent),
+      topN: 3
+    })
+    expect(mocks.aiRerankMock).toHaveBeenNthCalledWith(2, {
+      uniqueModelId: 'gitee-ai::bge-reranker-v2-m3',
+      query: 'hello',
+      documents: ['document-25', 'document-26'],
+      topN: 2
+    })
+    expect(result.map((item) => item.chunkId)).toEqual(['chunk-25', 'chunk-24', 'chunk-0'])
+  })
+
+  it('caps Gitee AI topN to the size of each request batch', async () => {
+    const searchResults = createSearchResultBatch(26)
+    mocks.aiRerankMock.mockResolvedValue({ ranking: [] })
+
+    await rerankKnowledgeSearchResults(
+      createKnowledgeBase({ rerankModelId: 'gitee-ai::bge-reranker-v2-m3', documentCount: 30 }),
+      'hello',
+      searchResults
+    )
+
+    expect(mocks.aiRerankMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ topN: 25 }))
+    expect(mocks.aiRerankMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ topN: 1 }))
+  })
+
+  it('keeps non-Gitee rerank providers on a single request', async () => {
+    const searchResults = createSearchResultBatch(27)
+    mocks.aiRerankMock.mockResolvedValueOnce({ ranking: [] })
+
+    await rerankKnowledgeSearchResults(createKnowledgeBase({ documentCount: 30 }), 'hello', searchResults)
+
+    expect(mocks.aiRerankMock).toHaveBeenCalledOnce()
+    expect(mocks.aiRerankMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uniqueModelId: 'jina::jina-reranker-v2-base-multilingual',
+        documents: searchResults.map((item) => item.pageContent),
+        topN: 30
+      })
+    )
   })
 
   it('skips rerank when the rerank model id is invalid', async () => {

--- a/src/main/features/knowledge/pipeline/indexing/rerank.ts
+++ b/src/main/features/knowledge/pipeline/indexing/rerank.ts
@@ -10,6 +10,7 @@ const logger = loggerService.withContext('KnowledgeRerank')
 // HTTP statuses that signal a persistent rerank misconfiguration (bad key / no access /
 // wrong model) rather than a transient blip — these will keep failing every search.
 const PERSISTENT_RERANK_STATUS_CODES = new Set([401, 403, 404])
+const GITEE_AI_RERANK_BATCH_SIZE = 25
 
 function isPersistentRerankMisconfig(error: unknown): boolean {
   return APICallError.isInstance(error) && PERSISTENT_RERANK_STATUS_CODES.has(error.statusCode ?? 0)
@@ -55,14 +56,29 @@ async function rerankWithAiService(
   }
 
   try {
-    const result = await application.get('AiService').rerank({
-      uniqueModelId: parsed.data,
-      query,
-      documents: searchResults.map((result) => result.pageContent),
-      topN
-    })
+    const isGiteeAi = parsed.data.startsWith('gitee-ai::')
+    const batchSize = isGiteeAi ? GITEE_AI_RERANK_BATCH_SIZE : searchResults.length
+    const ranking: Array<{ originalIndex: number; score: number }> = []
 
-    return mergeRerankResults(searchResults, result.ranking)
+    for (let offset = 0; offset < searchResults.length; offset += batchSize) {
+      const batch = searchResults.slice(offset, offset + batchSize)
+      const result = await application.get('AiService').rerank({
+        uniqueModelId: parsed.data,
+        query,
+        documents: batch.map((result) => result.pageContent),
+        topN: isGiteeAi ? Math.min(topN, batch.length) : topN
+      })
+
+      ranking.push(
+        ...result.ranking.map((result) => ({
+          originalIndex: offset + result.originalIndex,
+          score: result.score
+        }))
+      )
+    }
+
+    const mergedResults = mergeRerankResults(searchResults, ranking)
+    return isGiteeAi ? mergedResults.slice(0, topN) : mergedResults
   } catch (error) {
     const normalizedError = error instanceof Error ? error : new Error(String(error))
     const context = {


### PR DESCRIPTION
## Summary

- split Gitee AI rerank candidates into requests of at most 25 documents
- cap each batch's `topN` to its actual size, translate batch-local indexes back to the original candidates, and rank the merged results globally
- keep every other rerank provider on the existing single-request path
- preserve the existing all-or-nothing fallback when any rerank request fails

## Why

Web-search RAG compression can produce more chunks than the configured search-result count. Gitee AI rejects rerank requests when `documents` or `top_n` exceeds 25, so a page set producing 27–30 chunks currently fails with HTTP 400 and returns no compressed results.

For Gitee AI only, this change respects the provider limit while retaining the requested global result count. A candidate below the top N within its own batch cannot enter the global top N, so requesting at most the global N from each batch is sufficient before merging and sorting.

## Tests

- `pnpm exec vitest run src/main/features/knowledge/pipeline/indexing/__tests__/rerank.test.ts` (14 passed)
- `pnpm lint`
- `git diff --check`

The regressions cover 27 candidates across two batches, batch-local to global index translation, cross-batch score ordering, final global truncation, `topN` values above 25, and the unchanged single-request behavior for non-Gitee providers.

Closes #17141
