### PR TITLE
fix(anthropic-tools): preserve non-strict catchall schemas

### DIFF
--- a/patches/@ai-sdk__anthropic.patch
+++ b/patches/@ai-sdk__anthropic.patch
@@ -77,7 +77,7 @@ index fe20f4d..e58418f 100644
        if (isAnthropicModel && topP != null && temperature != null) {
          warnings.push({
 diff --git a/dist/internal/index.js b/dist/internal/index.js
-index b408db2..7cbffe6 100644
+index b408db2..613ff6d 100644
 --- a/dist/internal/index.js
 +++ b/dist/internal/index.js
 @@ -1521,7 +1521,7 @@ async function prepareTools({
@@ -85,20 +85,94 @@ index b408db2..7cbffe6 100644
            name: tool.name,
            description: tool.description,
 -          input_schema: tool.inputSchema,
-+          input_schema: sanitizeJsonSchema(tool.inputSchema),
++          input_schema: sanitizeJsonSchema(tool.inputSchema, supportsStrictTools === true && tool.strict === true),
            cache_control: cacheControl,
            ...eagerInputStreaming ? { eager_input_streaming: true } : {},
            ...supportsStrictTools === true && tool.strict != null ? { strict: tool.strict } : {},
-@@ -3272,7 +3272,7 @@ function sanitizeSchema(schema) {
+@@ -3199,17 +3199,18 @@ var DESCRIPTION_CONSTRAINT_KEYS = [
+   "maxProperties",
+   "not"
+ ];
+-function sanitizeJsonSchema(schema) {
+-  return sanitizeSchema(schema);
++function sanitizeJsonSchema(schema, strictTool) {
++  return sanitizeSchema(schema, strictTool);
+ }
+-function sanitizeDefinition(definition) {
++function sanitizeDefinition(definition, strictTool) {
+   if (typeof definition === "boolean" || !isPlainObject(definition)) {
+     return definition;
+   }
+-  return sanitizeSchema(definition);
++  return sanitizeSchema(definition, strictTool);
+ }
+-function sanitizeSchema(schema) {
++function sanitizeSchema(schema, strictTool) {
+   const result = {};
++  const sanitizeChild = (definition) => sanitizeDefinition(definition, strictTool);
+   const schemaWithDefs = schema;
+   if (schema.$ref != null) {
+     return { $ref: schema.$ref };
+@@ -3239,18 +3240,18 @@ function sanitizeSchema(schema) {
+     result.type = schema.type;
+   }
+   if (schema.anyOf != null) {
+-    result.anyOf = schema.anyOf.map(sanitizeDefinition);
++    result.anyOf = schema.anyOf.map(sanitizeChild);
+   } else if (schema.oneOf != null) {
+-    result.anyOf = schema.oneOf.map(sanitizeDefinition);
++    result.anyOf = schema.oneOf.map(sanitizeChild);
+   }
+   if (schema.allOf != null) {
+-    result.allOf = schema.allOf.map(sanitizeDefinition);
++    result.allOf = schema.allOf.map(sanitizeChild);
+   }
+   if (schema.definitions != null) {
+     result.definitions = Object.fromEntries(
+       Object.entries(schema.definitions).map(([name, definition]) => [
+         name,
+-        sanitizeDefinition(definition)
++        sanitizeChild(definition)
+       ])
+     );
+   }
+@@ -3259,7 +3260,7 @@ function sanitizeSchema(schema) {
+     resultWithDefs.$defs = Object.fromEntries(
+       Object.entries(schemaWithDefs.$defs).map(([name, definition]) => [
+         name,
+-        sanitizeDefinition(definition)
++        sanitizeChild(definition)
+       ])
+     );
+   }
+@@ -3268,17 +3269,23 @@ function sanitizeSchema(schema) {
+       result.properties = Object.fromEntries(
+         Object.entries(schema.properties).map(([name, definition]) => [
+           name,
+-          sanitizeDefinition(definition)
++          sanitizeChild(definition)
          ])
        );
      }
 -    result.additionalProperties = false;
-+    result.additionalProperties = schema.additionalProperties === true ? true : false;
++    if (strictTool !== false) {
++      result.additionalProperties = false;
++    } else if (isPlainObject(schema.additionalProperties)) {
++      result.additionalProperties = sanitizeChild(schema.additionalProperties);
++    } else {
++      result.additionalProperties = schema.additionalProperties === true;
++    }
      if (schema.required != null) {
        result.required = schema.required;
      }
-@@ -3468,7 +3468,7 @@ var AnthropicMessagesLanguageModel = class {
+   }
+   if (schema.items != null) {
+-    result.items = Array.isArray(schema.items) ? schema.items.map(sanitizeDefinition) : sanitizeDefinition(schema.items);
++    result.items = Array.isArray(schema.items) ? schema.items.map(sanitizeChild) : sanitizeChild(schema.items);
+   }
+   if (typeof schema.format === "string" && SUPPORTED_STRING_FORMATS.has(schema.format)) {
+     result.format = schema.format;
+@@ -3468,7 +3475,7 @@ var AnthropicMessagesLanguageModel = class {
        warnings.push({
          type: "compatibility",
          feature: "maxOutputTokens",
@@ -107,7 +181,7 @@ index b408db2..7cbffe6 100644
        });
      }
      if (rejectsSamplingParameters) {
-@@ -3561,12 +3561,12 @@ var AnthropicMessagesLanguageModel = class {
+@@ -3561,12 +3568,12 @@ var AnthropicMessagesLanguageModel = class {
      const sendThinking = isThinking || thinkingType === "disabled";
      let thinkingBudget = thinkingType === "enabled" ? (_g = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _g.budgetTokens : void 0;
      const thinkingDisplay = thinkingType === "adaptive" ? (_h = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _h.display : void 0;
@@ -122,7 +196,7 @@ index b408db2..7cbffe6 100644
        temperature,
        top_k: topK,
        top_p: topP,
-@@ -3737,7 +3737,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -3737,7 +3744,9 @@ var AnthropicMessagesLanguageModel = class {
            details: "topP is not supported when thinking is enabled"
          });
        }
@@ -134,7 +208,7 @@ index b408db2..7cbffe6 100644
        if (isAnthropicModel && topP != null && temperature != null) {
          warnings.push({
 diff --git a/dist/internal/index.mjs b/dist/internal/index.mjs
-index 168f139..7365bc0 100644
+index 168f139..66419e5 100644
 --- a/dist/internal/index.mjs
 +++ b/dist/internal/index.mjs
 @@ -1536,7 +1536,7 @@ async function prepareTools({
@@ -142,20 +216,94 @@ index 168f139..7365bc0 100644
            name: tool.name,
            description: tool.description,
 -          input_schema: tool.inputSchema,
-+          input_schema: sanitizeJsonSchema(tool.inputSchema),
++          input_schema: sanitizeJsonSchema(tool.inputSchema, supportsStrictTools === true && tool.strict === true),
            cache_control: cacheControl,
            ...eagerInputStreaming ? { eager_input_streaming: true } : {},
            ...supportsStrictTools === true && tool.strict != null ? { strict: tool.strict } : {},
-@@ -3313,7 +3313,7 @@ function sanitizeSchema(schema) {
+@@ -3240,17 +3240,18 @@ var DESCRIPTION_CONSTRAINT_KEYS = [
+   "maxProperties",
+   "not"
+ ];
+-function sanitizeJsonSchema(schema) {
+-  return sanitizeSchema(schema);
++function sanitizeJsonSchema(schema, strictTool) {
++  return sanitizeSchema(schema, strictTool);
+ }
+-function sanitizeDefinition(definition) {
++function sanitizeDefinition(definition, strictTool) {
+   if (typeof definition === "boolean" || !isPlainObject(definition)) {
+     return definition;
+   }
+-  return sanitizeSchema(definition);
++  return sanitizeSchema(definition, strictTool);
+ }
+-function sanitizeSchema(schema) {
++function sanitizeSchema(schema, strictTool) {
+   const result = {};
++  const sanitizeChild = (definition) => sanitizeDefinition(definition, strictTool);
+   const schemaWithDefs = schema;
+   if (schema.$ref != null) {
+     return { $ref: schema.$ref };
+@@ -3280,18 +3281,18 @@ function sanitizeSchema(schema) {
+     result.type = schema.type;
+   }
+   if (schema.anyOf != null) {
+-    result.anyOf = schema.anyOf.map(sanitizeDefinition);
++    result.anyOf = schema.anyOf.map(sanitizeChild);
+   } else if (schema.oneOf != null) {
+-    result.anyOf = schema.oneOf.map(sanitizeDefinition);
++    result.anyOf = schema.oneOf.map(sanitizeChild);
+   }
+   if (schema.allOf != null) {
+-    result.allOf = schema.allOf.map(sanitizeDefinition);
++    result.allOf = schema.allOf.map(sanitizeChild);
+   }
+   if (schema.definitions != null) {
+     result.definitions = Object.fromEntries(
+       Object.entries(schema.definitions).map(([name, definition]) => [
+         name,
+-        sanitizeDefinition(definition)
++        sanitizeChild(definition)
+       ])
+     );
+   }
+@@ -3300,7 +3301,7 @@ function sanitizeSchema(schema) {
+     resultWithDefs.$defs = Object.fromEntries(
+       Object.entries(schemaWithDefs.$defs).map(([name, definition]) => [
+         name,
+-        sanitizeDefinition(definition)
++        sanitizeChild(definition)
+       ])
+     );
+   }
+@@ -3309,17 +3310,23 @@ function sanitizeSchema(schema) {
+       result.properties = Object.fromEntries(
+         Object.entries(schema.properties).map(([name, definition]) => [
+           name,
+-          sanitizeDefinition(definition)
++          sanitizeChild(definition)
          ])
        );
      }
 -    result.additionalProperties = false;
-+    result.additionalProperties = schema.additionalProperties === true ? true : false;
++    if (strictTool !== false) {
++      result.additionalProperties = false;
++    } else if (isPlainObject(schema.additionalProperties)) {
++      result.additionalProperties = sanitizeChild(schema.additionalProperties);
++    } else {
++      result.additionalProperties = schema.additionalProperties === true;
++    }
      if (schema.required != null) {
        result.required = schema.required;
      }
-@@ -3509,7 +3509,7 @@ var AnthropicMessagesLanguageModel = class {
+   }
+   if (schema.items != null) {
+-    result.items = Array.isArray(schema.items) ? schema.items.map(sanitizeDefinition) : sanitizeDefinition(schema.items);
++    result.items = Array.isArray(schema.items) ? schema.items.map(sanitizeChild) : sanitizeChild(schema.items);
+   }
+   if (typeof schema.format === "string" && SUPPORTED_STRING_FORMATS.has(schema.format)) {
+     result.format = schema.format;
+@@ -3509,7 +3516,7 @@ var AnthropicMessagesLanguageModel = class {
        warnings.push({
          type: "compatibility",
          feature: "maxOutputTokens",
@@ -164,7 +312,7 @@ index 168f139..7365bc0 100644
        });
      }
      if (rejectsSamplingParameters) {
-@@ -3602,12 +3602,12 @@ var AnthropicMessagesLanguageModel = class {
+@@ -3602,12 +3609,12 @@ var AnthropicMessagesLanguageModel = class {
      const sendThinking = isThinking || thinkingType === "disabled";
      let thinkingBudget = thinkingType === "enabled" ? (_g = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _g.budgetTokens : void 0;
      const thinkingDisplay = thinkingType === "adaptive" ? (_h = anthropicOptions == null ? void 0 : anthropicOptions.thinking) == null ? void 0 : _h.display : void 0;
@@ -179,7 +327,7 @@ index 168f139..7365bc0 100644
        temperature,
        top_k: topK,
        top_p: topP,
-@@ -3778,7 +3778,9 @@ var AnthropicMessagesLanguageModel = class {
+@@ -3778,7 +3785,9 @@ var AnthropicMessagesLanguageModel = class {
            details: "topP is not supported when thinking is enabled"
          });
        }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,7 @@ overrides:
   ai: 6.0.185
 
 patchedDependencies:
-  '@ai-sdk/anthropic': b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46
+  '@ai-sdk/anthropic': 237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651
   '@ai-sdk/deepseek@2.0.30': db4c4c1e60c18e61952ec4432de7a401adf44420bdbfe4bb6f726a8958642790
   '@ai-sdk/google@3.0.64': 8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312
   '@ai-sdk/openai-compatible@2.0.62': 751d8232954604c922e8f313a49247f4652aaebc90177665dfcd994192102773
@@ -193,7 +193,7 @@ importers:
         version: 4.0.96(zod@4.3.4)
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+        version: 3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -1319,7 +1319,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.4.3)
+        version: 3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.64
         version: 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.4.3)
@@ -1350,7 +1350,7 @@ importers:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: 3.0.103
-        version: 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+        version: 3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.3.4)
       '@ai-sdk/azure':
         specifier: ^3.0.54
         version: 3.0.54(zod@4.3.4)
@@ -14207,7 +14207,7 @@ snapshots:
 
   '@ai-sdk/amazon-bedrock@4.0.96(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       '@smithy/eventstream-codec': 4.2.14
@@ -14215,13 +14215,13 @@ snapshots:
       aws4fetch: 1.0.20
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)':
+  '@ai-sdk/anthropic@3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.3.4)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.3.4)
       zod: 4.3.4
 
-  '@ai-sdk/anthropic@3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@ai-sdk/provider-utils': 4.0.40(zod@4.4.3)
@@ -14281,7 +14281,7 @@ snapshots:
 
   '@ai-sdk/google-vertex@4.0.112(zod@4.3.4)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.103(patch_hash=b2bc7d39b24cc63ee2638efcb8543eb64d7f3b86c71234b809418b6097768a46)(zod@4.3.4)
+      '@ai-sdk/anthropic': 3.0.103(patch_hash=237bacc4fffb6be35bbfa85aa265bb9cddf140e12da723c16601d44fcf22e651)(zod@4.3.4)
       '@ai-sdk/google': 3.0.64(patch_hash=8486f495c82f8187fcc9dfe9b4c77b9f54026c273fab22ab7d4bbdc2e50d0312)(zod@4.3.4)
       '@ai-sdk/openai-compatible': 2.0.41(zod@4.3.4)
       '@ai-sdk/provider': 3.0.8

--- a/src/main/ai/provider/custom/__tests__/boundary/aihubmix.anthropicTools.test.ts
+++ b/src/main/ai/provider/custom/__tests__/boundary/aihubmix.anthropicTools.test.ts
@@ -19,7 +19,7 @@ import { captureWithFetch } from './captureRequest'
  * (`minItems`/`maxItems`/`minLength`/`maxLength`/...) and folds the dropped
  * constraints into the node `description`, keeping `type`/`items`/`required`.
  */
-function callOptionsWithToolSchema(inputSchema: unknown): LanguageModelV3CallOptions {
+function callOptionsWithToolSchema(inputSchema: unknown, strict?: boolean): LanguageModelV3CallOptions {
   return {
     prompt: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
     tools: [
@@ -27,7 +27,8 @@ function callOptionsWithToolSchema(inputSchema: unknown): LanguageModelV3CallOpt
         type: 'function',
         name: 'web_fetch',
         description: 'Fetch URLs',
-        inputSchema
+        inputSchema,
+        strict
       }
     ]
   } as unknown as LanguageModelV3CallOptions
@@ -83,6 +84,54 @@ describe('AiHubMix → Anthropic tool-schema boundary (patched @ai-sdk/anthropic
     const urls = urlsSchemaFrom(req.body)
     expect(urls.minLength).toBeUndefined()
     expect(urls.maxLength).toBeUndefined()
+  })
+
+  it('preserves schema-valued catchalls unless strict mode is actually supported', async () => {
+    const catchallSchema = {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            fields: { type: 'object', properties: {}, additionalProperties: {} }
+          },
+          required: ['fields']
+        }
+      },
+      required: ['data']
+    }
+
+    const nonStrictRequest = await captureWithFetch((fetch) =>
+      createAihubmix({ apiKey: 'sk', fetch })
+        .languageModel('claude-sonnet-4-6')
+        .doStream(callOptionsWithToolSchema(catchallSchema))
+    )
+    const strictRequest = await captureWithFetch((fetch) =>
+      createAihubmix({ apiKey: 'sk', fetch })
+        .languageModel('claude-sonnet-4-6')
+        .doStream(callOptionsWithToolSchema(catchallSchema, true))
+    )
+    const unsupportedStrictRequest = await captureWithFetch((fetch) =>
+      createAihubmix({ apiKey: 'sk', fetch })
+        .languageModel('claude-sonnet-4-0')
+        .doStream(callOptionsWithToolSchema(catchallSchema, true))
+    )
+
+    const fieldsSchemaFrom = (body: unknown) => {
+      const inputSchema = (body as { tools: Array<{ input_schema: Record<string, unknown> }> }).tools[0].input_schema
+      const data = (inputSchema.properties as Record<string, { properties: Record<string, unknown> }>).data
+      return {
+        additionalProperties: inputSchema.additionalProperties,
+        fields: data.properties.fields as { additionalProperties?: unknown }
+      }
+    }
+
+    const nonStrictSchema = fieldsSchemaFrom(nonStrictRequest.body)
+    expect(nonStrictSchema.fields.additionalProperties).toEqual({})
+    expect(nonStrictSchema.additionalProperties).toBe(false)
+    expect(fieldsSchemaFrom(strictRequest.body).fields.additionalProperties).toBe(false)
+    expect(fieldsSchemaFrom(unsupportedStrictRequest.body).fields.additionalProperties).toEqual({})
+    expect((unsupportedStrictRequest.body as { tools: Array<{ strict?: boolean }> }).tools[0].strict).toBeUndefined()
   })
 
   // `tool_invoke` carries an open `params` object (additionalProperties:true) so the model can pass

--- a/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
+++ b/src/main/ai/tools/adapters/aiSdk/mcp/__tests__/mcpTools.execute.test.ts
@@ -35,14 +35,19 @@ vi.mock('@main/data/services/McpServerService', () => ({
 // Import AFTER vi.mock so the mocks bind correctly.
 const { syncMcpToolsToRegistry } = await import('../mcpTools')
 
-function mcpTool(serverId: string, name: string, description = '') {
+function mcpTool(
+  serverId: string,
+  name: string,
+  description = '',
+  inputSchema: Record<string, unknown> = { type: 'object', properties: {} }
+) {
   return {
     id: `mcp__${serverId}__${name}`,
     serverId,
     serverName: serverId,
     name,
     description,
-    inputSchema: { type: 'object', properties: {} }
+    inputSchema
   }
 }
 
@@ -51,9 +56,12 @@ function activeServer(id: string, disabledAutoApproveTools: string[] = []) {
 }
 
 /** Register a single tool via the production sync path and return its SDK execute fn. */
-async function registerToolExecute(reg: ToolRegistry) {
+async function registerToolExecute(
+  reg: ToolRegistry,
+  inputSchema: Record<string, unknown> = { type: 'object', properties: {} }
+) {
   list.mockReturnValue({ items: [activeServer('s1')] })
-  listTools.mockReturnValue([mcpTool('s1', 't')])
+  listTools.mockReturnValue([mcpTool('s1', 't', '', inputSchema)])
   await syncMcpToolsToRegistry(reg)
   const entry = reg.getByName('mcp__s1__t')
   if (!entry) throw new Error('expected mcp__s1__t to be registered')
@@ -123,6 +131,34 @@ describe('mcpTools execute wrapper', () => {
     })
     expect(out.content).toEqual([{ type: 'text', text: 'ok' }])
     expect(out.metadata).toEqual({ description: '', name: 't', serverName: 's1', serverId: 's1', type: 'mcp' })
+  })
+
+  it('forwards catchall field values unchanged to the MCP runtime', async () => {
+    const reg = new ToolRegistry()
+    const execute = await registerToolExecute(reg, {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            fields: { type: 'object', properties: {}, additionalProperties: {} }
+          }
+        }
+      }
+    })
+    const args = { data: { fields: { Title: 'Quarterly plan', Count: 3 } } }
+
+    getById.mockReturnValue(activeServer('s1'))
+    callTool.mockResolvedValue({ isError: false, content: [{ type: 'text', text: 'ok' }] } as McpCallToolResponse)
+
+    await execute(args, { toolCallId: 'call-catchall' } as any)
+
+    expect(callTool).toHaveBeenCalledExactlyOnceWith({
+      serverId: 's1',
+      name: 't',
+      args,
+      callId: 'call-catchall'
+    })
   })
 
   it('executes the explicitly selected server when display names normalize alike', async () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

The patched Anthropic provider sanitizer recursively forced every object schema to `additionalProperties: false`. Non-strict MCP tools using schema-valued catchalls therefore lost their arbitrary fields before execution.

After this PR:

Anthropic tool schemas preserve boolean and schema-valued `additionalProperties` for non-strict tools. They remain closed only when strict mode is both supported and explicitly requested.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The sanitizer now propagates the effective strict-tool state through nested definitions, so catchall handling is decided at the provider boundary where the schema is transformed.

The following tradeoffs were made:

The dependency patch carries the strictness flag recursively through object properties, definitions, unions, and array items, adding a small amount of patch surface to preserve the original schema contract.

The following alternatives were considered:

Rewriting catchall schemas in the MCP adapter was rejected because it would duplicate provider-specific behavior downstream and would not cover every Anthropic tool call path.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The patch updates both CommonJS and ESM Anthropic provider builds and refreshes the pnpm patch hash.
- Boundary coverage verifies non-strict, supported strict, and unsupported strict behavior.
- MCP execution coverage verifies arbitrary catchall fields reach the runtime unchanged.
- The required repository validation gate passed.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
MCP tools using catchall object schemas now preserve arbitrary fields when used with Anthropic-compatible providers.
```
