### PR TITLE
fix(tab-router): cover outgoing page during external retargets

### DIFF
--- a/src/renderer/components/layout/TabRouter.tsx
+++ b/src/renderer/components/layout/TabRouter.tsx
@@ -33,10 +33,16 @@ export const TabRouter = ({ tab, isActive, onUrlChange }: TabRouterProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tab.id])
 
+  // External retargets update tab.url before an async route can replace the outgoing page.
+  // Cover that interval so teardown effects cannot repaint stale page loading UI.
+  const [resolvedHref, setResolvedHref] = useState(tab.url)
+  const transitionUrl = tab.url !== resolvedHref ? tab.url : null
+
   // Sync internal navigation back to tab state
   useEffect(() => {
     return router.subscribe('onResolved', ({ toLocation }) => {
       const nextHref = toLocation.href
+      setResolvedHref(nextHref)
       if (nextHref !== tab.url) {
         onUrlChange(nextHref)
       }
@@ -71,6 +77,13 @@ export const TabRouter = ({ tab, isActive, onUrlChange }: TabRouterProps) => {
               <RouterProvider router={router} />
             </DialogPortalContainerProvider>
           </PortalContainerProvider>
+          {transitionUrl && (
+            <div
+              data-testid="tab-route-transition-cover"
+              className="absolute inset-0 z-50 bg-card"
+              aria-hidden="true"
+            />
+          )}
         </div>
       </TabIdProvider>
     </Activity>

--- a/src/renderer/components/layout/__tests__/TabRouter.test.tsx
+++ b/src/renderer/components/layout/__tests__/TabRouter.test.tsx
@@ -8,7 +8,7 @@ import { Combobox } from '@cherrystudio/ui/components/primitives/combobox'
 import { Dialog, DialogContent } from '@cherrystudio/ui/components/primitives/dialog'
 import type { Tab } from '@shared/data/cache/cacheValueTypes'
 import { createMemoryHistory, createRouter } from '@tanstack/react-router'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
@@ -18,7 +18,11 @@ const knobs = vi.hoisted(() => ({
 
 const routerMocks = vi.hoisted(() => ({
   navigate: vi.fn(),
-  subscribe: vi.fn(() => vi.fn())
+  onResolved: undefined as undefined | ((event: { toLocation: { href: string } }) => void),
+  subscribe: vi.fn((event: string, listener: (event: { toLocation: { href: string } }) => void) => {
+    if (event === 'onResolved') routerMocks.onResolved = listener
+    return vi.fn()
+  })
 }))
 
 // PageSidePanel scopes to its owning tab by reading the SAME PortalContainerContext that
@@ -41,12 +45,16 @@ vi.mock('@renderer/routeTree.gen', () => ({ routeTree: {} }))
 // resolved portal container for the scoping assertions.
 vi.mock('@tanstack/react-router', async () => {
   const { usePortalContainer } = await import('@cherrystudio/ui')
+  const DestinationPending = () => <div aria-busy="true">Loading destination</div>
 
   return {
     createMemoryHistory: vi.fn((options: { initialEntries: string[] }) => options),
     createRouter: vi.fn(({ history }: { history: { initialEntries: string[] } }) => ({
       navigate: routerMocks.navigate,
       subscribe: routerMocks.subscribe,
+      routesByPath: {
+        '/app/agents': { options: { pendingComponent: DestinationPending } }
+      },
       state: {
         location: {
           href: history.initialEntries[0]
@@ -92,6 +100,7 @@ beforeAll(() => {
 afterEach(() => {
   cleanup()
   knobs.renderPage = () => null
+  routerMocks.onResolved = undefined
   vi.clearAllMocks()
 })
 
@@ -285,5 +294,20 @@ describe('TabRouter', () => {
 
     expect(createMemoryHistory).toHaveBeenCalledTimes(1)
     expect(routerMocks.navigate).toHaveBeenCalledWith({ to: '/app/chat?topicId=current-topic' })
+  })
+
+  it('quietly covers the outgoing page while an external retarget is unresolved', () => {
+    const { rerender } = render(
+      <TabRouter tab={tab('route-tab', '/app/mini-app/claude')} isActive onUrlChange={() => {}} />
+    )
+
+    rerender(<TabRouter tab={tab('route-tab', '/app/agents')} isActive onUrlChange={() => {}} />)
+
+    expect(screen.getByTestId('tab-route-transition-cover')).toHaveClass('bg-card')
+    expect(screen.queryByText('Loading destination')).not.toBeInTheDocument()
+
+    act(() => routerMocks.onResolved?.({ toLocation: { href: '/app/agents' } }))
+
+    expect(screen.queryByTestId('tab-route-transition-cover')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Switching the active tab away from an open mini app (e.g. sidebar mini-app tab → Agents/Chat) flashed the **mini app's own loading mask** (logo + BeatLoader) over the transition. The sidebar rewrites `tab.url` immediately, so `MiniAppTabsPool` evicts the webview and broadcasts `loaded=false` while the async `beforeLoad` of the destination route still keeps the outgoing `MiniAppPage` mounted — the stale page then repaints its loading mask until the navigation commits.

After this PR:

`TabRouter` derives a transition state (`tab.url !== resolvedHref`) and covers the outgoing page with a quiet `bg-card` backdrop **in the same commit the external retarget lands**, lifting it on the router's `onResolved`. The stale mask can still mount underneath but can never paint over the transition. Internal (in-tab) navigations never trigger the cover because `onResolved` lands the new href together with the `tab.url` write-back in one batch.

<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>
 

https://github.com/user-attachments/assets/87eeb7eb-41c6-4f66-aaf8-84a26fcf712b


 <td>

https://github.com/user-attachments/assets/cc46efc8-7c5d-4f05-a4fa-aeb345d86cfd


</table>

### Why we need it and why it was done in this way

The root asymmetry: `tab.url` is written eagerly (intent) while the rendered content follows asynchronously (fact), and the webview pool reacts destructively to the intent. The cover closes that gap at the only place that owns both sides — `TabRouter`.

The following tradeoffs were made:

- During the brief transition (~100–600 ms in dev; instant on warm re-entry) the tab shows a quiet blank backdrop instead of stale content. A delayed activity indicator was prototyped and removed: real transitions finish right around any reasonable delay threshold, so it only produced flicker.
- The cover clears on `onResolved` (full pending completion), which is the same event the existing url write-back already relies on.

The following alternatives were considered:

- Route-level `pendingComponent` + `pendingMs: 0` on the conversation routes — insufficient: with fast entry resolution React coalesces the pending commit into the final one, so the mask still painted for 100–400 ms.
- Making `tab.url` a committed-only value (router as the single writer) — rejected after auditing consumers: sidebar highlight, conversation data-source pre-warming, and re-entrancy guards all depend on the eager url flip; that change is a separate architectural project.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Regression test simulates the external retarget against the mocked per-tab router and asserts the cover appears synchronously and clears on `onResolved`; it fails without the fix.
- Runtime verified frame-by-frame via CDP screencast on a dev build: 0 frames of the mini-app mask visible across mini-app → agents/chat/translate transitions, tab-bar switching, pinned-tab forks, and a retarget-then-switch-away race (the deferred `onResolved` re-emits when the hidden tab is shown again — `Activity` preserves refs).
- The cover intentionally renders no destination pending UI; the test pins that decision.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed the mini app's loading mask briefly flashing over the tab when switching from an open mini app to Agents, Chat, or another view from the sidebar.
```
