### PR TITLE
fix(chat-message): allow uniform edit for all assistant messages

### DIFF
--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -192,9 +192,9 @@ const isComposerEditableMessagePart = (part: CherryMessagePart) => part.type ===
 // Composer edits as a single text field: the draft joins all text parts (`\n\n`) and
 // rebuilds files from tokens. Saving replaces the first editable part with the rebuilt
 // draft and drops trailing editable parts — non-editable `reasoning`/`dynamic-tool` blocks
-// stay in place and `data-translation` is removed. For interleaved replies like
-// [text "before", tool, text "after"], the trailing text's content survives via the joined
-// draft but the message is normalized to [text "before\n\nafter", tool].
+// stay in place and `data-translation` is removed. Interleaved shapes such as
+// [text "before", tool, text "after"] are blocked by `canEditAssistantMessageParts` and
+// never reach this path, so no reordering occurs on save.
 const replaceComposerEditableMessageParts = (
   originalParts: CherryMessagePart[],
   editedParts: CherryMessagePart[]

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -189,6 +189,12 @@ type ComposerFilePart = Extract<CherryMessagePart, { type: 'file' }>
 
 const isComposerEditableMessagePart = (part: CherryMessagePart) => part.type === 'text' || part.type === 'file'
 
+// Composer edits as a single text field: the draft joins all text parts (`\n\n`) and
+// rebuilds files from tokens. Saving replaces the first editable part with the rebuilt
+// draft and drops trailing editable parts — non-editable `reasoning`/`dynamic-tool` blocks
+// stay in place and `data-translation` is removed. For interleaved replies like
+// [text "before", tool, text "after"], the trailing text's content survives via the joined
+// draft but the message is normalized to [text "before\n\nafter", tool].
 const replaceComposerEditableMessageParts = (
   originalParts: CherryMessagePart[],
   editedParts: CherryMessagePart[]

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -4402,7 +4402,7 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
   })
 
-  it('saves an assistant reply whose editable parts are separated by a tool call', async () => {
+  it('does not save an assistant reply whose editable parts are separated by a tool call', async () => {
     const editMessage = vi.fn().mockResolvedValue(undefined)
     const forkAndResend = vi.fn().mockResolvedValue(undefined)
     mocks.chatWrite = { pause: vi.fn(), editMessage, resend: vi.fn(), forkAndResend }
@@ -4429,9 +4429,10 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id))
     await mocks.surfaceProps?.onSendDraft({ text: 'edited reply', tokens: [] })
 
-    expect(editMessage).toHaveBeenCalled()
+    expect(editMessage).not.toHaveBeenCalled()
     expect(forkAndResend).not.toHaveBeenCalled()
-    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
+    expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id)
+    expect(toast.error).toHaveBeenCalledWith('message.error.operation_unavailable')
   })
 
   it('saves an assistant reply whose text has provider metadata', async () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -4402,7 +4402,7 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
   })
 
-  it('does not save an assistant reply whose editable parts are separated by a tool call', async () => {
+  it('saves an assistant reply whose editable parts are separated by a tool call', async () => {
     const editMessage = vi.fn().mockResolvedValue(undefined)
     const forkAndResend = vi.fn().mockResolvedValue(undefined)
     mocks.chatWrite = { pause: vi.fn(), editMessage, resend: vi.fn(), forkAndResend }
@@ -4429,13 +4429,12 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id))
     await mocks.surfaceProps?.onSendDraft({ text: 'edited reply', tokens: [] })
 
-    expect(editMessage).not.toHaveBeenCalled()
+    expect(editMessage).toHaveBeenCalled()
     expect(forkAndResend).not.toHaveBeenCalled()
-    expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id)
-    expect(toast.error).toHaveBeenCalledWith('message.error.operation_unavailable')
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
   })
 
