### PR TITLE
fix(code-mate): normalize sidebar icon sizing

### DIFF
--- a/src/renderer/pages/code/components/CliIcon.tsx
+++ b/src/renderer/pages/code/components/CliIcon.tsx
@@ -9,6 +9,14 @@ type SvgIcon = ComponentType<SVGProps<SVGSVGElement>>
 // Single icon registry: derived from CLI_TOOLS so a tool's icon is declared once.
 const CLI_ICONS: Record<string, SvgIcon> = Object.fromEntries(CLI_TOOLS.map((tool) => [tool.value, tool.icon]))
 
+// Crop transparent source-canvas padding so the artwork shares a consistent optical size.
+const OPTICAL_VIEWBOXES: Partial<Record<CodeCli, string>> = {
+  [CodeCli.OPEN_CODE]: '16 16 88 88',
+  [CodeCli.HERMES]: '26 26 68 68',
+  [CodeCli.OPENCLAW]: '26 26 68 68',
+  [CodeCli.DEEPSEEK_HARNESS]: '26 26 68 68'
+}
+
 interface CliIconProps {
   id: string
   size?: number
@@ -30,10 +38,9 @@ export const CliIcon: FC<CliIconProps> = ({ id, size = 28, className }) => {
     )
   }
 
-  // The OpenClaw artwork occupies only the center of its 120×120 canvas.
-  // Crop that transparent margin so its optical size matches the other CLI icons.
-  if (id === CodeCli.OPENCLAW) {
-    return <Icon width={size} height={size} viewBox="20 20 80 80" className={className} />
+  const opticalViewBox = OPTICAL_VIEWBOXES[id as CodeCli]
+  if (opticalViewBox) {
+    return <Icon width={size} height={size} viewBox={opticalViewBox} className={className} />
   }
 
   return <Icon width={size} height={size} className={className} />

--- a/src/renderer/pages/code/components/CodeCliSidebar.tsx
+++ b/src/renderer/pages/code/components/CodeCliSidebar.tsx
@@ -57,7 +57,9 @@ export const CodeCliSidebar: FC<CodeCliSidebarProps> = ({
   const { t } = useTranslation()
 
   return (
-    <div data-ui="code.navigation" className="flex h-full min-h-0 w-72 shrink-0 flex-col border-border-subtle border-r">
+    <div
+      data-ui="code.navigation"
+      className="flex h-full min-h-0 w-[264px] shrink-0 flex-col border-border-subtle border-r">
       <Scrollbar className="min-h-0 flex-1 overflow-x-hidden p-2.5">
         {tools.length === 0 ? (
           <div className="py-8 text-center text-foreground-tertiary text-xs">{t('code.no_tools')}</div>

--- a/src/renderer/pages/code/components/CodeCliSidebar.tsx
+++ b/src/renderer/pages/code/components/CodeCliSidebar.tsx
@@ -57,9 +57,7 @@ export const CodeCliSidebar: FC<CodeCliSidebarProps> = ({
   const { t } = useTranslation()
 
   return (
-    <div
-      data-ui="code.navigation"
-      className="flex h-full min-h-0 w-[264px] shrink-0 flex-col border-border-subtle border-r">
+    <div data-ui="code.navigation" className="flex h-full min-h-0 w-66 shrink-0 flex-col border-border-subtle border-r">
       <Scrollbar className="min-h-0 flex-1 overflow-x-hidden p-2.5">
         {tools.length === 0 ? (
           <div className="py-8 text-center text-foreground-tertiary text-xs">{t('code.no_tools')}</div>

--- a/src/renderer/pages/code/components/CodeCliSidebar.tsx
+++ b/src/renderer/pages/code/components/CodeCliSidebar.tsx
@@ -57,7 +57,7 @@ export const CodeCliSidebar: FC<CodeCliSidebarProps> = ({
   const { t } = useTranslation()
 
   return (
-    <div data-ui="code.navigation" className="flex h-full min-h-0 w-60 shrink-0 flex-col border-border-subtle border-r">
+    <div data-ui="code.navigation" className="flex h-full min-h-0 w-72 shrink-0 flex-col border-border-subtle border-r">
       <Scrollbar className="min-h-0 flex-1 overflow-x-hidden p-2.5">
         {tools.length === 0 ? (
           <div className="py-8 text-center text-foreground-tertiary text-xs">{t('code.no_tools')}</div>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Transparent canvas padding made several CodeMate icons appear smaller than their neighbors, while long tool names were truncated beside the installation status.

After this PR: CodeMate applies per-tool optical view boxes for consistent artwork sizing and gives the sidebar enough width to show every tool name alongside its installation status.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Normalizing the SVG view boxes in `CliIcon` keeps the artwork fix local to CodeMate. Widening the CodeMate navigation to Tailwind's `w-66` spacing token (264px) preserves the existing single-line name and status layout while accommodating the longest labels.

The following tradeoffs were made: The sidebar uses 24px more horizontal space, and per-icon view boxes need adjustment if source artwork changes.

The following alternatives were considered: Changing every icon's CSS size was rejected because equal outer dimensions do not remove internal SVG padding. Wrapping names or moving statuses to another row was rejected because the wider sidebar preserves the existing compact layout.

Links to places where the discussion took place: N/A

| Before | After |
| --- | --- |
| <img width="482" height="1332" alt="codemate-sidebar-before" src="https://github.com/user-attachments/assets/bf670c10-6a77-45a7-a3bd-f46ee3b13a92" /> | 
<img width="578" height="1332" alt="codemate-sidebar-full-labels" src="https://github.com/user-attachments/assets/4d7cab5b-58c0-4e8d-aa39-641285fd609e" />
 |

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Validated with 36 focused renderer tests, `pnpm lint`, `git diff --check`, and live Electron/CDP screenshots.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed inconsistent icon sizing and truncated tool names in the CodeMate sidebar.
```



