### PR TITLE
fix(messages): restore legacy tool step ordering

### DIFF
--- a/src/main/ai/messages/__tests__/messageRules.legacyToolSteps.test.ts
+++ b/src/main/ai/messages/__tests__/messageRules.legacyToolSteps.test.ts
@@ -1,0 +1,167 @@
+import { createOpenAI } from '@ai-sdk/openai'
+import { type DynamicToolUIPart, generateText, type ModelMessage, type UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { toModelMessages } from '../messageRules'
+
+const completedTool = (toolCallId: string): DynamicToolUIPart => ({
+  type: 'dynamic-tool',
+  toolName: 'lookup',
+  toolCallId,
+  state: 'output-available',
+  input: { query: toolCallId },
+  output: { result: toolCallId }
+})
+
+const failedTool = (toolCallId: string): DynamicToolUIPart => ({
+  type: 'dynamic-tool',
+  toolName: 'lookup',
+  toolCallId,
+  state: 'output-error',
+  input: { query: toolCallId },
+  errorText: 'lookup failed'
+})
+
+const assistant = (parts: UIMessage['parts'], id = 'assistant'): UIMessage => ({ id, role: 'assistant', parts })
+
+const partTypes = (message: ModelMessage) =>
+  Array.isArray(message.content) ? message.content.map((part) => part.type) : []
+
+describe('legacy tool step replay', () => {
+  it('keeps parallel tool outputs ahead of the following assistant text (#19465)', async () => {
+    const model = await toModelMessages([
+      assistant([
+        { type: 'text', text: 'Before tools' },
+        completedTool('call-1'),
+        failedTool('call-2'),
+        { type: 'text', text: 'After tools' }
+      ])
+    ])
+
+    expect(model.map((message) => message.role)).toEqual(['assistant', 'tool', 'assistant'])
+    expect(partTypes(model[0])).toEqual(['text', 'tool-call', 'tool-call'])
+    expect(partTypes(model[1])).toEqual(['tool-result', 'tool-result'])
+    expect(model[2]).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'After tools' }] })
+  })
+
+  it('serializes Responses tool outputs before the next assistant item', async () => {
+    const prompt = await toModelMessages([
+      assistant([
+        { type: 'text', text: 'Before tools' },
+        completedTool('call-1'),
+        completedTool('call-2'),
+        { type: 'text', text: 'After tools' }
+      ])
+    ])
+    let requestBody: { input?: Array<{ role?: string; type?: string }> } = {}
+    const model = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.com/v1',
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body))
+        return new Response(
+          JSON.stringify({
+            id: 'resp_1',
+            created_at: 1,
+            model: 'deepseek-v4-pro',
+            status: 'completed',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1 }
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+    }).responses('deepseek-v4-pro')
+
+    await generateText({ model, messages: prompt })
+
+    expect(requestBody.input?.map((item) => (item.type === 'message' ? item.role : item.type))).toEqual([
+      'assistant',
+      'function_call',
+      'function_call',
+      'function_call_output',
+      'function_call_output',
+      'assistant'
+    ])
+  })
+
+  it('restores every inferable boundary in a multi-step legacy message', async () => {
+    const model = await toModelMessages([
+      assistant([
+        { type: 'text', text: 'Step 1' },
+        completedTool('call-1'),
+        { type: 'text', text: 'Step 2' },
+        completedTool('call-2'),
+        { type: 'text', text: 'Done' }
+      ])
+    ])
+
+    expect(model.map((message) => message.role)).toEqual(['assistant', 'tool', 'assistant', 'tool', 'assistant'])
+    expect(partTypes(model[0])).toEqual(['text', 'tool-call'])
+    expect(partTypes(model[1])).toEqual(['tool-result'])
+    expect(partTypes(model[2])).toEqual(['text', 'tool-call'])
+    expect(partTypes(model[3])).toEqual(['tool-result'])
+    expect(model[4]).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'Done' }] })
+  })
+
+  it('preserves explicit step boundaries in current messages', async () => {
+    const model = await toModelMessages([
+      assistant([
+        { type: 'step-start' },
+        { type: 'text', text: 'Before tools' },
+        completedTool('call-1'),
+        { type: 'step-start' },
+        { type: 'text', text: 'After tools' }
+      ])
+    ])
+
+    expect(model.map((message) => message.role)).toEqual(['assistant', 'tool', 'assistant'])
+    expect(partTypes(model[0])).toEqual(['text', 'tool-call'])
+    expect(partTypes(model[1])).toEqual(['tool-result'])
+    expect(model[2]).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'After tools' }] })
+  })
+
+  it('restores a boundary after a denied local tool', async () => {
+    const model = await toModelMessages([
+      assistant([
+        {
+          type: 'dynamic-tool',
+          toolName: 'lookup',
+          toolCallId: 'call-denied',
+          state: 'output-denied',
+          input: {},
+          approval: { id: 'approval-1', approved: false, reason: 'Not allowed' }
+        },
+        { type: 'text', text: 'Alternative' }
+      ])
+    ])
+
+    expect(model.map((message) => message.role)).toEqual(['assistant', 'tool', 'assistant'])
+    expect(model[2]).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'Alternative' }] })
+  })
+
+  it('does not split provider-executed or incomplete tools', async () => {
+    const providerTool = await toModelMessages([
+      assistant([
+        { ...completedTool('provider-call'), providerExecuted: true },
+        { type: 'text', text: 'Same provider step' }
+      ])
+    ])
+    const incompleteTool = await toModelMessages([
+      assistant([
+        {
+          type: 'dynamic-tool',
+          toolName: 'lookup',
+          toolCallId: 'pending-call',
+          state: 'input-available',
+          input: {}
+        },
+        { type: 'text', text: 'Still here' }
+      ])
+    ])
+
+    expect(providerTool.map((message) => message.role)).toEqual(['assistant'])
+    expect(partTypes(providerTool[0])).toEqual(['tool-call', 'tool-result', 'text'])
+    expect(incompleteTool).toEqual([{ role: 'assistant', content: [{ type: 'text', text: 'Still here' }] }])
+  })
+})

