### PR TITLE
feat(builtin-knowledge): add feature-level catalog to product manifest

### DIFF
--- a/resources/builtin-agents/cherry-assistant/product-manifest.json
+++ b/resources/builtin-agents/cherry-assistant/product-manifest.json
@@ -789,5 +789,61 @@
         "pi"
       ]
     }
+  },
+  "features": {
+    "context": {
+      "defaults": {
+        "enabled": true,
+        "truncateThreshold": 50000,
+        "maxMessages": null,
+        "compress": {
+          "enabled": true,
+          "modelId": null
+        }
+      },
+      "limits": {
+        "minTruncateThreshold": 2000,
+        "compressionMinOutputTokens": 4096,
+        "compressionMaxOutputTokens": 16384
+      }
+    },
+    "mcp": {
+      "serverTypes": [
+        "stdio",
+        "sse",
+        "streamableHttp",
+        "inMemory"
+      ],
+      "installSources": [
+        "builtin",
+        "manual",
+        "ai_assisted",
+        "protocol",
+        "unknown"
+      ]
+    },
+    "knowledge": {
+      "supportedFileExtensions": [
+        ".txt",
+        ".markdown",
+        ".md",
+        ".mdx",
+        ".pdf",
+        ".html",
+        ".htm",
+        ".xlsx",
+        ".xls",
+        ".docx",
+        ".csv",
+        ".doc",
+        ".pptx",
+        ".ppt",
+        ".epub",
+        ".draftsexport"
+      ],
+      "fileProcessingExtensions": [
+        ".pdf"
+      ]
+    }
   }
 }

--- a/scripts/generate-cherry-assistant-knowledge/__tests__/manifest.test.ts
+++ b/scripts/generate-cherry-assistant-knowledge/__tests__/manifest.test.ts
@@ -6,6 +6,16 @@ import { describe, expect, it } from 'vitest'
 import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
 import { CodeCli } from '../../../src/shared/types/codeCli'
 import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
