### PR TITLE
perf(composer): lazy-load editor dialogs

### DIFF
--- a/src/renderer/components/composer/tools/components/QuickPhrasesButton.tsx
+++ b/src/renderer/components/composer/tools/components/QuickPhrasesButton.tsx
@@ -10,7 +10,6 @@ import {
   type QuickPanelOpenOptions
 } from '@renderer/components/QuickPanel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
-import { PromptEditDialog } from '@renderer/components/resourceCatalog/dialogs/edit'
 import { openResourceEditDialog } from '@renderer/components/resourceCatalog/dialogs/ResourceEditDialogEventHost'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
@@ -20,7 +19,7 @@ import type { ListPromptsQueryParams } from '@shared/data/api/schemas/prompts'
 import type { Prompt, PromptBindingTarget, PromptVisibility } from '@shared/data/types/prompt'
 import { Plus, Settings, Zap } from 'lucide-react'
 import type { Dispatch, SetStateAction } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -32,6 +31,11 @@ interface Props {
 
 const logger = loggerService.withContext('QuickPhrasesButton')
 const PROMPT_QUERY_SWR_OPTIONS = { keepPreviousData: false } as const
+const PromptEditDialog = lazy(() =>
+  import('@renderer/components/resourceCatalog/dialogs/edit').then((module) => ({
+    default: module.PromptEditDialog
+  }))
+)
 
 const useQuickPhrasesToolController = ({ agentId, assistantId, launcher, setInputValue }: Props) => {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false)
@@ -275,15 +279,18 @@ const QuickPhrasesModal = ({
 }: Pick<
   ReturnType<typeof useQuickPhrasesToolController>,
   'defaultVisibility' | 'handleAddModalSave' | 'isAddModalOpen' | 'isCreatingPrompt' | 'closeAddModal'
->) => (
-  <PromptEditDialog
-    open={isAddModalOpen}
-    defaultVisibility={defaultVisibility}
-    saving={isCreatingPrompt}
-    onSave={handleAddModalSave}
-    onCancel={closeAddModal}
-  />
-)
+>) =>
+  isAddModalOpen ? (
+    <Suspense fallback={null}>
+      <PromptEditDialog
+        open={isAddModalOpen}
+        defaultVisibility={defaultVisibility}
+        saving={isCreatingPrompt}
+        onSave={handleAddModalSave}
+        onCancel={closeAddModal}
+      />
+    </Suspense>
+  ) : null
 
 export const QuickPhrasesToolRuntime = (props: Props) => {
   const controller = useQuickPhrasesToolController(props)

--- a/src/renderer/components/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
+++ b/src/renderer/components/composer/tools/components/__tests__/QuickPhrasesButton.test.tsx
@@ -1,5 +1,5 @@
 import type { ToolLauncherApi } from '@renderer/components/composer/tools/types'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type * as LucideReact from 'lucide-react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   quickPanelClose: vi.fn(),
   quickPanelOpen: vi.fn(),
   quickPanelUpdateList: vi.fn(),
+  renderPromptEditDialog: vi.fn(),
   setTimeoutTimer: vi.fn(),
   useMutation: vi.fn(),
   useQuery: vi.fn()
@@ -42,8 +43,9 @@ vi.mock('@renderer/components/resourceCatalog/dialogs/edit', () => ({
     open: boolean
     onCancel: () => void
     onSave: (data: { title: string; content: string; visibility: 'global' | 'restricted' }) => Promise<void>
-  }) =>
-    open ? (
+  }) => {
+    mocks.renderPromptEditDialog()
+    return open ? (
       <div data-testid="prompt-edit-dialog">
         <button
           type="button"
@@ -57,6 +59,7 @@ vi.mock('@renderer/components/resourceCatalog/dialogs/edit', () => ({
         </button>
       </div>
     ) : null
+  }
 }))
 vi.mock('@renderer/components/resourceCatalog/dialogs/ResourceEditDialogEventHost', () => ({
   openResourceEditDialog: (...args: unknown[]) => mocks.openResourceEditDialog(...args)
@@ -124,6 +127,12 @@ describe('QuickPhrasesToolRuntime', () => {
   afterEach(() => {
     restoreRequestAnimationFrame?.()
     restoreRequestAnimationFrame = undefined
+  })
+
+  it('does not mount the prompt editor while the add dialog is closed', () => {
+    render(<QuickPhrasesToolRuntime launcher={createLauncherApi()} setInputValue={vi.fn()} />)
+
+    expect(mocks.renderPromptEditDialog).not.toHaveBeenCalled()
   })
 
   it('opens the quick phrases panel with the global fallback when no binding context exists', async () => {
@@ -261,10 +270,10 @@ describe('QuickPhrasesToolRuntime', () => {
     ])
 
     const addItem = panelOptions.list.find((item: { label: string }) => item.label === 'settings.prompts.add')
-    act(() => {
+    await act(async () => {
       addItem.action({} as never)
     })
-    screen.getByRole('button', { name: 'save prompt' }).click()
+    fireEvent.click(await screen.findByRole('button', { name: 'save prompt' }))
 
     await waitFor(() =>
       expect(mocks.createPrompt).toHaveBeenCalledWith({
@@ -345,11 +354,11 @@ describe('QuickPhrasesToolRuntime', () => {
     const panelOptions = mocks.quickPanelOpen.mock.calls[0][0]
     const addItem = panelOptions.list.find((item: { label: string }) => item.label === 'settings.prompts.add')
 
-    act(() => {
+    await act(async () => {
       addItem.action({ inputAdapter } as never)
     })
     act(() => {
-      screen.getByText('close prompt edit').click()
+      screen.getByRole('button', { name: 'close prompt edit' }).click()
     })
 
     expect(inputAdapter.focus).toHaveBeenCalledTimes(1)
@@ -376,10 +385,10 @@ describe('QuickPhrasesToolRuntime', () => {
     const panelOptions = mocks.quickPanelOpen.mock.calls[0][0]
     const addItem = panelOptions.list.find((item: { label: string }) => item.label === 'settings.prompts.add')
 
-    act(() => {
+    await act(async () => {
       addItem.action({} as never)
     })
-    screen.getByRole('button', { name: 'save prompt' }).click()
+    fireEvent.click(await screen.findByRole('button', { name: 'save prompt' }))
 
     await waitFor(() =>
       expect(mocks.createPrompt).toHaveBeenCalledWith({

--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -1,8 +1,5 @@
 import { loggerService } from '@logger'
-import {
-  ResourceCreateWizard,
-  type ResourceCreateWizardValues
-} from '@renderer/components/resourceCatalog/dialogs/create'
+import type { ResourceCreateWizardValues } from '@renderer/components/resourceCatalog/dialogs/create'
 import type { SelectorShellMountStrategy, SelectorShellProps } from '@renderer/components/SelectorShell'
 import { useQuery } from '@renderer/data/hooks/useDataApi'
 import { useAgentMutations } from '@renderer/hooks/resourceCatalog'
@@ -18,6 +15,11 @@ import { useTranslation } from 'react-i18next'
 import { ResourceSelectorShell, type ResourceSelectorShellItem } from './ResourceSelectorShell'
 
 const logger = loggerService.withContext('AgentSelector')
+const ResourceCreateWizard = lazy(() =>
+  import('@renderer/components/resourceCatalog/dialogs/create').then((module) => ({
+    default: module.ResourceCreateWizard
+  }))
+)
 const ResourceEditDialogHost = lazy(() =>
   import('@renderer/components/resourceCatalog/dialogs/edit').then((module) => ({
     default: module.ResourceEditDialogHost
@@ -186,15 +188,17 @@ export function AgentSelector(props: AgentSelectorProps) {
     [autoSelectOnCreate, createAgent, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  const createDialog = (
-    <ResourceCreateWizard
-      kind="agent"
-      open={createDialogOpen}
-      isSubmitting={isCreatingAgent}
-      onOpenChange={handleCreateDialogOpenChange}
-      onSubmit={handleSubmitCreate}
-    />
-  )
+  const createDialog = createDialogOpen ? (
+    <Suspense fallback={null}>
+      <ResourceCreateWizard
+        kind="agent"
+        open={createDialogOpen}
+        isSubmitting={isCreatingAgent}
+        onOpenChange={handleCreateDialogOpenChange}
+        onSubmit={handleSubmitCreate}
+      />
+    </Suspense>
+  ) : null
 
   const editDialog = editDialogTarget ? (
     <Suspense fallback={null}>

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -1,8 +1,5 @@
 import { loggerService } from '@logger'
-import {
-  ResourceCreateWizard,
-  type ResourceCreateWizardValues
-} from '@renderer/components/resourceCatalog/dialogs/create'
+import type { ResourceCreateWizardValues } from '@renderer/components/resourceCatalog/dialogs/create'
 import type { SelectorShellMountStrategy, SelectorShellProps } from '@renderer/components/SelectorShell'
 import { useMutation, useQuery } from '@renderer/data/hooks/useDataApi'
 import { useGroups } from '@renderer/hooks/useGroups'
@@ -22,6 +19,11 @@ import {
 } from './ResourceSelectorShell'
 
 const logger = loggerService.withContext('AssistantSelector')
+const ResourceCreateWizard = lazy(() =>
+  import('@renderer/components/resourceCatalog/dialogs/create').then((module) => ({
+    default: module.ResourceCreateWizard
+  }))
+)
 const ResourceEditDialogHost = lazy(() =>
   import('@renderer/components/resourceCatalog/dialogs/edit').then((module) => ({
     default: module.ResourceEditDialogHost
@@ -230,16 +232,18 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     [autoSelectOnCreate, createAssistant, handleSelectorOpenChange, onDialogCloseAutoFocus, props, refetch, t]
   )
 
-  const createDialog = (
-    <ResourceCreateWizard
-      kind="assistant"
-      open={createDialogOpen}
-      isSubmitting={isCreatingAssistant}
-      onOpenChange={handleCreateDialogOpenChange}
-      onSubmit={handleSubmitCreate}
-      modelFilter={(candidate) => !isNonChatModel(candidate)}
-    />
-  )
+  const createDialog = createDialogOpen ? (
+    <Suspense fallback={null}>
+      <ResourceCreateWizard
+        kind="assistant"
+        open={createDialogOpen}
+        isSubmitting={isCreatingAssistant}
+        onOpenChange={handleCreateDialogOpenChange}
+        onSubmit={handleSubmitCreate}
+        modelFilter={(candidate) => !isNonChatModel(candidate)}
+      />
+    </Suspense>
+  ) : null
 
   const editDialog = editDialogTarget ? (
     <Suspense fallback={null}>

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -1,9 +1,10 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import type * as ModelSelectorModule from '@renderer/components/ModelSelector'
+import type * as ResourceCreateDialogModule from '@renderer/components/resourceCatalog/dialogs/create'
 import type * as UseModelModule from '@renderer/hooks/useModel'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,6 +12,7 @@ const {
   createAgentMock,
   refetchAgentsMock,
   refetchPinsMock,
+  renderResourceCreateWizardMock,
   togglePinMock,
   updateAgentMock,
   useMutationMock,
@@ -21,6 +23,7 @@ const {
   createAgentMock: vi.fn(),
   refetchAgentsMock: vi.fn(),
   refetchPinsMock: vi.fn(),
+  renderResourceCreateWizardMock: vi.fn(),
   togglePinMock: vi.fn(),
   updateAgentMock: vi.fn(),
   useMutationMock: vi.fn(),
@@ -60,6 +63,17 @@ vi.mock('@renderer/components/ModelSelector', async (importOriginal) => ({
     </div>
   )
 }))
+
+vi.mock('@renderer/components/resourceCatalog/dialogs/create', async (importOriginal) => {
+  const actual = await importOriginal<typeof ResourceCreateDialogModule>()
+  return {
+    ...actual,
+    ResourceCreateWizard: (props: ComponentProps<typeof actual.ResourceCreateWizard>) => {
+      renderResourceCreateWizardMock()
+      return <actual.ResourceCreateWizard {...props} />
+    }
+  }
+})
 
 // Stub the capability step: it pulls in MCP-runtime + skills hooks not mocked
 // here. The wizard's own test covers it; this test only needs to reach submit.
@@ -254,7 +268,7 @@ const AGENTS_RESPONSE = {
   page: 1
 } as const
 
-beforeAll(() => {
+beforeAll(async () => {
   globalThis.ResizeObserver = class {
     observe() {}
     unobserve() {}
@@ -270,6 +284,9 @@ beforeAll(() => {
     HTMLElement.prototype.setPointerCapture = () => {}
   }
   HTMLElement.prototype.scrollIntoView = () => {}
+
+  // These integration cases exercise the real wizard; warm its lazy module outside per-test timeouts.
+  await import('@renderer/components/resourceCatalog/dialogs/create')
 })
 
 beforeEach(() => {
@@ -341,8 +358,10 @@ function openPopover() {
 
 async function openCreateDialog() {
   openPopover()
-  fireEvent.click(screen.getByRole('button', { name: 'Create agent' }))
-  await screen.findByRole('dialog')
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Create agent' }))
+  })
+  await screen.findByRole('dialog', {}, { timeout: 5000 })
 }
 
 describe('AgentSelector', () => {
@@ -464,6 +483,12 @@ describe('AgentSelector', () => {
     expect(screen.getByPlaceholderText('Name this resource')).toBeInTheDocument()
     expect(screen.getByText('Model')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Describe this resource')).toBeInTheDocument()
+  })
+
+  it('does not mount the create wizard while it is closed', () => {
+    renderSelector()
+
+    expect(renderResourceCreateWizardMock).not.toHaveBeenCalled()
   })
 
   it('calls the dialog-close autofocus callback when the create dialog closes', async () => {

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -1,9 +1,10 @@
 import type * as CherryStudioUi from '@cherrystudio/ui'
 import { DIALOG_UNMOUNT_DELAY_MS } from '@cherrystudio/ui/utils'
 import type * as ModelSelectorModule from '@renderer/components/ModelSelector'
+import type * as ResourceCreateDialogModule from '@renderer/components/resourceCatalog/dialogs/create'
 import type * as UseModelModule from '@renderer/hooks/useModel'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -11,6 +12,7 @@ const {
   createAssistantMock,
   refetchAssistantsMock,
   refetchPinsMock,
+  renderResourceCreateWizardMock,
   togglePinMock,
   updateAssistantMock,
   useMutationMock,
@@ -20,6 +22,7 @@ const {
   createAssistantMock: vi.fn(),
   refetchAssistantsMock: vi.fn(),
   refetchPinsMock: vi.fn(),
+  renderResourceCreateWizardMock: vi.fn(),
   togglePinMock: vi.fn(),
   updateAssistantMock: vi.fn(),
   useMutationMock: vi.fn(),
@@ -57,6 +60,17 @@ vi.mock('@renderer/components/ModelSelector', async (importOriginal) => ({
     </div>
   )
 }))
+
+vi.mock('@renderer/components/resourceCatalog/dialogs/create', async (importOriginal) => {
+  const actual = await importOriginal<typeof ResourceCreateDialogModule>()
+  return {
+    ...actual,
+    ResourceCreateWizard: (props: ComponentProps<typeof actual.ResourceCreateWizard>) => {
+      renderResourceCreateWizardMock()
+      return <actual.ResourceCreateWizard {...props} />
+    }
+  }
+})
 
 vi.mock('@cherrystudio/ui', async (importOriginal) => {
   const actual = await importOriginal<typeof CherryStudioUi>()
@@ -270,7 +284,7 @@ const ASSISTANTS_RESPONSE = {
   page: 1
 } as const
 
-beforeAll(() => {
+beforeAll(async () => {
   globalThis.ResizeObserver = class {
     observe() {}
     unobserve() {}
@@ -286,6 +300,9 @@ beforeAll(() => {
     HTMLElement.prototype.setPointerCapture = () => {}
   }
   HTMLElement.prototype.scrollIntoView = () => {}
+
+  // These integration cases exercise the real wizard; warm its lazy module outside per-test timeouts.
+  await import('@renderer/components/resourceCatalog/dialogs/create')
 })
 
 beforeEach(() => {
@@ -354,8 +371,10 @@ function openPopover() {
 
 async function openCreateDialog() {
   openPopover()
-  fireEvent.click(screen.getByRole('button', { name: 'Create assistant' }))
-  await screen.findByRole('dialog')
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: 'Create assistant' }))
+  })
+  await screen.findByRole('dialog', {}, { timeout: 5000 })
 }
 
 describe('AssistantSelector', () => {
@@ -415,6 +434,12 @@ describe('AssistantSelector', () => {
     expect(screen.getByPlaceholderText('Name this resource')).toBeInTheDocument()
     expect(screen.getByText('Model')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('Describe this resource')).toBeInTheDocument()
+  })
+
+  it('does not mount the create wizard while it is closed', () => {
+    renderSelector()
+
+    expect(renderResourceCreateWizardMock).not.toHaveBeenCalled()
   })
 
   it('calls the dialog-close autofocus callback when the create dialog closes', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Frequently loaded composer and resource selector entry points synchronously imported closed editor dialogs and their CodeMirror/Markdown dependency trees.

After this PR:

Prompt and resource creation dialogs are lazy-loaded and mounted only while open. Existing create, save, close, autofocus, and selector behavior remains unchanged.

Fixes #19064

### Why we need it and why it was done in this way

The editor dialogs are infrequent interaction surfaces, so their implementation should not be part of the normal chat/composer module graph. The change keeps the existing dialog APIs and state ownership intact while moving only the import and mount boundaries behind `lazy()` and local null `Suspense` fallbacks.

The following tradeoffs were made:

The first dialog open now waits for its async chunk. A null fallback preserves the existing layout and avoids introducing a new loading surface for this short transition.

The following alternatives were considered:

Refactoring the dialog/editor implementations or introducing a shared loader was rejected because neither is required to remove the eager dependency edge.

Links to places where the discussion took place: #19064

### Breaking changes

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Validation:

- `pnpm format`
- Focused resource selector tests (29 tests)
- `pnpm build:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
