### PR TITLE
fix(model-selector): handle structured queries and missing limits

### DIFF
--- a/src/main/ai/runtime/__tests__/agentContextWindow.test.ts
+++ b/src/main/ai/runtime/__tests__/agentContextWindow.test.ts
@@ -1,0 +1,20 @@
+import type { Model } from '@shared/data/types/model'
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_AGENT_CONTEXT_WINDOW, resolveAgentContextWindow } from '../agentContextWindow'
+
+const modelWith = (contextWindow: unknown) => ({ id: 'p::m', contextWindow }) as unknown as Model
+
+describe('resolveAgentContextWindow', () => {
+  it('keeps a declared positive window', () => {
+    expect(resolveAgentContextWindow(modelWith(128_000))).toBe(128_000)
+  })
+
+  // A non-positive or non-finite window would make pi/dsh compact immediately or never.
+  it.each([undefined, null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY, '200000'])(
+    'falls back to the default for %p',
+    (contextWindow) => {
+      expect(resolveAgentContextWindow(modelWith(contextWindow))).toBe(DEFAULT_AGENT_CONTEXT_WINDOW)
+    }
+  )
+})

--- a/src/main/ai/runtime/agentContextWindow.ts
+++ b/src/main/ai/runtime/agentContextWindow.ts
@@ -1,0 +1,17 @@
+/**
+ * Runtime-neutral context-window fallback for agent runtimes (pi, dsh), which
+ * need a compaction boundary even when Cherry's model row declares none. Model
+ * filtering no longer gates on the window, so this stays main-side.
+ */
+
+import type { Model } from '@shared/data/types/model'
+
+/** Decimal 256K: a model whose real window is 256K never overflows this boundary. */
+export const DEFAULT_AGENT_CONTEXT_WINDOW = 256_000
+
+/** The model's declared context window, or the default when it declares none. */
+export function resolveAgentContextWindow(model: Model): number {
+  return typeof model.contextWindow === 'number' && Number.isFinite(model.contextWindow) && model.contextWindow > 0
+    ? model.contextWindow
+    : DEFAULT_AGENT_CONTEXT_WINDOW
+}

--- a/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
@@ -38,7 +38,6 @@ import { buildDshCompositionYaml } from '../compositionBuilder'
 import {
   assertDshProviderUsable,
   buildDshGatewayInjection,
-  DshMissingContextWindowError,
   DshUnsupportedProviderError,
   resolveDshProviderInjectionFromSnapshot
 } from '../modelInjection'
@@ -136,12 +135,12 @@ describe('buildDshGatewayInjection', () => {
     expect(route.models[0].id).toBe('vertexai:gemini-2.5-pro')
   })
 
-  it('rejects models the gateway cannot route and still requires a context window', () => {
+  it('rejects models the gateway cannot route and defaults an undeclared context window', () => {
     const nonChat = makeModel({ endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS] })
     expect(() => buildDshGatewayInjection(vertexProvider, nonChat, GATEWAY)).toThrow(DshUnsupportedProviderError)
 
     const windowless = makeModel({ contextWindow: undefined })
-    expect(() => buildDshGatewayInjection(vertexProvider, windowless, GATEWAY)).toThrow(DshMissingContextWindowError)
+    expect(buildDshGatewayInjection(vertexProvider, windowless, GATEWAY).modelConfig.contextWindow).toBe(256_000)
   })
 })
 

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -18,7 +18,6 @@ import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
 import {
   type DshApi,
   hasDshTextInput,
-  hasKnownDshContextWindow,
   mapEndpointToDshApi,
   resolveDshEndpointType
 } from '@shared/ai/dshModelCompatibility'
@@ -32,6 +31,7 @@ import { isLoginBasedProvider } from '@shared/utils/provider'
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import { ApiGatewayNotRunningError, resolveApiGatewayRuntime } from '../agentApiGateway'
+import { resolveAgentContextWindow } from '../agentContextWindow'
 import type { AgentSessionUsageCapture } from '../types'
 
 // dsh-llm-pi-ai uses maxTokens as a per-request output cap. Keep pi's