--- a/src/main/ai/messages/messageRules.ts
+++ b/src/main/ai/messages/messageRules.ts
@@ -18,6 +18,42 @@ function contentToParts(content: unknown): unknown[] {
   return Array.isArray(content) ? content : []
 }
 
+const TERMINAL_LOCAL_TOOL_STATES = new Set(['output-available', 'output-error', 'output-denied'])
+
+function isCompletedLocalTool(part: UIMessage['parts'][number]): boolean {
+  return isToolUIPart(part) && part.providerExecuted !== true && TERMINAL_LOCAL_TOOL_STATES.has(part.state)
+}
+
+function isAssistantContinuation(part: UIMessage['parts'][number]): boolean {
+  return part.type === 'text' || part.type === 'reasoning' || part.type === 'file'
+}
+
+/** Restore inferable step boundaries that the v1 flat-block migration could not persist. */
+function restoreLegacyToolStepBoundaries(messages: UIMessage[]): UIMessage[] {
+  let out: UIMessage[] | undefined
+  messages.forEach((message, messageIndex) => {
+    if (message.role !== 'assistant' || message.parts.some((part) => part.type === 'step-start')) return
+
+    let parts: UIMessage['parts'] | undefined
+    let completedToolGroup = false
+    message.parts.forEach((part, partIndex) => {
+      if (completedToolGroup && isAssistantContinuation(part)) {
+        parts ??= message.parts.slice(0, partIndex)
+        parts.push({ type: 'step-start' })
+        completedToolGroup = false
+      }
+      parts?.push(part)
+      if (isCompletedLocalTool(part)) completedToolGroup = true
+    })
+
+    if (parts) {
+      out ??= [...messages]
+      out[messageIndex] = { ...message, parts }
+    }
+  })
+  return out ?? messages
+}
+
 /**
  * Merge adjacent same-role messages into one (concatenate content). Cleans up the
  * adjacency left when `convertToModelMessages` drops an empty turn.
@@ -135,9 +171,9 @@ export function dropUnansweredApprovals<T extends UIMessage>(messages: T[]): T[]
  *
  * render persisted tool-output envelopes back into their <persisted-output> markers →
  * make legacy v1 tool names wire-legal → strip media the model can't accept → drop tool
- * calls parked on an unanswered approval → convert, dropping incomplete tool calls that
- * would otherwise dangle without a result → gate media inside tool-result outputs by
- * `toolResultCaps` (wire-aware, see
+ * calls parked on an unanswered approval → restore inferable legacy step boundaries →
+ * convert, dropping incomplete tool calls that would otherwise dangle without a result →
+ * gate media inside tool-result outputs by `toolResultCaps` (wire-aware, see
  * `resolveToolResultMediaCapabilities`; defaults to `caps`) → merge adjacent same-role turns
  * left by drops → placeholder any turn that still converted to empty content. See #16195.
  */
