### PR TITLE
refactor(http): merge request headers case-insensitively

### DIFF
--- a/src/main/ai/__tests__/AiService.test.ts
+++ b/src/main/ai/__tests__/AiService.test.ts
@@ -1740,14 +1740,9 @@ describe('AiService tool approval', () => {
     })
 
     expect(mockProviderResolveApiKey).toHaveBeenCalledWith('ollama', 'sk-selected')
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('/api/show'),
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          'X-Api-Key': 'sk-selected'
-        })
-      })
-    )
+    const [url, init] = fetchSpy.mock.calls.at(-1) as [string, RequestInit]
+    expect(url).toContain('/api/show')
+    expect(new Headers(init.headers).get('x-api-key')).toBe('sk-selected')
   })
 
   it('surfaces Ollama string error from /api/show', async () => {

--- a/src/main/ai/provider/__tests__/config.test.ts
+++ b/src/main/ai/provider/__tests__/config.test.ts
@@ -28,8 +28,9 @@ const { resolveApiKeyMock, getAuthConfigMock, getByProviderIdMock } = vi.hoisted
   getAuthConfigMock: vi.fn<(providerId: string) => AuthConfig | null>(),
   getByProviderIdMock: vi.fn()
 }))
-const { generateSignatureMock } = vi.hoisted(() => ({
-  generateSignatureMock: vi.fn()
+const { generateSignatureMock, getCopilotTokenMock } = vi.hoisted(() => ({
+  generateSignatureMock: vi.fn(),
+  getCopilotTokenMock: vi.fn()
 }))
 
 vi.mock('@main/data/services/ProviderService', () => ({
@@ -44,6 +45,12 @@ vi.mock('@main/ai/provider/cherryai', () => ({
   generateSignature: generateSignatureMock
 }))
 
+vi.mock('@main/services/CopilotService', () => ({
+  copilotService: {
+    getToken: getCopilotTokenMock
+  }
+}))
+
 // Import the SUT after the mock is declared.
 const { providerToAiSdkConfig, resolveProviderAiSdkConfig } = await import('../config')
 
@@ -56,6 +63,7 @@ beforeEach(() => {
       : { attribution: 'explicit', id: 'test-key', masked: 'sk-t****-key' }
   }))
   getAuthConfigMock.mockReturnValue(null)
+  getCopilotTokenMock.mockResolvedValue({ token: 'copilot-token' })
 })
 
 afterEach(() => {
@@ -141,6 +149,37 @@ describe('providerToAiSdkConfig — builder dispatch matrix', () => {
     const resolved = await resolveProviderAiSdkConfig(provider, model)
 
     expect(resolved.credentialReceipt).toEqual({ attribution: 'unknown' })
+  })
+
+  it('merges Copilot extra headers over defaults case-insensitively', async () => {
+    const provider = makeProvider({
+      id: 'copilot',
+      authType: 'oauth',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          baseUrl: 'https://api.githubcopilot.com',
+          adapterFamily: 'github-copilot-openai-compatible'
+        }
+      },
+      settings: {
+        extraHeaders: { 'User-Agent': 'CustomAgent/1.0', 'X-Custom': 'on' }
+      } as never
+    })
+    const model = makeModel({
+      id: 'copilot::gpt-4o',
+      apiModelId: 'gpt-4o',
+      providerId: 'copilot',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+
+    const config = await providerToAiSdkConfig(provider, model)
+    const headers = (config.providerSettings as { headers: Record<string, string> }).headers
+    const normalizedHeaders = new Headers(headers)
+
+    expect(normalizedHeaders.get('user-agent')).toBe('CustomAgent/1.0')
+    expect(normalizedHeaders.get('x-custom')).toBe('on')
+    expect(Object.keys(headers).filter((name) => name.toLowerCase() === 'user-agent')).toHaveLength(1)
   })
 
   describe('OpenCode Go session header', () => {

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -217,7 +217,7 @@ describe('listModels — geminiFetcher API key transport', () => {
     expect(call.headers['x-goog-api-key']).toBe('AIza-secret-key')
   })
 
-  it('forwards provider extraHeaders alongside x-goog-api-key', async () => {
+  it('merges provider extraHeaders over application defaults case-insensitively', async () => {
     const provider = makeProvider({
       id: 'gemini',
       defaultChatEndpoint: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
@@ -226,7 +226,9 @@ describe('listModels — geminiFetcher API key transport', () => {
           baseUrl: 'https://generativelanguage.googleapis.com/v1beta'
         }
       },
-      settings: { extraHeaders: { 'X-Custom': 'on' } } as never
+      settings: {
+        extraHeaders: { 'http-referer': 'https://provider.example', 'X-Custom': 'on' }
+      } as never
     })
 
     await listModels(provider)
@@ -235,6 +237,8 @@ describe('listModels — geminiFetcher API key transport', () => {
     const headers = new Headers(call.headers)
     expect(headers.get('x-goog-api-key')).toBe('AIza-secret-key')
     expect(headers.get('x-custom')).toBe('on')
+    expect(headers.get('http-referer')).toBe('https://provider.example')
+    expect(Object.keys(call.headers).filter((name) => name.toLowerCase() === 'http-referer')).toHaveLength(1)
   })
 
   it('maps the listed models, stripping the models/ prefix from the id', async () => {

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -232,8 +232,9 @@ describe('listModels — geminiFetcher API key transport', () => {
     await listModels(provider)
 
     const call = aiSdkGetFromApiMock.mock.calls[0][0] as { headers: Record<string, string> }
-    expect(call.headers['x-goog-api-key']).toBe('AIza-secret-key')
-    expect(call.headers['X-Custom']).toBe('on')
+    const headers = new Headers(call.headers)
+    expect(headers.get('x-goog-api-key')).toBe('AIza-secret-key')
+    expect(headers.get('x-custom')).toBe('on')
   })
 
   it('maps the listed models, stripping the models/ prefix from the id', async () => {
@@ -595,8 +596,8 @@ describe('listModels — Radeon Cloud source header', () => {
     const radeonCall = aiSdkGetFromApiMock.mock.calls[0][0] as { url: string; headers: Record<string, string> }
     const otherCall = aiSdkGetFromApiMock.mock.calls[1][0] as { url: string; headers: Record<string, string> }
     expect(radeonCall.url).toBe('https://developer.amd.com.cn/radeon/api/v1/models')
-    expect(radeonCall.headers['X-Source']).toBe('cherry-studio')
-    expect(otherCall.headers).not.toHaveProperty('X-Source')
+    expect(new Headers(radeonCall.headers).get('x-source')).toBe('cherry-studio')
+    expect(new Headers(otherCall.headers).has('x-source')).toBe(false)
   })
 })
 

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -9,7 +9,7 @@ import { formatPrivateKey, hasProviderConfig, type StringKeys } from '@cherrystu
 import type { CherryInProviderSettings } from '@cherrystudio/ai-sdk-provider'
 import { providerService, type ResolvedProviderApiKey } from '@main/data/services/ProviderService'
 import { copilotService } from '@main/services/CopilotService'
-import { defaultAppHeaders } from '@main/utils/http'
+import { defaultAppHeaders, mergeHeaders } from '@main/utils/http'
 import { CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import { OPENAI_CODEX_PROVIDER_ID } from '@shared/data/presets/codex'
 import { GROK_CLI_PROVIDER_ID } from '@shared/data/presets/grokCli'
@@ -385,7 +385,7 @@ export async function resolveProviderAiSdkConfig(
 
 async function buildCopilotConfig(ctx: BuilderContext): Promise<ProviderConfig<'github-copilot-openai-compatible'>> {
   const storedHeaders = {} // TODO: read from PreferenceService if copilot headers are persisted
-  const headers = { ...COPILOT_DEFAULT_HEADERS, ...storedHeaders }
+  const headers = mergeHeaders(COPILOT_DEFAULT_HEADERS, storedHeaders)
   const { token } = await copilotService.getToken(null as any, headers)
 
   return {

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -394,7 +394,7 @@ async function buildCopilotConfig(ctx: BuilderContext): Promise<ProviderConfig<'
     providerSettings: {
       ...ctx.baseConfig,
       apiKey: token,
-      headers: { ...headers, ...getExtraHeaders(ctx.actualProvider) },
+      headers: mergeHeaders(headers, getExtraHeaders(ctx.actualProvider)),
       name: ctx.actualProvider.id
     }
   }

--- a/src/main/ai/provider/constants.ts
+++ b/src/main/ai/provider/constants.ts
@@ -8,7 +8,5 @@ export const COPILOT_DEFAULT_HEADERS = {
   'User-Agent': COPILOT_USER_AGENT,
   'Editor-Version': COPILOT_EDITOR_VERSION,
   'Editor-Plugin-Version': COPILOT_PLUGIN_VERSION,
-  'editor-version': COPILOT_EDITOR_VERSION,
-  'editor-plugin-version': COPILOT_PLUGIN_VERSION,
   'copilot-vision-request': 'true'
 } as const

--- a/src/main/ai/provider/custom/minimax/minimaxImageModel.ts
+++ b/src/main/ai/provider/custom/minimax/minimaxImageModel.ts
@@ -1,5 +1,6 @@
 import { APICallError, type ImageModelV3, type ImageModelV3CallOptions } from '@ai-sdk/provider'
-import { combineHeaders, type FetchFunction, removeUndefinedEntries } from '@ai-sdk/provider-utils'
+import { type FetchFunction } from '@ai-sdk/provider-utils'
+import { mergeHeaders } from '@main/utils/http'
 
 import { fileToDataUrl } from '../transportUtils'
 
@@ -78,9 +79,7 @@ export class MinimaxImageModel implements ImageModelV3 {
     const fetchFn = this.config.fetch ?? globalThis.fetch
     const response = await fetchFn(url, {
       method: 'POST',
-      headers: removeUndefinedEntries(
-        combineHeaders(this.config.headers(), headers, { 'Content-Type': 'application/json' })
-      ),
+      headers: mergeHeaders(this.config.headers(), headers, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
       signal: abortSignal
     })

--- a/src/main/ai/provider/custom/silicon/SiliconImageModel.ts
+++ b/src/main/ai/provider/custom/silicon/SiliconImageModel.ts
@@ -1,5 +1,6 @@
 import { APICallError, type ImageModelV3, type ImageModelV3CallOptions, type SharedV3Warning } from '@ai-sdk/provider'
-import { combineHeaders, type FetchFunction, removeUndefinedEntries } from '@ai-sdk/provider-utils'
+import { type FetchFunction } from '@ai-sdk/provider-utils'
+import { mergeHeaders } from '@main/utils/http'
 
 import { fileToDataUrl } from '../transportUtils'
 
@@ -99,9 +100,7 @@ export class SiliconImageModel implements ImageModelV3 {
     const fetchFn = this.config.fetch ?? globalThis.fetch
     const response = await fetchFn(url, {
       method: 'POST',
-      headers: removeUndefinedEntries(
-        combineHeaders(this.config.headers(), headers, { 'Content-Type': 'application/json' })
-      ),
+      headers: mergeHeaders(this.config.headers(), headers, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
       signal: abortSignal
     })

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -15,7 +15,7 @@ import {
 import { loggerService } from '@logger'
 import { providerService } from '@main/data/services/ProviderService'
 import { copilotService } from '@main/services/CopilotService'
-import { defaultAppHeaders } from '@main/utils/http'
+import { defaultAppHeaders, mergeHeaders } from '@main/utils/http'
 import type { EndpointType, Model } from '@shared/data/types/model'
 import {
   createUniqueModelId,
@@ -265,7 +265,7 @@ const geminiFetcher: ModelFetcher = {
     // would persist the key into local logs users attach to bug reports.
     const response = await getFromApi({
       url: `${baseUrl}/v1beta/models`,
-      headers: { ...defaultAppHeaders(), 'x-goog-api-key': apiKey, ...provider.settings?.extraHeaders },
+      headers: mergeHeaders(defaultAppHeaders(), { 'x-goog-api-key': apiKey }, provider.settings?.extraHeaders),
       responseSchema: GeminiModelsResponseSchema,
       abortSignal: signal
     })
@@ -376,20 +376,14 @@ const vertexFetcher: ModelFetcher = {
 const copilotFetcher: ModelFetcher = {
   match: (p) => matchesPreset(p, SystemProviderIds.copilot),
   fetch: async (provider, signal) => {
-    const copilotHeaders = {
-      ...COPILOT_DEFAULT_HEADERS,
-      ...provider.settings.extraHeaders
-    }
+    const copilotHeaders = mergeHeaders(COPILOT_DEFAULT_HEADERS, provider.settings.extraHeaders)
     // getToken exchanges the stored GitHub OAuth token for a Copilot session token.
     // It must NOT carry the provider's `Authorization: Bearer <apiKey>` (added by
     // defaultHeaders) — GitHub's token endpoint rejects the conflicting header with 401.
     const { token } = await copilotService.getToken(null as any, copilotHeaders)
     const response = await getFromApi({
       url: `${withoutTrailingSlash(getBaseUrl(provider, ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS))}/models`,
-      headers: {
-        ...copilotHeaders,
-        Authorization: `Bearer ${token}`
-      },
+      headers: mergeHeaders(copilotHeaders, { Authorization: `Bearer ${token}` }),
       responseSchema: CopilotModelsResponseSchema,
       abortSignal: signal
     })
@@ -697,12 +691,11 @@ const anthropicFetcher: ModelFetcher = {
     const apiKey = providerService.getRotatedApiKey(provider.id)
     const response = await getFromApi({
       url: `${baseUrl}/models?limit=1000`,
-      headers: {
-        ...defaultAppHeaders(),
-        'x-api-key': apiKey,
-        'anthropic-version': ANTHROPIC_VERSION,
-        ...provider.settings?.extraHeaders
-      },
+      headers: mergeHeaders(
+        defaultAppHeaders(),
+        { 'x-api-key': apiKey, 'anthropic-version': ANTHROPIC_VERSION },
+        provider.settings?.extraHeaders
+      ),
       responseSchema: AnthropicModelsResponseSchema,
       abortSignal: signal
     })
@@ -776,15 +769,10 @@ export async function probeOllamaModel(
   const start = performance.now()
   const baseUrl = formatOllamaApiHost(getBaseUrl(provider))
   const resolved = providerService.resolveApiKey(provider.id, apiKeyOverride)
-  const headers: Record<string, string> = {
-    ...defaultAppHeaders(),
-    ...getExtraHeaders(provider),
-    'Content-Type': 'application/json'
-  }
-  if (resolved.value) {
-    headers.Authorization = `Bearer ${resolved.value}`
-    headers['X-Api-Key'] = resolved.value
-  }
+  const headers = mergeHeaders(defaultAppHeaders(), getExtraHeaders(provider), {
+    'Content-Type': 'application/json',
+    ...(resolved.value ? { Authorization: `Bearer ${resolved.value}`, 'X-Api-Key': resolved.value } : {})
+  })
   const response = await fetch(`${baseUrl}/show`, {
     method: 'POST',
     headers,

--- a/src/main/ai/utils/provider.ts
+++ b/src/main/ai/utils/provider.ts
@@ -1,5 +1,5 @@
 import { providerService } from '@data/services/ProviderService'
-import { defaultAppHeaders } from '@main/utils/http'
+import { defaultAppHeaders, mergeHeaders } from '@main/utils/http'
 import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 
@@ -58,11 +58,11 @@ export function getExtraHeaders(provider: Provider): Record<string, string> {
 
 export function defaultHeaders(provider: Provider): Record<string, string> {
   const apiKey = providerService.getRotatedApiKey(provider.id)
-  return {
-    ...defaultAppHeaders(),
-    ...(apiKey ? { Authorization: `Bearer ${apiKey}`, 'X-Api-Key': apiKey } : {}),
-    ...getExtraHeaders(provider)
-  }
+  return mergeHeaders(
+    defaultAppHeaders(),
+    apiKey ? { Authorization: `Bearer ${apiKey}`, 'X-Api-Key': apiKey } : undefined,
+    getExtraHeaders(provider)
+  )
 }
 
 export function routeToEndpoint(apiHost: string): { baseURL: string; endpoint: string } {

--- a/src/main/services/CopilotService.ts
+++ b/src/main/services/CopilotService.ts
@@ -1,5 +1,6 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { mergeHeaders } from '@main/utils/http'
 import { net, safeStorage } from 'electron'
 import fs from 'fs'
 import path from 'path'
@@ -38,15 +39,12 @@ const BASE_HEADERS = {
   'user-agent': 'Visual Studio Code (desktop)'
 }
 
-const mergeHeaders = (headers?: Record<string, string>): Record<string, string> => {
-  const mergedHeaders = new Headers(BASE_HEADERS)
-  for (const [name, value] of Object.entries(headers ?? {})) {
-    mergedHeaders.set(name, value)
-  }
-  mergedHeaders.set('accept', BASE_HEADERS.accept)
-  mergedHeaders.set('content-type', BASE_HEADERS['content-type'])
-  return Object.fromEntries(mergedHeaders.entries())
-}
+// accept / content-type are forced back on: GitHub's OAuth endpoints only speak JSON.
+const authHeaders = (headers?: Record<string, string>): Record<string, string> =>
+  mergeHeaders(BASE_HEADERS, headers, {
+    accept: BASE_HEADERS.accept,
+    'content-type': BASE_HEADERS['content-type']
+  })
 
 // 接口定义移到顶部，便于查阅
 interface UserResponse {
@@ -167,7 +165,7 @@ class CopilotService {
     headers?: Record<string, string>
   ): Promise<AuthResponse> => {
     try {
-      const requestHeaders = mergeHeaders(headers)
+      const requestHeaders = authHeaders(headers)
 
       const response = await net.fetch(CONFIG.API_URLS.GITHUB_DEVICE_CODE, {
         method: 'POST',
@@ -197,7 +195,7 @@ class CopilotService {
     device_code: string,
     headers?: Record<string, string>
   ): Promise<TokenResponse> => {
-    const requestHeaders = mergeHeaders(headers)
+    const requestHeaders = authHeaders(headers)
 
     let currentDelay = CONFIG.POLLING.INITIAL_DELAY_MS
 
@@ -266,17 +264,14 @@ class CopilotService {
     headers?: Record<string, string>
   ): Promise<CopilotTokenResponse> => {
     try {
-      const requestHeaders = mergeHeaders(headers)
+      const requestHeaders = authHeaders(headers)
 
       const encryptedToken = await fs.promises.readFile(this.tokenFilePath)
       const access_token = safeStorage.decryptString(Buffer.from(encryptedToken))
 
       const response = await net.fetch(CONFIG.API_URLS.COPILOT_TOKEN, {
         method: 'GET',
-        headers: {
-          ...requestHeaders,
-          authorization: `token ${access_token}`
-        }
+        headers: mergeHeaders(requestHeaders, { authorization: `token ${access_token}` })
       })
 
       if (!response.ok) {

--- a/src/main/utils/__tests__/http.test.ts
+++ b/src/main/utils/__tests__/http.test.ts
@@ -24,6 +24,7 @@ describe('mergeHeaders', () => {
   it('drops undefined values and skips absent parts', () => {
     const merged = mergeHeaders({ Authorization: 'Bearer k' }, undefined, { 'X-Api-Key': undefined })
 
-    expect(merged).toEqual({ authorization: 'Bearer k' })
+    expect(merged.authorization).toBe('Bearer k')
+    expect(Object.hasOwn(merged, 'x-api-key')).toBe(false)
   })
 })

--- a/src/main/utils/__tests__/http.test.ts
+++ b/src/main/utils/__tests__/http.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeHeaders } from '../http'
+
+describe('mergeHeaders', () => {
+  it('collapses case variants of the same header so the last writer wins', () => {
+    const merged = mergeHeaders({ 'User-Agent': 'Copilot/1.0' }, { 'user-agent': 'MyAgent/1.0' })
+
+    expect(Object.keys(merged)).toEqual(['user-agent'])
+    expect(new Headers(merged).get('user-agent')).toBe('MyAgent/1.0')
+  })
+
+  it('lets a trailing part force a header back regardless of the casing a caller used', () => {
+    const merged = mergeHeaders(
+      { 'content-type': 'application/json' },
+      { 'Content-Type': 'text/plain' },
+      { 'content-type': 'application/json' }
+    )
+
+    expect(new Headers(merged).get('content-type')).toBe('application/json')
+    expect(Object.keys(merged).filter((k) => k.toLowerCase() === 'content-type')).toHaveLength(1)
+  })
+
+  it('drops undefined values and skips absent parts', () => {
+    const merged = mergeHeaders({ Authorization: 'Bearer k' }, undefined, { 'X-Api-Key': undefined })
+
+    expect(merged).toEqual({ authorization: 'Bearer k' })
+  })
+})

--- a/src/main/utils/http.ts
+++ b/src/main/utils/http.ts
@@ -1,6 +1,23 @@
+import { normalizeHeaders } from '@ai-sdk/provider-utils'
+
 export const defaultAppHeaders = () => {
   return {
     'HTTP-Referer': 'https://cherry-ai.com',
     'X-Title': 'Cherry Studio'
   }
 }
+
+/**
+ * Merge header records with case-insensitive last-writer-wins.
+ *
+ * A plain `{ ...defaults, ...extraHeaders }` keeps case variants of the same
+ * name as separate keys — a default `User-Agent` plus a user-supplied
+ * `user-agent` both reach the wire, and `new Headers(...).get()` comma-joins
+ * them. Normalizing each part to lowercase first collapses them so the last
+ * writer actually wins.
+ *
+ * @param parts - Header records in precedence order; later parts override earlier ones.
+ * @returns A record with lowercase header names and no duplicates.
+ */
+export const mergeHeaders = (...parts: Array<Record<string, string | undefined> | undefined>): Record<string, string> =>
+  Object.assign({}, ...parts.map(normalizeHeaders))


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: request headers were assembled with plain object spread — `{ ...defaultAppHeaders(), ...getExtraHeaders(provider) }`, `{ ...COPILOT_DEFAULT_HEADERS, ...extraHeaders }`, `combineHeaders(a, b, c)`. Object spread is case-sensitive but HTTP header names are not, so a default `User-Agent` and a user-supplied `user-agent` from `provider.settings.extraHeaders` survive as **two separate keys** and both reach the wire. `new Headers(...).get('user-agent')` then comma-joins them into `"GitHubCopilotChat/0.26.7, MyAgent/1.0"`, and the user's override is silently corrupted rather than applied.

The same shape appears in reverse where a required header is forced on *after* the user's: `{ ...defaultAppHeaders(), ...getExtraHeaders(provider), 'Content-Type': 'application/json' }` emits both `content-type` and `Content-Type` if the user typed the lowercase form.

Two in-tree workarounds already existed for this, each patching one symptom:

- `COPILOT_DEFAULT_HEADERS` shipped `'Editor-Version'` **and** `'editor-version'` (same value) so that whichever casing the server matched would be present.
- `customFetch.resolveUserAgent()` hand-rolls case-insensitive last-writer-wins, but only for `user-agent`.

After this PR: one helper next to `defaultAppHeaders`, built on the AI SDK's `normalizeHeaders` (already a direct dependency):

```ts
export const mergeHeaders = (...parts: Array<Record<string, string | undefined> | undefined>): Record<string, string> =>
  Object.assign({}, ...parts.map(normalizeHeaders))
```

Header names are lowercased before merging, so case variants collapse and the last part genuinely wins. Routed through it: `defaultHeaders(provider)`, the four header sites in `listModels.ts` (Gemini, Anthropic, Copilot, the Ollama `/api/show` check), `buildCopilotConfig`, and `CopilotService`'s auth requests. The duplicate-casing rows in `COPILOT_DEFAULT_HEADERS` are deleted, and the two `removeUndefinedEntries(combineHeaders(...))` pairs in the Minimax/Silicon image models are replaced — `combineHeaders` is itself a plain spread reduce and does not solve this, while `normalizeHeaders` already drops `undefined`.

Fixes #

### Why we need it and why it was done in this way

`provider.settings.extraHeaders` is a user-facing text field; users type `content-type`, `Content-Type`, `User-Agent` interchangeably and reasonably expect the value they entered to be the one sent. Today the result depends on whether their casing happens to match the app default.

The following tradeoffs were made:

- **All header names become lowercase.** RFC 7230 defines header names as case-insensitive and HTTP/2 mandates lowercase on the wire, so this is spec-safe; a server that keys on exact casing would be non-conforming. This is also what makes the `COPILOT_DEFAULT_HEADERS` double-casing workaround safely deletable (both rows carry the same value, so they collapse to one).
- **Only header sites that mix app defaults with user-supplied `extraHeaders` were converted.** The remaining inline `{ ...defaultAppHeaders(), ... }` spreads that mix only app-owned constants have no collision risk, and rewriting them would enlarge the diff without fixing anything.
- **`customFetch.resolveUserAgent()` is kept.** Its motivating case is gone, but it still has to accept `Headers` and tuple-array inputs handed to it by the AI SDK, which are outside this helper's scope.

The following alternatives were considered:

- **A hand-written `new Headers()` merge loop.** Works, but `@ai-sdk/provider-utils` already exports `normalizeHeaders`, which handles `Headers`/array/record inputs and `undefined` values.
- **`combineHeaders` from the same package.** Rejected: it is `headers.reduce((acc, cur) => ({ ...acc, ...cur }), {})` — identical to plain spread, case-sensitive, and therefore reproduces the bug. Its three existing call sites in this repo were the ones converted.

Links to places where the discussion took place: follow-up to #19473, which fixed the Copilot-specific instance of this (headers replaced instead of merged, and leaked across calls via mutable service state).

### Breaking changes

None user-facing. Outbound request headers are now lowercase, which is transparent to spec-conforming servers.

### Special notes for your reviewer

Three test assertions indexed captured headers by exact-cased key (`call.headers['X-Custom']`, `['X-Source']`, `['X-Api-Key']`) and were updated to read through `new Headers(...)` case-insensitively. The behavior they pin — header present with the expected value — is unchanged; they were asserting the object's key casing rather than the contract.

Gates run: `pnpm lint`, `pnpm test:lint` (exit 0), full `main` Vitest project (845 files / 13050 tests, all passing).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: N/A — no user-facing feature or behavior change.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
