### PR TITLE
feat(notes): add create action to empty notes page

### DIFF
--- a/packages/ui/src/components/composites/empty-state/__tests__/empty-state.test.tsx
+++ b/packages/ui/src/components/composites/empty-state/__tests__/empty-state.test.tsx
@@ -2,6 +2,7 @@
 import '@testing-library/jest-dom/vitest'
 
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { EmptyState } from '../index'
@@ -28,10 +29,24 @@ describe('EmptyState', () => {
   it('renders action button and fires callback', () => {
     const onAction = vi.fn()
     render(<EmptyState title="Empty" actionLabel="Create" onAction={onAction} />)
-    const btn = screen.getByText('Create')
+    const btn = screen.getByRole('button', { name: 'Create' })
     expect(btn).toBeInTheDocument()
     fireEvent.click(btn)
     expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates the action from the keyboard using the button accessible name', async () => {
+    const user = userEvent.setup()
+    const onAction = vi.fn()
+    render(<EmptyState title="Empty" actionLabel="Create" onAction={onAction} />)
+
+    const button = screen.getByRole('button', { name: 'Create' })
+    button.focus()
+    await user.keyboard('{Enter}')
+    expect(onAction).toHaveBeenCalledTimes(1)
+
+    await user.keyboard(' ')
+    expect(onAction).toHaveBeenCalledTimes(2)
   })
 
   it('renders secondary button and fires callback', () => {

--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -42,10 +42,20 @@ interface NotesEditorProps {
   editorRef: RefObject<RichEditorRef | null>
   codeEditorRef: RefObject<CodeEditorHandles | null>
   onMarkdownChange: (content: string) => void
+  onCreateNote?: () => void
 }
 
 const NotesEditor: FC<NotesEditorProps> = memo(
-  ({ activeNodeId, currentContent, contentLoadError, tokenCount, onMarkdownChange, editorRef, codeEditorRef }) => {
+  ({
+    activeNodeId,
+    currentContent,
+    contentLoadError,
+    tokenCount,
+    onMarkdownChange,
+    editorRef,
+    codeEditorRef,
+    onCreateNote
+  }) => {
     const { t } = useTranslation()
     const { settings } = useNotesSettings()
     const { activeCmTheme } = useCodeStyle()
@@ -76,7 +86,12 @@ const NotesEditor: FC<NotesEditorProps> = memo(
     if (!activeNodeId) {
       return (
         <div data-ui="notes.editor" className="flex h-full w-full flex-1 items-center justify-center">
-          <EmptyState preset="no-note" title={t('notes.empty')} />
+          <EmptyState
+            preset="no-note"
+            title={t('notes.empty')}
+            actionLabel={t('notes.new_note')}
+            onAction={onCreateNote}
+          />
         </div>
       )
     }

--- a/src/renderer/pages/notes/NotesPage.tsx
+++ b/src/renderer/pages/notes/NotesPage.tsx
@@ -1125,6 +1125,7 @@ const NotesPage: FC = () => {
               onMarkdownChange={handleMarkdownChange}
               editorRef={editorRef}
               codeEditorRef={codeEditorRef}
+              onCreateNote={() => void handleCreateNote(t('notes.untitled_note'))}
             />
           )}
         </div>

--- a/src/renderer/pages/notes/NotesPage.tsx
+++ b/src/renderer/pages/notes/NotesPage.tsx
@@ -581,6 +581,10 @@ const NotesPage: FC = () => {
     [createNote, requestFileTransition]
   )
 
+  const handleCreateUntitledNote = useCallback(() => {
+    void handleCreateNote(t('notes.untitled_note'))
+  }, [handleCreateNote, t])
+
   const handleToggleExpanded = useCallback(
     (nodeId: string) => {
       const targetNode = findNode(notesTree, nodeId)
@@ -1125,7 +1129,7 @@ const NotesPage: FC = () => {
               onMarkdownChange={handleMarkdownChange}
               editorRef={editorRef}
               codeEditorRef={codeEditorRef}
-              onCreateNote={() => void handleCreateNote(t('notes.untitled_note'))}
+              onCreateNote={handleCreateUntitledNote}
             />
           )}
         </div>

--- a/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
@@ -155,21 +155,6 @@ describe('NotesEditor empty state', () => {
     expect(onCreateNote).toHaveBeenCalledTimes(1)
   })
 
-  it('activates the empty-state create action from the keyboard', async () => {
-    const user = userEvent.setup()
-    const onCreateNote = vi.fn()
-
-    render(<NotesEditor {...emptyEditorProps} onCreateNote={onCreateNote} />)
-
-    const createButton = screen.getByRole('button', { name: 'notes.new_note' })
-    createButton.focus()
-    await user.keyboard('{Enter}')
-    expect(onCreateNote).toHaveBeenCalledTimes(1)
-
-    await user.keyboard(' ')
-    expect(onCreateNote).toHaveBeenCalledTimes(2)
-  })
-
   it('does not expose a create-note action while a note is open', async () => {
     render(
       <NotesEditor

--- a/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -125,5 +126,82 @@ describe('NotesEditor focus behavior', () => {
     expect(mocks.richEditorProps.mock.lastCall?.[0]).not.toHaveProperty('onCommandsReady')
     // Hiding the image command must not disable image paste, which notes have always supported.
     expect(mocks.richEditorProps.mock.lastCall?.[0]).not.toHaveProperty('enableImageInsertion')
+  })
+})
+
+describe('NotesEditor empty state', () => {
+  const emptyEditorProps = {
+    currentContent: '',
+    tokenCount: 0,
+    editorRef: { current: null },
+    codeEditorRef: { current: null },
+    onMarkdownChange: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exposes the canonical create-note action when no note is selected', async () => {
+    const user = userEvent.setup()
+    const onCreateNote = vi.fn()
+
+    render(<NotesEditor {...emptyEditorProps} onCreateNote={onCreateNote} />)
+
+    expect(screen.getByText('notes.empty')).toBeInTheDocument()
+    const createButton = screen.getByRole('button', { name: 'notes.new_note' })
+    await user.click(createButton)
+
+    expect(onCreateNote).toHaveBeenCalledTimes(1)
+  })
+
+  it('activates the empty-state create action from the keyboard', async () => {
+    const user = userEvent.setup()
+    const onCreateNote = vi.fn()
+
+    render(<NotesEditor {...emptyEditorProps} onCreateNote={onCreateNote} />)
+
+    const createButton = screen.getByRole('button', { name: 'notes.new_note' })
+    createButton.focus()
+    await user.keyboard('{Enter}')
+    expect(onCreateNote).toHaveBeenCalledTimes(1)
+
+    await user.keyboard(' ')
+    expect(onCreateNote).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not expose a create-note action while a note is open', async () => {
+    render(
+      <NotesEditor
+        activeNodeId="/notes/example.md"
+        currentContent="note"
+        tokenCount={4}
+        editorRef={{ current: null }}
+        codeEditorRef={{ current: null }}
+        onMarkdownChange={vi.fn()}
+        onCreateNote={vi.fn()}
+      />
+    )
+
+    await screen.findByTestId('rich-editor')
+    expect(screen.queryByRole('button', { name: 'notes.new_note' })).not.toBeInTheDocument()
+  })
+
+  it('does not expose a create-note action on a load error', () => {
+    render(
+      <NotesEditor
+        activeNodeId="/notes/example.md"
+        currentContent=""
+        contentLoadError={new Error('read failed')}
+        tokenCount={0}
+        editorRef={{ current: null }}
+        codeEditorRef={{ current: null }}
+        onMarkdownChange={vi.fn()}
+        onCreateNote={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('notes.load_failed')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'notes.new_note' })).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/pages/notes/__tests__/NotesPage.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesPage.test.tsx
@@ -1,3 +1,4 @@
+import { addNote } from '@renderer/services/NotesService'
 import { toast } from '@renderer/services/toast'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -62,6 +63,7 @@ const mocks = vi.hoisted(() => {
     updateNotesPath: vi.fn(),
     updateSettings: vi.fn(),
     updateSortType: vi.fn(),
+    activeFilePath: '/notes/note.md' as string | undefined,
     noteNode
   }
 })
@@ -157,7 +159,7 @@ vi.mock('@renderer/ipc', () => ({
 }))
 
 vi.mock('@renderer/data/hooks/useCache', () => ({
-  useCache: () => ['/notes/note.md', mocks.setActiveFilePath]
+  useCache: () => [mocks.activeFilePath, mocks.setActiveFilePath]
 }))
 
 vi.mock('@renderer/hooks/useShowWorkspace', () => ({
@@ -252,8 +254,18 @@ vi.mock('../NotesEditor', async (importOriginal) => {
   const original = await importOriginal<{ NotesEditorLoading: typeof NotesEditorLoading }>()
   const React = await import('react')
 
-  function MockNotesEditor({ activeNodeId, codeEditorRef, currentContent, editorRef, onMarkdownChange }: any) {
+  function MockNotesEditor({
+    activeNodeId,
+    codeEditorRef,
+    currentContent,
+    editorRef,
+    onCreateNote,
+    onMarkdownChange
+  }: any) {
     React.useEffect(() => {
+      if (!activeNodeId) {
+        return
+      }
       codeEditorRef.current =
         mocks.mountedEditor === 'rich'
           ? null
@@ -283,7 +295,15 @@ vi.mock('../NotesEditor', async (importOriginal) => {
         codeEditorRef.current = null
         editorRef.current = null
       }
-    }, [codeEditorRef, editorRef, onMarkdownChange])
+    }, [activeNodeId, codeEditorRef, editorRef, onMarkdownChange])
+
+    if (!activeNodeId) {
+      return React.createElement(
+        'div',
+        { 'data-testid': 'notes-editor' },
+        onCreateNote ? React.createElement('button', { type: 'button', onClick: onCreateNote }, 'notes.new_note') : null
+      )
+    }
 
     return React.createElement('div', {
       'data-active-node-id': activeNodeId,
@@ -357,6 +377,7 @@ describe('NotesPage print payloads', () => {
     mocks.treeVersion = 0
     mocks.treeIsLoading = false
     mocks.projectedNodes = [mocks.noteNode]
+    mocks.activeFilePath = '/notes/note.md'
 
     Object.assign(window, {
       api: {
@@ -628,5 +649,22 @@ describe('NotesPage print payloads', () => {
     expect(screen.getByTestId('notes-editor')).toHaveAttribute('data-current-content', 'recoverable draft')
     expect(mocks.discardSession).not.toHaveBeenCalled()
     expect(mocks.setActiveFilePath).not.toHaveBeenCalledWith(undefined)
+  })
+
+  it('creates an untitled note from the empty editor using the canonical create flow', async () => {
+    mocks.activeFilePath = undefined
+    mocks.projectedNodes = []
+    vi.mocked(addNote).mockResolvedValue({ path: '/notes/Untitled Note.md', name: 'Untitled Note' })
+
+    render(<NotesPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'notes.new_note' }))
+
+    await waitFor(() => {
+      expect(addNote).toHaveBeenCalledWith('notes.untitled_note', '', '/notes')
+    })
+    await waitFor(() => {
+      expect(mocks.setActiveFilePath).toHaveBeenCalledWith('/notes/Untitled Note.md')
+    })
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
The Notes page empty state (`notes.empty`) showed only a title. With no notes selected — including a profile that has zero notes — there was no create-note action on that default page. Creating a note required the sidebar control, which is easy to miss when the workspace is hidden or the tree is empty.

After this PR:
The existing notes empty state exposes a create action labeled with `notes.new_note`. It invokes the same `handleCreateNote(untitled_note)` path used by the sidebar and context menu, so it does not add a parallel creation flow or redesign the empty page.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

DEV Base: recvoRdW75b8z4

### Why we need it and why it was done in this way

The following tradeoffs were made:
The create button is attached to the existing `!activeNodeId` empty state rather than introducing a separate "zero notes" page. That is slightly broader than "tree is empty" (it also appears when notes exist but none is selected), which still uses the canonical create path and avoids a speculative empty-state redesign.

The following alternatives were considered:
- A new empty-page layout with illustration/description changes — rejected as a speculative redesign.
- A new create-note command/registry entry — rejected; Notes already has `handleCreateNote` plus `notes.new_note`.
- Adding the action only when `notesTree.length === 0` — extra branching for no extra product value on the current default page.

Links to places where the discussion took place: DEV Base recvoRdW75b8z4 (P3, preview.5, attachment image.png)

### Breaking changes

None

### Special notes for your reviewer

- UI QA in Electron was skipped: a worktree-owned disposable profile could not be guaranteed in this setup, so the packaged/user profiles were not touched.
- Keyboard activation and accessible naming are covered on the real EmptyState `Button` plus NotesEditor/NotesPage contract tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Notes: the empty notes page now has a Create a new note button that uses the same create-note flow as the sidebar.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only notes feature reusing the existing create-note flow; no auth, persistence, or security surface changes beyond current note creation.
> 
> **Overview**
> **Adds a create-note button** on the Notes editor empty state (when no note is selected), using the same untitled-note creation path as the sidebar.
> 
> `NotesEditor` accepts optional `onCreateNote` and passes it to `EmptyState` with `notes.new_note` as the action label. `NotesPage` wires `handleCreateUntitledNote` → existing `handleCreateNote` / `requestFileTransition` flow. The load-error empty state is unchanged (no create action).
> 
> **Tests:** `EmptyState` action queries use accessible names; keyboard Enter/Space activation is covered. `NotesEditor` and `NotesPage` tests assert the button only appears with no selection and that clicking it calls `addNote` and sets the active file path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7491236afbf5cd0d907e2f568b749b8e51fc6aa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->