### PR TITLE
perf(composer-tools): preserve dependency-scoped registrations

### DIFF
--- a/src/renderer/components/composer/ComposerToolRuntime.tsx
+++ b/src/renderer/components/composer/ComposerToolRuntime.tsx
@@ -3,6 +3,7 @@ import {
   ComposerToolDerivedStateProvider,
   type ComposerToolDispatch,
   ComposerToolProvider,
+  type ComposerToolsRegistryApi,
   type ComposerToolState,
   useComposerToolProviderDispatch,
   useComposerToolProviderLaunchers,
@@ -15,8 +16,7 @@ import type {
   ToolContext,
   ToolDefinition,
   ToolRenderContext,
-  ToolStateKey,
-  ToolStateMap
+  ToolStateKey
 } from '@renderer/components/composer/tools/types'
 import type { QuickPanelInputAdapter } from '@renderer/components/QuickPanel'
 import { useQuickPanel } from '@renderer/components/QuickPanel'
@@ -25,7 +25,7 @@ import type { ComposerAttachment } from '@renderer/utils/message/composerAttachm
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import type { Model } from '@shared/data/types/model'
 import { Plus } from 'lucide-react'
-import React, { createContext, use, useCallback, useEffect, useMemo, useRef } from 'react'
+import React, { createContext, memo, use, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ComposerUnifiedPanelControl } from './quickPanel'
@@ -68,11 +68,81 @@ interface ComposerToolRuntimeBootstrapProps {
 type AnyToolDefinition = ToolDefinition<readonly ToolStateKey[], readonly ToolActionKey[]>
 type AnyToolRenderContext = ToolRenderContext<readonly ToolStateKey[], readonly ToolActionKey[]>
 
-const ComposerToolRuntimeSlot = ({ tool, context }: { tool: AnyToolDefinition; context: AnyToolRenderContext }) => {
-  const Runtime = tool.composer?.runtime
-  if (!Runtime) return null
-  return <Runtime context={context} />
+interface ComposerToolRuntimeEntryProps extends ComposerToolRuntimeBootstrapProps {
+  tool: AnyToolDefinition
+  toolState: ComposerToolState
+  toolActions: ToolActionMap
+  launcher: AnyToolRenderContext['launcher']
+  toolsRegistry: ComposerToolsRegistryApi
+  t: ReturnType<typeof useTranslation>['t']
 }
+
+const ComposerToolRuntimeEntry = ({
+  tool,
+  toolState,
+  toolActions,
+  launcher,
+  toolsRegistry,
+  scope,
+  assistant,
+  model,
+  session,
+  t
+}: ComposerToolRuntimeEntryProps) => {
+  const context = useMemo<AnyToolRenderContext>(() => {
+    const state: Record<string, unknown> = {}
+    for (const key of tool.dependencies?.state ?? []) state[key] = toolState[key]
+
+    const actions: Record<string, unknown> = {}
+    for (const key of tool.dependencies?.actions ?? []) {
+      const action = toolActions[key]
+      if (action) actions[key] = action
+    }
+
+    return {
+      scope,
+      assistant,
+      model,
+      session,
+      state,
+      actions,
+      launcher,
+      t
+    } as AnyToolRenderContext
+  }, [assistant, launcher, model, scope, session, t, tool, toolActions, toolState])
+
+  useEffect(() => {
+    if (!tool.composer?.menuItems) return
+    return toolsRegistry.registerLaunchers(tool.key, tool.composer.menuItems.createItems(context))
+  }, [context, tool, toolsRegistry])
+
+  const Runtime = tool.composer?.runtime
+  return Runtime ? <Runtime context={context} /> : null
+}
+
+const MemoizedComposerToolRuntimeEntry = memo(ComposerToolRuntimeEntry, (previous, next) => {
+  if (
+    previous.tool !== next.tool ||
+    previous.launcher !== next.launcher ||
+    previous.toolsRegistry !== next.toolsRegistry ||
+    previous.scope !== next.scope ||
+    previous.assistant !== next.assistant ||
+    previous.model !== next.model ||
+    previous.session !== next.session ||
+    previous.t !== next.t
+  ) {
+    return false
+  }
+
+  for (const key of next.tool.dependencies?.state ?? []) {
+    if (!Object.is(previous.toolState[key], next.toolState[key])) return false
+  }
+  for (const key of next.tool.dependencies?.actions ?? []) {
+    if (!Object.is(previous.toolActions[key], next.toolActions[key])) return false
+  }
+
+  return true
+})
 
 export const ComposerToolRuntimeHost = ({ scope, assistant, model, session }: ComposerToolRuntimeBootstrapProps) => {
   const { t } = useTranslation()
@@ -111,76 +181,23 @@ export const ComposerToolRuntimeHost = ({ scope, assistant, model, session }: Co
     [toolsRegistry]
   )
 
-  const buildRenderContext = useCallback(
-    <S extends readonly ToolStateKey[], A extends readonly ToolActionKey[]>(
-      tool: ToolDefinition<S, A>
-    ): ToolRenderContext<S, A> => {
-      const deps = tool.dependencies
-
-      const state = (deps?.state || ([] as unknown as S)).reduce(
-        (acc, key) => {
-          acc[key] = toolState[key]
-          return acc
-        },
-        {} as Pick<ToolStateMap, S[number]>
-      )
-
-      const runtimeActions = (deps?.actions || ([] as unknown as A)).reduce(
-        (acc, key) => {
-          const actionValue = toolActions[key]
-          if (actionValue) {
-            acc[key] = actionValue
-          }
-          return acc
-        },
-        {} as Pick<ToolActionMap, A[number]>
-      )
-
-      return {
-        scope,
-        assistant,
-        model,
-        session,
-        state,
-        actions: runtimeActions,
-        launcher: getLauncherApiForTool(tool.key),
-        t
-      } as ToolRenderContext<S, A>
-    },
-    [assistant, getLauncherApiForTool, model, scope, session, t, toolActions, toolState]
-  )
-
-  const toolRuntimeEntries = useMemo(
-    () =>
-      availableTools.map((tool) => ({
-        tool,
-        context: buildRenderContext(tool)
-      })),
-    [availableTools, buildRenderContext]
-  )
-
-  useEffect(() => {
-    const disposeCallbacks: Array<() => void> = []
-
-    for (const { tool, context } of toolRuntimeEntries) {
-      if (tool.composer?.menuItems) {
-        const launchers = tool.composer.menuItems.createItems(context)
-        const dispose = toolsRegistry.registerLaunchers(tool.key, launchers)
-        disposeCallbacks.push(dispose)
-      }
-    }
-
-    return () => {
-      disposeCallbacks.forEach((dispose) => dispose())
-    }
-  }, [toolRuntimeEntries, toolsRegistry])
-
   return (
     <>
-      {toolRuntimeEntries.map(({ tool, context }) => {
-        if (!tool.composer?.runtime) return null
-        return <ComposerToolRuntimeSlot key={`${tool.key}-composer-runtime`} tool={tool} context={context} />
-      })}
+      {availableTools.map((tool) => (
+        <MemoizedComposerToolRuntimeEntry
+          key={`${tool.key}-composer-runtime`}
+          tool={tool}
+          toolState={toolState}
+          toolActions={toolActions}
+          launcher={getLauncherApiForTool(tool.key)}
+          toolsRegistry={toolsRegistry}
+          scope={scope}
+          assistant={assistant}
+          model={model}
+          session={session}
+          t={t}
+        />
+      ))}
     </>
   )
 }

--- a/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToolRuntime.test.tsx
@@ -1,11 +1,12 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { type ReactNode, useEffect } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerToolLauncher } from '../toolLauncher'
 import type { ToolRenderContext } from '../tools/types'
 
-const { mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanel } = vi.hoisted(() => {
+const { mockGetToolsForScope, mockQuickPanelValue, mockTranslate, mockUseQuickPanel } = vi.hoisted(() => {
   const mockQuickPanelValue = {
     close: vi.fn(),
     isVisible: false,
@@ -17,6 +18,7 @@ const { mockGetToolsForScope, mockQuickPanelValue, mockUseQuickPanel } = vi.hois
   return {
     mockGetToolsForScope: vi.fn(),
     mockQuickPanelValue,
+    mockTranslate: (key: string) => key,
     mockUseQuickPanel: vi.fn(() => mockQuickPanelValue)
   }
 })
@@ -38,7 +40,7 @@ vi.mock('@renderer/components/QuickPanel', () => ({
 }))
 
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key })
+  useTranslation: () => ({ t: mockTranslate })
 }))
 
 vi.mock('@cherrystudio/ui', () => ({
@@ -140,6 +142,23 @@ const FileStateWriter = ({ nextFiles }: { nextFiles: any[] }) => {
   }, [nextFiles, setFiles])
 
   return null
+}
+
+const ToolStateControls = () => {
+  const { setFiles, setSelectedKnowledgeBases } = useComposerToolDispatch()
+
+  return (
+    <>
+      <button type="button" onClick={() => setFiles([{ id: 'file-1', path: '/tmp/file.txt' } as any])}>
+        Add file
+      </button>
+      <button
+        type="button"
+        onClick={() => setSelectedKnowledgeBases([{ id: 'knowledge-1', name: 'Knowledge' } as any])}>
+        Select knowledge
+      </button>
+    </>
+  )
 }
 
 const LauncherRegistrationProbe = ({
@@ -310,6 +329,59 @@ describe('ComposerToolRuntimeHost', () => {
     expect(onNonReactiveRender).toHaveBeenCalledTimes(1)
     expect(createItems).toHaveBeenCalledTimes(1)
     expect(runtimeRegisterCount).toBe(1)
+  })
+
+  it('re-registers only tools whose declared state dependencies change', async () => {
+    const user = userEvent.setup()
+    const createFileItems = vi.fn<
+      (context: ToolRenderContext<readonly ['files'], readonly []>) => ComposerToolLauncher[]
+    >(() => [menuLauncher])
+    const createKnowledgeItems = vi.fn<
+      (context: ToolRenderContext<readonly ['selectedKnowledgeBases'], readonly []>) => ComposerToolLauncher[]
+    >(() => [runtimeLauncher])
+
+    mockGetToolsForScope.mockReturnValue([
+      {
+        key: 'file-tool',
+        label: 'File tool',
+        dependencies: { state: ['files'] },
+        composer: { menuItems: { createItems: createFileItems } }
+      },
+      {
+        key: 'knowledge-tool',
+        label: 'Knowledge tool',
+        dependencies: { state: ['selectedKnowledgeBases'] },
+        composer: { menuItems: { createItems: createKnowledgeItems } }
+      }
+    ])
+
+    render(
+      <ComposerToolRuntimeProvider
+        actions={{
+          addNewTopic: vi.fn(),
+          onTextChange: vi.fn()
+        }}>
+        <ComposerToolRuntimeHost scope={TopicType.Chat} assistant={assistant} model={model} />
+        <ToolStateControls />
+      </ComposerToolRuntimeProvider>
+    )
+
+    await waitFor(() => {
+      expect(createFileItems).toHaveBeenCalledTimes(1)
+      expect(createKnowledgeItems).toHaveBeenCalledTimes(1)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Add file' }))
+
+    await waitFor(() => expect(createFileItems).toHaveBeenCalledTimes(2))
+    expect(createKnowledgeItems).toHaveBeenCalledTimes(1)
+    expect(createFileItems.mock.lastCall?.[0].state.files).toHaveLength(1)
+
+    await user.click(screen.getByRole('button', { name: 'Select knowledge' }))
+
+    await waitFor(() => expect(createKnowledgeItems).toHaveBeenCalledTimes(2))
+    expect(createFileItems).toHaveBeenCalledTimes(2)
+    expect(createKnowledgeItems.mock.lastCall?.[0].state.selectedKnowledgeBases).toHaveLength(1)
   })
 
   it('keeps the latest launcher registration when a stale disposer runs', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Any composer state change rebuilt every tool render context, causing all launcher contributions to unregister and register again even when their declared dependencies were unchanged.

After this PR:

Each tool owns a memoized runtime entry that compares only its declared state and action dependencies. Unrelated composer state changes preserve that tool's context and launcher registration, while relevant dependency changes still refresh its launchers and runtime.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19406

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Tool entries still refresh when shared runtime inputs such as scope, model, session, or translation change because those values are available to every tool contribution.
- The dependency comparison follows each tool declaration, keeping the provider API and launcher replacement semantics unchanged.

The following alternatives were considered:

- Adding selector-based subscriptions to the composer provider would avoid the host render as well, but it would widen the provider contract and is unnecessary to stop registration churn.
- Keeping one aggregate registration effect with a context cache would retain centralized lifecycle ownership but make stale registration cleanup harder to reason about.

Links to places where the discussion took place: #19406

### Breaking changes

None.

### Special notes for your reviewer

- Added a focused contract test proving that changing files refreshes only the file-dependent tool and changing knowledge selection refreshes only the knowledge-dependent tool.
- `pnpm format` passed.
- `pnpm build:check` passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
