### PR TITLE
fix(tokens): count literal special-token text safely

### DIFF
--- a/src/main/ai/tokens/__tests__/textTokenizer.test.ts
+++ b/src/main/ai/tokens/__tests__/textTokenizer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { loadGptO200kTokenizer } from '../textTokenizer'
+
+describe('loadGptO200kTokenizer', () => {
+  it.each(['<|im_start|>', '<|im_end|>', '<|endoftext|>', '<|endofturn|>', '<|endofmessage|>'])(
+    'counts the literal special-token text %s without rejecting the message',
+    async (literal) => {
+      const tokenizer = await loadGptO200kTokenizer()
+      const literalTokenCount = tokenizer.count(literal)
+
+      expect(literalTokenCount).toBeGreaterThan(1)
+      expect(tokenizer.count(`Before ${literal} after`)).toBeGreaterThan(literalTokenCount)
+    }
+  )
+})

--- a/src/main/ai/tokens/textTokenizer.ts
+++ b/src/main/ai/tokens/textTokenizer.ts
@@ -27,7 +27,13 @@ let o200k: TextTokenizer | undefined
 export async function loadGptO200kTokenizer(): Promise<TextTokenizer> {
   if (!o200k) {
     const { countTokens } = await import('gpt-tokenizer/encoding/o200k_base')
-    o200k = { id: 'gpt-tokenizer/o200k', count: (text) => (text ? countTokens(text) : 0) }
+    const ordinaryTextOptions = { disallowedSpecial: new Set<string>() }
+    o200k = {
+      id: 'gpt-tokenizer/o200k',
+      // This counter estimates arbitrary user and persisted text. Special-token spellings are
+      // content here, not encoder control instructions, so count them instead of rejecting them.
+      count: (text) => (text ? countTokens(text, ordinaryTextOptions) : 0)
+    }
   }
   return o200k
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The exact o200k token-budget estimator used gpt-tokenizer's default special-token policy. Persisted or user-authored text containing a literal such as `<|im_start|>` therefore threw before the provider request was created, and the persisted error text could trigger the same failure on the next send.

After this PR:

The estimator counts special-token spellings as ordinary BPE text. It does not mutate message content or treat those spellings as encoder control tokens. Regression coverage exercises all five literals reported in the issue, both alone and inside surrounding prose.

Refs #19465

### Why we need it and why it was done in this way

This tokenizer boundary estimates budgets over arbitrary user and persisted content; it is not the provider encoder. gpt-tokenizer exposes `disallowedSpecial`, so an empty set expresses the required semantics directly at the narrow adapter boundary and keeps every downstream budget consumer safe.

The following tradeoffs were made:

- Literal special-token spellings count as multiple ordinary text tokens, which is intentionally more conservative than counting each spelling as one control token.
- The options object and empty set are allocated once with the lazily loaded tokenizer.

The following alternatives were considered:

- Sanitizing or removing the literals would change user content.
- Allowing all special tokens would count the literals as control tokens and understate ordinary-text usage.
- Catching the exception and falling back to the heuristic tokenizer would make estimates depend on message content.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19465#issuecomment-5429130357

### Breaking changes

None.

### Special notes for your reviewer

Validation completed locally:

- Confirmed the regression test fails on the previous implementation for `<|im_start|>`, `<|im_end|>`, and `<|endoftext|>`.
- `pnpm exec vitest run --project main src/main/ai/tokens/__tests__` (55 tests)
- Full main-process Vitest suite
- `pnpm typecheck:node`
- Biome, Oxlint, ESLint, and `git diff --check`
- `pnpm build`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed chat sends failing when message history contains literal special-token text.
```
