### PR TITLE
fix(app-updater): hide raw 503 bodies in check-for-update errors

### DIFF
--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Neue Version {{version}} gefunden",
   "settings.about.updateError": "Aktualisierungsfehler",
   "settings.about.updateNotAvailable": "Ihre Software ist bereits auf dem neuesten Stand",
+  "settings.about.updateNotPublished": "Es ist noch keine veröffentlichte Aktualisierung verfügbar. Bitte versuchen Sie es später erneut.",
   "settings.about.website.button": "Anzeigen",
   "settings.about.website.title": "Offizielle Website",
   "settings.agent.position.label": "Sitzungsposition",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Νέα έκδοση {{version}} εντοπίστηκε",
   "settings.about.updateError": "Σφάλμα κατά την ενημέρωση",
   "settings.about.updateNotAvailable": "Το λογισμικό σας είναι ήδη στην πιο πρόσφατη έκδοση",
+  "settings.about.updateNotPublished": "Δεν υπάρχει ακόμα δημοσιευμένη ενημέρωση. Δοκιμάστε ξανά αργότερα.",
   "settings.about.website.button": "Προβολή",
   "settings.about.website.title": "Ιστοσελίδα",
   "settings.agent.position.label": "Θέση συνεδρίας",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Found new version {{version}}",
   "settings.about.updateError": "Update error",
   "settings.about.updateNotAvailable": "You are using the latest version",
+  "settings.about.updateNotPublished": "No published update is available yet. Please try again later.",
   "settings.about.website.button": "Website",
   "settings.about.website.title": "Official Website",
   "settings.agent.position.label": "Session position",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Versión nueva disponible {{version}}",
   "settings.about.updateError": "Error de actualización",
   "settings.about.updateNotAvailable": "Tu software ya está actualizado",
+  "settings.about.updateNotPublished": "Aún no hay una actualización publicada. Inténtalo de nuevo más tarde.",
   "settings.about.website.button": "Ver",
   "settings.about.website.title": "Sitio web oficial",
   "settings.agent.position.label": "Posición de sesión",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Nouvelle version disponible {{version}}",
   "settings.about.updateError": "Erreur lors de la mise à jour",
   "settings.about.updateNotAvailable": "Votre logiciel est déjà à jour",
+  "settings.about.updateNotPublished": "Aucune mise à jour publiée n'est disponible pour le moment. Réessayez plus tard.",
   "settings.about.website.button": "Visiter le site web",
   "settings.about.website.title": "Site web officiel",
   "settings.agent.position.label": "Position de session",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "新しいバージョン {{version}} が見つかりました",
   "settings.about.updateError": "更新エラー",
   "settings.about.updateNotAvailable": "最新バージョンを使用しています",
+  "settings.about.updateNotPublished": "公開済みの更新はまだありません。しばらくしてから再試行してください。",
   "settings.about.website.button": "ウェブサイト",
   "settings.about.website.title": "公式ウェブサイト",
   "settings.agent.position.label": "セッション位置",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Nova versão disponível {{version}}",
   "settings.about.updateError": "Erro ao atualizar",
   "settings.about.updateNotAvailable": "Já está a utilizar a versão mais recente",
+  "settings.about.updateNotPublished": "Ainda não há uma atualização publicada. Tente novamente mais tarde.",
   "settings.about.website.button": "Ver",
   "settings.about.website.title": "Site oficial",
   "settings.agent.position.label": "Posição da sessão",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "S-a găsit o nouă versiune {{version}}",
   "settings.about.updateError": "Eroare actualizare",
   "settings.about.updateNotAvailable": "Utilizezi cea mai recentă versiune",
+  "settings.about.updateNotPublished": "Nu există încă o actualizare publicată. Încercați din nou mai târziu.",
   "settings.about.website.button": "Site web",
   "settings.about.website.title": "Site oficial",
   "settings.agent.position.label": "Poziția sesiunii",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Найдено новое обновление {{version}}",
   "settings.about.updateError": "Ошибка обновления",
   "settings.about.updateNotAvailable": "Вы используете последнюю версию",