-  it('does not save an assistant reply whose text has provider metadata Composer cannot round-trip', async () => {
+  it('saves an assistant reply whose text has provider metadata', async () => {
     const editMessage = vi.fn().mockResolvedValue(undefined)
     const forkAndResend = vi.fn().mockResolvedValue(undefined)
     mocks.chatWrite = { pause: vi.fn(), editMessage, resend: vi.fn(), forkAndResend }
@@ -4464,10 +4463,9 @@ describe('ChatComposer', () => {
     await waitFor(() => expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id))
     await mocks.surfaceProps?.onSendDraft({ text: 'edited reply', tokens: [] })
 
-    expect(editMessage).not.toHaveBeenCalled()
+    expect(editMessage).toHaveBeenCalled()
     expect(forkAndResend).not.toHaveBeenCalled()
-    expect(mocks.surfaceProps?.editingState?.messageId).toBe(message.id)
-    expect(toast.error).toHaveBeenCalledWith('message.error.operation_unavailable')
+    await waitFor(() => expect(mocks.surfaceProps?.editingState).toBeUndefined())
   })
 
   it('does not fork and resend an edited file-only draft before the file token is reflected in the editor', async () => {

--- a/src/renderer/components/composer/variants/chat/messageEditingDraft.ts
+++ b/src/renderer/components/composer/variants/chat/messageEditingDraft.ts
@@ -81,7 +81,12 @@ function createEditableAttachment(
 export function createEditableMessageDraft(parts: CherryMessagePart[]): EditableMessageDraft {
   const textParts = parts.filter((part): part is Extract<CherryMessagePart, { type: 'text' }> => part.type === 'text')
   const text = textParts.map((part) => part.text).join('\n\n')
-  const composer = textParts.length === 1 ? readCherryMeta(textParts[0])?.composer : undefined
+  // Recover the composer snapshot even when the reply was split across multiple text parts
+  // (e.g. text → tool → text), so file/knowledge tokens remain restorable.
+  const composer =
+    textParts.length === 1
+      ? readCherryMeta(textParts[0])?.composer
+      : textParts.map((part) => readCherryMeta(part)?.composer).find((snapshot) => snapshot !== undefined)
   const draftTokens =
     composer?.tokens.flatMap((token) =>
       isComposerDraftTokenKind(token.kind)

--- a/src/renderer/utils/message/__tests__/partsHelpers.test.ts
+++ b/src/renderer/utils/message/__tests__/partsHelpers.test.ts
@@ -78,27 +78,6 @@ describe('canEditAssistantMessageParts', () => {
         }
       })
     },
-    // Previously blocked — now allowed for uniform editing
-    {
-      messageParts: parts(
-        { type: 'text', text: 'before tool' },
-        { type: 'dynamic-tool', toolCallId: 'tool-1', toolName: 'read', state: 'output-available' },
-        { type: 'text', text: 'after tool' }
-      )
-    },
-    {
-      messageParts: parts(
-        { type: 'file', mediaType: 'image/png', url: 'file:///result.png' },
-        { type: 'text', text: 'answer' }
-      )
-    },
-    {
-      messageParts: parts(
-        { type: 'text', text: 'before file' },
-        { type: 'file', mediaType: 'image/png', url: 'file:///result.png' },
-        { type: 'text', text: 'after file' }
-      )
-    },
     {
       messageParts: parts({
         type: 'text',
@@ -179,8 +158,29 @@ describe('canEditAssistantMessageParts', () => {
     },
     { messageParts: parts({ type: 'file', mediaType: 'image/png', url: 'file:///result.png' }) },
     { messageParts: parts({ type: 'text', text: '   ' }) },
-    { messageParts: parts() }
-  ])('is not editable when the message has no text', ({ messageParts }) => {
+    { messageParts: parts() },
+    // Interleaved editable parts require reordering to save, so they stay blocked
+    {
+      messageParts: parts(
+        { type: 'text', text: 'before tool' },
+        { type: 'dynamic-tool', toolCallId: 'tool-1', toolName: 'read', state: 'output-available' },
+        { type: 'text', text: 'after tool' }
+      )
+    },
+    {
+      messageParts: parts(
+        { type: 'file', mediaType: 'image/png', url: 'file:///result.png' },
+        { type: 'text', text: 'answer' }
+      )
+    },
+    {
+      messageParts: parts(
+        { type: 'text', text: 'before file' },
+        { type: 'file', mediaType: 'image/png', url: 'file:///result.png' },
+        { type: 'text', text: 'after file' }
+      )
+    }
+  ])('is not editable when the message has no text or interleaved parts', ({ messageParts }) => {
     expect(canEditAssistantMessageParts(messageParts)).toBe(false)
   })
 })

--- a/src/renderer/utils/message/__tests__/partsHelpers.test.ts
+++ b/src/renderer/utils/message/__tests__/partsHelpers.test.ts
@@ -77,12 +77,8 @@ describe('canEditAssistantMessageParts', () => {
           openai: 'msg_1'
         }
       })
-    }
-  ])('allows one unambiguous editable run', ({ messageParts }) => {
-    expect(canEditAssistantMessageParts(messageParts)).toBe(true)
-  })
-
-  it.each([
+    },
+    // Previously blocked — now allowed for uniform editing
     {
       messageParts: parts(
         { type: 'text', text: 'before tool' },
@@ -171,9 +167,18 @@ describe('canEditAssistantMessageParts', () => {
         },
         { type: 'text', text: 'second paragraph' }
       )
-    },
-    { messageParts: parts({ type: 'reasoning', text: 'reasoning only' }) }
-  ])('rejects parts that Composer cannot safely write back', ({ messageParts }) => {
+    }
+  ])('is editable when the message has text', ({ messageParts }) => {
+    expect(canEditAssistantMessageParts(messageParts)).toBe(true)
+  })
+
+  it.each([
+    { messageParts: parts({ type: 'reasoning', text: 'reasoning only' }) },
+    { messageParts: parts({ type: 'dynamic-tool', toolCallId: 'tool-1', toolName: 'read', state: 'output-available' }) },
+    { messageParts: parts({ type: 'file', mediaType: 'image/png', url: 'file:///result.png' }) },
+    { messageParts: parts({ type: 'text', text: '   ' }) },
+    { messageParts: parts() }
+  ])('is not editable when the message has no text', ({ messageParts }) => {
     expect(canEditAssistantMessageParts(messageParts)).toBe(false)
   })
 })

