### PR TITLE
fix(channels-settings): localize log and edit dialog close labels

### DIFF
--- a/packages/ui/src/components/primitives/__tests__/dialog.test.tsx
+++ b/packages/ui/src/components/primitives/__tests__/dialog.test.tsx
@@ -372,4 +372,29 @@ describe('Dialog primitive', () => {
     await waitFor(() => expect(screen.queryByRole('option', { name: 'Beta' })).not.toBeInTheDocument())
     expect(handleOpenChange).not.toHaveBeenCalledWith(false)
   })
+
+  it('names the close control Close by default', () => {
+    render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined}>
+          <DialogTitle>Rename item</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    )
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('uses a caller-provided closeLabel as the close control name', () => {
+    render(
+      <Dialog open>
+        <DialogContent aria-describedby={undefined} closeLabel="关闭">
+          <DialogTitle>频道日志</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    )
+
+    expect(screen.getByRole('button', { name: '关闭' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+  })
 })

--- a/packages/ui/src/components/primitives/dialog.tsx
+++ b/packages/ui/src/components/primitives/dialog.tsx
@@ -54,6 +54,7 @@ const dialogContentSizeClass: Record<DialogContentSize, string> = {
 }
 
 type DialogContentProps = React.ComponentProps<typeof DialogPrimitive.Content> & {
+  closeLabel?: string
   closeOnOverlayClick?: boolean
   motion?: DialogContentMotion
   overlayClassName?: string
@@ -73,6 +74,7 @@ export { DIALOG_CLOSE_DURATION_MS }
 function DialogContent({
   className,
   children,
+  closeLabel = 'Close',
   closeOnOverlayClick = true,
   showCloseButton = true,
   motion = 'directional',
@@ -141,7 +143,7 @@ function DialogContent({
               data-slot="dialog-close"
               className="data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-md opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus-visible:bg-accent focus-visible:opacity-100 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
               <XIcon />
-              <span className="sr-only">Close</span>
+              <span className="sr-only">{closeLabel}</span>
             </DialogPrimitive.Close>
           )}
         </PortalContainerProvider>

--- a/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/ChannelDetail.tsx
@@ -152,7 +152,7 @@ const ChannelLogModal: FC<{
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
-      <DialogContent className="max-w-150">
+      <DialogContent className="max-w-150" closeLabel={t('common.close')}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <span>{`${channelName} — ${t('agent.channels.logs')}`}</span>
@@ -260,7 +260,7 @@ const ChannelEditModal: FC<EditModalProps> = ({ open, channel, agents, onClose, 
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
-      <DialogContent closeOnOverlayClick={false} className="max-w-125">
+      <DialogContent closeOnOverlayClick={false} className="max-w-125" closeLabel={t('common.close')}>
         {renderedChannel && (
           <>
             <DialogHeader>

--- a/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
@@ -86,8 +86,18 @@ vi.mock('@cherrystudio/ui', () => {
 
   const passthrough =
     (tag: keyof React.JSX.IntrinsicElements) =>
-    ({ children, closeOnOverlayClick, ...props }: { children?: React.ReactNode; closeOnOverlayClick?: boolean }) => {
+    ({
+      children,
+      closeOnOverlayClick,
+      closeLabel,
+      ...props
+    }: {
+      children?: React.ReactNode
+      closeOnOverlayClick?: boolean
+      closeLabel?: string
+    }) => {
       void closeOnOverlayClick
+      void closeLabel
       return React.createElement(tag, props, children)
     }
 
@@ -113,26 +123,7 @@ vi.mock('@cherrystudio/ui', () => {
         {open && onOpenChange && <button type="button" aria-label="close dialog" onClick={() => onOpenChange(false)} />}
       </div>
     ),
-    DialogContent: ({
-      children,
-      closeOnOverlayClick,
-      closeLabel = 'Close',
-      showCloseButton = true,
-      ...props
-    }: {
-      children?: React.ReactNode
-      closeOnOverlayClick?: boolean
-      closeLabel?: string
-      showCloseButton?: boolean
-    }) => {
-      void closeOnOverlayClick
-      return (
-        <div {...props}>
-          {children}
-          {showCloseButton ? <button type="button" aria-label={closeLabel} /> : null}
-        </div>
-      )
-    },
+    DialogContent: passthrough('div'),
     DialogHeader: passthrough('div'),
     DialogTitle: passthrough('h2'),
     EmptyState: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
@@ -342,11 +333,5 @@ describe('ChannelDetail', () => {
     const title = screen.getByRole('heading', { name: 'Telegram channel' })
     expect(title).toBeInTheDocument()
     expect(title.closest('[data-open]')).toHaveAttribute('data-open', 'false')
-  })
-
-  it('names channel log and edit dialog close controls with the localized close label', () => {
-    render(<ChannelDetail channelDef={channelDef} />)
-
-    expect(screen.getAllByRole('button', { name: 'common.close' })).toHaveLength(2)
   })
 })

--- a/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
+++ b/src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx
@@ -113,7 +113,26 @@ vi.mock('@cherrystudio/ui', () => {
         {open && onOpenChange && <button type="button" aria-label="close dialog" onClick={() => onOpenChange(false)} />}
       </div>
     ),
-    DialogContent: passthrough('div'),
+    DialogContent: ({
+      children,
+      closeOnOverlayClick,
+      closeLabel = 'Close',
+      showCloseButton = true,
+      ...props
+    }: {
+      children?: React.ReactNode
+      closeOnOverlayClick?: boolean
+      closeLabel?: string
+      showCloseButton?: boolean
+    }) => {
+      void closeOnOverlayClick
+      return (
+        <div {...props}>
+          {children}
+          {showCloseButton ? <button type="button" aria-label={closeLabel} /> : null}
+        </div>
+      )
+    },
     DialogHeader: passthrough('div'),
     DialogTitle: passthrough('h2'),
     EmptyState: ({ description }: { description?: React.ReactNode }) => <div>{description}</div>,
@@ -323,5 +342,11 @@ describe('ChannelDetail', () => {
     const title = screen.getByRole('heading', { name: 'Telegram channel' })
     expect(title).toBeInTheDocument()
     expect(title.closest('[data-open]')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('names channel log and edit dialog close controls with the localized close label', () => {
+    render(<ChannelDetail channelDef={channelDef} />)
+
+    expect(screen.getAllByRole('button', { name: 'common.close' })).toHaveLength(2)
   })
 })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Channel log and edit dialogs in Settings → Channels used the shared `DialogContent` close control with a hard-coded English `sr-only` label (`Close`). In a Chinese UI, screen readers and accessibility inspectors announced `Close` while the rest of the dialog was already localized.

After this PR:

`DialogContent` accepts `closeLabel`. The channel log and edit dialogs pass `t('common.close')`, so a Chinese UI names the close control `关闭` and an English UI keeps `Close`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19518

### Why we need it and why it was done in this way

Localized interfaces should not expose an English-only accessible name on a dialog close control. The primitive stays language-agnostic with an English default for stories and unlocalized callers; product dialogs pass the existing `common.close` key.

The following tradeoffs were made:

QR login dialogs in `ChannelForms` still use the primitive default. This PR only covers the reported log and edit dialogs.

The following alternatives were considered:

Hard-coding Chinese in the primitive was rejected because the UI package does not own i18n. Adding a visible footer Close button was rejected because the existing control is the top-right close button with an `sr-only` name.

Links to places where the discussion took place: None.

### Breaking changes

None.

### Special notes for your reviewer

DEV record recvqyjY6Q1syp. Head `5a442b38983049159d88cdb8ca81732316ac9650`.

Accessible-name contract is owned by the real `packages/ui` Dialog primitive tests (`names the close control Close by default`, `uses a caller-provided closeLabel as the close control name`). Those cases fail if the default sr-only name changes or if `closeLabel` is ignored.

The ChannelDetail renderer case that queried `common.close` against a local `@cherrystudio/ui` stand-in was removed: it never opened the dialogs, asserted translation keys, and would still pass if production `DialogContent` ignored `closeLabel`. The ChannelDetail mock no longer recreates a close-button accessible name. Remaining ChannelDetail tests cover create/edit/close behavior, not a11y naming.

Focused tests: `packages/ui/src/components/primitives/__tests__/dialog.test.tsx`, `src/renderer/pages/settings/ChannelsSettings/__tests__/ChannelDetail.test.tsx`. `pnpm lint` and `pnpm test:lint` passed locally after the test repair.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Localized the close control name on channel log and edit dialogs so it follows the selected app language.
```
