### PR TITLE
fix(appearance): name the list position controls for assistive technology

### DIFF
--- a/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
@@ -451,6 +451,7 @@ const AppearanceSettings: FC = () => {
             value={topicListPosition}
             onValueChange={setTopicListPosition}
             options={listPositionOptions}
+            aria-label={t('settings.display.list_position.chat')}
             size="sm"
           />
         </SettingRow>
@@ -461,6 +462,7 @@ const AppearanceSettings: FC = () => {
             value={sessionListPosition}
             onValueChange={setSessionListPosition}
             options={listPositionOptions}
+            aria-label={t('settings.display.list_position.work')}
             size="sm"
           />
         </SettingRow>

--- a/src/renderer/pages/settings/AppearanceSettings/__tests__/AppearanceSettings.test.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/__tests__/AppearanceSettings.test.tsx
@@ -90,17 +90,20 @@ vi.mock('@cherrystudio/ui', async () => {
     PopoverTrigger: ({ children, asChild }: any) =>
       asChild && React.isValidElement(children) ? children : React.createElement('div', null, children),
     RowFlex: passthrough('div'),
-    SegmentedControl: ({ options = [], value, onValueChange }: any) =>
+    // Mirrors the real control's radiogroup/radio semantics so tests address it the way
+    // assistive technology does, rather than through whatever DOM the mock happens to emit.
+    SegmentedControl: ({ options = [], value, onValueChange, ...props }: any) =>
       React.createElement(
         'div',
-        null,
+        { 'aria-label': props['aria-label'], role: 'radiogroup' },
         options.map((option: any) =>
           React.createElement(
             'button',
             {
-              'aria-pressed': value === option.value,
+              'aria-checked': value === option.value,
               key: option.value,
               onClick: () => onValueChange?.(option.value),
+              role: 'radio',
               type: 'button'
             },
             option.label
@@ -362,16 +365,16 @@ describe('AppearanceSettings selectors', () => {
 
     render(<AppearanceSettings />)
 
-    const chatRow = screen.getByText('settings.display.list_position.chat').parentElement as HTMLElement
-    fireEvent.click(within(chatRow).getByRole('button', { name: 'settings.topic.position.right' }))
+    const chatGroup = screen.getByRole('radiogroup', { name: 'settings.display.list_position.chat' })
+    fireEvent.click(within(chatGroup).getByRole('radio', { name: 'settings.topic.position.right' }))
 
     await waitFor(() => {
       expect(MockUsePreferenceUtils.getPreferenceValue('topic.tab.position')).toBe('right')
     })
     expect(MockUsePreferenceUtils.getPreferenceValue('agent.session.position')).toBe('left')
 
-    const workRow = screen.getByText('settings.display.list_position.work').parentElement as HTMLElement
-    fireEvent.click(within(workRow).getByRole('button', { name: 'settings.topic.position.right' }))
+    const workGroup = screen.getByRole('radiogroup', { name: 'settings.display.list_position.work' })
+    fireEvent.click(within(workGroup).getByRole('radio', { name: 'settings.topic.position.right' }))
 
     await waitFor(() => {
       expect(MockUsePreferenceUtils.getPreferenceValue('agent.session.position')).toBe('right')


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Follow-up to #19200, which merged with two review warnings unaddressed.

Before this PR: the two list-position rows in Settings → Appearance render `radiogroup`s with no accessible name. A screen reader announces both as the same bare "Left / Right" pair, so there is nothing to tell the conversation-list control apart from the task-list one.

After this PR: each group carries the accessible name its row title already shows, and the routing test addresses the groups through that name.

Fixes #

### Why we need it and why it was done in this way

`SegmentedControl` already spreads extra props onto its `role="radiogroup"` root, so an `aria-label` is all that was missing — no component change needed.

The test fix is the same finding from the other direction. It previously walked up from the row's text with `parentElement` and matched the mock's plain `button` elements, so it pinned incidental mock DOM instead of the control surface a user actually meets, and stayed green whether or not the groups were labeled. The file-local mock now mirrors the real `radiogroup`/`radio` semantics, and the test resolves each group by accessible name — which means the labels are now load-bearing: removing either one turns the test red (verified).

The following tradeoffs were made:

- Only the two rows this PR's predecessor introduced are labeled. The neighbouring "context menu style" row has the same gap, but that is pre-existing and out of scope here.

### Breaking changes

None.

### Special notes for your reviewer

Both warnings came from `cherry-ai-bot` on #19200 (`inv_d0d659316937435b#c0` and `#c1`); this PR closes both.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: N/A — no user-visible behavior change
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
NONE
```
