### PR TITLE
fix(api-gateway): handle tokenless knowledge queries

### DIFF
--- a/src/main/features/apiGateway/routes/__tests__/knowledge.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/knowledge.test.ts
@@ -124,6 +124,79 @@ describe('knowledge routes (v2)', () => {
     expect(body.warnings).toHaveLength(1)
   })
 
+  it('POST /search → 422 when query is empty', async () => {
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: '' })
+    expect(status).toBe(422)
+    expect(body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('POST /search returns an empty result with warnings when query has no searchable tokens', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockRejectedValue(
+      DataApiErrorFactory.validation({ query: ['Query has no searchable tokens'] }, 'Query has no searchable tokens')
+    )
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: '🎉' })
+
+    expect(status).toBe(200)
+    expect(body.results).toEqual([])
+    expect(body.total).toBe(0)
+    expect(body.warnings).toEqual([
+      'Knowledge base "KB 1" search failed: Query has no searchable tokens',
+      'Knowledge base "KB 2" search failed: Query has no searchable tokens'
+    ])
+  })
+
+  it('POST /search returns warnings for mixed no-token validation and infrastructure failures', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockImplementation(async (baseId: string) => {
+      if (baseId === 'kb-1') {
+        throw DataApiErrorFactory.validation(
+          { query: ['Query has no searchable tokens'] },
+          'Query has no searchable tokens'
+        )
+      }
+      throw new Error('vector store unavailable')
+    })
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: '✨' })
+
+    expect(status).toBe(200)
+    expect(body.results).toEqual([])
+    expect(body.total).toBe(0)
+    expect(body.warnings).toEqual([
+      'Knowledge base "KB 1" search failed: Query has no searchable tokens',
+      'Knowledge base "KB 2" search failed: vector store unavailable'
+    ])
+  })
+
+  it('POST /search → 503 when every targeted base fails with another validation error', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockRejectedValue(
+      DataApiErrorFactory.validation(
+        { base: ['Knowledge base is in failed state'] },
+        'Cannot search failed knowledge base'
+      )
+    )
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: 'hi' })
+
+    expect(status).toBe(503)
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE')
+  })
+
+  it('POST /search → 503 when every targeted base fails with INVALID_OPERATION', async () => {
+    mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
+    mockSearch.mockRejectedValue(
+      DataApiErrorFactory.invalidOperation('search', 'Knowledge index store was closed; retry the operation')
+    )
+
+    const { status, body } = await call('POST', '/knowledge-bases/search', { query: 'hi' })
+
+    expect(status).toBe(503)
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE')
+  })
+
   it('POST /search → 503 when every targeted base search fails', async () => {
     mockList.mockReturnValue({ items: [kb('kb-1', 'KB 1'), kb('kb-2', 'KB 2')], total: 2, page: 1 })
     mockSearch.mockRejectedValue(new Error('vector store unavailable'))

--- a/src/main/features/apiGateway/routes/knowledge.ts
+++ b/src/main/features/apiGateway/routes/knowledge.ts
@@ -1,7 +1,13 @@
 import { application } from '@application'
 import { knowledgeBaseService } from '@data/services/KnowledgeBaseService'
 import { loggerService } from '@logger'
-import { DataApiError, DataApiErrorFactory, ERROR_STATUS_MAP, ErrorCode } from '@shared/data/api/errors'
+import {
+  DataApiError,
+  DataApiErrorFactory,
+  ERROR_STATUS_MAP,
+  ErrorCode,
+  type ValidationErrorDetails
+} from '@shared/data/api/errors'
 import { Elysia } from 'elysia'
 
 import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
@@ -101,30 +107,39 @@ export const knowledgeRoutes = new Elysia({ prefix: '/knowledge-bases' })
                 knowledge_base_id: base.id,
                 knowledge_base_name: base.name
               })),
-              error: undefined as string | undefined
+              error: undefined as Error | undefined
             }
           } catch (error) {
-            logger.error(`Error searching knowledge base ${base.id}`, error as Error)
-            return { base, results: [], error: (error as Error).message }
+            const searchError = error instanceof Error ? error : new Error(String(error))
+            logger.error(`Error searching knowledge base ${base.id}`, searchError)
+            return { base, results: [], error: searchError }
           }
         })
       )
 
