### PR TITLE
fix(nutstore): clean up abandoned SSO listeners

### DIFF
--- a/src/renderer/hooks/__tests__/useNutstoreSso.test.tsx
+++ b/src/renderer/hooks/__tests__/useNutstoreSso.test.tsx
@@ -77,16 +77,20 @@ describe('useNutstoreSso', () => {
   it('replaces the previous attempt instead of accumulating listeners', async () => {
     const { result } = renderHook(() => useNutstoreSso())
     const first = result.current()
+    let firstSettled = false
+    void first.then(() => {
+      firstSettled = true
+    })
     const second = result.current()
 
     expect(mocks.activeListeners.size).toBe(1)
-    await expect(first).resolves.toBeNull()
 
     act(() => {
       emitProtocolData('cherrystudio://?s=second-token')
     })
 
     await expect(second).resolves.toBe('second-token')
+    expect(firstSettled).toBe(false)
     expect(mocks.activeListeners.size).toBe(0)
   })
 
@@ -113,13 +117,18 @@ describe('useNutstoreSso', () => {
     expect(mocks.logger.error).toHaveBeenCalledWith('Failed to listen for Nutstore SSO callback', subscriptionError)
   })
 
-  it('settles and removes the active attempt when the owner unmounts', async () => {
+  it('removes the active attempt when the owner unmounts without settling it', async () => {
     const { result, unmount } = renderHook(() => useNutstoreSso())
     const pending = result.current()
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
 
     unmount()
 
-    await expect(pending).resolves.toBeNull()
+    await Promise.resolve()
+    expect(settled).toBe(false)
     expect(mocks.activeListeners.size).toBe(0)
   })
 })

--- a/src/renderer/hooks/__tests__/useNutstoreSso.test.tsx
+++ b/src/renderer/hooks/__tests__/useNutstoreSso.test.tsx
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type ProtocolData = { url: string }
+type ProtocolListener = (data: ProtocolData) => void
+
+const mocks = vi.hoisted(() => ({
+  activeListeners: new Set<ProtocolListener>(),
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn()
+  },
+  on: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: {
+    withContext: () => mocks.logger
+  }
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: {
+    on: mocks.on
+  }
+}))
+
+import { useNutstoreSso } from '../useNutstoreSso'
+
+function emitProtocolData(url: string) {
+  for (const listener of [...mocks.activeListeners]) {
+    listener({ url })
+  }
+}
+
+describe('useNutstoreSso', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.activeListeners.clear()
+    mocks.logger.error.mockReset()
+    mocks.logger.warn.mockReset()
+    mocks.on.mockReset()
+    mocks.on.mockImplementation((_event: string, listener: ProtocolListener) => {
+      mocks.activeListeners.add(listener)
+      return vi.fn(() => mocks.activeListeners.delete(listener))
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('accepts only a token-bearing Cherry Studio callback and cleans up after success', async () => {
+    const { result } = renderHook(() => useNutstoreSso())
+    const pending = result.current()
+
+    act(() => {
+      emitProtocolData('not a url')
+      emitProtocolData('https://example.com/callback?s=wrong-scheme')
+      emitProtocolData('cherrystudio://navigate/settings')
+      emitProtocolData('cherrystudio://unknown/callback?s=forged-token')
+    })
+
+    expect(mocks.activeListeners.size).toBe(1)
+
+    act(() => {
+      emitProtocolData('cherrystudio://?s=encrypted-token')
+    })
+
+    await expect(pending).resolves.toBe('encrypted-token')
+    expect(mocks.activeListeners.size).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
+    expect(mocks.logger.warn).not.toHaveBeenCalledWith('Nutstore SSO timed out')
+  })
+
+  it('replaces the previous attempt instead of accumulating listeners', async () => {
+    const { result } = renderHook(() => useNutstoreSso())
+    const first = result.current()
+    const second = result.current()
+
+    expect(mocks.activeListeners.size).toBe(1)
+    await expect(first).resolves.toBeNull()
+
+    act(() => {
+      emitProtocolData('cherrystudio://?s=second-token')
+    })
+
+    await expect(second).resolves.toBe('second-token')
+    expect(mocks.activeListeners.size).toBe(0)
+  })
+
+  it('settles and removes an abandoned attempt after the bounded timeout', async () => {
+    const { result } = renderHook(() => useNutstoreSso())
+    const pending = result.current()
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+    await expect(pending).resolves.toBeNull()
+    expect(mocks.activeListeners.size).toBe(0)
+    expect(mocks.logger.warn).toHaveBeenCalledWith('Nutstore SSO timed out')
+  })
+
+  it('settles cleanly when the protocol subscription cannot be installed', async () => {
+    const subscriptionError = new Error('subscription failed')
+    mocks.on.mockImplementationOnce(() => {
+      throw subscriptionError
+    })
+    const { result } = renderHook(() => useNutstoreSso())
+
+    await expect(result.current()).resolves.toBeNull()
+    expect(mocks.activeListeners.size).toBe(0)
+    expect(mocks.logger.error).toHaveBeenCalledWith('Failed to listen for Nutstore SSO callback', subscriptionError)
+  })
+
+  it('settles and removes the active attempt when the owner unmounts', async () => {
+    const { result, unmount } = renderHook(() => useNutstoreSso())
+    const pending = result.current()
+
+    unmount()
+
+    await expect(pending).resolves.toBeNull()
+    expect(mocks.activeListeners.size).toBe(0)
+  })
+})

--- a/src/renderer/hooks/useNutstoreSso.ts
+++ b/src/renderer/hooks/useNutstoreSso.ts
@@ -22,17 +22,26 @@ export function useNutstoreSso() {
       const resources: { removeListener?: () => void; timeoutId?: number } = {}
       let settled = false
 
-      const finish = (encryptedToken: string | null) => {
-        if (settled) return
+      const release = () => {
         settled = true
         resources.removeListener?.()
         if (resources.timeoutId !== undefined) window.clearTimeout(resources.timeoutId)
         if (cancelPendingAttemptRef.current === cancel) {
           cancelPendingAttemptRef.current = null
         }
+      }
+
+      const finish = (encryptedToken: string | null) => {
+        if (settled) return
+        release()
         resolve(encryptedToken)
       }
-      const cancel = () => finish(null)
+
+      // 取消（被新尝试替换、组件卸载）不结算：调用方不该为一次主动放弃的尝试报错
+      const cancel = () => {
+        if (settled) return
+        release()
+      }
       cancelPendingAttemptRef.current = cancel
 
       const onProtocolData = (data: { url: string }) => {

--- a/src/renderer/hooks/useNutstoreSso.ts
+++ b/src/renderer/hooks/useNutstoreSso.ts
@@ -1,26 +1,71 @@
 import { loggerService } from '@logger'
 import { ipcApi } from '@renderer/ipc'
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 
 const logger = loggerService.withContext('useNutstoreSso')
+const NUTSTORE_SSO_TIMEOUT_MS = 5 * 60 * 1000
 
 export function useNutstoreSso() {
+  const cancelPendingAttemptRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    return () => {
+      cancelPendingAttemptRef.current?.()
+      cancelPendingAttemptRef.current = null
+    }
+  }, [])
+
   const nutstoreSsoHandler = useCallback(() => {
-    return new Promise<string>((resolve, reject) => {
-      const removeListener = ipcApi.on('navigation.protocol_data', async (data) => {
-        try {
-          const url = new URL(data.url)
-          const params = new URLSearchParams(url.search)
-          const encryptedToken = params.get('s')
-          if (!encryptedToken) return reject(null)
-          resolve(encryptedToken)
-        } catch (error) {
-          logger.error('解析URL失败:', error as Error)
-          reject(null)
-        } finally {
-          removeListener()
+    cancelPendingAttemptRef.current?.()
+
+    return new Promise<string | null>((resolve) => {
+      const resources: { removeListener?: () => void; timeoutId?: number } = {}
+      let settled = false
+
+      const finish = (encryptedToken: string | null) => {
+        if (settled) return
+        settled = true
+        resources.removeListener?.()
+        if (resources.timeoutId !== undefined) window.clearTimeout(resources.timeoutId)
+        if (cancelPendingAttemptRef.current === cancel) {
+          cancelPendingAttemptRef.current = null
         }
-      })
+        resolve(encryptedToken)
+      }
+      const cancel = () => finish(null)
+      cancelPendingAttemptRef.current = cancel
+
+      const onProtocolData = (data: { url: string }) => {
+        let url: URL
+        try {
+          url = new URL(data.url)
+        } catch (error) {
+          logger.warn('Ignored malformed protocol URL during Nutstore SSO', error as Error)
+          return
+        }
+
+        const encryptedToken = url.searchParams.get('s')
+        const isSchemeRoot = url.hostname === '' && (url.pathname === '' || url.pathname === '/')
+        if (url.protocol !== 'cherrystudio:' || !isSchemeRoot || !encryptedToken) return
+        finish(encryptedToken)
+      }
+
+      try {
+        const unsubscribe = ipcApi.on('navigation.protocol_data', onProtocolData)
+        resources.removeListener = unsubscribe
+        if (settled) unsubscribe()
+      } catch (error) {
+        logger.error('Failed to listen for Nutstore SSO callback', error as Error)
+        finish(null)
+        return
+      }
+
+      const timer = window.setTimeout(() => {
+        logger.warn('Nutstore SSO timed out')
+        finish(null)
+      }, NUTSTORE_SSO_TIMEOUT_MS)
+      resources.timeoutId = timer
+      if (settled) window.clearTimeout(timer)
     })
   }, [])
 

--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Mit Nutstore verbunden",
   "settings.data.nutstore.isLogin": "Angemeldet",
   "settings.data.nutstore.login.button": "Anmelden",
+  "settings.data.nutstore.login.failed": "Die Nutstore-Anmeldung wurde nicht abgeschlossen. Bitte versuche es erneut.",
   "settings.data.nutstore.logout.button": "Abmelden",
   "settings.data.nutstore.logout.content": "Nach Abmeldung kein Backup zu/von Nutstore möglich",
   "settings.data.nutstore.logout.title": "Wirklich von Nutstore abmelden?",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Συνδεδεμένο στο Jotunn Cloud",
   "settings.data.nutstore.isLogin": "Συνδεδεμένος",
   "settings.data.nutstore.login.button": "Σύνδεση",
+  "settings.data.nutstore.login.failed": "Η σύνδεση στο Nutstore δεν ολοκληρώθηκε. Δοκιμάστε ξανά.",
   "settings.data.nutstore.logout.button": "Αποσύνδεση",
   "settings.data.nutstore.logout.content": "Μετά την αποσύνδεση δεν θα μπορείτε να κάνετε αντίγραφο ασφαλείας ή να ανακτήσετε δεδομένα από το Jotunn Cloud",
   "settings.data.nutstore.logout.title": "Επιβεβαίωση αποσύνδεσης από το Jotunn Cloud;",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Connected to Nutstore",
   "settings.data.nutstore.isLogin": "Logged in",
   "settings.data.nutstore.login.button": "Login",
+  "settings.data.nutstore.login.failed": "Nutstore login did not complete. Please try again.",
   "settings.data.nutstore.logout.button": "Logout",
   "settings.data.nutstore.logout.content": "After logout, you will not be able to backup to Nutstore or restore from Nutstore.",
   "settings.data.nutstore.logout.title": "Are you sure you want to logout from Nutstore?",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Conexión con Nutstore establecida",
   "settings.data.nutstore.isLogin": "Iniciado sesión",
   "settings.data.nutstore.login.button": "Iniciar Sesión",
+  "settings.data.nutstore.login.failed": "El inicio de sesión en Nutstore no se completó. Inténtalo de nuevo.",
   "settings.data.nutstore.logout.button": "Cerrar Sesión",
   "settings.data.nutstore.logout.content": "Después de cerrar sesión no podrás hacer copias de seguridad ni restaurar desde Nutstore",
   "settings.data.nutstore.logout.title": "¿Seguro que quieres cerrar la sesión de Nutstore?",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Connecté à Nutstore",
   "settings.data.nutstore.isLogin": "Connecté",
   "settings.data.nutstore.login.button": "Se connecter",
+  "settings.data.nutstore.login.failed": "La connexion à Nutstore n'a pas abouti. Veuillez réessayer.",
   "settings.data.nutstore.logout.button": "Se déconnecter",
   "settings.data.nutstore.logout.content": "Après la déconnexion, il ne sera plus possible de sauvegarder vers Nutstore ni de restaurer depuis Nutstore.",
   "settings.data.nutstore.logout.title": "Êtes-vous sûr de vouloir vous déconnecter de Nutstore ?",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Nutstoreに接続しました",
   "settings.data.nutstore.isLogin": "ログイン済み",
   "settings.data.nutstore.login.button": "ログイン",
+  "settings.data.nutstore.login.failed": "Nutstoreへのログインが完了しませんでした。もう一度お試しください。",
   "settings.data.nutstore.logout.button": "ログアウト",
   "settings.data.nutstore.logout.content": "ログアウト後、Nutstoreへのバックアップや復元ができなくなります。",
   "settings.data.nutstore.logout.title": "Nutstoreからログアウトしますか？",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Conectado ao Nutstore",
   "settings.data.nutstore.isLogin": "Logado",
   "settings.data.nutstore.login.button": "Entrar",
+  "settings.data.nutstore.login.failed": "O início de sessão no Nutstore não foi concluído. Tente novamente.",
   "settings.data.nutstore.logout.button": "Sair",
   "settings.data.nutstore.logout.content": "Após sair, não será possível fazer backup ou restaurar dados do Nutstore",
   "settings.data.nutstore.logout.title": "Tem a certeza de que pretende sair da conta do Nutstore?",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Conectat la Nutstore",
   "settings.data.nutstore.isLogin": "Conectat",
   "settings.data.nutstore.login.button": "Conectare",
+  "settings.data.nutstore.login.failed": "Autentificarea Nutstore nu a fost finalizată. Încercați din nou.",
   "settings.data.nutstore.logout.button": "Deconectare",
   "settings.data.nutstore.logout.content": "După deconectare, nu vei mai putea face backup în Nutstore sau restaura din Nutstore.",
   "settings.data.nutstore.logout.title": "Ești sigur că vrei să te deconectezi de la Nutstore?",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Подключение к Nutstore установлено",
   "settings.data.nutstore.isLogin": "Выполнен вход",
   "settings.data.nutstore.login.button": "Войти",
+  "settings.data.nutstore.login.failed": "Вход в Nutstore не завершён. Попробуйте ещё раз.",
   "settings.data.nutstore.logout.button": "Выйти",
   "settings.data.nutstore.logout.content": "После выхода вы не сможете создавать резервные копии в Nutstore или восстанавливать данные из Nutstore.",
   "settings.data.nutstore.logout.title": "Вы уверены, что хотите выйти из Nutstore?",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "Đã kết nối với Nutstore",
   "settings.data.nutstore.isLogin": "Đã đăng nhập",
   "settings.data.nutstore.login.button": "Đăng nhập",
+  "settings.data.nutstore.login.failed": "Đăng nhập Nutstore chưa hoàn tất. Vui lòng thử lại.",
   "settings.data.nutstore.logout.button": "Đăng xuất",
   "settings.data.nutstore.logout.content": "Sau khi đăng xuất, bạn sẽ không thể sao lưu lên Nutstore hoặc khôi phục từ Nutstore.",
   "settings.data.nutstore.logout.title": "Bạn có chắc chắn muốn đăng xuất khỏi Nutstore không?",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "已连接坚果云",
   "settings.data.nutstore.isLogin": "已登录",
   "settings.data.nutstore.login.button": "登录",
+  "settings.data.nutstore.login.failed": "坚果云登录未完成，请重试。",
   "settings.data.nutstore.logout.button": "退出登录",
   "settings.data.nutstore.logout.content": "退出后将无法备份至坚果云和从坚果云恢复",
   "settings.data.nutstore.logout.title": "确定要退出坚果云登录？",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -3440,6 +3440,7 @@
   "settings.data.nutstore.checkConnection.success": "已連線至堅果雲",
   "settings.data.nutstore.isLogin": "已登入",
   "settings.data.nutstore.login.button": "登入",
+  "settings.data.nutstore.login.failed": "堅果雲登入未完成，請重試。",
   "settings.data.nutstore.logout.button": "登出",
   "settings.data.nutstore.logout.content": "登出後將無法備份到堅果雲或從堅果雲還原。",
   "settings.data.nutstore.logout.title": "確定要登出堅果雲嗎？",

--- a/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -64,10 +64,13 @@ const NutstoreSettings: FC = () => {
     window.open(ssoUrl, '_blank')
     const nutstoreToken = await nutstoreSsoHandler()
 
-    if (nutstoreToken) {
-      void setNutstoreToken(nutstoreToken)
+    if (!nutstoreToken) {
+      toast.error(t('settings.data.nutstore.login.failed'))
+      return
     }
-  }, [nutstoreSsoHandler, setNutstoreToken])
+
+    void setNutstoreToken(nutstoreToken)
+  }, [nutstoreSsoHandler, setNutstoreToken, t])
 
   useEffect(() => {
     async function decryptTokenEffect() {

--- a/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -64,7 +64,9 @@ const NutstoreSettings: FC = () => {
     window.open(ssoUrl, '_blank')
     const nutstoreToken = await nutstoreSsoHandler()
 
-    void setNutstoreToken(nutstoreToken)
+    if (nutstoreToken) {
+      void setNutstoreToken(nutstoreToken)
+    }
   }, [nutstoreSsoHandler, setNutstoreToken])
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Abandoned or repeated Nutstore SSO attempts could leave callback listeners and timers active, allowing stale callbacks to outlive the initiating component.

After this PR:

The SSO hook owns a single in-flight callback lifecycle and cleans it up on success, timeout, replacement, and unmount while rejecting malformed callback URLs.

Fixes #19408

### Why we need it and why it was done in this way

Lifecycle ownership stays inside the existing Nutstore SSO hook so every caller receives the same cleanup and callback validation behavior.

The following tradeoffs were made:

Starting a new login attempt replaces the prior in-flight attempt instead of allowing multiple callback listeners to compete.

The following alternatives were considered:

Cleaning listeners only in the settings component was rejected because it would duplicate hook internals and miss other future callers.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19408

### Breaking changes

None.

### Special notes for your reviewer

Verified with 5 deterministic hook tests covering success, timeout, replacement, unmount, and malformed callbacks. `pnpm typecheck:web`, `pnpm test:lint`, and `pnpm format:check` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Clean up abandoned Nutstore SSO attempts so stale callbacks and timers cannot affect later logins.
```
