### PR TITLE
fix(binary-manager): support npm lifecycle allowlists

### DIFF
--- a/docs/references/binary-manager/README.md
+++ b/docs/references/binary-manager/README.md
@@ -142,6 +142,8 @@ For a built-in Dependency settings preset, add an entry to `PRESETS_BINARY_TOOLS
 
 For a Code CLI, add its executable/specification to the Code CLI preset source. `getToolSnapshots()` already includes those candidates, so no BinaryManager adapter is needed.
 
+Fixed npm presets that require lifecycle scripts must list the exact packages in `npmAllowBuilds`. BinaryManager passes that list to mise's per-tool `allow_builds` option; packages not listed keep mise's default script blocking, and broad allow-all execution is not exposed.
+
 To ship a bundled executable, add its platform download/checksum definition to `scripts/download-binaries.js` and its executable names/version marker to `BUNDLED_TOOLS` in `src/main/services/binaryManager/BinaryManager.ts`. Both entries are required: one supplies the artifact and the other makes extraction and snapshot availability aware of it.
 
 `scripts/download-binaries.js` fills `resources/binaries/<platform>-<arch>/`, which is what the app extracts from at boot. During packaging (`before-pack.js` passes `--packaging`) it downloads there directly.

--- a/src/main/services/binaryManager/BinaryManager.ts
+++ b/src/main/services/binaryManager/BinaryManager.ts
@@ -223,7 +223,8 @@ export type ManagedCliInventoryEntry = {
 }
 
 /** A code-owned fixed tool definition. Structural — never a persisted custom entry. */
-type FixedToolDefinition = { name: string; tool: string }
+type FixedToolDefinition = { name: string; tool: string; npmAllowBuilds?: readonly string[] }
+type InstallableToolDefinition = CustomToolDefinition & Pick<FixedToolDefinition, 'npmAllowBuilds'>
 type MiseInstallEntry = { version?: string; active?: boolean; install_path?: string }
 
 // One build's env and the facts derived from it, so no caller can pair them
@@ -248,14 +249,30 @@ type IsolatedEnvSnapshot = {
 const normalizeToolIdentity = (tool: string): string =>
   (tool.startsWith('core:') ? tool.slice('core:'.length) : tool).replace(/\[[^\]]*]/g, '')
 
+function addNpmAllowBuildsOption(tool: string, packages?: readonly string[]): string {
+  if (!packages?.length) return tool
+  // mise 2026.7.14 splits ToolArg on `@` before parsing options, so scoped values use TOML Unicode escapes.
+  const allowBuilds = JSON.stringify(packages).replaceAll('@', '\\u0040')
+  const option = `allow_builds=${allowBuilds}`
+  return tool.endsWith(']') ? `${tool.slice(0, -1)},${option}]` : `${tool}[${option}]`
+}
+
 const FIXED_CATALOG: ReadonlyMap<string, FixedToolDefinition> = new Map<string, FixedToolDefinition>([
   ...PRESETS_BINARY_TOOLS.map((preset): [string, FixedToolDefinition] => [
     preset.name,
-    { name: preset.name, tool: preset.tool }
+    {
+      name: preset.name,
+      tool: preset.tool,
+      ...(preset.npmAllowBuilds?.length ? { npmAllowBuilds: preset.npmAllowBuilds } : {})
+    }
   ]),
   ...CODE_CLI_TOOL_PRESETS.map((preset): [string, FixedToolDefinition] => [
     preset.executable,
-    { name: preset.executable, tool: preset.miseTool }
+    {
+      name: preset.executable,
+      tool: preset.miseTool,
+      ...(preset.npmAllowBuilds?.length ? { npmAllowBuilds: preset.npmAllowBuilds } : {})
+    }
   ])
 ])
 // Re-exported for main-process callers and tests.
@@ -1282,7 +1299,7 @@ export class BinaryManager extends BaseService {
   }
 
   private async installWithMise(
-    definition: CustomToolDefinition,
+    definition: InstallableToolDefinition,
     targetVersion: string | undefined,
     definitions: CustomToolDefinition[]
   ): Promise<string> {
@@ -1304,7 +1321,7 @@ export class BinaryManager extends BaseService {
       const runtimeVersion = pinnedRuntime.requestedVersion ?? (await this.getInstalledVersion(runtimeTool))
       runtime = `${runtimeTool}@${runtimeVersion}`
     }
-    const toolSpec = `${definition.tool}@${requested}`
+    const toolSpec = `${addNpmAllowBuildsOption(definition.tool, definition.npmAllowBuilds)}@${requested}`
     const includePrerelease = MISE_PRERELEASE_TOOLS.has(definition.tool)
     const shellOutNpm = MISE_NPM_SHELL_OUT_TOOLS.has(definition.tool)
     const releaseAgeArgs = includePrerelease ? ['--minimum-release-age', '0s'] : []
@@ -1493,7 +1510,7 @@ export class BinaryManager extends BaseService {
    * version, so there is no pin to hand back.
    */
   private async applyDefinition(
-    definition: CustomToolDefinition,
+    definition: InstallableToolDefinition,
     targetVersion: string | undefined,
     definitions: CustomToolDefinition[]
   ): Promise<void> {

--- a/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
+++ b/src/main/services/binaryManager/__tests__/BinaryManager.test.ts
@@ -2046,6 +2046,41 @@ describe('BinaryManager', () => {
       expect(mockPreferenceService.set).not.toHaveBeenCalled()
     })
 
+    it('passes a fixed npm lifecycle allowlist as typed mise tool options', async () => {
+      const service = new BinaryManager()
+      ;(service as any).miseBin = '/mock/mise'
+      ;(service as any).isolatedEnv = { env: {}, usesDefaultChinaPipIndex: false }
+      mockExecFileAsync.mockImplementation(async (_bin: string, args: string[]) => {
+        if (args[0] === 'ls') {
+          return {
+            stdout: JSON.stringify({ 'npm:@vendor/native-cli': [{ version: '1.2.3', active: true }] }),
+            stderr: ''
+          }
+        }
+        if (args[0] === 'which') return { stdout: '/mock/mise/shims/native-cli\n', stderr: '' }
+        return { stdout: '', stderr: '' }
+      })
+
+      await expect(
+        (service as any).applyDefinition(
+          {
+            name: 'native-cli',
+            tool: 'npm:@vendor/native-cli',
+            npmAllowBuilds: ['@vendor/native-cli', 'better-sqlite3']
+          },
+          undefined,
+          []
+        )
+      ).resolves.toBeUndefined()
+
+      expect(mockExecFileAsync.mock.calls.map((call: any[]) => call[1])).toContainEqual([
+        'use',
+        '-g',
+        'node@22',
+        'npm:@vendor/native-cli[allow_builds=["\\u0040vendor/native-cli","better-sqlite3"]]@latest'
+      ])
+    })
+
     it('accepts a recipe whose bins are not named after it (core:rust ships rustc/cargo)', async () => {
       const service = new BinaryManager()
       ;(service as any).miseBin = '/mock/mise'

--- a/src/shared/data/presets/binaryTools.ts
+++ b/src/shared/data/presets/binaryTools.ts
@@ -54,6 +54,8 @@ export function validateBinaryToolDefinition(tool: BinaryToolGrammar): void {
 export interface BinaryToolPreset {
   name: string
   tool: string
+  /** Exact npm packages whose lifecycle scripts mise may run during installation. */
+  npmAllowBuilds?: readonly string[]
   displayName: string
   icon?: string
   repoUrl: string

--- a/src/shared/data/presets/codeCliTools.ts
+++ b/src/shared/data/presets/codeCliTools.ts
@@ -10,6 +10,8 @@ export interface CodeCliToolPreset {
   misePrerelease?: boolean
   /** Use npm CLI when mise's embedded installer cannot install this package. */
   miseNpmShellOut?: boolean
+  /** Exact npm packages whose lifecycle scripts mise may run during installation. */
+  npmAllowBuilds?: readonly string[]
   /**
    * A peer this tool needs at runtime but whose absence an install still reports
    * as success, named as `peer` resolved from `host`'s own entry point.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Fixed npm tools could not declare a per-tool lifecycle-script allowlist. mise therefore kept lifecycle scripts disabled, so a package could expose its CLI shim while a required native dependency never installed its binding.

After this PR:

Code-owned Dependency and Code CLI presets can declare exact packages in `npmAllowBuilds`. BinaryManager composes those packages into mise's typed `allow_builds` array for `mise use`, preserves the canonical tool identity for snapshots and removal, and keeps lifecycle scripts blocked for every unlisted package.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Native npm dependencies often obtain or compile their platform binding from lifecycle scripts. The permission belongs to code-owned acquisition metadata because it must be narrowly reviewed per fixed tool; it must not become a user-controlled broad script-execution switch.

The following tradeoffs were made:

- Only fixed, code-owned presets can opt in; custom tool definitions remain unchanged.
- Existing installations are not rebuilt automatically. The immediate consumer is the still-unmerged PR #19291, whose test installation can be removed and reinstalled after it adopts this capability.
- Scoped package names are TOML-Unicode-escaped inside the inline option because mise 2026.7.14 splits `ToolArg` at `@` before parsing bracketed options.

The following alternatives were considered:

- Allowing all lifecycle scripts was rejected because unrelated transitive packages would gain install-time code execution.
- Running package-specific `postinstall` or `npm rebuild` commands from Cherry was rejected because it would bypass mise's package-manager contract and duplicate package behavior.
- Embedding `allow_builds` in the canonical `miseTool` identity was rejected because install policy is not tool identity and would leak into snapshot, lookup, and removal comparisons.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/pull/19291

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This PR is the prerequisite mechanism for #19291. After this merges, that PR should declare `npmAllowBuilds: ['@minimax-ai/code', 'better-sqlite3']` and retest a clean MiniMax Code installation.

Validation completed locally:

- `CI=1 pnpm test:main src/main/services/binaryManager/__tests__/BinaryManager.test.ts` (206 tests)
- `CI=1 pnpm test:shared src/shared/data/presets/__tests__/codeCliTools.test.ts` (15 tests)
- `CI=1 pnpm typecheck`
- `CI=1 pnpm i18n:check`
- `CI=1 pnpm docs:check`
- Changed-file Oxlint, ESLint, and Biome checks

The repository-wide `pnpm lint` command was also attempted, but local ignored checkouts under `.claude/worktrees/` were traversed by ESLint and produced unrelated pre-existing errors. Its incidental fixes in those nested worktrees were reverted; no nested-worktree change is included here.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