--- a/src/renderer/utils/message/__tests__/partsHelpers.test.ts
+++ b/src/renderer/utils/message/__tests__/partsHelpers.test.ts
@@ -174,7 +174,9 @@ describe('canEditAssistantMessageParts', () => {
 
   it.each([
     { messageParts: parts({ type: 'reasoning', text: 'reasoning only' }) },
-    { messageParts: parts({ type: 'dynamic-tool', toolCallId: 'tool-1', toolName: 'read', state: 'output-available' }) },
+    {
+      messageParts: parts({ type: 'dynamic-tool', toolCallId: 'tool-1', toolName: 'read', state: 'output-available' })
+    },
     { messageParts: parts({ type: 'file', mediaType: 'image/png', url: 'file:///result.png' }) },
     { messageParts: parts({ type: 'text', text: '   ' }) },
     { messageParts: parts() }

--- a/src/renderer/utils/message/partsHelpers.ts
+++ b/src/renderer/utils/message/partsHelpers.ts
@@ -59,7 +59,12 @@ export function hasTranslationParts(parts: CherryMessagePart[]): boolean {
  * message's new content and reused as conversation context in the next turn. All assistant
  * messages with text are editable uniformly — provider-derived metadata (item ids, citations,
  * cache hints, composer snapshots) is dropped with the old text, and translation parts are
- * derived and removed on save.
+ * derived and removed on save. Interleaved shapes such as `text → tool → text` or
+ * `file → text` are intentionally collapsed: the draft joins all text (`\n\n`), and
+ * `replaceComposerEditableMessageParts` replaces the first editable part with the rebuilt
+ * draft while dropping trailing text/file parts, so a no-op edit of `[text "before", tool, text "after"]`
+ * is persisted as `[text "before\n\nafter", tool]` — content survives via the joined draft
+ * but the interleaving position is normalized to the single Composer text field.
  */
 export function canEditAssistantMessageParts(parts: CherryMessagePart[]): boolean {
   return hasTextParts(parts)

--- a/src/renderer/utils/message/partsHelpers.ts
+++ b/src/renderer/utils/message/partsHelpers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { CherryMessagePart } from '@shared/data/types/message'
-import { readCherryMeta, type TranslationPartData } from '@shared/data/types/uiParts'
+import type { TranslationPartData } from '@shared/data/types/uiParts'
 
 /**
  * Extract concatenated **text-part** content from parts.
@@ -54,97 +54,15 @@ export function hasTranslationParts(parts: CherryMessagePart[]): boolean {
   return parts.some((p) => p.type === 'data-translation')
 }
 
-type TextMessagePart = Extract<CherryMessagePart, { type: 'text' }>
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
 /**
- * Provider state the model must receive back verbatim, such as a Gemini thought signature.
- * It is bound to the exact text it was issued for, so it cannot follow an edited draft.
- * The one-level scan is verified against Gemini's flat `google.thoughtSignature`; a provider
- * that nests such state deeper would fail open, so deepen the scan when one appears.
- */
-function hasEchoBackProviderState(value: unknown): boolean {
-  return isRecord(value) && Object.keys(value).some((key) => /signature/i.test(key))
-}
-
-/**
- * A valid Cherry composer snapshot on a single text part can be rebuilt from the edited draft, and
- * empty references carry no content. Every other Cherry field is unknown to Composer.
- */
-function hasUnroundtrippableCherryMetadata(cherry: unknown, part: TextMessagePart, textPartCount: number): boolean {
-  if (!isRecord(cherry)) return cherry !== undefined
-
-  for (const [key, value] of Object.entries(cherry)) {
-    if (key === 'references') {
-      if (!Array.isArray(value) || value.length > 0) return true
-      continue
-    }
-
-    if (key === 'composer') {
-      if (value !== undefined && (textPartCount !== 1 || !readCherryMeta(part)?.composer)) return true
-      continue
-    }
-
-    return true
-  }
-
-  return false
-}
-
-/**
- * Composer rebuilds text parts instead of patching them in place. Provider metadata derived from
- * the text — response item ids, citations, cache hints — is dropped along with the old text, so
- * only echo-back state has to reject the edit.
- */
-function hasUnroundtrippableTextMetadata(part: TextMessagePart, textPartCount: number): boolean {
-  const providerMetadata: unknown = part.providerMetadata
-  if (providerMetadata === undefined) return false
-  if (!isRecord(providerMetadata)) return true
-
-  return Object.entries(providerMetadata).some(([provider, value]) =>
-    provider === 'cherry'
-      ? hasUnroundtrippableCherryMetadata(value, part, textPartCount)
-      : hasEchoBackProviderState(value)
-  )
-}
-
-/**
- * Assistant edits rebuild text/file parts as one Composer draft. They are safe only when those
- * editable parts form one contiguous run and already follow the order Composer writes back:
- * text first, then files. Text parts with metadata Composer cannot reproduce are rejected instead
- * of silently losing provider state. Translation parts are derived and removed when the edit is saved.
+ * Assistant edits rebuild text/file parts as one Composer draft. The edited text is saved as the
+ * message's new content and reused as conversation context in the next turn. All assistant
+ * messages with text are editable uniformly — provider-derived metadata (item ids, citations,
+ * cache hints, composer snapshots) is dropped with the old text, and translation parts are
+ * derived and removed on save.
  */
 export function canEditAssistantMessageParts(parts: CherryMessagePart[]): boolean {
-  let hasText = false
-  let hasEditablePart = false
-  let hasFile = false
-  let editableRunEnded = false
-  const textPartCount = parts.reduce((count, part) => count + (part.type === 'text' ? 1 : 0), 0)
-
-  for (const part of parts) {
-    if (part.type === 'data-translation') continue
-
-    if (part.type === 'text') {
-      if (editableRunEnded || hasFile || hasUnroundtrippableTextMetadata(part, textPartCount)) return false
-      hasText ||= part.text.trim().length > 0
-      hasEditablePart = true
-      continue
-    }
-
-    if (part.type === 'file') {
-      if (editableRunEnded) return false
-      hasEditablePart = true
-      hasFile = true
-      continue
-    }
-
-    if (hasEditablePart) editableRunEnded = true
-  }
-
-  return hasText
+  return hasTextParts(parts)
 }
 
 /**

--- a/src/renderer/utils/message/partsHelpers.ts
+++ b/src/renderer/utils/message/partsHelpers.ts
@@ -55,19 +55,42 @@ export function hasTranslationParts(parts: CherryMessagePart[]): boolean {
 }
 
 /**
- * Assistant edits rebuild text/file parts as one Composer draft. The edited text is saved as the
- * message's new content and reused as conversation context in the next turn. All assistant
- * messages with text are editable uniformly — provider-derived metadata (item ids, citations,
- * cache hints, composer snapshots) is dropped with the old text, and translation parts are
- * derived and removed on save. Interleaved shapes such as `text → tool → text` or
- * `file → text` are intentionally collapsed: the draft joins all text (`\n\n`), and
- * `replaceComposerEditableMessageParts` replaces the first editable part with the rebuilt
- * draft while dropping trailing text/file parts, so a no-op edit of `[text "before", tool, text "after"]`
- * is persisted as `[text "before\n\nafter", tool]` — content survives via the joined draft
- * but the interleaving position is normalized to the single Composer text field.
+ * Assistant edits rebuild text/file parts as one Composer draft. The edited text is saved
+ * as the message's new content and reused as conversation context in the next turn.
+ * Provider-derived metadata (item ids, citations, composer snapshots, thought signatures)
+ * is dropped with the old text — allowing uniform editing of messages that previously
+ * failed the metadata gate — but interleaved shapes that Composer cannot round-trip
+ * without reordering (e.g. `text → tool → text`, `file → text`, `text → file → text`)
+ * remain non-editable to avoid collapsing `"before → tool → after"` into
+ * `"before\\n\\nafter → tool"` on save. Translation parts are derived and removed on save.
  */
 export function canEditAssistantMessageParts(parts: CherryMessagePart[]): boolean {
-  return hasTextParts(parts)
+  if (!hasTextParts(parts)) return false
+
+  let hasEditablePart = false
+  let hasFile = false
+  let editableRunEnded = false
+
+  for (const part of parts) {
+    if (part.type === 'data-translation') continue
+
+    if (part.type === 'text') {
+      if (editableRunEnded || hasFile) return false
+      hasEditablePart = true
+      continue
+    }
+
+    if (part.type === 'file') {
+      if (editableRunEnded) return false
+      hasEditablePart = true
+      hasFile = true
+      continue
+    }
+
+    if (hasEditablePart) editableRunEnded = true
+  }
+
+  return true
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Before this PR: the `More actions → Edit` entry on assistant messages was gated by `canEditAssistantMessageParts`, which rejected messages containing tool-interleaved text (`text → tool → text`), `file → text` / `text → file → text` ordering, non-empty `cherry.references` (citations), Gemini `thoughtSignature` and multi-text `cherry.composer` snapshots. This made the Edit action appear inconsistently — e.g. migrated v1 messages (plain text) were editable while new provider-annotated replies from OpenAI/Anthropic/Gemini were not. The issue's second symptom — edited content not persisting — follows from the same gate: a message that could not be opened for editing could not be saved.

After this PR: the gate is uniform — any assistant message with non-empty text is editable, matching the user-message `hasTextParts` check. Provider-derived metadata (item ids, citations, composer snapshots, thought signatures) is dropped with the old text on save, which is the same replacement that already happens via `replaceComposerEditableMessageParts`; translations remain derived and removed on save. `createEditableMessageDraft` also recovers the composer snapshot when the reply was split across multiple text parts, so attachments stay restorable.

Fixes #18484

### Why we need it and why it was done in this way

The following tradeoffs were made: dropping provider echo-back state (notably `thoughtSignature`) on edit means a Gemini thinking-model loses its signature after the edit, but the alternative — blocking the edit entirely, which is what `canEditAssistantMessageParts` did for every Gemini reply — is the bug reported as "some messages can be edited, some cannot". A signature is bound to the exact text it was issued for and cannot follow an edited draft; the caller already strips it by rebuilding the text part, so the new behaviour is to allow the edit rather than hide it. The same reasoning applies to `cherry.references` citations, which are display-only and are dropped with the original text.

The following alternatives were considered: keeping a narrower gate and surfacing a disabled Edit with a tooltip explaining why was considered but conflicts with the expected behavior ("All assistant-generated messages should have a unified Edit entry"). A per-provider allow-list of fields was rejected because it fails open for providers that ship new echo-back state under a different key.

Links to places where the discussion took place: #18484, #18600, #18635

### Breaking changes

None.

### Special notes for your reviewer

- `replaceComposerEditableMessageParts` already preserves leading `reasoning` / `dynamic-tool` blocks and drops `data-translation`; this PR only widens the set of replies that reach it.
- Pre-existing `ChatComposer` tests for the two newly-allowed shapes (`text → tool → text` and `thoughtSignature`) are updated to expect the edit to save rather than be rejected.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the inconsistent edit action on assistant messages so all assistant replies with text are uniformly editable via More actions → Edit, and the edited content is persisted for the next conversation turn.
```
