### PR TITLE
fix(agent): tolerate malformed tool search output

### DIFF
--- a/src/main/ai/messages/__tests__/messageRules.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.test.ts
@@ -2,6 +2,8 @@ import { type ModelMessage, tool, type UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 import * as z from 'zod'
 
+import { createToolSearchTool } from '../../tools/adapters/aiSdk/meta/toolSearch'
+import { ToolRegistry } from '../../tools/adapters/aiSdk/registry'
 import { coalesceConsecutiveSameRole, ensureNonEmptyAssistantContent, toModelMessages } from '../messageRules'
 
 const ui = (role: UIMessage['role'], parts: UIMessage['parts'], id = 'm'): UIMessage => ({ id, role, parts })
@@ -169,6 +171,39 @@ describe('toModelMessages', () => {
     })
     expect(JSON.stringify(model)).not.toContain(imageData)
     expect(messages).toEqual(originalMessages)
+  })
+
+  it('replays a malformed stored tool_search result without making the topic unsendable', async () => {
+    const toolSearch = createToolSearchTool(new ToolRegistry(), new Set(), new Set())
+    const model = await toModelMessages(
+      [
+        ui('assistant', [
+          {
+            type: 'tool-tool_search',
+            toolCallId: 'search-1',
+            state: 'output-available',
+            input: {},
+            output: { content: [{ type: 'text', text: 'Process started' }], metadata: {} }
+          }
+        ]),
+        ui('user', [{ type: 'text', text: 'continue' }], 'u1')
+      ],
+      undefined,
+      { tool_search: toolSearch }
+    )
+
+    expect(model[1]).toMatchObject({
+      role: 'tool',
+      content: [
+        expect.objectContaining({
+          toolName: 'tool_search',
+          output: {
+            type: 'text',
+            value: 'The stored tool search result could not be read. Ignore it and run `tool_search` again.'
+          }
+        })
+      ]
+    })
   })
 
   it('replays a completed legacy MCP tool name unchanged', async () => {

--- a/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/__tests__/toolSearch.test.ts
@@ -108,6 +108,26 @@ describe('tool_search meta-tool', () => {
     expect(out.value).toMatch(/No tools matched/)
   })
 
+  it.each([
+    ['undefined output', undefined],
+    ['null output', null],
+    ['an unrelated MCP result', { content: [{ type: 'text', text: 'Process started' }], metadata: {} }],
+    ['a non-array namespace value', { matchedNamespaces: {} }],
+    ['a malformed nested namespace', { matchedNamespaces: [{ namespace: 'mcp:s1', tools: null }] }]
+  ])('toModelOutput safely falls back for %s', (_name, output) => {
+    const reg = setup()
+    const tool = createToolSearchTool(reg, new Set(), new Set())
+    const out = tool.toModelOutput!({ toolCallId: 'tc-1', input: {}, output } as never) as {
+      type: string
+      value: string
+    }
+
+    expect(out).toEqual({
+      type: 'text',
+      value: 'The stored tool search result could not be read. Ignore it and run `tool_search` again.'
+    })
+  })
+
   it('advertises inputExamples', () => {
     const reg = setup()
     const tool = createToolSearchTool(reg, new Set(['mcp__s1__a']), new Set())

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
@@ -29,6 +29,7 @@ const ToolSearchOutputSchema = z.object({
     })
   )
 })
+type ToolSearchOutput = z.infer<typeof ToolSearchOutputSchema>
 
 const NO_MATCHING_TOOLS_MESSAGE = 'No tools matched. Broaden `query`, or omit it to browse all namespaces.'
 const INVALID_SEARCH_OUTPUT_MESSAGE =
@@ -59,10 +60,7 @@ export function createToolSearchTool(
     inputExamples: [{ input: { query: 'gmail', verbose: false } }, { input: { namespace: 'web', verbose: true } }],
     execute: async ({ query, namespace, verbose }) => {
       const grouped = registry.getByNamespace({ query, namespace })
-      const matchedNamespaces: Array<{
-        namespace: string
-        tools: Array<{ name: string; description: string; inputSchema?: unknown }>
-      }> = []
+      const matchedNamespaces: ToolSearchOutput['matchedNamespaces'] = []
 
       for (const [ns, entries] of grouped) {
         const filtered = entries.filter((e) => deferredNames.has(e.name))

--- a/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
+++ b/src/main/ai/tools/adapters/aiSdk/meta/toolSearch.ts
@@ -15,6 +15,25 @@ import { serializeToolSchema } from './schemaStub'
 
 export const TOOL_SEARCH_TOOL_NAME = 'tool_search'
 
+const ToolSearchOutputSchema = z.object({
+  matchedNamespaces: z.array(
+    z.object({
+      namespace: z.string(),
+      tools: z.array(
+        z.object({
+          name: z.string(),
+          description: z.string(),
+          inputSchema: z.unknown().optional()
+        })
+      )
+    })
+  )
+})
+
+const NO_MATCHING_TOOLS_MESSAGE = 'No tools matched. Broaden `query`, or omit it to browse all namespaces.'
+const INVALID_SEARCH_OUTPUT_MESSAGE =
+  'The stored tool search result could not be read. Ignore it and run `tool_search` again.'
+
 export function createToolSearchTool(
   registry: ToolRegistry,
   deferredNames: ReadonlySet<string>,
@@ -76,17 +95,13 @@ export function createToolSearchTool(
   })
 }
 
-function formatSearchForModel(output: {
-  matchedNamespaces: Array<{
-    namespace: string
-    tools: Array<{ name: string; description: string; inputSchema?: unknown }>
-  }>
-}): string {
-  if (output.matchedNamespaces.length === 0) {
-    return 'No tools matched. Broaden `query`, or omit it to browse all namespaces.'
-  }
+function formatSearchForModel(output: unknown): string {
+  const parsed = ToolSearchOutputSchema.safeParse(output)
+  if (!parsed.success) return INVALID_SEARCH_OUTPUT_MESSAGE
+  if (parsed.data.matchedNamespaces.length === 0) return NO_MATCHING_TOOLS_MESSAGE
+
   const lines: string[] = []
-  for (const group of output.matchedNamespaces) {
+  for (const group of parsed.data.matchedNamespaces) {
     lines.push(group.namespace)
     for (const t of group.tools) {
       lines.push(`  - ${t.name} — ${t.description}`)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`tool_search` trusted every replayed output to contain a complete `matchedNamespaces` tree. One historical part containing `null`, an unrelated MCP result, or a partially malformed namespace made `formatSearchForModel` throw during `convertToModelMessages`, so every later send in that topic failed before reaching the provider.

After this PR:

The formatter validates the complete tool-search output structure before reading it. Valid search results keep their existing compact representation, a valid empty result keeps the existing “No tools matched” guidance, and unreadable output becomes a fixed model-facing instruction to ignore the damaged result and run `tool_search` again.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Refs #19465

### Why we need it and why it was done in this way

Historical tool results are replayed through each declared tool's `toModelOutput` formatter when a conversation is converted back to model messages. That makes the formatter a persistence boundary: its static TypeScript output type does not prove that older or misattributed stored JSON has the same runtime shape.

The following tradeoffs were made:

- The complete nested structure is validated rather than optional-chaining only `matchedNamespaces`; otherwise malformed groups or tools could still throw later in the formatter.
- Invalid output uses a distinct recovery message instead of pretending the search legitimately returned no matches.
- The damaged payload is not echoed to the model, avoiding accidental prompt content from an unrelated tool result.

The following alternatives were considered:

- Normalizing malformed rows in SQLite was rejected because it would require identifying and mutating user history, while the reader must remain safe for any future invalid value.
- Catching only the reported `.length` access was rejected because the subsequent namespace and tool loops made the same unchecked assumptions.
- Guessing at the parallel writer-attribution race was rejected because the issue does not contain a deterministic writer reproduction and also reports two unrelated serialization/token-loop defects.

Links to places where the discussion took place: #19465

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Regression coverage includes:

- `undefined`, `null`, unrelated MCP output, non-array namespaces, and malformed nested namespaces;
- unchanged valid and valid-empty formatter behavior;
- the real history replay path through `toModelMessages`, proving a malformed `output-available` part no longer makes the topic unsendable.

Validation performed:

- 33 focused `tool_search` and message-conversion tests passed
- `pnpm typecheck:node`
- Targeted Biome and ESLint checks
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Malformed historical tool-search results no longer prevent a conversation from sending new messages.
```
