### PR TITLE
fix(knowledge): stop spinning after search errors

### DIFF
--- a/src/renderer/components/chat/messages/tools/knowledge/MessageKnowledgeSearch.tsx
+++ b/src/renderer/components/chat/messages/tools/knowledge/MessageKnowledgeSearch.tsx
@@ -11,6 +11,15 @@ function MessageKnowledgeSearchToolLabel({ toolResponse }: { toolResponse: Norma
   const query = inputParse.success ? inputParse.data.query : ''
   const resultCount = outputParse.success ? outputParse.data.length : 0
 
+  if (toolResponse.status === 'error') {
+    return (
+      <span className="flex min-w-0 flex-1 items-center justify-between gap-3 py-0.5 text-[13px] text-muted-foreground leading-5">
+        <span className="min-w-0 truncate">{query}</span>
+        <span className="shrink-0 text-danger">{i18n.t('message.tools.error')}</span>
+      </span>
+    )
+  }
+
   return toolResponse.status !== 'done' ? (
     <Spinner
       text={

--- a/src/renderer/components/chat/messages/tools/knowledge/__tests__/MessageKnowledgeSearch.test.tsx
+++ b/src/renderer/components/chat/messages/tools/knowledge/__tests__/MessageKnowledgeSearch.test.tsx
@@ -8,6 +8,7 @@ vi.mock('@renderer/i18n/resolver', () => ({
   default: {
     t: (key: string, params?: Record<string, number>) => {
       if (key === 'message.searching') return 'Searching'
+      if (key === 'message.tools.error') return 'Failed'
       if (key === 'message.websearch.fetch_complete') return `${params?.count} search results`
       return key
     }
@@ -25,6 +26,40 @@ vi.mock('lucide-react', async (importOriginal) => {
 })
 
 describe('MessageKnowledgeSearchToolTitle', () => {
+  const invokingResponse = {
+    id: 'tool-call-1',
+    toolCallId: 'tool-call-1',
+    tool: { id: 'knowledge-search', name: 'kb_search', type: 'builtin' },
+    status: 'invoking',
+    arguments: { query: 'Cherry Studio', baseIds: ['base-1'] }
+  } as NormalToolResponse
+
+  it('keeps showing the spinner while the search is in flight', () => {
+    render(<MessageKnowledgeSearchToolTitle toolResponse={invokingResponse} />)
+
+    expect(screen.getByText('Searching')).toBeInTheDocument()
+    expect(screen.getByText('Cherry Studio')).toBeInTheDocument()
+    expect(screen.queryByText('Failed')).not.toBeInTheDocument()
+  })
+
+  it('marks a failed search instead of spinning forever', () => {
+    render(<MessageKnowledgeSearchToolTitle toolResponse={{ ...invokingResponse, status: 'error' }} />)
+
+    expect(screen.getByText('Cherry Studio')).toBeInTheDocument()
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.queryByText('Searching')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders a terminal error when malformed input has no usable query', () => {
+    render(
+      <MessageKnowledgeSearchToolTitle toolResponse={{ ...invokingResponse, status: 'error', arguments: undefined }} />
+    )
+
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.queryByText('Searching')).not.toBeInTheDocument()
+  })
+
   it('wraps result details in the shared disclosure container', async () => {
     render(
       <MessageKnowledgeSearchToolTitle


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The dedicated knowledge-search renderer displayed its loading spinner for every state other than `done`. A tool-call parse or provider failure already reached the renderer as the terminal `error` state, but the card continued to say “Searching” indefinitely.

After this PR:

Knowledge searches show the existing localized tool-error label when their response reaches `error`. Pending, streaming, and invoking calls continue to show the spinner, while successful searches retain their current result count and disclosure behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #19452

### Why we need it and why it was done in this way

The shared tool-response adapter already maps AI SDK `output-error` parts to `status: 'error'`. The bug was isolated to this bespoke renderer treating that terminal state as in flight. Handling it at the presentation boundary fixes the permanent spinner without changing provider request behavior or duplicating error-state inference.

The following tradeoffs were made:

- This is intentionally limited to the deterministic terminal-state UI defect. The sanitized report proves a tool-call parse failure but does not expose enough provider payload data to identify a OneAPI-specific parser defect.
- The error presentation mirrors the existing web-search tool rather than introducing a knowledge-search-only status component.
- Cancelled searches retain their existing behavior because cancellation was not part of the reported provider/parse failure path.

The following alternatives were considered:

- Changing the shared tool-state adapter was rejected because it already emits `error` correctly and is used by many unrelated tools.
- Adding a speculative OneAPI response repair was rejected because the current evidence does not establish the malformed wire shape; Cherry Studio already applies the shared AI tool-call repair path to knowledge-search calls.
- Treating all non-success states as errors was rejected because pending, streaming, and invoking are valid in-flight states.

Links to places where the discussion took place: #19452

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regression coverage verifies that:

- an invoking search still displays “Searching” and its query;
- an errored search displays the localized error label, with no spinner or disclosure;
- an error with malformed/missing arguments still terminates cleanly without a usable query;
- successful result disclosure remains unchanged.

Validation performed:

- 9 focused knowledge-search and web-search renderer tests passed
- `pnpm typecheck:web`
- Targeted Biome and ESLint checks
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Knowledge-base searches now leave the loading state and show an error when the tool call fails.
```
