### PR TITLE
build(release): standardize platform asset filenames

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -141,24 +141,24 @@ jobs:
           # Windows artifacts - based on actual file naming pattern
           if [ "${{ matrix.os }}" == "windows-2022" ]; then
             # Setup installer
-            find dist -name "*-x64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-x64-setup.exe \;
-            find dist -name "*-arm64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-arm64-setup.exe \;
+            find dist -name "*-win-x64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-win-x64-setup.exe \;
+            find dist -name "*-win-arm64-setup.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-win-arm64-setup.exe \;
 
             # Portable exe
-            find dist -name "*-x64-portable.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-x64-portable.exe \;
-            find dist -name "*-arm64-portable.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-arm64-portable.exe \;
+            find dist -name "*-win-x64-portable.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-win-x64-portable.exe \;
+            find dist -name "*-win-arm64-portable.exe" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-win-arm64-portable.exe \;
           fi
 
           # macOS artifacts
           if [ "${{ matrix.os }}" == "macos-latest" ]; then
-            find dist -name "*-arm64.dmg" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-arm64.dmg \;
-            find dist -name "*-x64.dmg" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-x64.dmg \;
+            find dist -name "*-mac-arm64.dmg" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-mac-arm64.dmg \;
+            find dist -name "*-mac-x64.dmg" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-mac-x64.dmg \;
           fi
 
           # Linux artifacts
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            find dist -name "*-x86_64.AppImage" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-x86_64.AppImage \;
-            find dist -name "*-arm64.AppImage" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-arm64.AppImage \;
+            find dist -name "*-linux-x64.AppImage" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-linux-x64.AppImage \;
+            find dist -name "*-linux-arm64.AppImage" -exec cp {} renamed-artifacts/cherry-studio-nightly-${DATE}-linux-arm64.AppImage \;
           fi
 
           # Copy update files

--- a/scripts/__tests__/artifact-build-completed.test.ts
+++ b/scripts/__tests__/artifact-build-completed.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import artifactBuildCompleted, { normalizeArtifactFilePath } from '../artifact-build-completed'
+
+const PRODUCT_NAME = 'Cherry Studio'
+const VERSION = '2.0.9'
+
+const temporaryDirectories: string[] = []
+
+function temporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cherry-artifact-name-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('normalizeArtifactFilePath', () => {
+  it.each([
+    ['windows', 'Cherry Studio-2.0.9-x64-setup.exe', 'Cherry-Studio-2.0.9-win-x64-setup.exe'],
+    ['windows', 'Cherry Studio-2.0.9-arm64-portable.exe', 'Cherry-Studio-2.0.9-win-arm64-portable.exe'],
+    ['mac', 'Cherry Studio-2.0.9-x64.dmg', 'Cherry-Studio-2.0.9-mac-x64.dmg'],
+    ['mac', 'Cherry Studio-2.0.9-arm64.zip.blockmap', 'Cherry-Studio-2.0.9-mac-arm64.zip.blockmap'],
+    ['linux', 'Cherry Studio-2.0.9-x86_64.AppImage', 'Cherry-Studio-2.0.9-linux-x64.AppImage'],
+    ['linux', 'Cherry Studio-2.0.9-amd64.deb', 'Cherry-Studio-2.0.9-linux-x64.deb'],
+    ['linux', 'Cherry Studio-2.0.9-aarch64.rpm', 'Cherry-Studio-2.0.9-linux-arm64.rpm']
+  ])('normalizes the %s release asset %s', (platform, source, expected) => {
+    expect(normalizeArtifactFilePath(path.join('dist', source), PRODUCT_NAME, VERSION, platform)).toBe(
+      path.join('dist', expected)
+    )
+  })
+
+  it('is idempotent for an already normalized asset', () => {
+    const file = path.join('dist', 'Cherry-Studio-2.0.9-linux-x64.AppImage')
+    expect(normalizeArtifactFilePath(file, PRODUCT_NAME, VERSION, 'linux')).toBe(file)
+  })
+
+  it.each(['latest.yml', 'latest-linux.yml', 'release-history.json', 'other-product-2.0.9-x64.zip'])(
+    'does not add a platform prefix to %s',
+    (fileName) => {
+      const file = path.join('dist', fileName)
+      expect(normalizeArtifactFilePath(file, PRODUCT_NAME, VERSION, 'linux')).toBe(file)
+    }
+  )
+})
+
+describe('artifactBuildCompleted', () => {
+  it('renames the file and exposes its final path to later publisher hooks', () => {
+    const directory = temporaryDirectory()
+    const source = path.join(directory, 'Cherry Studio-2.0.9-x86_64.AppImage')
+    const expected = path.join(directory, 'Cherry-Studio-2.0.9-linux-x64.AppImage')
+    fs.writeFileSync(source, 'artifact')
+    const buildResult = {
+      file: source,
+      safeArtifactName: 'Cherry-Studio-2.0.9-x86_64.AppImage',
+      packager: {
+        appInfo: { productName: PRODUCT_NAME, version: VERSION },
+        platform: { name: 'linux' }
+      }
+    }
+
+    artifactBuildCompleted(buildResult)
+
+    expect(buildResult.file).toBe(expected)
+    expect(buildResult.safeArtifactName).toBe('Cherry-Studio-2.0.9-linux-x64.AppImage')
+    expect(fs.existsSync(source)).toBe(false)
+    expect(fs.readFileSync(expected, 'utf8')).toBe('artifact')
+  })
+})

