### PR TITLE
perf(files): hydrate only the visible view

### DIFF
--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -174,6 +174,17 @@ function canStartInlineRename(file: FileItem | undefined): file is FileItem {
   return Boolean(file && !file.trashed && !file.isMissing)
 }
 
+function useStableFileEntries(entries: FileEntry[]): FileEntry[] {
+  const stableRef = useRef(entries)
+  if (
+    stableRef.current.length !== entries.length ||
+    stableRef.current.some((entry, index) => entry !== entries[index])
+  ) {
+    stableRef.current = entries
+  }
+  return stableRef.current
+}
+
 function toFileItem(
   entry: FileEntry,
   metadataById: FileMetadataById,
@@ -313,6 +324,7 @@ function FilesPage() {
   const [physicalPathById, setPhysicalPathById] = useState<PhysicalPathById>({})
   const [danglingStateById, setDanglingStateById] = useState<DanglingStateById>({})
   const [filter, setFilter] = useState<SidebarFilter>({ kind: 'library', value: 'all' })
+  const isTrash = filter.kind === 'library' && filter.value === 'trash'
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
 
   const [sortKey, setSortKey] = useState<SortKey>('updatedAt')
@@ -345,6 +357,7 @@ function FilesPage() {
   } = useInfiniteQuery('/files/entries', {
     query: activeFilesQuery,
     limit: FILES_PAGE_LIMIT,
+    enabled: !isTrash,
     swrOptions: { keepPreviousData: true }
   })
   const {
@@ -359,6 +372,7 @@ function FilesPage() {
   } = useInfiniteQuery('/files/entries', {
     query: trashedFilesQuery,
     limit: FILES_PAGE_LIMIT,
+    enabled: isTrash,
     swrOptions: { keepPreviousData: true }
   })
   const {
@@ -369,24 +383,31 @@ function FilesPage() {
     swrOptions: { keepPreviousData: true }
   })
 
-  const isFilesLoading = isActiveFilesLoading || isTrashedFilesLoading
-  const isFilesRefreshing = isActiveFilesRefreshing || isTrashedFilesRefreshing
-  const activeEntries = useInfiniteFlatItems(activeFilePages)
-  const trashedEntries = useInfiniteFlatItems(trashedFilePages)
-  const activeFilesTotal = activeFilePages[0]?.total ?? activeEntries.length
-  const trashedFilesTotal = trashedFilePages[0]?.total ?? trashedEntries.length
-  const entries = useMemo(() => [...activeEntries, ...trashedEntries], [activeEntries, trashedEntries])
-  const previousNonEmptyEntriesRef = useRef<FileEntry[]>([])
-  const isFileQueryPending = isFilesLoading || isFilesRefreshing
+  const viewKey = isTrash ? 'trash' : 'active'
+  const currentFilePages = isTrash ? trashedFilePages : activeFilePages
+  const entries = useStableFileEntries(useInfiniteFlatItems(currentFilePages))
+  const activeFilesTotal =
+    activeFilePages[0]?.total ?? activeFilePages.reduce((sum, page) => sum + page.items.length, 0)
+  const trashedFilesTotal =
+    trashedFilePages[0]?.total ?? trashedFilePages.reduce((sum, page) => sum + page.items.length, 0)
+  const isFilesLoading = isTrash ? isTrashedFilesLoading : isActiveFilesLoading
+  const isFilesRefreshing = isTrash ? isTrashedFilesRefreshing : isActiveFilesRefreshing
+  const previousNonEmptyEntriesRef = useRef<{ active: FileEntry[]; trash: FileEntry[] }>({ active: [], trash: [] })
+  const previousEntries = previousNonEmptyEntriesRef.current[viewKey]
   const displayEntryCandidate =
-    entries.length === 0 && isFileQueryPending && previousNonEmptyEntriesRef.current.length > 0
-      ? previousNonEmptyEntriesRef.current
+    entries.length === 0 && (isFilesLoading || isFilesRefreshing) && previousEntries.length > 0
+      ? previousEntries
       : entries
-  const displayEntries = useDeferredValue(displayEntryCandidate)
+  const displayStateCandidate = useMemo(
+    () => ({ viewKey, entries: displayEntryCandidate }),
+    [displayEntryCandidate, viewKey]
+  )
+  const deferredDisplayState = useDeferredValue(displayStateCandidate)
+  const displayEntries = deferredDisplayState.viewKey === viewKey ? deferredDisplayState.entries : displayEntryCandidate
 
   useEffect(() => {
-    if (entries.length > 0) previousNonEmptyEntriesRef.current = entries
-  }, [entries])
+    if (entries.length > 0) previousNonEmptyEntriesRef.current[viewKey] = entries
+  }, [entries, viewKey])
 
   useEffect(() => {
     resetActiveFiles()
@@ -437,7 +458,7 @@ function FilesPage() {
     return () => {
       cancelled = true
     }
-  }, [displayEntries, isFilesLoading, isFilesRefreshing])
+  }, [displayEntries, isFilesLoading, isFilesRefreshing, viewKey])
 
   const files = useMemo(() => {
     return displayEntries.map((entry) => toFileItem(entry, metadataById, physicalPathById, danglingStateById))
@@ -449,7 +470,6 @@ function FilesPage() {
     await Promise.all([refreshActiveFiles(), refreshTrashedFiles(), refetchFileStats()])
   }, [refetchFileStats, refreshActiveFiles, refreshTrashedFiles, resetActiveFiles, resetTrashedFiles])
 
-  const isTrash = filter.kind === 'library' && filter.value === 'trash'
   const isImageGrid = filter.kind === 'type' && filter.value === 'image'
   const activeFilterLabel =
     filter.kind === 'library'

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -98,6 +98,13 @@ const imageEntry = {
   updatedAt: 1_719_216_000_000
 } as unknown as FileEntry
 
+const trashedImageEntry = {
+  ...imageEntry,
+  id: 'file-trash-image',
+  name: 'trashed-photo',
+  deletedAt: 1_719_216_000_000
+} as unknown as FileEntry
+
 const externalEntry = {
   id: 'file-external',
   origin: 'external',
@@ -172,16 +179,22 @@ function mockFileStats(stats: FileEntryStats, refetch = vi.fn().mockResolvedValu
 
 function mockFiles(entries: FileEntry[]) {
   mockFileStats(statsForEntries(entries))
+  const activePages = [{ items: entries }]
+  const trashedPages: Array<{ items: FileEntry[] }> = []
+  const loadNext = vi.fn()
+  const refresh = vi.fn().mockResolvedValue(undefined)
+  const reset = vi.fn()
+  const mutate = vi.fn().mockResolvedValue(undefined)
   mockUseInfiniteQuery.mockImplementation((_path, options) => ({
-    pages: (options?.query as { inTrash?: boolean } | undefined)?.inTrash ? [] : [{ items: entries }],
+    pages: (options?.query as { inTrash?: boolean } | undefined)?.inTrash ? trashedPages : activePages,
     isLoading: false,
     isRefreshing: false,
     error: undefined,
     hasNext: false,
-    loadNext: vi.fn(),
-    refresh: vi.fn().mockResolvedValue(undefined),
-    reset: vi.fn(),
-    mutate: vi.fn().mockResolvedValue(undefined)
+    loadNext,
+    refresh,
+    reset,
+    mutate
   }))
 }
 
@@ -204,6 +217,208 @@ afterEach(() => {
   cleanup()
   vi.useRealTimers()
   vi.clearAllMocks()
+})
+
+describe('FilesPage visible-view hydration', () => {
+  it('enables and hydrates only the visible file query', async () => {
+    mockFileStats(statsForEntries([imageEntry, trashedImageEntry]))
+    ipcMocks.request.mockResolvedValue({})
+    const activeResult = {
+      pages: [{ items: [imageEntry] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    const trashResult = {
+      ...activeResult,
+      pages: [{ items: [trashedImageEntry] }],
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    mockUseInfiniteQuery.mockImplementation((_path, options) => {
+      const inTrash = Boolean((options?.query as { inTrash?: boolean } | undefined)?.inTrash)
+      return inTrash ? trashResult : activeResult
+    })
+
+    render(<FilesPage />)
+
+    await waitFor(() => {
+      const activeCall = mockUseInfiniteQuery.mock.calls
+        .filter((call) => !(call[1]?.query as { inTrash?: boolean } | undefined)?.inTrash)
+        .at(-1)
+      const trashCall = mockUseInfiniteQuery.mock.calls
+        .filter((call) => (call[1]?.query as { inTrash?: boolean } | undefined)?.inTrash)
+        .at(-1)
+      expect(activeCall?.[1]?.enabled).toBe(true)
+      expect(trashCall?.[1]?.enabled).toBe(false)
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_metadata', {
+        items: [{ key: imageEntry.id, handle: { kind: 'entry', entryId: imageEntry.id } }]
+      })
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_physical_paths', { ids: [imageEntry.id] })
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_dangling_states', { ids: [imageEntry.id] })
+    })
+    expect(ipcMocks.request).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ids: expect.arrayContaining([trashedImageEntry.id]) })
+    )
+    expect(ipcMocks.request).not.toHaveBeenCalledWith('file.batch_get_metadata', {
+      items: expect.arrayContaining([expect.objectContaining({ key: trashedImageEntry.id })])
+    })
+
+    ipcMocks.request.mockClear()
+    fireEvent.click(screen.getByText('files.trash'))
+
+    await waitFor(() => {
+      const activeCall = mockUseInfiniteQuery.mock.calls
+        .filter((call) => !(call[1]?.query as { inTrash?: boolean } | undefined)?.inTrash)
+        .at(-1)
+      const trashCall = mockUseInfiniteQuery.mock.calls
+        .filter((call) => (call[1]?.query as { inTrash?: boolean } | undefined)?.inTrash)
+        .at(-1)
+      expect(activeCall?.[1]?.enabled).toBe(false)
+      expect(trashCall?.[1]?.enabled).toBe(true)
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_metadata', {
+        items: [{ key: trashedImageEntry.id, handle: { kind: 'entry', entryId: trashedImageEntry.id } }]
+      })
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_physical_paths', {
+        ids: [trashedImageEntry.id]
+      })
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_dangling_states', {
+        ids: [trashedImageEntry.id]
+      })
+    })
+    expect(ipcMocks.request).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ids: expect.arrayContaining([imageEntry.id]) })
+    )
+    expect(ipcMocks.request).not.toHaveBeenCalledWith('file.batch_get_metadata', {
+      items: expect.arrayContaining([expect.objectContaining({ key: imageEntry.id })])
+    })
+  })
+
+  it('does not reuse active rows while the trash query is loading', () => {
+    mockFileStats(statsForEntries([entry]))
+    const activeResult = {
+      pages: [{ items: [entry] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    const trashResult = {
+      ...activeResult,
+      pages: [],
+      isLoading: true,
+      isRefreshing: true,
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    mockUseInfiniteQuery.mockImplementation((_path, options) => {
+      const inTrash = Boolean((options?.query as { inTrash?: boolean } | undefined)?.inTrash)
+      return inTrash ? trashResult : activeResult
+    })
+
+    render(<FilesPage />)
+    expect(screen.getByText('report.md')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('files.trash'))
+
+    expect(screen.queryByText('report.md')).not.toBeInTheDocument()
+    expect(screen.getByText('common.loading')).toBeInTheDocument()
+  })
+
+  it('ignores active hydration that resolves after switching to trash', async () => {
+    mockFileStats(statsForEntries([imageEntry, trashedImageEntry]))
+    const activeResult = {
+      pages: [{ items: [imageEntry] }],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    const trashResult = {
+      ...activeResult,
+      pages: [{ items: [trashedImageEntry] }],
+      loadNext: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      mutate: vi.fn().mockResolvedValue(undefined)
+    }
+    mockUseInfiniteQuery.mockImplementation((_path, options) =>
+      (options?.query as { inTrash?: boolean } | undefined)?.inTrash ? trashResult : activeResult
+    )
+
+    let resolveActiveMetadata!: (value: Record<string, unknown>) => void
+    let resolveActivePhysicalPaths!: (value: Record<string, unknown>) => void
+    let resolveActiveDanglingStates!: (value: Record<string, unknown>) => void
+    const activeMetadata = new Promise<Record<string, unknown>>((resolve) => {
+      resolveActiveMetadata = resolve
+    })
+    const activePhysicalPaths = new Promise<Record<string, unknown>>((resolve) => {
+      resolveActivePhysicalPaths = resolve
+    })
+    const activeDanglingStates = new Promise<Record<string, unknown>>((resolve) => {
+      resolveActiveDanglingStates = resolve
+    })
+    ipcMocks.request.mockImplementation((route: string, input: { items?: Array<{ key: string }>; ids?: string[] }) => {
+      const ids = route === 'file.batch_get_metadata' ? (input.items?.map((item) => item.key) ?? []) : (input.ids ?? [])
+      const isActiveRequest = ids.includes(imageEntry.id)
+      if (isActiveRequest && route === 'file.batch_get_metadata') return activeMetadata
+      if (isActiveRequest && route === 'file.batch_get_physical_paths') return activePhysicalPaths
+      if (isActiveRequest && route === 'file.batch_get_dangling_states') return activeDanglingStates
+      if (route === 'file.batch_get_metadata') {
+        return Promise.resolve({
+          [trashedImageEntry.id]: {
+            size: 2048,
+            createdAt: Date.UTC(2030, 0, 2),
+            modifiedAt: Date.UTC(2030, 0, 2)
+          }
+        })
+      }
+      if (route === 'file.batch_get_physical_paths') {
+        return Promise.resolve({ [trashedImageEntry.id]: '/tmp/trashed-photo.png' })
+      }
+      return Promise.resolve({})
+    })
+
+    render(<FilesPage />)
+    await waitFor(() => {
+      expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_get_dangling_states', { ids: [imageEntry.id] })
+    })
+
+    fireEvent.click(screen.getByText('files.trash'))
+    await waitFor(() => expect(screen.getAllByText(/^2030-/).length).toBeGreaterThan(0))
+
+    act(() => {
+      resolveActiveMetadata({
+        [imageEntry.id]: { size: 2048, createdAt: Date.UTC(2040, 0, 2), modifiedAt: Date.UTC(2040, 0, 2) }
+      })
+      resolveActivePhysicalPaths({ [imageEntry.id]: '/tmp/photo.png' })
+      resolveActiveDanglingStates({})
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/^2030-/).length).toBeGreaterThan(0)
+      expect(screen.queryByText(/^2040-/)).not.toBeInTheDocument()
+    })
+  })
 })
 
 describe('FilesPage keyboard rename', () => {


### PR DESCRIPTION
## Summary

- enable only the active or trash infinite query for the currently visible Files view
- keep previous non-empty rows and deferred transitions isolated per view
- cancel late hydration from the previous view so stale IPC results cannot overwrite the current list
- hydrate metadata, physical paths, and dangling states only for visible entry IDs

## Tests

- `pnpm exec vitest run src/renderer/pages/files/__tests__/FilesPage.test.tsx` (51 passed)
- `pnpm lint`
- `pnpm test:lint`
- targeted Biome and ESLint checks

Closes #19507