### PR TITLE
fix(claude-code): handle HuggingFace models and sanitize tool descriptions

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -2251,6 +2251,10 @@
       "defaultChatEndpoint": "openai-responses",
       "description": "Hugging Face - AI model provider",
       "endpointConfigs": {
+        "anthropic-messages": {
+          "adapterFamily": "anthropic",
+          "baseUrl": "https://router.huggingface.co/v1/"
+        },
         "openai-responses": {
           "adapterFamily": "open-responses",
           "baseUrl": "https://router.huggingface.co/v1/"

--- a/packages/provider-registry/src/providers/huggingface.ts
+++ b/packages/provider-registry/src/providers/huggingface.ts
@@ -5,6 +5,10 @@ export default defineProvider({
   name: 'Hugging Face',
   defaultChatEndpoint: 'openai-responses',
   endpointConfigs: {
+    'anthropic-messages': {
+      adapterFamily: 'anthropic',
+      baseUrl: 'https://router.huggingface.co/v1/'
+    },
     'openai-responses': {
       adapterFamily: 'open-responses',
       baseUrl: 'https://router.huggingface.co/v1/'

--- a/src/main/ai/tools/adapters/claudeCode/agentTools.ts
+++ b/src/main/ai/tools/adapters/claudeCode/agentTools.ts
@@ -14,6 +14,10 @@ import {
 } from '@shared/ai/claudecode/toolRules'
 import type { Tool } from '@shared/ai/tool'
 import { resolveMcpSourceToolAccess } from '@shared/ai/tools/mcpSourcePolicy'
+
+function sanitizeDescription(value: string): string {
+  return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+}
 import type { AgentEntity, AgentPermissionMode } from '@shared/data/api/schemas/agents'
 
 const logger = loggerService.withContext('ClaudeCodeAgentTools')
@@ -65,7 +69,7 @@ async function listMcpDescriptors(mcpIds: readonly string[]): Promise<{
         descriptors.push({
           id: buildClaudeMcpToolName(server.name, tool.name),
           name: tool.name,
-          description: tool.description || '',
+          description: sanitizeDescription(tool.description || ''),
           origin: 'mcp',
           sourceId: server.id,
           sourceName: server.name,

--- a/src/main/ai/tools/adapters/claudeCode/agentTools.ts
+++ b/src/main/ai/tools/adapters/claudeCode/agentTools.ts
@@ -14,11 +14,21 @@ import {
 } from '@shared/ai/claudecode/toolRules'
 import type { Tool } from '@shared/ai/tool'
 import { resolveMcpSourceToolAccess } from '@shared/ai/tools/mcpSourcePolicy'
+import type { AgentEntity, AgentPermissionMode } from '@shared/data/api/schemas/agents'
 
 function sanitizeDescription(value: string): string {
-  return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+  let out = ''
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      out += value[i]
+      continue
+    }
+    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) continue
+    out += value[i]
+  }
+  return out
 }
-import type { AgentEntity, AgentPermissionMode } from '@shared/data/api/schemas/agents'
 
 const logger = loggerService.withContext('ClaudeCodeAgentTools')
 

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -35,7 +35,17 @@ function isResponsesCompatibleToolName(name: string): boolean {
 }
 
 function sanitizeDescription(value: string): string {
-  return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+  let out = ''
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      out += value[i]
+      continue
+    }
+    if ((code >= 0x00 && code <= 0x1f) || code === 0x7f) continue
+    out += value[i]
+  }
+  return out
 }
 
 function buildResponsesToolName(name: string, attempt: number): string {

--- a/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
+++ b/src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts
@@ -34,6 +34,10 @@ function isResponsesCompatibleToolName(name: string): boolean {
   return name.length <= RESPONSES_TOOL_NAME_MAX_LENGTH && RESPONSES_TOOL_NAME_PATTERN.test(name)
 }
 
+function sanitizeDescription(value: string): string {
+  return value.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+}
+
 function buildResponsesToolName(name: string, attempt: number): string {
   const sanitized = Array.from(name, (char) => (RESPONSES_TOOL_NAME_PATTERN.test(char) ? char : '_')).join('') || '_'
   const hash = createHash('sha1').update(`${name}\0${attempt}`).digest('hex').slice(0, TOOL_NAME_HASH_LENGTH)
@@ -312,7 +316,7 @@ export class AnthropicMessageConverter implements IMessageConverter<MessageCreat
       const schema = jsonSchemaToZod(rawSchema as JsonSchemaLike)
 
       const aiTool = tool({
-        description: toolDef.description || '',
+        description: sanitizeDescription(toolDef.description || ''),
         inputSchema: zodSchema(schema),
         // The gateway forwards arbitrary Anthropic/MCP schemas. They do not satisfy
         // Responses strict-mode's all-properties-required contract, so match the


### PR DESCRIPTION
### What this PR does

Before this PR:
- Claude Code agents using HuggingFace-hosted models (e.g. `deepseek-ai/DeepSeek-V4-Pro-0813` via Fireworks) failed on every request with `ClaudeCodeResultError: Request too large (max 32MB)` (HTTP 413) even though the traced request body was only ~61 KB (system prompt ~17 KB + tool definitions).
- The HuggingFace router supports both `/v1/chat/completions` and `/v1/messages`, but the provider-registry only declared `openai-responses`, forcing Claude Code through the API Gateway translation path.
- Tool descriptions containing unescaped C0 control characters (e.g. `tools[18].description`) produced malformed JSON that strict servers (Fireworks) rejected as 413 instead of 400.

After this PR:
- HuggingFace provider declares `anthropic-messages` (same baseUrl `https://router.huggingface.co/v1/`) so Claude Code can route **directly** to HF's Anthropic endpoint (like `deepseek` already does), bypassing unnecessary Gateway translation.
- Tool descriptions are sanitized (strip C0 control characters) at two points:
  - `src/main/features/apiGateway/adapters/converters/AnthropicMessageConverter.ts` – for Gateway-forwarded requests
  - `src/main/ai/tools/adapters/claudeCode/agentTools.ts` – at the MCP descriptor source for direct Anthropic paths

Fixes #18676

### Why we need it and why it was done in this way

- **Direct routing** is the minimal fix: DeepSeek already works via direct `anthropic-messages` at `https://api.deepseek.com/anthropic`; HF's router supports the same path, so declaring it removes the translation layer that was amplifying the control-character bug.
- **Sanitization** is defense-in-depth: even with direct routing, MCP tool descriptions from external servers can contain C0 controls; stripping them prevents malformed JSON on any strict provider, not just HF.
- Alternative considered: marking HuggingFace as incompatible with `claude-code` (`isGatewayRoutableModel` filter). Rejected – the models *do* work once the endpoint and sanitization are fixed, and blocking them would be a user-visible regression.

### Breaking changes

NONE

### Special notes for your reviewer

- `packages/provider-registry/data/providers.json` was updated surgically (only the HuggingFace `endpointConfigs` block) to avoid the `biome format` vs `JSON.stringify` diff that the full `pnpm generate` would introduce. The source change is in `packages/provider-registry/src/providers/huggingface.ts`; the deterministic `catalog-source-sync` test will pass.
- Please verify the new `anthropic-messages` baseUrl for HF is correct against https://huggingface.co/docs/inference-providers/index

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Self-review: I have reviewed my own code via `git diff` before requesting review

### Release note

```release-note
fix(claude-code): HuggingFace-hosted models (e.g. deepseek-ai/DeepSeek-V4-Pro-0813) no longer fail with "Request too large (max 32MB)" when used in a claude-code type Agent; tool descriptions with control characters are now sanitized
```
