### PR TITLE
fix(error-boundary): allow copying error details

### DIFF
--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button } from '@cherrystudio/ui'
 import { loggerService } from '@logger'
+import { ErrorFallbackCopyButton, ErrorFallbackDetails } from '@renderer/components/ErrorFallbackDetails'
 import { ipcApi } from '@renderer/ipc'
-import { formatErrorDetails } from '@renderer/utils/errorDetails'
 import type { ComponentType, ErrorInfo, ReactNode } from 'react'
 import type { FallbackProps } from 'react-error-boundary'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -22,10 +22,11 @@ const DefaultFallback: ComponentType<FallbackProps> = (props: FallbackProps): Re
       <Alert
         message={t('error.boundary.default.message')}
         showIcon
-        description={formatErrorDetails(error)}
+        description={<ErrorFallbackDetails error={error} />}
         type="error"
         action={
           <div className="flex items-center gap-2">
+            <ErrorFallbackCopyButton error={error} />
             <Button size="sm" onClick={debug}>
               {t('error.boundary.default.devtools')}
             </Button>

--- a/src/renderer/components/ErrorFallbackDetails.tsx
+++ b/src/renderer/components/ErrorFallbackDetails.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@cherrystudio/ui'
+import i18n from '@renderer/i18n/resolver'
+import { toast } from '@renderer/services/toast'
+import { formatErrorDetails } from '@renderer/utils/errorDetails'
+import { Copy } from 'lucide-react'
+import type { FC } from 'react'
+
+interface ErrorFallbackDetailsProps {
+  error: unknown
+}
+
+const ErrorFallbackDetails: FC<ErrorFallbackDetailsProps> = ({ error }) => (
+  <pre className="selectable whitespace-pre-wrap break-words font-sans">{formatErrorDetails(error)}</pre>
+)
+
+const ErrorFallbackCopyButton: FC<ErrorFallbackDetailsProps> = ({ error }) => {
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(formatErrorDetails(error))
+      toast.success(i18n.t('common.copied'))
+    } catch {
+      toast.error(i18n.t('common.copy_failed'))
+    }
+  }
+
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={() => void copy()} aria-label={i18n.t('common.copy')}>
+      <Copy size={14} />
+      {i18n.t('common.copy')}
+    </Button>
+  )
+}
+
+export { ErrorFallbackCopyButton, ErrorFallbackDetails }

--- a/src/renderer/components/WindowFatalFallback.tsx
+++ b/src/renderer/components/WindowFatalFallback.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button } from '@cherrystudio/ui'
+import { ErrorFallbackCopyButton, ErrorFallbackDetails } from '@renderer/components/ErrorFallbackDetails'
 import i18n from '@renderer/i18n/resolver'
 import { ipcApi } from '@renderer/ipc'
-import { formatErrorDetails } from '@renderer/utils/errorDetails'
 import { useEffect } from 'react'
 import type { FallbackProps } from 'react-error-boundary'
 
@@ -26,10 +26,11 @@ export const WindowFatalFallback = ({ error }: FallbackProps) => {
       <Alert
         type="error"
         message={i18n.t('error.boundary.default.message')}
-        description={formatErrorDetails(error)}
+        description={<ErrorFallbackDetails error={error} />}
         className="max-w-xl"
       />
       <div className="flex items-center gap-2">
+        <ErrorFallbackCopyButton error={error} />
         <Button size="sm" onClick={() => void ipcApi.request('system.toggle_dev_tools')}>
           {i18n.t('error.boundary.default.devtools')}
         </Button>

--- a/src/renderer/components/__tests__/WindowFatalFallback.test.tsx
+++ b/src/renderer/components/__tests__/WindowFatalFallback.test.tsx
@@ -12,9 +12,11 @@ describe('WindowFatalFallback', () => {
   // Both buttons dispatch through the typed IpcApi bridge (window.api.ipcApi.request);
   // stub the transport so the fallback's own (provider-free) render stays exercised.
   const request = vi.fn()
+  const writeText = vi.fn()
 
   beforeEach(() => {
     request.mockReset().mockResolvedValue({ ok: true, data: undefined })
+    writeText.mockReset().mockResolvedValue(undefined)
     vi.stubGlobal('api', { ipcApi: { request } })
   })
 
@@ -24,6 +26,24 @@ describe('WindowFatalFallback', () => {
     const alert = screen.getByRole('alert')
     expect(alert).toHaveTextContent(i18n.t('error.boundary.default.message'))
     expect(alert).toHaveTextContent('boom from provider')
+  })
+
+  it('keeps error details selectable and copies them from the provider-free fallback', async () => {
+    const user = userEvent.setup()
+    const errorMessage = 'boom from provider\nRetry after reopening the window'
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+    render(<WindowFatalFallback error={new Error(errorMessage)} resetErrorBoundary={vi.fn()} />)
+
+    const details = screen.getByText((_, element) => element?.textContent === errorMessage)
+    // The global body rule disables selection; this class is the user-visible bug contract.
+    expect(details).toHaveClass('selectable')
+
+    await user.click(screen.getByRole('button', { name: i18n.t('common.copy') }))
+
+    expect(writeText).toHaveBeenCalledWith(errorMessage)
   })
 
   it('reloads the window when the reload button is clicked', async () => {

--- a/src/renderer/components/layout/RouteErrorFallback.tsx
+++ b/src/renderer/components/layout/RouteErrorFallback.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button } from '@cherrystudio/ui'
+import { ErrorFallbackCopyButton, ErrorFallbackDetails } from '@renderer/components/ErrorFallbackDetails'
 import { ipcApi } from '@renderer/ipc'
-import { formatErrorDetails } from '@renderer/utils/errorDetails'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 
@@ -19,10 +19,11 @@ export const RouteErrorFallback = ({ error, reset }: ErrorComponentProps) => {
       <Alert
         type="error"
         message={t('error.boundary.default.message')}
-        description={formatErrorDetails(error)}
+        description={<ErrorFallbackDetails error={error} />}
         className="max-w-xl"
       />
       <div className="flex items-center gap-2">
+        <ErrorFallbackCopyButton error={error} />
         <Button size="sm" onClick={() => reset()}>
           {t('common.retry')}
         </Button>


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Error details in error fallback dialogs are not selectable, and there is no direct copy action.

After this PR:
All error fallback surfaces render formatted details in a selectable block and provide a copy button for the complete diagnostic text.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when merged)*: -->

Fixes #19391

### Why we need it and why it was done in this way

The shared fallback details component keeps the existing `formatErrorDetails()` formatting and sensitive-field filtering while adding selectable output and a reusable copy action across all three error fallback surfaces.

The following tradeoffs were made:
The copy action uses the browser clipboard API and existing localized messages. No new translation keys or reporting backend are introduced.

The following alternatives were considered:
Changing only the global text-selection CSS would not provide a discoverable copy action. Reusing the existing diagnostic/reporting workflow would not cover offline and privacy-preserving troubleshooting.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

Focused renderer tests passed:

- `ErrorBoundary.test.tsx`
- `WindowFatalFallback.test.tsx`
- `RouteErrorFallback.test.tsx`
- 12 tests passed in total

Also passed:

- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required. This fix is self-contained and does not change user-guide workflows or instructions.
- [x] Self-review: I have reviewed my own code via staged diff inspection and focused tests before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Error fallback dialogs now allow users to select and copy complete error details.
```