### PR TITLE
feat(sidebar): distinguish tabs that are open from the one you are looking at

### DIFF
--- a/src/renderer/components/Sidebar/Sidebar.css
+++ b/src/renderer/components/Sidebar/Sidebar.css
@@ -1,13 +1,13 @@
 .sidebar-theme {
-  --sidebar-active-bg: rgba(16, 185, 129, 0.08);
-  --sidebar-active-border: rgba(16, 185, 129, 0.15);
+  --sidebar-active-bg: rgba(16, 185, 129, 0.16);
+  --sidebar-active-border: rgba(16, 185, 129, 0.42);
   --sidebar-glow-bg: rgba(16, 185, 129, 0.25);
   --sidebar-glow-line: rgba(16, 185, 129, 0.5);
 }
 
 .dark .sidebar-theme {
-  --sidebar-active-bg: rgba(114, 255, 121, 0.05);
-  --sidebar-active-border: rgba(114, 255, 121, 0.08);
+  --sidebar-active-bg: rgba(114, 255, 121, 0.14);
+  --sidebar-active-border: rgba(114, 255, 121, 0.18);
   --sidebar-glow-bg: rgba(114, 255, 121, 0.15);
   --sidebar-glow-line: rgba(114, 255, 121, 0.35);
 }

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -11,14 +11,14 @@ import { DefaultLogo } from './primitives'
 import { SidebarFooter, type SidebarFooterActions } from './SidebarFooter'
 import { SidebarList } from './SidebarList'
 import { SidebarTooltip } from './Tooltip'
