### PR TITLE
fix(context-menu): pop the webContents menu on its owner window

### DIFF
--- a/src/main/services/ContextMenu.ts
+++ b/src/main/services/ContextMenu.ts
@@ -1,6 +1,21 @@
 import { getI18n } from '@main/i18n'
 import type { MenuItemConstructorOptions } from 'electron'
-import { Menu } from 'electron'
+import { BrowserWindow, Menu } from 'electron'
+
+// Without an owner Electron picks one itself — the focused window, else any
+// window — and on Windows a menu owned by another window is not dismissed by
+// clicks in the one it appears over. Webview guests resolve through their host.
+function ownerWindow(w: Electron.WebContents): BrowserWindow | undefined {
+  const direct = BrowserWindow.fromWebContents(w)
+  if (direct) {
+    return direct
+  }
+  const host = w.hostWebContents
+  if (!host || host.isDestroyed()) {
+    return undefined
+  }
+  return BrowserWindow.fromWebContents(host) ?? undefined
+}
 
 class ContextMenu {
   public contextMenu(w: Electron.WebContents) {
@@ -20,7 +35,7 @@ class ContextMenu {
           ]
         }
         const menu = Menu.buildFromTemplate(template)
-        menu.popup()
+        menu.popup({ window: ownerWindow(w) })
       }
     })
   }

--- a/src/main/services/__tests__/ContextMenu.test.ts
+++ b/src/main/services/__tests__/ContextMenu.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { menuMock, browserWindowMock, popupMock, windowMock } = vi.hoisted(() => {
+  const popupMock = vi.fn()
+  return {
+    popupMock,
+    windowMock: { id: 1 },
+    menuMock: {
+      buildFromTemplate: vi.fn(() => ({ popup: popupMock }))
+    },
+    browserWindowMock: {
+      fromWebContents: vi.fn()
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  BrowserWindow: browserWindowMock,
+  Menu: menuMock
+}))
+
+vi.mock('@main/i18n', () => ({
+  getI18n: () => ({
+    translation: { common: { copy: 'Copy', paste: 'Paste', cut: 'Cut', inspect: 'Inspect' } }
+  })
+}))
+
+import { contextMenu } from '../ContextMenu'
+
+const createProperties = () =>
+  ({
+    selectionText: 'hello',
+    isEditable: false,
+    misspelledWord: '',
+    dictionarySuggestions: [],
+    editFlags: { canCopy: true, canPaste: false, canCut: false }
+  }) as unknown as Electron.ContextMenuParams
+
+/** Registers the menu on a fake webContents and fires a `context-menu` event on it. */
+const popupFor = (properties = createProperties(), hostWebContents: unknown = null) => {
+  let handler: ((event: unknown, properties: Electron.ContextMenuParams) => void) | undefined
+  const webContents = {
+    hostWebContents,
+    on: vi.fn((channel: string, listener: typeof handler) => {
+      if (channel === 'context-menu') handler = listener
+    })
+  } as unknown as Electron.WebContents
+
+  contextMenu.contextMenu(webContents)
+  handler?.({}, properties)
+  return webContents
+}
+
+describe('ContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('pops the menu on the window owning the webContents', () => {
+    browserWindowMock.fromWebContents.mockReturnValue(windowMock)
+
+    const webContents = popupFor()
+
+    expect(browserWindowMock.fromWebContents).toHaveBeenCalledWith(webContents)
+    expect(popupMock).toHaveBeenCalledWith({ window: windowMock })
+  })
+
+  it('falls back to the host window for a webview guest', () => {
+    const host = { isDestroyed: () => false }
+    browserWindowMock.fromWebContents.mockImplementation((contents: unknown) => (contents === host ? windowMock : null))
+
+    popupFor(createProperties(), host)
+
+    expect(popupMock).toHaveBeenCalledWith({ window: windowMock })
+  })
+
+  it('does not reach into a destroyed host, whose members throw', () => {
+    const host = { isDestroyed: () => true }
+    browserWindowMock.fromWebContents.mockReturnValue(null)
+
+    popupFor(createProperties(), host)
+
+    expect(browserWindowMock.fromWebContents).toHaveBeenCalledTimes(1)
+    expect(popupMock).toHaveBeenCalledWith({ window: undefined })
+  })
+
+  it('still pops the menu when neither the webContents nor a host resolves a window', () => {
+    browserWindowMock.fromWebContents.mockReturnValue(null)
+
+    expect(() => popupFor()).not.toThrow()
+    expect(popupMock).toHaveBeenCalledWith({ window: undefined })
+  })
+
+  it('does not pop an empty menu', () => {
+    browserWindowMock.fromWebContents.mockReturnValue(windowMock)
+
+    popupFor({
+      selectionText: '',
+      isEditable: false,
+      misspelledWord: '',
+      dictionarySuggestions: [],
+      editFlags: { canCopy: false, canPaste: false, canCut: false }
+    } as unknown as Electron.ContextMenuParams)
+
+    expect(popupMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Electron chose a context menu owner implicitly. With pooled windows, the menu could belong to a different window and remain open when the user clicked inside the window where it appeared on Windows.

After this PR:

Context menus resolve and use the `BrowserWindow` that owns the triggering web contents. Webview guests fall back to their live host web contents, while unresolved owners preserve Electron's existing fallback.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Passing the actual owner to `Menu.popup` keeps native menu focus and dismissal behavior attached to the correct window.

The following tradeoffs were made:

Webview guests require one extra owner lookup through `hostWebContents`; destroyed hosts and unresolved windows retain the previous undefined-owner fallback.

The following alternatives were considered:

Resolving only the direct owner was considered, but it would not cover context-menu events from webview guests.

Links to places where the discussion took place: None

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

The repository test gate passed. Unit coverage includes direct owners, webview hosts, destroyed hosts, unresolved owners, and empty menus.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix context menus so clicks in their owning window dismiss them correctly on Windows.
```