+import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
+import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
+import {
+  knowledgeFileProcessingExts,
+  knowledgeSupportedFileExts
+} from '../../../src/shared/utils/file/fileExtensions'
+import {
+  COMPRESSION_MAX_OUTPUT_TOKENS,
+  COMPRESSION_MIN_OUTPUT_TOKENS
+} from '../../../packages/aiCore/src/core/context/middleware'
 import { generateProductManifest, serializeProductManifest } from '../generators/manifest'
 
 describe('generateProductManifest', () => {
@@ -65,6 +75,21 @@ describe('generateProductManifest', () => {
     expect(new Set(manifest.agents.scheduleTriggerKinds).size).toBe(manifest.agents.scheduleTriggerKinds.length)
     expect(manifest.agents.codeCli.route).toBe(manifest.routes.primary.find(({ id }) => id === 'code_tools')?.path)
     expect(manifest.agents.codeCli.tools).toEqual(Object.values(CodeCli))
+  })
+
+  it('includes feature-level catalog derived from source-of-truth constants', () => {
+    const manifest = generateProductManifest()
+
+    expect(manifest.features.context.defaults).toEqual(DEFAULT_CONTEXT_SETTINGS)
+    expect(manifest.features.context.limits).toEqual({
+      minTruncateThreshold: MIN_TRUNCATE_THRESHOLD,
+      compressionMinOutputTokens: COMPRESSION_MIN_OUTPUT_TOKENS,
+      compressionMaxOutputTokens: COMPRESSION_MAX_OUTPUT_TOKENS
+    })
+    expect(manifest.features.mcp.serverTypes).toEqual([...McpServerTypeSchema.options])
+    expect(manifest.features.mcp.installSources).toEqual([...McpServerInstallSourceSchema.options])
+    expect(manifest.features.knowledge.supportedFileExtensions).toEqual([...knowledgeSupportedFileExts])
+    expect(manifest.features.knowledge.fileProcessingExtensions).toEqual([...knowledgeFileProcessingExts])
   })
 
   it('serializes the manifest as stable JSON', () => {

--- a/scripts/generate-cherry-assistant-knowledge/__tests__/manifest.test.ts
+++ b/scripts/generate-cherry-assistant-knowledge/__tests__/manifest.test.ts
@@ -3,19 +3,16 @@ import * as path from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
-import { CodeCli } from '../../../src/shared/types/codeCli'
-import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
-import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
-import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
-import {
-  knowledgeFileProcessingExts,
-  knowledgeSupportedFileExts
-} from '../../../src/shared/utils/file/fileExtensions'
 import {
   COMPRESSION_MAX_OUTPUT_TOKENS,
   COMPRESSION_MIN_OUTPUT_TOKENS
 } from '../../../packages/aiCore/src/core/context/middleware'
+import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
+import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
+import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
+import { CodeCli } from '../../../src/shared/types/codeCli'
+import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
+import { knowledgeFileProcessingExts, knowledgeSupportedFileExts } from '../../../src/shared/utils/file/fileExtensions'
 import { generateProductManifest, serializeProductManifest } from '../generators/manifest'
 
 describe('generateProductManifest', () => {

--- a/scripts/generate-cherry-assistant-knowledge/generators/manifest.ts
+++ b/scripts/generate-cherry-assistant-knowledge/generators/manifest.ts
@@ -6,6 +6,16 @@ import { Node, type ObjectLiteralExpression, Project, SyntaxKind } from 'ts-morp
 import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
 import { CodeCli } from '../../../src/shared/types/codeCli'
 import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
+import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
+import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
+import {
+  knowledgeFileProcessingExts,
+  knowledgeSupportedFileExts
+} from '../../../src/shared/utils/file/fileExtensions'
+import {
+  COMPRESSION_MAX_OUTPUT_TOKENS,
+  COMPRESSION_MIN_OUTPUT_TOKENS
+} from '../../../packages/aiCore/src/core/context/middleware'
 
 const ROOT_DIR = path.resolve(__dirname, '..', '..', '..')
 const PACKAGE_JSON_FILE = path.join(ROOT_DIR, 'package.json')
@@ -61,6 +71,32 @@ export interface ProductManifest {
     codeCli: {
       route: string
       tools: string[]
+    }
+  }
+  features: {
+    context: {
+      defaults: {
+        enabled: boolean
+        truncateThreshold: number
+        maxMessages: number | null
+        compress: {
+          enabled: boolean
+          modelId: string | null
+        }
+      }
+      limits: {
+        minTruncateThreshold: number
+        compressionMinOutputTokens: number
+        compressionMaxOutputTokens: number
+      }
+    }
+    mcp: {
+      serverTypes: string[]
+      installSources: string[]
+    }
+    knowledge: {
+      supportedFileExtensions: string[]
+      fileProcessingExtensions: string[]
     }
   }
 }
@@ -191,6 +227,27 @@ function readAgentCapabilities(primaryRoutes: ProductManifest['routes']['primary
   }
 }
 
+function readFeatures(): ProductManifest['features'] {
+  return {
+    context: {
+      defaults: { ...DEFAULT_CONTEXT_SETTINGS },
+      limits: {
+        minTruncateThreshold: MIN_TRUNCATE_THRESHOLD,
+        compressionMinOutputTokens: COMPRESSION_MIN_OUTPUT_TOKENS,
+        compressionMaxOutputTokens: COMPRESSION_MAX_OUTPUT_TOKENS
+      }
+    },
+    mcp: {
+      serverTypes: [...McpServerTypeSchema.options],
+      installSources: [...McpServerInstallSourceSchema.options]
+    },
+    knowledge: {
+      supportedFileExtensions: [...knowledgeSupportedFileExts],
+      fileProcessingExtensions: [...knowledgeFileProcessingExts]
+    }
+  }
+}
+
 export function generateProductManifest(): ProductManifest {
   const primaryRoutes = readPrimaryRoutes()
   return {
@@ -203,7 +260,8 @@ export function generateProductManifest(): ProductManifest {
     commands: JSON.parse(JSON.stringify(COMMAND_DEFINITIONS)) as ProductManifest['commands'],
     providers: readProviders(),
     locales: [...appLanguageOptions],
-    agents: readAgentCapabilities(primaryRoutes)
+    agents: readAgentCapabilities(primaryRoutes),
+    features: readFeatures()
   }
 }
 

--- a/scripts/generate-cherry-assistant-knowledge/generators/manifest.ts
+++ b/scripts/generate-cherry-assistant-knowledge/generators/manifest.ts
@@ -3,19 +3,16 @@ import * as path from 'node:path'
 
 import { Node, type ObjectLiteralExpression, Project, SyntaxKind } from 'ts-morph'
 
-import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
-import { CodeCli } from '../../../src/shared/types/codeCli'
-import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
-import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
-import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
-import {
-  knowledgeFileProcessingExts,
-  knowledgeSupportedFileExts
-} from '../../../src/shared/utils/file/fileExtensions'
 import {
   COMPRESSION_MAX_OUTPUT_TOKENS,
   COMPRESSION_MIN_OUTPUT_TOKENS
 } from '../../../packages/aiCore/src/core/context/middleware'
+import { appLanguageOptions } from '../../../src/renderer/i18n/languages'
+import { DEFAULT_CONTEXT_SETTINGS, MIN_TRUNCATE_THRESHOLD } from '../../../src/shared/data/types/contextSettings'
+import { McpServerInstallSourceSchema, McpServerTypeSchema } from '../../../src/shared/data/types/mcpServer'
+import { CodeCli } from '../../../src/shared/types/codeCli'
+import { COMMAND_DEFINITIONS } from '../../../src/shared/utils/command/definitions'
+import { knowledgeFileProcessingExts, knowledgeSupportedFileExts } from '../../../src/shared/utils/file/fileExtensions'
 
 const ROOT_DIR = path.resolve(__dirname, '..', '..', '..')
 const PACKAGE_JSON_FILE = path.join(ROOT_DIR, 'package.json')


### PR DESCRIPTION
### What this PR does

Before this PR: `product-manifest.json` exposed only structural metadata (package, routes, commands, providers, locales, agents). When users or built-in Agents asked core feature questions like "What is the compression mechanism?", the agent called `product_info` but found no feature-level answers and had to unpack `app.asar` and search source — slow and rediscovered each time.

After this PR: adds a compact `features` section to the manifest, derived from source-of-truth constants so `product_info` can answer directly:

- **context**: defaults from `DEFAULT_CONTEXT_SETTINGS` (`enabled`, `truncateThreshold: 50_000`, `maxMessages`, `compress`) + limits (`minTruncateThreshold: 2000`, `compressionMinOutputTokens: 4096`, `compressionMaxOutputTokens: 16384`)
- **mcp**: `serverTypes` (`stdio`, `sse`, `streamableHttp`, `inMemory`) and `installSources` from `McpServerTypeSchema` / `McpServerInstallSourceSchema`
- **knowledge**: `supportedFileExtensions` and `fileProcessingExtensions` from `knowledgeSupportedFileExts` / `knowledgeFileProcessingExts`

Generator reads live constants — no hand-maintained duplication — and `pnpm build:builtin-knowledge` regenerates `resources/builtin-agents/cherry-assistant/product-manifest.json`. Existing `agents` section already covers channel types / scheduled triggers / Code CLI, so no duplication there.

Fixes #18384

### Why we need it and why it was done in this way

- Import constants directly in `scripts/generate-cherry-assistant-knowledge/generators/manifest.ts` (`DEFAULT_CONTEXT_SETTINGS`, `MIN_TRUNCATE_THRESHOLD`, `COMPRESSION_*`, `McpServer*Schema`, `knowledge*Exts`) and expose via `readFeatures()` — keeps the manifest concise and in sync with code, avoids duplicating long-form docs.
- Alternatives considered: structured API endpoints in official docs (higher maintenance, not as direct as embedding in manifest — as noted in the issue).

### Checklist

- [x] Branch targets `main`
- [x] `pnpm build:builtin-knowledge` regenerates `product-manifest.json`
- [x] `scripts/generate-cherry-assistant-knowledge/__tests__/manifest.test.ts` covers the new `features` catalog

### Release note

```release-note
feat(builtin-knowledge): product-manifest now includes feature-level catalog (context defaults/limits, MCP server types, knowledge file extensions) for Agent queries
```