-      // Every targeted search failed (e.g. broken embedding/vector-store config). Surface a
-      // retryable upstream-dependency failure (503) instead of a 200 with empty results, so
-      // clients can tell infrastructure failure apart from "no matches".
-      if (resultsPerBase.every((r) => r.error)) {
+      const hasNoSearchableTokensError = resultsPerBase.some(
+        ({ error }) =>
+          error instanceof DataApiError &&
+          error.code === ErrorCode.VALIDATION_ERROR &&
+          (error.details as ValidationErrorDetails | undefined)?.fieldErrors.query?.includes(
+            'Query has no searchable tokens'
+          ) === true
+      )
+
+      // All-target failure remains a 503 unless this query has no searchable tokens,
+      // which cannot produce matches in any base.
+      if (resultsPerBase.every((r) => r.error !== undefined) && !hasNoSearchableTokensError) {
         throw new DataApiError(
           ErrorCode.SERVICE_UNAVAILABLE,
           'All knowledge base searches failed',
           ERROR_STATUS_MAP[ErrorCode.SERVICE_UNAVAILABLE],
-          { originalError: resultsPerBase.map((r) => r.error).join('; ') }
+          { originalError: resultsPerBase.flatMap((r) => (r.error ? [r.error.message] : [])).join('; ') }
         )
       }
 
-      const warnings = resultsPerBase
-        .filter((r) => r.error)
-        .map((r) => `Knowledge base "${r.base.name}" search failed: ${r.error}`)
+      const warnings = resultsPerBase.flatMap((r) =>
+        r.error ? [`Knowledge base "${r.base.name}" search failed: ${r.error.message}`] : []
+      )
       const sortedResults = resultsPerBase
         .flatMap((r) => r.results)
         .sort((a, b) => b.score - a.score)

--- a/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
+++ b/src/main/features/knowledge/__tests__/KnowledgeService.test.ts
@@ -2014,6 +2014,19 @@ describe('KnowledgeService', () => {
     )
   })
 
