### PR TITLE
fix(chat): keep token details closed after locating message

### DIFF
--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -62,13 +62,18 @@ function AssistantMessageTokens({
     setIsDetailsOpen(open)
   }
   const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+    if (event.button !== 0) return
+
     pointerDownPositionRef.current = { x: event.clientX, y: event.clientY }
     setIsDetailsDismissed(true)
     setIsDetailsOpen(false)
   }
   const handleMouseBoundary = (event: MouseEvent<HTMLButtonElement>) => {
     const pointerDownPosition = pointerDownPositionRef.current
-    if (!pointerDownPosition) return
+    if (!pointerDownPosition) {
+      setIsDetailsDismissed(false)
+      return
+    }
 
     const movedDistance = Math.hypot(event.clientX - pointerDownPosition.x, event.clientY - pointerDownPosition.y)
     if (movedDistance < 2) return

--- a/src/renderer/components/chat/messages/frame/MessageTokens.tsx
+++ b/src/renderer/components/chat/messages/frame/MessageTokens.tsx
@@ -1,7 +1,7 @@
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@cherrystudio/ui'
 import { useInfiniteFlatItems, useInfiniteQuery } from '@renderer/data/hooks/useDataApi'
 import type { MessageStats } from '@shared/data/types/message'
-import type { FC } from 'react'
+import type { FC, MouseEvent } from 'react'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -40,6 +40,7 @@ function AssistantMessageTokens({
 }) {
   const [showAllDetails, setShowAllDetails] = useState(false)
   const [isDetailsOpen, setIsDetailsOpen] = useState(false)
+  const [isDetailsDismissed, setIsDetailsDismissed] = useState(false)
   const contentId = useId()
   const messageKind = useMessageListMeta().aiUsageMessageKind ?? 'chat'
   const { pages, isRefreshing, hasNext, loadNext } = useInfiniteQuery('/ai-usage-records', {
@@ -53,7 +54,40 @@ function AssistantMessageTokens({
     limit: 200
   })
   const records = useInfiniteFlatItems(pages)
+  const isDetailsVisible = isDetailsOpen && !isDetailsDismissed
   const requestedPageCountRef = useRef(1)
+  const pointerDownPositionRef = useRef<{ x: number; y: number } | undefined>(undefined)
+  const handleDetailsOpenChange = (open: boolean) => {
+    if (open && isDetailsDismissed) return
+    setIsDetailsOpen(open)
+  }
+  const handleMouseDown = (event: MouseEvent<HTMLButtonElement>) => {
+    pointerDownPositionRef.current = { x: event.clientX, y: event.clientY }
+    setIsDetailsDismissed(true)
+    setIsDetailsOpen(false)
+  }
+  const handleMouseBoundary = (event: MouseEvent<HTMLButtonElement>) => {
+    const pointerDownPosition = pointerDownPositionRef.current
+    if (!pointerDownPosition) return
+
+    const movedDistance = Math.hypot(event.clientX - pointerDownPosition.x, event.clientY - pointerDownPosition.y)
+    if (movedDistance < 2) return
+
+    pointerDownPositionRef.current = undefined
+    setIsDetailsDismissed(false)
+  }
+  const handleLocate = (event: MouseEvent<HTMLButtonElement>) => {
+    if (event.detail === 0) {
+      setIsDetailsDismissed(true)
+      setIsDetailsOpen(false)
+    }
+    onLocate()
+  }
+  const handleBlur = () => {
+    pointerDownPositionRef.current = undefined
+    setIsDetailsDismissed(false)
+    setShowAllDetails(false)
+  }
 
   useEffect(() => {
     if (!isDetailsOpen) {
@@ -67,15 +101,18 @@ function AssistantMessageTokens({
   }, [hasNext, isDetailsOpen, isRefreshing, loadNext, pages.length])
 
   return (
-    <HoverCard open={isDetailsOpen} onOpenChange={setIsDetailsOpen} openDelay={200} closeDelay={100}>
+    <HoverCard open={isDetailsVisible} onOpenChange={handleDetailsOpenChange} openDelay={200} closeDelay={100}>
       <HoverCardTrigger asChild>
         <button
           type="button"
-          aria-describedby={showAllDetails ? contentId : undefined}
+          aria-describedby={showAllDetails && isDetailsVisible ? contentId : undefined}
           className="message-tokens cursor-pointer select-text text-right text-muted-foreground text-xs tabular-nums leading-5 transition-colors duration-150 hover:text-foreground focus-visible:text-foreground focus-visible:underline focus-visible:outline-none"
           onFocus={() => setShowAllDetails(true)}
-          onBlur={() => setShowAllDetails(false)}
-          onClick={onLocate}>
+          onBlur={handleBlur}
+          onMouseDown={handleMouseDown}
+          onMouseEnter={handleMouseBoundary}
+          onMouseLeave={handleMouseBoundary}
+          onClick={handleLocate}>
           {label}
         </button>
       </HoverCardTrigger>

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -138,7 +138,7 @@ function openDetails() {
   if (!trigger) throw new Error('Message token trigger was not rendered')
 
   fireEvent.pointerEnter(trigger)
-  act(() => vi.advanceTimersByTime(200))
+  void act(() => vi.advanceTimersByTime(200))
   return trigger
 }
 
@@ -392,7 +392,7 @@ describe('MessageTokens', () => {
 
     const trigger = screen.getByRole('button', { name: '200 Tokens' })
     fireEvent.focus(trigger)
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
 
     const card = getDetailsCard()
     expect(trigger).toHaveAttribute('aria-describedby', card.id)
@@ -412,7 +412,7 @@ describe('MessageTokens', () => {
     expect(trigger).toHaveAttribute('data-state', 'closed')
 
     fireEvent.click(trigger, { detail: 1 })
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
 
     expect(trigger).toHaveAttribute('data-state', 'closed')
     expect(trigger).toHaveFocus()
@@ -420,17 +420,17 @@ describe('MessageTokens', () => {
     expect(locateMessage).toHaveBeenCalledWith(message.id, false)
 
     fireEvent.pointerEnter(trigger)
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
     expect(trigger).toHaveAttribute('data-state', 'closed')
 
     fireEvent.mouseEnter(trigger, { clientX: 100, clientY: 100 })
     fireEvent.pointerEnter(trigger)
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
     expect(trigger).toHaveAttribute('data-state', 'closed')
 
     fireEvent.mouseEnter(trigger, { clientX: 120, clientY: 100 })
     fireEvent.pointerEnter(trigger)
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
     expect(trigger).toHaveAttribute('data-state', 'open')
 
     fireEvent.mouseDown(trigger, { clientX: 120, clientY: 100 })
@@ -445,7 +445,7 @@ describe('MessageTokens', () => {
 
     act(() => trigger.focus())
     fireEvent.click(trigger, { detail: 0 })
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
 
     expect(trigger).toHaveAttribute('data-state', 'closed')
     expect(trigger).toHaveFocus()
@@ -454,7 +454,7 @@ describe('MessageTokens', () => {
 
     act(() => trigger.blur())
     fireEvent.pointerEnter(trigger)
-    act(() => vi.advanceTimersByTime(200))
+    void act(() => vi.advanceTimersByTime(200))
     expect(trigger).toHaveAttribute('data-state', 'open')
   })
 })

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -438,7 +438,20 @@ describe('MessageTokens', () => {
     expect(locateMessage).toHaveBeenCalledTimes(2)
   })
 
-  it('closes details for keyboard activation without discarding focus', () => {
+  it('keeps details open for non-primary pointer presses', () => {
+    const message = createMessage('assistant', { totalTokens: 42 })
+    const { locateMessage } = renderWithProvider(message)
+    const trigger = openDetails()
+
+    fireEvent.mouseDown(trigger, { button: 1, clientX: 100, clientY: 100 })
+    expect(trigger).toHaveAttribute('data-state', 'open')
+
+    fireEvent.mouseDown(trigger, { button: 2, clientX: 100, clientY: 100 })
+    expect(trigger).toHaveAttribute('data-state', 'open')
+    expect(locateMessage).not.toHaveBeenCalled()
+  })
+
+  it('closes details for keyboard activation and reopens after deliberate pointer re-entry without discarding focus', () => {
     const message = createMessage('assistant', { totalTokens: 42 })
     const { locateMessage } = renderWithProvider(message)
     const trigger = openDetails()
@@ -452,7 +465,10 @@ describe('MessageTokens', () => {
     expect(trigger).not.toHaveAttribute('aria-describedby')
     expect(locateMessage).toHaveBeenCalledWith(message.id, false)
 
-    act(() => trigger.blur())
+    fireEvent.pointerLeave(trigger)
+    fireEvent.mouseLeave(trigger)
+    expect(trigger).toHaveFocus()
+
     fireEvent.pointerEnter(trigger)
     void act(() => vi.advanceTimersByTime(200))
     expect(trigger).toHaveAttribute('data-state', 'open')

--- a/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
+++ b/src/renderer/components/chat/messages/frame/__tests__/MessageTokens.test.tsx
@@ -1,9 +1,9 @@
 import '@testing-library/jest-dom/vitest'
 
+import type * as CherryStudioUi from '@cherrystudio/ui'
 import type { Topic } from '@renderer/types/topic'
-import { fireEvent, render, screen, within } from '@testing-library/react'
-import type { ReactNode } from 'react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { MessageListProvider } from '../../MessageListProvider'
 import { defaultMessageRenderConfig, type MessageListItem, type MessageListProviderValue } from '../../types'
@@ -22,19 +22,7 @@ const dataApiMocks = vi.hoisted(() => ({
 
 vi.mock('@renderer/data/hooks/useDataApi', () => dataApiMocks)
 
-vi.mock('@cherrystudio/ui', () => ({
-  HoverCard: ({ children, onOpenChange }: { children: ReactNode; onOpenChange?: (open: boolean) => void }) => (
-    <div data-testid="message-token-hover-root" onMouseEnter={() => onOpenChange?.(true)}>
-      {children}
-    </div>
-  ),
-  HoverCardContent: ({ children, className, id }: { children: ReactNode; className?: string; id?: string }) => (
-    <div id={id} className={className} data-testid="message-token-hover-card">
-      {children}
-    </div>
-  ),
-  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
-}))
+vi.mock('@cherrystudio/ui', async (importOriginal) => importOriginal<typeof CherryStudioUi>())
 
 vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
   default: ({ model }: { model: { id: string } }) => <span data-model-id={model.id} data-testid="model-avatar" />
@@ -145,7 +133,25 @@ function renderWithProvider(
   }
 }
 
+function openDetails() {
+  const trigger = document.querySelector<HTMLButtonElement>('button.message-tokens')
+  if (!trigger) throw new Error('Message token trigger was not rendered')
+
+  fireEvent.pointerEnter(trigger)
+  act(() => vi.advanceTimersByTime(200))
+  return trigger
+}
+
+function getDetailsCard() {
+  const card = document.querySelector<HTMLElement>('[data-slot="hover-card-content"]')
+  if (!card) throw new Error('Message token details card was not rendered')
+  return card
+}
+
 describe('MessageTokens', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
   it('does not query invocation details until a new-format details card opens', () => {
     renderWithProvider(
       createMessage('assistant', {
@@ -159,7 +165,7 @@ describe('MessageTokens', () => {
       expect.objectContaining({ enabled: false })
     )
 
-    fireEvent.mouseEnter(screen.getByTestId('message-token-hover-root'))
+    openDetails()
 
     expect(dataApiMocks.useInfiniteQuery).toHaveBeenLastCalledWith(
       '/ai-usage-records',
@@ -182,7 +188,7 @@ describe('MessageTokens', () => {
       'agent-session'
     )
 
-    fireEvent.mouseEnter(screen.getByTestId('message-token-hover-root'))
+    openDetails()
 
     expect(dataApiMocks.useInfiniteQuery).toHaveBeenLastCalledWith(
       '/ai-usage-records',
@@ -214,7 +220,7 @@ describe('MessageTokens', () => {
     )
 
     expect(loadNext).not.toHaveBeenCalled()
-    fireEvent.mouseEnter(screen.getByTestId('message-token-hover-root'))
+    openDetails()
     expect(loadNext).toHaveBeenCalledTimes(1)
   })
 
@@ -224,7 +230,7 @@ describe('MessageTokens', () => {
 
     expect(tokenStats).toHaveTextContent('42 Tokens')
     expect(tokenStats).toHaveClass('text-xs', 'leading-5', 'text-muted-foreground', 'tabular-nums')
-    expect(screen.queryByTestId('message-token-hover-card')).not.toBeInTheDocument()
+    expect(document.querySelector('[data-slot="hover-card-content"]')).not.toBeInTheDocument()
   })
 
   it('shows the compact total when throughput is unavailable', () => {
@@ -249,6 +255,7 @@ describe('MessageTokens', () => {
       }
     )
     renderWithProvider(message)
+    openDetails()
 
     const expectedLocalTime = new Intl.DateTimeFormat('en-US', {
       year: 'numeric',
@@ -274,6 +281,7 @@ describe('MessageTokens', () => {
         totalTokens: 200
       })
     )
+    openDetails()
 
     const detail = screen.getByTestId('metric-detail-token-usage')
     const usageBar = screen.getByTestId('metric-bar-token-usage')
@@ -296,6 +304,7 @@ describe('MessageTokens', () => {
         inputTokenDetails: { noCacheTokens: 10, cacheReadTokens: 70, cacheWriteTokens: 20 }
       })
     )
+    openDetails()
 
     fireEvent.pointerEnter(screen.getByTestId('metric-segment-input-breakdown-cache-read'))
 
@@ -314,6 +323,7 @@ describe('MessageTokens', () => {
         timeCompletionMs: 14000
       })
     )
+    openDetails()
 
     const trigger = screen.getByRole('button', { name: '200 Tokens · 10 Tokens/s' })
     expect(trigger).toHaveClass('message-tokens')
@@ -348,6 +358,7 @@ describe('MessageTokens', () => {
         }
       })
     )
+    openDetails()
 
     const timeline = screen.getByTestId('message-performance-timeline')
     expect(within(timeline).getByText('Model')).toBeInTheDocument()
@@ -359,11 +370,12 @@ describe('MessageTokens', () => {
 
   it('omits unavailable performance measurements instead of rendering zero values', () => {
     renderWithProvider(createMessage('assistant', { inputTokens: 10, outputTokens: 2, totalTokens: 12 }))
+    openDetails()
 
     const trigger = screen.getByRole('button', { name: '12 Tokens' })
     expect(trigger).toHaveClass('message-tokens')
 
-    const card = screen.getByTestId('message-token-hover-card')
+    const card = getDetailsCard()
     expect(within(card).queryByTestId('metric-bar-request-duration')).not.toBeInTheDocument()
     expect(within(card).queryByText(/Tokens\/s/)).not.toBeInTheDocument()
   })
@@ -380,19 +392,69 @@ describe('MessageTokens', () => {
 
     const trigger = screen.getByRole('button', { name: '200 Tokens' })
     fireEvent.focus(trigger)
+    act(() => vi.advanceTimersByTime(200))
 
-    const card = screen.getByTestId('message-token-hover-card')
+    const card = getDetailsCard()
     expect(trigger).toHaveAttribute('aria-describedby', card.id)
     expect(within(screen.getByTestId('metric-bar-token-usage')).getByText('25 Tokens · 12.5%')).toBeInTheDocument()
     expect(within(card).queryAllByRole('button')).toHaveLength(0)
   })
 
-  it('keeps the existing click-to-locate behavior on the compact trigger', () => {
+  it('dismisses pointer-opened details until the pointer deliberately re-enters while keeping locate clicks stable', () => {
     const message = createMessage('assistant', { totalTokens: 42 })
     const { locateMessage } = renderWithProvider(message)
+    const trigger = openDetails()
 
-    fireEvent.click(screen.getByRole('button', { name: '42 Tokens' }))
+    expect(trigger).toHaveAttribute('data-state', 'open')
+    act(() => trigger.focus())
 
+    fireEvent.mouseDown(trigger, { clientX: 100, clientY: 100 })
+    expect(trigger).toHaveAttribute('data-state', 'closed')
+
+    fireEvent.click(trigger, { detail: 1 })
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(trigger).toHaveAttribute('data-state', 'closed')
+    expect(trigger).toHaveFocus()
+    expect(trigger).not.toHaveAttribute('aria-describedby')
     expect(locateMessage).toHaveBeenCalledWith(message.id, false)
+
+    fireEvent.pointerEnter(trigger)
+    act(() => vi.advanceTimersByTime(200))
+    expect(trigger).toHaveAttribute('data-state', 'closed')
+
+    fireEvent.mouseEnter(trigger, { clientX: 100, clientY: 100 })
+    fireEvent.pointerEnter(trigger)
+    act(() => vi.advanceTimersByTime(200))
+    expect(trigger).toHaveAttribute('data-state', 'closed')
+
+    fireEvent.mouseEnter(trigger, { clientX: 120, clientY: 100 })
+    fireEvent.pointerEnter(trigger)
+    act(() => vi.advanceTimersByTime(200))
+    expect(trigger).toHaveAttribute('data-state', 'open')
+
+    fireEvent.mouseDown(trigger, { clientX: 120, clientY: 100 })
+    fireEvent.click(trigger, { detail: 1 })
+    expect(locateMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes details for keyboard activation without discarding focus', () => {
+    const message = createMessage('assistant', { totalTokens: 42 })
+    const { locateMessage } = renderWithProvider(message)
+    const trigger = openDetails()
+
+    act(() => trigger.focus())
+    fireEvent.click(trigger, { detail: 0 })
+    act(() => vi.advanceTimersByTime(200))
+
+    expect(trigger).toHaveAttribute('data-state', 'closed')
+    expect(trigger).toHaveFocus()
+    expect(trigger).not.toHaveAttribute('aria-describedby')
+    expect(locateMessage).toHaveBeenCalledWith(message.id, false)
+
+    act(() => trigger.blur())
+    fireEvent.pointerEnter(trigger)
+    act(() => vi.advanceTimersByTime(200))
+    expect(trigger).toHaveAttribute('data-state', 'open')
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Clicking a message's token count could navigate to the usage record while leaving its details card visible or allowing a delayed hover/focus callback to reopen it immediately.
<img width="1574" height="1514" alt="PixPin_2026-08-26_20-14-05" src="https://github.com/user-attachments/assets/4db377ac-c95e-43d1-accc-9f6081339fb1" />

After this PR:

Clicking the token count closes the details card immediately, keeps message navigation stable, and suppresses stale reopen requests until the pointer deliberately moves away and re-enters. Keyboard activation also closes the card without discarding focus or leaving an invalid `aria-describedby` reference.
<img width="1280" height="1224" alt="PixPin_2026-08-26_20-12-03" src="https://github.com/user-attachments/assets/51cf2be0-05af-42e7-b8c6-0f357e41cbdf" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The hover card primitive can emit delayed pointer or focus-driven open requests after the click has already started navigation. The trigger now owns a small dismissal state that closes the controlled card on activation and ignores only those stale requests. The state resets at clear interaction boundaries, preserving intentional hover and keyboard access. Tests use the real shared hover-card primitive so its timing and event composition remain covered.

The following tradeoffs were made:

- Pointer reopening requires a small movement from the original press position, which distinguishes a deliberate new hover interaction from the same click gesture.
- The suppression state remains local to the token trigger instead of changing the shared hover-card contract.

The following alternatives were considered:

- Closing only in `onClick` was insufficient because delayed primitive callbacks could reopen the card.
- Changing the shared hover-card primitive would broaden the behavior change to unrelated consumers.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

Please verify pointer and keyboard activation while the details card is open, including repeated click-to-locate behavior and deliberate pointer re-entry.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix token usage details staying open or reopening after clicking the token count to locate a message.
```
