### PR TITLE
fix(sidebar): pinned agent/assistant tabs activate or create, never replace

### DIFF
--- a/src/renderer/components/Sidebar/types.ts
+++ b/src/renderer/components/Sidebar/types.ts
@@ -1,4 +1,5 @@
 import type { CommandContextMenuExtraItem } from '@renderer/components/command'
+import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import type { ReactNode } from 'react'
 
 export interface SidebarMiniApp {
@@ -19,6 +20,12 @@ export interface SidebarActiveState {
   activeItem: string
   /** Active mini app id (concrete mini app route). */
   activeTabId?: string
+  /**
+   * Open tabs — lets conversation-backed entries (agents, assistants) decide
+   * "already open" by their tab's entity-ownership tag, the same signal the
+   * click handler uses.
+   */
+  tabs?: readonly Tab[]
 }
 
 /**

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -35,7 +35,7 @@ import {
   UserAvatar
 } from '../Sidebar'
 import UserPopup from '../UserPopup'
-import { resolveSidebarEntry, type SidebarVariantContext } from './sidebarVariants'
+import { isTabForConversationEntry, resolveSidebarEntry, type SidebarVariantContext } from './sidebarVariants'
 
 const FeedbackDialog = lazy(() => import('../feedback/FeedbackDialog'))
 const REQUIRED_SIDEBAR_FAVORITE_SET = new Set<SidebarAppId>(REQUIRED_SIDEBAR_FAVORITES)
@@ -54,7 +54,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
     removeAssistant,
     reorderFavorites
   } = useSidebarFavorites()
-  const { activeTab, tabs, updateTab, openTab, setActiveTab } = useTabs()
+  const { activeTab, tabs, openTab, setActiveTab } = useTabs()
   const { miniApps, pinned } = useMiniApps({ enabled: miniAppFavoriteIds.length > 0 })
   const { agents } = useAgents({ enabled: agentFavoriteIds.length > 0 })
   const { assistants } = useAssistantsApi({ enabled: assistantFavoriteIds.length > 0 })
@@ -152,31 +152,13 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
 
   const navigateRouteTab = useCallback(
     (path: string, title: string, options?: { inNewTab?: boolean; icon?: string }) => {
-      if (options?.inNewTab) {
-        openTab(path, { forceNew: true, title, icon: options.icon })
-        return
-      }
-
-      if (activeTab?.url === path) return
-
-      if (activeTab?.isPinned) {
-        openTab(path, { forceNew: true, title, icon: options?.icon })
-        return
-      }
-
-      if (activeTab) {
-        updateTab(activeTab.id, {
-          url: path,
-          title,
-          icon: options?.icon,
-          metadata: undefined
-        })
-        return
-      }
-
+      // Never reuse the current tab — the pre-existing behavior replaced it with
+      // the target route, dropping whatever conversation was open. All sidebar
+      // entries (apps, mini apps, pinned entities) open a fresh tab when their
+      // target isn't already the active one.
       openTab(path, { forceNew: true, title, icon: options?.icon })
     },
-    [activeTab, openTab, updateTab]
+    [openTab]
   )
 
   const handleNavigate = useCallback(
@@ -215,7 +197,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   }, [])
 
   const handleOpenMiniAppTab = useCallback(
-    (appId: string, options?: { inNewTab?: boolean }) => {
+    (appId: string) => {
       const app = openableMiniAppById.get(appId)
       if (!app) return
 
@@ -231,28 +213,55 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       const title = app.nameKey ? t(app.nameKey) : app.name
       // Uploaded logo → main-resolved `logoSrc`; preset key → `logo`.
       const icon = app.logoSrc ?? app.logo
-      navigateRouteTab(path, title, { ...options, icon })
+      // Never reuse the current tab for a not-yet-open mini app — always open a
+      // fresh one, matching how pinned agents/assistants behave.
+      openTab(path, { forceNew: true, title, icon })
     },
-    [activeTab, navigateRouteTab, openableMiniAppById, setActiveTab, t, tabs]
+    [activeTab, openableMiniAppById, openTab, setActiveTab, t, tabs]
   )
 
-  // Pinned entities reuse tabs like mini apps do; the route interceptor turns the
-  // `agentId` / `assistantId` param into that entity's most recent conversation.
+  // Pinned entities find-and-activate an open tab or open a fresh one, sharing the
+  // same "already open" signal as the active-state highlight. The route interceptor
+  // turns the `agentId` / `assistantId` param into that entity's most recent
+  // conversation, so each entity tab is tagged with its owning entity at open time
+  // instead of relying on the URL (which loses the entity id on rewrite).
+  const openConversationTab = useCallback(
+    (type: 'agent' | 'assistant', entityId: string, title: string, inNewTab?: boolean) => {
+      if (!inNewTab) {
+        const existingTab = tabs.find((tab) => isTabForConversationEntry(tab, { type, entityId }))
+        if (existingTab) {
+          setActiveTab(existingTab.id)
+          return
+        }
+      }
+      const path =
+        type === 'agent'
+          ? `/app/agents?agentId=${encodeURIComponent(entityId)}`
+          : `/app/chat?assistantId=${encodeURIComponent(entityId)}`
+      openTab(path, {
+        forceNew: true,
+        title,
+        metadata: { conversationEntry: { type, entityId } }
+      })
+    },
+    [openTab, setActiveTab, tabs]
+  )
+
   const handleOpenAgentTab = useCallback(
     (agentId: string, options?: { inNewTab?: boolean }) => {
       const agent = installedAgents.get(agentId)
       if (!agent) return
-      navigateRouteTab(`/app/agents?agentId=${encodeURIComponent(agentId)}`, agent.name, options)
+      openConversationTab('agent', agentId, agent.name, options?.inNewTab)
     },
-    [installedAgents, navigateRouteTab]
+    [installedAgents, openConversationTab]
   )
   const handleOpenAssistantTab = useCallback(
     (assistantId: string, options?: { inNewTab?: boolean }) => {
       const assistant = installedAssistants.get(assistantId)
       if (!assistant) return
-      navigateRouteTab(`/app/chat?assistantId=${encodeURIComponent(assistantId)}`, assistant.name, options)
+      openConversationTab('assistant', assistantId, assistant.name, options?.inNewTab)
     },
-    [installedAssistants, navigateRouteTab]
+    [installedAssistants, openConversationTab]
   )
 
   // All per-type sidebar knowledge (icon, label, route, active-match, open, remove)
@@ -354,7 +363,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   // Common props shared between normal and floating sidebar
   const sidebarProps = {
     entries,
-    active: { activeItem, activeTabId: activeMiniAppId },
+    active: { activeItem, activeTabId: activeMiniAppId, tabs },
     title: sidebarUser.name,
     logo: sidebarLogo,
     actions: (footerLayout: SidebarVisibleLayout, onOverlayOpenChange?: (open: boolean) => void) => (

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -208,7 +208,7 @@ vi.mock('../../layout/ShellTabBarActions', () => ({
 type MockSidebarEntry = {
   key: string
   label: string
-  isActive: (active: { activeItem: string; activeTabId?: string }) => boolean
+  isActive: (active: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }) => boolean
   onOpen: () => void
   onOpenNewTab?: () => void
   contextMenuItems?: Array<{ id: string; label: string; enabled?: boolean; onSelect?: () => void }>
@@ -246,7 +246,7 @@ vi.mock('../../Sidebar', async () => {
     }: {
       isFloating?: boolean
       isFloatingClosing?: boolean
-      active?: { activeItem: string; activeTabId?: string }
+      active?: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }
       entries?: MockSidebarEntry[]
       title?: string
       logo?: ReactNode
@@ -343,6 +343,7 @@ vi.mock('../../Sidebar', async () => {
               <div key={agentItem.key} role="group" aria-label={agentItem.label}>
                 <button
                   type="button"
+                  data-active={agentItem.isActive(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-agent-${parseEntryKey(agentItem.key).id}`}
                   onClick={() => agentItem.onOpen()}
                   onAuxClick={(e) => {
@@ -368,6 +369,7 @@ vi.mock('../../Sidebar', async () => {
               <div key={assistantItem.key} role="group" aria-label={assistantItem.label}>
                 <button
                   type="button"
+                  data-active={assistantItem.isActive(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-assistant-${parseEntryKey(assistantItem.key).id}`}
                   onClick={() => assistantItem.onOpen()}
                   onAuxClick={(e) => {
@@ -687,7 +689,7 @@ describe('app Sidebar', () => {
     expect(screen.queryByTestId('sidebar-mini-app-calculator')).not.toBeInTheDocument()
   })
 
-  it('reuses the active tab from the sidebar mini app section', () => {
+  it('opens a new mini app tab instead of reusing the active tab', () => {
     configureMiniApps(['calculator'])
     mocks.activeTab = {
       id: 'chat',
@@ -701,13 +703,12 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-mini-app-calculator'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/mini-app/calculator',
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/mini-app/calculator', {
+      forceNew: true,
       title: 'Calculator',
-      icon: 'calculator-logo',
-      metadata: undefined
+      icon: 'calculator-logo'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('switches to an existing mini app tab without replacing the active tab', async () => {
@@ -791,7 +792,7 @@ describe('app Sidebar', () => {
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
-  it('reuses the active tab without revealing its resource list', () => {
+  it('opens a new agents tab when the active tab is a foreign route', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -804,18 +805,16 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('replaces the active tab with the bare route', () => {
+  it('opens a new agents tab instead of replacing the active tab', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -828,16 +827,14 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    // Which session the tab lands on is the route interceptor's decision — the
-    // sidebar only replaces the tab with the app's bare entry route.
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    // The route interceptor decides which session the fresh tab lands on; the
+    // sidebar just opens a new tab instead of repurposing the current one.
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('stays put when the active tab already holds a conversation of the target app', () => {
@@ -858,7 +855,7 @@ describe('app Sidebar', () => {
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('navigates a message-only viewer of the same app back to the app entry', () => {
+  it('opens a new agents tab when the active tab is a message-only viewer of the app', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'viewer',
@@ -870,15 +867,14 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('viewer', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('clears route-specific metadata when reusing the active tab', () => {
+  it('opens a new translate tab instead of reusing the active tab', () => {
     mocks.sidebarFavorites = [appFavorite('translate')]
     mocks.activeTab = {
       id: 'chat',
@@ -892,17 +888,15 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-translate'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/translate',
-      title: 'Translate',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/translate', {
+      forceNew: true,
+      title: 'Translate'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
-  it('reuses the active tab for single-policy routes too', () => {
+  it('opens a new tab for single-policy routes instead of reusing the active one', () => {
     mocks.sidebarFavorites = [appFavorite('translate')]
     mocks.activeTab = {
       id: 'chat',
@@ -914,13 +908,11 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-translate'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/translate',
-      title: 'Translate',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/translate', {
+      forceNew: true,
+      title: 'Translate'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('opens a forced tab without revealing its resource list when the active tab is pinned', () => {
@@ -1052,11 +1044,12 @@ describe('app Sidebar', () => {
     expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('opens a new tab on middle-click (auxclick with button 1) on an agent item', () => {
+  it('opens a new tagged tab on middle-click (auxclick with button 1) on an agent item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
     mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const button = screen.getByTestId('sidebar-agent-agent-1')
@@ -1064,32 +1057,37 @@ describe('app Sidebar', () => {
 
     expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
       forceNew: true,
-      title: 'Code Reviewer'
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
     })
   })
 
-  it('opens a new tab via context menu "open in new tab" option on an agent item', () => {
+  it('opens a new tagged tab via context menu "open in new tab" option on an agent item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
     mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.agent:agent-1')
     expect(menuButton).toHaveTextContent('common.open_in_new_tab')
 
     fireEvent.click(menuButton)
+
     expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
       forceNew: true,
-      title: 'Code Reviewer'
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
     })
   })
 
-  it('opens a new tab on middle-click (auxclick with button 1) on an assistant item', () => {
+  it('opens a new tagged tab on middle-click (auxclick with button 1) on an assistant item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
     mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const button = screen.getByTestId('sidebar-assistant-assistant-1')
@@ -1097,24 +1095,96 @@ describe('app Sidebar', () => {
 
     expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
       forceNew: true,
-      title: 'Helper'
+      title: 'Helper',
+      metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
     })
   })
 
-  it('opens a new tab via context menu "open in new tab" option on an assistant item', () => {
+  it('opens a new tagged tab via context menu "open in new tab" option on an assistant item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
     mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.assistant:assistant-1')
     expect(menuButton).toHaveTextContent('common.open_in_new_tab')
 
     fireEvent.click(menuButton)
+
     expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
       forceNew: true,
-      title: 'Helper'
+      title: 'Helper',
+      metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
     })
+  })
+
+  it('activates the existing tab when the entity is already open (left-click)', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      {
+        id: 'agent-open',
+        type: 'route',
+        url: '/app/agents?sessionId=s1',
+        title: 'Code Reviewer',
+        metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+      }
+    ]
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-agent-agent-1')
+    fireEvent.click(button)
+
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('agent-open')
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('opens a fresh tagged tab when the entity is not yet open (left-click)', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-agent-agent-1')
+    fireEvent.click(button)
+
+    expect(mocks.setActiveTab).not.toHaveBeenCalled()
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
+      forceNew: true,
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+    })
+  })
+
+  it('highlights a pinned entity while any of its conversation tabs is open', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      {
+        id: 'agent-open',
+        type: 'route',
+        url: '/app/agents?sessionId=s1',
+        title: 'Code Reviewer',
+        metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+      }
+    ]
+
+    render(<Sidebar />)
+
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-active', 'true')
+    // The assistant has no open tab, so its row stays inactive.
+    expect(screen.getByTestId('sidebar-assistant-assistant-1')).toHaveAttribute('data-active', 'false')
   })
 })

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -139,7 +139,7 @@ describe('sidebarVariants icons', () => {
       expect(openApp).toHaveBeenCalledWith('assistants', { inNewTab: true })
     })
 
-    it('wires openMiniApp with and without inNewTab for mini_app variant', () => {
+    it('wires openMiniApp for both open actions of the mini_app variant', () => {
       const openMiniApp = vi.fn()
       const miniApp = {
         appId: 'mini-1',
@@ -158,8 +158,10 @@ describe('sidebarVariants icons', () => {
       entry?.onOpen()
       expect(openMiniApp).toHaveBeenCalledWith('mini-1')
 
+      // A mini app has one instance per id, so "open in new tab" resolves to the
+      // same find-or-activate as a plain click.
       entry?.onOpenNewTab?.()
-      expect(openMiniApp).toHaveBeenCalledWith('mini-1', { inNewTab: true })
+      expect(openMiniApp).toHaveBeenLastCalledWith('mini-1')
     })
 
     it('wires openAgent with and without inNewTab for agent variant', () => {

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -111,7 +111,7 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       renderIcon: (_size, miniAppSize) => <MiniAppIcon tab={tab} size={miniAppSize} />,
       isActive: (active) => active.activeTabId === app.appId,
       onOpen: () => ctx.openMiniApp(app.appId),
-      onOpenNewTab: () => ctx.openMiniApp(app.appId, { inNewTab: true }),
+      onOpenNewTab: () => ctx.openMiniApp(app.appId),
       contextMenuItems: [
         {
           type: 'item',
@@ -122,6 +122,25 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       ]
     }
   }
+}
+
+/** A conversation tab carrying an entity-ownership tag (see `openConversationTab`). */
+export interface ConversationEntryTag {
+  type: 'agent' | 'assistant'
+  entityId: string
+}
+
+/**
+ * Whether a tab belongs to this entity — the single "is this entity's conversation
+ * open" signal shared by the active-state highlight and the click handler. A tab
+ * is tagged with its owning entity at open time (its URL is rewritten to
+ * sessionId/topicId by the route interceptor, so the URL cannot carry the entity
+ * id back). Route tabs opened from a conversation history (history link, search)
+ * have no tag and never highlight.
+ */
+export function isTabForConversationEntry(tab: unknown, entry: ConversationEntryTag): boolean {
+  const metadata = (tab as { metadata?: { conversationEntry?: ConversationEntryTag } } | null)?.metadata
+  return metadata?.conversationEntry?.type === entry.type && metadata.conversationEntry.entityId === entry.entityId
 }
 
 const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 'agent' }>> = {
@@ -142,9 +161,10 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // Active-state highlight stays on the built-in agents app entry; this row
-      // only navigates the conversation the interceptor resolves.
-      isActive: () => false,
+      // A pinned entity highlights while any of its conversation tabs is open,
+      // matching the click behavior below (open tab → activate, none → create).
+      isActive: (active) =>
+        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'agent', entityId: agent.id })) ?? false,
       onOpen: () => ctx.openAgent(agent.id),
       onOpenNewTab: () => ctx.openAgent(agent.id, { inNewTab: true }),
       contextMenuItems: [
@@ -177,8 +197,10 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // Active-state highlight stays on the built-in assistants app entry.
-      isActive: () => false,
+      // Same shared "is this entity open" signal as the agent variant.
+      isActive: (active) =>
+        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'assistant', entityId: assistant.id })) ??
+        false,
       onOpen: () => ctx.openAssistant(assistant.id),
       onOpenNewTab: () => ctx.openAssistant(assistant.id, { inNewTab: true }),
       contextMenuItems: [


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Clicking a pinned agent or assistant in the sidebar replaced the active tab, discarding whatever conversation was open in it.

Before this PR:

- Clicking a pinned agent / assistant navigated the active tab to the target conversation, dropping what was there
- A fresh tab was only opened when the active tab happened to be pinned

After this PR:

- The entity already has a tab open → activate it
- No tab open for it → open a fresh one
- The active tab is never reused
- Middle-click / right-click "open in new tab" still always creates a fresh tab

Mini apps went down the same replacing path and now open a fresh tab too, matching how pinned entities behave.

Fixes #

### Why we need it and why it was done in this way

Deciding whether an entity is already open is harder than it looks: the route interceptor rewrites `?assistantId=X` / `?agentId=X` into `?topicId=` / `?sessionId=`, so the entity id is gone from the URL and a tab's URL cannot say which entity it belongs to.

A tab is therefore tagged with its owning entity when it is opened (`Tab.metadata.conversationEntry`). `AppShell.handleUrlChange` only syncs the url for page-titled routes such as chat / agents and leaves metadata alone, so the tag survives the rewrite.

The following tradeoffs were made:

- The tag is written only when the tab is opened. If the user navigates to another entity from inside the tab, the tag no longer matches what the tab shows — addressed in a follow-up PR.
- The check reads the tag synchronously instead of resolving "this entity's latest conversation" on every click, keeping the click path free of an await.

The following alternatives were considered:

- Resolving the entity's latest topic / session asynchronously on click and matching tabs by URL: every click waits on a query, and tabs opened from a conversation history would be misread as belonging to an entity.
- Keeping the entity id in the tab URL: that means changing how the route interceptor rewrites, a far wider change than this bug fix.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

Not to be confused with #19464, which relabels pinned tabs in the **top tab strip** (`layout/AppShellTabBar.tsx`). This PR is about the **left sidebar**; the two share no files.

The "reuse the active tab" branch in `navigateRouteTab` is gone entirely — it was the direct source of this bug. Every sidebar entry (built-in apps, mini apps, pinned entities) now either activates an existing tab or opens a fresh one.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Pinned agents and assistants in the sidebar no longer replace the active tab. Clicking one activates its already-open tab or opens a fresh one, leaving the conversation you were in untouched.
```
