### PR TITLE
fix(native-rebuild): invalidate stale Electron metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "pnpm rebuild:electron && electron-vite preview",
     "download:binaries": "node scripts/download-binaries.js",
     "rebuild:electron": "electron-rebuild --force --only better-sqlite3",
-    "rebuild:node": "pnpm rebuild better-sqlite3",
+    "rebuild:node": "node scripts/invalidate-electron-rebuild-metadata.js && pnpm rebuild better-sqlite3",
     "dev": "pnpm rebuild:electron && pnpm download:binaries && dotenv electron-vite dev",
     "dev:watch": "pnpm rebuild:electron && dotenv electron-vite dev -- -w",
     "debug": "pnpm rebuild:electron && dotenv -- electron-vite -- --inspect --sourcemap --remote-debugging-port=9222",

--- a/scripts/__tests__/invalidate-electron-rebuild-metadata.test.ts
+++ b/scripts/__tests__/invalidate-electron-rebuild-metadata.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { invalidateElectronRebuildMetadata } from '../invalidate-electron-rebuild-metadata'
+
+const temporaryDirectories: string[] = []
+
+function temporaryModuleDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'cherry-native-rebuild-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('invalidateElectronRebuildMetadata', () => {
+  it('removes the stale Electron marker without removing the native binary', () => {
+    const moduleDirectory = temporaryModuleDirectory()
+    const releaseDirectory = path.join(moduleDirectory, 'build', 'Release')
+    const metadataPath = path.join(releaseDirectory, '.forge-meta')
+    const binaryPath = path.join(releaseDirectory, 'better_sqlite3.node')
+    fs.mkdirSync(releaseDirectory, { recursive: true })
+    fs.writeFileSync(metadataPath, 'arm64--145')
+    fs.writeFileSync(binaryPath, 'node binary')
+
+    invalidateElectronRebuildMetadata(moduleDirectory)
+
+    expect(fs.existsSync(metadataPath)).toBe(false)
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe('node binary')
+  })
+
+  it('does nothing when Electron has not written a marker', () => {
+    expect(() => invalidateElectronRebuildMetadata(temporaryModuleDirectory())).not.toThrow()
+  })
+})

--- a/scripts/invalidate-electron-rebuild-metadata.js
+++ b/scripts/invalidate-electron-rebuild-metadata.js
@@ -2,6 +2,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 function invalidateElectronRebuildMetadata(moduleDirectory) {
+  // pnpm rebuild replaces the binary without invalidating @electron/rebuild's ABI marker.
   fs.rmSync(path.join(moduleDirectory, 'build', 'Release', '.forge-meta'), { force: true })
 }
 

--- a/scripts/invalidate-electron-rebuild-metadata.js
+++ b/scripts/invalidate-electron-rebuild-metadata.js
@@ -1,0 +1,13 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+function invalidateElectronRebuildMetadata(moduleDirectory) {
+  fs.rmSync(path.join(moduleDirectory, 'build', 'Release', '.forge-meta'), { force: true })
+}
+
+exports.invalidateElectronRebuildMetadata = invalidateElectronRebuildMetadata
+
+if (require.main === module) {
+  const moduleDirectory = path.dirname(require.resolve('better-sqlite3/package.json'))
+  invalidateElectronRebuildMetadata(moduleDirectory)
+}


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`pnpm rebuild:node` could replace `better-sqlite3` with a Node ABI binary while leaving Electron's `.forge-meta` marker behind. A later electron-builder run trusted that stale marker, skipped rebuilding the module, and could package an incompatible native binary.

After this PR:

`rebuild:node` removes only the stale Electron rebuild marker before rebuilding `better-sqlite3` for Node. Electron Builder then performs the required Electron ABI rebuild instead of incorrectly skipping it.

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Packaging after a Node rebuild may spend a few extra seconds rebuilding `better-sqlite3`; this happens only when the previous Electron marker was invalidated.
- The native binary itself is preserved until pnpm performs the requested Node rebuild.

The following alternatives were considered:

- Forcing every electron-builder native dependency rebuild was broader and would slow repeated packaging.
- Patching `@electron/rebuild` to validate binary contents belongs upstream and is unnecessary for the repository-owned command that invalidates its metadata.

Links to places where the discussion took place:

- https://github.com/electron-userland/electron-builder/issues/10031

### Breaking changes

None.

### Special notes for your reviewer

- `pnpm test:scripts` passed: 36 test files and 431 tests.
- The full lint pipeline passed using the worktree-local Oxlint config explicitly; direct `pnpm lint` in this nested worktree otherwise treats the outer worktree config as its root. Oxlint reported 0 warnings and 0 errors, type checks and i18n checks passed, and formatting required no changes.
- A manual `rebuild:electron` → `rebuild:node` → `electron-builder install-app-deps --arch=arm64` sequence confirmed that the stale marker is removed, electron-builder rebuilds instead of skipping, and Electron loads `better-sqlite3` under ABI 145.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