@@ -148,7 +184,9 @@ export async function toModelMessages(
   toolResultCaps?: MediaCapabilities
 ): Promise<ModelMessage[]> {
   const rendered = sanitizeDynamicToolNames(renderPersistedToolOutputs(messages), tools)
-  const shaped = dropUnansweredApprovals(stripUnsupportedMedia(rendered, caps ?? ALL_MEDIA))
+  const shaped = restoreLegacyToolStepBoundaries(
+    dropUnansweredApprovals(stripUnsupportedMedia(rendered, caps ?? ALL_MEDIA))
+  )
   const model = await convertToModelMessages(shaped, { ignoreIncompleteToolCalls: true, tools })
   const gated = routeToolResultMedia(model, caps ?? ALL_MEDIA, toolResultCaps ?? caps ?? ALL_MEDIA)
   return ensureNonEmptyAssistantContent(coalesceConsecutiveSameRole(gated))


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Legacy v1 conversations can contain completed parallel tool calls and later assistant text in one flat parts array without AI SDK `step-start` markers. Replaying that history through a Responses provider serializes the later assistant item before the matching `function_call_output` items, and strict endpoints reject the request.

After this PR:

The replay-only message shaping restores inferable boundaries after completed local tool groups. Tool outputs are serialized before the following assistant continuation, while current messages with explicit step markers and provider-executed or incomplete tools keep their existing behavior.

Refs #19465

### Why we need it and why it was done in this way

The v1 migrator flattened historical blocks, while AI SDK uses `step-start` to decide when tool outputs belong before a later assistant message. Restoring the missing marker at Cherry's provider-neutral replay boundary repairs already-migrated conversations without changing persisted data.

The following tradeoffs were made:

- Inference is limited to assistant messages with no existing step marker.
- Only completed local tool states open an inferred boundary; current provider-executed and incomplete tool semantics are preserved.
- Boundaries are inferred only when later text, reasoning, or file content makes the old step transition observable.

The following alternatives were considered:

- Reordering only the OpenAI Responses payload was rejected because it would duplicate provider logic and leave other strict adapters exposed.
- A new database migration was rejected because existing migrated rows need immediate repair and the request-time transformation is pure and idempotent.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19465#issuecomment-5429312513

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The regression suite covers parallel success/error results, denied tools, multiple inferred steps, explicit modern markers, provider-executed tools, incomplete tools, and the actual `@ai-sdk/openai` Responses wire order.

Validation completed:

- 23 focused main-process tests
- `pnpm lint`
- `pnpm test:lint`
- `pnpm build`
- Independent read-only review: approved

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix legacy conversations that could fail on Responses API providers after parallel tool calls.
```
