### PR TITLE
fix(chat-messages): always show token usage in the message footer

### DIFF
--- a/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageMenuBar.tsx
@@ -79,8 +79,7 @@ const MessageMenuBar: FC<Props> = (props) => {
   const isSelectedForContext = !!message.isActiveBranch
 
   const softHoverBg = isBubbleStyle && !isLastMessage
-  const showMessageTokens =
-    renderConfig.showEstimatedTokens && variant === 'footer' && (!isBubbleStyle || isAssistantMessage)
+  const showMessageTokens = variant === 'footer' && (!isBubbleStyle || isAssistantMessage)
   const isUserBubbleStyleMessage = variant === 'footer' && isBubbleStyle && isUserMessage
 
   const actionContext = useMemo<MessageMenuBarActionContext>(

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageMenuBar.test.tsx
@@ -130,22 +130,7 @@ function renderWithProvider(children: ReactNode, renderConfig: Partial<typeof de
 }
 
 describe('MessageMenuBar', () => {
-  it('hides token usage when estimated tokens are disabled', () => {
-    const { container } = renderWithProvider(
-      <MessageMenuBar
-        message={assistantMessage}
-        isLastMessage
-        isAssistantMessage
-        isProcessing={false}
-        messageContainerRef={{ current: null } as unknown as React.RefObject<HTMLDivElement>}
-      />
-    )
-
-    expect(container.querySelector('.message-tokens')).toBeNull()
-    expect(container.querySelector('[data-ui~="part:message-actions"]')).not.toBeNull()
-  })
-
-  it('shows assistant token usage in the bubble footer toolbar', () => {
+  it('shows assistant token usage in the bubble footer toolbar regardless of the estimated-tokens setting', () => {
     const { container } = renderWithProvider(
       <MessageMenuBar
         message={assistantMessage}
@@ -154,7 +139,7 @@ describe('MessageMenuBar', () => {
         isProcessing={false}
         messageContainerRef={{ current: null } as unknown as React.RefObject<HTMLDivElement>}
       />,
-      { showEstimatedTokens: true }
+      { showEstimatedTokens: false }
     )
 
     expect(container.querySelector('.message-tokens')).toHaveTextContent('42 Tokens')


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The token label in a message's footer menubar — the count, the tokens/s figure, and the usage detail hover card behind it — only rendered when **Settings → Messages → Input → Show estimated tokens** was on. That preference (`chat.input.show_estimated_tokens`) came from the v1 composer token estimate, which no longer exists in v2, so an input-side setting was silently gating assistant output token info.

After this PR:

The footer token label always renders. The remaining placement rules are untouched: it only shows in the `footer` variant, and in bubble style only for assistant messages (bubble-style user messages keep showing their tokens in the message header). `chat.input.show_estimated_tokens` still controls that header case and is otherwise unchanged.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: dropping the gate rather than introducing a new `chat.message.show_tokens` preference — the info is small, hover-revealed, and already had no honest toggle, so a new setting would be added complexity for a display that was never meant to be optional.

The following alternatives were considered: (a) rename the preference key to match what it actually gates, rejected because renaming a shipped key silently resets existing users' choice; (b) add a dedicated message-token preference, rejected as above.

Links to places where the discussion took place: N/A

### Breaking changes

None. Users who had "Show estimated tokens" off will now see the footer token label on assistant messages.

### Special notes for your reviewer

`renderConfig.showEstimatedTokens` now has a single consumer (`MessageHeader.tsx:185`, bubble-style user messages). If we want that one ungated too, the preference and its settings switch should be removed outright — deliberately left out of this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Message token usage in the footer toolbar is now always shown, instead of being hidden by the "Show estimated tokens" input setting.
```
