### PR TITLE
feat(composer): preview Markdown attachments in a popup

### DIFF
--- a/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerToken.test.tsx
@@ -21,10 +21,14 @@ import { composerInputTokenComponentByKind, ComposerToken, FileComposerToken } f
 
 const ipcRequestMock = vi.hoisted(() => vi.fn())
 const imagePreviewShowMock = vi.hoisted(() => vi.fn())
-const openFilePreviewTabMock = vi.hoisted(() => vi.fn())
+const contentPopupShowMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@renderer/components/FilePreview', () => ({
-  useOptionalOpenFilePreviewTab: () => openFilePreviewTabMock
+  FilePreview: ({ filePath }: { filePath: string }) => <section aria-label={`File preview: ${filePath}`} />
+}))
+
+vi.mock('@renderer/components/popups/ContentPopup', () => ({
+  default: { show: contentPopupShowMock }
 }))
 
 vi.mock('@renderer/ipc', () => ({
@@ -218,8 +222,8 @@ beforeEach(() => {
   ipcRequestMock.mockResolvedValue(undefined)
   imagePreviewShowMock.mockReset()
   imagePreviewShowMock.mockResolvedValue(undefined)
-  openFilePreviewTabMock.mockReset()
-  openFilePreviewTabMock.mockReturnValue('file-preview-tab')
+  contentPopupShowMock.mockReset()
+  contentPopupShowMock.mockResolvedValue(undefined)
   readPastedTextMock.mockReset()
   readPastedTextMock.mockResolvedValue('第一段粘贴文本\n第二段粘贴文本')
   Object.defineProperty(window, 'api', {
@@ -566,7 +570,7 @@ describe('ComposerToken', () => {
     expectTokenPathTooltip(container, '/tmp/report-q2-final.pdf', '2 KB')
   })
 
-  it('opens an editable Markdown attachment in the file preview tab by pointer or keyboard', async () => {
+  it('opens an editable Markdown attachment in a popup by pointer or keyboard', async () => {
     const user = userEvent.setup()
     render(
       <ComposerToken
@@ -588,16 +592,21 @@ describe('ComposerToken', () => {
     const attachment = screen.getByRole('button', { name: 'requirements.md' })
     await user.click(attachment)
 
-    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/managed-file.md', 'requirements.md')
+    expect(contentPopupShowMock).toHaveBeenCalledOnce()
+    expect(contentPopupShowMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ title: 'requirements.md', width: 700 })
+    )
+    render(contentPopupShowMock.mock.lastCall?.[0].content)
+    expect(screen.getByRole('region', { name: 'File preview: /tmp/managed-file.md' })).toBeInTheDocument()
 
-    openFilePreviewTabMock.mockClear()
+    contentPopupShowMock.mockClear()
     attachment.focus()
     await user.keyboard('{Enter}')
 
-    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/managed-file.md', 'requirements.md')
+    expect(contentPopupShowMock).toHaveBeenCalledOnce()
   })
 
-  it('opens a sent Markdown attachment from its managed file URL', async () => {
+  it('opens a sent Markdown attachment from its managed file URL in a popup', async () => {
     const user = userEvent.setup()
     render(
       <FileComposerToken
@@ -620,7 +629,9 @@ describe('ComposerToken', () => {
 
     await user.click(screen.getByRole('button', { name: 'requirements.md' }))
 
-    expect(openFilePreviewTabMock).toHaveBeenCalledWith('/tmp/message-files/managed-file.md', 'requirements.md')
+    expect(contentPopupShowMock).toHaveBeenCalledOnce()
+    render(contentPopupShowMock.mock.lastCall?.[0].content)
+    expect(screen.getByRole('region', { name: 'File preview: /tmp/message-files/managed-file.md' })).toBeInTheDocument()
   })
 
   it('renders office file tokens with dedicated variants', () => {

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -5,9 +5,10 @@ import {
   QUOTE_TOOLTIP_BODY_CLASS_NAME,
   QUOTE_TOOLTIP_CONTENT_CLASS_NAME
 } from '@renderer/components/composer/quoteToken'
-import { useOptionalOpenFilePreviewTab } from '@renderer/components/FilePreview'
+import { FilePreview } from '@renderer/components/FilePreview'
 import { BracesVariableIcon } from '@renderer/components/icons/BracesVariableIcon'
 import Favicon from '@renderer/components/icons/FallbackFavicon'
+import ContentPopup from '@renderer/components/popups/ContentPopup'
 import { ipcApi } from '@renderer/ipc'
 import { ImagePreviewService } from '@renderer/services/ImagePreviewService'
 import { COMPOSER_FILE_KIND, type ComposerFileKind, FILE_TYPE } from '@renderer/types/file'
@@ -711,7 +712,6 @@ function ComposerTokenHoverPopover({
 }
 
 export function FileComposerToken(props: FileComposerTokenProps) {
-  const openFilePreviewTab = useOptionalOpenFilePreviewTab()
   const { imageIconPreview = false, onRemove, removeLabel: removeLabelProp, tooltipActions } = props
   const tokenFile = isComposerAttachment(props.token.payload) ? props.token.payload : undefined
   const previewFileType = props.readOnlyFilePreview?.mediaType?.startsWith('image/') ? FILE_TYPE.IMAGE : undefined
@@ -741,11 +741,28 @@ export function FileComposerToken(props: FileComposerTokenProps) {
   const readOnlyFilePreviewPath = getReadOnlyFilePreviewPath(props.readOnlyFilePreview)
   const pathTooltipPath = props.readOnly ? readOnlyFilePreviewPath : file?.path
   const filePreviewPath = props.readOnly ? readOnlyFilePreviewPath : getEditableFilePreviewPath(file)
-  const canOpenFilePreview = presentation.variant === 'markdown' && Boolean(filePreviewPath && openFilePreviewTab)
+  const canOpenFilePreview = presentation.variant === 'markdown' && Boolean(filePreviewPath)
   const openFilePreview = useCallback(() => {
-    if (!canOpenFilePreview || !filePreviewPath || !openFilePreviewTab) return
-    openFilePreviewTab(filePreviewPath, label)
-  }, [canOpenFilePreview, filePreviewPath, label, openFilePreviewTab])
+    if (!canOpenFilePreview || !filePreviewPath) return
+    void ContentPopup.show({
+      content: (
+        <div className="h-full min-h-0 overflow-hidden">
+          <FilePreview filePath={filePreviewPath} />
+        </div>
+      ),
+      title: label,
+      width: 700,
+      styles: {
+        body: { height: '100%', minHeight: 0, overflow: 'hidden' },
+        content: {
+          gridTemplateRows: 'auto minmax(0, 1fr)',
+          height: 'min(80vh, 760px)',
+          maxHeight: 'calc(100vh - 2rem)',
+          overflow: 'hidden'
+        }
+      }
+    })
+  }, [canOpenFilePreview, filePreviewPath, label])
   const handleFilePreviewClick = useCallback(
     (event: ReactMouseEvent<HTMLSpanElement>) => {
       if (!canOpenFilePreview || (event.target as HTMLElement | null)?.closest('[data-composer-token-remove]')) return


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Clicking a Markdown attachment token opened a dedicated file-preview tab. This restored Markdown rendering after messages were sent, but it required leaving the current conversation view for a lightweight attachment preview.

After this PR:

Clicking a Markdown attachment token opens a compact in-app dialog that embeds the canonical `FilePreview` component. The same dialog is used for editable attachments and sent-message attachments, and keyboard activation with Enter or Space remains supported.

Related to #19090 (follow-up UX request; the original issue is already closed).

### Why we need it and why it was done in this way

The reporter confirmed that v2.0.9 fixed the original post-send preview bug, then requested the compact popup behavior that existed in v1. Reusing `ContentPopup` and the existing `FilePreview` keeps the conversation visible while preserving the current Markdown preview/source modes, loading behavior, and error handling.

The following tradeoffs were made:

- The change is intentionally limited to Markdown composer tokens. Other attachment types and the general file-preview tab workflow are unchanged.
- The popup uses a 700 px responsive width and a viewport-capped height so it remains compact without overflowing smaller windows.
- The existing singleton popup service is used, so opening this preview follows the same modal lifecycle as other content popups.

The following alternatives were considered:

- Restoring the legacy text-preview modal was rejected because it would duplicate Markdown rendering and provide only a source editor instead of the current preview/source experience.
- Adding a second Markdown-specific preview implementation was rejected to avoid divergent rendering and error states.

Links to places where the discussion took place: #19090

### Breaking changes

None.

### Special notes for your reviewer

- Added regression coverage for editable and sent Markdown attachments, including managed `file://` path normalization and keyboard activation.
- `pnpm build:check` passes (all 3,170 final-suite tests passed).
- `pnpm test:lint` passes; the 46 ESLint warnings shown are existing repository warnings and none are in the changed files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Markdown attachments now open in a compact in-app preview dialog instead of a separate tab.
```
