### PR TITLE
fix(deepseek-harness): migrate legacy provider model maps

### DIFF
--- a/src/main/services/deepSeekHarness/__tests__/config.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/config.test.ts
@@ -269,18 +269,35 @@ describe('DeepSeek Harness config transaction', () => {
     const settingsPath = path.join(dir, 'settings.yaml')
     await writeFile(
       settingsPath,
-      `model-template: &model-template\n  name: Template model\nmodel-id: &model-id aliased-id\nllm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      api: openai-completions\n      baseURL: https://legacy.example/v1\n      models:\n        aliased-model: *model-template\n        aliased-id:\n          id: *model-id\n          name: Aliased id model\n`,
+      `model-template: &model-template\n  # template field note\n  name: Template model\nmodel-id: &model-id aliased-id\nllm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      api: openai-completions\n      baseURL: https://legacy.example/v1\n      models:\n        aliased-model: *model-template\n        aliased-id:\n          id: *model-id\n          name: Aliased id model\n`,
       { mode: 0o600 }
     )
 
     await writeDeepSeekHarnessConfig(dir, projection())
 
-    const settings = parse(await readFile(settingsPath, 'utf8'))
+    const settingsText = await readFile(settingsPath, 'utf8')
+    const settings = parse(settingsText)
+    expect(settingsText).toContain('# template field note')
     expect(settings['llm-pi-ai'].providers['legacy-route'].models).toEqual([
       { id: 'aliased-model', name: 'Template model' },
       { id: 'aliased-id', name: 'Aliased id model' }
     ])
     expect(settings['model-template']).toEqual({ name: 'Template model' })
+  })
+
+  it('does not change an individually anchored model referenced outside provider models', async () => {
+    const credentialsPath = path.join(dir, '.credentials.yaml')
+    const settingsPath = path.join(dir, 'settings.yaml')
+    const originalCredentials = 'EXTERNAL_KEY: keep\n'
+    const originalSettings = `llm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      api: openai-completions\n      baseURL: https://legacy.example/v1\n      models:\n        anchored-model: &anchored-model\n          name: Anchored model\nunrelated-model: *anchored-model\n`
+    await writeFile(credentialsPath, originalCredentials, { mode: 0o600 })
+    await writeFile(settingsPath, originalSettings, { mode: 0o600 })
+
+    await expect(writeDeepSeekHarnessConfig(dir, projection())).rejects.toThrow(
+      'route legacy-route legacy model anchored-model anchor anchored-model is referenced outside provider models'
+    )
+    expect(await readFile(credentialsPath, 'utf8')).toBe(originalCredentials)
+    expect(await readFile(settingsPath, 'utf8')).toBe(originalSettings)
   })
 
   it('does not change an anchored legacy map that is also referenced outside provider models', async () => {

--- a/src/main/services/deepSeekHarness/__tests__/config.test.ts
+++ b/src/main/services/deepSeekHarness/__tests__/config.test.ts
@@ -1,7 +1,9 @@
 import { mkdtemp, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
+import { resolveBundledDshRuntimeEntry } from '@cherrystudio/dsh-bridge'
 import type * as FileUtils from '@main/utils/file'
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, MODALITY, MODEL_CAPABILITY } from '@shared/data/types/model'
@@ -217,6 +219,107 @@ describe('DeepSeek Harness config transaction', () => {
     })
     expect(settings['agent-default-model']).toEqual({ provider: identity.route, model: 'claude-sonnet' })
     expect(settings['agent-presets']).toEqual({ default: 'code' })
+  })
+
+  it('migrates legacy sibling model maps without disabling the managed route', async () => {
+    const settingsPath = path.join(dir, 'settings.yaml')
+    await writeFile(
+      settingsPath,
+      `shared-models: &shared-models\n  - id: shared-model\n    name: Shared model\nllm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      api: openai-completions\n      baseURL: https://legacy.example/v1\n      models: &legacy-models\n        # first legacy model\n        first-model:\n          name: First model\n          contextWindow: 4096\n        second-model:\n          id: second-model\n          name: Second model\n      headers:\n        X-Keep: keep\n    mirrored-legacy-route:\n      apiKeyEnv: MIRRORED_KEY\n      api: openai-completions\n      baseURL: https://mirrored.example/v1\n      models: *legacy-models\n    list-route:\n      apiKeyEnv: LIST_KEY\n      api: openai-completions\n      baseURL: https://list.example/v1\n      models:\n        - id: list-model\n          name: List model\n    aliased-list-route:\n      apiKeyEnv: ALIASED_LIST_KEY\n      api: openai-completions\n      baseURL: https://aliased.example/v1\n      models: *shared-models\n`,
+      { mode: 0o600 }
+    )
+
+    await writeDeepSeekHarnessConfig(dir, projection())
+
+    const firstWrite = await readFile(settingsPath, 'utf8')
+    const settings = parse(firstWrite)
+    const dshRuntime = (await import(
+      pathToFileURL(resolveBundledDshRuntimeEntry('@deepseek-ai/dsh-llm-pi-ai')).href
+    )) as { Config: (input: unknown) => unknown }
+    expect(firstWrite).toContain('# first legacy model')
+    expect(firstWrite).toContain('&legacy-models')
+    expect(firstWrite).toContain('models: *legacy-models')
+    expect(settings['llm-pi-ai'].providers['legacy-route']).toEqual({
+      apiKeyEnv: 'LEGACY_KEY',
+      api: 'openai-completions',
+      baseURL: 'https://legacy.example/v1',
+      models: [
+        { id: 'first-model', name: 'First model', contextWindow: 4096 },
+        { id: 'second-model', name: 'Second model' }
+      ],
+      headers: { 'X-Keep': 'keep' }
+    })
+    expect(settings['llm-pi-ai'].providers['list-route'].models).toEqual([{ id: 'list-model', name: 'List model' }])
+    expect(settings['llm-pi-ai'].providers['mirrored-legacy-route'].models).toEqual(
+      settings['llm-pi-ai'].providers['legacy-route'].models
+    )
+    expect(settings['llm-pi-ai'].providers['aliased-list-route'].models).toEqual([
+      { id: 'shared-model', name: 'Shared model' }
+    ])
+    expect(settings['llm-pi-ai'].providers[projection().route].models).toContainEqual(
+      expect.objectContaining({ id: 'claude-sonnet' })
+    )
+    expect(() => dshRuntime.Config(settings['llm-pi-ai'])).not.toThrow()
+
+    await writeDeepSeekHarnessConfig(dir, projection())
+    expect(await readFile(settingsPath, 'utf8')).toBe(firstWrite)
+  })
+
+  it('materializes aliased legacy models and accepts an aliased matching id', async () => {
+    const settingsPath = path.join(dir, 'settings.yaml')
+    await writeFile(
+      settingsPath,
+      `model-template: &model-template\n  name: Template model\nmodel-id: &model-id aliased-id\nllm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      api: openai-completions\n      baseURL: https://legacy.example/v1\n      models:\n        aliased-model: *model-template\n        aliased-id:\n          id: *model-id\n          name: Aliased id model\n`,
+      { mode: 0o600 }
+    )
+
+    await writeDeepSeekHarnessConfig(dir, projection())
+
+    const settings = parse(await readFile(settingsPath, 'utf8'))
+    expect(settings['llm-pi-ai'].providers['legacy-route'].models).toEqual([
+      { id: 'aliased-model', name: 'Template model' },
+      { id: 'aliased-id', name: 'Aliased id model' }
+    ])
+    expect(settings['model-template']).toEqual({ name: 'Template model' })
+  })
+
+  it('does not change an anchored legacy map that is also referenced outside provider models', async () => {
+    const credentialsPath = path.join(dir, '.credentials.yaml')
+    const settingsPath = path.join(dir, 'settings.yaml')
+    const originalCredentials = 'EXTERNAL_KEY: keep\n'
+    const originalSettings = `llm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      models: &legacy-models\n        legacy-model:\n          name: Legacy model\nunrelated-backup: *legacy-models\n`
+    await writeFile(credentialsPath, originalCredentials, { mode: 0o600 })
+    await writeFile(settingsPath, originalSettings, { mode: 0o600 })
+
+    await expect(writeDeepSeekHarnessConfig(dir, projection())).rejects.toThrow(
+      'route legacy-route legacy models anchor legacy-models is referenced outside provider models'
+    )
+    expect(await readFile(credentialsPath, 'utf8')).toBe(originalCredentials)
+    expect(await readFile(settingsPath, 'utf8')).toBe(originalSettings)
+  })
+
+  it.each([
+    {
+      name: 'a scalar model entry',
+      models: '        legacy-model: invalid\n',
+      error: 'route legacy-route legacy model legacy-model must be a mapping'
+    },
+    {
+      name: 'a conflicting declared model id',
+      models: '        legacy-model:\n          id: different-model\n',
+      error: 'route legacy-route legacy model legacy-model declares conflicting id "different-model"'
+    }
+  ])('rejects $name without writing either config file', async ({ models, error }) => {
+    const credentialsPath = path.join(dir, '.credentials.yaml')
+    const settingsPath = path.join(dir, 'settings.yaml')
+    const originalCredentials = 'EXTERNAL_KEY: keep\n'
+    const originalSettings = `llm-pi-ai:\n  providers:\n    legacy-route:\n      apiKeyEnv: LEGACY_KEY\n      models:\n${models}`
+    await writeFile(credentialsPath, originalCredentials, { mode: 0o600 })
+    await writeFile(settingsPath, originalSettings, { mode: 0o600 })
+
+    await expect(writeDeepSeekHarnessConfig(dir, projection())).rejects.toThrow(error)
+    expect(await readFile(credentialsPath, 'utf8')).toBe(originalCredentials)
+    expect(await readFile(settingsPath, 'utf8')).toBe(originalSettings)
   })
 
   it('preserves sibling credential entries without validating their names or values', async () => {

--- a/src/main/services/deepSeekHarness/config.ts
+++ b/src/main/services/deepSeekHarness/config.ts
@@ -264,10 +264,16 @@ function migrateLegacyProviderModels(document: Document): void {
   if (!isMap(providers)) return
 
   const providerModelAliases = new Set<unknown>()
+  const providerModelValueAliases = new Set<unknown>()
   for (const providerPair of providers.items) {
     if (!isMap(providerPair.value)) continue
     const models = providerPair.value.get('models', true)
     if (isAlias(models)) providerModelAliases.add(models)
+    if (isMap(models)) {
+      for (const modelPair of models.items) {
+        if (isAlias(modelPair.value)) providerModelValueAliases.add(modelPair.value)
+      }
+    }
   }
 
   for (const providerPair of providers.items) {
@@ -317,17 +323,37 @@ function migrateLegacyProviderModels(document: Document): void {
       if (!modelId) {
         throw new Error(`DeepSeek Harness route ${route} has a legacy model with an invalid id key`)
       }
-      let model = modelPair.value
-      if (isAlias(model)) {
-        const resolvedModel = model.resolve(document)
+      const sourceModel = modelPair.value
+      let resolvedModel = sourceModel
+      if (isAlias(sourceModel)) {
+        resolvedModel = sourceModel.resolve(document)
         if (!isMap(resolvedModel)) {
           throw new Error(`DeepSeek Harness route ${route} legacy model ${modelId} must be a mapping`)
         }
-        model = document.createNode(resolvedModel.toJS(document))
       }
-      if (!isMap(model)) {
+      if (!isMap(resolvedModel)) {
         throw new Error(`DeepSeek Harness route ${route} legacy model ${modelId} must be a mapping`)
       }
+      if (resolvedModel.anchor) {
+        let hasExternalAlias = false
+        visit(document, {
+          Alias(_key, alias) {
+            if (alias.source === resolvedModel.anchor && !providerModelValueAliases.has(alias)) hasExternalAlias = true
+          }
+        })
+        if (hasExternalAlias) {
+          throw new Error(
+            `DeepSeek Harness route ${route} legacy model ${modelId} anchor ${resolvedModel.anchor} is referenced outside provider models`
+          )
+        }
+      }
+      // Always edit a detached YAML node. Individual legacy models may be anchored and referenced
+      // elsewhere in the document; mutating the provider-owned node in place would silently add the
+      // synthesized id to those external aliases. YAMLMap.clone preserves comments, tags, and scalar
+      // styles that a toJS()/createNode() round trip would discard.
+      const model = resolvedModel.clone(document.schema)
+      if (!isMap(model)) throw new Error('Failed to clone DeepSeek Harness legacy model mapping')
+      model.anchor = undefined
 
       const declaredIdNode = model.get('id', true)
       const resolvedIdNode = isAlias(declaredIdNode) ? declaredIdNode.resolve(document) : declaredIdNode
@@ -342,7 +368,8 @@ function migrateLegacyProviderModels(document: Document): void {
       }
 
       if (isScalar(modelPair.key)) {
-        prependComments(model, [modelPair.key.commentBefore, modelPair.key.comment])
+        const aliasComments = isAlias(sourceModel) ? [sourceModel.commentBefore, sourceModel.comment] : []
+        prependComments(model, [modelPair.key.commentBefore, modelPair.key.comment, ...aliasComments])
       }
       migratedModels.add(model)
     }

--- a/src/main/services/deepSeekHarness/config.ts
+++ b/src/main/services/deepSeekHarness/config.ts
@@ -9,7 +9,7 @@ import type { Provider } from '@shared/data/types/provider'
 import type { DeepSeekHarnessAgentPreset } from '@shared/types/codeCli'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
 import { formatApiHost, withoutTrailingApiVersion } from '@shared/utils/api'
-import { Document, isMap, isSeq, parseDocument, type YAMLError } from 'yaml'
+import { Document, isAlias, isMap, isScalar, isSeq, parseDocument, visit, type YAMLError } from 'yaml'
 
 export type DeepSeekHarnessMode = 'direct' | 'gateway'
 export type DeepSeekHarnessProtocol = 'anthropic-messages' | 'openai-responses' | 'openai-completions'
@@ -241,6 +241,116 @@ function projectReasoningEfforts(model: Model): false | Record<string, string | 
   return undefined
 }
 
+function yamlStringKey(key: unknown): string | undefined {
+  const value = isScalar(key) ? key.value : key
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function prependComments(target: { commentBefore?: string | null }, comments: Array<string | null | undefined>): void {
+  const combined = [...comments, target.commentBefore].filter((comment): comment is string => Boolean(comment))
+  if (combined.length > 0) target.commentBefore = combined.join('\n')
+}
+
+/**
+ * DSH has always consumed provider models as a sequence, but pre-release
+ * integrations could leave a map keyed by model id in the shared settings
+ * file. One invalid sibling route makes DSH reject the entire llm-pi-ai
+ * section, including Cherry's managed route. Convert only maps whose meaning
+ * can be preserved exactly; fail loudly instead of deleting or guessing at
+ * ambiguous user-owned data.
+ */
+function migrateLegacyProviderModels(document: Document): void {
+  const providers = document.getIn(['llm-pi-ai', 'providers'], true)
+  if (!isMap(providers)) return
+
+  const providerModelAliases = new Set<unknown>()
+  for (const providerPair of providers.items) {
+    if (!isMap(providerPair.value)) continue
+    const models = providerPair.value.get('models', true)
+    if (isAlias(models)) providerModelAliases.add(models)
+  }
+
+  for (const providerPair of providers.items) {
+    if (!isMap(providerPair.value)) continue
+    const models = providerPair.value.get('models', true)
+    const route = yamlStringKey(providerPair.key)
+    const routeLabel = route ?? '<invalid route>'
+    if (models == null || isSeq(models)) continue
+    if (isAlias(models)) {
+      const resolvedModels = models.resolve(document)
+      if (isSeq(resolvedModels)) continue
+      if (isMap(resolvedModels)) {
+        throw new Error(
+          `DeepSeek Harness route ${routeLabel} models aliases a legacy map that cannot be safely migrated in place`
+        )
+      }
+    }
+    if (!isMap(models)) {
+      throw new Error(`DeepSeek Harness route ${routeLabel} has a non-list models field`)
+    }
+    if (!route) {
+      throw new Error('DeepSeek Harness provider route with legacy models must have a non-empty string key')
+    }
+    if (models.anchor) {
+      let hasExternalAlias = false
+      visit(document, {
+        Alias(_key, alias) {
+          if (alias.source === models.anchor && !providerModelAliases.has(alias)) hasExternalAlias = true
+        }
+      })
+      if (hasExternalAlias) {
+        throw new Error(
+          `DeepSeek Harness route ${route} legacy models anchor ${models.anchor} is referenced outside provider models`
+        )
+      }
+    }
+
+    const migratedModels = document.createNode<unknown[]>([])
+    if (!isSeq(migratedModels)) throw new Error('Failed to create DeepSeek Harness models list')
+    migratedModels.commentBefore = models.commentBefore
+    migratedModels.comment = models.comment
+    migratedModels.spaceBefore = models.spaceBefore
+    migratedModels.anchor = models.anchor
+
+    for (const modelPair of models.items) {
+      const modelId = yamlStringKey(modelPair.key)
+      if (!modelId) {
+        throw new Error(`DeepSeek Harness route ${route} has a legacy model with an invalid id key`)
+      }
+      let model = modelPair.value
+      if (isAlias(model)) {
+        const resolvedModel = model.resolve(document)
+        if (!isMap(resolvedModel)) {
+          throw new Error(`DeepSeek Harness route ${route} legacy model ${modelId} must be a mapping`)
+        }
+        model = document.createNode(resolvedModel.toJS(document))
+      }
+      if (!isMap(model)) {
+        throw new Error(`DeepSeek Harness route ${route} legacy model ${modelId} must be a mapping`)
+      }
+
+      const declaredIdNode = model.get('id', true)
+      const resolvedIdNode = isAlias(declaredIdNode) ? declaredIdNode.resolve(document) : declaredIdNode
+      const declaredId = isScalar(resolvedIdNode) ? resolvedIdNode.value : resolvedIdNode
+      if (declaredIdNode == null) {
+        model.set('id', modelId)
+      } else if (declaredId !== modelId) {
+        const declaredIdLabel = typeof declaredId === 'string' ? JSON.stringify(declaredId) : `<${typeof declaredId}>`
+        throw new Error(
+          `DeepSeek Harness route ${route} legacy model ${modelId} declares conflicting id ${declaredIdLabel}`
+        )
+      }
+
+      if (isScalar(modelPair.key)) {
+        prependComments(model, [modelPair.key.commentBefore, modelPair.key.comment])
+      }
+      migratedModels.add(model)
+    }
+
+    providerPair.value.set('models', migratedModels)
+  }
+}
+
 function updateManagedModel(document: Document, projection: DeepSeekHarnessProjection): void {
   const modelsPath = ['llm-pi-ai', 'providers', projection.route, 'models']
   if (!document.hasIn(modelsPath)) document.setIn(modelsPath, document.createNode([]))
@@ -275,6 +385,8 @@ function renderSettings(snapshot: FileSnapshot, projection: DeepSeekHarnessProje
       throw new Error(`DeepSeek Harness route ${projection.route} is not owned by CodeMate`)
     }
   }
+
+  migrateLegacyProviderModels(document)
 
   document.setIn([...routePath, 'apiKeyEnv'], projection.credentialRef)
   document.setIn([...routePath, 'displayName'], projection.displayName)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

An object-form `models` value left by an older DeepSeek Harness integration in any provider route made the bundled runtime reject the entire shared `llm-pi-ai` section. That also hid Cherry Studio's otherwise valid managed unified-gateway route.

After this PR:

Cherry Studio migrates unambiguous legacy model maps to the current model-list schema before syncing its managed route. The migration preserves route/model order, comments, supported aliases and user-owned fields, fills a missing model `id` from its map key, remains byte-stable on subsequent syncs, and fails before writing when a legacy structure cannot be converted without changing its meaning.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19477

### Why we need it and why it was done in this way

DeepSeek Harness validates all configured provider routes together, so preserving an invalid legacy sibling route is not sufficient: it prevents the managed route from loading as well. Migrating only the known old map shape repairs existing settings without deleting third-party routes or silently discarding user data.

The following tradeoffs were made:

- The migration is intentionally conservative. Scalar model entries, conflicting explicit IDs, and anchors referenced outside provider `models` fail loudly before either settings file is written.
- Aliased model values are materialized as independent mappings so inserting IDs cannot mutate another legacy entry through a shared YAML node.
- This runs during settings synchronization instead of introducing a separate one-shot migration, keeping the repair idempotent and colocated with the schema projection it protects.

The following alternatives were considered:

- Removing or quarantining the incompatible route was rejected because those routes are user-owned and may still contain valid credentials and provider settings.
- Migrating only the selected managed route was rejected because one incompatible sibling still invalidates the complete `llm-pi-ai` configuration.
- Passing legacy maps through to the runtime was rejected because both the affected and current bundled DeepSeek Harness schemas require a model list.

Links to places where the discussion took place: #19477

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation performed:

- 45 focused DeepSeek Harness tests passed, including loading the migrated section through the actual bundled DSH `Config` implementation.
- `pnpm typecheck:node`
- Targeted Biome and ESLint checks
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Repair legacy DeepSeek Harness provider model maps so they no longer disable Cherry Studio's managed gateway route.
```
