### PR TITLE
fix(about-settings): name GitHub and logo controls for assistive tech

### DIFF
--- a/src/renderer/components/icons/LogoAvatar.tsx
+++ b/src/renderer/components/icons/LogoAvatar.tsx
@@ -27,7 +27,7 @@ const LogoAvatar: FC<Props> = ({ logo, size = 32, shape = 'rounded', className }
     <Avatar
       className={`${borderClass} ${shape === 'circle' ? 'rounded-full' : 'rounded-[20%]'} ${className ?? ''}`.trim()}
       style={{ width: size, height: size }}>
-      <AvatarImage src={logo} />
+      <AvatarImage alt="" src={logo} />
     </Avatar>
   )
 }

--- a/src/renderer/components/icons/LogoAvatar.tsx
+++ b/src/renderer/components/icons/LogoAvatar.tsx
@@ -7,13 +7,15 @@ interface Props {
   size?: number
   shape?: 'circle' | 'rounded'
   className?: string
+  /** Accessible name for URL logos. Pass `""` when the image is decorative. */
+  alt?: string
 }
 
 /**
  * Renders either a CompoundIcon avatar or a plain image avatar,
  * depending on whether the logo is a CompoundIcon or a string URL.
  */
-const LogoAvatar: FC<Props> = ({ logo, size = 32, shape = 'rounded', className }) => {
+const LogoAvatar: FC<Props> = ({ logo, size = 32, shape = 'rounded', className, alt }) => {
   if (!logo) return null
 
   const borderClass = 'border border-border'
@@ -27,7 +29,7 @@ const LogoAvatar: FC<Props> = ({ logo, size = 32, shape = 'rounded', className }
     <Avatar
       className={`${borderClass} ${shape === 'circle' ? 'rounded-full' : 'rounded-[20%]'} ${className ?? ''}`.trim()}
       style={{ width: size, height: size }}>
-      <AvatarImage alt="" src={logo} />
+      <AvatarImage alt={alt} src={logo} />
     </Avatar>
   )
 }

--- a/src/renderer/components/icons/MiniAppLogoAvatar.tsx
+++ b/src/renderer/components/icons/MiniAppLogoAvatar.tsx
@@ -8,6 +8,8 @@ interface Props {
   logo: string | undefined
   size?: number
   className?: string
+  /** Accessible name for URL logos. Pass `""` when the image is decorative. */
+  alt?: string
 }
 
 /**
@@ -15,13 +17,13 @@ interface Props {
  * brand icon path (with a size-stable placeholder while the icon chunk loads);
  * anything else renders as an image URL via LogoAvatar's string path.
  */
-const MiniAppLogoAvatar: FC<Props> = ({ logo, size = 32, className }) => {
+const MiniAppLogoAvatar: FC<Props> = ({ logo, size = 32, className, alt }) => {
   const logoRef = getMiniAppsLogoRef(logo)
   const Icon = useMiniAppLogo(logo)
   if (logoRef && !Icon) {
     return <span className="inline-block shrink-0" style={{ width: size, height: size }} />
   }
-  return <LogoAvatar logo={Icon ?? logo} size={size} className={className} />
+  return <LogoAvatar logo={Icon ?? logo} size={size} className={className} alt={alt} />
 }
 
 export default MiniAppLogoAvatar

--- a/src/renderer/components/icons/__tests__/LogoAvatar.test.tsx
+++ b/src/renderer/components/icons/__tests__/LogoAvatar.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import LogoAvatar from '../LogoAvatar'
+
+const LOGO_SRC = 'https://example.com/logo.png'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LogoAvatar URL logos', () => {
+  it('keeps an unnamed URL logo in the accessibility tree by default', () => {
+    render(<LogoAvatar logo={LOGO_SRC} />)
+
+    const image = screen.getByRole('img')
+    expect(image).toHaveAttribute('src', LOGO_SRC)
+    expect(image).not.toHaveAttribute('alt', '')
+  })
+
+  it('hides a URL logo from the accessibility tree when alt is empty', () => {
+    render(<LogoAvatar logo={LOGO_SRC} alt="" />)
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+  })
+
+  it('names a URL logo when alt is provided', () => {
+    render(<LogoAvatar logo={LOGO_SRC} alt="ChatGPT" />)
+
+    expect(screen.getByRole('img', { name: 'ChatGPT' })).toHaveAttribute('src', LOGO_SRC)
+  })
+})

