### PR TITLE
fix(agent): deliver DSH tool rejection feedback

### DIFF
--- a/packages/dsh-bridge/__tests__/plugin.test.ts
+++ b/packages/dsh-bridge/__tests__/plugin.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import { JsonRpcLineTransport } from '@deepseek-ai/dsh-sdk-protocol'
+import type { ApprovalOutcome, ApprovalRequest } from '@deepseek-ai/dsh-user-approval'
 import type { UserQuestionProvider } from '@deepseek-ai/dsh-user-questions'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -27,7 +28,9 @@ afterEach(async () => {
 })
 
 /** Host peer: answers the plugin's `ready` and drives host→plugin requests. */
-async function startHost() {
+async function startHost(
+  respond: (method: string, params: Record<string, unknown>) => unknown | Promise<unknown> = () => ({})
+) {
   const socketPath =
     process.platform === 'win32'
       ? `\\\\.\\pipe\\cherry-dsh-plugin-${randomUUID()}`
@@ -40,7 +43,7 @@ async function startHost() {
     transport = new JsonRpcLineTransport(socket, socket)
     transport.onRequest(async (method, params) => {
       requests.push({ method, params })
-      return {}
+      return respond(method, params)
     })
     transport.start()
   })
@@ -207,6 +210,51 @@ describe('cherry bridge plugin', () => {
         params: { sessionId: 'session-1', callId: 'exit-plan-call-2' }
       })
     await expect(answer).resolves.toEqual({})
+  })
+
+  it('delivers rejected approval feedback to the same agent after settling the outcome', async () => {
+    const host = await startHost((method) =>
+      method === 'approval/ask' ? { outcome: 'rejected', rejectionReason: 'use a copy instead' } : {}
+    )
+    const followup = vi.fn()
+    const agent = { id: 'session-1', followup, session: { events: [] } } as unknown as Agent
+    let approvalHandler: ((request: ApprovalRequest) => Promise<ApprovalOutcome>) | undefined
+    const on = vi.fn((event: string, handler: unknown) => {
+      if (event === 'approval/request') {
+        approvalHandler = handler as (request: ApprovalRequest) => Promise<ApprovalOutcome>
+      }
+      return () => undefined
+    })
+    const ctx = makeContext({ on })
+    process.env[BRIDGE_SOCKET_ENV] = host.socketPath
+    process.env[BRIDGE_TOKEN_ENV] = 'one-time-token'
+
+    apply(ctx)
+    await expect.poll(() => host.requests[0]?.method).toBe('ready')
+    if (!approvalHandler) throw new Error('approval handler was not registered')
+
+    await expect(
+      approvalHandler({
+        agent,
+        toolName: 'bash',
+        callId: 'call-with-feedback',
+        reason: 'needs approval'
+      } as ApprovalRequest)
+    ).resolves.toBe('rejected')
+    expect(followup).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(followup).toHaveBeenCalledOnce())
+    expect(followup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'user',
+        source: { kind: 'user' },
+        content: [
+          {
+            type: 'text',
+            text: 'Tool approval feedback for "bash":\nuse a copy instead'
+          }
+        ]
+      })
+    )
   })
 
   it('rejects an unknown method instead of answering it', async () => {

--- a/packages/dsh-bridge/src/plugin.ts
+++ b/packages/dsh-bridge/src/plugin.ts
@@ -395,7 +395,7 @@ export function apply(ctx: Context): void {
     if (req.signal?.aborted) return 'cancelled'
     if (!link.connected) return 'rejected'
     try {
-      const { outcome } = await link.request(
+      const { outcome, rejectionReason } = await link.request(
         'approval/ask',
         {
           sessionId: req.agent.id,
@@ -406,6 +406,20 @@ export function apply(ctx: Context): void {
         },
         req.signal
       )
+      if (outcome === 'rejected' && rejectionReason) {
+        setImmediate(() => {
+          try {
+            req.agent.followup(
+              createUserMessage({
+                content: [{ type: 'text', text: `Tool approval feedback for "${req.toolName}":\n${rejectionReason}` }],
+                source: { kind: 'user' }
+              })
+            )
+          } catch (error) {
+            console.error('[cherry-bridge] failed to deliver tool rejection feedback:', error)
+          }
+        })
+      }
       return outcome
     } catch {
       // Fail closed: a host disconnect (or error response) denies the call.

--- a/packages/dsh-bridge/src/protocol.ts
+++ b/packages/dsh-bridge/src/protocol.ts
@@ -132,7 +132,7 @@ export interface BridgePluginRequestMap {
   ready: { params: { pid: number; token: string }; result: Record<string, never> }
   'approval/ask': {
     params: { sessionId: string; toolName: string; callId?: string; args?: unknown; reason?: string }
-    result: { outcome: 'allowed-once' | 'rejected' }
+    result: { outcome: 'allowed-once' | 'rejected'; rejectionReason?: string }
   }
   'tool/call': {
     /** `sessionId` is always the root session id — the host rejects child session ids. */

--- a/src/main/ai/runtime/dsh/DshBridgeServer.ts
+++ b/src/main/ai/runtime/dsh/DshBridgeServer.ts
@@ -291,7 +291,9 @@ export class DshBridgeServer {
           if (decision.approved && decision.updatedInput) {
             logger.warn('editing tool input is not supported by the dsh runtime; rejecting', { toolName })
           }
-          resolve({ outcome: decision.approved && !decision.updatedInput ? 'allowed-once' : 'rejected' })
+          const outcome = decision.approved && !decision.updatedInput ? 'allowed-once' : 'rejected'
+          const rejectionReason = decision.approved ? undefined : decision.reason?.trim()
+          resolve({ outcome, ...(rejectionReason ? { rejectionReason } : {}) })
         }
       })
       // Only surface the approval card when the request is actually pending; a synchronous

--- a/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshBridgeServer.test.ts
@@ -357,6 +357,47 @@ describe('DshBridgeServer', () => {
     await expect(ask).resolves.toEqual({ outcome: 'rejected' })
   })
 
+  it('returns a trimmed rejection reason for the plugin to deliver to the agent', async () => {
+    const harness = await makeHarness()
+    const ask = harness.transport.request('approval/ask', {
+      sessionId: SESSION_ID,
+      toolName: 'bash',
+      callId: 'call-with-feedback'
+    })
+    await vi.waitFor(() => expect(harness.events).toHaveLength(1))
+    const event = harness.events[0]
+    if (event.type !== 'tool-approval-request') throw new Error('unreachable')
+
+    toolApprovalRegistry.dispatch(event.request.approvalId, {
+      approved: false,
+      reason: '  use a copy instead  '
+    })
+
+    await expect(ask).resolves.toEqual({
+      outcome: 'rejected',
+      rejectionReason: 'use a copy instead'
+    })
+  })
+
+  it('does not attach feedback to approvals, blank denials, or edited-input fallbacks', async () => {
+    const harness = await makeHarness()
+
+    for (const decision of [
+      { approved: true, reason: 'ignored' },
+      { approved: false, reason: '   ' },
+      { approved: true, reason: 'rewritten', updatedInput: { command: 'echo edited' } }
+    ]) {
+      const ask = harness.transport.request('approval/ask', { sessionId: SESSION_ID, toolName: 'bash' })
+      await vi.waitFor(() => expect(harness.events).toHaveLength(1))
+      const event = harness.events.shift()
+      if (event?.type !== 'tool-approval-request') throw new Error('unreachable')
+      toolApprovalRegistry.dispatch(event.request.approvalId, decision)
+      await expect(ask).resolves.toEqual({
+        outcome: decision.approved && !decision.updatedInput ? 'allowed-once' : 'rejected'
+      })
+    }
+  })
+
   it('answers rejected immediately when no responder is available, without surfacing a card', async () => {
     const harness = await makeHarness('unavailable')
     await expect(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

DSH tool approvals returned only the upstream string outcome, so a custom reason entered while denying a tool call was persisted in Cherry but never reached the DSH agent.

After this PR:

Cherry's bridge response carries an optional, trimmed rejection reason. The DSH plugin first settles the unchanged upstream `rejected` outcome, then queues that feedback as user context on the same agent. Approvals, blank denials, edited-input fallbacks, and unattended denials keep their previous behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19357

### Why we need it and why it was done in this way

The following tradeoffs were made:

- `@deepseek-ai/dsh-user-approval` exposes a closed string-only `ApprovalOutcome`, so the feedback is delivered as a separate follow-up rather than being attached to the native approval result.
- Delivery is scheduled only after the approval handler resolves, preserving DSH's existing rejection lifecycle while giving the next model step the user's explanation.
- The bridge forwards only non-empty reasons from explicit denials; it does not reinterpret approvals or unsupported edited-input approvals as feedback.

The following alternatives were considered:

- Widening the upstream outcome was rejected because the dependency's public contract accepts only bare outcome strings.
- Hiding the reason field for DSH sessions was rejected because it would remove useful cross-runtime behavior instead of completing it.
- Sending another host-side prompt request was rejected because the approval response already identifies the exact requesting agent, including delegated agents, and can enqueue the feedback without a second correlation hop.

Links to places where the discussion took place: #19357, #19023

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

- The wire outcome remains `allowed-once | rejected`; only Cherry's bridge result gains the optional `rejectionReason` field.
- The plugin regression asserts that the native rejection settles before `followup` is called and that the feedback targets the same agent.
- Verification: 148 DSH main-process tests, 67 `@cherrystudio/dsh-bridge` tests, bridge build, `pnpm lint`, `pnpm test:lint`, and node/web/AI-core type checks.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
DSH agents now receive the user's custom feedback after a tool call is rejected.
```
