### PR TITLE
fix(agents): hide delete for built-in agents (#19383)

### DIFF
--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -17,7 +17,12 @@ import { nullsToUndefined, timestampToISO } from '@data/services/utils/rowMapper
 import { loggerService } from '@logger'
 import { Emitter, type Event } from '@main/core/lifecycle'
 import { t } from '@main/i18n'
-import { BUILTIN_AGENT_ROLE, type BuiltinAgentRole, CHERRY_SUPPORT_AGENT_ID } from '@shared/ai/builtinAgent'
+import {
+  BUILTIN_AGENT_ROLE,
+  type BuiltinAgentRole,
+  CHERRY_SUPPORT_AGENT_ID,
+  isProtectedBuiltinAgentRole
+} from '@shared/ai/builtinAgent'
 import { resolveReasoningEffortForModel } from '@shared/ai/reasoning'
 import { DataApiErrorFactory } from '@shared/data/api/errors'
 import type { OrderRequest } from '@shared/data/api/schemas/_endpointHelpers'
@@ -786,6 +791,14 @@ export class AgentService {
     affectedSessionIds: string[]
     deliveryResults: AgentSessionMessageEntity[]
   } {
+    const existing = this.findAgentRow(id)
+    if (
+      existing &&
+      isProtectedBuiltinAgentRole(getBuiltinRole(removeUntrustedSupportRole(id, existing.configuration)))
+    ) {
+      throw DataApiErrorFactory.invalidOperation('delete agent', 'built-in agents cannot be deleted')
+    }
+
     // By default sessions detach (agentId → NULL) via FK ON DELETE SET NULL; callers
     // can opt into deleting them in this same transaction. `pin` has no FK back
     // to agent, so purge it alongside the agent row. Junction table rows are

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -335,10 +335,22 @@ describe('AgentService', () => {
       expect(activeBuiltinRows()).toHaveLength(1)
     })
 
-    it('restores the assistant after the Agent delete endpoint removed its row', () => {
+    it('rejects the Agent delete endpoint for the built-in assistant', () => {
       const first = agentService.ensureBuiltinAgent(defaults)
 
-      expect(agentService.deleteAgent(first.id, { deleteSessions: true })).toMatchObject({ deleted: true })
+      const error = captureError(() => agentService.deleteAgent(first.id, { deleteSessions: true }))
+      expect(error).toMatchObject({
+        code: ErrorCode.INVALID_OPERATION,
+        message: expect.stringContaining('built-in agents cannot be deleted')
+      })
+      expect(agentService.getAgent(first.id)?.id).toBe(first.id)
+    })
+
+    it('restores the assistant after its row was hard-deleted', () => {
+      const first = agentService.ensureBuiltinAgent(defaults)
+      application.get('DbService').withWriteTx((tx) => {
+        agentService.deleteAgentTx(tx, first.id)
+      })
 
       const restored = agentService.ensureBuiltinAgent(defaults)
 
@@ -1073,6 +1085,41 @@ describe('AgentService', () => {
       expect(result.deletedSessionIds).toBeUndefined()
       const rows = await dbh.db.select().from(agentTable)
       expect(rows.find((r) => r.id === id)).toBeUndefined()
+    })
+
+    it('rejects deleting a protected builtin agent', async () => {
+      const { id } = await insertAgent({
+        id: 'agent_builtin_delete',
+        configuration: { builtin_role: 'assistant' }
+      })
+
+      const error = captureError(() => agentService.deleteAgent(id))
+      expect(error).toMatchObject({
+        code: ErrorCode.INVALID_OPERATION,
+        message: expect.stringContaining('built-in agents cannot be deleted')
+      })
+      expect(agentService.getAgent(id)?.id).toBe(id)
+    })
+
+    it('rejects deleting the reserved support agent', async () => {
+      await insertAgent({
+        id: 'cherry-support',
+        configuration: { builtin_role: 'support' }
+      })
+
+      const error = captureError(() => agentService.deleteAgent('cherry-support'))
+      expect(error).toMatchObject({ code: ErrorCode.INVALID_OPERATION })
+      expect(agentService.getAgent('cherry-support')?.id).toBe('cherry-support')
+    })
+
+    it('still deletes an ordinary agent that only has a leftover support marker', async () => {
+      const { id } = await insertAgent({
+        id: 'legacy-support-delete',
+        configuration: { builtin_role: 'support', avatar: 'U' }
+      })
+
+      expect(agentService.deleteAgent(id)).toMatchObject({ deleted: true })
+      expect(agentService.getAgent(id)).toBeNull()
     })
 
     it('purges agent pins on delete (pin table has no FK)', async () => {

--- a/src/renderer/components/resourceCatalog/catalog/ResourceCards.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/ResourceCards.tsx
@@ -4,6 +4,7 @@ import { toast } from '@renderer/services/toast'
 import type { ResourceItem } from '@renderer/types/resourceCatalog'
 import { RESOURCE_TYPE_META } from '@renderer/utils/resourceCatalog'
 import { cn } from '@renderer/utils/style'
+import { isProtectedBuiltinAgentRole } from '@shared/ai/builtinAgent'
 import type { Group } from '@shared/data/types/group'
 import { Trash2 } from 'lucide-react'
 import type { KeyboardEvent } from 'react'
@@ -35,6 +36,10 @@ interface ResourceCardProps {
 
 function hasOverflowActions(resource: ResourceItem) {
   return resource.type === 'assistant'
+}
+
+function canDeleteResource(resource: ResourceItem) {
+  return resource.type !== 'agent' || !isProtectedBuiltinAgentRole(resource.raw.configuration?.builtin_role)
 }
 
 function SkillGlobalToggle({ resource }: { resource: Extract<ResourceItem, { type: 'skill' }> }) {
@@ -151,7 +156,7 @@ export function ResourceCard({
                 allGroups={allGroups}
                 triggerClassName="text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100"
               />
-            ) : (
+            ) : canDeleteResource(r) ? (
               <Button
                 variant="ghost"
                 size="icon-sm"
@@ -160,7 +165,7 @@ export function ResourceCard({
                 className="text-muted-foreground opacity-0 hover:bg-error-subtle hover:text-error-subtle-foreground focus-visible:opacity-100 group-hover:opacity-100">
                 <Trash2 size={12} className="lucide-custom" />
               </Button>
-            )}
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
+++ b/src/renderer/components/resourceCatalog/catalog/__tests__/ResourceGrid.test.tsx
@@ -409,7 +409,7 @@ function createAssistantResource(overrides: Partial<Extract<ResourceItem, { type
   }
 }
 
-function createAgentResource(): ResourceItem {
+function createAgentResource(raw: Partial<Extract<ResourceItem, { type: 'agent' }>['raw']> = {}): ResourceItem {
   return {
     id: 'agent-1',
     type: 'agent',
@@ -418,7 +418,7 @@ function createAgentResource(): ResourceItem {
     avatar: 'A',
     createdAt: '2026-05-06T00:00:00.000Z',
     updatedAt: '2026-05-06T00:00:00.000Z',
-    raw: {} as Extract<ResourceItem, { type: 'agent' }>['raw']
+    raw: raw as Extract<ResourceItem, { type: 'agent' }>['raw']
   }
 }
 
@@ -839,6 +839,14 @@ describe('ResourceGrid card actions', () => {
     await user.click(screen.getByRole('button', { name: '删除' }))
 
     expect(onDelete).toHaveBeenCalledWith(resource)
+  })
+
+  it('hides delete for protected builtin agents', () => {
+    const resource = createAgentResource({ configuration: { builtin_role: 'support' } })
+
+    render(<ResourceCard resource={resource} {...getResourceCardProps({ onDelete: vi.fn() })} />)
+
+    expect(screen.queryByRole('button', { name: '删除' })).not.toBeInTheDocument()
   })
 
   it('shows only one assistant group in the compact card layout', () => {

--- a/src/renderer/hooks/resourceCatalog/__tests__/agentAdapter.test.ts
+++ b/src/renderer/hooks/resourceCatalog/__tests__/agentAdapter.test.ts
@@ -26,14 +26,40 @@ describe('useAgentMutationsById', () => {
     })
   })
 
-  it('refreshes agent list and details after scoped mutations', () => {
+  it('patches through DataApi and deletes through IpcApi', () => {
     renderHook(() => useAgentMutationsById('agent-1'))
 
     expect(useMutationMock).toHaveBeenCalledWith('PATCH', '/agents/agent-1', {
       refresh: expect.any(Function)
     })
-    expect(useMutationMock).toHaveBeenCalledWith('DELETE', '/agents/agent-1', {
-      refresh: ['/agents', '/agents/*', '/pins']
+    expect(useMutationMock).not.toHaveBeenCalledWith('DELETE', expect.anything(), expect.anything())
+  })
+
+  it('deletes through IpcApi then invalidates agent caches', async () => {
+    ipcRequestMock.mockResolvedValue({ deleted: true })
+    invalidateMock.mockResolvedValue(undefined)
+    const { result } = renderHook(() => useAgentMutationsById('agent-1'))
+
+    await act(async () => {
+      await result.current.deleteAgent()
+    })
+
+    expect(ipcRequestMock).toHaveBeenCalledWith('ai.agent.delete', {
+      agentId: 'agent-1',
+      deleteSessions: false
+    })
+    expect(invalidateMock).toHaveBeenCalledWith('/agents')
+    expect(invalidateMock).toHaveBeenCalledWith('/agent-sessions')
+    expect(invalidateMock).toHaveBeenCalledWith('/pins')
+  })
+
+  it('keeps a committed deletion successful when cache refresh fails', async () => {
+    ipcRequestMock.mockResolvedValue({ deleted: true })
+    invalidateMock.mockRejectedValueOnce(new Error('revalidation failed'))
+    const { result } = renderHook(() => useAgentMutationsById('agent-1'))
+
+    await act(async () => {
+      await expect(result.current.deleteAgent()).resolves.toBeUndefined()
     })
   })
 

--- a/src/renderer/hooks/resourceCatalog/agentAdapter.ts
+++ b/src/renderer/hooks/resourceCatalog/agentAdapter.ts
@@ -1,4 +1,6 @@
 import { useInvalidateCache, useMutation, useQuery } from '@data/hooks/useDataApi'
+import { loggerService } from '@logger'
+import { ipcApi } from '@renderer/ipc'
 import { createAgentAndRefresh } from '@renderer/services/createAgent'
 import type { AgentDetail } from '@renderer/types/resourceCatalog'
 import { AGENTS_MAX_LIMIT, type UpdateAgentDto } from '@shared/data/api/schemas/agents'
@@ -6,6 +8,8 @@ import type { CreateAgentCommand } from '@shared/ipc/schemas/ai'
 import { useCallback, useState } from 'react'
 
 import type { ResourceAdapter, ResourceListQuery, ResourceListResult } from './types'
+
+const logger = loggerService.withContext('agentAdapter')
 
 /**
  * List hook for agent resources — mirrors `assistantAdapter.useAssistantList`.
@@ -63,10 +67,11 @@ export function useAgentMutations() {
 /**
  * Mutation hook scoped to a single agent id. PATCH accepts any `AgentBase`
  * subset (typed as `UpdateAgentDto`); the backend merges at the row level.
- * Plain DELETE removes the agent only; sessions remain as history.
+ * Deletion is a mixed DB/runtime command on IpcApi; sessions remain as history.
  */
 export function useAgentMutationsById(id: string) {
   const path = `/agents/${id}` as const
+  const invalidate = useInvalidateCache()
 
   const { trigger: updateTrigger } = useMutation('PATCH', path, {
     // skillUpdates writes the agent_skill join table, which backs `GET /skills?agentId=…`
@@ -74,15 +79,19 @@ export function useAgentMutationsById(id: string) {
     refresh: ({ args }) =>
       args?.body?.skillUpdates !== undefined ? ['/agents', '/agents/*', '/skills'] : ['/agents', '/agents/*']
   })
-  const { trigger: deleteTrigger } = useMutation('DELETE', path, {
-    refresh: ['/agents', '/agents/*', '/pins']
-  })
 
   const updateAgent = useCallback(
     (dto: UpdateAgentDto): Promise<AgentDetail> => updateTrigger({ body: dto }),
     [updateTrigger]
   )
-  const deleteAgent = useCallback((): Promise<void> => deleteTrigger().then(() => undefined), [deleteTrigger])
+  const deleteAgent = useCallback(async (): Promise<void> => {
+    await ipcApi.request('ai.agent.delete', { agentId: id, deleteSessions: false })
+    try {
+      await Promise.all([invalidate('/agents'), invalidate('/agent-sessions'), invalidate('/pins')])
+    } catch (error) {
+      logger.warn('Failed to refresh after deleting Agent', error as Error, { agentId: id })
+    }
+  }, [id, invalidate])
 
   return { updateAgent, deleteAgent }
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
The agent library showed a delete action on official built-in agents (e.g. Product Feedback / `cherry-support`). Confirming delete called a non-existent DataApi `DELETE /agents/:id` and surfaced `Handler with id 'DELETE /agents/cherry-support' not found`. The same catalog path would also fail for user-created agents. `AgentService.deleteAgent` did not reject protected built-ins.

After this PR:
Catalog cards hide delete for protected built-in agents (`assistant` / reserved `support`). Catalog delete goes through IpcApi `ai.agent.delete`. The service rejects deleting protected built-ins with a 4xx invalid-operation error. User-created agents can still be deleted.

Fixes #19383

### Why we need it and why it was done in this way

The following tradeoffs were made:
UI hides the control using the existing `isProtectedBuiltinAgentRole` marker (with the reserved support-id sanitization on the service). The catalog adapter was switched to the existing mixed-effect IpcApi delete instead of adding a DataApi DELETE route.

The following alternatives were considered:
Returning a friendlier DataApi error only, while still showing delete; adding a DataApi DELETE handler. Both still let users reach a dead-end dialog for built-ins, and DataApi is not the deletion contract.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19383

### Breaking changes

None

### Special notes for your reviewer

Session-list delete for built-ins was already "delete tasks/sessions only" and is unchanged. Verify: Work → manage agents → built-in cards have no trash; a user-created agent still deletes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Hide the delete action for official built-in agents in the agent library, and stop catalog delete from failing with Handler not found.
```
