### PR TITLE
fix(artifact-pane): wrap long lines in preview edit mode

### DIFF
--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -610,7 +610,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
               onChange={(content) => fileSession.setDraft(content)}
               height="100%"
               expanded={false}
-              wrapped={false}
+              wrapped
               fontSize={14}
               style={{ minHeight: 0 }}
               options={{ keymap: true, lineNumbers: true }}

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -279,6 +279,7 @@ vi.mock('@cherrystudio/ui', async (importActual) => {
         <textarea
           data-testid="code-editor"
           data-font-size={props.fontSize}
+          data-wrapped={String(props.wrapped)}
           readOnly={props.editable === false}
           value={props.value}
           onChange={(event) => props.onChange?.(event.currentTarget.value)}
@@ -1591,6 +1592,23 @@ describe('ArtifactPane', () => {
     await waitFor(() =>
       expect(mocks.ipcRequest.mock.calls.filter(([route]) => route === 'file.write_if_unchanged')).toHaveLength(3)
     )
+  })
+
+  it('wraps long lines in the artifact preview editor', async () => {
+    mockWorkspaceTree('/tmp/workspace', ['notes.txt'])
+    mocks.fsReadText.mockResolvedValue('first\n')
+    mocks.ipcRequest.mockResolvedValueOnce(binaryReadResult(new TextEncoder().encode('first\n')))
+
+    render(<EditablePaneHarness workspacePath="/tmp/workspace" />)
+    await waitFor(() => expect(screen.getByTestId('tree-node-notes.txt')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('tree-node-notes.txt'))
+
+    const overlay = await screen.findByTestId('artifact-file-preview-overlay')
+    fireEvent.click(await within(overlay).findByRole('button', { name: 'common.edit' }))
+
+    const editor = await within(overlay).findByTestId('code-editor')
+    // wrapped={false} is the bug: long lines stay on one row and need a bottom-only scrollbar.
+    expect(editor).not.toHaveAttribute('data-wrapped', 'false')
   })
 
   it('edits at 14px and preserves UTF-8 BOM and CRLF when saving', async () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Opening a text file in the agent artifact preview overlay and switching to edit mode disabled line wrapping. Long lines stayed on one row, so reading required a horizontal scrollbar that was only reachable after scrolling to the bottom of a tall file.

After this PR:
The overlay editor keeps CodeEditor's default wrapping enabled. Long lines wrap in the preview pane; keyboard shortcuts, line numbers, autosave, and UTF-8/CRLF handling are unchanged.

Fixes #19541

### Why we need it and why it was done in this way

`CodeEditor` already defaults to `wrapped = true`. The overlay was the only caller that overrode it with `wrapped={false}`. Restoring wrap is the minimum contract for DEV recvsbeXAA5OIC.

The following tradeoffs were made:
The editor now wraps instead of scrolling horizontally. That matches read-only FilePreview plugins and the user request; no wrap toggle is added.

The following alternatives were considered:
Leaving wrap off and adding a sticky horizontal scrollbar. That still splits reading across two axes and does not match the reported contract.

Links to places where the discussion took place: DEV recvsbeXAA5OIC; GitHub #19541

### Breaking changes

None.

### Special notes for your reviewer

Focused renderer tests: `src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx` (46 passed), including a regression that fails if edit mode passes `wrapped={false}`.

Also passed: `pnpm lint`, `pnpm test:lint`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required. This is a self-contained wrap contract fix.
- [x] Self-review: I have reviewed my own code via staged diff inspection and focused tests before requesting review from others

### Release note

```release-note
Long lines now wrap when editing a file in the agent artifact preview overlay.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single prop change in renderer UI with no auth, I/O, or save-path changes; behavior aligns with `CodeEditor`'s default and read-only previews.
> 
> **Overview**
> **Artifact preview edit mode** now keeps **line wrapping** enabled on `CodeEditor` instead of forcing `wrapped={false}`. Long lines wrap in the overlay editor so users are not stuck scrolling to the bottom for a horizontal scrollbar.
> 
> A regression test opens edit mode in the artifact overlay and asserts the editor is not passed `wrapped={false}`; the test mock exposes `data-wrapped` from the `wrapped` prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d64463418e73286a4f6586e69d73db130f78cd78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->