### PR TITLE
fix(knowledge): refresh note snapshot content

### DIFF
--- a/src/main/data/services/KnowledgeItemService.ts
+++ b/src/main/data/services/KnowledgeItemService.ts
@@ -5,11 +5,12 @@
  */
 
 import { application } from '@application'
+import { notifyDataApiDataChange } from '@data/dataApiDataChange'
 import { knowledgeItemTable } from '@data/db/schemas/knowledge'
 import { type SqliteErrorHandlers, withSqliteErrors } from '@data/db/sqliteErrors'
 import type { DbOrTx, DbType } from '@data/db/types'
 import { loggerService } from '@logger'
-import { DataApiErrorFactory } from '@shared/data/api/errors'
+import { DataApiErrorFactory, toDataApiError } from '@shared/data/api/errors'
 import type { KnowledgeItemListResponse, ListKnowledgeItemsQuery } from '@shared/data/api/schemas/knowledges'
 import {
   type CreateKnowledgeItemDto,
@@ -17,7 +18,8 @@ import {
   type KnowledgeItemData,
   KnowledgeItemSchema,
   type KnowledgeItemStatus,
-  type KnowledgeItemType
+  type KnowledgeItemType,
+  NoteItemDataSchema
 } from '@shared/data/types/knowledge'
 import { and, asc, desc, eq, gt, inArray, isNull, lt, ne, or, type SQL, sql } from 'drizzle-orm'
 
@@ -693,6 +695,71 @@ export class KnowledgeItemService {
    */
   updateSnapshotRelativePath(id: string, type: 'url' | 'note', relativePath: string): KnowledgeItem {
     return this.patchItemData(id, [type], { relativePath }, `${type} snapshot relative path`)
+  }
+
+  /**
+   * Reconcile the canonical text read from a captured Note snapshot back into
+   * the main database. The per-base index stores the same text separately; this
+   * update keeps detail/preview consumers of `data.content` consistent after a
+   * successful refresh without changing the Note's source or snapshot path.
+   */
+  updateNoteSnapshotContent(id: string, content: string): KnowledgeItem {
+    const dbService = application.get('DbService')
+    const { item, blocked } = dbService.withWriteTx((tx) => {
+      const [existingRow] = tx.select().from(knowledgeItemTable).where(eq(knowledgeItemTable.id, id)).limit(1).all()
+
+      if (!existingRow) {
+        throw DataApiErrorFactory.notFound('KnowledgeItem', id)
+      }
+
+      const existingItem = rowToKnowledgeItem(existingRow)
+      if (existingItem.type !== 'note') {
+        throw DataApiErrorFactory.validation({
+          type: [`Knowledge item ${id} must be of type note to update its snapshot content`]
+        })
+      }
+
+      if (existingItem.status === 'deleting') {
+        return { item: existingItem, blocked: true }
+      }
+
+      const nextDataValidation = NoteItemDataSchema.safeParse({ ...existingItem.data, content })
+      if (!nextDataValidation.success) {
+        throw toDataApiError(nextDataValidation.error, 'update note snapshot content')
+      }
+
+      const [updatedRow] = tx
+        .update(knowledgeItemTable)
+        .set({ data: nextDataValidation.data })
+        .where(eq(knowledgeItemTable.id, id))
+        .returning()
+        .all()
+
+      if (!updatedRow) {
+        throw DataApiErrorFactory.dataInconsistent(
+          'KnowledgeItem',
+          `Knowledge item note snapshot content update result missing for id '${id}'`
+        )
+      }
+
+      return { item: rowToKnowledgeItem(updatedRow), blocked: false }
+    })
+
+    if (blocked) {
+      logger.warn('Skipped note snapshot content update for deleting item', { id })
+    } else {
+      logger.info('Updated knowledge item note snapshot content', { id, contentLength: content.length })
+      notifyDataApiDataChange([
+        { endpoint: '/knowledge-items/:id', routeParams: { id }, entityIds: [id] },
+        {
+          endpoint: '/knowledge-bases/:id/items',
+          kind: 'projection',
+          routeParams: { id: item.baseId },
+          entityIds: [id]
+        }
+      ])
+    }
+    return item
   }
 
   /**

--- a/src/main/data/services/__tests__/KnowledgeItemService.test.ts
+++ b/src/main/data/services/__tests__/KnowledgeItemService.test.ts
@@ -4,13 +4,17 @@ import { userProviderTable } from '@data/db/schemas/userProvider'
 import { KnowledgeItemService } from '@data/services/KnowledgeItemService'
 import { generateOrderKeyBetween } from '@data/services/utils/orderKey'
 import { ErrorCode } from '@shared/data/api/errors'
-import type { CreateKnowledgeItemDto } from '@shared/data/types/knowledge'
+import { type CreateKnowledgeItemDto, KNOWLEDGE_NOTE_CONTENT_MAX } from '@shared/data/types/knowledge'
 import { createUniqueModelId } from '@shared/data/types/model'
 import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { setupTestDatabase } from '@test-helpers/db'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
 import { eq } from 'drizzle-orm'
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+
+const { notifyDataApiDataChangeMock } = vi.hoisted(() => ({ notifyDataApiDataChangeMock: vi.fn() }))
+
+vi.mock('@data/dataApiDataChange', () => ({ notifyDataApiDataChange: notifyDataApiDataChangeMock }))
 
 const KNOWLEDGE_BASE_ID = '11111111-1111-4111-8111-111111111111'
 const itemId = (sequence: string) => `0198f3f2-${sequence}-7abc-8def-123456789abc`
@@ -46,6 +50,7 @@ describe('KnowledgeItemService', () => {
   let service: KnowledgeItemService
 
   beforeEach(async () => {
+    notifyDataApiDataChangeMock.mockClear()
     service = new KnowledgeItemService()
     await dbh.db.insert(userProviderTable).values({
       providerId: 'openai',
@@ -1393,6 +1398,115 @@ describe('KnowledgeItemService', () => {
       expect(err).toMatchObject({
         code: ErrorCode.VALIDATION_ERROR
       })
+    })
+  })
+
+  describe('updateNoteSnapshotContent', () => {
+    it('updates the note snapshot while preserving its source and relative path', async () => {
+      await seedItem({
+        id: NOTE_A_ID,
+        type: 'note',
+        data: {
+          source: 'Meeting notes',
+          content: 'old body',
+          relativePath: 'Meeting notes.md' as PosixRelativeFilePath
+        },
+        status: 'embedding',
+        createdAt: 1,
+        updatedAt: 1
+      })
+
+      const result = service.updateNoteSnapshotContent(NOTE_A_ID, '# Meeting\n\nnew body')
+
+      expect(result).toMatchObject({
+        id: NOTE_A_ID,
+        type: 'note',
+        status: 'embedding',
+        data: {
+          source: 'Meeting notes',
+          content: '# Meeting\n\nnew body',
+          relativePath: 'Meeting notes.md' as PosixRelativeFilePath
+        }
+      })
+      expect(Date.parse(result.createdAt)).toBe(1)
+      expect(Date.parse(result.updatedAt)).toBeGreaterThan(1)
+      expect(notifyDataApiDataChangeMock).toHaveBeenCalledExactlyOnceWith([
+        {
+          endpoint: '/knowledge-items/:id',
+          routeParams: { id: NOTE_A_ID },
+          entityIds: [NOTE_A_ID]
+        },
+        {
+          endpoint: '/knowledge-bases/:id/items',
+          kind: 'projection',
+          routeParams: { id: KNOWLEDGE_BASE_ID },
+          entityIds: [NOTE_A_ID]
+        }
+      ])
+    })
+
+    it('accepts note content at the persisted size limit', async () => {
+      await seedItem({ id: NOTE_A_ID, status: 'embedding' })
+      const content = 'x'.repeat(KNOWLEDGE_NOTE_CONTENT_MAX)
+
+      const result = service.updateNoteSnapshotContent(NOTE_A_ID, content)
+
+      if (result.type !== 'note') {
+        throw new Error(`Expected note item, received ${result.type}`)
+      }
+      expect(result.data.content).toBe(content)
+    })
+
+    it('rejects oversized content without changing the stored note', async () => {
+      await seedItem({ id: NOTE_A_ID, data: { source: 'note', content: 'old body' }, updatedAt: 1 })
+
+      let err: unknown
+      try {
+        service.updateNoteSnapshotContent(NOTE_A_ID, 'x'.repeat(KNOWLEDGE_NOTE_CONTENT_MAX + 1))
+      } catch (e) {
+        err = e
+      }
+
+      expect(err).toMatchObject({ code: ErrorCode.VALIDATION_ERROR })
+      const [stored] = await dbh.db.select().from(knowledgeItemTable).where(eq(knowledgeItemTable.id, NOTE_A_ID))
+      expect(stored.data).toMatchObject({ content: 'old body' })
+      expect(stored.updatedAt).toBe(1)
+      expect(notifyDataApiDataChangeMock).not.toHaveBeenCalled()
+    })
+
+    it('rejects updating snapshot content for a missing knowledge item', () => {
+      expect(() => service.updateNoteSnapshotContent(OTHER_ITEM_ID, 'new body')).toThrowError(
+        expect.objectContaining({ code: ErrorCode.NOT_FOUND })
+      )
+    })
+
+    it('rejects updating snapshot content for a non-note item', async () => {
+      await seedItem({
+        id: ITEM_1_ID,
+        type: 'url',
+        data: { source: 'https://example.com', url: 'https://example.com' }
+      })
+
+      expect(() => service.updateNoteSnapshotContent(ITEM_1_ID, 'new body')).toThrowError(
+        expect.objectContaining({ code: ErrorCode.VALIDATION_ERROR })
+      )
+    })
+
+    it('does not update a note that is being deleted', async () => {
+      await seedItem({
+        id: DELETING_NOTE_ID,
+        data: { source: 'note', content: 'old body', relativePath: 'note.md' as PosixRelativeFilePath },
+        status: 'deleting',
+        updatedAt: 1
+      })
+
+      const result = service.updateNoteSnapshotContent(DELETING_NOTE_ID, 'new body')
+
+      expect(result).toMatchObject({ status: 'deleting', data: { content: 'old body' } })
+      const [stored] = await dbh.db.select().from(knowledgeItemTable).where(eq(knowledgeItemTable.id, DELETING_NOTE_ID))
+      expect(stored.data).toMatchObject({ content: 'old body' })
+      expect(stored.updatedAt).toBe(1)
+      expect(notifyDataApiDataChangeMock).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
+++ b/src/main/features/knowledge/tasks/__tests__/indexDocumentsJobHandler.test.ts
@@ -1,4 +1,5 @@
 import { LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
+import { KNOWLEDGE_NOTE_CONTENT_MAX } from '@shared/data/types/knowledge'
 import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { MockMainCacheServiceExport } from '@test-mocks/main/CacheService'
 import { describe, expect, it } from 'vitest'
@@ -21,6 +22,7 @@ import {
   FILE_ITEM_ID,
   knowledgeBaseGetByIdMock,
   knowledgeItemGetByIdMock,
+  knowledgeItemUpdateNoteSnapshotContentMock,
   knowledgeItemUpdateSnapshotRelativePathMock,
   knowledgeItemUpdateStatusMock,
   knowledgeLockManager,
@@ -72,6 +74,16 @@ describe('index-documents job handler', () => {
         units: expect.arrayContaining([expect.objectContaining({ unitType: 'chunk' })]),
         embeddings: expect.any(Array)
       })
+    )
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'hello world')
+    expect(rebuildMaterialMock.mock.invocationCallOrder[0]).toBeLessThan(
+      knowledgeItemUpdateNoteSnapshotContentMock.mock.invocationCallOrder[0]
+    )
+    const completedCallOrder = knowledgeItemUpdateStatusMock.mock.calls.findIndex(
+      ([id, status]) => id === NOTE_ITEM_ID && status === 'completed'
+    )
+    expect(knowledgeItemUpdateNoteSnapshotContentMock.mock.invocationCallOrder[0]).toBeLessThan(
+      knowledgeItemUpdateStatusMock.mock.invocationCallOrder[completedCallOrder]
     )
     expect(knowledgeItemUpdateStatusMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
     expect(handler.defaultQueue?.({ baseId: 'kb-1', itemId: NOTE_ITEM_ID })).toBe('base.kb-1')
@@ -363,6 +375,7 @@ describe('index-documents job handler', () => {
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: FILE_ITEM_ID }))
 
     expect(loadKnowledgeItemDocumentsMock).toHaveBeenCalledWith(expect.objectContaining({ id: FILE_ITEM_ID }))
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).not.toHaveBeenCalled()
   })
 
   it('completes with empty vectors when the reader returns no documents', async () => {
@@ -391,6 +404,35 @@ describe('index-documents job handler', () => {
     await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
 
     expect(rebuildMaterialMock).not.toHaveBeenCalled()
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).not.toHaveBeenCalled()
+    expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
+  })
+
+  it('does not mark completed when the note becomes deleting during snapshot reconciliation', async () => {
+    const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+    knowledgeItemUpdateNoteSnapshotContentMock.mockReturnValueOnce(createNoteItem(NOTE_ITEM_ID, null, 'deleting'))
+
+    await handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))
+
+    expect(rebuildMaterialMock).toHaveBeenCalledTimes(1)
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).toHaveBeenCalledWith(NOTE_ITEM_ID, 'hello world')
+    expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
+  })
+
+  it('rejects an oversized note snapshot before rebuilding its material', async () => {
+    const handler = createIndexDocumentsJobHandler(knowledgeLockManager as never)
+    knowledgeItemGetByIdMock.mockReturnValue(createNoteItem(NOTE_ITEM_ID))
+    loadKnowledgeItemDocumentsMock.mockResolvedValueOnce([
+      { text: 'x'.repeat(KNOWLEDGE_NOTE_CONTENT_MAX + 1), metadata: { source: NOTE_ITEM_ID } }
+    ])
+
+    await expect(handler.execute(createCtx({ baseId: 'kb-1', itemId: NOTE_ITEM_ID }))).rejects.toMatchObject({
+      code: 'VALIDATION_ERROR'
+    })
+
+    expect(rebuildMaterialMock).not.toHaveBeenCalled()
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).not.toHaveBeenCalled()
     expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
   })
 
@@ -406,6 +448,7 @@ describe('index-documents job handler', () => {
     )
 
     expect(knowledgeItemUpdateStatusMock).not.toHaveBeenCalledWith(NOTE_ITEM_ID, 'completed')
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).not.toHaveBeenCalled()
   })
 
   it('stops before side effects when aborted before execution', async () => {
@@ -449,6 +492,7 @@ describe('index-documents job handler', () => {
     // item-id virtual placeholder — so it points at the bytes captureUrlSnapshotFile
     // wrote and agrees with what the v1→v2 migrator stamps for the same url.
     expect(lastRebuildInput().material.relativePath).toBe('example-page.md')
+    expect(knowledgeItemUpdateNoteSnapshotContentMock).not.toHaveBeenCalled()
     // README's lock-boundary contract: the network fetch must complete before the
     // (first) mutation lock is taken, never inside it.
     expect(fetchKnowledgeWebPageMock.mock.invocationCallOrder[0]).toBeLessThan(

--- a/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
+++ b/src/main/features/knowledge/tasks/__tests__/jobHandlerTestUtils.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   knowledgeItemUpdateIndexedRelativePathMock: vi.fn(),
   knowledgeItemGetItemsByBaseIdMock: vi.fn(),
   knowledgeItemUpdateSnapshotRelativePathMock: vi.fn(),
+  knowledgeItemUpdateNoteSnapshotContentMock: vi.fn(),
   listMock: vi.fn(),
   loadKnowledgeItemDocumentsMock: vi.fn(),
   prepareKnowledgeItemMock: vi.fn(),
@@ -62,6 +63,7 @@ export const {
   knowledgeItemUpdateIndexedRelativePathMock,
   knowledgeItemGetItemsByBaseIdMock,
   knowledgeItemUpdateSnapshotRelativePathMock,
+  knowledgeItemUpdateNoteSnapshotContentMock,
   listMock,
   loadKnowledgeItemDocumentsMock,
   prepareKnowledgeItemMock,
@@ -134,6 +136,7 @@ vi.mock('@data/services/KnowledgeItemService', () => ({
     setSubtreeStatus: knowledgeItemSetSubtreeStatusMock,
     updateIndexedRelativePath: knowledgeItemUpdateIndexedRelativePathMock,
     updateSnapshotRelativePath: knowledgeItemUpdateSnapshotRelativePathMock,
+    updateNoteSnapshotContent: knowledgeItemUpdateNoteSnapshotContentMock,
     updateStatus: knowledgeItemUpdateStatusMock
   }
 }))
@@ -385,6 +388,10 @@ beforeEach(() => {
     (id: string, type: 'url' | 'note', relativePath: PosixRelativeFilePath) =>
       type === 'url' ? createUrlItem(id, relativePath) : createNoteItem(id, null, 'processing', relativePath)
   )
+  knowledgeItemUpdateNoteSnapshotContentMock.mockImplementation((id: string, content: string) => ({
+    ...createNoteItem(id, null, 'embedding'),
+    data: { ...createNoteItem(id).data, content }
+  }))
   loadKnowledgeItemDocumentsMock.mockResolvedValue([
     {
       text: 'hello world',

--- a/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
+++ b/src/main/features/knowledge/tasks/indexDocumentsJobHandler.ts
@@ -6,10 +6,10 @@ import { knowledgeItemService } from '@data/services/KnowledgeItemService'
 import { loggerService } from '@logger'
 import type { KeyedMutex } from '@main/core/concurrency/KeyedMutex'
 import type { JobContext, JobHandler } from '@main/core/job/types'
-import { isDataApiNotFoundError } from '@shared/data/api/errors'
+import { isDataApiNotFoundError, toDataApiError } from '@shared/data/api/errors'
 import { LOCAL_EMBEDDING_UNIQUE_MODEL_ID } from '@shared/data/presets/localEmbedding'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
-import { isCompletedVectorKnowledgeBase } from '@shared/data/types/knowledge'
+import { isCompletedVectorKnowledgeBase, NoteItemDataSchema } from '@shared/data/types/knowledge'
 
 import type { IndexableKnowledgeItem } from '../items'
 import { isIndexableKnowledgeItem, toMaterialRelativePath } from '../items'
@@ -93,6 +93,7 @@ export function createIndexDocumentsJobHandler(
       const readableItem = await ensureSnapshot(ctx, item, knowledgeLockManager)
       const documents = await readItemDocuments(ctx, readableItem)
       const chunked = await chunkItemDocuments(base, documents, ctx.signal)
+      validateNoteSnapshotContent(readableItem, chunked.contentText)
       if (chunked.chunks.length === 0) {
         // Deliberate: the item still completes (an empty material is written) so the
         // UI doesn't show a stuck/failed item, but leave a trace — an image-only PDF
@@ -131,6 +132,17 @@ export function createIndexDocumentsJobHandler(
     async onSettled(event) {
       await markKnowledgeItemFailedOnSettled(event, logger, 'Failed to flip knowledge item to failed in onSettled')
     }
+  }
+}
+
+function validateNoteSnapshotContent(item: IndexableKnowledgeItem, content: string): void {
+  if (item.type !== 'note') {
+    return
+  }
+
+  const validation = NoteItemDataSchema.safeParse({ ...item.data, content })
+  if (!validation.success) {
+    throw toDataApiError(validation.error, 'refresh note snapshot content')
   }
 }
 
@@ -379,6 +391,19 @@ async function writeItemMaterial(
     const vectorStoreService = application.get('KnowledgeVectorStoreService')
     const store = vectorStoreService.getIndexStore(base)
     store.rebuildMaterial(itemId, input)
+
+    if (result.item.type === 'note') {
+      const updatedItem = knowledgeItemService.updateNoteSnapshotContent(itemId, input.content.text)
+      if (updatedItem.status === 'deleting') {
+        logger.info('Skipping completed status for note deleted during snapshot reconciliation', {
+          baseId,
+          itemId,
+          jobId: ctx.jobId
+        })
+        return
+      }
+    }
+
     knowledgeItemService.updateStatus(itemId, 'completed')
   })
 }

--- a/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemNoteContentPanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/KnowledgeItemNoteContentPanel.tsx
@@ -1,6 +1,6 @@
 import { Button, Scrollbar } from '@cherrystudio/ui'
 import { cn } from '@cherrystudio/ui/lib/utils'
-import { useQuery } from '@data/hooks/useDataApi'
+import { useDataChange, useQuery } from '@data/hooks/useDataApi'
 import { ArrowLeft } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -30,11 +30,21 @@ const KnowledgeItemNoteContentPanel = ({ itemId, onBack }: KnowledgeItemNoteCont
   const {
     data: item,
     isLoading,
-    error
+    error,
+    refetch
   } = useQuery('/knowledge-items/:id', {
     params: { id: itemId },
     enabled: Boolean(itemId)
   })
+  useDataChange(
+    '/knowledge-items/:id',
+    (effects) => {
+      if (effects.some((effect) => !effect.entityIds || effect.entityIds.includes(itemId))) {
+        void refetch()
+      }
+    },
+    { routeParams: { id: itemId } }
+  )
   const viewModel = item ? toKnowledgeItemRowViewModel(item, language) : null
   const Icon = viewModel?.icon.icon
   const content = item?.type === 'note' ? item.data.content : ''

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemNoteContentPanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/KnowledgeItemNoteContentPanel.test.tsx
@@ -1,12 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import KnowledgeItemNoteContentPanel from '../KnowledgeItemNoteContentPanel'
 import { createNoteItem } from './testUtils'
 
 const mockUseQuery = vi.fn()
+const mockUseDataChange = vi.fn()
 
 vi.mock('@data/hooks/useDataApi', () => ({
+  useDataChange: (...args: unknown[]) => mockUseDataChange(...args),
   useQuery: (...args: unknown[]) => mockUseQuery(...args)
 }))
 
@@ -41,7 +43,8 @@ describe('KnowledgeItemNoteContentPanel', () => {
     mockUseQuery.mockReturnValue({
       data: createNoteItem({ id: 'note-1', content: '第一行标题\n第二行完整正文内容' }),
       isLoading: false,
-      error: undefined
+      error: undefined,
+      refetch: vi.fn()
     })
   })
 
@@ -67,11 +70,36 @@ describe('KnowledgeItemNoteContentPanel', () => {
   })
 
   it('shows a loading state while the item is being fetched', () => {
-    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true, error: undefined })
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true, error: undefined, refetch: vi.fn() })
 
     render(<KnowledgeItemNoteContentPanel itemId="note-1" onBack={vi.fn()} />)
 
     // Both the placeholder title and the body render the loading label while the item resolves.
     expect(screen.getAllByText('加载中').length).toBeGreaterThan(0)
+  })
+
+  it('refetches when the displayed note snapshot changes', () => {
+    const refetch = vi.fn()
+    mockUseQuery.mockReturnValue({
+      data: createNoteItem({ id: 'note-1', content: 'old body' }),
+      isLoading: false,
+      error: undefined,
+      refetch
+    })
+    let listener: ((effects: Array<{ entityIds?: string[] }>) => void) | undefined
+    mockUseDataChange.mockImplementation((_endpoint, nextListener) => {
+      listener = nextListener
+    })
+
+    render(<KnowledgeItemNoteContentPanel itemId="note-1" onBack={vi.fn()} />)
+
+    expect(mockUseDataChange).toHaveBeenCalledWith('/knowledge-items/:id', expect.any(Function), {
+      routeParams: { id: 'note-1' }
+    })
+    act(() => listener?.([{ entityIds: ['another-note'] }]))
+    expect(refetch).not.toHaveBeenCalled()
+
+    act(() => listener?.([{ entityIds: ['note-1'] }]))
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Refreshing a Note knowledge item rebuilt its per-base search material from the latest captured snapshot, but left `knowledge_item.data.content` unchanged in the main database. Search therefore used the new text while the Note preview and other main-DB consumers continued to show the old content and timestamp. An already-open preview also had no signal to refetch after the background job finished.

After this PR:

- Note refresh reconciles the exact canonical text written to the search material back into `data.content` before the item is marked completed.
- The persisted Note schema is validated before any material replacement, so an externally edited oversized snapshot cannot split the index and main DB.
- Missing, non-Note, and deleting items remain protected; file and URL indexing behavior is unchanged.
- Successful reconciliation publishes scoped detail/list data-change effects, and an open Note preview refetches only when its item changes.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19492

### Why we need it and why it was done in this way

The indexing pipeline already has the correct source of truth: `chunked.contentText`, produced from the captured Note snapshot and passed verbatim to `rebuildMaterial`. Reusing that exact value avoids a second file read and guarantees that preview/search reconciliation refers to the same text.

The final write remains inside the existing per-base mutation lock. It rebuilds the per-base material first, reconciles the type-guarded main-DB Note snapshot second, and marks the item completed last. The two SQLite stores cannot share a transaction; this ordering avoids exposing a completed item with stale/newly mismatched content, while a main-DB failure remains retryable through the existing idempotent material rebuild.

The following tradeoffs were made:

- Snapshot content is validated before embedding/material side effects and again at the service boundary. This duplicates a small validation step but protects both the job and any future caller.
- Data-change notifications are best-effort and emitted only after the main-DB write commits. They keep live previews current without coupling the write transaction to renderer delivery.
- A deleting Note returns unchanged and is never marked completed, matching the existing status-update guard.

The following alternatives were considered:

- Re-reading the snapshot after rebuilding the material was rejected because the file could change between reads and make the two stores diverge again.
- Reading Note previews directly from the per-base raw file was rejected because it would bypass the DataApi/main-DB contract used by other consumers.
- Updating `data.content` before rebuilding the index was rejected because an index failure would expose new preview content while retrieval still used old material.
- A cross-database transaction was not used because the main database and each knowledge-base index are separate SQLite stores.

Links to places where the discussion took place: #19492

### Breaking changes

None.

### Special notes for your reviewer

Validation performed locally:

- 710 main-process knowledge tests passed across 49 files.
- 107 renderer data-source panel tests passed across 7 files.
- `typecheck:node` and `typecheck:web` passed.
- Changed-file Oxlint, ESLint, Biome format/lint, signed-commit, and DCO checks passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Note knowledge-base refreshes so search, previews, and timestamps stay in sync with the latest captured content.
```
