### PR TITLE
feat(composer): support editing quote tokens

### DIFF
--- a/src/renderer/components/composer/ComposerTokenNode.tsx
+++ b/src/renderer/components/composer/ComposerTokenNode.tsx
@@ -5,12 +5,14 @@ import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
 import { type ReactNode, useCallback, useLayoutEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { getComposerSerializedTextLength } from './composerDocumentSerializer'
 import { type PromptVariableCommitReason, PromptVariableToken } from './PromptVariableToken'
+import { formatQuoteTokenPromptText } from './quoteToken'
 import type { ActiveComposerInputToken, ComposerDraftToken, PromptVariableComposerInputToken } from './tokens'
-import { normalizeComposerTokenAttrs } from './tokens'
+import { COMPOSER_INPUT_MAX_LENGTH, COMPOSER_TOKEN_NODE_NAME, normalizeComposerTokenAttrs } from './tokens'
 import { ComposerToken, FileComposerToken } from './tokenView'
 
-export const COMPOSER_TOKEN_NODE_NAME = 'composerToken'
+export { COMPOSER_TOKEN_NODE_NAME } from './tokens'
 export const COMPOSER_PROMPT_VARIABLE_EDIT_EVENT = 'composer-prompt-variable-edit'
 
 export interface ComposerPromptVariableEditEventDetail {
@@ -122,6 +124,23 @@ function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTo
       label: value || token.label,
       promptText: value
     })
