### PR TITLE
fix(composer): show the active permission mode

### DIFF
--- a/src/renderer/components/PermissionModeOption.tsx
+++ b/src/renderer/components/PermissionModeOption.tsx
@@ -31,7 +31,12 @@ const PERMISSION_MODE_ICONS: Record<PermissionMode, typeof Hand> = {
 
 export function PermissionModeIcon({ mode, size = 18 }: { mode: PermissionMode; size?: number }): ReactNode {
   const Icon = PERMISSION_MODE_ICONS[mode] ?? Hand
-  return <Icon size={size} className={mode === 'bypassPermissions' ? 'text-destructive' : 'text-muted-foreground'} />
+  return (
+    <Icon
+      size={size}
+      className={mode === 'bypassPermissions' ? 'lucide-custom text-destructive' : 'text-muted-foreground'}
+    />
+  )
 }
 
 function getPermissionModeWarning(card: PermissionModeCard, t: TFunction) {

--- a/src/renderer/components/__tests__/PermissionModeOption.test.tsx
+++ b/src/renderer/components/__tests__/PermissionModeOption.test.tsx
@@ -10,7 +10,8 @@ import { QuickPanelRow } from '../QuickPanel/list'
 
 vi.mock('@cherrystudio/ui', () => vi.importActual('@cherrystudio/ui'))
 
-const { PermissionModeOptionLabel, PermissionModeSelect, PermissionModeWarning } = PermissionModeComponents
+const { PermissionModeIcon, PermissionModeOptionLabel, PermissionModeSelect, PermissionModeWarning } =
+  PermissionModeComponents
 
 // The component only ever calls t(key, fallback); rendering the fallback keeps these
 // assertions about layout rather than about the locale files.
@@ -84,6 +85,21 @@ function renderOpenPermissionSelect() {
   fireEvent.pointerDown(trigger)
   fireEvent.click(trigger)
 }
+
+describe('PermissionModeIcon', () => {
+  it('marks only Full Access as a custom destructive toolbar icon', () => {
+    const { container, rerender } = render(<PermissionModeIcon mode="default" />)
+    const defaultIcon = container.querySelector('svg')
+
+    expect(defaultIcon).toHaveClass('text-muted-foreground')
+    expect(defaultIcon).not.toHaveClass('lucide-custom')
+
+    rerender(<PermissionModeIcon mode="bypassPermissions" />)
+    const fullAccessIcon = container.querySelector('svg')
+
+    expect(fullAccessIcon).toHaveClass('text-destructive', 'lucide-custom')
+  })
+})
 
 describe('PermissionModeOptionLabel', () => {
   it('keeps permanent copy to the title and optional description', () => {

--- a/src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx
+++ b/src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx
@@ -6,11 +6,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   registerLaunchers: vi.fn<(launchers: ComposerToolLauncher[]) => () => void>(() => () => undefined),
-  updateAgent: vi.fn()
+  updateAgent: vi.fn(),
+  permissionMode: 'default'
 }))
 
 vi.mock('@renderer/hooks/agent/useAgent', () => ({
-  useAgent: () => ({ agent: { id: 'agent-1', configuration: { permission_mode: 'default' } } }),
+  useAgent: () => ({ agent: { id: 'agent-1', configuration: { permission_mode: mocks.permissionMode } } }),
   useUpdateAgent: () => ({ updateAgent: mocks.updateAgent })
 }))
 
@@ -37,6 +38,7 @@ const renderRuntime = () => renderLauncher()?.submenu ?? []
 describe('permissionModeTool submenu', () => {
   beforeEach(() => {
     mocks.registerLaunchers.mockClear()
+    mocks.permissionMode = 'default'
   })
 
   it('keeps the current mode in the description so the submenu indicator remains visible', () => {
@@ -58,6 +60,23 @@ describe('permissionModeTool submenu', () => {
       />
     )
     expect(container.querySelector('.lucide-chevron-right')).toBeInTheDocument()
+  })
+
+  it('keeps the live permission mode in the pinned toolbar tooltip', () => {
+    const Runtime = permissionModeTool.composer!.runtime!
+    const context = {
+      t,
+      launcher: { registerLaunchers: mocks.registerLaunchers },
+      session: { agentId: 'agent-1' }
+    }
+    const { rerender } = render(<Runtime context={context as any} />)
+
+    expect(mocks.registerLaunchers.mock.calls.at(-1)?.[0][0]?.tooltip).toBe('Permission Mode · Ask Before Acting')
+
+    mocks.permissionMode = 'bypassPermissions'
+    rerender(<Runtime context={context as any} />)
+
+    expect(mocks.registerLaunchers.mock.calls.at(-1)?.[0][0]?.tooltip).toBe('Permission Mode · Full Access')
   })
 
   // The quick panel row is a fixed-height single line: a stacked warning under the title

--- a/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
+++ b/src/renderer/components/composer/tools/definitions/permissionModeTool.tsx
@@ -36,6 +36,8 @@ const usePermissionModeToolController = (context: PermissionModeContext) => {
 
   const modeCard = permissionModeCards.find((card) => card.mode === currentMode)
   const tooltipTitle = modeCard ? t(modeCard.titleKey, modeCard.titleFallback) : ''
+  const launcherLabel = t('agent.settings.permissionMode.title', 'Permission Mode')
+  const launcherTooltip = tooltipTitle ? `${launcherLabel} · ${tooltipTitle}` : launcherLabel
   const modeSubmenu = useMemo(
     () =>
       permissionModeCards.map((card, index) => ({
@@ -69,14 +71,15 @@ const usePermissionModeToolController = (context: PermissionModeContext) => {
       {
         ...PERMISSION_MODE_TOOLBAR_MANIFEST.toolbar,
         sources: ['popover'],
-        label: t('agent.settings.permissionMode.title', 'Permission Mode'),
+        label: launcherLabel,
         description: tooltipTitle,
+        tooltip: launcherTooltip,
         searchAliases: getQuickPanelSearchAliases(t, 'agent.settings.permissionMode.title'),
         icon: <PermissionModeIcon mode={currentMode} />,
         submenu: modeSubmenu
       }
     ])
-  }, [currentMode, launcher, modeSubmenu, t, tooltipTitle])
+  }, [currentMode, launcher, launcherLabel, launcherTooltip, modeSubmenu, t, tooltipTitle])
 
   return { currentMode, tooltipTitle }
 }


### PR DESCRIPTION
## Summary

- preserve the destructive color of the Full Access permission icon on the pinned composer toolbar
- include the localized current permission mode in the toolbar tooltip
- cover the icon class contract and live default-to-Full-Access tooltip update

## Tests

- `pnpm exec vitest run src/renderer/components/__tests__/PermissionModeOption.test.tsx src/renderer/components/composer/tools/definitions/__tests__/permissionModeTool.test.tsx` (13 passed)
- `pnpm lint`
- `pnpm test:lint`

Closes #18217