+  "settings.about.updateNotPublished": "Опубликованное обновление пока недоступно. Повторите попытку позже.",
   "settings.about.website.button": "Сайт",
   "settings.about.website.title": "Официальный сайт",
   "settings.agent.position.label": "Позиция сессии",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "Đã tìm thấy phiên bản mới {{version}}",
   "settings.about.updateError": "Lỗi cập nhật",
   "settings.about.updateNotAvailable": "Bạn đang sử dụng phiên bản mới nhất",
+  "settings.about.updateNotPublished": "Chưa có bản cập nhật được phát hành. Vui lòng thử lại sau.",
   "settings.about.website.button": "Trang web",
   "settings.about.website.title": "Trang web chính thức",
   "settings.agent.position.label": "Vị trí phiên",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "发现新版本 {{version}}",
   "settings.about.updateError": "更新出错",
   "settings.about.updateNotAvailable": "你的软件已是最新版本",
+  "settings.about.updateNotPublished": "当前没有已发布的更新，请稍后再试。",
   "settings.about.website.button": "查看",
   "settings.about.website.title": "官方网站",
   "settings.agent.position.label": "会话位置",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -3273,6 +3273,7 @@
   "settings.about.updateAvailable": "發現新版本 {{version}}",
   "settings.about.updateError": "更新錯誤",
   "settings.about.updateNotAvailable": "您正在使用最新版本",
+  "settings.about.updateNotPublished": "目前沒有已發布的更新，請稍後再試。",
   "settings.about.website.button": "網站",
   "settings.about.website.title": "官方網站",
   "settings.agent.position.label": "工作階段位置",

--- a/src/renderer/windows/main/hooks/__tests__/useAppUpdateHandler.test.ts
+++ b/src/renderer/windows/main/hooks/__tests__/useAppUpdateHandler.test.ts
@@ -59,7 +59,7 @@ vi.mock('@renderer/components/UpdateDialogPopup', () => ({
   default: { show: mocks.updateDialogShow }
 }))
 
-import { useAppUpdateHandler } from '../useAppUpdateHandler'
+import { getManualUpdateErrorMessageKey, useAppUpdateHandler } from '../useAppUpdateHandler'
 
 const releaseInfo: UpdateInfo = {
   version: '2.1.0',
@@ -160,8 +160,44 @@ describe('useAppUpdateHandler', () => {
     })
     expect(mocks.popupInfo).toHaveBeenCalledExactlyOnceWith({
       title: 'settings.about.updateError',
-      content: 'manual failure',
+      content: 'settings.about.updateError',
       icon: null
     })
+  })
+
+  it('maps unpublished 503 bodies to a friendly message instead of the raw HTTP response', () => {
+    mocks.appUpdateState.manualCheck = true
+    renderHook(() => useAppUpdateHandler())
+
+    emit(
+      'app.updater.error',
+      new Error('HttpError: 503\nnot_published\nCannot download https://releases.cherry-ai.com/latest.yml')
+    )
+
+    expect(mocks.popupInfo).toHaveBeenCalledExactlyOnceWith({
+      title: 'settings.about.updateError',
+      content: 'settings.about.updateNotPublished',
+      icon: null
+    })
+  })
+})
+
+describe('getManualUpdateErrorMessageKey', () => {
+  it('classifies unpublished release artifacts without exposing the updater body', () => {
+    expect(getManualUpdateErrorMessageKey(new Error('503 not_published'))).toBe('settings.about.updateNotPublished')
+    expect(getManualUpdateErrorMessageKey(new Error('HttpError: 503 Cannot find latest.yml'))).toBe(
+      'settings.about.updateNotPublished'
+    )
+    expect(
+      getManualUpdateErrorMessageKey(new Error('<html>503 not_published</html>\nPlease report this issue to GitHub'))
+    ).toBe('settings.about.updateNotPublished')
+  })
+
+  it('falls back to the generic update error for unrelated failures', () => {
+    expect(getManualUpdateErrorMessageKey(new Error('manual failure'))).toBe('settings.about.updateError')
+    expect(getManualUpdateErrorMessageKey(new Error('ENOTFOUND releases.cherry-ai.com'))).toBe(
+      'settings.about.updateError'
+    )
+    expect(getManualUpdateErrorMessageKey(undefined)).toBe('settings.about.updateError')
   })
 })