@@ -57,17 +57,6 @@ export class DshMissingApiKeyError extends Error {
     super(`Provider "${providerId}" has no API key configured for dsh agents`)
     this.name = 'DshMissingApiKeyError'
     this.providerId = providerId
-  }
-}
-
-/** Thrown when dsh cannot safely drive a model without its real context window. */
-export class DshMissingContextWindowError extends Error {
-  readonly modelId: string
-
-  constructor(modelId: string) {
-    super(`Model "${modelId}" has no context window configured; set it in model settings before using dsh`)
-    this.name = 'DshMissingContextWindowError'
-    this.modelId = modelId
   }
 }
 
@@ -212,7 +201,6 @@ export function buildDshProviderInjection(
     throw new DshUnsupportedProviderError(provider.id)
   }
   if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-  if (!hasKnownDshContextWindow(model)) throw new DshMissingContextWindowError(model.id)
   if (!apiKey.trim()) throw new DshMissingApiKeyError(provider.id)
 
   const baseUrl = formatDshBaseUrl(resolvedEndpoint.baseUrl, api)
@@ -232,7 +220,7 @@ export function buildDshProviderInjection(
     modelConfig: {
       id: modelId,
       ...(model.name ? { name: model.name } : {}),
-      contextWindow: model.contextWindow,
+      contextWindow: resolveAgentContextWindow(model),
       maxTokens: model.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
       input: isVisionModel(model) ? ['text', 'image'] : ['text'],
       reasoningEfforts: buildDshReasoningEfforts(model, reasoning)
@@ -274,7 +262,6 @@ export function buildDshGatewayInjection(
 ): DshProviderInjection {
   if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(provider.id)
   if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-  if (!hasKnownDshContextWindow(model)) throw new DshMissingContextWindowError(model.id)
 
   const modelId = formatGatewayModelId(provider.id, getRawModelId(model))
   const reasoning = resolveDshReasoningEffort(model, reasoningEffort)
@@ -289,7 +276,7 @@ export function buildDshGatewayInjection(
     modelConfig: {
       id: modelId,
       ...(model.name ? { name: model.name } : {}),
-      contextWindow: model.contextWindow,
+      contextWindow: resolveAgentContextWindow(model),
       maxTokens: model.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
       input: isVisionModel(model) ? ['text', 'image'] : ['text'],
       reasoningEfforts: buildDshReasoningEfforts(model, reasoning)
@@ -357,13 +344,11 @@ export async function assertDshProviderUsable(uniqueModelId: UniqueModelId): Pro
   if (resolveDshInjectionApi(provider, model) === undefined) {
     if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(providerId)
     if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-    if (!hasKnownDshContextWindow(model)) throw new DshMissingContextWindowError(model.id)
     // Consent only (persisted intent) — no ensureRunning/ensureValidApiKey side effects here.
     if (!application.get('ApiGatewayService').getCurrentConfig().enabled) throw new ApiGatewayNotRunningError()
     return
   }
   if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-  if (!hasKnownDshContextWindow(model)) throw new DshMissingContextWindowError(model.id)
 
   const apiKeys = providerService.getApiKeys(providerId, { enabled: true })
   if (!apiKeys.some((entry) => entry.key.trim())) throw new DshMissingApiKeyError(providerId)

--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -28,7 +28,6 @@ import {
   buildPiProviderInjection,
   PI_PLACEHOLDER_API_KEY,
   PiMissingApiKeyError,
-  PiMissingContextWindowError,
   PiUnsupportedProviderError,
   resolvePiProviderInjection,
   resolvePiProviderInjectionFromSnapshot
@@ -390,16 +389,15 @@ describe('buildPiProviderInjection', () => {
     expect(() => buildPiProviderInjection(provider, makeModel({}), '   ')).toThrow(PiMissingApiKeyError)
   })
 
-  it('rejects a model whose context window is unknown', () => {
+  it('falls back to the default context window when the model declares none', () => {
     const provider = makeProvider({
       id: 'anthropic',
       defaultChatEndpoint: 'anthropic-messages',
       endpointConfigs: { 'anthropic-messages': { adapterFamily: 'anthropic', baseUrl: 'https://api.anthropic.com' } }
     })
 
-    expect(() => buildPiProviderInjection(provider, makeModel({ contextWindow: undefined }), REAL_KEY)).toThrow(
-      PiMissingContextWindowError
-    )
+    const injection = buildPiProviderInjection(provider, makeModel({ contextWindow: undefined }), REAL_KEY)
+    expect(injection.providerConfig.models?.[0].contextWindow).toBe(256_000)
   })
 
   it('throws PiUnsupportedProviderError for a provider with no pi mapping', () => {
@@ -541,19 +539,6 @@ describe('modelInjection service resolution', () => {
       endpointConfigs: { 'ollama-chat': { adapterFamily: 'ollama', baseUrl: 'http://localhost:11434' } }
     })
     await expect(assertPiProviderUsable('p::m')).rejects.toThrow(PiUnsupportedProviderError)
-  })
-
-  it('rejects an unknown context window before checking credentials', async () => {
-    serviceMocks.getByKey.mockResolvedValueOnce({
-      id: 'p::m',
-      providerId: 'p',
-      name: 'M',
-      capabilities: [],
-      contextWindow: undefined
-    })
-
-    await expect(assertPiProviderUsable('p::m')).rejects.toThrow(PiMissingContextWindowError)
-    expect(serviceMocks.getApiKeys).not.toHaveBeenCalled()
   })
 
   it('validates app-managed OAuth through its live session', async () => {

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -16,7 +16,7 @@ import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
 import type { ProviderConfig, ProviderModelConfig } from '@earendil-works/pi-coding-agent'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
-import { hasKnownPiContextWindow, mapEndpointToPiApi, type PiApi } from '@shared/ai/piModelCompatibility'
+import { mapEndpointToPiApi, type PiApi } from '@shared/ai/piModelCompatibility'
 import { isCodexProviderId } from '@shared/data/presets/codex'
 import { hasRuntimeTransportAdapter } from '@shared/data/presets/runtimeTransport'
 import {
@@ -35,6 +35,7 @@ import { isLoginBasedProvider, resolveEndpointDialect } from '@shared/utils/prov
 
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import { getProviderTransportAdapter, type ProviderTransportAdapter } from '../../provider/runtimeTransport'
+import { resolveAgentContextWindow } from '../agentContextWindow'
 import type { AgentSessionUsageCapture } from '../types'
 import { loadPiAnthropicMessagesApi, loadPiApiStreamSimple } from './piSdk'
 import { withCherryInThinkingReplay } from './piThinkingReplay'
@@ -70,17 +71,6 @@ export class PiMissingApiKeyError extends Error {
     super(`Provider "${providerId}" has no API key configured for pi agents`)
     this.name = 'PiMissingApiKeyError'
     this.providerId = providerId
-  }
-}
-
-/** Thrown when Pi cannot safely drive a model without its real compaction boundary. */
-export class PiMissingContextWindowError extends Error {
-  readonly modelId: string
-
-  constructor(modelId: string) {
-    super(`Model "${modelId}" has no context window configured; set it in model settings before using Pi`)
-    this.name = 'PiMissingContextWindowError'
-    this.modelId = modelId
   }
 }
 
@@ -158,7 +148,6 @@ export function buildPiProviderInjection(
   if (!api) {
     throw new PiUnsupportedProviderError(provider.id)
   }
-  if (!hasKnownPiContextWindow(model)) throw new PiMissingContextWindowError(model.id)
   // Transport-adapter (app-managed-OAuth) providers authenticate per stream call
   // via the adapter; the connect-time `apiKey` is only the placeholder, so the
   // empty-key guard does not apply to them.
@@ -287,8 +276,6 @@ export async function assertPiProviderUsable(uniqueModelId: UniqueModelId): Prom
   ) {
     throw new PiUnsupportedProviderError(providerId)
   }
-  if (!hasKnownPiContextWindow(model)) throw new PiMissingContextWindowError(model.id)
-
   // Transport-adapter providers validate the OAuth session (cheap `hasToken`),
   // not app-side keys; a signed-out provider is surfaced as a missing credential.
   if (getProviderTransportAdapter(providerId)) {
@@ -303,7 +290,7 @@ export async function assertPiProviderUsable(uniqueModelId: UniqueModelId): Prom
 
 function buildPiModelConfig(
   provider: Provider,
-  model: Model & { contextWindow: number },
+  model: Model,
   id: string,
   api: PiApi,
   endpointType: EndpointType | undefined
@@ -325,7 +312,7 @@ function buildPiModelConfig(
     // pi tracks per-token cost for its own UI; Cherry owns cost accounting, so
     // leave zeros — pi's tracking is unused here.
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: model.contextWindow,
+    contextWindow: resolveAgentContextWindow(model),
     maxTokens: model.maxOutputTokens ?? DEFAULT_MAX_TOKENS,
     // Cherry's provider capability is the source of truth; pi otherwise infers
     // developer-role support from the endpoint URL.

--- a/src/renderer/utils/model/__tests__/search.test.ts
+++ b/src/renderer/utils/model/__tests__/search.test.ts
@@ -24,6 +24,23 @@ describe('search', () => {
     expect(score).not.toBeNull()
   })
 
+  it('should treat explicit query structure as literal text', () => {
+    const searchFields = (value: string): ModelSearchField[] => [{ value, weight: 0, allowAbbreviation: true }]
+    const cases = [
+      ['3.8', 'GPT-3.8', true],
+      ['3.8', 'Qwen3 8B', false],
+      ['3.8', 'MiniMax-M2.7', false],
+      ['org/model', 'org/model', true],
+      ['org/model', 'org-model', false],
+      ['c++', 'C++', true],
+      ['c++', 'C--', false]
+    ] as const
+
+    for (const [query, value, matches] of cases) {
+      expect(getSearchMatchScore(query, searchFields(value)) !== null).toBe(matches)
+    }
+  })
+
   it('should return null for punctuation-only keyword', () => {
     expect(getSearchMatchScore(':', fields)).toBeNull()
     expect(getSearchMatchScore('---', fields)).toBeNull()

--- a/src/renderer/utils/model/search.ts
+++ b/src/renderer/utils/model/search.ts
@@ -16,7 +16,7 @@ export type ModelSearchField = {
 }
 
 function normalizeSearchSegment(value: string) {
-  return value.toLowerCase().replace(/[\s._:/\\-]+/g, '')
+  return value.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '')
 }
 
 function getSearchTokens(value: string) {
@@ -64,6 +64,7 @@ function getKeywordMatchScore(keyword: string, fields: ModelSearchField[]) {
   if (!normalizedKeyword) {
     return null
   }
+  const allowsFlexibleMatching = keyword === normalizedKeyword
 
   let bestScore: number | null = null
 
@@ -77,6 +78,10 @@ function getKeywordMatchScore(keyword: string, fields: ModelSearchField[]) {
     if (textIndex !== -1) {
       const score = field.weight * 100 + textIndex
       bestScore = bestScore === null ? score : Math.min(bestScore, score)
+    }
+
+    if (!allowsFlexibleMatching) {
+      continue
     }
 
     const normalizedText = normalizeSearchSegment(field.value)

--- a/src/shared/ai/__tests__/dshModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/dshModelCompatibility.test.ts
@@ -72,8 +72,8 @@ describe('isDshCompatibleModel', () => {
     ).toBe(false)
   })
 
-  it('still requires a known context window and text input on the gateway route', () => {
-    expect(isDshCompatibleModel(azureProvider, makeModel({ contextWindow: undefined }))).toBe(false)
+  it('still requires text input on the gateway route, but not a declared context window', () => {
+    expect(isDshCompatibleModel(azureProvider, makeModel({ contextWindow: undefined }))).toBe(true)
     expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: [] }))).toBe(false)
   })
 })

--- a/src/shared/ai/__tests__/piModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/piModelCompatibility.test.ts
@@ -86,13 +86,13 @@ describe('resolvePiApi', () => {
     expect(isPiCompatibleModel(provider, makeModel({}))).toBe(false)
   })
 
-  it('rejects a model whose context window is unknown', () => {
+  it('accepts a model whose context window is unknown', () => {
     const provider = makeProvider({
       defaultChatEndpoint: 'anthropic-messages',
       endpointConfigs: { 'anthropic-messages': { adapterFamily: 'anthropic' } }
     })
 
-    expect(isPiCompatibleModel(provider, makeModel({ contextWindow: undefined }))).toBe(false)
+    expect(isPiCompatibleModel(provider, makeModel({ contextWindow: undefined }))).toBe(true)
   })
 
   it('uses a cloned gateway per-model route before an unsupported provider default', () => {

--- a/src/shared/ai/dshModelCompatibility.ts
+++ b/src/shared/ai/dshModelCompatibility.ts
@@ -82,11 +82,6 @@ export function resolveDshApi(provider: Provider, model: Model): DshApi | undefi
   return mapEndpointToDshApi(endpointType, adapterFamily)
 }
 
-/** dsh's route config requires a per-model context window, so an unknown value is not safely drivable. */
-export function hasKnownDshContextWindow(model: Model): model is Model & { contextWindow: number } {
-  return typeof model.contextWindow === 'number' && Number.isFinite(model.contextWindow) && model.contextWindow > 0
-}
-
 /** DSH rc.7 always requires text input; undeclared modalities retain the existing chat-model default. */
 export function hasDshTextInput(model: Model): boolean {
   return model.inputModalities === undefined || model.inputModalities.includes(MODALITY.TEXT)
@@ -97,5 +92,5 @@ export function isDshCompatibleModel(provider: Provider, model: Model): boolean 
   // No native wire family → the local API Gateway can still front any gateway-routable
   // model as OpenAI-compatible (claude's picker rule); everything else stays fail-closed.
   if (resolveDshApi(provider, model) === undefined && !isGatewayRoutableModel(model)) return false
-  return hasKnownDshContextWindow(model) && hasDshTextInput(model)
+  return hasDshTextInput(model)
 }

--- a/src/shared/ai/piModelCompatibility.ts
+++ b/src/shared/ai/piModelCompatibility.ts
@@ -115,12 +115,7 @@ export function resolvePiApi(provider: Provider, model: Model): PiApi | undefine
   return mapEndpointToPiApi(endpointType, adapterFamily)
 }
 
-/** Pi uses this limit for compaction and overflow recovery, so an unknown value is not safely drivable. */
-export function hasKnownPiContextWindow(model: Model): model is Model & { contextWindow: number } {
-  return typeof model.contextWindow === 'number' && Number.isFinite(model.contextWindow) && model.contextWindow > 0
-}
-
 /** Whether a pi agent can use this provider+model. Used for renderer filtering. */
 export function isPiCompatibleModel(provider: Provider, model: Model): boolean {
-  return resolvePiApi(provider, model) !== undefined && hasKnownPiContextWindow(model)
+  return resolvePiApi(provider, model) !== undefined
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Structured search terms such as `3.8` could trigger broad fuzzy matches, while Pi and DSH hid models without configured token limits.

After this PR: Explicit query structure is matched literally, plain alphanumeric queries retain flexible matching, and missing context windows use a 256K runtime fallback.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: Structured input favors precision, while unstructured input keeps separator-insensitive and abbreviation matching.

The following alternatives were considered: Continuing to reject models with sparse metadata was discarded because it hides otherwise usable models.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

This restores the missing-context behavior introduced by #18847 after it was unintentionally reverted by overlapping changes in #18609. Validation passed with `pnpm lint` and focused renderer, shared, and main tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Model searches now respect structured terms, and Pi/DSH model lists include models without configured token limits.
```
