### PR TITLE
perf(message-list): isolate editing subscriptions

### DIFF
--- a/src/renderer/components/chat/messages/MessageListProvider.tsx
+++ b/src/renderer/components/chat/messages/MessageListProvider.tsx
@@ -1,5 +1,5 @@
 import type { Context, ReactNode } from 'react'
-import { createContext, use, useMemo } from 'react'
+import { createContext, use, useCallback, useLayoutEffect, useMemo, useState, useSyncExternalStore } from 'react'
 
 import { PartsProvider } from './blocks/MessagePartsContext'
 import type {
@@ -82,10 +82,55 @@ const MessageListRenderConfigContext = createContext<MessageRenderConfig | null>
 const MessageListSelectionContext = createContext<MessageListSelectionState | undefined | null>(null)
 const MessageListUiStaticContext = createContext<MessageListUiStaticValue | null>(null)
 const MessageListUiSelectorsContext = createContext<MessageListUiSelectorsValue | null>(null)
-const MessageListEditingContext = createContext<string | null>(null)
+
+interface MessageListEditingStore {
+  isEditing: (messageId: string) => boolean
+  setEditingMessageId: (messageId: string | null) => void
+  subscribe: (messageId: string, listener: () => void) => () => void
+}
+
+const createMessageListEditingStore = (initialMessageId: string | null): MessageListEditingStore => {
+  let editingMessageId = initialMessageId
+  const listenersByMessageId = new Map<string, Set<() => void>>()
+
+  return {
+    isEditing: (messageId) => editingMessageId === messageId,
+    setEditingMessageId: (messageId) => {
+      if (messageId === editingMessageId) return
+
+      const previousMessageId = editingMessageId
+      editingMessageId = messageId
+
+      if (previousMessageId) {
+        listenersByMessageId.get(previousMessageId)?.forEach((listener) => listener())
+      }
+      if (messageId) {
+        listenersByMessageId.get(messageId)?.forEach((listener) => listener())
+      }
+    },
+    subscribe: (messageId, listener) => {
+      const listeners = listenersByMessageId.get(messageId) ?? new Set<() => void>()
+      listeners.add(listener)
+      listenersByMessageId.set(messageId, listeners)
+
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0) listenersByMessageId.delete(messageId)
+      }
+    }
+  }
+}
+
+const MessageListEditingStoreContext = createContext<MessageListEditingStore | null>(null)
 
 export const MessageListProvider = ({ value, children }: { value: MessageListProviderValue; children: ReactNode }) => {
   const { state, actions, meta } = value
+  const editingMessageId = state.editingMessageId ?? null
+  const [editingStore] = useState(() => createMessageListEditingStore(editingMessageId))
+
+  useLayoutEffect(() => {
+    editingStore.setEditingMessageId(editingMessageId)
+  }, [editingMessageId, editingStore])
 
   const data = useMemo<MessageListDataValue>(
     () => ({
@@ -162,9 +207,7 @@ export const MessageListProvider = ({ value, children }: { value: MessageListPro
                 <MessageListSelectionContext value={state.selection}>
                   <MessageListUiStaticContext value={uiStatic}>
                     <MessageListUiSelectorsContext value={uiSelectors}>
-                      <MessageListEditingContext value={state.editingMessageId ?? null}>
-                        {children}
-                      </MessageListEditingContext>
+                      <MessageListEditingStoreContext value={editingStore}>{children}</MessageListEditingStoreContext>
                     </MessageListUiSelectorsContext>
                   </MessageListUiStaticContext>
                 </MessageListSelectionContext>
@@ -263,9 +306,17 @@ export const useMessageListSelection = (): MessageListSelectionState | undefined
   return value
 }
 
-/** Id of the message currently being edited (null when none). Non-throwing: "not editing"
- * is a valid state, so embeds that never set it simply get null. */
-export const useMessageListEditingId = (): string | null => use(MessageListEditingContext)
+/** Whether this message is currently being edited. Embeds without editing state return false. */
+export const useIsMessageEditing = (messageId: string): boolean => {
+  const store = use(MessageListEditingStoreContext)
+  const subscribe = useCallback(
+    (listener: () => void) => store?.subscribe(messageId, listener) ?? (() => {}),
+    [messageId, store]
+  )
+  const getSnapshot = useCallback(() => store?.isEditing(messageId) ?? false, [messageId, store])
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
 
 /**
  * Back-compat hook: merged static + selectors UI value. Required variant

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -201,7 +201,7 @@ vi.mock('../MessageListProvider', () => ({
     }
   },
   useMessageListSelection: () => mocks.messageListSelection(),
-  useMessageListEditingId: () => mocks.messageListEditingId(),
+  useIsMessageEditing: (messageId: string) => mocks.messageListEditingId() === messageId,
   useMessageListMeta: () => ({
     userProfile: { avatar: '' }
   }),

--- a/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import { type ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { MessageListProvider, useIsMessageEditing } from '../MessageListProvider'
+import { defaultMessageRenderConfig, type MessageListProviderValue } from '../types'
+
+const baseValue: MessageListProviderValue = {
+  state: {
+    topic: { id: 'topic-1', name: 'Topic' } as MessageListProviderValue['state']['topic'],
+    messages: [],
+    partsByMessageId: {},
+    messageNavigation: 'none',
+    estimateSize: 400,
+    overscan: 0,
+    loadOlderDelayMs: 0,
+    loadingResetDelayMs: 0,
+    renderConfig: defaultMessageRenderConfig
+  },
+  actions: {},
+  meta: { selectionLayer: false }
+}
+
+const createValue = (editingMessageId: string | null): MessageListProviderValue => ({
+  ...baseValue,
+  state: { ...baseValue.state, editingMessageId }
+})
+
+describe('MessageListProvider editing state', () => {
+  it('updates only the previous and current editing message subscribers', () => {
+    const renderCounts = new Map<string, number>()
+
+    const EditingProbe = ({ messageId }: { messageId: string }) => {
+      const isEditing = useIsMessageEditing(messageId)
+      renderCounts.set(messageId, (renderCounts.get(messageId) ?? 0) + 1)
+      return <span>{`${messageId}:${isEditing ? 'editing' : 'idle'}`}</span>
+    }
+    const probes: ReactNode = (
+      <>
+        <EditingProbe messageId="message-a" />
+        <EditingProbe messageId="message-b" />
+        <EditingProbe messageId="message-c" />
+      </>
+    )
+
+    const { rerender } = render(<MessageListProvider value={createValue(null)}>{probes}</MessageListProvider>)
+
+    rerender(<MessageListProvider value={createValue('message-a')}>{probes}</MessageListProvider>)
+    expect(screen.getByText('message-a:editing')).toBeInTheDocument()
+    expect(renderCounts).toEqual(
+      new Map([
+        ['message-a', 2],
+        ['message-b', 1],
+        ['message-c', 1]
+      ])
+    )
+
+    rerender(<MessageListProvider value={createValue('message-b')}>{probes}</MessageListProvider>)
+    expect(screen.getByText('message-a:idle')).toBeInTheDocument()
+    expect(screen.getByText('message-b:editing')).toBeInTheDocument()
+    expect(renderCounts).toEqual(
+      new Map([
+        ['message-a', 3],
+        ['message-b', 2],
+        ['message-c', 1]
+      ])
+    )
+
+    rerender(<MessageListProvider value={createValue(null)}>{probes}</MessageListProvider>)
+    expect(screen.getByText('message-b:idle')).toBeInTheDocument()
+    expect(renderCounts.get('message-b')).toBe(3)
+    expect(renderCounts.get('message-c')).toBe(1)
+  })
+})

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -15,8 +15,8 @@ import { MessagePartsScopeProvider, useMessageParts } from '../blocks/MessagePar
 import { useScrollRuntimeNavigation } from '../list/ScrollOwnershipContext'
 import SiblingNavigator from '../list/SiblingNavigator'
 import {
+  useIsMessageEditing,
   useMessageListActions,
-  useMessageListEditingId,
   useMessageListMeta,
   useMessageListSelection,
   useMessageListUiSelectors,
@@ -84,14 +84,13 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
   const navigateWithScrollRuntime = useScrollRuntimeNavigation()
   const messageParts = useMessageParts(message.id)
   const [isMessageMenuOpen, setIsMessageMenuOpen] = useState(false)
-  const editingMessageId = useMessageListEditingId()
+  const isEditing = useIsMessageEditing(message.id)
   const { setTimeoutTimer } = useTimer()
   const canEditMessage = !!actions.editMessage
   const isAssistantMessage = message.role === 'assistant'
   const isTranslating = messageUi.isMessageTranslating?.(message.id) ?? false
   const canStartEditing =
     canEditMessage && (!isAssistantMessage || (canEditAssistantMessageParts(messageParts) && !isTranslating))
-  const isEditing = editingMessageId === message.id
   const handleStartEditing = useCallback(
     (messageId: string) => {
       if (canStartEditing && messageId === message.id) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Changing `editingMessageId` invalidated every visible message frame because each frame consumed the raw context value.

After this PR:

Message frames subscribe to a stable editing store by message ID. Only the previous and current editing targets update while the existing editor actions and lifecycle remain unchanged.

Fixes #19407

### Why we need it and why it was done in this way

The provider now owns a selector-style external store whose snapshots are per-message booleans. The store only notifies listener sets for the old and new IDs, preserving the existing provider boundary without moving editing state into individual frames.

The following tradeoffs were made:

- Editing ID changes are published in a layout effect so subscribers update before paint while the store context identity remains stable.
- The focused test asserts render isolation because avoiding unrelated message renders is the regression contract.

The following alternatives were considered:

- Splitting the raw ID into another React context would still invalidate every consumer.
- Passing `isEditing` through list/group props would widen the list composition contract and couple grouping to editor state.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19407

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `CI=true pnpm test:renderer src/renderer/components/chat/messages/__tests__/MessageListProvider.test.tsx src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx`
- `CI=true pnpm format`
- `CI=true pnpm build:check`
- `CI=true pnpm test:lint`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
