### PR TITLE
fix(chat): stabilize keyboard scrolling in message list

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -536,6 +536,15 @@ describe('MessageGroup', () => {
     expect(contentContainer.style.width).toBe('')
   })
 
+  it('keeps ordinary message content out of the keyboard tab order', () => {
+    const messages = [createMessage('msg-1', 0, 'vertical')]
+
+    const { container } = render(<MessageGroup messages={messages} />)
+
+    const contentContainer = container.querySelector('#message-msg-1 .message-content-container')
+    expect(contentContainer).not.toHaveAttribute('tabindex')
+  })
+
   it('renders adapter-owned tail content only after its target assistant message', () => {
     const messages = [createMessage('msg-1', 0, 'vertical'), createMessage('msg-2', 1, 'vertical')]
 
@@ -609,6 +618,7 @@ describe('MessageGroup', () => {
     const contentContainer = container.querySelector('#message-msg-1 .message-content-container')
     expect(contentContainer).not.toBeNull()
     expect(getComputedStyle(contentContainer as HTMLElement).overflowY).toBe('auto')
+    expect(contentContainer).toHaveAttribute('tabindex', '0')
 
     const horizontalGroup = outerWrapper!.parentElement as HTMLElement
     expect(getComputedStyle(horizontalGroup).overflowX).toBe('auto')

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -545,6 +545,23 @@ describe('MessageGroup', () => {
     expect(contentContainer).not.toHaveAttribute('tabindex')
   })
 
+  it('keeps bubble-style user message content out of the keyboard tab order', () => {
+    mocks.settings.mockReturnValue({
+      multiModelMessageStyle: 'fold',
+      gridColumns: 2,
+      gridPopoverTrigger: 'click',
+      messageFont: 'system',
+      fontSize: 14,
+      messageStyle: 'bubble',
+      showMessageOutline: false
+    })
+    const messages = [{ ...createMessage('msg-1', 0, 'vertical'), role: 'user' as const }]
+
+    const { container } = render(<MessageGroup messages={messages} />)
+
+    expect(container.querySelector('#message-msg-1 .message-content-container')).not.toHaveAttribute('tabindex')
+  })
+
   it('renders adapter-owned tail content only after its target assistant message', () => {
     const messages = [createMessage('msg-1', 0, 'vertical'), createMessage('msg-2', 1, 'vertical')]
 

--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -496,6 +496,25 @@ describe('MessageGroup', () => {
     expect(grid.style.gridTemplateColumns).toBe('repeat(2, minmax(0, 1fr))')
   })
 
+  it('makes every grid popover scroll owner keyboard-focusable', () => {
+    mocks.settings.mockReturnValue({
+      multiModelMessageStyle: 'grid',
+      gridColumns: 2,
+      gridPopoverTrigger: 'click',
+      messageFont: 'system',
+      fontSize: 14,
+      messageStyle: 'plain',
+      showMessageOutline: false
+    })
+    const messages = [createMessage('msg-1', 0, 'grid'), createMessage('msg-2', 1, 'grid')]
+
+    const { container } = render(<MessageGroup messages={messages} />)
+
+    const popoverScrollOwners = container.querySelectorAll('.in-popover')
+    expect(popoverScrollOwners).toHaveLength(2)
+    popoverScrollOwners.forEach((scrollOwner) => expect(scrollOwner).toHaveAttribute('tabindex', '0'))
+  })
+
   it('keeps model identity in the existing selector for fold layout', () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'fold',

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -206,7 +206,7 @@ const MessageItemContent: FC<Omit<Props, 'messageParts'>> = ({
       <Scrollbar
         data-ui="part:message-content"
         className="message-content-container mt-0 min-h-0 max-w-full overflow-y-auto pl-0"
-        tabIndex={0}
+        tabIndex={isHorizontalMultiModelLayout ? 0 : undefined}
         style={{
           fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
           fontSize,

--- a/src/renderer/components/chat/messages/frame/MessageFrame.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageFrame.tsx
@@ -365,7 +365,6 @@ const UserBubbleMessage = ({
           <Scrollbar
             data-ui="part:message-content"
             className="message-content-container mt-0 max-w-full overflow-y-auto rounded-[10px] bg-muted px-4 py-2.5 has-[.code-block]:w-full [&_.block-wrapper:last-child>*:last-child]:mb-0! [&_.markdown>p:last-child]:mb-0!"
-            tabIndex={0}
             style={{
               fontFamily: messageFont === 'serif' ? 'var(--font-family-serif)' : 'var(--font-family)',
               fontSize,

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -312,6 +312,7 @@ const MessageGroup = ({
             trigger={gridPopoverTrigger}
             content={
               <MessageWrapper
+                tabIndex={0}
                 className={classNames([
                   'in-popover',
                   {

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Scrollbar, Tooltip } from '@cherrystudio/ui'
+import { cn } from '@cherrystudio/ui/lib/utils'
 import { ArrowDown } from 'lucide-react'
 import { type ReactNode, type Ref, useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -30,11 +31,14 @@ export const MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX = 12
 const MESSAGE_SCROLL_TO_BOTTOM_BUTTON_DEFAULT_BOTTOM_OFFSET_PX = 24
 const KEYBOARD_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])
 const KEYBOARD_ACTIVATION_SELECTOR = 'button,a,input,textarea,select,[role="button"]'
+const KEYBOARD_SCROLL_OWNER_SELECTOR =
+  'input,textarea,select,[contenteditable]:not([contenteditable="false"]),[role="textbox"],[role="combobox"],[role="listbox"],[role="slider"],[role="spinbutton"]'
+const KEYBOARD_FOCUS_OWNER_SELECTOR = `${KEYBOARD_SCROLL_OWNER_SELECTOR},button,a[href],summary,[tabindex]:not([tabindex="-1"])`
 
 function isKeyboardScrollIntent(event: KeyboardEvent, scroller: HTMLElement): boolean {
-  if (KEYBOARD_SCROLL_KEYS.has(event.key)) return true
-  if (event.key !== ' ' && event.key !== 'Spacebar') return false
   const target = event.target instanceof HTMLElement ? event.target : null
+  if (KEYBOARD_SCROLL_KEYS.has(event.key)) return !target?.closest(KEYBOARD_SCROLL_OWNER_SELECTOR)
+  if (event.key !== ' ' && event.key !== 'Spacebar') return false
   return target === scroller || !target?.closest(KEYBOARD_ACTIVATION_SELECTOR)
 }
 
@@ -51,6 +55,22 @@ function getEventTargetElement(target: EventTarget | null): HTMLElement | null {
 
 function findNestedScroller(target: EventTarget | null, scroller: HTMLElement): HTMLElement | null {
   return findNearestVerticalScrollContainer(getEventTargetElement(target), scroller)
+}
+
+function hasIndependentKeyboardFocusOwner(target: EventTarget | null, scroller: HTMLElement): boolean {
+  const owner = getEventTargetElement(target)?.closest(KEYBOARD_FOCUS_OWNER_SELECTOR)
+  return owner instanceof HTMLElement && owner !== scroller
+}
+
+function focusScrollerForKeyboard(scroller: HTMLElement): void {
+  scroller.focus({ preventScroll: true })
+}
+
+function isDocumentFocusUnowned(ownerDocument: Document): boolean {
+  const { activeElement } = ownerDocument
+  return (
+    activeElement === ownerDocument.body || activeElement === ownerDocument.documentElement || activeElement === null
+  )
 }
 
 export type { MessageVirtualListHandle }
@@ -160,6 +180,11 @@ export function MessageVirtualList<T>({
       if (event.deltaY === 0) return
       const target = event.target instanceof Element ? event.target : null
       if (findVerticalWheelConsumer(target, event.deltaY, scrollerElement)) return
+      if (
+        isDocumentFocusUnowned(scrollerElement.ownerDocument) &&
+        !hasIndependentKeyboardFocusOwner(event.target, scrollerElement)
+      )
+        focusScrollerForKeyboard(scrollerElement)
       onWheel(event)
     }
     scrollerElement.addEventListener('wheel', handleWheel, { passive: true })
@@ -177,11 +202,14 @@ export function MessageVirtualList<T>({
     if (!scrollerElement) return
     const ownerDocument = scrollerElement.ownerDocument
     const onPointerDown = (event: PointerEvent) => {
+      const nestedScroller = findNestedScroller(event.target, scrollerElement)
       pointerGestureRef.current = {
-        nestedScroller: findNestedScroller(event.target, scrollerElement),
+        nestedScroller,
         pointerType: event.pointerType,
         lastClientY: event.clientY
       }
+      if (!nestedScroller && !hasIndependentKeyboardFocusOwner(event.target, scrollerElement))
+        focusScrollerForKeyboard(scrollerElement)
       if (event.target === scrollerElement) beginScrollbarDrag()
     }
     const onPointerMove = (event: PointerEvent) => {
@@ -211,16 +239,49 @@ export function MessageVirtualList<T>({
       if (nestedScroller && canConsumeVerticalWheel(nestedScroller, getKeyboardScrollDelta(event))) return
       markUserInput()
     }
+    let focusedVirtualDescendant: Node | null = null
+    const restoreFocusAfterOwnerRemoval = () => {
+      const focusOwner = focusedVirtualDescendant
+      if (!focusOwner || (focusOwner.isConnected && scrollerElement.contains(focusOwner))) return
+      focusedVirtualDescendant = null
+
+      if (scrollerElement.isConnected && ownerDocument.hasFocus() && isDocumentFocusUnowned(ownerDocument))
+        focusScrollerForKeyboard(scrollerElement)
+    }
+    const onFocusIn = (event: FocusEvent) => {
+      const target = event.target
+      focusedVirtualDescendant =
+        target instanceof Node && target !== scrollerElement && scrollerElement.contains(target) ? target : null
+    }
+    const onFocusOut = (event: FocusEvent) => {
+      const target = event.target
+      if (!(target instanceof Node) || target !== focusedVirtualDescendant) return
+      queueMicrotask(() => {
+        if (focusedVirtualDescendant !== target) return
+        if (target.isConnected && scrollerElement.contains(target)) {
+          focusedVirtualDescendant = null
+          return
+        }
+        restoreFocusAfterOwnerRemoval()
+      })
+    }
+    const focusOwnerObserver = new MutationObserver(restoreFocusAfterOwnerRemoval)
+    focusOwnerObserver.observe(scrollerElement, { childList: true, subtree: true })
     scrollerElement.addEventListener('pointerdown', onPointerDown, { passive: true })
     scrollerElement.addEventListener('pointermove', onPointerMove, { passive: true })
     ownerDocument.addEventListener('pointerup', onPointerEnd, { passive: true })
     ownerDocument.addEventListener('pointercancel', onPointerEnd, { passive: true })
+    scrollerElement.addEventListener('focusin', onFocusIn)
+    scrollerElement.addEventListener('focusout', onFocusOut)
     scrollerElement.addEventListener('keydown', onKeyDown)
     return () => {
+      focusOwnerObserver.disconnect()
       scrollerElement.removeEventListener('pointerdown', onPointerDown)
       scrollerElement.removeEventListener('pointermove', onPointerMove)
       ownerDocument.removeEventListener('pointerup', onPointerEnd)
       ownerDocument.removeEventListener('pointercancel', onPointerEnd)
+      scrollerElement.removeEventListener('focusin', onFocusIn)
+      scrollerElement.removeEventListener('focusout', onFocusOut)
       scrollerElement.removeEventListener('keydown', onKeyDown)
     }
   }, [beginScrollbarDrag, endScrollbarDrag, markUserInput, scrollerElement])
@@ -241,7 +302,8 @@ export function MessageVirtualList<T>({
       <Scrollbar
         ref={setScrollerRef}
         data-message-virtual-list-scroller
-        className={className}
+        tabIndex={0}
+        className={cn('focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset', className)}
         style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', overflowAnchor: 'none' }}>
         <div ref={runtime.contentRef} style={{ paddingBottom: bottomPadding }}>
           <ScrollOwnershipProvider

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -236,8 +236,9 @@ export function MessageVirtualList<T>({
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented || !isKeyboardScrollIntent(event, scrollerElement)) return
       const nestedScroller = findNestedScroller(event.target, scrollerElement)
-      if (nestedScroller && canConsumeVerticalWheel(nestedScroller, getKeyboardScrollDelta(event))) return
-      markUserInput()
+      const delta = getKeyboardScrollDelta(event)
+      if (nestedScroller && canConsumeVerticalWheel(nestedScroller, delta)) return
+      markUserInput(delta < 0 ? 'up' : 'down')
     }
     let focusedVirtualDescendant: Node | null = null
     const restoreFocusAfterOwnerRemoval = () => {
@@ -303,6 +304,8 @@ export function MessageVirtualList<T>({
         ref={setScrollerRef}
         data-message-virtual-list-scroller
         tabIndex={0}
+        role="region"
+        aria-label={t('globalSearch.groups.message')}
         className={cn('focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset', className)}
         style={{ flex: 1, minHeight: 0, overflowY: 'auto', overflowX: 'hidden', overflowAnchor: 'none' }}>
         <div ref={runtime.contentRef} style={{ paddingBottom: bottomPadding }}>

--- a/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
+++ b/src/renderer/components/chat/messages/list/MessageVirtualList.tsx
@@ -30,7 +30,6 @@ export const MESSAGE_VIRTUAL_LIST_DEFAULT_TOP_PADDING_PX = 6
 export const MESSAGE_VIRTUAL_LIST_DEFAULT_BOTTOM_PADDING_PX = 12
 const MESSAGE_SCROLL_TO_BOTTOM_BUTTON_DEFAULT_BOTTOM_OFFSET_PX = 24
 const KEYBOARD_SCROLL_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End'])
-const KEYBOARD_ACTIVATION_SELECTOR = 'button,a,input,textarea,select,[role="button"]'
 const KEYBOARD_SCROLL_OWNER_SELECTOR =
   'input,textarea,select,[contenteditable]:not([contenteditable="false"]),[role="textbox"],[role="combobox"],[role="listbox"],[role="slider"],[role="spinbutton"]'
 const KEYBOARD_FOCUS_OWNER_SELECTOR = `${KEYBOARD_SCROLL_OWNER_SELECTOR},button,a[href],summary,[tabindex]:not([tabindex="-1"])`
@@ -39,7 +38,7 @@ function isKeyboardScrollIntent(event: KeyboardEvent, scroller: HTMLElement): bo
   const target = event.target instanceof HTMLElement ? event.target : null
   if (KEYBOARD_SCROLL_KEYS.has(event.key)) return !target?.closest(KEYBOARD_SCROLL_OWNER_SELECTOR)
   if (event.key !== ' ' && event.key !== 'Spacebar') return false
-  return target === scroller || !target?.closest(KEYBOARD_ACTIVATION_SELECTOR)
+  return target === scroller || !hasIndependentKeyboardFocusOwner(target, scroller)
 }
 
 function getKeyboardScrollDelta(event: KeyboardEvent): number {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -49,7 +49,7 @@ vi.mock('lucide-react', () => {
 vi.mock('react-i18next', () => {
   return {
     useTranslation: () => ({
-      t: (key: string) => key
+      t: (key: string) => (key === 'globalSearch.groups.message' ? 'Messages' : key)
     })
   }
 })
@@ -145,8 +145,9 @@ describe('MessageVirtualList', () => {
   it('makes the message viewport keyboard-focusable with visible focus feedback', () => {
     const scroller = renderMessageList()
     expect(scroller).toHaveAttribute('tabindex', '0')
-    expect(scroller).toHaveAttribute('role', 'region')
-    expect(scroller).toHaveAccessibleName('globalSearch.groups.message')
+    expect(screen.getByRole('region', { name: 'Messages' })).toBe(scroller)
+    scroller.focus()
+    expect(scroller).toHaveFocus()
     expect(scroller).toHaveClass('focus-visible:ring-1', 'focus-visible:ring-ring', 'focus-visible:ring-inset')
   })
 
@@ -433,6 +434,17 @@ describe('MessageVirtualList', () => {
     renderMessageList(() => <textarea aria-label="Editable message content" />)
 
     fireEvent.keyDown(screen.getByRole('textbox', { name: 'Editable message content' }), { key: 'ArrowDown' })
+
+    expect(runtimeMockState.markUserInput).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['contenteditable', <div key="contenteditable" data-testid="editable-message-content" contentEditable />],
+    ['textbox role', <div key="textbox" data-testid="editable-message-content" role="textbox" tabIndex={0} />]
+  ])('leaves Space with editable message content exposed through %s', (_, editor) => {
+    renderMessageList(() => editor)
+
+    fireEvent.keyDown(screen.getByTestId('editable-message-content'), { key: ' ' })
 
     expect(runtimeMockState.markUserInput).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { Activity } from 'react'
+import { Activity, type ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageVirtualList } from '../MessageVirtualList'
@@ -12,7 +12,6 @@ const runtimeMockState = vi.hoisted(() => ({
   notifyWheelIntent: vi.fn(),
   scrollByWheel: vi.fn(() => true),
   markUserInput: vi.fn(),
-  hasRecentUserScrollIntent: vi.fn(() => false),
   beginScrollbarDrag: vi.fn(),
   endScrollbarDrag: vi.fn(),
   onWheel: vi.fn(),
@@ -24,8 +23,10 @@ const virtuaMockState = vi.hoisted(() => ({
   scrollRefReadyAtMount: [] as boolean[]
 }))
 
-vi.mock('@cherrystudio/ui', () => {
+vi.mock('@cherrystudio/ui', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
   return {
+    ...actual,
     Button: ({ children, size, variant, ...props }: any) => {
       void size
       void variant
@@ -35,11 +36,6 @@ vi.mock('@cherrystudio/ui', () => {
         </button>
       )
     },
-    Scrollbar: ({ ref, children, ...props }: any) => (
-      <div ref={ref} {...props}>
-        {children}
-      </div>
-    ),
     Tooltip: ({ children }: any) => <>{children}</>
   }
 })
@@ -93,7 +89,6 @@ vi.mock('../chatVirtualizerRuntime', async () => {
       notifyWheelIntent: runtimeMockState.notifyWheelIntent,
       scrollByWheel: runtimeMockState.scrollByWheel,
       markUserInput: runtimeMockState.markUserInput,
-      hasRecentUserScrollIntent: runtimeMockState.hasRecentUserScrollIntent,
       beginScrollbarDrag: runtimeMockState.beginScrollbarDrag,
       endScrollbarDrag: runtimeMockState.endScrollbarDrag,
       shift: runtimeMockState.shift,
@@ -118,6 +113,11 @@ function ScrollRuntimeBoundaryProbe() {
   )
 }
 
+function renderMessageList(renderItem: () => ReactNode = () => <span>message-1</span>): HTMLElement {
+  render(<MessageVirtualList items={['message-1']} getItemKey={(item) => item} renderItem={renderItem} />)
+  return document.querySelector('[data-message-virtual-list-scroller]') as HTMLElement
+}
+
 describe('MessageVirtualList', () => {
   beforeEach(() => {
     runtimeMockState.isScrollToBottomButtonVisible = false
@@ -126,7 +126,6 @@ describe('MessageVirtualList', () => {
     runtimeMockState.notifyWheelIntent.mockClear()
     runtimeMockState.scrollByWheel.mockClear()
     runtimeMockState.markUserInput.mockClear()
-    runtimeMockState.hasRecentUserScrollIntent.mockClear()
     runtimeMockState.beginScrollbarDrag.mockClear()
     runtimeMockState.endScrollbarDrag.mockClear()
     runtimeMockState.onWheel.mockClear()
@@ -136,17 +135,110 @@ describe('MessageVirtualList', () => {
   })
 
   it('mounts virtua only after the external scroller ref is ready', () => {
-    render(
-      <MessageVirtualList
-        items={['message-1']}
-        getItemKey={(item) => item}
-        renderItem={(item) => <span>{item}</span>}
-      />
-    )
+    renderMessageList()
 
     expect(screen.getByTestId('virtualizer')).toBeInTheDocument()
     expect(virtuaMockState.scrollRefReadyAtMount).not.toContain(false)
     expect(virtuaMockState.scrollRefReadyAtMount.length).toBeGreaterThan(0)
+  })
+
+  it('makes the message viewport keyboard-focusable with visible focus feedback', () => {
+    const scroller = renderMessageList()
+    expect(scroller).toHaveAttribute('tabindex', '0')
+    expect(scroller).toHaveClass('focus-visible:ring-1', 'focus-visible:ring-ring', 'focus-visible:ring-inset')
+  })
+
+  it('takes keyboard scroll ownership after direct interaction with plain message content', () => {
+    const scroller = renderMessageList(() => <span data-testid="plain-message-content">content</span>)
+    const content = screen.getByTestId('plain-message-content')
+
+    fireEvent.pointerDown(content)
+    expect(scroller).toHaveFocus()
+
+    scroller.blur()
+    fireEvent.wheel(content, { deltaY: 40 })
+    expect(scroller).toHaveFocus()
+  })
+
+  it('does not take keyboard ownership from editable message content', () => {
+    renderMessageList(() => <textarea aria-label="Editable message content" />)
+
+    const editor = screen.getByRole('textbox', { name: 'Editable message content' })
+    editor.focus()
+    fireEvent.pointerDown(editor)
+    fireEvent.wheel(editor, { deltaY: 40 })
+
+    expect(editor).toHaveFocus()
+  })
+
+  it('does not take keyboard ownership from an editor outside the message viewport on wheel', () => {
+    render(
+      <>
+        <textarea aria-label="Composer" />
+        <MessageVirtualList
+          items={['message-1']}
+          getItemKey={(item) => item}
+          renderItem={() => <span data-testid="plain-message-content">content</span>}
+        />
+      </>
+    )
+
+    const composer = screen.getByRole('textbox', { name: 'Composer' })
+    composer.focus()
+    fireEvent.wheel(screen.getByTestId('plain-message-content'), { deltaY: 40 })
+
+    expect(composer).toHaveFocus()
+  })
+
+  it('restores keyboard ownership when a focused virtualized descendant is removed', async () => {
+    const scroller = renderMessageList(() => <div data-testid="virtualized-focus-owner" tabIndex={0} />)
+    const focusOwner = screen.getByTestId('virtualized-focus-owner')
+    focusOwner.focus()
+    expect(focusOwner).toHaveFocus()
+
+    focusOwner.remove()
+
+    await waitFor(() => expect(scroller).toHaveFocus())
+  })
+
+  it('does not restore keyboard ownership when a mounted descendant deliberately blurs', async () => {
+    const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+    const scroller = renderMessageList(() => <div data-testid="virtualized-focus-owner" tabIndex={0} />)
+    const focusOwner = screen.getByTestId('virtualized-focus-owner')
+    try {
+      focusOwner.focus()
+
+      focusOwner.blur()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(document.body).toHaveFocus()
+      expect(scroller).not.toHaveFocus()
+    } finally {
+      hasFocusSpy.mockRestore()
+    }
+  })
+
+  it('preserves an explicit focus move from a virtualized descendant to the composer', async () => {
+    render(
+      <>
+        <textarea aria-label="Composer" />
+        <MessageVirtualList
+          items={['message-1']}
+          getItemKey={(item) => item}
+          renderItem={() => <div data-testid="virtualized-focus-owner" tabIndex={0} />}
+        />
+      </>
+    )
+
+    const composer = screen.getByRole('textbox', { name: 'Composer' })
+    const focusOwner = screen.getByTestId('virtualized-focus-owner')
+    focusOwner.focus()
+
+    composer.focus()
+    focusOwner.remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(composer).toHaveFocus()
   })
 
   it('keeps virtua mounted when a hidden tab detaches the scroller ref', () => {
@@ -333,6 +425,14 @@ describe('MessageVirtualList', () => {
     runtimeMockState.takeUserControl.mockClear()
     fireEvent.scroll(scroller)
     expect(runtimeMockState.takeUserControl).not.toHaveBeenCalled()
+  })
+
+  it('leaves vertical navigation keys with editable message content', () => {
+    renderMessageList(() => <textarea aria-label="Editable message content" />)
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Editable message content' }), { key: 'ArrowDown' })
+
+    expect(runtimeMockState.markUserInput).not.toHaveBeenCalled()
   })
 
   it('hands keyboard and touch scrolling to the outer runtime at a nested boundary', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -142,13 +142,12 @@ describe('MessageVirtualList', () => {
     expect(virtuaMockState.scrollRefReadyAtMount.length).toBeGreaterThan(0)
   })
 
-  it('makes the message viewport keyboard-focusable with visible focus feedback', () => {
+  it('exposes the message viewport as a keyboard-focusable named region', () => {
     const scroller = renderMessageList()
     expect(scroller).toHaveAttribute('tabindex', '0')
     expect(screen.getByRole('region', { name: 'Messages' })).toBe(scroller)
     scroller.focus()
     expect(scroller).toHaveFocus()
-    expect(scroller).toHaveClass('focus-visible:ring-1', 'focus-visible:ring-ring', 'focus-visible:ring-inset')
   })
 
   it('takes keyboard scroll ownership after direct interaction with plain message content', () => {

--- a/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx
@@ -145,6 +145,8 @@ describe('MessageVirtualList', () => {
   it('makes the message viewport keyboard-focusable with visible focus feedback', () => {
     const scroller = renderMessageList()
     expect(scroller).toHaveAttribute('tabindex', '0')
+    expect(scroller).toHaveAttribute('role', 'region')
+    expect(scroller).toHaveAccessibleName('globalSearch.groups.message')
     expect(scroller).toHaveClass('focus-visible:ring-1', 'focus-visible:ring-ring', 'focus-visible:ring-inset')
   })
 
@@ -454,9 +456,15 @@ describe('MessageVirtualList', () => {
     region.scrollTop = 200
 
     fireEvent.keyDown(region, { key: 'PageDown' })
-    expect(runtimeMockState.markUserInput).toHaveBeenCalledTimes(1)
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledWith('down')
 
     runtimeMockState.markUserInput.mockClear()
+    region.scrollTop = 0
+    fireEvent.keyDown(region, { key: 'ArrowUp' })
+    expect(runtimeMockState.markUserInput).toHaveBeenCalledWith('up')
+
+    runtimeMockState.markUserInput.mockClear()
+    region.scrollTop = 200
     const fireTouchPointerEvent = (type: 'pointerdown' | 'pointermove', clientY: number, buttons: number) => {
       const event = new Event(type, { bubbles: true, cancelable: true })
       Object.defineProperties(event, {

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3394,12 +3394,63 @@ describe('useChatVirtualizerRuntime', () => {
     }
   })
 
+  it('keeps the settled viewport anchored after repeated keyboard scrolling', () => {
+    const callbacks: ResizeObserverCallback[] = []
+    const restoreResizeObserver = installResizeObserverMock(callbacks)
+    const raf = installQueuedAnimationFrame()
+    let now = 1_000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 2000)
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+
+      now = 1_010
+      act(() => {
+        runtime!.markUserInput()
+        scrollTop = 460
+        runtime!.scrollerProps.onScroll(460)
+      })
+
+      now = 1_020
+      act(() => {
+        runtime!.markUserInput()
+        scrollTop = 420
+        runtime!.scrollerProps.onScroll(420)
+        runtime!.scrollerProps.onScrollEnd()
+      })
+
+      now = 1_030
+      scrollTop = 430
+      act(() => callbacks[0]?.([], {} as ResizeObserver))
+      expect(scrollTop).toBe(420)
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
+
   it('treats a later resize as programmatic when keydown intent expires without a scroll', () => {
     const callbacks: ResizeObserverCallback[] = []
     const restoreResizeObserver = installResizeObserverMock(callbacks)
     const raf = installQueuedAnimationFrame()
-    // Advance time past the intent window after markUserInput fires so
-    // hasRecentUserScrollIntent() returns false when the ResizeObserver runs.
+    // Advance time past the pending-intent window after markUserInput fires.
     let now = 1_000
     const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
 

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3442,6 +3442,14 @@ describe('useChatVirtualizerRuntime', () => {
       })
 
       expect(scrollTop).toBe(500)
+
+      // The corrective scroll back to the anchor must not reuse the rejected
+      // downward intent and become a new user gesture.
+      act(() => runtime!.scrollerProps.onScroll(500))
+      runtime!.scrollerProps.onScrollEnd()
+      scrollTop = 510
+      act(() => runtime!.scrollerProps.onScroll(510))
+      expect(scrollTop).toBe(500)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()

--- a/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
+++ b/src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx
@@ -3359,6 +3359,14 @@ describe('useChatVirtualizerRuntime', () => {
       runtime!.vlistHandleRef.current = createHandle()
       raf.tick(60)
 
+      // Establish the offset that the runtime would already know from the
+      // browser's normal scroll event stream before this keyboard gesture.
+      act(() => {
+        runtime!.markUserInput()
+        runtime!.scrollerProps.onScroll(500)
+        runtime!.scrollerProps.onScrollEnd()
+      })
+
       // Enter reading mode — the viewport freezes at scrollTop 500.
       act(() => runtime!.takeUserControl('user-scrolled-up'))
       expect(scrollTop).toBe(500)
@@ -3367,7 +3375,7 @@ describe('useChatVirtualizerRuntime', () => {
       // before the ResizeObserver fires.
       now = 1_010
       act(() => {
-        runtime!.markUserInput()
+        runtime!.markUserInput('up')
         // The browser scrolled — but the ResizeObserver hasn't fired yet.
         scrollTop = 460
       })
@@ -3387,6 +3395,53 @@ describe('useChatVirtualizerRuntime', () => {
       scrollTop = 470
       act(() => callbacks[0]?.([], {} as ResizeObserver))
       expect(scrollTop).toBe(460)
+    } finally {
+      nowSpy.mockRestore()
+      restoreResizeObserver()
+      raf.restore()
+    }
+  })
+
+  it('does not claim a scroll that moves opposite to fresh keyboard intent', () => {
+    const restoreResizeObserver = installResizeObserverMock([])
+    const raf = installQueuedAnimationFrame()
+    let now = 1_000
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+
+    try {
+      let runtime: ChatVirtualizerRuntime<string> | undefined
+      let scrollTop = 500
+      render(<RuntimeDomProbe items={['message-a']} onRuntime={(nextRuntime) => (runtime = nextRuntime)} />)
+      const scroller = runtime!.scrollerRef.current!
+      Object.defineProperty(scroller, 'scrollTop', {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value) => {
+          scrollTop = value
+        }
+      })
+      setElementMetric(scroller, 'clientHeight', () => 400)
+      setElementMetric(scroller, 'scrollHeight', () => 2000)
+      runtime!.vlistHandleRef.current = createHandle()
+      raf.tick(60)
+
+      act(() => {
+        runtime!.markUserInput()
+        runtime!.scrollerProps.onScroll(500)
+        runtime!.scrollerProps.onScrollEnd()
+      })
+
+      act(() => runtime!.takeUserControl('user-scrolled-up'))
+      expect(scrollTop).toBe(500)
+
+      now = 1_010
+      act(() => {
+        runtime!.markUserInput('down')
+        scrollTop = 460
+        runtime!.scrollerProps.onScroll(460)
+      })
+
+      expect(scrollTop).toBe(500)
     } finally {
       nowSpy.mockRestore()
       restoreResizeObserver()

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -674,6 +674,15 @@ export function useChatVirtualizerRuntime<T>({
     const pendingUserInput = pendingUserInputRef.current
     const deltaDirection = getScrollDirection(delta)
     const hasRecentUserScrollIntent = isUserScrollIntentPending(deltaDirection)
+    if (
+      pendingUserInput &&
+      performance.now() - pendingUserInput.at < USER_SCROLL_INPUT_WINDOW_MS &&
+      pendingUserInput.direction !== 'none' &&
+      deltaDirection !== 'none' &&
+      pendingUserInput.direction !== deltaDirection
+    ) {
+      pendingUserInputRef.current = null
+    }
     const isUserInitiated = scrollbarDragActiveRef.current || userScrollGestureRef.current || hasRecentUserScrollIntent
     const wheelDir = lastWheelDirRef.current
     const direction = wheelDir !== 'none' ? wheelDir : deltaDirection

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -140,12 +140,6 @@ export interface ChatVirtualizerRuntime<T> {
    * keyboard scroll commands.
    */
   markUserInput(): void
-  /**
-   * True while a recent keyboard/pointer/wheel intent is still inside the
-   * `USER_SCROLL_INPUT_WINDOW_MS` grace period. Used by the ResizeObserver
-   * to skip its snap-back before a real `onScroll` can claim the gesture.
-   */
-  hasRecentUserScrollIntent(): boolean
   /** Keep native scrollbar ownership latched until the pointer is actually released. */
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */
@@ -153,6 +147,8 @@ export interface ChatVirtualizerRuntime<T> {
 }
 
 const SCROLL_WHEEL_DEBOUNCE_MS = 100
+type ScrollDirection = 'up' | 'down' | 'none'
+type PendingUserInput = { at: number; direction: ScrollDirection }
 // scrollToKey animates smoothly for nearby targets but jumps instantly once the
 // distance exceeds this many viewports — see the behavior choice in scrollToKey.
 const LONG_JUMP_VIEWPORTS = 3
@@ -167,6 +163,10 @@ const USER_SCROLL_INPUT_WINDOW_MS = 250
 const FREEZE_REASSERT_TOLERANCE_PX = 2
 const FREEZE_SEMANTIC_ANCHOR_SELECTOR =
   'button,[role="button"],a,input,textarea,select,h1,h2,h3,h4,h5,h6,.block-wrapper,[data-message-id],p,pre,li,table'
+
+function getScrollDirection(delta: number): ScrollDirection {
+  return delta < 0 ? 'up' : delta > 0 ? 'down' : 'none'
+}
 
 function keysMatchAt(container: readonly string[], candidate: readonly string[], offset: number): boolean {
   return candidate.every((key, index) => container[index + offset] === key)
@@ -202,23 +202,23 @@ export function useChatVirtualizerRuntime<T>({
   // or late render makes content shorter while the user owns the viewport.
   const freezeSpacerHeightRef = useRef(0)
   const freezeBaselineScrollHeightRef = useRef<number | null>(null)
-  // A timestamp only starts a genuine scroll gesture. Trackpad/keyboard motion
-  // remains active until scrollend; a native scrollbar drag has its own latch.
-  const lastUserInputAtRef = useRef(0)
-  const lastUserInputDirectionRef = useRef<'up' | 'down' | 'none'>('none')
+  // Pending input only starts a genuine scroll gesture when a matching scroll arrives.
+  // Trackpad/keyboard motion then remains active until scrollend; a native drag has its own latch.
+  const pendingUserInputRef = useRef<PendingUserInput | null>(null)
   const userScrollGestureRef = useRef(false)
   const scrollbarDragActiveRef = useRef(false)
   const readNavigationActiveRef = useRef(false)
   const explicitNavigationBaseRef = useRef<ExplicitNavigationBase | null>(null)
   const lastScrollOffsetRef = useRef(0)
-  const markUserInput = useCallback(() => {
-    lastUserInputAtRef.current = performance.now()
-    lastUserInputDirectionRef.current = 'none'
+  const markUserInput = useCallback((direction: ScrollDirection = 'none') => {
+    pendingUserInputRef.current = { at: performance.now(), direction }
   }, [])
-  const hasRecentUserScrollIntent = useCallback(
-    () => performance.now() - lastUserInputAtRef.current < USER_SCROLL_INPUT_WINDOW_MS,
-    []
-  )
+  const isUserScrollIntentPending = useCallback((direction: ScrollDirection = 'none') => {
+    const input = pendingUserInputRef.current
+    if (!input) return false
+    const directionMatches = input.direction === 'none' || direction === 'none' || input.direction === direction
+    return performance.now() - input.at < USER_SCROLL_INPUT_WINDOW_MS && directionMatches
+  }, [])
   const itemsRef = useRef(items)
   itemsRef.current = items
   const getItemKeyRef = useRef(getItemKey)
@@ -439,16 +439,14 @@ export function useChatVirtualizerRuntime<T>({
   }, [markUserInput])
 
   const beginUserScrollGesture = useCallback(() => {
+    // A real scroll has claimed the latest input, even when the gesture is already active.
+    pendingUserInputRef.current = null
     if (userScrollGestureRef.current) return
     explicitNavigationBaseRef.current = null
     // Any slack belongs to the old resting position. Once the user moves the
     // native thumb, its live scroll range must be the only range in play.
     setFreezeSpacerHeight(0)
     freezeBaselineScrollHeightRef.current = getNaturalScrollHeight()
-    // Consume the pre-scroll intent: a real onScroll now owns the gesture, so
-    // the ResizeObserver must not keep suppressing reassertFreeze for the
-    // remainder of the input window.
-    lastUserInputAtRef.current = 0
     userScrollGestureRef.current = true
   }, [getNaturalScrollHeight, setFreezeSpacerHeight])
 
@@ -584,7 +582,7 @@ export function useChatVirtualizerRuntime<T>({
         // but the gesture latch is not set yet (onScroll hasn't fired).
         // Suppress the snap-back so the native scroll can land; onScroll will
         // call beginUserScrollGesture() once it observes the real offset.
-        if (!hasRecentUserScrollIntent()) {
+        if (!isUserScrollIntentPending()) {
           reassertFreeze()
         }
       }
@@ -599,7 +597,7 @@ export function useChatVirtualizerRuntime<T>({
     return () => observer.disconnect()
   }, [
     autoStick,
-    hasRecentUserScrollIntent,
+    isUserScrollIntentPending,
     maintainFreezeScrollRange,
     reassertFreeze,
     updateScrollToBottomButtonVisibility,
@@ -613,13 +611,12 @@ export function useChatVirtualizerRuntime<T>({
   // ---- scroll / wheel handlers ---------------------------------------
 
   const wheelTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const lastWheelDirRef = useRef<'up' | 'down' | 'none'>('none')
+  const lastWheelDirRef = useRef<ScrollDirection>('none')
 
   const notifyWheelIntent = useCallback(
     (deltaY: number) => {
-      markUserInput()
-      const dir: 'up' | 'down' | 'none' = deltaY < 0 ? 'up' : deltaY > 0 ? 'down' : 'none'
-      lastUserInputDirectionRef.current = dir
+      const dir = getScrollDirection(deltaY)
+      markUserInput(dir)
       if (readNavigationActiveRef.current && dir !== 'none') {
         takeUserControl('navigation')
       }
@@ -674,17 +671,14 @@ export function useChatVirtualizerRuntime<T>({
     // Only a genuine user scroll (recent wheel / pointer / keyboard) is treated as
     // intent. virtua's remeasure-compensation jumps and child `scrollIntoView`
     // calls also fire scroll events, with no preceding input.
-    const recentInputDirection = lastUserInputDirectionRef.current
-    const inputDirectionMatchesScroll =
-      recentInputDirection === 'none' || delta === 0 || (recentInputDirection === 'up' ? delta < 0 : delta > 0)
-    const hasRecentUserScrollIntent =
-      performance.now() - lastUserInputAtRef.current < USER_SCROLL_INPUT_WINDOW_MS && inputDirectionMatchesScroll
+    const pendingUserInput = pendingUserInputRef.current
+    const deltaDirection = getScrollDirection(delta)
+    const hasRecentUserScrollIntent = isUserScrollIntentPending(deltaDirection)
     const isUserInitiated = scrollbarDragActiveRef.current || userScrollGestureRef.current || hasRecentUserScrollIntent
     const wheelDir = lastWheelDirRef.current
-    const direction: 'up' | 'down' | 'none' =
-      wheelDir !== 'none' ? wheelDir : delta < 0 ? 'up' : delta > 0 ? 'down' : 'none'
-    if (hasRecentUserScrollIntent && recentInputDirection === 'none' && direction !== 'none') {
-      lastUserInputDirectionRef.current = direction
+    const direction = wheelDir !== 'none' ? wheelDir : deltaDirection
+    if (hasRecentUserScrollIntent && pendingUserInput?.direction === 'none' && direction !== 'none') {
+      pendingUserInput.direction = direction
     }
 
     // Smooth scrolling is reserved for explicit reading navigation. Any real
@@ -752,6 +746,7 @@ export function useChatVirtualizerRuntime<T>({
   }, [
     beginUserScrollGesture,
     enterFollowingMode,
+    isUserScrollIntentPending,
     maintainFreezeScrollRange,
     maybeNotifyReachTop,
     reassertFreeze,
@@ -1009,7 +1004,6 @@ export function useChatVirtualizerRuntime<T>({
     notifyWheelIntent,
     scrollByWheel,
     markUserInput,
-    hasRecentUserScrollIntent,
     beginScrollbarDrag,
     endScrollbarDrag
   }

--- a/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
+++ b/src/renderer/components/chat/messages/list/chatVirtualizerRuntime.tsx
@@ -139,7 +139,7 @@ export interface ChatVirtualizerRuntime<T> {
    * `scrollerProps.onWheel`; the host calls this for pointer drags and
    * keyboard scroll commands.
    */
-  markUserInput(): void
+  markUserInput(direction?: ScrollDirection): void
   /** Keep native scrollbar ownership latched until the pointer is actually released. */
   beginScrollbarDrag(): void
   /** Finish a native scrollbar drag and anchor the viewport at its final position. */


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

In long, virtualized conversations, repeated Arrow Up/Down or Page Up/Down input could be classified as programmatic movement while `ResizeObserver` reasserted the frozen viewport. This caused intermittent jitter or no visible movement, especially after focusing the composer and then clicking back into the conversation.

After this PR:

The message viewport explicitly owns keyboard scrolling after direct interaction with non-interactive message content, while editable controls keep focus. Pending user input is represented as one timestamp-and-direction intent and is consumed as soon as a real scroll claims the gesture, so resize reconciliation no longer fights repeated keyboard scrolling. If a focused virtualized descendant unmounts, focus returns to the stable viewport, which now has visible focus feedback.

Fixes #18707

### Why we need it and why it was done in this way

The virtualizer must preserve a reading anchor during programmatic remeasurement while yielding immediately to genuine user scrolling. The previous grace-window approach could leave a fresh repeated input pending after the gesture was already active, allowing `ResizeObserver` to reassert the old anchor and oppose native keyboard movement.

This change makes the ownership boundary explicit: the stable message viewport owns keyboard scrolling, interactive descendants retain their own focus, and one pending intent record bridges input to the corresponding native scroll event.

The following tradeoffs were made:

A `MutationObserver` watches the message viewport subtree so focus can be restored when the browser removes a focused virtualized row without firing `blur`. Its callback is constant-time unless a tracked focused descendant has actually left the viewport.

The following alternatives were considered:

- Extending input grace timers or suppressing more resize reconciliation was rejected because it masks the race and can preserve stale intent.
- Focusing the message viewport on every wheel event was rejected because it would steal focus from the composer and editable message content.
- Disabling viewport freeze or virtualizer compensation was rejected because it would regress reading-position stability during streaming and remeasurement.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18707

### Breaking changes

None.

### Special notes for your reviewer

Validation:

- `pnpm test:renderer src/renderer/components/chat/messages/list/__tests__/MessageVirtualList.test.tsx src/renderer/components/chat/messages/list/__tests__/chatVirtualizerRuntime.test.tsx` (96 tests)
- `pnpm test:renderer src/renderer/components/chat/messages src/renderer/pages/home/__tests__/ChatContent.test.tsx` (1,031 tests)
- `pnpm lint`
- CDP: 12 long-press trials across Arrow Up/Down and Page Up/Down after focusing the composer and clicking the chat viewport; zero failed trials or reverse programmatic writes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix intermittent keyboard scrolling jitter and stalls in long chat conversations.
```
