### PR TITLE
fix(moonshot): omit fixed top_p for Kimi models

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -17648,6 +17648,16 @@
       "providerId": "modelscope"
     },
     {
+      "apiModelId": "kimi-k2.5",
+      "modelId": "kimi-k2-5",
+      "parameterSupport": {
+        "topP": {
+          "supported": false
+        }
+      },
+      "providerId": "moonshot"
+    },
+    {
       "apiModelId": "kimi-k2.6",
       "modelId": "kimi-k2-6",
       "providerId": "moonshot",
@@ -17694,6 +17704,11 @@
     },
     {
       "modelId": "kimi-k3",
+      "parameterSupport": {
+        "topP": {
+          "supported": false
+        }
+      },
       "providerId": "moonshot",
       "reasoningContracts": {
         "openai-chat-completions": {

--- a/packages/provider-registry/src/__tests__/catalog-source-sync.test.ts
+++ b/packages/provider-registry/src/__tests__/catalog-source-sync.test.ts
@@ -119,14 +119,19 @@ describe('catalog ↔ source sync (regenerate guard)', () => {
         if (!raw.modelId) continue
         // Generation splits an authored served-id into canonical key + apiModelId; mirror it here.
         const ov = splitOverrideWireId(raw)
-        if (p.modelsDevProvider && !ov.apiModelId && (ov.reasoningContracts || ov.requestControls)) {
+        if (
+          p.modelsDevProvider &&
+          !ov.apiModelId &&
+          (ov.reasoningContracts || ov.requestControls || ov.parameterSupport)
+        ) {
           const rows = overrides.filter((row) => row.providerId === p.id && row.modelId === ov.modelId)
           if (rows.length === 0) problems.push(`missing ${p.id}/${ov.modelId}/model-template`)
           else if (
             rows.some(
               (row) =>
                 stable(row.reasoningContracts) !== stable(ov.reasoningContracts) ||
-                stable(row.requestControls) !== stable(ov.requestControls)
+                stable(row.requestControls) !== stable(ov.requestControls) ||
+                stable(row.parameterSupport) !== stable(ov.parameterSupport)
             )
           ) {
             problems.push(`stale ${p.id}/${ov.modelId}/model-template`)

--- a/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { splitOverrideWireId } from '../../scripts/canonicalize'
+import { PROVIDERS } from '../providers'
+
+const provider = (providerId: string) => {
+  const result = PROVIDERS.find(({ id }) => id === providerId)
+  if (!result) throw new Error(`Missing provider: ${providerId}`)
+  return result
+}
+
+const overrideOf = (providerId: string, modelId: string) => {
+  const override = provider(providerId)
+    .overrides?.map((entry) => splitOverrideWireId(entry))
+    .find((entry) => entry.modelId === modelId)
+  if (!override) throw new Error(`Missing override: ${providerId}/${modelId}`)
+  return override
+}
+
+describe('moonshot parameter support', () => {
+  it.each(['kimi-k2-5', 'kimi-k3'])('omits the fixed top_p parameter for %s', (modelId) => {
+    expect(overrideOf('moonshot', modelId).parameterSupport?.topP).toEqual({ supported: false })
+  })
+})

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -3,6 +3,8 @@ import { EFFORT, modeWire } from './wires'
 
 const effortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
 
+const fixedTopPParameterSupport = { topP: { supported: false } } as const
+
 export default openaiCompatible({
   id: 'moonshot',
   name: 'Moonshot AI',
@@ -32,10 +34,16 @@ export default openaiCompatible({
     models: 'https://platform.moonshot.cn/docs/',
     official: 'https://www.moonshot.cn/'
   },
-  overrides: ['kimi-k2.6', 'kimi-k3'].map((modelId) => ({
-    modelId,
-    reasoningContracts: {
-      'openai-chat-completions': { wire: effortWire }
-    }
-  }))
+  overrides: [
+    // Moonshot fixes top_p at 0.95 for these models. Omitting the non-configurable
+    // parameter uses that server default; sending Cherry's default of 1 is rejected.
+    { modelId: 'kimi-k2.5', parameterSupport: fixedTopPParameterSupport },
+    ...['kimi-k2.6', 'kimi-k3'].map((modelId) => ({
+      modelId,
+      ...(modelId === 'kimi-k3' ? { parameterSupport: fixedTopPParameterSupport } : {}),
+      reasoningContracts: {
+        'openai-chat-completions': { wire: effortWire }
+      }
+    }))
+  ]
 })

--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -93,6 +93,22 @@ describe('getTopP', () => {
     expect(getTopP(a, makeModel(), OMIT_REASONING)).toBe(0.9)
   })
 
+  it('omits topP when the resolved provider-model marks it unsupported', () => {
+    const a = makeAssistant({ enableTopP: true, topP: 1 })
+    const model = makeModel({
+      id: 'moonshot::kimi-k3',
+      providerId: 'moonshot',
+      parameterSupport: {
+        topP: { supported: false, min: 0, max: 1 },
+        maxTokens: true,
+        stopSequences: true,
+        systemMessage: true
+      }
+    })
+
+    expect(getTopP(a, model, OMIT_REASONING)).toBeUndefined()
+  })
+
   it('clamps topP to [0.95, 1] from the resolved request reasoning', () => {
     // `enableTemperature: false` — Claude 4.5 has mutually-exclusive
     // temperature/topP (`isTemperatureTopPMutuallyExclusiveModel`); leaving


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The official Moonshot provider could send the assistant default `top_p=1` to Kimi K2.5 and K3 models, which reject that fixed value with HTTP 400.

After this PR:

Moonshot's Kimi K2.5 and K3 catalog entries mark `topP` unsupported so the request builder omits it and lets the official API use its accepted server default.

Fixes #12691

### Why we need it and why it was done in this way

The constraint is expressed in provider-scoped capability metadata and flows through the existing parameter-support path instead of adding request-time model-name conditionals.

The following tradeoffs were made:

The change applies only to the official `moonshot` provider. Other providers serving the same model families keep their own parameter behavior.

The following alternatives were considered:

Forcing `top_p=0.95` was rejected because the API already owns the supported default and a hardcoded client value could become stale.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/12691

### Breaking changes

None.

### Special notes for your reviewer

Verified with 30 focused provider-registry and request-parameter tests covering normalized K2.5 IDs, K3, provider scoping, catalog generation, and final omission. `pnpm typecheck`, `pnpm test:lint`, and `pnpm format:check` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix HTTP 400 errors from the official Moonshot API by omitting unsupported `top_p` values for Kimi K2.5 and K3 models.
```