--- a/src/renderer/windows/main/hooks/useAppUpdateHandler.ts
+++ b/src/renderer/windows/main/hooks/useAppUpdateHandler.ts
@@ -10,6 +10,22 @@ import { useTranslation } from 'react-i18next'
 
 const logger = loggerService.withContext('useAppUpdateHandler')
 
+/** Map updater failures to i18n keys. Never surface the raw HTTP body. */
+export function getManualUpdateErrorMessageKey(error: { message?: string } | null | undefined): string {
+  const message = error?.message ?? ''
+  if (isUnpublishedReleaseError(message)) {
+    return 'settings.about.updateNotPublished'
+  }
+  return 'settings.about.updateError'
+}
+
+function isUnpublishedReleaseError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return (
+    lower.includes('not_published') || (/\b503\b/.test(message) && /latest\.yml|httperror|http error/i.test(message))
+  )
+}
+
 // Main-only IPC->notification subscriber (twin of useStorageMonitorNotification):
 // maps updater IPC events onto toasts, notifications, and the update dialog.
 //
@@ -92,7 +108,7 @@ export function useAppUpdateHandler() {
     if (manualCheckRef.current) {
       void popup.info({
         title: t('settings.about.updateError'),
-        content: error?.message || t('settings.about.updateError'),
+        content: t(getManualUpdateErrorMessageKey(error)),
         icon: null
       })
     }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
A failed **Check for updates** (especially HTTP 503 `not_published` from `latest.yml`) dumped the raw electron-updater/HTTP body into the error popup, including internal status text.

After this PR:
Manual update-check failures show a localized message. Unpublished-release / 503 `not_published` responses use `settings.about.updateNotPublished`. Other failures use the generic `settings.about.updateError`. The popup never displays the raw updater body. Scheduled/background checks still do not pop an error.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19544

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Classification happens in the renderer, where the popup is built. The main process still logs the full updater error.
- Generic failures also hide `error.message` instead of showing a truncated raw string. Users already get a title of "Update error"; the body is a localized sentence.

The following alternatives were considered:
- Sanitizing only 503/`not_published` and still showing other `error.message` values. That would keep leaking HTTP bodies for similar updater failures.
- Rewriting the Error in `AppUpdaterService` before IPC. That would help every consumer, but the only user-visible leak is this popup, and the renderer already owns the copy.

Links to places where the discussion took place: DEV record recvsDdIMM3uf8

### Breaking changes

None

### Special notes for your reviewer

- Contract tests live in `useAppUpdateHandler.test.ts`: 503/`not_published` → unpublished copy; unrelated errors → generic copy; background checks still do not popup.
- Electron UI proof was not captured: reproducing 503 requires an unpublished release channel, and OOBE can block a tracked instance. Residual risk is copy-only; scheduled checks already skip the popup.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix Check for updates so unpublished/503 channels show a friendly message instead of the raw HTTP body.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in the About manual update-check popup path; no auth, data, or upgrade-install logic changes.
> 
> **Overview**
> Manual **Check for updates** failures no longer put `error.message` (including raw electron-updater HTTP bodies) in the error popup. The handler now maps failures to i18n keys via **`getManualUpdateErrorMessageKey`**: 503 / `not_published` / `latest.yml`-style errors use the new **`settings.about.updateNotPublished`** string across all locales; everything else uses the generic **`settings.about.updateError`**. Background checks are unchanged—they still do not show this popup.
> 
> Tests in **`useAppUpdateHandler.test.ts`** cover the unpublished case and assert unrelated errors still get the generic key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e5a7534d3b57aa1b654325c3cac5d61c78f80a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->