-import type { ResolvedSidebarEntry, SidebarActiveState, SidebarUser } from './types'
+import type { ResolvedSidebarEntry, SidebarTabState, SidebarUser } from './types'
 import { useSidebarResize } from './useSidebarResize'
 
 export interface SidebarProps {
   width: number
   setWidth: (width: number) => void
   entries: ResolvedSidebarEntry[]
-  active: SidebarActiveState
+  active: SidebarTabState
   title?: string
   logo?: React.ReactNode
   user?: SidebarUser

--- a/src/renderer/components/Sidebar/SidebarList.tsx
+++ b/src/renderer/components/Sidebar/SidebarList.tsx
@@ -6,12 +6,12 @@ import { ActiveIndicator } from './primitives'
 import type { SidebarClickGuard } from './SidebarSortableList'
 import { SidebarSortableList } from './SidebarSortableList'
 import { SidebarTooltip } from './Tooltip'
-import type { ResolvedSidebarEntry, SidebarActiveState, SidebarVisibleLayout } from './types'
+import type { ResolvedSidebarEntry, SidebarTabState, SidebarVisibleLayout } from './types'
 
 export interface SidebarListProps {
   layout: SidebarVisibleLayout
   entries: ResolvedSidebarEntry[]
-  active: SidebarActiveState
+  active: SidebarTabState
   onReorder?: (event: { oldIndex: number; newIndex: number }) => void
   onContextMenuOpenChange?: (open: boolean) => void
 }
@@ -73,7 +73,8 @@ function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
       onReorder={onReorder}
       className="flex flex-col items-center gap-0.5 px-1.5 [-webkit-app-region:no-drag]">
       {(entry, guardClick) => {
-        const isActive = entry.isActive(active)
+        const isCurrent = entry.isCurrent(active)
+        const isOpen = isCurrent || entry.isOpen(active)
 
         return (
           <SidebarTooltip key={entry.key} content={entry.label}>
@@ -85,11 +86,13 @@ function IconList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 onMouseDown={preventMiddleClickAutoscroll}
                 onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className={`relative flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 ${
-                  isActive
+                  isCurrent
                     ? 'bg-[var(--sidebar-active-bg)] text-foreground'
-                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                    : isOpen
+                      ? 'text-foreground hover:bg-accent/60'
+                      : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
                 }`}>
-                {isActive && <ActiveIndicator className="rounded-full" />}
+                {isOpen && <ActiveIndicator className="rounded-full" />}
                 {entry.renderIcon(18, 'lg')}
               </button>
             </EntryContextMenu>
@@ -108,7 +111,8 @@ function FullList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
       onReorder={onReorder}
       className="space-y-0.5 px-2 [-webkit-app-region:no-drag]">
       {(entry, guardClick: SidebarClickGuard) => {
-        const isActive = entry.isActive(active)
+        const isCurrent = entry.isCurrent(active)
+        const isOpen = isCurrent || entry.isOpen(active)
 
         return (
           <div key={entry.key} className="relative">
@@ -117,14 +121,14 @@ function FullList({ entries, active, onReorder, onContextMenuOpenChange }: ListP
                 variant="ghost"
                 icon={entry.renderIcon(16, 'md')}
                 label={entry.label}
-                active={isActive}
+                active={isCurrent}
                 onClick={guardClick(entry.key, entry.onOpen)}
                 onMouseDown={preventMiddleClickAutoscroll}
                 onAuxClick={createAuxClickHandler(entry, guardClick)}
                 className="rounded-xl data-[active=true]:bg-[var(--sidebar-active-bg)]"
               />
             </EntryContextMenu>
-            {isActive && <ActiveIndicator className="rounded-xl" />}
+            {isOpen && <ActiveIndicator className="rounded-xl" />}
           </div>
         )
       }}

--- a/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/Sidebar.test.tsx
@@ -133,7 +133,8 @@ const appEntry = (item: AppItem): ResolvedSidebarEntry => ({
     const Icon = item.icon
     return <Icon size={size} strokeWidth={1.6} />
   },
-  isActive: (active) => active.activeItem === item.id,
+  isOpen: () => false,
+  isCurrent: (state) => state.activeItem === item.id,
   onOpen: () => {},
   contextMenuItems: item.contextMenuItems
 })
@@ -144,7 +145,8 @@ const miniEntry = (
   key: `mini_app:${tab.miniApp.id}`,
   label: tab.title,
   renderIcon: (_size, miniAppSize) => <MiniAppIcon tab={tab} size={miniAppSize} />,
-  isActive: (active) => active.activeTabId === tab.miniApp.id,
+  isOpen: () => false,
+  isCurrent: (state) => state.activeItem === tab.miniApp.id,
   onOpen: () => {},
   contextMenuItems
 })
@@ -519,14 +521,16 @@ describe('Sidebar resize handle', () => {
         key: 'app:chat',
         label: 'Chat',
         renderIcon: () => null,
-        isActive: (active) => active.activeItem === 'chat',
+        isOpen: () => false,
+        isCurrent: (state) => state.activeItem === 'chat',
         onOpen: onChatOpen
       },
       {
         key: 'app:agent',
         label: 'Agent',
         renderIcon: () => null,
-        isActive: (active) => active.activeItem === 'agent',
+        isOpen: () => false,
+        isCurrent: (state) => state.activeItem === 'agent',
         onOpen: onAgentOpen
       }
     ]
@@ -560,7 +564,8 @@ describe('Sidebar resize handle', () => {
         key: 'app:chat',
         label: 'Chat',
         renderIcon: () => null,
-        isActive: (active) => active.activeItem === 'chat',
+        isOpen: () => false,
+        isCurrent: (state) => state.activeItem === 'chat',
         onOpen: vi.fn(),
         onOpenNewTab: onChatOpenNewTab
       },
@@ -568,7 +573,8 @@ describe('Sidebar resize handle', () => {
         key: 'app:agent',
         label: 'Agent',
         renderIcon: () => null,
-        isActive: (active) => active.activeItem === 'agent',
+        isOpen: () => false,
+        isCurrent: (state) => state.activeItem === 'agent',
         onOpen: vi.fn(),
         onOpenNewTab: onAgentOpenNewTab
       }
@@ -638,7 +644,8 @@ describe('Sidebar resize handle', () => {
         key: 'app:chat',
         label: 'Chat',
         renderIcon: () => <span>chat-icon</span>,
-        isActive: () => false,
+        isOpen: () => false,
+        isCurrent: () => false,
         onOpen: onChatOpen,
         onOpenNewTab: onChatOpenNewTab
       }
@@ -666,7 +673,8 @@ describe('Sidebar resize handle', () => {
         key: 'app:chat',
         label: 'Chat',
         renderIcon: () => <span>chat-icon</span>,
-        isActive: () => false,
+        isOpen: () => false,
+        isCurrent: () => false,
         onOpen: onChatOpen,
         onOpenNewTab: onChatOpenNewTab
       }
@@ -699,7 +707,8 @@ describe('Sidebar resize handle', () => {
         key: 'app:chat',
         label: 'Chat',
         renderIcon: () => <span>chat-icon</span>,
-        isActive: () => false,
+        isOpen: () => false,
+        isCurrent: () => false,
         onOpen: onChatOpen,
         onOpenNewTab: onChatOpenNewTab
       }

--- a/src/renderer/components/Sidebar/index.ts
+++ b/src/renderer/components/Sidebar/index.ts
@@ -12,10 +12,10 @@ export { MiniAppIcon, UserAvatar } from './primitives'
 export { Sidebar, type SidebarProps } from './Sidebar'
 export type {
   ResolvedSidebarEntry,
-  SidebarActiveState,
   SidebarLayout,
   SidebarMiniApp,
   SidebarMiniAppTab,
+  SidebarTabState,
   SidebarUser,
   SidebarVisibleLayout
 } from './types'

--- a/src/renderer/components/Sidebar/types.ts
+++ b/src/renderer/components/Sidebar/types.ts
@@ -14,18 +14,14 @@ export interface SidebarMiniAppTab {
   miniApp: SidebarMiniApp
 }
 
-/** The active-route state a resolved entry matches itself against. */
-export interface SidebarActiveState {
-  /** Active built-in app id. */
+/** The tab state a resolved entry matches itself against. */
+export interface SidebarTabState {
+  /** Built-in app id of the current tab. */
   activeItem: string
-  /** Active mini app id (concrete mini app route). */
-  activeTabId?: string
-  /**
-   * Open tabs — lets conversation-backed entries (agents, assistants) decide
-   * "already open" by their tab's entity-ownership tag, the same signal the
-   * click handler uses.
-   */
+  /** Every open tab, foreground or not. */
   tabs?: readonly Tab[]
+  /** The foreground tab. */
+  currentTab?: Tab
 }
 
 /**
@@ -40,7 +36,10 @@ export interface ResolvedSidebarEntry {
   key: string
   label: string
   renderIcon: (size: number, miniAppSize: 'md' | 'lg') => ReactNode
-  isActive: (active: SidebarActiveState) => boolean
+  /** Open in some tab, foreground or not — drives the click (activate vs. create). */
+  isOpen: (state: SidebarTabState) => boolean
+  /** Open in the foreground tab. Implies `isOpen`. */
+  isCurrent: (state: SidebarTabState) => boolean
   onOpen: () => void
   onOpenNewTab?: () => void
   contextMenuItems?: readonly CommandContextMenuExtraItem[]

--- a/src/renderer/components/Sidebar/types.ts
+++ b/src/renderer/components/Sidebar/types.ts
@@ -1,4 +1,5 @@
 import type { CommandContextMenuExtraItem } from '@renderer/components/command'
+import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import type { ReactNode } from 'react'
 
 export interface SidebarMiniApp {
@@ -19,6 +20,12 @@ export interface SidebarActiveState {
   activeItem: string
   /** Active mini app id (concrete mini app route). */
   activeTabId?: string
+  /**
+   * Open tabs — lets conversation-backed entries (agents, assistants) decide
+   * "already open" by their tab's entity-ownership tag, the same signal the
+   * click handler uses.
+   */
+  tabs?: readonly Tab[]
 }
 
 /**

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -8,7 +8,7 @@ import useAvatar from '@renderer/hooks/useAvatar'
 import { useMiniApps } from '@renderer/hooks/useMiniApps'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
-import { MINI_APP_ROUTE_PREFIX, miniAppIdFromTabUrl } from '@renderer/utils/miniAppKeepAlive'
+import { MINI_APP_ROUTE_PREFIX } from '@renderer/utils/miniAppKeepAlive'
 import { getDefaultRouteTitle } from '@renderer/utils/routeTitle'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import {
@@ -128,7 +128,6 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
 
   // Menu items
   const pathname = activeTab?.url || '/'
-  const activeMiniAppId = miniAppIdFromTabUrl(activeTab?.url) ?? undefined
   const openableMiniAppById = useMemo(() => {
     const appById = new Map<string, (typeof miniApps)[number]>()
     for (const app of miniApps) {
@@ -363,7 +362,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   // Common props shared between normal and floating sidebar
   const sidebarProps = {
     entries,
-    active: { activeItem, activeTabId: activeMiniAppId, tabs },
+    active: { activeItem, tabs, currentTab: activeTab },
     title: sidebarUser.name,
     logo: sidebarLogo,
     actions: (footerLayout: SidebarVisibleLayout, onOverlayOpenChange?: (open: boolean) => void) => (

--- a/src/renderer/components/app/Sidebar.tsx
+++ b/src/renderer/components/app/Sidebar.tsx
@@ -35,7 +35,7 @@ import {
   UserAvatar
 } from '../Sidebar'
 import UserPopup from '../UserPopup'
-import { resolveSidebarEntry, type SidebarVariantContext } from './sidebarVariants'
+import { isTabForConversationEntry, resolveSidebarEntry, type SidebarVariantContext } from './sidebarVariants'
 
 const FeedbackDialog = lazy(() => import('../feedback/FeedbackDialog'))
 const REQUIRED_SIDEBAR_FAVORITE_SET = new Set<SidebarAppId>(REQUIRED_SIDEBAR_FAVORITES)
@@ -54,7 +54,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
     removeAssistant,
     reorderFavorites
   } = useSidebarFavorites()
-  const { activeTab, tabs, updateTab, openTab, setActiveTab } = useTabs()
+  const { activeTab, tabs, openTab, setActiveTab } = useTabs()
   const { miniApps, pinned } = useMiniApps({ enabled: miniAppFavoriteIds.length > 0 })
   const { agents } = useAgents({ enabled: agentFavoriteIds.length > 0 })
   const { assistants } = useAssistantsApi({ enabled: assistantFavoriteIds.length > 0 })
@@ -152,31 +152,13 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
 
   const navigateRouteTab = useCallback(
     (path: string, title: string, options?: { inNewTab?: boolean; icon?: string }) => {
-      if (options?.inNewTab) {
-        openTab(path, { forceNew: true, title, icon: options.icon })
-        return
-      }
-
-      if (activeTab?.url === path) return
-
-      if (activeTab?.isPinned) {
-        openTab(path, { forceNew: true, title, icon: options?.icon })
-        return
-      }
-
-      if (activeTab) {
-        updateTab(activeTab.id, {
-          url: path,
-          title,
-          icon: options?.icon,
-          metadata: undefined
-        })
-        return
-      }
-
+      // Never reuse the current tab — the pre-existing behavior replaced it with
+      // the target route, dropping whatever conversation was open. All sidebar
+      // entries (apps, mini apps, pinned entities) open a fresh tab when their
+      // target isn't already the active one.
       openTab(path, { forceNew: true, title, icon: options?.icon })
     },
-    [activeTab, openTab, updateTab]
+    [openTab]
   )
 
   const handleNavigate = useCallback(
@@ -215,7 +197,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   }, [])
 
   const handleOpenMiniAppTab = useCallback(
-    (appId: string, options?: { inNewTab?: boolean }) => {
+    (appId: string) => {
       const app = openableMiniAppById.get(appId)
       if (!app) return
 
@@ -231,28 +213,55 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
       const title = app.nameKey ? t(app.nameKey) : app.name
       // Uploaded logo → main-resolved `logoSrc`; preset key → `logo`.
       const icon = app.logoSrc ?? app.logo
-      navigateRouteTab(path, title, { ...options, icon })
+      // Never reuse the current tab for a not-yet-open mini app — always open a
+      // fresh one, matching how pinned agents/assistants behave.
+      openTab(path, { forceNew: true, title, icon })
     },
-    [activeTab, navigateRouteTab, openableMiniAppById, setActiveTab, t, tabs]
+    [activeTab, openableMiniAppById, openTab, setActiveTab, t, tabs]
   )
 
-  // Pinned entities reuse tabs like mini apps do; the route interceptor turns the
-  // `agentId` / `assistantId` param into that entity's most recent conversation.
+  // Pinned entities find-and-activate an open tab or open a fresh one, sharing the
+  // same "already open" signal as the active-state highlight. The route interceptor
+  // turns the `agentId` / `assistantId` param into that entity's most recent
+  // conversation, so each entity tab is tagged with its owning entity at open time
+  // instead of relying on the URL (which loses the entity id on rewrite).
+  const openConversationTab = useCallback(
+    (type: 'agent' | 'assistant', entityId: string, title: string, inNewTab?: boolean) => {
+      if (!inNewTab) {
+        const existingTab = tabs.find((tab) => isTabForConversationEntry(tab, { type, entityId }))
+        if (existingTab) {
+          setActiveTab(existingTab.id)
+          return
+        }
+      }
+      const path =
+        type === 'agent'
+          ? `/app/agents?agentId=${encodeURIComponent(entityId)}`
+          : `/app/chat?assistantId=${encodeURIComponent(entityId)}`
+      openTab(path, {
+        forceNew: true,
+        title,
+        metadata: { conversationEntry: { type, entityId } }
+      })
+    },
+    [openTab, setActiveTab, tabs]
+  )
+
   const handleOpenAgentTab = useCallback(
     (agentId: string, options?: { inNewTab?: boolean }) => {
       const agent = installedAgents.get(agentId)
       if (!agent) return
-      navigateRouteTab(`/app/agents?agentId=${encodeURIComponent(agentId)}`, agent.name, options)
+      openConversationTab('agent', agentId, agent.name, options?.inNewTab)
     },
-    [installedAgents, navigateRouteTab]
+    [installedAgents, openConversationTab]
   )
   const handleOpenAssistantTab = useCallback(
     (assistantId: string, options?: { inNewTab?: boolean }) => {
       const assistant = installedAssistants.get(assistantId)
       if (!assistant) return
-      navigateRouteTab(`/app/chat?assistantId=${encodeURIComponent(assistantId)}`, assistant.name, options)
+      openConversationTab('assistant', assistantId, assistant.name, options?.inNewTab)
     },
-    [installedAssistants, navigateRouteTab]
+    [installedAssistants, openConversationTab]
   )
 
   // All per-type sidebar knowledge (icon, label, route, active-match, open, remove)
@@ -354,7 +363,7 @@ export default function Sidebar({ ref }: { ref?: Ref<HTMLDivElement | null> }) {
   // Common props shared between normal and floating sidebar
   const sidebarProps = {
     entries,
-    active: { activeItem, activeTabId: activeMiniAppId },
+    active: { activeItem, activeTabId: activeMiniAppId, tabs },
     title: sidebarUser.name,
     logo: sidebarLogo,
     actions: (footerLayout: SidebarVisibleLayout, onOverlayOpenChange?: (open: boolean) => void) => (

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -205,10 +205,13 @@ vi.mock('../../layout/ShellTabBarActions', () => ({
   )
 }))
 
+type MockTabState = { activeItem: string; tabs?: FakeTab[]; currentTab?: FakeTab | null }
+
 type MockSidebarEntry = {
   key: string
   label: string
-  isActive: (active: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }) => boolean
+  isOpen: (state: MockTabState) => boolean
+  isCurrent: (state: MockTabState) => boolean
   onOpen: () => void
   onOpenNewTab?: () => void
   contextMenuItems?: Array<{ id: string; label: string; enabled?: boolean; onSelect?: () => void }>
@@ -246,7 +249,7 @@ vi.mock('../../Sidebar', async () => {
     }: {
       isFloating?: boolean
       isFloatingClosing?: boolean
-      active?: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }
+      active?: MockTabState
       entries?: MockSidebarEntry[]
       title?: string
       logo?: ReactNode
@@ -317,7 +320,8 @@ vi.mock('../../Sidebar', async () => {
               <div key={miniTab.key} role="group" aria-label={miniTab.label}>
                 <button
                   type="button"
-                  data-active={miniTab.isActive(activeState) ? 'true' : 'false'}
+                  data-open={miniTab.isOpen(activeState) ? 'true' : 'false'}
+                  data-active={miniTab.isCurrent(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-mini-app-${parseEntryKey(miniTab.key).id}`}
                   onClick={() => miniTab.onOpen()}
                   onAuxClick={(e) => {
@@ -343,7 +347,8 @@ vi.mock('../../Sidebar', async () => {
               <div key={agentItem.key} role="group" aria-label={agentItem.label}>
                 <button
                   type="button"
-                  data-active={agentItem.isActive(activeState) ? 'true' : 'false'}
+                  data-open={agentItem.isOpen(activeState) ? 'true' : 'false'}
+                  data-active={agentItem.isCurrent(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-agent-${parseEntryKey(agentItem.key).id}`}
                   onClick={() => agentItem.onOpen()}
                   onAuxClick={(e) => {
@@ -369,7 +374,8 @@ vi.mock('../../Sidebar', async () => {
               <div key={assistantItem.key} role="group" aria-label={assistantItem.label}>
                 <button
                   type="button"
-                  data-active={assistantItem.isActive(activeState) ? 'true' : 'false'}
+                  data-open={assistantItem.isOpen(activeState) ? 'true' : 'false'}
+                  data-active={assistantItem.isCurrent(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-assistant-${parseEntryKey(assistantItem.key).id}`}
                   onClick={() => assistantItem.onOpen()}
                   onAuxClick={(e) => {
@@ -573,6 +579,7 @@ describe('app Sidebar', () => {
       url: '/app/mini-app/calculator',
       title: 'Calculator'
     }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
 
@@ -1163,7 +1170,7 @@ describe('app Sidebar', () => {
     })
   })
 
-  it('highlights a pinned entity while any of its conversation tabs is open', () => {
+  it('marks a pinned entity open, but not current, while its tab sits in the background', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
     mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
@@ -1183,8 +1190,43 @@ describe('app Sidebar', () => {
 
     render(<Sidebar />)
 
-    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-active', 'true')
-    // The assistant has no open tab, so its row stays inactive.
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-active', 'false')
+    // The assistant has no tab at all — neither open nor current.
+    expect(screen.getByTestId('sidebar-assistant-assistant-1')).toHaveAttribute('data-open', 'false')
     expect(screen.getByTestId('sidebar-assistant-assistant-1')).toHaveAttribute('data-active', 'false')
+  })
+
+  it('marks a pinned entity current once its tab is in the foreground', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = {
+      id: 'agent-open',
+      type: 'route',
+      url: '/app/agents?sessionId=s1',
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+    }
+    mocks.tabs = [mocks.activeTab]
+
+    render(<Sidebar />)
+
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-active', 'true')
+  })
+
+  it('keeps a pinned mini app open while another tab is in the foreground', () => {
+    configureMiniApps(['calculator'], [calculatorMiniApp])
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      { id: 'calc-tab', type: 'route', url: '/app/mini-app/calculator', title: 'Calculator' }
+    ]
+
+    render(<Sidebar />)
+
+    expect(screen.getByTestId('sidebar-mini-app-calculator')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('sidebar-mini-app-calculator')).toHaveAttribute('data-active', 'false')
   })
 })

--- a/src/renderer/components/app/__tests__/Sidebar.test.tsx
+++ b/src/renderer/components/app/__tests__/Sidebar.test.tsx
@@ -208,7 +208,7 @@ vi.mock('../../layout/ShellTabBarActions', () => ({
 type MockSidebarEntry = {
   key: string
   label: string
-  isActive: (active: { activeItem: string; activeTabId?: string }) => boolean
+  isActive: (active: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }) => boolean
   onOpen: () => void
   onOpenNewTab?: () => void
   contextMenuItems?: Array<{ id: string; label: string; enabled?: boolean; onSelect?: () => void }>
@@ -246,7 +246,7 @@ vi.mock('../../Sidebar', async () => {
     }: {
       isFloating?: boolean
       isFloatingClosing?: boolean
-      active?: { activeItem: string; activeTabId?: string }
+      active?: { activeItem: string; activeTabId?: string; tabs?: FakeTab[] }
       entries?: MockSidebarEntry[]
       title?: string
       logo?: ReactNode
@@ -343,6 +343,7 @@ vi.mock('../../Sidebar', async () => {
               <div key={agentItem.key} role="group" aria-label={agentItem.label}>
                 <button
                   type="button"
+                  data-active={agentItem.isActive(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-agent-${parseEntryKey(agentItem.key).id}`}
                   onClick={() => agentItem.onOpen()}
                   onAuxClick={(e) => {
@@ -368,6 +369,7 @@ vi.mock('../../Sidebar', async () => {
               <div key={assistantItem.key} role="group" aria-label={assistantItem.label}>
                 <button
                   type="button"
+                  data-active={assistantItem.isActive(activeState) ? 'true' : 'false'}
                   data-testid={`sidebar-assistant-${parseEntryKey(assistantItem.key).id}`}
                   onClick={() => assistantItem.onOpen()}
                   onAuxClick={(e) => {
@@ -687,7 +689,7 @@ describe('app Sidebar', () => {
     expect(screen.queryByTestId('sidebar-mini-app-calculator')).not.toBeInTheDocument()
   })
 
-  it('reuses the active tab from the sidebar mini app section', () => {
+  it('opens a new mini app tab instead of reusing the active tab', () => {
     configureMiniApps(['calculator'])
     mocks.activeTab = {
       id: 'chat',
@@ -701,13 +703,12 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-mini-app-calculator'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/mini-app/calculator',
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/mini-app/calculator', {
+      forceNew: true,
       title: 'Calculator',
-      icon: 'calculator-logo',
-      metadata: undefined
+      icon: 'calculator-logo'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('switches to an existing mini app tab without replacing the active tab', async () => {
@@ -791,7 +792,7 @@ describe('app Sidebar', () => {
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
-  it('reuses the active tab without revealing its resource list', () => {
+  it('opens a new agents tab when the active tab is a foreign route', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -804,18 +805,16 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('replaces the active tab with the bare route', () => {
+  it('opens a new agents tab instead of replacing the active tab', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'chat',
@@ -828,16 +827,14 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    // Which session the tab lands on is the route interceptor's decision — the
-    // sidebar only replaces the tab with the app's bare entry route.
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    // The route interceptor decides which session the fresh tab lands on; the
+    // sidebar just opens a new tab instead of repurposing the current one.
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
     expect(mocks.setActiveTab).not.toHaveBeenCalled()
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('stays put when the active tab already holds a conversation of the target app', () => {
@@ -858,7 +855,7 @@ describe('app Sidebar', () => {
     expect(mocks.openTab).not.toHaveBeenCalled()
   })
 
-  it('navigates a message-only viewer of the same app back to the app entry', () => {
+  it('opens a new agents tab when the active tab is a message-only viewer of the app', () => {
     mocks.sidebarFavorites = [appFavorite('agents')]
     mocks.activeTab = {
       id: 'viewer',
@@ -870,15 +867,14 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-agents'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('viewer', {
-      url: '/app/agents',
-      title: 'Work',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents', {
+      forceNew: true,
+      title: 'Work'
     })
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('clears route-specific metadata when reusing the active tab', () => {
+  it('opens a new translate tab instead of reusing the active tab', () => {
     mocks.sidebarFavorites = [appFavorite('translate')]
     mocks.activeTab = {
       id: 'chat',
@@ -892,17 +888,15 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-translate'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/translate',
-      title: 'Translate',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/translate', {
+      forceNew: true,
+      title: 'Translate'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
     expect(mocks.emitResourceListReveal).not.toHaveBeenCalled()
   })
 
-  it('reuses the active tab for single-policy routes too', () => {
+  it('opens a new tab for single-policy routes instead of reusing the active one', () => {
     mocks.sidebarFavorites = [appFavorite('translate')]
     mocks.activeTab = {
       id: 'chat',
@@ -914,13 +908,11 @@ describe('app Sidebar', () => {
     render(<Sidebar />)
     fireEvent.click(screen.getByTestId('sidebar-item-translate'))
 
-    expect(mocks.updateTab).toHaveBeenCalledWith('chat', {
-      url: '/app/translate',
-      title: 'Translate',
-      icon: undefined,
-      metadata: undefined
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/translate', {
+      forceNew: true,
+      title: 'Translate'
     })
-    expect(mocks.openTab).not.toHaveBeenCalled()
+    expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
   it('opens a forced tab without revealing its resource list when the active tab is pinned', () => {
@@ -1052,11 +1044,12 @@ describe('app Sidebar', () => {
     expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('opens a new tab on middle-click (auxclick with button 1) on an agent item', () => {
+  it('opens a new tagged tab on middle-click (auxclick with button 1) on an agent item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
     mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const button = screen.getByTestId('sidebar-agent-agent-1')
@@ -1064,32 +1057,37 @@ describe('app Sidebar', () => {
 
     expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
       forceNew: true,
-      title: 'Code Reviewer'
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
     })
   })
 
-  it('opens a new tab via context menu "open in new tab" option on an agent item', () => {
+  it('opens a new tagged tab via context menu "open in new tab" option on an agent item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
     mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.agent:agent-1')
     expect(menuButton).toHaveTextContent('common.open_in_new_tab')
 
     fireEvent.click(menuButton)
+
     expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
       forceNew: true,
-      title: 'Code Reviewer'
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
     })
   })
 
-  it('opens a new tab on middle-click (auxclick with button 1) on an assistant item', () => {
+  it('opens a new tagged tab on middle-click (auxclick with button 1) on an assistant item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
     mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const button = screen.getByTestId('sidebar-assistant-assistant-1')
@@ -1097,24 +1095,96 @@ describe('app Sidebar', () => {
 
     expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
       forceNew: true,
-      title: 'Helper'
+      title: 'Helper',
+      metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
     })
   })
 
-  it('opens a new tab via context menu "open in new tab" option on an assistant item', () => {
+  it('opens a new tagged tab via context menu "open in new tab" option on an assistant item', () => {
     mocks.sidebarFavorites = []
     mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
     mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
     mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
 
     render(<Sidebar />)
     const menuButton = screen.getByTestId('sidebar-menu-sidebar.open-in-new-tab.assistant:assistant-1')
     expect(menuButton).toHaveTextContent('common.open_in_new_tab')
 
     fireEvent.click(menuButton)
+
     expect(mocks.openTab).toHaveBeenCalledWith('/app/chat?assistantId=assistant-1', {
       forceNew: true,
-      title: 'Helper'
+      title: 'Helper',
+      metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
     })
+  })
+
+  it('activates the existing tab when the entity is already open (left-click)', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      {
+        id: 'agent-open',
+        type: 'route',
+        url: '/app/agents?sessionId=s1',
+        title: 'Code Reviewer',
+        metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+      }
+    ]
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-agent-agent-1')
+    fireEvent.click(button)
+
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('agent-open')
+    expect(mocks.openTab).not.toHaveBeenCalled()
+  })
+
+  it('opens a fresh tagged tab when the entity is not yet open (left-click)', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [mocks.activeTab]
+
+    render(<Sidebar />)
+    const button = screen.getByTestId('sidebar-agent-agent-1')
+    fireEvent.click(button)
+
+    expect(mocks.setActiveTab).not.toHaveBeenCalled()
+    expect(mocks.openTab).toHaveBeenCalledWith('/app/agents?agentId=agent-1', {
+      forceNew: true,
+      title: 'Code Reviewer',
+      metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+    })
+  })
+
+  it('highlights a pinned entity while any of its conversation tabs is open', () => {
+    mocks.sidebarFavorites = []
+    mocks.sidebarAgentFavorites = [agentFavorite('agent-1')]
+    mocks.sidebarAssistantFavorites = [assistantFavorite('assistant-1')]
+    mocks.agents = [{ id: 'agent-1', name: 'Code Reviewer' }]
+    mocks.assistants = [{ id: 'assistant-1', name: 'Helper' }]
+    mocks.activeTab = { id: 'chat', type: 'route', url: '/app/chat', title: 'Chat' }
+    mocks.tabs = [
+      mocks.activeTab,
+      {
+        id: 'agent-open',
+        type: 'route',
+        url: '/app/agents?sessionId=s1',
+        title: 'Code Reviewer',
+        metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
+      }
+    ]
+
+    render(<Sidebar />)
+
+    expect(screen.getByTestId('sidebar-agent-agent-1')).toHaveAttribute('data-active', 'true')
+    // The assistant has no open tab, so its row stays inactive.
+    expect(screen.getByTestId('sidebar-assistant-assistant-1')).toHaveAttribute('data-active', 'false')
   })
 })

--- a/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
+++ b/src/renderer/components/app/__tests__/sidebarVariants.test.tsx
@@ -139,7 +139,7 @@ describe('sidebarVariants icons', () => {
       expect(openApp).toHaveBeenCalledWith('assistants', { inNewTab: true })
     })
 
-    it('wires openMiniApp with and without inNewTab for mini_app variant', () => {
+    it('wires openMiniApp for both open actions of the mini_app variant', () => {
       const openMiniApp = vi.fn()
       const miniApp = {
         appId: 'mini-1',
@@ -158,8 +158,10 @@ describe('sidebarVariants icons', () => {
       entry?.onOpen()
       expect(openMiniApp).toHaveBeenCalledWith('mini-1')
 
+      // A mini app has one instance per id, so "open in new tab" resolves to the
+      // same find-or-activate as a plain click.
       entry?.onOpenNewTab?.()
-      expect(openMiniApp).toHaveBeenCalledWith('mini-1', { inNewTab: true })
+      expect(openMiniApp).toHaveBeenLastCalledWith('mini-1')
     })
 
     it('wires openAgent with and without inNewTab for agent variant', () => {

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -1,6 +1,7 @@
 import { renderAgentEntityIcon, renderAssistantEntityIcon } from '@renderer/components/chat/resourceList/base'
 import { getSidebarIconLabelKey } from '@renderer/i18n/label'
 import type { Assistant } from '@renderer/types/assistant'
+import { miniAppIdFromTabUrl } from '@renderer/utils/miniAppKeepAlive'
 import type { SidebarAppId } from '@renderer/utils/sidebar'
 import { getSidebarFavoriteKey, getSidebarMenuPath, isSidebarAppId } from '@renderer/utils/sidebar'
 import type { AgentEntity } from '@shared/data/api/schemas/agents'
@@ -75,7 +76,8 @@ const appVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 
       key: getSidebarFavoriteKey(item),
       label: ctx.t(getSidebarIconLabelKey(id)),
       renderIcon: (size) => <Icon size={size} strokeWidth={1.6} />,
-      isActive: (active) => active.activeItem === id,
+      isOpen: () => false,
+      isCurrent: (state) => state.activeItem === id,
       onOpen: () => ctx.openApp(id),
       onOpenNewTab: () => ctx.openApp(id, { inNewTab: true }),
       contextMenuItems: [
@@ -109,7 +111,9 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       key: getSidebarFavoriteKey(item),
       label: title,
       renderIcon: (_size, miniAppSize) => <MiniAppIcon tab={tab} size={miniAppSize} />,
-      isActive: (active) => active.activeTabId === app.appId,
+      // A mini app route keeps its id in the URL, so its tabs need no ownership tag.
+      isOpen: (state) => state.tabs?.some((tab) => miniAppIdFromTabUrl(tab.url) === app.appId) ?? false,
+      isCurrent: (state) => miniAppIdFromTabUrl(state.currentTab?.url) === app.appId,
       onOpen: () => ctx.openMiniApp(app.appId),
       onOpenNewTab: () => ctx.openMiniApp(app.appId),
       contextMenuItems: [
@@ -131,8 +135,8 @@ export interface ConversationEntryTag {
 }
 
 /**
- * Whether a tab belongs to this entity — the single "is this entity's conversation
- * open" signal shared by the active-state highlight and the click handler. A tab
+ * Whether a tab belongs to this entity — the single ownership test behind both
+ * `isOpen` / `isCurrent` and the click handler. A tab
  * is tagged with its owning entity at open time (its URL is rewritten to
  * sessionId/topicId by the route interceptor, so the URL cannot carry the entity
  * id back). Route tabs opened from a conversation history (history link, search)
@@ -161,10 +165,9 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // A pinned entity highlights while any of its conversation tabs is open,
-      // matching the click behavior below (open tab → activate, none → create).
-      isActive: (active) =>
-        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'agent', entityId: agent.id })) ?? false,
+      isOpen: (state) =>
+        state.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'agent', entityId: agent.id })) ?? false,
+      isCurrent: (state) => isTabForConversationEntry(state.currentTab, { type: 'agent', entityId: agent.id }),
       onOpen: () => ctx.openAgent(agent.id),
       onOpenNewTab: () => ctx.openAgent(agent.id, { inNewTab: true }),
       contextMenuItems: [
@@ -197,10 +200,10 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // Same shared "is this entity open" signal as the agent variant.
-      isActive: (active) =>
-        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'assistant', entityId: assistant.id })) ??
+      isOpen: (state) =>
+        state.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'assistant', entityId: assistant.id })) ??
         false,
+      isCurrent: (state) => isTabForConversationEntry(state.currentTab, { type: 'assistant', entityId: assistant.id }),
       onOpen: () => ctx.openAssistant(assistant.id),
       onOpenNewTab: () => ctx.openAssistant(assistant.id, { inNewTab: true }),
       contextMenuItems: [

--- a/src/renderer/components/app/sidebarVariants.tsx
+++ b/src/renderer/components/app/sidebarVariants.tsx
@@ -111,7 +111,7 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       renderIcon: (_size, miniAppSize) => <MiniAppIcon tab={tab} size={miniAppSize} />,
       isActive: (active) => active.activeTabId === app.appId,
       onOpen: () => ctx.openMiniApp(app.appId),
-      onOpenNewTab: () => ctx.openMiniApp(app.appId, { inNewTab: true }),
+      onOpenNewTab: () => ctx.openMiniApp(app.appId),
       contextMenuItems: [
         {
           type: 'item',
@@ -122,6 +122,25 @@ const miniAppVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { ty
       ]
     }
   }
+}
+
+/** A conversation tab carrying an entity-ownership tag (see `openConversationTab`). */
+export interface ConversationEntryTag {
+  type: 'agent' | 'assistant'
+  entityId: string
+}
+
+/**
+ * Whether a tab belongs to this entity — the single "is this entity's conversation
+ * open" signal shared by the active-state highlight and the click handler. A tab
+ * is tagged with its owning entity at open time (its URL is rewritten to
+ * sessionId/topicId by the route interceptor, so the URL cannot carry the entity
+ * id back). Route tabs opened from a conversation history (history link, search)
+ * have no tag and never highlight.
+ */
+export function isTabForConversationEntry(tab: unknown, entry: ConversationEntryTag): boolean {
+  const metadata = (tab as { metadata?: { conversationEntry?: ConversationEntryTag } } | null)?.metadata
+  return metadata?.conversationEntry?.type === entry.type && metadata.conversationEntry.entityId === entry.entityId
 }
 
 const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type: 'agent' }>> = {
@@ -142,9 +161,10 @@ const agentVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { type
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // Active-state highlight stays on the built-in agents app entry; this row
-      // only navigates the conversation the interceptor resolves.
-      isActive: () => false,
+      // A pinned entity highlights while any of its conversation tabs is open,
+      // matching the click behavior below (open tab → activate, none → create).
+      isActive: (active) =>
+        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'agent', entityId: agent.id })) ?? false,
       onOpen: () => ctx.openAgent(agent.id),
       onOpenNewTab: () => ctx.openAgent(agent.id, { inNewTab: true }),
       contextMenuItems: [
@@ -177,8 +197,10 @@ const assistantVariant: SidebarVariantDescriptor<Extract<SidebarFavoriteItem, { 
           ctx.defaultModelId,
           ENTITY_ICON_PIXEL_SIZE[iconSize]
         ),
-      // Active-state highlight stays on the built-in assistants app entry.
-      isActive: () => false,
+      // Same shared "is this entity open" signal as the agent variant.
+      isActive: (active) =>
+        active.tabs?.some((tab) => isTabForConversationEntry(tab, { type: 'assistant', entityId: assistant.id })) ??
+        false,
       onOpen: () => ctx.openAssistant(assistant.id),
       onOpenNewTab: () => ctx.openAssistant(assistant.id, { inNewTab: true }),
       contextMenuItems: [

--- a/src/renderer/hooks/tab/__tests__/useTabSelfVisuals.test.tsx
+++ b/src/renderer/hooks/tab/__tests__/useTabSelfVisuals.test.tsx
@@ -59,7 +59,81 @@ describe('useTabSelfVisuals', () => {
     await waitFor(() =>
       expect(mocks.updateTab).toHaveBeenCalledWith('tab-1', {
         title: 'Topic title',
-        icon: 'icon:spark'
+        icon: 'icon:spark',
+        metadata: { conversationEntry: undefined }
+      })
+    )
+  })
+
+  it('stamps the entity that owns the conversation the tab is showing', async () => {
+    mocks.tabs = [{ id: 'tab-1', type: 'route', url: '/app/chat?topicId=topic-1', title: 'Old title' }]
+
+    render(
+      <TabIdProvider tabId="tab-1">
+        <TabVisualsWriter title="Topic title" appId="assistants" entityId="assistant-1" />
+      </TabIdProvider>
+    )
+
+    await waitFor(() =>
+      expect(mocks.updateTab).toHaveBeenCalledWith('tab-1', {
+        title: 'Topic title',
+        icon: undefined,
+        metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
+      })
+    )
+  })
+
+  it('re-stamps the owner when the tab switches to another entity, even with identical visuals', async () => {
+    mocks.tabs = [
+      {
+        id: 'tab-1',
+        type: 'route',
+        url: '/app/chat?topicId=topic-2',
+        title: 'Shared title',
+        metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-1' } }
+      }
+    ]
+
+    render(
+      <TabIdProvider tabId="tab-1">
+        <TabVisualsWriter title="Shared title" appId="assistants" entityId="assistant-2" />
+      </TabIdProvider>
+    )
+
+    await waitFor(() =>
+      expect(mocks.updateTab).toHaveBeenCalledWith('tab-1', {
+        title: 'Shared title',
+        icon: undefined,
+        metadata: { conversationEntry: { type: 'assistant', entityId: 'assistant-2' } }
+      })
+    )
+  })
+
+  it('keeps unrelated metadata when re-stamping the owner', async () => {
+    mocks.tabs = [
+      {
+        id: 'tab-1',
+        type: 'route',
+        url: '/app/agents?sessionId=session-1',
+        title: 'Old title',
+        metadata: { somethingElse: 'keep me' }
+      }
+    ]
+
+    render(
+      <TabIdProvider tabId="tab-1">
+        <TabVisualsWriter title="Session title" appId="agents" entityId="agent-9" />
+      </TabIdProvider>
+    )
+
+    await waitFor(() =>
+      expect(mocks.updateTab).toHaveBeenCalledWith('tab-1', {
+        title: 'Session title',
+        icon: undefined,
+        metadata: {
+          somethingElse: 'keep me',
+          conversationEntry: { type: 'agent', entityId: 'agent-9' }
+        }
       })
     )
   })
@@ -107,20 +181,21 @@ describe('useTabSelfVisuals', () => {
     expect(mocks.updateTab).not.toHaveBeenCalled()
   })
 
-  it('skips the update when title and icon already match', async () => {
+  it('skips the update when title, icon and owner already match', async () => {
     mocks.tabs = [
       {
         id: 'tab-1',
         type: 'route',
         url: '/app/agents?sessionId=session-1',
         title: 'Session title',
-        icon: 'icon:spark'
+        icon: 'icon:spark',
+        metadata: { conversationEntry: { type: 'agent', entityId: 'agent-1' } }
       }
     ]
 
     render(
       <TabIdProvider tabId="tab-1">
-        <TabVisualsWriter title="Session title" emoji="spark" appId="agents" />
+        <TabVisualsWriter title="Session title" emoji="spark" appId="agents" entityId="agent-1" />
       </TabIdProvider>
     )
 

--- a/src/renderer/hooks/tab/useTabSelfVisuals.ts
+++ b/src/renderer/hooks/tab/useTabSelfVisuals.ts
@@ -1,7 +1,7 @@
 import type { ConversationAppId } from '@renderer/types/conversation'
 import { emojiTabIcon } from '@renderer/utils/tabIcons'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { useCurrentTabId } from './useCurrentTab'
 import { useOptionalTabsContext } from './useTabsContext'
@@ -13,11 +13,29 @@ export interface TabSelfVisuals {
   appId?: ConversationAppId
   /** Keep the tab's stored title/icon while the bound conversation is still loading. */
   preserveVisuals?: boolean
+  /**
+   * The assistant / agent this tab is currently showing. Stamped alongside the
+   * visuals so the sidebar can tell which of its pinned entities are open: the
+   * route rewrites `assistantId` / `agentId` to a topic / session id, so the URL
+   * alone cannot answer that. Re-stamped on every switch, because a tab that
+   * navigates to another entity no longer belongs to the one it was opened from.
+   */
+  entityId?: string
 }
 
 const TAB_APP_ROUTE_PREFIX: Record<ConversationAppId, string> = {
   assistants: '/app/chat',
   agents: '/app/agents'
+}
+
+const CONVERSATION_ENTRY_TYPE: Record<ConversationAppId, 'assistant' | 'agent'> = {
+  assistants: 'assistant',
+  agents: 'agent'
+}
+
+function sameConversationEntry(tab: Pick<Tab, 'metadata'>, entry: { type: string; entityId: string } | undefined) {
+  const stamped = tab.metadata?.conversationEntry as { type?: string; entityId?: string } | undefined
+  return stamped?.type === entry?.type && stamped?.entityId === entry?.entityId
 }
 
 function tabBelongsToApp(tab: Pick<Tab, 'url'>, appId: ConversationAppId): boolean {
@@ -26,25 +44,39 @@ function tabBelongsToApp(tab: Pick<Tab, 'url'>, appId: ConversationAppId): boole
 }
 
 /**
- * Sync this tab's own title / icon into the tab model. Presentation only — the
- * tab's conversation identity lives in its URL. The owning page passes its
- * derived visuals; everything tab-specific (emoji → icon descriptor mapping,
- * which tab id, change dedupe) stays here so the page never touches the tab
- * system or the `Tab` shape. No-op without a TabsProvider / TabIdProvider
- * (tests, detached popups).
+ * Sync this tab's own title / icon and owning entity into the tab model. The
+ * owning page passes its derived visuals; everything tab-specific (emoji → icon
+ * descriptor mapping, which tab id, change dedupe) stays here so the page never
+ * touches the tab system or the `Tab` shape. No-op without a TabsProvider /
+ * TabIdProvider (tests, detached popups).
  */
-export function useTabSelfVisuals({ title, emoji, appId, preserveVisuals = false }: TabSelfVisuals): void {
+export function useTabSelfVisuals({ title, emoji, appId, preserveVisuals = false, entityId }: TabSelfVisuals): void {
   const currentTabId = useCurrentTabId()
   const tabsContext = useOptionalTabsContext()
-  const updateTab = tabsContext?.updateTab
   const currentTab = tabsContext?.tabs.find((tab) => tab.id === currentTabId)
 
+  // The stored values this hook compares against, as primitives: depending on the
+  // tab object itself would re-run the effect for every unrelated field (LRU
+  // timestamps, dormancy) that the tab system writes.
+  const storedTitle = currentTab?.title
+  const storedIcon = currentTab?.icon
+  const storedUrl = currentTab?.url
+  const storedMetadata = currentTab?.metadata
+
+  // `updateTab` is rebuilt whenever the tab list changes, so holding it in a ref
+  // keeps every tab mutation in the window out of this effect's dependencies.
+  const updateTabRef = useRef(tabsContext?.updateTab)
+  updateTabRef.current = tabsContext?.updateTab
+
   useEffect(() => {
-    if (!currentTabId || !updateTab || !currentTab) return
+    const updateTab = updateTabRef.current
+    if (!currentTabId || !updateTab || storedUrl === undefined) return
     if (preserveVisuals) return
-    if (appId && !tabBelongsToApp(currentTab, appId)) return
+    if (appId && !tabBelongsToApp({ url: storedUrl }, appId)) return
     const icon = emojiTabIcon(emoji)
-    if (currentTab.title === title && currentTab.icon === icon) return
-    updateTab(currentTabId, { title, icon })
-  }, [currentTabId, currentTab, updateTab, title, emoji, appId, preserveVisuals])
+    const entry = appId && entityId ? { type: CONVERSATION_ENTRY_TYPE[appId], entityId } : undefined
+    const visualsUnchanged = storedTitle === title && storedIcon === icon
+    if (visualsUnchanged && sameConversationEntry({ metadata: storedMetadata }, entry)) return
+    updateTab(currentTabId, { title, icon, metadata: { ...storedMetadata, conversationEntry: entry } })
+  }, [currentTabId, storedTitle, storedIcon, storedUrl, storedMetadata, title, emoji, appId, preserveVisuals, entityId])
 }

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -1009,6 +1009,7 @@ const AgentPage = () => {
         title={visibleSession?.name?.trim() || visibleAgent?.name?.trim() || getDefaultRouteTitle('/app/agents')}
         emoji={visibleAgent?.configuration?.avatar}
         preserveVisuals={preserveTabVisuals}
+        entityId={visibleAgent?.id}
         activeSessionId={activeSession?.id}
         activeSessionSource={activeSessionSource}
         onToggleSidebar={toggleShellPane}

--- a/src/renderer/pages/agents/components/AgentTabRuntime.tsx
+++ b/src/renderer/pages/agents/components/AgentTabRuntime.tsx
@@ -8,6 +8,7 @@ type Props = {
   title: string
   emoji?: string | null
   preserveVisuals: boolean
+  entityId?: string
   activeSessionId?: string | null
   activeSessionSource: AgentSessionSource
   onToggleSidebar: () => void
@@ -17,6 +18,7 @@ export function AgentTabRuntime({
   title,
   emoji,
   preserveVisuals,
+  entityId,
   activeSessionId,
   activeSessionSource,
   onToggleSidebar
@@ -27,7 +29,8 @@ export function AgentTabRuntime({
     title,
     emoji,
     appId: 'agents',
-    preserveVisuals
+    preserveVisuals,
+    entityId
   })
 
   useCommandHandler('app.sidebar.toggle', onToggleSidebar, { enabled: isActiveTab })

--- a/src/renderer/pages/agents/components/__tests__/AgentTabRuntime.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/AgentTabRuntime.test.tsx
@@ -33,6 +33,7 @@ describe('AgentTabRuntime', () => {
         title="Session A"
         emoji="agent-avatar"
         preserveVisuals={false}
+        entityId="agent-a"
         activeSessionId="session-a"
         activeSessionSource="query"
         onToggleSidebar={onToggleSidebar}
@@ -43,7 +44,8 @@ describe('AgentTabRuntime', () => {
       title: 'Session A',
       emoji: 'agent-avatar',
       appId: 'agents',
-      preserveVisuals: false
+      preserveVisuals: false,
+      entityId: 'agent-a'
     })
     expect(runtimeMocks.useCommandHandler).toHaveBeenCalledWith('app.sidebar.toggle', onToggleSidebar, {
       enabled: true

--- a/src/renderer/pages/home/HomePage.tsx
+++ b/src/renderer/pages/home/HomePage.tsx
@@ -660,6 +660,7 @@ const HomePage: FC = () => {
           title={tabTitle}
           emoji={visibleAssistant?.emoji}
           preserveVisuals={preserveTabVisuals}
+          entityId={visibleAssistant?.id}
           activeTopicId={activeTopic?.id}
           activeTopicSource={activeTopicSource}
         />
@@ -775,6 +776,7 @@ const HomePage: FC = () => {
         title={tabTitle}
         emoji={visibleAssistant?.emoji}
         preserveVisuals={preserveTabVisuals}
+        entityId={visibleAssistant?.id}
         activeTopicId={activeTopic?.id}
         activeTopicSource={activeTopicSource}
       />

--- a/src/renderer/pages/home/components/HomeTabRuntime.tsx
+++ b/src/renderer/pages/home/components/HomeTabRuntime.tsx
@@ -7,18 +7,20 @@ type Props = {
   title: string
   emoji?: string | null
   preserveVisuals: boolean
+  entityId?: string
   activeTopicId?: string | null
   activeTopicSource: ActiveTopicSource
 }
 
-export function HomeTabRuntime({ title, emoji, preserveVisuals, activeTopicId, activeTopicSource }: Props) {
+export function HomeTabRuntime({ title, emoji, preserveVisuals, entityId, activeTopicId, activeTopicSource }: Props) {
   const isActiveTab = useIsActiveTab()
 
   useTabSelfVisuals({
     title,
     emoji,
     appId: 'assistants',
-    preserveVisuals
+    preserveVisuals,
+    entityId
   })
 
   useEffect(() => {

--- a/src/renderer/pages/home/components/__tests__/HomeTabRuntime.test.tsx
+++ b/src/renderer/pages/home/components/__tests__/HomeTabRuntime.test.tsx
@@ -28,6 +28,7 @@ describe('HomeTabRuntime', () => {
         title="Topic A"
         emoji="🍒"
         preserveVisuals={false}
+        entityId="assistant-a"
         activeTopicId="topic-a"
         activeTopicSource="query"
       />
@@ -37,7 +38,8 @@ describe('HomeTabRuntime', () => {
       title: 'Topic A',
       emoji: '🍒',
       appId: 'assistants',
-      preserveVisuals: false
+      preserveVisuals: false,
+      entityId: 'assistant-a'
     })
     expect(cacheService.setPersist).toHaveBeenCalledWith('ui.chat.last_used_topic_id', 'topic-a')
   })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

**Stacked on #19425.** GitHub cannot base a pull request on a branch that lives in another fork, so this one targets `main` and its diff includes #19425's commit as well. Please review #19425 first — only the three commits after it belong here:

- `refactor(sidebar): distinguish open tabs from the current one`
- `fix(sidebar): keep a tab's owning entity in step with what it shows`
- `style(sidebar): make the open and current states legible`

Once #19425 lands, a rebase leaves only those three.

`isActive` on a sidebar row answered two different questions at once: "is this entity open in some tab" (which decides whether a click activates or creates) and "is this the tab I am looking at" (which tells the user where they are). A single boolean cannot carry both, so a pinned mini app whose tab sat in the background looked exactly like one that was not open at all.

Before this PR:

- A mini app row highlighted only while its tab was in the foreground, even with several open
- A pinned agent / assistant row was tagged when its tab was opened and never again, so a tab that walked to another entity from its own conversation list still counted as the original one — the sidebar highlighted an entity the tab no longer showed, and clicking it activated a tab that had moved on

After this PR:

- `isActive` splits into `isOpen` and `isCurrent`; a row can be open, current, or neither
- The owning entity is stamped by the page that owns the tab, alongside the title and icon it already syncs there, so it always matches the conversation on screen
- An entity the tab has navigated away from is genuinely no longer open: the sidebar stops highlighting it, and clicking it opens it afresh
- Open rows carry an outline; the current row additionally carries a fill

Fixes #

### Why we need it and why it was done in this way

The stamping lives in `useTabSelfVisuals`, the hook a conversation page already uses to push its title and icon into the tab model. The page knows which assistant / agent it is showing; the hook already owns "which tab am I", route-ownership guarding and change dedupe. Adding the owner there kept the page free of the tab system and needed no new effect.

Contrast was retuned per theme rather than by a shared multiplier. Light theme leans on the outline, which reads well on white. Dark theme's accent is a near-fluorescent green, where a bright outline outweighed the fill and made merely-open rows louder than the current one, so there the fill carries the current row and the outline stays quiet.

The following tradeoffs were made:

- Tabs can accumulate: after walking a tab away from an entity, clicking that entity opens a new tab rather than pulling the old one back. That is the honest answer — the entity really is not open anywhere — but it does mean more tabs than a "remember where I came from" rule would produce.
- `ResolvedSidebarEntry` gains a second predicate, so every variant implements both. Built-in app rows have no per-instance identity to track and answer `isOpen` with `false`.

The following alternatives were considered:

- Keeping the open-time tag and never updating it: fewer tabs, but the highlight lies about what a tab is showing, which is the bug this PR fixes.
- Deriving the owner from the URL by looking up which entity a topic / session belongs to: accurate without any stored state, but it puts a data query behind every sidebar render.
- Dropping the open state and highlighting only the current tab: simplest, but then pinning an entity to the sidebar no longer tells you whether it is already running.

Links to places where the discussion took place:

### Screenshots

<!-- SCREENSHOTS -->
<img width="2034" height="1222" alt="image" src="https://github.com/user-attachments/assets/3cf97e2e-2408-46c3-88cb-98df5104069c" />


### Breaking changes

None for users. `SidebarActiveState` is renamed to `SidebarTabState` and `ResolvedSidebarEntry.isActive` becomes `isOpen` + `isCurrent`; both are internal to the sidebar and all call sites are updated here.

### Special notes for your reviewer

The two colour tokens were checked by eye in both themes. Their alpha values differ a lot between light and dark on purpose — matching the numbers across themes would have made dark unusable, since the same alpha reads very differently against a dark ground with a fluorescent accent.

Not to be confused with #19464, which relabels pinned tabs in the **top tab strip** (`layout/AppShellTabBar.tsx`) — no shared files with this PR. The two are complementary: that one makes a pinned tab's title visible, while the entity stamping here keeps a conversation tab's title and owner matching what it actually shows.

This touches the hook and page roots called out in #19140. `useTabSelfVisuals` already subscribed to the unsliced Tabs context from the Home / Agent page roots; this PR gives it one more reason to write — an entity switch now calls `updateTab` as well as a title change does — so it adds to the rerender pressure that issue describes rather than causing it.

What is fixed here is the hook's own dependency honesty: the effect used to depend on the whole tab object and on `updateTab`, whose identity changes with every tab mutation, so it re-ran for unrelated tabs and for fields it never reads. It now depends on the four stored values it actually compares and holds the writer in a ref. That removes the redundant effect runs, but not the page-root rerender — the subscription itself is still there, and moving these hooks into page-local runtime leaves is #19140's own scope, deliberately left out of this PR.

Relates to #18925, which covers ownership semantics for tab-scoped state more broadly.

`ActiveIndicator` still accepts a `glow` prop that nothing passes. It was dead before this PR and is left alone rather than removed as drive-by cleanup.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Pinned sidebar entries now show whether they are open in any tab, with the tab you are looking at marked more strongly. A pinned agent or assistant follows whatever conversation its tab actually shows, so the highlight no longer points at an entity you have navigated away from.
```
