### PR TITLE
perf(notes): lazy-load optional menu workflows

### DIFF
--- a/src/renderer/pages/notes/HeaderNavbar.tsx
+++ b/src/renderer/pages/notes/HeaderNavbar.tsx
@@ -33,7 +33,6 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react'
 
 import type { MenuItem as NotesMenuItem } from './MenuConfig'
 import { menuItems } from './MenuConfig'
-import NotesSettings from './NotesSettings'
 
 const logger = loggerService.withContext('HeaderNavbar')
 
@@ -157,13 +156,19 @@ const HeaderNavbar = ({
 
   useCommandHandler('app.print', handlePrint, { enabled: isActiveTab && activeNode?.type === 'file' })
 
-  const handleShowSettings = useCallback(() => {
-    void ContentPopup.show({
-      title: t('notes.settings.title'),
-      content: <NotesSettings />,
-      width: 600,
-      styles: { body: { padding: 0, maxHeight: 'calc(100vh - 8rem)', display: 'flex', flexDirection: 'column' } }
-    })
+  const handleShowSettings = useCallback(async () => {
+    try {
+      const { default: NotesSettings } = await import('./NotesSettings')
+      void ContentPopup.show({
+        title: t('notes.settings.title'),
+        content: <NotesSettings />,
+        width: 600,
+        styles: { body: { padding: 0, maxHeight: 'calc(100vh - 8rem)', display: 'flex', flexDirection: 'column' } }
+      })
+    } catch (error) {
+      logger.error('Failed to load notes settings:', error as Error)
+      toast.error(t('common.error'))
+    }
   }, [])
 
   const handleBreadcrumbClick = useCallback(
@@ -252,7 +257,7 @@ const HeaderNavbar = ({
           } else if (item.printAction) {
             void handlePrint()
           } else if (item.showSettingsPopup) {
-            handleShowSettings()
+            void handleShowSettings()
           } else if (item.action) {
             item.action(settings, updateSettings)
           }

--- a/src/renderer/pages/notes/__tests__/NotesLazyBoundaries.test.ts
+++ b/src/renderer/pages/notes/__tests__/NotesLazyBoundaries.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const PROBE_TIMEOUT = 45_000
+
+const optionalModules = vi.hoisted(() => ({
+  exportServiceEvaluated: vi.fn(),
+  knowledgeHookEvaluated: vi.fn(),
+  notesSettingsEvaluated: vi.fn(),
+  obsidianPopupEvaluated: vi.fn(),
+  saveToKnowledgePopupEvaluated: vi.fn()
+}))
+
+vi.mock('@renderer/services/ExportService', () => {
+  optionalModules.exportServiceEvaluated()
+  return { exportNote: vi.fn() }
+})
+
+vi.mock('@renderer/hooks/useKnowledgeBase', () => {
+  optionalModules.knowledgeHookEvaluated()
+  return { useKnowledgeBases: vi.fn(() => ({ bases: [] })) }
+})
+
+vi.mock('@renderer/components/ObsidianExportPopup', () => {
+  optionalModules.obsidianPopupEvaluated()
+  return { default: { show: vi.fn() } }
+})
+
+vi.mock('@renderer/components/SaveToKnowledgePopup', () => {
+  optionalModules.saveToKnowledgePopupEvaluated()
+  return { default: { showForNote: vi.fn() } }
+})
+
+vi.mock('../NotesSettings', () => {
+  optionalModules.notesSettingsEvaluated()
+  return { default: () => null }
+})
+
+describe('Notes optional workflow lazy boundaries', () => {
+  it(
+    'does not evaluate optional workflow modules when the Notes menu surfaces load',
+    async () => {
+      await Promise.all([import('../hooks/useNotesMenu'), import('../HeaderNavbar')])
+
+      expect(optionalModules.exportServiceEvaluated).not.toHaveBeenCalled()
+      expect(optionalModules.knowledgeHookEvaluated).not.toHaveBeenCalled()
+      expect(optionalModules.notesSettingsEvaluated).not.toHaveBeenCalled()
+      expect(optionalModules.obsidianPopupEvaluated).not.toHaveBeenCalled()
+      expect(optionalModules.saveToKnowledgePopupEvaluated).not.toHaveBeenCalled()
+    },
+    PROBE_TIMEOUT
+  )
+
+  it(
+    'positive control: the optional modules remain loadable on demand',
+    async () => {
+      await Promise.all([
+        import('@renderer/services/ExportService'),
+        import('@renderer/hooks/useKnowledgeBase'),
+        import('@renderer/components/ObsidianExportPopup'),
+        import('@renderer/components/SaveToKnowledgePopup'),
+        import('../NotesSettings')
+      ])
+
+      expect(optionalModules.exportServiceEvaluated).toHaveBeenCalledTimes(1)
+      expect(optionalModules.knowledgeHookEvaluated).toHaveBeenCalledTimes(1)
+      expect(optionalModules.notesSettingsEvaluated).toHaveBeenCalledTimes(1)
+      expect(optionalModules.obsidianPopupEvaluated).toHaveBeenCalledTimes(1)
+      expect(optionalModules.saveToKnowledgePopupEvaluated).toHaveBeenCalledTimes(1)
+    },
+    PROBE_TIMEOUT
+  )
+})

--- a/src/renderer/pages/notes/hooks/useNotesMenu.tsx
+++ b/src/renderer/pages/notes/hooks/useNotesMenu.tsx
@@ -2,11 +2,7 @@ import { useMultiplePreferences } from '@data/hooks/usePreference'
 import { loggerService } from '@logger'
 import type { CommandContextMenuExtraItem } from '@renderer/components/command'
 import DeleteIcon from '@renderer/components/icons/DeleteIcon'
-import ObsidianExportPopup from '@renderer/components/ObsidianExportPopup'
-import SaveToKnowledgePopup from '@renderer/components/SaveToKnowledgePopup'
-import { useKnowledgeBases } from '@renderer/hooks/useKnowledgeBase'
 import { ipcApi } from '@renderer/ipc'
-import { exportNote } from '@renderer/services/ExportService'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
 import type { NotesTreeNode } from '@renderer/types/note'
@@ -41,7 +37,6 @@ export const useNotesMenu = ({
   activeNode
 }: UseNotesMenuProps) => {
   const { t } = useTranslation()
-  const { bases } = useKnowledgeBases()
   const [exportMenuOptions] = useMultiplePreferences({
     docx: 'data.export.menus.docx',
     image: 'data.export.menus.image',
@@ -56,11 +51,7 @@ export const useNotesMenu = ({
   const handleExportKnowledge = useCallback(
     async (note: NotesTreeNode) => {
       try {
-        if (bases.length === 0) {
-          toast.warning(t('chat.save.knowledge.empty.no_knowledge_base'))
-          return
-        }
-
+        const { default: SaveToKnowledgePopup } = await import('@renderer/components/SaveToKnowledgePopup')
         const result = await SaveToKnowledgePopup.showForNote(note)
 
         if (result?.success) {
@@ -71,17 +62,21 @@ export const useNotesMenu = ({
         logger.error(`Failed to export note to knowledge base: ${error}`)
       }
     },
-    [bases.length, t]
+    [t]
   )
 
   const handleImageAction = useCallback(
     async (node: NotesTreeNode, platform: 'copyImage' | 'exportImage') => {
       try {
+        const exportServicePromise = import('@renderer/services/ExportService')
+        let selectionReady = Promise.resolve()
+
         if (activeNode?.id !== node.id) {
           onSelectNode(node)
-          await new Promise((resolve) => setTimeout(resolve, 500))
+          selectionReady = new Promise((resolve) => setTimeout(resolve, 500))
         }
 
+        const [{ exportNote }] = await Promise.all([exportServicePromise, selectionReady])
         await exportNote({ node, platform })
       } catch (error) {
         logger.error(`Failed to ${platform === 'copyImage' ? 'copy' : 'export'} as image:`, error as Error)
@@ -104,7 +99,10 @@ export const useNotesMenu = ({
   )
 
   const handleObsidianExport = useCallback(async (node: NotesTreeNode) => {
-    const content = await window.api.file.readExternal(node.externalPath)
+    const [content, { default: ObsidianExportPopup }] = await Promise.all([
+      window.api.file.readExternal(node.externalPath),
+      import('@renderer/components/ObsidianExportPopup')
+    ])
     await ObsidianExportPopup.show({ title: node.name, processingMethod: '1', rawContent: content })
   }, [])
 
@@ -209,7 +207,11 @@ export const useNotesMenu = ({
             type: 'item',
             id,
             label,
-            onSelect: () => void runExport(() => exportNote({ node, platform }))
+            onSelect: () =>
+              void runExport(async () => {
+                const { exportNote } = await import('@renderer/services/ExportService')
+                return exportNote({ node, platform })
+              })
           })
         if (exportMenuOptions.image) {
           exportChildren.push(


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Opening Notes eagerly evaluated the full note export service, Obsidian export popup, Save-to-Knowledge popup and knowledge-base hook, plus the complete Notes settings panel, even when none of those optional actions was used.

After this PR:

Those workflows load only after their corresponding menu action is selected. Image export loads its chunk in parallel with the existing note-selection wait, and Obsidian export loads its popup in parallel with reading the note. A lazy-boundary regression test prevents these imports from becoming eager again.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19510

### Why we need it and why it was done in this way

Literal dynamic imports inside the existing action handlers create bundler-visible async boundaries without changing menu construction, ordering, or normal action behavior. Save-to-Knowledge now relies on its own on-demand knowledge-base query instead of keeping a duplicate subscription alive at Notes-page startup.

The following tradeoffs were made:

- The first use of each optional workflow pays its chunk-load cost.
- With no knowledge bases, the existing popup empty state is shown after invocation instead of the menu layer displaying an early warning toast.

The following alternatives were considered:

- Lazily mounting the whole Notes menu was broader than necessary and would delay common actions.
- Keeping an eager knowledge-base query solely for the empty-state warning would preserve the startup subscription this issue is intended to remove.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19510

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Verified with the focused Notes test suite, web type checking, lint/format checks, and a production build. The build emits separate chunks for `ExportService`, `NotesSettings`, `ObsidianExportPopup`, and `SaveToKnowledgePopup`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