+  }
+
+  const commitQuoteValue = (value: string) => {
+    if (token.kind !== 'quote') return
+
+    props.updateAttributes({
+      description: value,
+      promptText: formatQuoteTokenPromptText(value)
+    })
+  }
+
+  const getQuoteEditMaxLength = () => {
+    const currentPromptLength = token.kind === 'quote' ? (token.promptText?.length ?? 0) : 0
+    const fixedTextLength = getComposerSerializedTextLength(editor) - currentPromptLength
+    const promptWrapperLength = formatQuoteTokenPromptText('').length
+
+    return Math.max(0, COMPOSER_INPUT_MAX_LENGTH - fixedTextLength - promptWrapperLength)
   }
 
   const selectAdjacentPromptVariableToken = (direction: 1 | -1) => {
@@ -238,6 +257,8 @@ function ComposerTokenNodeView(props: NodeViewProps & { renderToken?: ComposerTo
       <ComposerToken
         token={token as ActiveComposerInputToken}
         selected={props.selected}
+        onEdit={token.kind === 'quote' ? commitQuoteValue : undefined}
+        getEditMaxLength={token.kind === 'quote' ? getQuoteEditMaxLength : undefined}
         onRemove={removeCurrentToken}
         removeLabel={t('common.delete')}
       />

--- a/src/renderer/components/composer/__tests__/QuoteTokenEditing.test.tsx
+++ b/src/renderer/components/composer/__tests__/QuoteTokenEditing.test.tsx
@@ -1,0 +1,250 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Editor, JSONContent } from '@tiptap/core'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { useEffect } from 'react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { COMPOSER_INPUT_MAX_LENGTH, createComposerDraftContent, serializeComposerDocument } from '../composerDraft'
+import { createComposerEditorPreset } from '../composerPreset'
+import { formatQuoteTokenPromptText } from '../quoteToken'
+import type { ComposerSerializedDraft, ComposerSerializedToken } from '../tokens'
+import { ComposerToken } from '../tokenView'
+
+vi.unmock('@cherrystudio/ui')
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  Object.defineProperty(document, 'elementFromPoint', {
+    configurable: true,
+    value: vi.fn(() => document.querySelector('[data-composer-token-kind="quote"]'))
+  })
+})
+
+function createQuoteDraft(content: string, prefix = '', payload?: unknown): ComposerSerializedDraft {
+  const promptText = formatQuoteTokenPromptText(content)
+  const quoteToken: ComposerSerializedToken = {
+    id: 'quote:editable',
+    kind: 'quote',
+    label: 'Quote',
+    description: content,
+    promptText,
+    ...(payload !== undefined && { payload }),
+    index: 0,
+    textOffset: prefix.length
+  }
+
+  return {
+    text: `${prefix}${promptText}`,
+    tokens: [quoteToken]
+  }
+}
+
+function ComposerEditorHarness({
+  draft,
+  content,
+  onEditor
+}: {
+  draft?: ComposerSerializedDraft
+  content?: JSONContent
+  onEditor: (editor: Editor) => void
+}) {
+  const editor = useEditor({
+    extensions: createComposerEditorPreset(),
+    content: content ?? createComposerDraftContent(draft ?? { text: '', tokens: [] })
+  })
+
+  useEffect(() => {
+    if (editor) onEditor(editor)
+  }, [editor, onEditor])
+
+  return <EditorContent editor={editor} />
+}
+
+describe('quote token editing', () => {
+  it('edits the complete quote and updates its serialized prompt atomically', async () => {
+    const user = userEvent.setup()
+    const payload = { sourceMessageId: 'message-1' }
+    let editor: Editor | null = null
+    render(
+      <ComposerEditorHarness
+        draft={createQuoteDraft('First line\nSecond line', '', payload)}
+        onEditor={(nextEditor) => (editor = nextEditor)}
+      />
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'common.edit Quote' }))
+    const input = await screen.findByRole('textbox', { name: 'Quote' })
+    expect(input).toHaveValue('First line\nSecond line')
+
+    await user.clear(input)
+    await user.type(input, 'Updated first line{Enter}Updated second line')
+    await user.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      const serialized = serializeComposerDocument(editor!)
+      expect(serialized.text).toBe('<blockquote>\n\nUpdated first line\nUpdated second line\n</blockquote>')
+      expect(serialized.tokens).toEqual([
+        expect.objectContaining({
+          id: 'quote:editable',
+          description: 'Updated first line\nUpdated second line',
+          promptText: '<blockquote>\n\nUpdated first line\nUpdated second line\n</blockquote>',
+          payload
+        })
+      ])
+    })
+
+    await user.click(screen.getByRole('button', { name: 'common.edit Quote' }))
+    expect(await screen.findByRole('textbox', { name: 'Quote' })).toHaveValue('Updated first line\nUpdated second line')
+  })
+
+  it('opens from the keyboard and discards both cancelled and escaped drafts', async () => {
+    const user = userEvent.setup()
+    const originalDraft = createQuoteDraft('Keep this quote')
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness draft={originalDraft} onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    const editButton = await screen.findByRole('button', { name: 'common.edit Quote' })
+    act(() => editButton.focus())
+    await user.keyboard('{Enter}')
+    let input = await screen.findByRole('textbox', { name: 'Quote' })
+    await user.clear(input)
+    await user.type(input, 'Discard with cancel')
+    await user.click(screen.getByRole('button', { name: 'common.cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(serializeComposerDocument(editor!).text).toBe(originalDraft.text)
+
+    act(() => editButton.focus())
+    await user.keyboard(' ')
+    input = await screen.findByRole('textbox', { name: 'Quote' })
+    await user.clear(input)
+    await user.type(input, 'Discard with escape')
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(serializeComposerDocument(editor!).text).toBe(originalDraft.text)
+  })
+
+  it('limits edited quote content to the remaining composer capacity and rejects blank content', async () => {
+    const user = userEvent.setup()
+    const allowedQuoteCharacters = 5
+    const wrapperLength = formatQuoteTokenPromptText('').length
+    const prefix = 'x'.repeat(COMPOSER_INPUT_MAX_LENGTH - wrapperLength - allowedQuoteCharacters)
+    let editor: Editor | null = null
+    render(
+      <ComposerEditorHarness draft={createQuoteDraft('old', prefix)} onEditor={(nextEditor) => (editor = nextEditor)} />
+    )
+
+    await user.click(await screen.findByRole('button', { name: 'common.edit Quote' }))
+    const input = await screen.findByRole('textbox', { name: 'Quote' })
+    const saveButton = screen.getByRole('button', { name: 'common.save' })
+    await user.clear(input)
+    expect(saveButton).toBeDisabled()
+
+    await user.type(input, '123456')
+    expect(input).toHaveValue('12345')
+    expect(saveButton).toBeEnabled()
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      const serialized = serializeComposerDocument(editor!)
+      expect(serialized.text).toHaveLength(COMPOSER_INPUT_MAX_LENGTH)
+      expect(serialized.tokens[0]).toEqual(expect.objectContaining({ description: '12345' }))
+    })
+  })
+
+  it('counts top-level block separators and a restored CRLF suffix at the exact composer boundary', async () => {
+    const user = userEvent.setup()
+    const allowedQuoteCharacters = 5
+    const wrapperLength = formatQuoteTokenPromptText('').length
+    const prefixLength = COMPOSER_INPUT_MAX_LENGTH - wrapperLength - allowedQuoteCharacters - 3
+    const firstParagraph = 'x'
+    const secondParagraph = 'x'.repeat(prefixLength - firstParagraph.length)
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: firstParagraph }] },
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: secondParagraph },
+            {
+              type: 'composerToken',
+              attrs: {
+                id: 'quote:boundary',
+                kind: 'quote',
+                label: 'Quote',
+                description: 'old',
+                promptText: formatQuoteTokenPromptText('old'),
+                payload: { restoredTextSuffix: '\r\n', sourceMessageId: 'message-boundary' }
+              }
+            }
+          ]
+        }
+      ]
+    }
+    let editor: Editor | null = null
+    render(<ComposerEditorHarness content={content} onEditor={(nextEditor) => (editor = nextEditor)} />)
+
+    await user.click(await screen.findByRole('button', { name: 'common.edit Quote' }))
+    const input = await screen.findByRole('textbox', { name: 'Quote' })
+    await user.clear(input)
+    await user.type(input, '123456')
+    expect(input).toHaveValue('12345')
+    await user.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      const serialized = serializeComposerDocument(editor!)
+      expect(serialized.text).toHaveLength(COMPOSER_INPUT_MAX_LENGTH)
+      expect(serialized.text).toBe(`${firstParagraph}\n${secondParagraph}${formatQuoteTokenPromptText('12345')}\r\n`)
+      expect(serialized.tokens[0]).toEqual(
+        expect.objectContaining({
+          id: 'quote:boundary',
+          description: '12345',
+          payload: { restoredTextSuffix: '\r\n', sourceMessageId: 'message-boundary' }
+        })
+      )
+    })
+  })
+
+  it('keeps sent quotes read-only and does not open the editor from the remove action', async () => {
+    const user = userEvent.setup()
+    let editor: Editor | null = null
+    const { rerender } = render(
+      <ComposerEditorHarness draft={createQuoteDraft('Remove me')} onEditor={(nextEditor) => (editor = nextEditor)} />
+    )
+
+    const editButton = await screen.findByRole('button', { name: 'common.edit Quote' })
+    const removeButton = screen.getByRole('button', { name: 'common.delete' })
+    expect(editButton.tagName).toBe('BUTTON')
+    expect(removeButton.tagName).toBe('BUTTON')
+    expect(editButton.parentElement).toBe(removeButton.parentElement)
+    expect(editButton).not.toContainElement(removeButton)
+
+    act(() => editButton.focus())
+    expect(editButton).toHaveFocus()
+    await user.keyboard('{Enter}')
+    await screen.findByRole('dialog')
+    await user.click(screen.getByRole('button', { name: 'common.cancel' }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    act(() => removeButton.focus())
+    expect(removeButton).toHaveFocus()
+    await user.keyboard('{Enter}')
+    await waitFor(() => expect(serializeComposerDocument(editor!).tokens).toEqual([]))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+    rerender(
+      <ComposerToken readOnly token={{ id: 'quote:sent', kind: 'quote', label: 'Quote', description: 'Sent quote' }} />
+    )
+    expect(screen.queryByRole('button', { name: 'common.edit Quote' })).not.toBeInTheDocument()
+    expect(screen.getByText('Quote')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/composer/composerDocumentSerializer.ts
+++ b/src/renderer/components/composer/composerDocumentSerializer.ts
@@ -1,0 +1,69 @@
+import type { Editor, JSONContent } from '@tiptap/core'
+
+import type { ComposerSerializedDraft, ComposerSerializedToken } from './tokens'
+import { COMPOSER_TOKEN_NODE_NAME, normalizeComposerTokenAttrs } from './tokens'
+
+type ComposerSerializableSource = Pick<Editor, 'getJSON'> | JSONContent
+
+function isEditorSource(source: ComposerSerializableSource): source is Pick<Editor, 'getJSON'> {
+  return typeof (source as Pick<Editor, 'getJSON'>).getJSON === 'function'
+}
+
+function getRestoredTextSuffix(payload: unknown): string {
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return ''
+
+  const restoredTextSuffix = (payload as Record<string, unknown>).restoredTextSuffix
+  return typeof restoredTextSuffix === 'string' ? restoredTextSuffix : ''
+}
+
+export function serializeComposerDocument(source: ComposerSerializableSource): ComposerSerializedDraft {
+  const json = isEditorSource(source) ? source.getJSON() : source
+  const tokens: ComposerSerializedToken[] = []
+  let text = ''
+
+  const visitNode = (node: JSONContent) => {
+    if (node.type === 'text') {
+      text += node.text ?? ''
+      return
+    }
+
+    if (node.type === 'hardBreak') {
+      text += '\n'
+      return
+    }
+
+    if (node.type === COMPOSER_TOKEN_NODE_NAME) {
+      const token = normalizeComposerTokenAttrs(node.attrs ?? {})
+      const restoredTextSuffix = getRestoredTextSuffix(token.payload)
+      tokens.push({
+        ...token,
+        index: tokens.length,
+        textOffset: text.length
+      })
+      text += token.promptText ?? ''
+      text += restoredTextSuffix
+      return
+    }
+
+    if (!node.content?.length) return
+
+    if (node.type === 'doc') {
+      node.content.forEach((child, index) => {
+        if (index > 0) text += '\n'
+        visitNode(child)
+      })
+      return
+    }
+
+    node.content.forEach(visitNode)
+  }
+
+  visitNode(json)
+
+  return { text, tokens }
+}
+
+/** Mirrors the serialized draft exactly, including block separators and restored token suffixes. */
+export function getComposerSerializedTextLength(source: ComposerSerializableSource): number {
+  return serializeComposerDocument(source).text.length
+}

--- a/src/renderer/components/composer/composerDraft.ts
+++ b/src/renderer/components/composer/composerDraft.ts
@@ -7,25 +7,19 @@ import type {
   ComposerMessageTokenPayload
 } from '@shared/data/types/uiParts'
 import { FileTypeSchema } from '@shared/types/file'
-import type { Editor, JSONContent } from '@tiptap/core'
+import type { JSONContent } from '@tiptap/core'
 
-import { COMPOSER_TOKEN_NODE_NAME } from './ComposerTokenNode'
 import { createPromptVariableContent } from './promptVariables'
 import type { ComposerDraftToken, ComposerSerializedDraft, ComposerSerializedToken } from './tokens'
-import { normalizeComposerTokenAttrs } from './tokens'
+import { COMPOSER_TOKEN_NODE_NAME } from './tokens'
+
+export { getComposerSerializedTextLength, serializeComposerDocument } from './composerDocumentSerializer'
+export { COMPOSER_INPUT_MAX_LENGTH } from './tokens'
 
 const COMPOSER_MESSAGE_SNAPSHOT_VERSION = 1
 
-/** Upper bound on a serialized draft's text — enforced by every path that grows the composer. */
-export const COMPOSER_INPUT_MAX_LENGTH = 40000
-
-type ComposerSerializableSource = Pick<Editor, 'getJSON'> | JSONContent
 type PersistedComposerSerializedToken = ComposerSerializedToken & {
   kind: ComposerMessageToken['kind']
-}
-
-function isEditorSource(source: ComposerSerializableSource): source is Pick<Editor, 'getJSON'> {
-  return typeof (source as Pick<Editor, 'getJSON'>).getJSON === 'function'
 }
 
 function appendTextContent(nodes: JSONContent[], text: string) {
@@ -33,13 +27,6 @@ function appendTextContent(nodes: JSONContent[], text: string) {
     if (index > 0) nodes.push({ type: 'hardBreak' })
     if (line) nodes.push({ type: 'text', text: line })
   })
-}
-
-function getRestoredTextSuffix(payload: unknown): string {
-  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) return ''
-
-  const restoredTextSuffix = (payload as Record<string, unknown>).restoredTextSuffix
-  return typeof restoredTextSuffix === 'string' ? restoredTextSuffix : ''
 }
 
 function readPayloadObject(payload: unknown): Record<string, unknown> | undefined {
@@ -167,53 +154,6 @@ export function createComposerDraftContent(draft: {
   if (!inputTokens.length) return createPromptVariableContent(draft.text)
 
   return createComposerContent(draft.text, inputTokens, isComposerInputTokenKind)
-}
-
-export function serializeComposerDocument(source: ComposerSerializableSource): ComposerSerializedDraft {
-  const json = isEditorSource(source) ? source.getJSON() : source
-  const tokens: ComposerSerializedToken[] = []
-  let text = ''
-
-  const visitNode = (node: JSONContent) => {
-    if (node.type === 'text') {
-      text += node.text ?? ''
-      return
-    }
-
-    if (node.type === 'hardBreak') {
-      text += '\n'
-      return
-    }
-
-    if (node.type === COMPOSER_TOKEN_NODE_NAME) {
-      const token = normalizeComposerTokenAttrs(node.attrs ?? {})
-      const restoredTextSuffix = getRestoredTextSuffix(token.payload)
-      tokens.push({
-        ...token,
-        index: tokens.length,
-        textOffset: text.length
-      })
-      text += token.promptText ?? ''
-      text += restoredTextSuffix
-      return
-    }
-
-    if (!node.content?.length) return
-
-    if (node.type === 'doc') {
-      node.content.forEach((child, index) => {
-        if (index > 0) text += '\n'
-        visitNode(child)
-      })
-      return
-    }
-
-    node.content.forEach(visitNode)
-  }
-
-  visitNode(json)
-
-  return { text, tokens }
 }
 
 /**

--- a/src/renderer/components/composer/tokenView/ComposerToken.tsx
+++ b/src/renderer/components/composer/tokenView/ComposerToken.tsx
@@ -21,9 +21,11 @@ import {
   type ComponentType,
   type FocusEvent as ReactFocusEvent,
   type KeyboardEvent as ReactKeyboardEvent,
+  lazy,
   type MouseEvent as ReactMouseEvent,
   type MouseEventHandler,
   type ReactNode,
+  Suspense,
   useCallback,
   useEffect,
   useRef,
@@ -34,6 +36,8 @@ import { useTranslation } from 'react-i18next'
 import type { ChatInputTokenKind, ChatTokenView } from '../chatTokenView'
 import { parseComposerLink } from '../linkToken'
 import { type FileTokenPresentation, getFileTokenPresentation } from './fileTokenPresentation'
+
+const QuoteTokenEditDialog = lazy(() => import('./QuoteTokenEditDialog'))
 
 const tokenIconClassName = 'size-[1em] shrink-0 text-current opacity-80'
 const tokenRemoveIconClassName = 'size-[0.95em] shrink-0 text-current'
@@ -70,6 +74,8 @@ export interface ComposerTokenProps {
   children?: ReactNode
   maxWidthClassName?: string
   onMouseDown?: MouseEventHandler<HTMLSpanElement>
+  onEdit?: (content: string) => void
+  getEditMaxLength?: () => number
   onRemove?: () => void
   removeLabel?: string
 }
@@ -102,11 +108,13 @@ interface ActiveComposerTokenProps extends ComposerTokenProps {
 function InlineTokenRemoveButton({
   label,
   onRemove,
+  overlay = true,
   className,
   iconClassName
 }: {
   label: string
   onRemove: () => void
+  overlay?: boolean
   className?: string
   iconClassName?: string
 }) {
@@ -122,7 +130,8 @@ function InlineTokenRemoveButton({
       title={label}
       data-composer-token-remove=""
       className={cn(
-        'pointer-events-none absolute inset-0 inline-flex items-center justify-center border-0 bg-transparent p-0 text-current leading-none opacity-0 outline-none transition-opacity',
+        'pointer-events-none inline-flex items-center justify-center border-0 bg-transparent p-0 text-current leading-none opacity-0 outline-none transition-opacity',
+        overlay && 'absolute inset-0',
         'hover:opacity-100',
         'focus-visible:pointer-events-auto focus-visible:opacity-100',
         'group-focus-within/composer-token:pointer-events-auto group-focus-within/composer-token:opacity-100 group-hover/composer-token:pointer-events-auto group-hover/composer-token:opacity-100',
@@ -941,12 +950,67 @@ export function ReferenceComposerToken(props: ComposerTokenProps) {
 }
 
 export function QuoteComposerToken(props: ComposerTokenProps) {
+  const { t } = useTranslation()
+  const [editDialogOpen, setEditDialogOpen] = useState(false)
+  const [editDialogLoaded, setEditDialogLoaded] = useState(false)
+  const [editMaxLength, setEditMaxLength] = useState(0)
   const quoteTooltipContent = getQuoteTooltipContent(props.token.description, props.token.promptText)
-  const tokenElement = renderActiveComposerTokenElement({ ...props, icon: tokenIconByKind.quote })
+  const canEdit = !props.readOnly && Boolean(quoteTooltipContent && props.onEdit && props.getEditMaxLength)
+  const editLabel = `${t('common.edit')} ${props.token.label}`
 
-  if (!quoteTooltipContent) return tokenElement
+  const openEditor = () => {
+    if (!canEdit || !props.getEditMaxLength) return
+    setEditMaxLength(props.getEditMaxLength())
+    setEditDialogLoaded(true)
+    setEditDialogOpen(true)
+  }
 
-  return (
+  const handleEditClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    stopTokenActionEvent(event)
+    openEditor()
+  }
+  const handleEditKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    event.stopPropagation()
+    openEditor()
+  }
+
+  const tokenElement = canEdit ? (
+    <span
+      className={cn(
+        'group/composer-token relative mx-0.5 inline-flex max-w-[calc(100%_-_0.25rem)] select-none items-baseline align-baseline text-primary leading-[inherit]',
+        props.selected && 'text-primary underline decoration-primary/40 underline-offset-2',
+        props.className
+      )}
+      data-composer-token-kind={props.token.kind}
+      onMouseDown={props.onMouseDown}>
+      <button
+        type="button"
+        className="inline-flex min-w-0 max-w-full cursor-pointer appearance-none items-baseline gap-1 rounded-[4px] border-0 bg-transparent p-0 text-current leading-[inherit] [font:inherit] focus-visible:bg-accent focus-visible:outline-none"
+        aria-label={editLabel}
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={handleEditClick}
+        onKeyDown={handleEditKeyDown}>
+        <span className="inline-flex shrink-0 translate-y-[0.08em] items-baseline text-current leading-[inherit] transition-opacity group-focus-within/composer-token:opacity-0 group-hover/composer-token:opacity-0">
+          {props.token.icon ? props.token.icon : tokenIconByKind.quote}
+        </span>
+        {props.children ?? <span className="min-w-0 truncate">{props.token.label}</span>}
+      </button>
+      {props.onRemove && (
+        <InlineTokenRemoveButton
+          label={props.removeLabel ?? 'Remove'}
+          onRemove={props.onRemove}
+          overlay={false}
+          className="absolute top-[0.08em] left-0 size-[1em] rounded-[4px]"
+        />
+      )}
+    </span>
+  ) : (
+    renderActiveComposerTokenElement({ ...props, icon: tokenIconByKind.quote })
+  )
+
+  const previewElement = quoteTooltipContent ? (
     <NormalTooltip
       content={<div className={QUOTE_TOOLTIP_BODY_CLASS_NAME}>{quoteTooltipContent}</div>}
       side="top"
@@ -957,6 +1021,31 @@ export function QuoteComposerToken(props: ComposerTokenProps) {
       triggerProps={props.readOnly ? { tabIndex: 0, 'aria-label': props.token.label } : undefined}>
       {tokenElement}
     </NormalTooltip>
+  ) : (
+    tokenElement
+  )
+
+  const handleSave = (content: string) => {
+    props.onEdit?.(content)
+    setEditDialogOpen(false)
+  }
+
+  return (
+    <>
+      {previewElement}
+      {editDialogLoaded && quoteTooltipContent !== undefined && (
+        <Suspense fallback={null}>
+          <QuoteTokenEditDialog
+            content={quoteTooltipContent}
+            label={props.token.label}
+            maxLength={editMaxLength}
+            open={editDialogOpen}
+            onCancel={() => setEditDialogOpen(false)}
+            onSave={handleSave}
+          />
+        </Suspense>
+      )}
+    </>
   )
 }
 

--- a/src/renderer/components/composer/tokenView/QuoteTokenEditDialog.tsx
+++ b/src/renderer/components/composer/tokenView/QuoteTokenEditDialog.tsx
@@ -1,0 +1,70 @@
+import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, Textarea } from '@cherrystudio/ui'
+import { type FormEvent, useEffect, useId, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+interface QuoteTokenEditDialogProps {
+  content: string
+  label: string
+  maxLength: number
+  open: boolean
+  onCancel: () => void
+  onSave: (content: string) => void
+}
+
+export default function QuoteTokenEditDialog({
+  content,
+  label,
+  maxLength,
+  open,
+  onCancel,
+  onSave
+}: QuoteTokenEditDialogProps) {
+  const { t } = useTranslation()
+  const inputId = useId()
+  const [value, setValue] = useState(content)
+  const canSave = value.trim().length > 0 && value.length <= maxLength
+
+  useEffect(() => {
+    if (open) setValue(content)
+  }, [content, open])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!canSave) return
+    onSave(value)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onCancel()}>
+      <DialogContent aria-describedby={undefined} closeOnOverlayClick={false} size="lg">
+        <form className="flex min-h-0 flex-col gap-4" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>
+              {t('common.edit')} {label}
+            </DialogTitle>
+          </DialogHeader>
+          <label className="sr-only" htmlFor={inputId}>
+            {label}
+          </label>
+          <Textarea.Input
+            id={inputId}
+            autoFocus
+            rows={10}
+            maxLength={maxLength}
+            value={value}
+            className="max-h-[60vh] min-h-48 w-full resize-y"
+            onChange={(event) => setValue(event.target.value)}
+          />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onCancel}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" variant="emphasis" disabled={!canSave}>
+              {t('common.save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/composer/tokens.ts
+++ b/src/renderer/components/composer/tokens.ts
@@ -9,6 +9,9 @@ import {
 
 export const COMPOSER_DRAFT_TOKEN_KINDS = COMPOSER_TOKEN_KINDS
 
+export const COMPOSER_TOKEN_NODE_NAME = 'composerToken'
+export const COMPOSER_INPUT_MAX_LENGTH = 40000
+
 export type ComposerDraftTokenKind = ComposerTokenKind
 
 export const ACTIVE_COMPOSER_INPUT_TOKEN_KINDS = COMPOSER_INPUT_TOKEN_KINDS


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Quote tokens in the composer only exposed a four-line hover preview. Longer quoted text could not be inspected in full or corrected before sending.

After this PR:

Editable quote tokens open an accessible multiline dialog from click, Enter, or Space. Saving atomically updates both the visible quote description and the blockquote text sent to the model. Sent/read-only quotes remain preview-only, and removing a token stays an independent action.

Fixes #19472

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Editing uses an in-app dialog rather than a new window, keeping focus, cancellation, and keyboard behavior inside the composer.
- The dialog is loaded only on first use.
- Edit and remove are separate sibling buttons so neither action hides the other from keyboard or assistive-technology users.
- The existing serializer was extracted without behavior changes and reused for capacity calculation. This keeps the 40,000-character limit exact for multi-block documents and restored quote suffixes instead of maintaining a second approximate counter.

The following alternatives were considered:

- Expanding the hover tooltip: rejected because it still would not provide a reliable multiline editing surface.
- Updating only `description`: rejected because the model would continue receiving the stale `promptText`.
- Estimating remaining capacity from visible text nodes: rejected because it misses serialized block separators and restored token suffixes.

Links to places where the discussion took place: #19472

### Breaking changes

None.

### Special notes for your reviewer

Regression coverage verifies:

- full multiline editing and canonical blockquote serialization;
- atomic `description` / `promptText` updates while preserving token identity and payload;
- save, cancel, Escape, Enter, Space, and reopen behavior;
- exact 40,000-character boundaries with multiple paragraphs and a restored CRLF suffix;
- independent keyboard focus and activation for edit and remove;
- read-only quotes remaining non-editable.

Validation:

- focused renderer tests: 80 passed
- `pnpm typecheck:web`
- changed-file ESLint and oxlint
- Biome check
- `git diff --check`

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is not required for this focused composer enhancement
- [x] Self-review: I reviewed the focused diff, serializer compatibility, accessibility structure, and boundary behavior before requesting review

### Release note

```release-note
Allow quoted composer content to be viewed in full and edited before sending.
```
