### PR TITLE
fix(copilot): preserve required request headers

### DIFF
--- a/src/main/services/CopilotService.ts
+++ b/src/main/services/CopilotService.ts
@@ -32,6 +32,22 @@ const CONFIG = {
   TOKEN_FILE_NAME: '.copilot_token'
 }
 
+const BASE_HEADERS = {
+  ...CONFIG.DEFAULT_HEADERS,
+  accept: 'application/json',
+  'user-agent': 'Visual Studio Code (desktop)'
+}
+
+const mergeHeaders = (headers?: Record<string, string>): Record<string, string> => {
+  const mergedHeaders = new Headers(BASE_HEADERS)
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    mergedHeaders.set(name, value)
+  }
+  mergedHeaders.set('accept', BASE_HEADERS.accept)
+  mergedHeaders.set('content-type', BASE_HEADERS['content-type'])
+  return Object.fromEntries(mergedHeaders.entries())
+}
+
 // 接口定义移到顶部，便于查阅
 interface UserResponse {
   login: string
@@ -67,15 +83,6 @@ class CopilotService {
   // Memoized backing field for the lazy `tokenFilePath` getter below.
   // `undefined` until first access; resolved exactly once and cached.
   private _tokenFilePath: string | undefined
-  private headers: Record<string, string>
-
-  constructor() {
-    this.headers = {
-      ...CONFIG.DEFAULT_HEADERS,
-      accept: 'application/json',
-      'user-agent': 'Visual Studio Code (desktop)'
-    }
-  }
 
   // TODO(v2): Lazy + memoized getter is a workaround, not a fix.
   //
@@ -120,15 +127,6 @@ class CopilotService {
   }
 
   /**
-   * 设置自定义请求头
-   */
-  private updateHeaders = (headers?: Record<string, string>): void => {
-    if (headers && Object.keys(headers).length > 0) {
-      this.headers = { ...headers }
-    }
-  }
-
-  /**
    * 获取GitHub登录信息
    */
   public getUser = async (_: Electron.IpcMainInvokeEvent, token: string): Promise<UserResponse> => {
@@ -169,14 +167,11 @@ class CopilotService {
     headers?: Record<string, string>
   ): Promise<AuthResponse> => {
     try {
-      this.updateHeaders(headers)
+      const requestHeaders = mergeHeaders(headers)
 
       const response = await net.fetch(CONFIG.API_URLS.GITHUB_DEVICE_CODE, {
         method: 'POST',
-        headers: {
-          ...this.headers,
-          'Content-Type': 'application/json'
-        },
+        headers: requestHeaders,
         body: JSON.stringify({
           client_id: CONFIG.GITHUB_CLIENT_ID,
           scope: 'read:user'
@@ -202,7 +197,7 @@ class CopilotService {
     device_code: string,
     headers?: Record<string, string>
   ): Promise<TokenResponse> => {
-    this.updateHeaders(headers)
+    const requestHeaders = mergeHeaders(headers)
 
     let currentDelay = CONFIG.POLLING.INITIAL_DELAY_MS
 
@@ -212,10 +207,7 @@ class CopilotService {
       try {
         const response = await net.fetch(CONFIG.API_URLS.GITHUB_ACCESS_TOKEN, {
           method: 'POST',
-          headers: {
-            ...this.headers,
-            'Content-Type': 'application/json'
-          },
+          headers: requestHeaders,
           body: JSON.stringify({
             client_id: CONFIG.GITHUB_CLIENT_ID,
             device_code,
@@ -274,7 +266,7 @@ class CopilotService {
     headers?: Record<string, string>
   ): Promise<CopilotTokenResponse> => {
     try {
-      this.updateHeaders(headers)
+      const requestHeaders = mergeHeaders(headers)
 
       const encryptedToken = await fs.promises.readFile(this.tokenFilePath)
       const access_token = safeStorage.decryptString(Buffer.from(encryptedToken))
@@ -282,7 +274,7 @@ class CopilotService {
       const response = await net.fetch(CONFIG.API_URLS.COPILOT_TOKEN, {
         method: 'GET',
         headers: {
-          ...this.headers,
+          ...requestHeaders,
           authorization: `token ${access_token}`
         }
       })

--- a/src/main/services/__tests__/CopilotService.test.ts
+++ b/src/main/services/__tests__/CopilotService.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { decryptStringMock, existsSyncMock, netFetchMock, readFileMock } = vi.hoisted(() => ({
+  decryptStringMock: vi.fn(),
+  existsSyncMock: vi.fn(),
+  netFetchMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock },
+  safeStorage: {
+    decryptString: decryptStringMock,
+    encryptString: vi.fn()
+  }
+}))
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: existsSyncMock,
+    promises: {
+      readFile: readFileMock
+    }
+  }
+}))
+
+import { copilotService } from '../CopilotService'
+
+const GITHUB_DEVICE_CODE_URL = 'https://github.com/login/device/code'
+const GITHUB_ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+const COPILOT_TOKEN_URL = 'https://api.github.com/copilot_internal/v2/token'
+const IPC_EVENT = undefined as unknown as Electron.IpcMainInvokeEvent
+
+const fetchResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => body
+})
+
+const getRequestHeaders = (url: string): Record<string, string> => {
+  const call = netFetchMock.mock.calls.find(([requestUrl]) => requestUrl === url)
+  if (!call) {
+    throw new Error(`No request captured for ${url}`)
+  }
+  return (call[1] as { headers: Record<string, string> }).headers
+}
+
+const countHeaderKeys = (headers: Record<string, string>, name: string): number =>
+  Object.keys(headers).filter((headerName) => headerName.toLowerCase() === name.toLowerCase()).length
+
+describe('CopilotService headers', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+    decryptStringMock.mockReset().mockReturnValue('github-access-token')
+    existsSyncMock.mockReset().mockReturnValue(false)
+    readFileMock.mockReset().mockResolvedValue(Buffer.from('encrypted-token'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves the device-code JSON contract while merging custom headers without leaks', async () => {
+    netFetchMock.mockResolvedValue(
+      fetchResponse({
+        device_code: 'device-code',
+        user_code: 'user-code',
+        verification_uri: 'https://github.com/login/device'
+      })
+    )
+
+    await copilotService.getAuthMessage(IPC_EVENT, {
+      Accept: 'application/xml',
+      'Content-Type': 'text/plain',
+      'User-Agent': 'custom-agent',
+      'X-Custom': '1'
+    })
+
+    const customHeaders = getRequestHeaders(GITHUB_DEVICE_CODE_URL)
+    const normalizedCustomHeaders = new Headers(customHeaders)
+    expect(normalizedCustomHeaders.get('accept')).toBe('application/json')
+    expect(normalizedCustomHeaders.get('content-type')).toBe('application/json')
+    expect(normalizedCustomHeaders.get('editor-version')).toBe('Neovim/0.6.1')
+    expect(normalizedCustomHeaders.get('user-agent')).toBe('custom-agent')
+    expect(normalizedCustomHeaders.get('x-custom')).toBe('1')
+    expect(countHeaderKeys(customHeaders, 'accept')).toBe(1)
+    expect(countHeaderKeys(customHeaders, 'content-type')).toBe(1)
+    expect(countHeaderKeys(customHeaders, 'user-agent')).toBe(1)
+
+    netFetchMock.mockClear()
+    await copilotService.getAuthMessage(IPC_EVENT)
+
+    const defaultHeaders = new Headers(getRequestHeaders(GITHUB_DEVICE_CODE_URL))
+    expect(defaultHeaders.get('accept')).toBe('application/json')
+    expect(defaultHeaders.get('editor-version')).toBe('Neovim/0.6.1')
+    expect(defaultHeaders.get('user-agent')).toBe('Visual Studio Code (desktop)')
+    expect(defaultHeaders.has('x-custom')).toBe(false)
+  })
+
+  it('merges custom headers with access-token polling defaults case-insensitively', async () => {
+    vi.useFakeTimers()
+    netFetchMock.mockResolvedValue(fetchResponse({ access_token: 'github-access-token' }))
+
+    const tokenPromise = copilotService.getCopilotToken(IPC_EVENT, 'device-code', {
+      'CONTENT-TYPE': 'text/plain',
+      'Editor-Version': 'custom-editor'
+    })
+    await vi.advanceTimersByTimeAsync(1000)
+
+    await expect(tokenPromise).resolves.toEqual({ access_token: 'github-access-token' })
+    const requestHeaders = getRequestHeaders(GITHUB_ACCESS_TOKEN_URL)
+    const normalizedHeaders = new Headers(requestHeaders)
+    expect(normalizedHeaders.get('accept')).toBe('application/json')
+    expect(normalizedHeaders.get('content-type')).toBe('application/json')
+    expect(normalizedHeaders.get('editor-version')).toBe('custom-editor')
+    expect(normalizedHeaders.get('user-agent')).toBe('Visual Studio Code (desktop)')
+    expect(countHeaderKeys(requestHeaders, 'content-type')).toBe(1)
+    expect(countHeaderKeys(requestHeaders, 'editor-version')).toBe(1)
+  })
+
+  it('merges custom headers with Copilot-token defaults and preserves service authorization', async () => {
+    netFetchMock.mockResolvedValue(fetchResponse({ token: 'copilot-token' }))
+
+    await expect(
+      copilotService.getToken(IPC_EVENT, {
+        'USER-AGENT': 'custom-agent'
+      })
+    ).resolves.toEqual({ token: 'copilot-token' })
+
+    const requestHeaders = getRequestHeaders(COPILOT_TOKEN_URL)
+    const normalizedHeaders = new Headers(requestHeaders)
+    expect(normalizedHeaders.get('accept')).toBe('application/json')
+    expect(normalizedHeaders.get('editor-version')).toBe('Neovim/0.6.1')
+    expect(normalizedHeaders.get('user-agent')).toBe('custom-agent')
+    expect(normalizedHeaders.get('authorization')).toBe('token github-access-token')
+    expect(countHeaderKeys(requestHeaders, 'user-agent')).toBe(1)
+  })
+
+  it('keeps headers isolated when token requests interleave', async () => {
+    vi.useFakeTimers()
+    netFetchMock.mockImplementation(async (url: string) =>
+      fetchResponse(
+        url === GITHUB_ACCESS_TOKEN_URL ? { access_token: 'github-access-token' } : { token: 'copilot-token' }
+      )
+    )
+
+    const pollingPromise = copilotService.getCopilotToken(IPC_EVENT, 'device-code', {
+      'X-Request': 'polling'
+    })
+    const copilotTokenPromise = copilotService.getToken(IPC_EVENT, {
+      'X-Request': 'copilot-token'
+    })
+
+    await expect(copilotTokenPromise).resolves.toEqual({ token: 'copilot-token' })
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(pollingPromise).resolves.toEqual({ access_token: 'github-access-token' })
+
+    expect(new Headers(getRequestHeaders(COPILOT_TOKEN_URL)).get('x-request')).toBe('copilot-token')
+    expect(new Headers(getRequestHeaders(GITHUB_ACCESS_TOKEN_URL)).get('x-request')).toBe('polling')
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Custom headers configured for the GitHub Copilot provider replaced the service's required baseline headers and polluted later calls. Device Code requests could therefore lose JSON negotiation headers, and token requests could lose required client headers. Case variants such as `Accept` and `Content-Type` could also override the JSON protocol contract.

After this PR:

Copilot request headers are rebuilt per call by case-insensitively merging custom headers over the baseline. The JSON protocol headers (`Accept` and `Content-Type`) remain fixed, while ordinary custom headers can still override baseline values. Calls no longer share mutable header state.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

N/A

### Why we need it and why it was done in this way

GitHub's Device Code endpoint returns form-encoded data unless JSON is requested, while this service always parses the response as JSON. The two OAuth POST requests also serialize JSON bodies and must keep `Content-Type: application/json`. Using the platform `Headers` implementation gives case-insensitive replacement semantics, and rebuilding from an immutable baseline for every request removes singleton cross-call pollution.

The following tradeoffs were made:

- Custom `Accept` and `Content-Type` values are ignored because those headers are part of this service's JSON protocol contract.
- Other custom headers retain case-insensitive override priority.

The following alternatives were considered:

- A manual lowercase-key map was rejected in favor of the standard `Headers` implementation.
- Keeping mutable service-level headers and resetting them after each call was rejected because concurrent calls could still interleave.

Links to places where the discussion took place: Original feedback in the `v2 预览版问题反馈` dev table, record `recvsKaAQIYQ5J`: https://cherryin.feishu.cn/base/NM62bC0Epaqy0JsKjZYcQCn7nVd?table=tblbuPFvvugxC8My&record=recvsKaAQIYQ5J

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- Added regression coverage for `getAuthMessage`, `getCopilotToken`, `getToken`, case-insensitive overrides, protected JSON headers, sequential calls, and concurrent interleaving.
- Verified with the focused Vitest suite, changed-file oxlint, main-process typecheck, formatting, and the repository test suites.
- Original feedback: 许思寅, Cherry Studio V2.0.7 / Win32 — the user was already logged in and provider models worked, but clicking “Start authorization” showed “Failed to get Device Code” despite a normal network environment.
- Out of scope: the separate “already logged in but still asks for authorization” symptom is driven by `provider.settings.isAuthed` and is not addressed in this PR.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix GitHub Copilot authorization failures when custom request headers are configured.
```
