### PR TITLE
fix(provider): show newly added providers first

### DIFF
--- a/src/main/data/services/ProviderService.ts
+++ b/src/main/data/services/ProviderService.ts
@@ -394,7 +394,8 @@ class ProviderService {
             isEnabled: false
           }
           return insertWithOrderKey(tx, userProviderTable, values, {
-            pkColumn: userProviderTable.providerId
+            pkColumn: userProviderTable.providerId,
+            position: 'first'
           }) as UserProviderRow
         }),
       {

--- a/src/main/data/services/__tests__/ProviderService.reorder.test.ts
+++ b/src/main/data/services/__tests__/ProviderService.reorder.test.ts
@@ -28,7 +28,7 @@ describe('ProviderService reorder', () => {
     return rows.map((row) => row.providerId)
   }
 
-  it('creates new providers at the end of the list', async () => {
+  it('creates new providers at the beginning without changing existing order', async () => {
     await seedProviders()
 
     const created = providerService.create({ providerId: 'grok', name: 'Grok' })
@@ -39,7 +39,7 @@ describe('ProviderService reorder', () => {
     // New providers are created disabled; the auto-enable flow turns them on once models exist.
     expect(created.isEnabled).toBe(false)
     expect(rows[0]?.isEnabled).toBe(false)
-    expect(await readOrder()).toEqual(['openai', 'anthropic', 'gemini', 'grok'])
+    expect(await readOrder()).toEqual(['grok', 'openai', 'anthropic', 'gemini'])
   })
 
   it('batchUpsert appends only missing providers in input order', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

New API providers were appended to the provider list, so users had to scroll to find the provider they had just created.

After this PR:

New providers are inserted at the first ordered position while the relative order of existing providers and explicit reorder behavior remain unchanged.

Fixes #19387

### Why we need it and why it was done in this way

The creation path now selects the shared ordered-insert helper's first position at the ProviderService boundary, matching the list's order-key semantics.

The following tradeoffs were made:

Only newly created providers move to the front. Batch insertion and user-initiated reordering retain their existing behavior.

The following alternatives were considered:

Reversing the provider query was rejected because it would also reverse existing user-defined order and conflict with explicit reorder operations.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19387

### Breaking changes

None.

### Special notes for your reviewer

Verified with 14 file-backed database tests covering creation, batch insertion, enable transitions, moves, failures, and managed-provider constraints. `pnpm typecheck:node`, `pnpm test:lint`, and `pnpm format:check` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Show newly added API providers at the top of the provider list.
```
