### PR TITLE
fix(aicore): forward proxy fetch for azure-anthropic variant

### DIFF
--- a/.changeset/aicore-azure-anthropic-fetch.md
+++ b/.changeset/aicore-azure-anthropic-fetch.md
@@ -2,4 +2,4 @@
 '@cherrystudio/ai-core': patch
 ---
 
-Forward the caller-injected `fetch` in the `azure-anthropic` provider variant. The variant rebuilds the Anthropic provider via `createAnthropic(...)` from a curated subset of settings and previously dropped `fetch`, so a custom fetch (e.g. a proxy-aware implementation) injected at the provider-config layer was silently lost for Azure Claude requests.
+Forward the caller-injected `fetch` in the `azure-anthropic` provider variant. The variant rebuilds the Anthropic provider via `createAnthropic(...)` from a curated subset of settings and previously dropped `fetch`, so a custom fetch (e.g. a proxy-aware implementation) injected at the provider-config layer was silently lost for Azure Claude requests. This restores proxy support for third-party APIs behind a proxy/VPN (e.g. yunwu.ai) when routed through the Azure Anthropic path — fixes #18633.


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The `azure-anthropic` provider variant in `packages/aiCore/src/core/providers/core/initialization.ts` rebuilds the Anthropic provider via `createAnthropic(...)` from a curated subset of `settings` (`baseURL`, `apiKey`, `headers`) and silently dropped `fetch`. A proxy-aware `customFetch` (Electron `net.fetch` via `src/main/ai/utils/customFetch.ts`, injected at `src/main/ai/provider/config.ts` as `providerSettings.fetch ??= customFetch`) was therefore lost for Azure Claude requests. Third-party APIs requiring a proxy/VPN (e.g. `yunwu.ai`) timed out with `ERR_CONNECTION_TIMED_OUT` when routed through this variant.

After this PR:

Forwards `fetch: settings?.fetch` in the `azure-anthropic` variant's `createAnthropic` call so the caller-injected proxy-aware fetch is preserved. Added regression test `packages/aiCore/src/core/providers/__tests__/coreExtensionsFetch.test.ts`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #18633

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Minimal single-line fix (`fetch: settings?.fetch`) instead of spreading all `settings` — keeps the variant's explicit allow-list and avoids forwarding unrelated keys.
- `fetch` is passed as `undefined` when not injected; `createAnthropic` falls back to its default, so no behavior change for non-proxied setups.

The following alternatives were considered:

- Spreading `...settings` into `createAnthropic` — rejected, would forward internal keys beyond the SDK's typed `AnthropicProviderSettings`.
- Fixing at `providerToAiSdkConfig` only — insufficient, the variant rebuilds the provider downstream of that layer.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18633

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

- Code change in `packages/aiCore/src/core/providers/core/initialization.ts:122` already present on `main` since `16ebe2443c`; this branch updates the changeset to link the fix to #18633 for release notes.
- Verify with `pnpm exec vitest run packages/aiCore/src/core/providers/__tests__/coreExtensionsFetch.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed `ERR_CONNECTION_TIMED_OUT` for third-party APIs requiring a proxy/VPN (e.g. `yunwu.ai`) when using Azure-hosted Claude models. The `azure-anthropic` provider variant now correctly forwards the proxy-aware `fetch` implementation.
```
