### PR TITLE
fix(model-selector): show provider names consistently

### DIFF
--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -179,8 +179,10 @@ function ModelRow({
   const rowTags = useMemo(() => getModelDisplayTags(item.model, undefined, item.provider), [item.model, item.provider])
   const providerName = getProviderDisplayName(item.provider)
   const disambiguationLabel = item.showIdentifier
-    ? `${providerName} · ${item.modelIdentifier}`
-    : item.isPinned
+    ? item.groupKind === 'pinned'
+      ? `${providerName} · ${item.modelIdentifier}`
+      : item.modelIdentifier
+    : item.groupKind === 'pinned'
       ? providerName
       : undefined
 

--- a/src/renderer/components/ModelSelector/__tests__/ModelSelector.test.tsx
+++ b/src/renderer/components/ModelSelector/__tests__/ModelSelector.test.tsx
@@ -183,6 +183,7 @@ function makeModelItem(modelId: UniqueModelId, overrides: Partial<ModelSelectorM
   return {
     key: modelId,
     type: 'model' as const,
+    groupKind: 'provider' as const,
     model,
     provider,
     modelId,
@@ -252,7 +253,7 @@ describe('ModelSelector', () => {
     vi.restoreAllMocks()
   })
 
-  it('shows the provider and model identifier when a model name needs disambiguation', () => {
+  it('shows only the model identifier under a persistent provider group', () => {
     const item = makeModelItem('openai::gpt-4-variant-a' as UniqueModelId, {
       model: { ...makeModel('openai::gpt-4-variant-a' as UniqueModelId), name: 'GPT-4' },
       modelIdentifier: 'gpt-4-variant-a',
@@ -281,7 +282,32 @@ describe('ModelSelector', () => {
       />
     )
 
-    expect(screen.getByText(/OpenAI · gpt-4-variant-a/)).toBeInTheDocument()
+    expect(screen.getByText('| gpt-4-variant-a')).toBeInTheDocument()
+    expect(screen.queryByText(/OpenAI · gpt-4-variant-a/)).not.toBeInTheDocument()
+  })
+
+  it('keeps the provider in a pinned row without a provider group', () => {
+    const item = makeModelItem('openai::gpt-4-variant-a' as UniqueModelId, {
+      key: 'openai::gpt-4-variant-a_pinned',
+      groupKind: 'pinned',
+      model: { ...makeModel('openai::gpt-4-variant-a' as UniqueModelId), name: 'GPT-4' },
+      modelIdentifier: 'gpt-4-variant-a',
+      isPinned: true,
+      showIdentifier: true
+    })
+    mocks.useModelSelectorData.mockReturnValue(makeData({ listItems: [item], modelItems: [item] }))
+
+    render(
+      <ModelSelector
+        multiple={false}
+        open
+        trigger={<button type="button">Open</button>}
+        value={item.model}
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('| OpenAI · gpt-4-variant-a')).toBeInTheDocument()
   })
 
   it('selects a model and closes the selector in single-select mode', async () => {

--- a/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
+++ b/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
@@ -24,7 +24,8 @@ const { mockHoverCardContentProps, mockHoverCardProps, mockHoverCardOpenChange }
   mockHoverCardOpenChange: { current: undefined as ((open: boolean) => void) | undefined }
 }))
 
-vi.mock('@renderer/i18n/label', () => ({
+vi.mock('@renderer/i18n/label', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@renderer/i18n/label')>()),
   getProviderLabel: (id: string) => id
 }))
 
@@ -132,6 +133,7 @@ function makeItem(model: Model): ModelSelectorModelItem {
   return {
     key: model.id,
     type: 'model',
+    groupKind: 'provider',
     model,
     provider,
     modelId: model.id,

--- a/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
+++ b/src/renderer/components/ModelSelector/__tests__/ModelSelectorDetailCard.test.tsx
@@ -1,3 +1,4 @@
+import type * as I18nLabelModule from '@renderer/i18n/label'
 import type { Model, UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { act, render, screen } from '@testing-library/react'
@@ -25,7 +26,7 @@ const { mockHoverCardContentProps, mockHoverCardProps, mockHoverCardOpenChange }
 }))
 
 vi.mock('@renderer/i18n/label', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@renderer/i18n/label')>()),
+  ...(await importOriginal<typeof I18nLabelModule>()),
   getProviderLabel: (id: string) => id
 }))
 

--- a/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
+++ b/src/renderer/components/ModelSelector/__tests__/useModelSelectorData.test.ts
@@ -252,7 +252,8 @@ describe('useModelSelectorData', () => {
     expect(result.current.modelItems).toHaveLength(1)
     expect(result.current.modelItems[0]).toMatchObject({
       modelId: 'anthropic::claude-3',
-      isPinned: true
+      isPinned: true,
+      groupKind: 'provider'
     })
   })
 
@@ -334,7 +335,7 @@ describe('useModelSelectorData', () => {
     expect(byModelId.get('openai::unique')?.showIdentifier).toBe(false)
   })
 
-  it('marks matching model names from different providers for disambiguation', () => {
+  it('uses provider groups to disambiguate matching names from different providers', () => {
     wireDeps({
       providers: [makeProvider('openai'), makeProvider('anthropic')],
       models: [
@@ -348,7 +349,7 @@ describe('useModelSelectorData', () => {
       result.current.modelItems.map((item) => [item.modelId, item])
     )
 
-    expect(byModelId.get('openai::gpt-4')?.showIdentifier).toBe(true)
-    expect(byModelId.get('anthropic::claude-alias')?.showIdentifier).toBe(true)
+    expect(byModelId.get('openai::gpt-4')?.showIdentifier).toBe(false)
+    expect(byModelId.get('anthropic::claude-alias')?.showIdentifier).toBe(false)
   })
 })

--- a/src/renderer/components/ModelSelector/__tests__/utils.test.ts
+++ b/src/renderer/components/ModelSelector/__tests__/utils.test.ts
@@ -33,10 +33,16 @@ function makeProvider(overrides: Partial<Provider> = {}): Provider {
 }
 
 describe('getProviderDisplayName', () => {
-  it('returns the localized label for canonical preset providers (id === presetProviderId)', () => {
+  it('returns the localized label for system providers', () => {
     const provider = makeProvider({ id: 'openai', presetProviderId: 'openai', name: 'My OpenAI' })
 
     expect(getProviderDisplayName(provider)).toBe('Label(openai)')
+  })
+
+  it('uses the system provider id when a registry provider inherits another preset', () => {
+    const provider = makeProvider({ id: 'minimax-global', presetProviderId: 'minimax', name: 'minimax-global' })
+
+    expect(getProviderDisplayName(provider)).toBe('Label(minimax-global)')
   })
 
   it('keeps multiple derived providers visually distinct instead of collapsing to the preset label', () => {

--- a/src/renderer/components/ModelSelector/types.ts
+++ b/src/renderer/components/ModelSelector/types.ts
@@ -84,6 +84,7 @@ export interface ModelSelectorGroupItem {
 export interface ModelSelectorModelItem {
   key: string
   type: 'model'
+  groupKind: 'pinned' | 'provider'
   model: Model
   provider: Provider
   modelId: UniqueModelId

--- a/src/renderer/components/ModelSelector/useModelSelectorData.ts
+++ b/src/renderer/components/ModelSelector/useModelSelectorData.ts
@@ -215,12 +215,19 @@ export function useModelSelectorData({
   )
 
   const createModelItem = useCallback(
-    (model: Model, provider: Provider, isPinned: boolean, showIdentifier: boolean): ModelSelectorModelItem => {
+    (
+      model: Model,
+      provider: Provider,
+      groupKind: ModelSelectorModelItem['groupKind'],
+      isPinned: boolean,
+      showIdentifier: boolean
+    ): ModelSelectorModelItem => {
       const modelId = model.id
 
       return {
-        key: isPinned ? `${modelId}_pinned` : modelId,
+        key: groupKind === 'pinned' ? `${modelId}_pinned` : modelId,
         type: 'model',
+        groupKind,
         model,
         provider,
         modelId,
@@ -241,14 +248,16 @@ export function useModelSelectorData({
       return (!showTagFilter || tagFilter(model, provider)) && baseModelFilter(model, provider)
     }
     // `searchFilter(provider)` runs fuzzy scoring + sort per provider; cache the tag-filtered
-    // result so duplicate-name detection and the list below share one pass per provider.
+    // result so provider-local duplicate-name detection and the list below share one pass.
     const tagFilteredModelsByProvider = new Map<string, Model[]>(
       sortedProviders.map((provider) => [
         provider.id,
         searchFilter(provider).filter((model) => (!showTagFilter ? true : tagFilter(model, provider)))
       ])
     )
-    const duplicateModelNames = getDuplicateModelNames([...tagFilteredModelsByProvider.values()].flat())
+    const duplicateModelNamesByProvider = new Map(
+      [...tagFilteredModelsByProvider].map(([providerId, models]) => [providerId, getDuplicateModelNames(models)])
+    )
 
     if (searchText.length === 0 && showPinnedModels && pinnedIdSet.size > 0) {
       const pinnedItems = pinnedIds.flatMap((modelId) => {
@@ -258,7 +267,15 @@ export function useModelSelectorData({
           return []
         }
 
-        return [createModelItem(model, provider, true, duplicateModelNames.has(model.name))]
+        return [
+          createModelItem(
+            model,
+            provider,
+            'pinned',
+            true,
+            duplicateModelNamesByProvider.get(provider.id)?.has(model.name) ?? false
+          )
+        ]
       })
 
       if (pinnedItems.length > 0) {
@@ -295,8 +312,9 @@ export function useModelSelectorData({
           createModelItem(
             model,
             provider,
+            'provider',
             showPinnedModels && pinnedIdSet.has(model.id),
-            duplicateModelNames.has(model.name)
+            duplicateModelNamesByProvider.get(provider.id)?.has(model.name) ?? false
           )
         )
       )

--- a/src/renderer/components/ModelSelector/utils.ts
+++ b/src/renderer/components/ModelSelector/utils.ts
@@ -1,17 +1,1 @@
-import { getProviderLabelKey } from '@renderer/i18n/label'
-import i18n from '@renderer/i18n/resolver'
-import type { Provider } from '@shared/data/types/provider'
-
-/**
- * 获取服务商展示名。
- *
- * 内置服务商 = `provider.id === provider.presetProviderId`（provider 本身就是 preset）。
- * 基于 preset 派生的自定义 provider（id 已换成用户自己的），`presetProviderId` 同样存在
- * 但 id 不同，此时走用户设置的 `provider.name`，避免多个派生 provider 全部被翻译成同名。
- */
-export function getProviderDisplayName(provider: Provider): string {
-  if (provider.presetProviderId && provider.id === provider.presetProviderId) {
-    return i18n.t(getProviderLabelKey(provider.presetProviderId))
-  }
-  return provider.name
-}
+export { getProviderDisplayName } from '@renderer/utils/naming'

--- a/src/renderer/components/composer/variants/ChatComposer.tsx
+++ b/src/renderer/components/composer/variants/ChatComposer.tsx
@@ -717,10 +717,9 @@ const ChatComposerInner = ({
         value: nextReasoningEffort ?? 'default',
         version
       })
-      // No web-search reconciliation here: `setModel` already runs `reconcileWebSearchForModel` with
-      // an ungated providers list. This duplicate read the composer's own list, which is deferred
-      // (`shouldLoadProviders`) and therefore empty in single-model chats — it would have cleared the
-      // setting for every model whose search is provider-native.
+      // No web-search reconciliation here: `setModel` already runs `reconcileWebSearchForModel`
+      // with the provider data owned by that operation. Repeating it here would duplicate the
+      // state transition against the composer's presentation-oriented provider list.
       const extraSettings: {
         reasoning_effort?: ReasoningEffortOption
       } = {}
@@ -843,7 +842,12 @@ const ChatComposerInner = ({
       : EMPTY_MODELS
   const shouldLoadProviders =
     !externalContextControls &&
-    (mentionedModels.length > 1 || mentionedModelSelectorValue.length > 1 || lockedMentionedModels.length > 1)
+    Boolean(
+      runtimeModel ||
+        mentionedModels.length > 0 ||
+        mentionedModelSelectorValue.length > 0 ||
+        lockedMentionedModels.length > 0
+    )
   const { providers: loadedProviders } = useProviders(undefined, { enabled: shouldLoadProviders })
   const providers = resolvedProviders ?? loadedProviders
   const effectiveSubmittedModels =

--- a/src/renderer/components/composer/variants/SelectedModelsTrigger.tsx
+++ b/src/renderer/components/composer/variants/SelectedModelsTrigger.tsx
@@ -3,6 +3,7 @@ import { cn } from '@cherrystudio/ui/lib/utils'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import { getModelDisplayTags, type ModelDisplayTag, ModelTag } from '@renderer/components/tags/Model'
 import { getProviderDisplayName } from '@renderer/hooks/useProvider'
+import { getProviderDisplayNameById } from '@renderer/utils/naming'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { ChevronDown, RotateCcw, X } from 'lucide-react'
@@ -34,7 +35,7 @@ const MODEL_TAG_SIZE = 8
 
 function getProviderName(model: Model, providers: Provider[]) {
   const provider = providers.find((currentProvider) => currentProvider.id === model.providerId)
-  return getProviderDisplayName(provider) || model.providerId
+  return getProviderDisplayName(provider) || getProviderDisplayNameById(model.providerId)
 }
 
 function SelectedModelTags({ tags }: { tags: ModelDisplayTag[] }) {
@@ -78,7 +79,9 @@ export const SelectedModelsTrigger = ({
   const [popoverOpen, setPopoverOpen] = useState(false)
   const closeTimerRef = useRef<number | null>(null)
   const singleModel = models.length === 1 ? models[0] : undefined
-  const singleModelLabel = singleModel ? singleModel.name : fallbackLabel
+  const singleModelLabel = singleModel
+    ? `${singleModel.name} | ${getProviderName(singleModel, providers)}`
+    : fallbackLabel
   const selectedModelsLabel = t('models.selection.selected_models')
   const hasSelectionPopover = models.length > 1
   const canShowSelectionPopover = hasSelectionPopover && !suppressSelectionPopover
@@ -285,7 +288,9 @@ export const SelectedModelsTrigger = ({
           ) : (
             <>
               {singleModel ? <ModelAvatar model={singleModel} size={20} /> : null}
-              <span className={cn('max-w-52 truncate', iconOnly && singleModel && 'sr-only')}>{singleModelLabel}</span>
+              <span className={cn('max-w-52 truncate', iconOnly && singleModel && 'sr-only')} title={singleModelLabel}>
+                {singleModelLabel}
+              </span>
             </>
           )}
           <ChevronDown

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -3,6 +3,7 @@ import { MessageEditingProvider, useMessageEditing } from '@renderer/components/
 import { toast } from '@renderer/services/toast'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
 import { IpcChannel } from '@shared/IpcChannel'
 import { MockCacheUtils } from '@test-mocks/renderer/CacheService'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
@@ -305,6 +306,7 @@ vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
 vi.mock('../SelectedModelsTrigger', () => ({
   SelectedModelsTrigger: ({
     models,
+    providers,
     assistantModel,
     fallbackLabel,
     iconOnly,
@@ -321,7 +323,11 @@ vi.mock('../SelectedModelsTrigger', () => ({
       data-model-count={String(models.length)}
       data-disabled={String(Boolean(disabled))}
       data-suppress-selection-popover={String(Boolean(suppressSelectionPopover))}>
-      <span className={iconOnly ? 'sr-only' : undefined}>{models.length === 0 ? fallbackLabel : models[0].name}</span>
+      <span className={iconOnly ? 'sr-only' : undefined}>
+        {models.length === 0
+          ? fallbackLabel
+          : `${models[0].name} | ${providers.find((provider: Provider) => provider.id === models[0].providerId)?.name}`}
+      </span>
       <button
         type="button"
         onClick={() => onModelsChange(models.filter((currentModel: Model) => currentModel.id !== modelB.id))}>
@@ -342,6 +348,7 @@ vi.mock('@renderer/components/EmojiIcon', () => ({
 }))
 
 vi.mock('@renderer/components/ModelSelector', () => ({
+  getProviderDisplayName: (provider: Provider) => provider.name,
   ModelSelector: (props: any) => {
     const {
       onSelect,
@@ -510,13 +517,24 @@ vi.mock('@renderer/hooks/useModel', () => ({
   }
 }))
 
-vi.mock('@renderer/hooks/useProvider', () => ({
-  getProviderDisplayName: () => 'Provider',
-  useProviders: (...args: unknown[]) => {
-    mocks.providerHookArgs.push(args)
-    return { providers: [{ id: 'provider', name: 'Provider', models: [mocks.model ?? model, modelB] }] }
+vi.mock('@renderer/hooks/useProvider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@renderer/hooks/useProvider')>()
+
+  return {
+    ...actual,
+    getProviderDisplayName: () => 'Provider',
+    useProviders: (...args: unknown[]) => {
+      mocks.providerHookArgs.push(args)
+      const options = args[1] as { enabled?: boolean } | undefined
+      return {
+        providers:
+          options?.enabled === false
+            ? []
+            : [{ id: 'provider', name: 'Provider', models: [mocks.model ?? model, modelB] }]
+      }
+    }
   }
-}))
+})
 
 vi.mock('@renderer/hooks/command', () => ({
   useCommandHandler: (command: string, handler: () => void, options?: { enabled?: boolean }) => {
@@ -884,12 +902,12 @@ describe('ChatComposer', () => {
     expect(nextConversationControlsChange).toHaveBeenLastCalledWith(null)
   })
 
-  it('defers optional resource catalogs on a normal single-model conversation', () => {
+  it('loads provider metadata needed by a normal single-model trigger', () => {
     render(<ChatComposer topic={topic} onSend={vi.fn()} />)
 
     expect(mocks.knowledgeBaseHookArgs.at(-1)).toEqual([{ enabled: false }])
     expect(mocks.modelHookArgs.at(-1)).toEqual([{ enabled: true }, { fetchEnabled: false }])
-    expect(mocks.providerHookArgs.at(-1)).toEqual([undefined, { enabled: false }])
+    expect(screen.getByTestId('composer-left-controls')).toHaveTextContent('Model A | Provider')
   })
 
   it('snapshots a newly selected reasoning effort before its assistant PATCH finishes', async () => {
@@ -1264,7 +1282,7 @@ describe('ChatComposer', () => {
     expect(mocks.surfaceProps?.deferQuickPanel).toBe(true)
     expect(screen.getByText('tool menu')).toBeInTheDocument()
     expect(screen.getByText('Assistant 1')).toBeInTheDocument()
-    expect(screen.getByText('Model A')).toBeInTheDocument()
+    expect(screen.getByText(/Model A/)).toBeInTheDocument()
   })
 
   it.each(['home', 'docked'] as const)(
@@ -1328,13 +1346,13 @@ describe('ChatComposer', () => {
     render(<ChatComposer topic={topic} onSend={vi.fn()} />)
 
     expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
-    expect(screen.getByText('Model A')).not.toHaveClass('sr-only')
+    expect(screen.getByText(/Model A/)).not.toHaveClass('sr-only')
 
     await notifyComposerBottomToolbarWidth(420)
 
     await waitFor(() => {
       expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
-      expect(screen.getByText('Model A')).toHaveClass('sr-only')
+      expect(screen.getByText(/Model A/)).toHaveClass('sr-only')
     })
   })
 
@@ -1344,7 +1362,7 @@ describe('ChatComposer', () => {
     await notifyComposerBottomToolbarWidth(420, 420)
 
     expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
-    expect(screen.getByText('Model A')).not.toHaveClass('sr-only')
+    expect(screen.getByText(/Model A/)).not.toHaveClass('sr-only')
   })
 
   it('passes attachment capabilities through the provider without effect mirroring', () => {
@@ -1632,7 +1650,7 @@ describe('ChatComposer', () => {
 
     expect(screen.getByTestId('assistant-selector')).toBeInTheDocument()
     expect(screen.getByText('Assistant 1')).toBeInTheDocument()
-    expect(screen.getByText('Model A')).toBeInTheDocument()
+    expect(screen.getByText(/Model A/)).toBeInTheDocument()
     expect(screen.queryByTestId('resource-edit-dialog-host')).not.toBeInTheDocument()
     expect(mocks.updateTopic).not.toHaveBeenCalled()
   })
@@ -3225,13 +3243,13 @@ describe('ChatComposer', () => {
     render(<ChatHomeComposer topic={topic} onSend={vi.fn()} />)
 
     expect(screen.getByText('Assistant 1')).not.toHaveClass('sr-only')
-    expect(screen.getByText('Model A')).not.toHaveClass('sr-only')
+    expect(screen.getByText(/Model A/)).not.toHaveClass('sr-only')
 
     await notifyComposerBottomToolbarWidth(420)
 
     await waitFor(() => {
       expect(screen.getByText('Assistant 1')).toHaveClass('sr-only')
-      expect(screen.getByText('Model A')).toHaveClass('sr-only')
+      expect(screen.getByText(/Model A/)).toHaveClass('sr-only')
     })
   })
 
@@ -3314,7 +3332,7 @@ describe('ChatComposer', () => {
     render(<ChatComposer topic={topic} onSend={vi.fn()} useMentionedModelSelector />)
 
     expect(screen.getByTestId('model-selector')).toHaveAttribute('data-value-count', '1')
-    expect(screen.getByText('Model A')).toBeInTheDocument()
+    expect(screen.getByText(/Model A/)).toBeInTheDocument()
   })
 
   it('does not read or write mentioned-model rich-text cache', () => {

--- a/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/ChatComposer.test.tsx
@@ -1,5 +1,6 @@
 import { cacheService } from '@data/CacheService'
 import { MessageEditingProvider, useMessageEditing } from '@renderer/components/chat/editing/MessageEditingContext'
+import type * as UseProviderModule from '@renderer/hooks/useProvider'
 import { toast } from '@renderer/services/toast'
 import type { KnowledgeBase } from '@shared/data/types/knowledge'
 import { type Model, MODEL_CAPABILITY } from '@shared/data/types/model'
@@ -518,7 +519,7 @@ vi.mock('@renderer/hooks/useModel', () => ({
 }))
 
 vi.mock('@renderer/hooks/useProvider', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@renderer/hooks/useProvider')>()
+  const actual = await importOriginal<typeof UseProviderModule>()
 
   return {
     ...actual,

--- a/src/renderer/components/composer/variants/__tests__/SelectedModelsTrigger.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/SelectedModelsTrigger.test.tsx
@@ -83,10 +83,6 @@ vi.mock('@renderer/components/tags/Model', () => ({
   )
 }))
 
-vi.mock('@renderer/hooks/useProvider', () => ({
-  getProviderDisplayName: (provider: { name: string } | undefined) => provider?.name ?? ''
-}))
-
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactI18nextModule>()
   return {
@@ -198,7 +194,7 @@ describe('SelectedModelsTrigger', () => {
     expect(onModelsChange).toHaveBeenCalledWith([modelA])
   })
 
-  it('does not expose remove actions for a single selected model', () => {
+  it('shows the model and provider without exposing remove actions for a single selected model', () => {
     const onModelsChange = vi.fn()
     const onRestore = vi.fn()
     render(
@@ -213,10 +209,32 @@ describe('SelectedModelsTrigger', () => {
     )
 
     expect(screen.queryByLabelText('Remove Model A')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Selected models' })).toHaveTextContent('Model A')
-    expect(screen.getByRole('button', { name: 'Selected models' })).not.toHaveTextContent('Provider A')
+    expect(screen.getByRole('button', { name: 'Selected models' })).toHaveTextContent('Model A | Provider A')
+    expect(screen.getByTitle('Model A | Provider A')).toBeInTheDocument()
     expect(onModelsChange).not.toHaveBeenCalled()
     expect(onRestore).not.toHaveBeenCalled()
+  })
+
+  it('uses the canonical system provider name while provider metadata is loading', () => {
+    const minimaxModel: Model = {
+      ...modelA,
+      id: 'minimax::MiniMax-M3',
+      providerId: 'minimax',
+      name: 'MiniMax-M3'
+    }
+
+    render(
+      <SelectedModelsTrigger
+        models={[minimaxModel]}
+        assistantModel={minimaxModel}
+        providers={[]}
+        fallbackLabel="Select model"
+        onModelsChange={vi.fn()}
+        onRestore={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Selected models' })).toHaveTextContent('MiniMax-M3 | MiniMax')
   })
 
   it('does not render popover content for a single selected model', () => {

--- a/src/renderer/components/composer/variants/chat/ChatConversationControls.tsx
+++ b/src/renderer/components/composer/variants/chat/ChatConversationControls.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@cherrystudio/ui'
 import ModelAvatar from '@renderer/components/Avatar/ModelAvatar'
 import EmojiIcon from '@renderer/components/EmojiIcon'
-import { ModelSelector } from '@renderer/components/ModelSelector'
+import { getProviderDisplayName, ModelSelector } from '@renderer/components/ModelSelector'
 import { openResourceEditDialog } from '@renderer/components/resourceCatalog/dialogs/ResourceEditDialogEventHost'
 import { AssistantSelector } from '@renderer/components/resourceCatalog/selectors'
-import { getLeadingEmoji } from '@renderer/utils/naming'
+import { getLeadingEmoji, getProviderDisplayNameById } from '@renderer/utils/naming'
 import { cn } from '@renderer/utils/style'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
@@ -89,7 +89,13 @@ export function ChatConversationControls({
     triggerClassName,
     iconOnly && selectedMentionedModels.length > 0 && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS
   )
-  const modelLabel = model ? model.name : selectModelLabel
+  const modelProvider = model ? providers.find((provider) => provider.id === model.providerId) : undefined
+  const modelProviderName = model
+    ? modelProvider
+      ? getProviderDisplayName(modelProvider)
+      : getProviderDisplayNameById(model.providerId)
+    : undefined
+  const modelLabel = model ? `${model.name} | ${modelProviderName}` : selectModelLabel
   const [mentionedModelSelectorOpen, setMentionedModelSelectorOpen] = useState(false)
   const handleMentionedModelSelect = useCallback(
     (nextModels: Model[]) => {
@@ -196,7 +202,9 @@ export function ChatConversationControls({
           trigger={
             <Button variant="ghost" size="sm" className={modelTriggerClassName} disabled={modelPending}>
               {model ? <ModelAvatar model={model} size={20} /> : null}
-              <span className={cn('max-w-52', modelLabelClassName)}>{modelLabel}</span>
+              <span className={cn('max-w-52', modelLabelClassName)} title={modelLabel}>
+                {modelLabel}
+              </span>
               <ChevronDown
                 size={14}
                 aria-hidden

--- a/src/renderer/components/composer/variants/chat/__tests__/ChatConversationControls.test.tsx
+++ b/src/renderer/components/composer/variants/chat/__tests__/ChatConversationControls.test.tsx
@@ -1,0 +1,118 @@
+import type { Model } from '@shared/data/types/model'
+import type { Provider } from '@shared/data/types/provider'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type * as ReactI18nextModule from 'react-i18next'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ChatConversationControls } from '../ChatConversationControls'
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof ReactI18nextModule>()
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key })
+  }
+})
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({
+  default: () => <span data-testid="model-avatar" />
+}))
+
+vi.mock('@renderer/components/EmojiIcon', () => ({
+  default: () => <span data-testid="assistant-avatar" />
+}))
+
+vi.mock('@renderer/components/ModelSelector', () => ({
+  getProviderDisplayName: (provider: Provider) => provider.name,
+  ModelSelector: ({ trigger }: { trigger: ReactNode }) => trigger
+}))
+
+vi.mock('@renderer/components/resourceCatalog/selectors', () => ({
+  AssistantSelector: ({ trigger }: { trigger: ReactNode }) => trigger
+}))
+
+vi.mock('@renderer/components/composer/variants/SelectedModelsTrigger', () => ({
+  SelectedModelsTrigger: () => null
+}))
+
+describe('ChatConversationControls', () => {
+  it('shows the model and provider in the model selector trigger', () => {
+    const provider = {
+      id: 'minimax',
+      name: 'MiniMax',
+      apiKeys: [],
+      authType: 'api-key',
+      reportsActualCost: false,
+      settings: {} as Provider['settings'],
+      isEnabled: true
+    } as Provider
+    const model = {
+      id: 'minimax::MiniMax-M3',
+      providerId: provider.id,
+      name: 'MiniMax-M3',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    } as Model
+
+    render(
+      <ChatConversationControls
+        assistantId="assistant"
+        assistantName="Assistant"
+        model={model}
+        providers={[provider]}
+        mentionedModels={[]}
+        mentionedModelSelectorValue={[]}
+        lockedMentionedModels={[]}
+        mentionedModelMultiSelectMode={false}
+        selectModelLabel="Select model"
+        shouldAutoSelectCreatedAssistant={false}
+        side="top"
+        onAssistantChange={vi.fn()}
+        onModelSelect={vi.fn()}
+        onMentionedModelsSelect={vi.fn()}
+        onMentionedModelMultiSelectModeChange={vi.fn()}
+        onMentionedModelSelectorRestore={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('MiniMax-M3 | MiniMax')).toHaveAttribute('title', 'MiniMax-M3 | MiniMax')
+  })
+
+  it('keeps the canonical provider name while provider metadata is loading', () => {
+    const model = {
+      id: 'minimax::MiniMax-M3',
+      providerId: 'minimax',
+      name: 'MiniMax-M3',
+      capabilities: [],
+      supportsStreaming: true,
+      isEnabled: true,
+      isHidden: false
+    } as Model
+
+    render(
+      <ChatConversationControls
+        assistantId="assistant"
+        assistantName="Assistant"
+        model={model}
+        providers={[]}
+        mentionedModels={[]}
+        mentionedModelSelectorValue={[]}
+        lockedMentionedModels={[]}
+        mentionedModelMultiSelectMode={false}
+        selectModelLabel="Select model"
+        shouldAutoSelectCreatedAssistant={false}
+        side="top"
+        onAssistantChange={vi.fn()}
+        onModelSelect={vi.fn()}
+        onMentionedModelsSelect={vi.fn()}
+        onMentionedModelMultiSelectModeChange={vi.fn()}
+        onMentionedModelSelectorRestore={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('MiniMax-M3 | MiniMax')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/hooks/useProvider.ts
+++ b/src/renderer/hooks/useProvider.ts
@@ -1,9 +1,7 @@
 import { useMutation, useQuery } from '@data/hooks/useDataApi'
 import { useDataChange } from '@data/hooks/useDataChange'
 import { loggerService } from '@logger'
-import { getProviderLabelKey } from '@renderer/i18n/label'
-import i18n from '@renderer/i18n/resolver'
-import { isSystemProviderId } from '@renderer/types/provider'
+import { getProviderDisplayName } from '@renderer/utils/naming'
 import type {
   CreateProviderDto,
   ListProvidersQuery,
@@ -278,15 +276,7 @@ export function useProviderPreset(providerId: string | null | undefined, fields:
   return query
 }
 
-/**
- * Pure resolver for a provider's display name. System providers get the
- * i18n label; custom providers use their user-set name. Returns empty
- * string when the provider is missing.
- */
-export function getProviderDisplayName(provider: Provider | undefined): string {
-  if (!provider) return ''
-  return isSystemProviderId(provider.id) ? i18n.t(getProviderLabelKey(provider.id)) : provider.name
-}
+export { getProviderDisplayName }
 
 /**
  * Hook variant of {@link getProviderDisplayName} for callers that have a

--- a/src/renderer/i18n/label.ts
+++ b/src/renderer/i18n/label.ts
@@ -98,13 +98,15 @@ const providerKeyMap = {
 /**
  * 获取内置供应商的本地化标签
  * @param id - 供应商的id
+ * @param fallback - 未登记该 id 时直接返回的值；省略时记录缺失 key
  * @returns 本地化后的供应商名称
  * @remarks
  * 该函数仅用于获取内置供应商的 i18n label
  *
  * 对于可能处理自定义供应商的情况，使用 getProviderName 或 getFancyProviderName 更安全
  */
-export const getProviderLabelKey = (id: string): string => {
+export const getProviderLabelKey = (id: string, fallback?: string): string => {
+  if (fallback !== undefined && !Object.hasOwn(providerKeyMap, id)) return fallback
   return getLabelKey(providerKeyMap, id)
 }
 

--- a/src/renderer/pages/home/Chat.tsx
+++ b/src/renderer/pages/home/Chat.tsx
@@ -101,14 +101,15 @@ const Chat: FC<Props> = (props) => {
     useState<ChatConversationControlsSnapshot | null>(null)
   const activeConversationControlsSnapshot =
     conversationControlsSnapshot?.scopeKey === activeTopicId ? conversationControlsSnapshot : null
-  // Provider metadata is only used by the selected-model details popover. A normal single-model
-  // conversation already carries everything its trigger needs on the Model entity itself.
+  // Provider metadata supplies the user-facing name for both the single-model trigger and
+  // selected-model details. Model entities only carry the provider id.
   const shouldLoadProviders = Boolean(
     activeTopic &&
-      activeConversationControlsSnapshot &&
-      (activeConversationControlsSnapshot.mentionedModels.length > 1 ||
-        activeConversationControlsSnapshot.mentionedModelSelectorValue.length > 1 ||
-        activeConversationControlsSnapshot.lockedMentionedModels.length > 1)
+      (assistantContext.model ||
+        (activeConversationControlsSnapshot &&
+          (activeConversationControlsSnapshot.mentionedModels.length > 0 ||
+            activeConversationControlsSnapshot.mentionedModelSelectorValue.length > 0 ||
+            activeConversationControlsSnapshot.lockedMentionedModels.length > 0)))
   )
   const { providers } = useProviders(undefined, { enabled: shouldLoadProviders })
   const locateMessageIdProp = props.locateMessageId

--- a/src/renderer/pages/home/__tests__/Chat.test.tsx
+++ b/src/renderer/pages/home/__tests__/Chat.test.tsx
@@ -18,7 +18,6 @@ const assistantContextMock = vi.hoisted(() => ({
   isLoading: false,
   isModelPending: false
 }))
-const providerHookArgs = vi.hoisted(() => [] as unknown[][])
 const commandHandlers = vi.hoisted(() => new Map<string, () => void | Promise<void>>())
 const eventEmitMock = vi.hoisted(() => vi.fn())
 const clearTopicMessagesMock = vi.hoisted(() => vi.fn(async () => undefined))
@@ -117,10 +116,9 @@ vi.mock('@renderer/hooks/useAssistant', () => ({
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({
-  useProviders: (...args: unknown[]) => {
-    providerHookArgs.push(args)
-    return { providers: [] }
-  }
+  useProviders: (_query?: unknown, options?: { enabled?: boolean }) => ({
+    providers: options?.enabled === false ? [] : [{ id: 'provider', name: 'Provider' }]
+  })
 }))
 
 vi.mock('@renderer/hooks/command', () => ({
@@ -148,9 +146,15 @@ vi.mock('@renderer/services/EventService', () => ({
 }))
 
 vi.mock('@renderer/components/composer/variants/chat/ChatConversationControls', () => ({
-  ChatConversationControls: ({ assistantName }: { assistantName: string }) => (
-    <div data-testid="chat-conversation-controls">{assistantName}</div>
-  )
+  ChatConversationControls: ({ assistantName, model, providers }: any) => {
+    const provider = providers.find((currentProvider: any) => currentProvider.id === model?.providerId)
+    return (
+      <div data-testid="chat-conversation-controls">
+        {assistantName}
+        {model && provider ? `${model.name} | ${provider.name}` : null}
+      </div>
+    )
+  }
 }))
 
 vi.mock('react-hotkeys-hook', () => ({
@@ -215,7 +219,6 @@ describe('Chat', () => {
     chatContentProps.current = null
     assistantContextMock.isLoading = false
     assistantContextMock.isModelPending = false
-    providerHookArgs.length = 0
     commandHandlers.clear()
     activeTabMock.current = true
   })
@@ -280,21 +283,10 @@ describe('Chat', () => {
     expect(chatContentProps.current?.assistantContext?.isModelPending).toBe(true)
   })
 
-  it('loads provider metadata only for multi-model control details', () => {
+  it('loads provider metadata for the single-model trigger', () => {
     render(<Chat activeTopic={topic} />)
 
-    expect(providerHookArgs.at(-1)).toEqual([undefined, { enabled: false }])
-
-    act(() => {
-      chatContentProps.current?.onConversationControlsChange?.({
-        scopeKey: topic.id,
-        mentionedModels: [],
-        mentionedModelSelectorValue: [{ id: 'provider::model-a' }, { id: 'provider::model-b' }],
-        lockedMentionedModels: []
-      })
-    })
-
-    expect(providerHookArgs.at(-1)).toEqual([undefined, { enabled: true }])
+    expect(screen.getByTestId('chat-conversation-controls')).toHaveTextContent('Model | Provider')
   })
 
   it('preserves the rail gutter while switching topics', async () => {

--- a/src/renderer/utils/__tests__/naming.test.ts
+++ b/src/renderer/utils/__tests__/naming.test.ts
@@ -380,6 +380,13 @@ describe('naming', () => {
       expect(getProviderDisplayNameById('minimax')).toBe('MiniMax CN')
     })
 
+    it.each([
+      ['openai-codex', 'OpenAI Codex'],
+      ['grok-cli', 'Grok CLI']
+    ])('uses the canonical label for the registry provider id %s', (providerId, expectedLabel) => {
+      expect(getProviderDisplayNameById(providerId)).toBe(expectedLabel)
+    })
+
     it('preserves a custom provider id when metadata is unavailable', () => {
       expect(getProviderDisplayNameById('my-custom')).toBe('my-custom')
     })

--- a/src/renderer/utils/__tests__/naming.test.ts
+++ b/src/renderer/utils/__tests__/naming.test.ts
@@ -11,6 +11,7 @@ import {
   getFirstCharacter,
   getLeadingEmoji,
   getLowerBaseModelName,
+  getProviderDisplayNameById,
   isEmoji,
   removeLeadingEmoji,
   removeSpecialCharactersForTopicName,
@@ -371,6 +372,16 @@ describe('naming', () => {
         models: []
       }
       expect(getFancyProviderName(mockProvider)).toBe('好名字')
+    })
+  })
+
+  describe('getProviderDisplayNameById', () => {
+    it('uses the canonical label for a system provider id', () => {
+      expect(getProviderDisplayNameById('minimax')).toBe('MiniMax CN')
+    })
+
+    it('preserves a custom provider id when metadata is unavailable', () => {
+      expect(getProviderDisplayNameById('my-custom')).toBe('my-custom')
     })
   })
 

--- a/src/renderer/utils/naming.ts
+++ b/src/renderer/utils/naming.ts
@@ -1,6 +1,6 @@
 import { getProviderLabelKey } from '@renderer/i18n/label'
 import i18n from '@renderer/i18n/resolver'
-import { isSystemProvider, type Provider } from '@renderer/types/provider'
+import { isSystemProvider, isSystemProviderId, type Provider } from '@renderer/types/provider'
 
 /**
  * 从模型 ID 中提取默认组名。
@@ -105,6 +105,23 @@ export const getLowerBaseModelName = (id: string, delimiter: string = '/'): stri
  */
 export const getFancyProviderName = (provider: Provider) => {
   return isSystemProvider(provider) ? i18n.t(getProviderLabelKey(provider.id)) : provider.name
+}
+
+/**
+ * Resolve the best provider label available from an id alone.
+ * Custom provider ids remain unchanged until provider metadata is available.
+ */
+export function getProviderDisplayNameById(providerId: string): string {
+  return isSystemProviderId(providerId) ? i18n.t(getProviderLabelKey(providerId)) : providerId
+}
+
+/**
+ * Resolve a provider's user-facing name from its runtime metadata.
+ * System providers use their canonical label; custom providers keep their user-set name.
+ */
+export function getProviderDisplayName(provider: Pick<Provider, 'id' | 'name'> | undefined): string {
+  if (!provider) return ''
+  return isSystemProviderId(provider.id) ? getProviderDisplayNameById(provider.id) : provider.name
 }
 
 // \uFE0F = VS16 (emoji-presentation selector); \u20E3 = combining enclosing keycap (1️⃣);

--- a/src/renderer/utils/naming.ts
+++ b/src/renderer/utils/naming.ts
@@ -112,7 +112,8 @@ export const getFancyProviderName = (provider: Provider) => {
  * Custom provider ids remain unchanged until provider metadata is available.
  */
 export function getProviderDisplayNameById(providerId: string): string {
-  return isSystemProviderId(providerId) ? i18n.t(getProviderLabelKey(providerId)) : providerId
+  const labelKey = getProviderLabelKey(providerId, '')
+  return labelKey ? i18n.t(labelKey) : providerId
 }
 
 /**


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- The single-model selector trigger displayed only the model name, so the active provider was not visible at a glance.
- Provider-group rows repeated the provider name when duplicate model names needed disambiguation, even though the provider header was already persistent.
- System provider IDs could briefly appear with raw lowercase casing while provider metadata was loading.

After this PR:

- The single-model selector trigger displays `model name | provider name`, with the full value available as a tooltip when space is limited.
- Provider-group rows rely on their existing provider header and show only the model identifier when needed; pinned rows keep the provider name because they have no provider header.
- System providers use their canonical localized casing, while custom providers keep their configured names.
- Single-model conversations load the provider metadata required to render custom provider names, with a canonical ID-based fallback during loading.

#### Screenshots

| Before | After |
| --- | --- |
| <img width="684" height="124" alt="Before: selected model without provider name" src="https://github.com/user-attachments/assets/9b6c4a32-a5b6-4e86-9a93-e76ad3cb57fe" /> | <img width="684" height="124" alt="After: selected model with canonical provider name" src="https://github.com/user-attachments/assets/6d6fe507-744d-42be-9e28-cc7f256c30f6" /> |

Fixes #19359
Fixes #18339
Fixes #19546 
Related to #13091
Related to #18309

### Why we need it and why it was done in this way

The selected-model trigger owns the compact identity of the active model, so it needs both the model and provider names. Provider-group rows already receive provider context from their persistent group header, so repeating that same fact on every duplicate row adds visual noise instead of useful disambiguation.

Provider display-name resolution is centralized in the existing naming utilities. This keeps canonical localization for built-in providers, preserves user-defined names for custom providers, and gives both selector variants the same fallback behavior while metadata is loading.

The following tradeoffs were made:

- A single-model conversation now enables the provider metadata query so custom providers can display their configured names.
- Pinned rows intentionally retain the provider name because the pinned section is not grouped by provider.

The following alternatives were considered:

- Formatting raw provider IDs in each component was rejected because IDs are not presentation labels and can lose canonical casing.
- Keeping provider labels on every duplicate provider-group row was rejected because the persistent group header already provides that context.
- Adding another selector-local resolver was rejected in favor of reusing one shared display-name contract.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Focused renderer tests: 10 files, 331 tests passed.
- `pnpm run typecheck:web` passed.
- Biome checks passed for all 19 changed TypeScript/TSX files.
- The before and after screenshots were captured from the same running Cherry Studio development instance and the same viewport region.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and no upgrade changes are required
- [x] Documentation: A user-guide update was considered and is not required for this self-explanatory label change
- [x] Self-review: I reviewed the complete diff against the latest `upstream/main`

### Release note

```release-note
Show the selected model together with its provider and remove redundant provider labels from grouped model menu rows.
```
