### PR TITLE
perf(composer): parallelize path-backed file paste

### DIFF
--- a/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
@@ -1,13 +1,10 @@
+import { toast } from '@renderer/services/toast'
 import { COMPOSER_FILE_KIND, FILE_TYPE, type FileMetadata } from '@renderer/types/file'
 import { type ComposerAttachment, toComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LONG_TEXT_PASTE_THRESHOLD } from '../../composerPaste'
 import pasteHandling from '../pasteHandling'
-
-const mockToast = vi.hoisted(() => ({ error: vi.fn(), info: vi.fn() }))
-
-vi.mock('@renderer/services/toast', () => ({ toast: mockToast }))
 
 vi.mock('@logger', () => ({
   loggerService: {
@@ -32,8 +29,6 @@ describe('pasteHandling', () => {
   }
 
   beforeEach(() => {
-    mockToast.error.mockReset()
-    mockToast.info.mockReset()
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
@@ -230,13 +225,19 @@ describe('pasteHandling', () => {
       path: '/tmp/b.png'
     }
     let resolveFirstFile: (file: FileMetadata) => void = () => undefined
+    let markSecondReadStarted: () => void = () => undefined
     const pendingFirstFile = new Promise<FileMetadata>((resolve) => {
       resolveFirstFile = resolve
     })
+    const secondReadStarted = new Promise<void>((resolve) => {
+      markSecondReadStarted = resolve
+    })
     vi.mocked(window.api.file.getPathForFile).mockImplementation((file) => `/tmp/${file.name}`)
-    vi.mocked(window.api.file.get).mockImplementation((path) =>
-      path === firstFile.path ? pendingFirstFile : Promise.resolve(secondFile)
-    )
+    vi.mocked(window.api.file.get).mockImplementation((path) => {
+      if (path === firstFile.path) return pendingFirstFile
+      markSecondReadStarted()
+      return Promise.resolve(secondFile)
+    })
     const clipboardFiles = [
       { name: firstFile.name, type: 'image/png' },
       { name: secondFile.name, type: 'image/png' }
@@ -254,16 +255,12 @@ describe('pasteHandling', () => {
     } as unknown as ClipboardEvent
 
     const pastePromise = pasteHandling.handlePaste(event, ['.png'], setFiles)
-    await Promise.resolve()
-    await Promise.resolve()
-    const secondReadStartedBeforeFirstResolved = vi
-      .mocked(window.api.file.get)
-      .mock.calls.some(([path]) => path === secondFile.path)
+    await secondReadStarted
 
     resolveFirstFile(firstFile)
     await pastePromise
 
-    expect(secondReadStartedBeforeFirstResolved).toBe(true)
+    expect(window.api.file.get).toHaveBeenCalledWith(secondFile.path)
     expect(setFiles).toHaveBeenCalledOnce()
     expect(files.map((file) => file.path)).toEqual([selectedFile.path, firstFile.path, secondFile.path])
   })
@@ -299,8 +296,8 @@ describe('pasteHandling', () => {
 
     expect(handled).toBe(true)
     expect(files.map((file) => file.path)).toEqual([successfulFile.path])
-    expect(mockToast.error).toHaveBeenCalledOnce()
-    expect(mockToast.error).toHaveBeenCalledWith('chat.input.file_error')
+    expect(toast.error).toHaveBeenCalledOnce()
+    expect(toast.error).toHaveBeenCalledWith('chat.input.file_error')
   })
 
   it('keeps supported path-backed files and reports unsupported files', async () => {
@@ -332,9 +329,9 @@ describe('pasteHandling', () => {
 
     expect(handled).toBe(true)
     expect(files.map((file) => file.path)).toEqual([supportedFile.path])
-    expect(mockToast.info).toHaveBeenCalledOnce()
-    expect(mockToast.info).toHaveBeenCalledWith('chat.input.file_not_supported')
-    expect(mockToast.error).not.toHaveBeenCalled()
+    expect(toast.info).toHaveBeenCalledOnce()
+    expect(toast.info).toHaveBeenCalledWith('chat.input.file_not_supported')
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   describe('handler registration and lifecycle', () => {

--- a/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
@@ -1,5 +1,5 @@
 import { COMPOSER_FILE_KIND, FILE_TYPE, type FileMetadata } from '@renderer/types/file'
-import type { ComposerAttachment } from '@renderer/utils/message/composerAttachment'
+import { type ComposerAttachment, toComposerAttachment } from '@renderer/utils/message/composerAttachment'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LONG_TEXT_PASTE_THRESHOLD } from '../../composerPaste'
@@ -204,6 +204,62 @@ describe('pasteHandling', () => {
     expect(window.api.file.write).toHaveBeenCalledWith(tempImageFile.path, new Uint8Array([1, 2, 3]))
     expect(files).toHaveLength(1)
     expect(files[0]).toMatchObject({ path: tempImageFile.path, ext: '.png', type: FILE_TYPE.IMAGE })
+  })
+
+  it('processes path-backed clipboard files concurrently and commits them once in order', async () => {
+    const firstFile = {
+      ...selectedFile,
+      id: 'file-a',
+      name: 'a.png',
+      origin_name: 'a.png',
+      path: '/tmp/a.png',
+      ext: '.png',
+      type: FILE_TYPE.IMAGE
+    }
+    const secondFile = {
+      ...firstFile,
+      id: 'file-b',
+      name: 'b.png',
+      origin_name: 'b.png',
+      path: '/tmp/b.png'
+    }
+    let resolveFirstFile: (file: FileMetadata) => void = () => undefined
+    const pendingFirstFile = new Promise<FileMetadata>((resolve) => {
+      resolveFirstFile = resolve
+    })
+    vi.mocked(window.api.file.getPathForFile).mockImplementation((file) => `/tmp/${file.name}`)
+    vi.mocked(window.api.file.get).mockImplementation((path) =>
+      path === firstFile.path ? pendingFirstFile : Promise.resolve(secondFile)
+    )
+    const clipboardFiles = [
+      { name: firstFile.name, type: 'image/png' },
+      { name: secondFile.name, type: 'image/png' }
+    ] as File[]
+    let files: ComposerAttachment[] = [toComposerAttachment(selectedFile)]
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        getData: () => '',
+        files: clipboardFiles
+      }
+    } as unknown as ClipboardEvent
+
+    const pastePromise = pasteHandling.handlePaste(event, ['.png'], setFiles)
+    await Promise.resolve()
+    await Promise.resolve()
+    const secondReadStartedBeforeFirstResolved = vi
+      .mocked(window.api.file.get)
+      .mock.calls.some(([path]) => path === secondFile.path)
+
+    resolveFirstFile(firstFile)
+    await pastePromise
+
+    expect(secondReadStartedBeforeFirstResolved).toBe(true)
+    expect(setFiles).toHaveBeenCalledOnce()
+    expect(files.map((file) => file.path)).toEqual([selectedFile.path, firstFile.path, secondFile.path])
   })
 
   describe('handler registration and lifecycle', () => {

--- a/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
+++ b/src/renderer/components/composer/paste/__tests__/pasteHandling.test.ts
@@ -5,6 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LONG_TEXT_PASTE_THRESHOLD } from '../../composerPaste'
 import pasteHandling from '../pasteHandling'
 
+const mockToast = vi.hoisted(() => ({ error: vi.fn(), info: vi.fn() }))
+
+vi.mock('@renderer/services/toast', () => ({ toast: mockToast }))
+
 vi.mock('@logger', () => ({
   loggerService: {
     withContext: () => ({
@@ -28,6 +32,8 @@ describe('pasteHandling', () => {
   }
 
   beforeEach(() => {
+    mockToast.error.mockReset()
+    mockToast.info.mockReset()
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
@@ -260,6 +266,75 @@ describe('pasteHandling', () => {
     expect(secondReadStartedBeforeFirstResolved).toBe(true)
     expect(setFiles).toHaveBeenCalledOnce()
     expect(files.map((file) => file.path)).toEqual([selectedFile.path, firstFile.path, secondFile.path])
+  })
+
+  it('keeps successful path-backed files when another read fails and reports one file error', async () => {
+    const successfulFile = {
+      ...selectedFile,
+      id: 'file-success',
+      name: 'success.png',
+      origin_name: 'success.png',
+      path: '/tmp/success.png',
+      ext: '.png',
+      type: FILE_TYPE.IMAGE
+    }
+    vi.mocked(window.api.file.getPathForFile).mockImplementation((file) => `/tmp/${file.name}`)
+    vi.mocked(window.api.file.get).mockImplementation((path) =>
+      path === '/tmp/failure.png' ? Promise.reject(new Error('read failed')) : Promise.resolve(successfulFile)
+    )
+    const clipboardFiles = [
+      { name: 'failure.png', type: 'image/png' },
+      { name: successfulFile.name, type: 'image/png' }
+    ] as File[]
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: { getData: () => '', files: clipboardFiles }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(event, ['.png'], setFiles, undefined, '', undefined, (key) => key)
+
+    expect(handled).toBe(true)
+    expect(files.map((file) => file.path)).toEqual([successfulFile.path])
+    expect(mockToast.error).toHaveBeenCalledOnce()
+    expect(mockToast.error).toHaveBeenCalledWith('chat.input.file_error')
+  })
+
+  it('keeps supported path-backed files and reports unsupported files', async () => {
+    const supportedFile = {
+      ...selectedFile,
+      id: 'file-supported',
+      name: 'supported.png',
+      origin_name: 'supported.png',
+      path: '/tmp/supported.png',
+      ext: '.png',
+      type: FILE_TYPE.IMAGE
+    }
+    vi.mocked(window.api.file.getPathForFile).mockImplementation((file) => `/tmp/${file.name}`)
+    vi.mocked(window.api.file.get).mockResolvedValue(supportedFile)
+    const clipboardFiles = [
+      { name: 'unsupported.exe', type: 'application/octet-stream' },
+      { name: supportedFile.name, type: 'image/png' }
+    ] as File[]
+    let files: ComposerAttachment[] = []
+    const setFiles = vi.fn((updater: (prevFiles: ComposerAttachment[]) => ComposerAttachment[]) => {
+      files = updater(files)
+    })
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: { getData: () => '', files: clipboardFiles }
+    } as unknown as ClipboardEvent
+
+    const handled = await pasteHandling.handlePaste(event, ['.png'], setFiles, undefined, '', undefined, (key) => key)
+
+    expect(handled).toBe(true)
+    expect(files.map((file) => file.path)).toEqual([supportedFile.path])
+    expect(mockToast.info).toHaveBeenCalledOnce()
+    expect(mockToast.info).toHaveBeenCalledWith('chat.input.file_not_supported')
+    expect(mockToast.error).not.toHaveBeenCalled()
   })
 
   describe('handler registration and lifecycle', () => {

--- a/src/renderer/components/composer/paste/pasteHandling.ts
+++ b/src/renderer/components/composer/paste/pasteHandling.ts
@@ -8,6 +8,23 @@ import { LONG_TEXT_PASTE_THRESHOLD, PASTED_TEXT_FILE_EXTENSION } from '../compos
 
 const logger = loggerService.withContext('pasteHandling')
 
+type PathBackedPasteResult =
+  | { kind: 'attachment'; attachment: ComposerAttachment }
+  | { kind: 'empty' }
+  | { kind: 'unsupported' }
+
+async function readPathBackedClipboardEntry(
+  filePath: string,
+  extensionSet: Set<string>
+): Promise<PathBackedPasteResult> {
+  if (!(await isSupportedFile(filePath, extensionSet))) {
+    return { kind: 'unsupported' }
+  }
+
+  const selectedFile = await window.api.file.get(filePath)
+  return selectedFile ? { kind: 'attachment', attachment: toComposerAttachment(selectedFile) } : { kind: 'empty' }
+}
+
 // Track last focused component
 type ComponentType = 'inputbar' | 'messageEditor' | 'TranslatePage' | null
 let lastFocusedComponent: ComponentType = 'inputbar' // Default to inputbar
@@ -89,16 +106,7 @@ export const handlePaste = async (
 
         if (pathBackedEntries.length === clipboardEntries.length) {
           const results = await Promise.allSettled(
-            pathBackedEntries.map(async ({ filePath }) => {
-              if (!(await isSupportedFile(filePath, extensionSet))) {
-                return { kind: 'unsupported' as const }
-              }
-
-              const selectedFile = await window.api.file.get(filePath)
-              return selectedFile
-                ? { kind: 'attachment' as const, attachment: toComposerAttachment(selectedFile) }
-                : { kind: 'empty' as const }
-            })
+            pathBackedEntries.map(({ filePath }) => readPathBackedClipboardEntry(filePath, extensionSet))
           )
           const attachments: ComposerAttachment[] = []
           let hasFileError = false
@@ -153,12 +161,10 @@ export const handlePaste = async (
             continue
           }
 
-          if (await isSupportedFile(filePath, extensionSet)) {
-            const selectedFile = await window.api.file.get(filePath)
-            if (selectedFile) {
-              setFiles((prevFiles) => [...prevFiles, toComposerAttachment(selectedFile)])
-            }
-          } else if (t) {
+          const result = await readPathBackedClipboardEntry(filePath, extensionSet)
+          if (result.kind === 'attachment') {
+            setFiles((prevFiles) => [...prevFiles, result.attachment])
+          } else if (result.kind === 'unsupported' && t) {
             toast.info(t('chat.input.file_not_supported'))
           }
         }

--- a/src/renderer/components/composer/paste/pasteHandling.ts
+++ b/src/renderer/components/composer/paste/pasteHandling.ts
@@ -79,10 +79,53 @@ export const handlePaste = async (
       event.preventDefault()
       const extensionSet = new Set(supportExts)
       try {
-        for (const file of clipboardFiles) {
-          // 使用新的API获取文件路径
-          const filePath = window.api.file.getPathForFile(file)
+        const clipboardEntries = clipboardFiles.map((file) => ({
+          file,
+          filePath: window.api.file.getPathForFile(file)
+        }))
+        const pathBackedEntries = clipboardEntries.filter((entry): entry is { file: File; filePath: string } =>
+          Boolean(entry.filePath)
+        )
 
+        if (pathBackedEntries.length === clipboardEntries.length) {
+          const results = await Promise.allSettled(
+            pathBackedEntries.map(async ({ filePath }) => {
+              if (!(await isSupportedFile(filePath, extensionSet))) {
+                return { kind: 'unsupported' as const }
+              }
+
+              const selectedFile = await window.api.file.get(filePath)
+              return selectedFile
+                ? { kind: 'attachment' as const, attachment: toComposerAttachment(selectedFile) }
+                : { kind: 'empty' as const }
+            })
+          )
+          const attachments: ComposerAttachment[] = []
+          let hasFileError = false
+
+          for (const result of results) {
+            if (result.status === 'rejected') {
+              hasFileError = true
+              logger.error('onPaste:', result.reason as Error)
+            } else if (result.value.kind === 'unsupported') {
+              if (t) {
+                toast.info(t('chat.input.file_not_supported'))
+              }
+            } else if (result.value.kind === 'attachment') {
+              attachments.push(result.value.attachment)
+            }
+          }
+
+          if (attachments.length > 0) {
+            setFiles((prevFiles) => [...prevFiles, ...attachments])
+          }
+          if (hasFileError && t) {
+            toast.error(t('chat.input.file_error'))
+          }
+          return true
+        }
+
+        for (const { file, filePath } of clipboardEntries) {
           // 如果没有路径，可能是剪贴板中的图像数据
           if (!filePath) {
             // 图像生成也支持图像编辑
@@ -110,16 +153,13 @@ export const handlePaste = async (
             continue
           }
 
-          // 有路径的情况
           if (await isSupportedFile(filePath, extensionSet)) {
             const selectedFile = await window.api.file.get(filePath)
             if (selectedFile) {
               setFiles((prevFiles) => [...prevFiles, toComposerAttachment(selectedFile)])
             }
-          } else {
-            if (t) {
-              toast.info(t('chat.input.file_not_supported'))
-            }
+          } else if (t) {
+            toast.info(t('chat.input.file_not_supported'))
           }
         }
       } catch (error) {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The whole path-backed clipboard loop ran inside one `try`, so a single failing file read aborted the loop: every remaining pasted file was silently dropped and the user saw one generic file error. Files were also processed serially, and each success performed its own composer state update.

After this PR:

When every clipboard item has a filesystem path, a failed read no longer discards the other files — successful attachments are all retained and one file-error toast is reported after the batch. The independent support checks and metadata reads for that batch run concurrently, results are consumed in clipboard order, successful attachments are appended through one functional state update, and unsupported-file notifications are preserved. Clipboard payloads containing pathless images keep the existing serial temporary-file and early-break behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19508

### Why we need it and why it was done in this way

The failure-isolation change is the user-visible part. A read can throw on a disconnected network volume, a permission-denied path, or a file that disappears between the handler's `existsSync` and `statSync`; losing every subsequent pasted file to that is a real data-loss-shaped defect.

The concurrency part is a smaller, secondary win and is not a fix for any reported slowness. The main-process handler is cheap (`statSync` plus an extension lookup; `getFileType` only reads bytes for unrecognized extensions), so what is saved is the accumulation of IPC round trips, plus collapsing N composer renders into one. It is measured in tens of milliseconds for large pastes, not a perceptible speedup for a handful of files.

The following tradeoffs were made:

- The concurrent fast path is limited to all-path-backed clipboard payloads, keeping screenshot handling behavior unchanged. Mixed payloads stay fully serial, including their path-backed files.
- The fan-out is bounded only by the clipboard item count. Pasting a very large folder of unrecognized-extension files issues that many concurrent metadata reads, each briefly holding a file descriptor. This is acceptable for realistic clipboard sizes; a concurrency cap can be added if it ever bites.

The following alternatives were considered:

- Parallelizing every clipboard item was rejected because pathless screenshots rely on temporary-file creation and stop after the first successful image.
- `Promise.all` was rejected because one rejected read would discard the whole batch — the exact failure mode this PR removes.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19508#issuecomment-5428521570

### Breaking changes

None.

### Special notes for your reviewer

The regression tests pin the three contracts this PR establishes: a rejected read retains the other attachments and emits exactly one file-error toast; an unsupported file still emits its informational toast while the supported file is retained; and the second metadata read starts before the first resolves, with clipboard-order output, an existing attachment preserved, and a single functional state update.

Validation:

- Focused paste handling tests passed (11/11).
- Full Node, renderer, and AI Core type checking passed.
- Oxlint, ESLint, and Biome format/lint checks passed (repository-wide ESLint reports only existing warnings).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Pasting multiple files into the composer no longer drops the remaining files when one of them fails to read.
```
