### PR TITLE
fix(chat): honor current model on regenerate

### DIFF
--- a/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
+++ b/src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx
@@ -62,7 +62,7 @@ function renderActions(
   stop: () => Promise<void> = vi.fn(async () => {})
 ) {
   const scrollToBottom = vi.fn()
-  const regenerate = vi.fn(async () => {})
+  const regenerate = vi.fn<Parameters<typeof useChatWriteActions>[0]['regenerate']>(async () => {})
   const setMessages = vi.fn()
   const seedReservedMessages = vi.fn(async () => {})
   const { result } = renderHook(() =>
@@ -526,7 +526,7 @@ describe('useChatWriteActions — regenerate', () => {
     })
   })
 
-  it('keeps successful non-text assistants on the ordinary regenerate path', async () => {
+  it('lets Main resolve the current model when regenerating a successful assistant response', async () => {
     const nonTextAssistant = uiMsg('a1', 'assistant', 'u1', false, 'success')
     nonTextAssistant.metadata.modelId = 'provider::model-a'
     nonTextAssistant.parts = [{ type: 'data-code', data: { content: 'const ok = true', language: 'ts' } }]
@@ -537,8 +537,9 @@ describe('useChatWriteActions — regenerate', () => {
     expect(streamOpen).not.toHaveBeenCalled()
     expect(regenerate).toHaveBeenCalledWith({
       messageId: 'a1',
-      body: expect.objectContaining({ parentAnchorId: 'u1', mentionedModels: ['provider::model-a'] })
+      body: expect.objectContaining({ parentAnchorId: 'u1' })
     })
+    expect(regenerate.mock.calls[0][0]?.body).not.toHaveProperty('mentionedModels')
   })
 
   it('routes an explicit @ model through Main so a live reply group can append without moving the branch', async () => {
@@ -602,6 +603,7 @@ describe('useChatWriteActions — regenerate', () => {
         fastMode: false
       })
     )
+    expect(streamOpen.mock.calls[0][0]).not.toHaveProperty('mentionedModelIds')
   })
 })
 

--- a/src/renderer/pages/home/hooks/useChatWriteActions.ts
+++ b/src/renderer/pages/home/hooks/useChatWriteActions.ts
@@ -294,19 +294,19 @@ export function useChatWriteActions(params: Params): Result {
       // Anchor semantics depend on the target role:
       //   - assistant: keep parent user intact, spawn sibling — anchor = parentId
       //   - user:      keep the user itself, spawn assistant child — anchor = target.id
-      // `mentionedModels`: plain retry on an assistant uses the target's
-      // own model (otherwise retrying kimi would produce a gemini reply
-      // when assistant default is gemini). User resend picks the default.
+      // Ordinary regeneration leaves the model unspecified so Main observes the current default.
+      // Failed in-place retries keep their original model; an explicit model always wins.
       const target = messageId ? uiMessages.find((m) => m.id === messageId) : undefined
       const parentAnchorId = target
         ? target.role === 'user'
           ? target.id
           : (target.metadata?.parentId ?? undefined)
         : undefined
-      const regenModelId =
+      const regenerateModelId = options?.modelId
+      const retryModelId =
         target?.role === 'assistant'
-          ? (options?.modelId ?? (target.metadata?.modelId as UniqueModelId | undefined))
-          : options?.modelId
+          ? (regenerateModelId ?? (target.metadata?.modelId as UniqueModelId | undefined))
+          : regenerateModelId
       const turnOptions = options?.turnOptions ?? getInheritedTurnOptions(uiMessages, target)
       const targetStatus = target?.metadata?.status
       const isFailedAssistant =
@@ -316,7 +316,7 @@ export function useChatWriteActions(params: Params): Result {
       const canRetryInPlace =
         isFailedAssistant &&
         parentAnchorId !== undefined &&
-        regenModelId !== undefined &&
+        retryModelId !== undefined &&
         (options?.modelId === undefined || options.modelId === target.metadata?.modelId)
 
       if (canRetryInPlace) {
@@ -325,7 +325,7 @@ export function useChatWriteActions(params: Params): Result {
           topicId: topic.id,
           parentAnchorId,
           retryMessageId: target.id,
-          mentionedModelIds: [regenModelId],
+          mentionedModelIds: [retryModelId],
           ...turnOptionsRequestFields(turnOptions)
         })
         if (ack.mode === 'blocked') throw new Error(getStreamBlockedMessage(ack))
@@ -369,7 +369,7 @@ export function useChatWriteActions(params: Params): Result {
         body: {
           ...capabilityBody,
           ...(parentAnchorId && { parentAnchorId }),
-          ...(regenModelId && { mentionedModels: [regenModelId] }),
+          ...(regenerateModelId && { mentionedModels: [regenerateModelId] }),
           ...turnOptionsRequestFields(turnOptions)
         }
       })


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

After switching the current chat model, ordinary Regenerate still forwarded the source reply's persisted `modelId` as `mentionedModelIds`. Main therefore never resolved the newly selected Assistant/default model, and the new reply continued using the old model.

After this PR:

Ordinary regeneration of a successful response leaves the model selector unspecified, so Main resolves the current Assistant/default model at dispatch time. Failed in-place retries still preserve the failed response's original model, and an explicit per-message `@` model selection remains authoritative.

Fixes #19504

### Why we need it and why it was done in this way

The following tradeoffs were made:

The behavior change is intentionally limited to ordinary successful-response regeneration. Identity-preserving retries for failed, paused, or empty responses retain their original model, while explicit model selection continues through the existing live-group path.

The following alternatives were considered:

- Reading and forwarding the current model from renderer state: rejected because Main already owns the canonical Assistant/default model resolution and can observe the latest persisted selection.
- Removing all source-model reuse: rejected because failed in-place retries must keep the existing row and execution identity on the same model.

Links to places where the discussion took place: #19504 and Discussion #17912

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage distinguishes three adjacent contracts:

- successful ordinary Regenerate does not send an implicit model override;
- failed in-place retry keeps the original model;
- explicit `@` model selection keeps using the selected model.

Validation:

- `pnpm test:renderer src/renderer/pages/home/hooks/__tests__/useChatWriteActions.test.tsx src/renderer/pages/home/__tests__/ChatContent.test.tsx` (52 passed)
- `pnpm test:main src/main/ai/streamManager/context/__tests__/PersistentChatContextProvider.test.ts` (19 passed)
- `pnpm typecheck:web`
- changed-file ESLint and oxlint
- `git diff --check`

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this bug fix
- [x] Self-review: I reviewed the focused diff and all affected model-selection paths before requesting review

### Release note

```release-note
Fix Regenerate continuing to use the previous response model after the current chat model was switched.
```