+  it('validates a tokenless query before checking whether the base can be searched', async () => {
+    const service = new KnowledgeService()
+    knowledgeBaseGetByIdMock.mockReturnValue(
+      createBase({ status: 'failed', error: KNOWLEDGE_BASE_ERROR_MISSING_EMBEDDING_MODEL })
+    )
+
+    await expect(service.search('kb-1', '🎉')).rejects.toMatchObject({
+      code: ErrorCode.VALIDATION_ERROR,
+      message: 'Query has no searchable tokens',
+      details: { fieldErrors: { query: ['Query has no searchable tokens'] } }
+    })
+  })
+
   it('enriches each hit with its Concept ID (relative path) and display title for deep-read follow-up', async () => {
     const service = new KnowledgeService()
     const FILE_ITEM_ID = 'file-item-1'

--- a/src/main/features/knowledge/query/KnowledgeQueryService.ts
+++ b/src/main/features/knowledge/query/KnowledgeQueryService.ts
@@ -50,8 +50,6 @@ export class KnowledgeQueryService {
 
   @TraceMethod({ spanName: 'Knowledge.search', tag: 'Knowledge' })
   async search(baseId: string, query: string): Promise<KnowledgeSearchResult[]> {
-    const base = assertBaseCanRunRuntimeOperation(baseId, 'search')
-
     // Same tokenization the FTS layer uses: no token means no BM25 hit is even possible.
     if (extractFtsTokens(query).length === 0) {
       throw DataApiErrorFactory.validation(
@@ -59,6 +57,8 @@ export class KnowledgeQueryService {
         'Query has no searchable tokens'
       )
     }
+
+    const base = assertBaseCanRunRuntimeOperation(baseId, 'search')
 
     // Vector/hybrid retrieval needs an embedding model; a base without one is
     // BM25-only. This is a fixed runtime policy, not a stored preference — mode is


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

With the local API Gateway enabled, `POST /v1/knowledge-bases/search` with a query made only of emoji or punctuation (e.g. `🎉`, `!!!`) returned `503 SERVICE_UNAVAILABLE`, as if the service were down. An empty query correctly returned `422`, and ordinary words searched fine.

Two defects combined to produce this:

1. `routes/knowledge.ts` caught each per-base search failure and kept only `(error as Error).message`, discarding the error type and its `ErrorCode`.
2. The follow-up branch treated "every targeted base failed" as an infrastructure outage and mapped it to `503`. That branch exists for broken embedding / vector-store configuration — a retryable upstream-dependency failure — but a pure client-input problem was being swept into it.

The input error itself is legitimate: `KnowledgeQueryService.search()` rejects a query that `extractFtsTokens` reduces to zero tokens, because no BM25 hit is possible. Emoji and punctuation always tokenize to nothing, so every base failed and the request was reported as a service outage.

After this PR:

- The per-base `catch` keeps the `Error` object (so a `DataApiError` is no longer downgraded to a string); `warnings` read `.message` from it.
- The all-bases-failed `503` is skipped only when at least one failure is exactly the no-searchable-tokens validation error — matched on **both** `ErrorCode.VALIDATION_ERROR` and the structured `details.fieldErrors.query` entry. Such a query cannot match in any base, so the request returns `200` with `results: []`, `total: 0`, and one explanatory `warnings` entry per failed base.
- Every other all-failed case still returns `503`: other validation errors (e.g. a failed base), `INVALID_OPERATION` (index not ready, closed store), other typed errors, and generic runtime errors.
- `KnowledgeQueryService.search()` now runs its tokenless-query check *before* `assertBaseCanRunRuntimeOperation`. Previously an emoji query against a base in `failed` state reported the base error instead of the input error, so the gateway still returned `503`.
- The empty-query contract is untouched: an empty string is rejected by the HTTP body schema in `knowledgeSchemas.ts` and still returns `422`. A non-empty, schema-valid query that simply has no searchable tokens is a zero-match search, not a schema violation — the two layers stay distinct.

Fixes #18328

### Why we need it and why it was done in this way

A client cannot distinguish "the knowledge service is down, retry later" from "your query text is not indexable" when both are reported as `503`. The reporter explicitly expected this input to short-circuit to `200` with an empty result rather than masquerade as service unavailability.

The following tradeoffs were made:

- **`200` + empty results over a `422` validation error.** The empty-string `422` comes from HTTP body schema validation; an emoji query passes that schema and only fails deeper, at retrieval. Returning `422` here would make the API contradict itself about what "invalid input" means. `200` + `total: 0` + `warnings` keeps schema validation and retrieval semantics on separate layers.
- **Exact error matching over a general retryability rule.** The bypass requires `ErrorCode.VALIDATION_ERROR` *and* the `details.fieldErrors.query` marker together. Classifying by something broader (e.g. `DataApiError.isRetryable`) would silently turn genuine infrastructure failures into `200` empty results — the exact failure mode this PR is fixing, only inverted.
- **Mixed failures are decided by the same rule.** If any failure is the no-searchable-tokens error, the request returns `200` with successful bases' results aggregated as usual and one warning per failed base. Without that exact error present, mixed and all-failed cases keep returning `503`.

The following alternatives were considered:

- Deleting the token check in `KnowledgeQueryService` — rejected: it would send a query that can never produce a BM25 hit through the full embedding and retrieval path.
- Turning the `503` branch into an unconditional `200` — rejected: it would hide real broken embedding / vector-store configuration, which is what that branch is for.
- Relaxing `extractFtsTokens` so emoji become FTS tokens — rejected: the trigram tokenizer cannot index them, so this would only move the empty result further downstream.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18328

### Breaking changes

None. The only behavior change is that a previously-`503` response for a tokenless query is now `200` with an empty result set. All other error paths are unchanged, including the empty-query `422` and every genuine all-bases-failed `503`.

### Special notes for your reviewer

Original report (verbatim from the internal feedback record):

> Enable the local API Gateway → `POST /v1/knowledge-bases/search`, query containing only emoji or symbols → returns 503; an empty query correctly returns 422, and ordinary letters are searchable.

Environment: macOS arm64 / Cherry Studio 2.0.3 / local API Gateway 127.0.0.1:23333 / 3 knowledge bases / Ollama bge-m3 / hybrid retrieval. Upstream source: CherryHQ/cherry-studio#18328.

The reporter explicitly stated that this input should short-circuit to `200` with an empty result rather than masquerade as service unavailability.

Test coverage — regression tests were written first and confirmed red on this exact base (reverting only the two production files makes exactly these fail):

- emoji-only query → `200`, empty results, warnings (was `503`)
- mixed no-searchable-tokens + infrastructure failure → `200` with warnings (was `503`)
- tokenless query on a `failed` base → the query validation error, not the base error

Guard tests that must keep returning the old behavior, and do:

- all bases failing with another `VALIDATION_ERROR` → still `503`
- all bases failing with `INVALID_OPERATION` → still `503`
- all bases failing with a generic runtime error → still `503` (the pre-existing test)
- empty query → still `422`

Verified on this branch: `pnpm lint` exit 0 (oxlint 0 warnings / 0 errors; typecheck node + web + aicore clean; i18n check passes; Biome applied no changes) and `pnpm test:main` exit 0 (843 files, 13041 passed / 62 skipped). The change is main-process only — no renderer, UI, or i18n files are touched.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the local API Gateway reporting 503 SERVICE_UNAVAILABLE for a knowledge base search whose query contains only emoji or symbols. Such a query now returns 200 with an empty result set and an explanatory warning, while genuine infrastructure failures still return 503.
```
