### PR TITLE
fix(notes): preserve math formulas in plain-text copy

### DIFF
--- a/src/renderer/components/RichEditor/__tests__/nativeMarkdown.test.ts
+++ b/src/renderer/components/RichEditor/__tests__/nativeMarkdown.test.ts
@@ -25,6 +25,22 @@ const parse = (content: string): JSONContent[] => make(content).getJSON().conten
 /** Round-trip markdown -> doc -> markdown. */
 const roundTrip = (content: string): string => make(content).getMarkdown().trim()
 
+const copySelectionAsPlainText = (instance: Editor): string => {
+  const clipboard = new Map<string, string>()
+  const clipboardData = {
+    clearData: () => clipboard.clear(),
+    setData: (type: string, value: string) => {
+      clipboard.set(type, value)
+    }
+  } as unknown as DataTransfer
+  const event = new Event('copy', { bubbles: true, cancelable: true }) as ClipboardEvent
+  Object.defineProperty(event, 'clipboardData', { value: clipboardData })
+
+  instance.view.dom.dispatchEvent(event)
+
+  return clipboard.get('text/plain') ?? ''
+}
+
 afterEach(() => {
   editor?.destroy()
   editor = undefined
@@ -172,6 +188,52 @@ describe('native markdown round-trip matrix', () => {
 
   it('serializes an empty document to an empty string', () => {
     expect(roundTrip('')).toBe('')
+  })
+})
+
+describe('plain-text clipboard serialization', () => {
+  it('copies inline and multiline block math as parseable LaTeX', () => {
+    const e = make('')
+    e.commands.setContent({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'Inline ' },
+            { type: 'inlineMath', attrs: { latex: 'a + b' } },
+            { type: 'text', text: ' math' }
+          ]
+        },
+        { type: 'blockMath', attrs: { latex: 'x = y\ny = z' } },
+        { type: 'paragraph', content: [{ type: 'text', text: 'After' }] }
+      ]
+    })
+    e.commands.selectAll()
+
+    expect(copySelectionAsPlainText(e)).toBe('Inline $a + b$ math\n\n$$\nx = y\ny = z\n$$\n\nAfter')
+  })
+
+  it('does not copy delimiters for math nodes without LaTeX', () => {
+    const e = make('')
+
+    e.commands.setContent({
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [{ type: 'inlineMath', attrs: { latex: '' } }] }]
+    })
+    e.commands.selectAll()
+    const inlineText = copySelectionAsPlainText(e)
+    expect(inlineText).not.toContain('$')
+    expect(inlineText.trim()).toBe('')
+
+    e.commands.setContent({
+      type: 'doc',
+      content: [{ type: 'blockMath', attrs: { latex: '' } }]
+    })
+    e.commands.selectAll()
+    const blockText = copySelectionAsPlainText(e)
+    expect(blockText).not.toContain('$')
+    expect(blockText.trim()).toBe('')
   })
 })
 

--- a/src/renderer/components/RichEditor/extensions/enhancedMath.ts
+++ b/src/renderer/components/RichEditor/extensions/enhancedMath.ts
@@ -41,6 +41,10 @@ export const EnhancedMath = Extension.create({
   addExtensions() {
     return [
       BlockMath.extend({
+        renderText({ node }) {
+          const latex = node.attrs.latex
+          return latex ? ['$$', latex, '$$'].join('\n') : ''
+        },
         addInputRules() {
           return [
             new InputRule({
@@ -57,6 +61,10 @@ export const EnhancedMath = Extension.create({
         }
       }).configure({ ...this.options.blockOptions, katexOptions: this.options.katexOptions }),
       InlineMath.extend({
+        renderText({ node }) {
+          const latex = node.attrs.latex
+          return latex ? `$${latex}$` : ''
+        },
         addInputRules() {
           return [
             new InputRule({


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Copying note text that contained inline or block math omitted every formula from the clipboard's `text/plain` data. Pasting that text into the chat textarea therefore preserved the surrounding prose but silently lost the formulas.

After this PR:

Inline math is copied as `$<latex>$`, and block math is copied in the existing parseable Markdown layout `$$\n<latex>\n$$`. Empty math nodes produce no orphan delimiters.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

Tiptap's `inlineMath` and `blockMath` are atom nodes whose content exists only in `node.attrs.latex`. Neither the upstream mathematics extension nor Cherry Studio's enhanced extensions provided `renderText`, so ProseMirror's `clipboardTextSerializer` serialized both nodes as empty strings. The chat composer is a plain textarea and its short-text paste path consumes `text/plain`, making the formula loss unavoidable downstream.

This adds `renderText` at the math node extension boundary, which is the shared Tiptap hook for ProseMirror plain-text serialization. Block math deliberately matches the existing `renderMarkdown` delimiter layout so multiline formulas remain valid mathematical Markdown when pasted.

The following tradeoffs were made:

- `editor.getText()` uses the same serialization hook, so note character counts and the existing 2,000-character autofocus threshold now include LaTeX source. This is the intended plain-text representation.
- Empty or undefined `latex` values serialize to an empty string instead of standalone `$` or `$$` delimiters.

The following alternatives were considered:

- Recovering formulas from HTML in the chat paste handler was rejected because it would duplicate rich-editor semantics in a downstream textarea path and would not fix other plain-text consumers.
- Changing `@tiptap/markdown` serialization was rejected because note persistence already uses its independent `getMarkdown()` path and is not affected by this bug.

Links to places where the discussion took place: https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvsx8z37SbIj

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Original feedback:

- Source: Product/R&D dev Base “V2 Preview Feedback”, base `NM62bC0Epaqy0JsKjZYcQCn7nVd`, table `tblbuPFvvugxC8My`.
- Record: `recvsx8z37SbIj` — P2 / BUG / status 未修复 / version v2.0.5 / Windows.
- Feishu record: https://feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvsx8z37SbIj
- Submitter/source: EuOU archive feedback; original record `rec27Z5nmAOwlb`; item 73.
- User report summary: 「在 Cherry Studio 笔记中编写包含数学公式（如 S: 2x²+y²+z²=1）的文段 → 选中复制(Ctrl+C) → 在聊天输入框粘贴(Ctrl+V)：文字完整保留，但公式部分整体消失。」 The issue is consistently reproducible on Cherry Studio 2.0.5 zh-CN / Windows 11 / Electron 41.8.0.

Validation:

- Added a regression test that selects a real ProseMirror document, dispatches a `copy` event, and captures `clipboardData.setData('text/plain', ...)` through the production `clipboardTextSerializer` path.
- Confirmed the regression test failed before the implementation (`Inline  math\n\n\n\nAfter`) and passes after it.
- `pnpm exec vitest run --project renderer src/renderer/components/RichEditor/__tests__/nativeMarkdown.test.ts` — 23/23 passed after rebasing onto the latest `upstream/main`.
- `pnpm typecheck:web` — passed.
- `pnpm exec oxlint --deny-warnings src/renderer/components/RichEditor/extensions/enhancedMath.ts src/renderer/components/RichEditor/__tests__/nativeMarkdown.test.ts` — 0 warnings, 0 errors.
- `pnpm lint`, `pnpm format`, and `pnpm docs:check` — passed before the final rebase; the three intervening upstream commits did not modify dependency manifests or the touched files.
- A local full-suite attempt was affected by unrelated fixed-timeout failures under shared-machine I/O pressure: main 13,024 passed / 62 skipped / 10 timed out, renderer 10,076 passed / 1 timed out. The focused regression and all requested static checks pass.

This is a pure serialization fix with no visual changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed copying mathematical formulas from Notes so pasting into chat preserves them as LaTeX.
```
