### PR TITLE
fix(web-search): accept SearXNG engines tagged general only

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -841,6 +841,96 @@ describe('main web search API providers', () => {
     `)
   })
 
+  it('selects enabled Searxng engines whose categories are general only', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          engines: [
+            { categories: ['general'], enabled: true, name: 'wikipedia' },
+            { categories: ['images'], enabled: true, name: 'google_images' }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(createJsonResponse(loadFixtureJson('searxng-search-response.json')))
+    fetchRemoteTextMock.mockResolvedValueOnce(loadFixtureText('searxng-page.html'))
+
+    const provider = createProviderDriver(
+      SearxngProvider,
+      createProvider({
+        id: 'searxng',
+        name: 'Searxng',
+        apiHost: 'https://searx.example',
+        engines: []
+      })
+    )
+
+    await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(toRequestSnapshot(fetchMock.mock.calls[1] as [string, RequestInit | undefined]).url).toBe(
+      'https://searx.example/search?q=hello&language=auto&format=json&engines=wikipedia'
+    )
+  })
+
+  it('prefers enabled dual general+web Searxng engines and excludes specialized engines', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          engines: [
+            { categories: ['images'], enabled: true, name: 'google_images' },
+            { categories: ['general'], enabled: true, name: 'wikipedia' },
+            { categories: ['science'], enabled: true, name: 'arxiv' },
+            { categories: ['general', 'web'], enabled: true, name: 'duckduckgo' },
+            { categories: ['general', 'web'], enabled: false, name: 'google' }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(createJsonResponse(loadFixtureJson('searxng-search-response.json')))
+    fetchRemoteTextMock.mockResolvedValueOnce(loadFixtureText('searxng-page.html'))
+
+    const provider = createProviderDriver(
+      SearxngProvider,
+      createProvider({
+        id: 'searxng',
+        name: 'Searxng',
+        apiHost: 'https://searx.example',
+        engines: []
+      })
+    )
+
+    await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(toRequestSnapshot(fetchMock.mock.calls[1] as [string, RequestInit | undefined]).url).toBe(
+      'https://searx.example/search?q=hello&language=auto&format=json&engines=duckduckgo%2Cwikipedia'
+    )
+  })
+
+  it('throws when Searxng config has no enabled general search engines', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({
+        engines: [
+          { categories: ['images'], enabled: true, name: 'google_images' },
+          { categories: ['science'], enabled: true, name: 'arxiv' },
+          { categories: ['general'], enabled: false, name: 'google' }
+        ]
+      })
+    )
+
+    const provider = createProviderDriver(
+      SearxngProvider,
+      createProvider({
+        id: 'searxng',
+        name: 'Searxng',
+        apiHost: 'https://searx.example',
+        engines: []
+      })
+    )
+
+    await expect(provider.searchKeywords('hello', runtimeConfig)).rejects.toThrow(
+      'No enabled general web search engines found in Searxng configuration'
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('filters empty fetched content from Searxng results', async () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse(loadFixtureJson('searxng-search-response.json')))
     fetchRemoteTextMock.mockResolvedValueOnce('<html><body><div></div></body></html>')

--- a/src/main/services/webSearch/providers/api/SearxngProvider.ts
+++ b/src/main/services/webSearch/providers/api/SearxngProvider.ts
@@ -81,7 +81,8 @@ export class SearxngProvider extends BaseWebSearchProvider {
     })
 
     const engines = payload.engines
-      .filter((engine) => engine.enabled && engine.categories.includes('general') && engine.categories.includes('web'))
+      .filter((engine) => engine.enabled && engine.categories.includes('general'))
+      .sort((left, right) => Number(right.categories.includes('web')) - Number(left.categories.includes('web')))
       .map((engine) => engine.name)
 
     if (engines.length === 0) {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
SearXNG auto-discovery required each enabled engine to include both `general` and `web`. Instances that tag enabled web engines as `["general"]` only failed with `No enabled general web search engines found in Searxng configuration`, even when the instance was reachable in v1 and in a browser.

After this PR:
Enabled engines tagged `general` are selected, including general-only engines. Dual `general`+`web` engines remain valid and are preferred when both kinds are present. Images-only and other non-general specialized engines stay excluded. The existing error is still thrown when no enabled general search engine exists.

Fixes #19494

### Why we need it and why it was done in this way

The following tradeoffs were made:
The filter change is limited to engine category matching inside `SearxngProvider.resolveEngines`. URL joining, request transport, proxy behavior, 502 handling, and the provider abstraction are unchanged.

The following alternatives were considered:
Accepting any `web` category without `general` would also admit specialized/non-general engines. Requiring both `general` and `web` is the current bug. Selecting enabled engines that include `general` is the smallest contract that matches real SearXNG configs.

Links to places where the discussion took place: DEV Base recvtj4ZFD1K5J; GitHub issue #19494

### Breaking changes

None.

### Special notes for your reviewer

Contract tests cover: general-only engines are selected; dual `general`+`web` engines remain valid and preferred; images-only and specialized engines are excluded; the original error is retained when no enabled general engine exists.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed SearXNG web search failing with "No enabled general web search engines found" when the instance tags enabled engines as general only.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to SearXNG engine category filtering during config auto-discovery; no auth, transport, or shared web-search pipeline changes.
> 
> **Overview**
> Fixes SearXNG auto-discovery when instances tag enabled web engines with only the **`general`** category (previously both **`general`** and **`web`** were required, causing *No enabled general web search engines found*).
> 
> **`SearxngProvider.resolveEngines`** now selects enabled engines that include **`general`**, sorts so **`general`+`web`** engines come first, and still excludes non-general engines (e.g. images/science). The same error is thrown when no enabled general engine exists.
> 
> Three contract tests cover general-only selection, dual-category preference, and the no-engine failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b6d11b4cfaf7c40de151844bb6cb848c26aad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->