--- a/scripts/artifact-build-completed.js
+++ b/scripts/artifact-build-completed.js
@@ -1,18 +1,68 @@
 const fs = require('fs')
+const path = require('path')
 
-exports.default = function (buildResult) {
+const PLATFORM_PREFIXES = {
+  linux: 'linux',
+  mac: 'mac',
+  windows: 'win'
+}
+
+const ARCH_ALIASES = {
+  aarch64: 'arm64',
+  amd64: 'x64',
+  arm64: 'arm64',
+  x64: 'x64',
+  x86_64: 'x64'
+}
+
+function normalizeArtifactFilePath(file, productName, version, platform) {
+  const normalizedFileName = path.basename(file).replace(/ /g, '-')
+  const normalizedProductName = productName.replace(/ /g, '-')
+  const productVersionPrefix = `${normalizedProductName}-${version}-`
+  const platformPrefix = PLATFORM_PREFIXES[platform]
+
+  // Update manifests and unrelated files must keep their stable names. Only
+  // electron-builder artifacts carrying this app's product + version prefix
+  // participate in the public release-asset naming contract.
+  if (!platformPrefix || !normalizedFileName.startsWith(productVersionPrefix)) {
+    return path.join(path.dirname(file), normalizedFileName)
+  }
+
+  let artifactSuffix = normalizedFileName.slice(productVersionPrefix.length)
+  artifactSuffix = artifactSuffix.replace(/^(?:win|windows|mac|linux)-/, '')
+
+  const archMatch = /^(aarch64|amd64|arm64|x64|x86_64)(?=[.-])/.exec(artifactSuffix)
+  if (archMatch) {
+    artifactSuffix = `${ARCH_ALIASES[archMatch[1]]}${artifactSuffix.slice(archMatch[1].length)}`
+  }
+
+  return path.join(path.dirname(file), `${productVersionPrefix}${platformPrefix}-${artifactSuffix}`)
+}
+
+function artifactBuildCompleted(buildResult) {
   try {
-    console.log('[artifact build completed] rename artifact file...')
-    if (!buildResult.file.includes(' ')) {
-      return
-    }
+    const oldFilePath = buildResult.file
+    const newFilePath = normalizeArtifactFilePath(
+      oldFilePath,
+      buildResult.packager.appInfo.productName,
+      buildResult.packager.appInfo.version,
+      buildResult.packager.platform.name
+    )
 
-    let oldFilePath = buildResult.file
-    const newfilePath = oldFilePath.replace(/ /g, '-')
-    fs.renameSync(oldFilePath, newfilePath)
-    buildResult.file = newfilePath
-    console.log(`[artifact build completed] rename file ${oldFilePath} to ${newfilePath} `)
+    if (oldFilePath === newFilePath) return
+
+    fs.renameSync(oldFilePath, newFilePath)
+    buildResult.file = newFilePath
+    if (buildResult.safeArtifactName != null) {
+      buildResult.safeArtifactName = path.basename(newFilePath)
+    }
+    console.log(`[artifact build completed] renamed ${oldFilePath} to ${newFilePath}`)
   } catch (error) {
     console.error('Error renaming file:', error)
   }
 }
+
+exports.ARCH_ALIASES = ARCH_ALIASES
+exports.PLATFORM_PREFIXES = PLATFORM_PREFIXES
+exports.normalizeArtifactFilePath = normalizeArtifactFilePath
+exports.default = artifactBuildCompleted


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Published installer filenames used target-specific flat names that made operating systems and architecture aliases difficult to identify consistently.

After this PR:

Packaged assets receive stable `win`, `mac`, or `linux` prefixes, Linux architecture aliases are normalized, and nightly artifact matching follows the new names. Update metadata filenames remain unchanged.

Fixes #17961

### Why we need it and why it was done in this way

Filename normalization runs in the existing artifact-completion hook, before publish metadata is finalized, so electron-builder and nightly publishing share one naming contract.

The following tradeoffs were made:

Only packaged assets are renamed. `latest*.yml` update-channel files keep their existing names to avoid breaking updater discovery.

The following alternatives were considered:

Renaming files only in the release workflow was considered, but it would leave electron-builder metadata pointing at stale filenames and duplicate naming logic across workflows.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/17961

### Breaking changes

Release asset filenames change to include a platform prefix. Auto-update metadata names and update-channel discovery are unchanged.

### Special notes for your reviewer

Verified with 13 focused artifact tests covering platform prefixes, architecture aliases, sidecars, idempotence, update metadata, and unrelated files. `pnpm test:lint` and `pnpm format:check` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Prefix release asset filenames with their target platform and normalize architecture names for easier identification.
```