--- a/src/renderer/pages/miniApps/MiniAppSettings/MiniAppListColumn.tsx
+++ b/src/renderer/pages/miniApps/MiniAppSettings/MiniAppListColumn.tsx
@@ -72,7 +72,7 @@ const MiniAppListColumn: FC<Props> = ({ title, count, apps, onToggle, onReorder,
                      * custom rows carry a main-resolved image URL on `app.logoSrc` —
                      * MiniAppLogoAvatar branches between the brand icon and the image.
                      */}
-                    <MiniAppLogoAvatar logo={app.logoSrc ?? app.logo} size={16} />
+                    <MiniAppLogoAvatar logo={app.logoSrc ?? app.logo} size={16} alt="" />
                     <span className="min-w-0 flex-1 truncate text-left text-foreground text-sm">{displayName}</span>
                     <span
                       className="flex size-6 shrink-0 items-center justify-center text-foreground-tertiary"

--- a/src/renderer/pages/miniApps/NewMiniAppPanel.tsx
+++ b/src/renderer/pages/miniApps/NewMiniAppPanel.tsx
@@ -180,7 +180,7 @@ const NewMiniAppPanel: FC<Props> = ({ open, app, onClose }) => {
                 className="rounded-md outline-none transition-opacity focus-visible:opacity-80"
                 onClick={() => fileInputRef.current?.click()}
                 aria-label={t('settings.miniApps.custom.logo_upload_label')}>
-                <MiniAppLogoAvatar logo={logoValue} size={64} />
+                <MiniAppLogoAvatar logo={logoValue} size={64} alt="" />
               </button>
               <div className="flex flex-wrap gap-2">
                 <Button

--- a/src/renderer/pages/miniApps/components/MiniAppPane.tsx
+++ b/src/renderer/pages/miniApps/components/MiniAppPane.tsx
@@ -5,6 +5,7 @@ import type { MiniApp } from '@shared/data/types/miniApp'
 import type { WebviewTag } from 'electron'
 import type { FC } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import BeatLoader from 'react-spinners/BeatLoader'
 
 import MinimalToolbar, { type SplitMode } from './MinimalToolbar'
@@ -40,6 +41,8 @@ const MiniAppPane: FC<Props> = ({
   onActivate,
   className
 }) => {
+  const { t } = useTranslation()
+  const displayName = app.nameKey ? t(app.nameKey) : app.name
   const webviewRef = useRef<WebviewTag | null>(null)
   // Read through a ref so attaching the webview listener does not depend on a
   // callback identity that changes every render.
@@ -149,7 +152,7 @@ const MiniAppPane: FC<Props> = ({
       />
       {!isReady && (
         <div className="absolute inset-x-0 top-8.75 bottom-0 z-4 flex flex-col items-center justify-center gap-3 bg-card">
-          <MiniAppLogoAvatar logo={app.logoSrc ?? app.logo} size={60} />
+          <MiniAppLogoAvatar logo={app.logoSrc ?? app.logo} size={60} alt={displayName} />
           <BeatLoader color={MINI_APP_LOADING_COLOR} size={8} style={{ marginTop: 12 }} />
         </div>
       )}

--- a/src/renderer/pages/miniApps/components/__tests__/MiniAppPane.test.tsx
+++ b/src/renderer/pages/miniApps/components/__tests__/MiniAppPane.test.tsx
@@ -1,0 +1,56 @@
+import type { MiniApp } from '@shared/data/types/miniApp'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import MiniAppPane from '../MiniAppPane'
+
+vi.mock('../MinimalToolbar', () => ({
+  default: () => <div data-testid="minimal-toolbar" />
+}))
+
+vi.mock('../WebviewSearch', () => ({
+  default: () => null
+}))
+
+vi.mock('@renderer/utils/webviewStateManager', () => ({
+  getWebviewLoaded: () => false,
+  onWebviewStateChange: () => () => {},
+  setWebviewLoaded: vi.fn()
+}))
+
+vi.mock('@renderer/components/icons/miniAppsLogo', () => ({
+  getMiniAppsLogoRef: () => undefined,
+  useMiniAppLogo: () => undefined
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('react-spinners/BeatLoader', () => ({
+  default: () => <div data-testid="beat-loader" />
+}))
+
+const customApp: MiniApp = {
+  appId: 'custom-chatgpt',
+  presetMiniAppId: null,
+  status: 'enabled',
+  orderKey: 'a0',
+  name: 'ChatGPT',
+  url: 'https://chat.openai.com',
+  logoSrc: 'file:///files/chatgpt.webp'
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MiniAppPane loading logo', () => {
+  it('names the standalone loading logo with the mini-app identity', () => {
+    render(<MiniAppPane app={customApp} splitMode="open" onSplit={vi.fn()} />)
+
+    expect(screen.getByRole('img', { name: 'ChatGPT' })).toHaveAttribute('src', 'file:///files/chatgpt.webp')
+  })
+})

--- a/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
@@ -229,7 +229,7 @@ const AboutSettings: FC = () => {
                     />
                   </div>
                 )}
-                <LogoAvatar logo={AppLogo} size={72} className="rounded-full" />
+                <LogoAvatar logo={AppLogo} size={72} className="rounded-full" alt="" />
               </span>
             </button>
 

--- a/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
+++ b/src/renderer/pages/settings/AboutSettings/AboutSettings.tsx
@@ -203,7 +203,7 @@ const AboutSettings: FC = () => {
             aria-label={t('settings.about.repository')}
             onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
             className="inline-flex items-center justify-center rounded-md p-1 text-foreground transition-colors hover:bg-muted">
-            <Github className="size-5" />
+            <Github aria-hidden="true" className="size-5" />
           </button>
         </SettingTitle>
 
@@ -213,22 +213,24 @@ const AboutSettings: FC = () => {
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <button
               type="button"
-              aria-label="Cherry Studio"
+              aria-label={t('settings.about.repository')}
               onClick={() => onOpenWebsite('https://github.com/CherryHQ/cherry-studio')}
               className="relative cursor-pointer">
-              {appUpdateState.downloading && appUpdateState.downloadProgress > 0 && (
-                <div className="-top-0.5 -left-0.5 pointer-events-none absolute">
-                  <CircularProgress
-                    value={appUpdateState.downloadProgress}
-                    size={76}
-                    strokeWidth={4}
-                    shape="square"
-                    className="stroke-transparent"
-                    progressClassName="stroke-[#67ad5b]"
-                  />
-                </div>
-              )}
-              <LogoAvatar logo={AppLogo} size={72} className="rounded-full" />
+              <span aria-hidden="true">
+                {appUpdateState.downloading && appUpdateState.downloadProgress > 0 && (
+                  <div className="-top-0.5 -left-0.5 pointer-events-none absolute">
+                    <CircularProgress
+                      value={appUpdateState.downloadProgress}
+                      size={76}
+                      strokeWidth={4}
+                      shape="square"
+                      className="stroke-transparent"
+                      progressClassName="stroke-[#67ad5b]"
+                    />
+                  </div>
+                )}
+                <LogoAvatar logo={AppLogo} size={72} className="rounded-full" />
+              </span>
             </button>
 
             <div className="flex min-h-18 flex-col items-start justify-center">

--- a/src/renderer/pages/settings/AboutSettings/__tests__/AboutSettings.test.tsx
+++ b/src/renderer/pages/settings/AboutSettings/__tests__/AboutSettings.test.tsx
@@ -58,9 +58,9 @@ vi.mock('../../FeedbackDialog', () => ({
   FeedbackDialog: () => null
 }))
 
-// Unlabeled img stands in for decorative logo media so the About page must hide it.
+// Forwards alt so empty-alt decorative logos stay hidden even without the wrapper.
 vi.mock('@renderer/components/icons/LogoAvatar', () => ({
-  default: ({ logo }: { logo: string }) => <img src={logo} />
+  default: ({ logo, alt }: { logo: string; alt?: string }) => <img src={logo} alt={alt} />
 }))
 
 import { AboutSettings } from '..'

--- a/src/renderer/pages/settings/AboutSettings/__tests__/AboutSettings.test.tsx
+++ b/src/renderer/pages/settings/AboutSettings/__tests__/AboutSettings.test.tsx
@@ -58,7 +58,19 @@ vi.mock('../../FeedbackDialog', () => ({
   FeedbackDialog: () => null
 }))
 
+// Unlabeled img stands in for decorative logo media so the About page must hide it.
+vi.mock('@renderer/components/icons/LogoAvatar', () => ({
+  default: ({ logo }: { logo: string }) => <img src={logo} />
+}))
+
 import { AboutSettings } from '..'
+
+const REPOSITORY_URL = 'https://github.com/CherryHQ/cherry-studio'
+
+async function renderAboutSettings() {
+  render(<AboutSettings />)
+  await waitFor(() => expect(mocks.request).toHaveBeenCalledWith('app.get_info'))
+}
 
 describe('AboutSettings diagnostics entry', () => {
   beforeEach(() => {
@@ -71,8 +83,7 @@ describe('AboutSettings diagnostics entry', () => {
 
   it('places diagnostics next to the debug panel and opens the export dialog', async () => {
     const user = userEvent.setup()
-    render(<AboutSettings />)
-    await waitFor(() => expect(mocks.request).toHaveBeenCalledWith('app.get_info'))
+    await renderAboutSettings()
 
     const diagnostics = screen.getByRole('button', { name: 'settings.about.diagnostics.entry.button' })
     const debug = screen.getByRole('button', { name: 'settings.about.debug.open' })
@@ -81,5 +92,31 @@ describe('AboutSettings diagnostics entry', () => {
 
     await user.click(diagnostics)
     expect(screen.getByText('diagnostic-dialog-open')).toBeInTheDocument()
+  })
+})
+
+describe('AboutSettings repository controls accessibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.request.mockImplementation(async (route: string) => {
+      if (route === 'app.get_info') return { isPortable: false, version: '2.0.0' }
+      return undefined
+    })
+  })
+
+  it('names the GitHub icon and app logo by their repository destination and hides decorative media', async () => {
+    const user = userEvent.setup()
+    await renderAboutSettings()
+
+    const repositoryButtons = screen.getAllByRole('button', { name: 'settings.about.repository' })
+    expect(repositoryButtons).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: 'Cherry Studio' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+
+    await user.click(repositoryButtons[0])
+    expect(mocks.request).toHaveBeenCalledWith('system.shell.open_website', REPOSITORY_URL)
+
+    await user.click(repositoryButtons[1])
+    expect(mocks.request).toHaveBeenCalledWith('system.shell.open_website', REPOSITORY_URL)
   })
 })

--- a/tests/renderer.setup.ts
+++ b/tests/renderer.setup.ts
@@ -969,8 +969,7 @@ vi.mock('@cherrystudio/ui', () => {
       React.createElement('div', { 'data-testid': 'scrollbar', ...props }, children),
     Avatar: ({ children, src, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'avatar' }, src ? null : children),
-    AvatarImage: ({ src, ...props }) =>
-      React.createElement('img', { ...props, src, alt: '', 'data-testid': 'avatar-image' }),
+    AvatarImage: ({ src, ...props }) => React.createElement('img', { ...props, src, 'data-testid': 'avatar-image' }),
     AvatarFallback: ({ children, ...props }) =>
       React.createElement('div', { ...props, 'data-testid': 'avatar-fallback' }, children),
     EmojiAvatar: ({ children, ...props }) =>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
- Settings > About exposed the GitHub icon button and the clickable Cherry Studio logo as unnamed (or inaccurately named) controls.
- The logo used a hardcoded `aria-label="Cherry Studio"` instead of a destination-based name, and decorative logo/GitHub media could leak into the accessibility tree (including an unlabeled image path).

After this PR:
- Both native buttons use `settings.about.repository` so assistive tech names them by the GitHub repository they open.
- Decorative GitHub icon, logo image, and download overlay are `aria-hidden`, and `LogoAvatar` image content uses `alt=""`.
- Visible layout/styling and native keyboard behavior are unchanged.
- A component test would fail if either control lost that name or decorative media became a named image.

Fixes N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Both controls share the same accessible name because they open the same repository URL. Distinguishing labels would have required a new i18n key without a destination difference.
- Download progress inside the logo button is hidden from the accessibility tree with the decorative media. The control name stays the destination action.

The following alternatives were considered:
- Replacing native `<button>` with `@cherrystudio/ui` `Button` — rejected to keep the existing visual treatment.
- Adding new i18n keys for "Open GitHub repository" — rejected because `settings.about.repository` already names that destination in every locale.

Links to places where the discussion took place: DEV Base record recvqKnE2ccysF

### Breaking changes

None

### Special notes for your reviewer

UI QA against a worktree-owned Electron profile was not completed: an isolated `CS_DEV_USER_DATA_SUFFIX=DevAboutA11y20260826` launch redirected helpers onto `/Users/siin/Documents/Cherry Studio`, so the instance was stopped and not retried. Verification is unit tests + static review.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
About page: GitHub icon and app logo now have accessible names for screen readers, and decorative images are hidden from the accessibility tree.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only labeling changes with no auth, data, or business-logic impact; visual layout and click targets stay the same.
> 
> **Overview**
> Improves screen-reader behavior for logo avatars and **Settings → About** repository shortcuts.
> 
> `LogoAvatar` and `MiniAppLogoAvatar` accept an optional **`alt`** for URL-based logos (forwarded to `AvatarImage`). Call sites pass **`alt=""`** when the logo sits inside a control that already has a name (mini-app list rows, custom logo upload), and **`alt={displayName}`** on the standalone loading logo in `MiniAppPane`.
> 
> On **About**, the GitHub icon button and clickable app logo both use **`settings.about.repository`** as their accessible name (replacing a hardcoded “Cherry Studio” label on the logo button). Decorative GitHub icon, download progress, and logo image are **`aria-hidden`** / **`alt=""`** so they do not duplicate or leak unnamed images in the tree.
> 
> Unit tests cover `LogoAvatar` alt behavior, About repository buttons, and the loading-pane logo name; the global UI test mock stops forcing empty `alt` on every `AvatarImage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ba0f849b67c45fbdb6c116b21e405d8afccb199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->