### PR TITLE
fix(newapi): preserve exact versioned base URLs

### DIFF
--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makeModel } from '../../__tests__/fixtures/model'
 import { makeProvider } from '../../__tests__/fixtures/provider'
 import { customFetch } from '../../utils/customFetch'
+import { createNewApi, type NewApiProviderSettings } from '../custom/newapiProvider'
 
 // Key-backed builders resolve their serving API key lazily; Vertex/Bedrock read
 // provider auth config from the direct-import ProviderService singleton. Mock
@@ -1426,6 +1427,64 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
   })
 
   describe('NewAPI builder', () => {
+    it.each([
+      ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      ENDPOINT_TYPE.OPENAI_RESPONSES,
+      ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+      ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT
+    ])('keeps the exact versioned base URL for %s when it ends with #', async (endpointType) => {
+      const provider = makeProvider({
+        id: 'my-newapi',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [endpointType]: {
+            baseUrl: 'https://gateway.example.com/custom/v4#',
+            adapterFamily: 'newapi'
+          }
+        }
+      })
+      const model = makeModel({ endpointTypes: [endpointType] })
+
+      const config = await providerToAiSdkConfig(provider, model)
+
+      expect((config.providerSettings as Record<string, unknown>).baseURL).toBe('https://gateway.example.com/custom/v4')
+    })
+
+    it('sends chat requests through the exact versioned base URL selected with #', async () => {
+      const provider = makeProvider({
+        id: 'my-newapi',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+            baseUrl: 'https://gateway.example.com/custom/v4#',
+            adapterFamily: 'newapi'
+          }
+        }
+      })
+      const model = makeModel({ apiModelId: 'gpt-4o', endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS] })
+      const config = await providerToAiSdkConfig(provider, model)
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            id: 'chatcmpl-test',
+            choices: [{ message: { role: 'assistant', content: 'ok' } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      )
+      const runtimeProvider = createNewApi({
+        ...(config.providerSettings as NewApiProviderSettings),
+        fetch: fetchSpy
+      })
+
+      await runtimeProvider.languageModel('gpt-4o').doGenerate({
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }]
+      })
+
+      expect(fetchSpy.mock.calls[0][0]).toBe('https://gateway.example.com/custom/v4/chat/completions')
+    })
+
     it('uses the provider default anthropic endpoint when the model has no endpoint types', async () => {
       const provider = makeProvider({
         id: 'my-newapi',

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -886,14 +886,7 @@ function formatNewApiBaseURL(baseURL: string, endpointType: EndpointType | undef
 
 function buildNewApiConfig(ctx: BuilderContext): ProviderConfig<'newapi'> {
   const endpointType = ctx.endpointType
-  let rawBaseURL: string
-
-  if (endpointType === ENDPOINT_TYPE.ANTHROPIC_MESSAGES) {
-    const anthropicBaseURL = getBaseUrl(ctx.actualProvider, endpointType)
-    rawBaseURL = anthropicBaseURL || ctx.baseConfig.baseURL
-  } else {
-    rawBaseURL = ctx.baseConfig.baseURL
-  }
+  const rawBaseURL = getBaseUrl(ctx.actualProvider, endpointType) || ctx.baseConfig.baseURL
 
   const baseURL = formatNewApiBaseURL(rawBaseURL, endpointType)
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

NewAPI only read the endpoint-specific base URL for Anthropic Messages. Chat Completions, Responses, and Google Generate Content fell back to the provider-wide base URL, so a versioned endpoint override ending in `#` lost its exact-URL contract and could be routed through an unintended API version path.

After this PR:

NewAPI resolves the endpoint-specific base URL for every supported protocol before applying its existing route formatting. A trailing `#` therefore preserves the user-supplied versioned path for Chat Completions, Responses, Anthropic Messages, and Google Generate Content. The marker itself is still removed before the request is sent.

Fixes #19255

### Why we need it and why it was done in this way

The shared `formatApiHost` helper already implements the trailing-`#` exact-base convention correctly. The contract was lost earlier in the NewAPI builder because only the Anthropic path consulted `endpointConfigs`; other protocols formatted the provider-wide fallback instead. Resolving the active endpoint URL uniformly fixes the source-of-truth mismatch without changing the shared URL grammar.

The following tradeoffs were made:

- Endpoint-specific NewAPI configuration now consistently takes precedence over the provider-wide base URL for all protocols. This is the intended configuration hierarchy, but it makes previously ignored endpoint overrides effective.
- The change stays inside the NewAPI builder and does not alter URL normalization for other provider adapters.

The following alternatives were considered:

- Changing `formatApiHost` was rejected because its trailing-`#` behavior is already correct and covered independently.
- Adding a second NewAPI-only `#` parser was rejected because it would duplicate URL semantics and still leave the wrong base URL source selected.
- Special-casing only Chat Completions was rejected because the same endpoint-selection bug affects Responses and Google routes.

Links to places where the discussion took place: #19255

### Breaking changes

None.

### Special notes for your reviewer

- Added table-driven coverage for Chat Completions, Responses, Anthropic Messages, and Google Generate Content.
- Added a request-level regression proving `https://gateway.example.com/custom/v4#` reaches `https://gateway.example.com/custom/v4/chat/completions` without leaking `#` or inserting another version.
- Verified the focused provider configuration suite (77 tests), main-process type checking, strict lint, and the full `pnpm build:check` workflow on the latest `main`.
- No documentation update is required because this restores the existing trailing-`#` behavior already documented by the URL formatter.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NewAPI endpoint-specific addresses ending in `#` now preserve their exact versioned path instead of being routed through a different API version.
```
