### PR TITLE
fix(usage-settings): cap dashboard content width on ultrawide windows

### DIFF
--- a/src/renderer/pages/settings/UsageSettings/UsageSettingsPrimitives.tsx
+++ b/src/renderer/pages/settings/UsageSettings/UsageSettingsPrimitives.tsx
@@ -220,7 +220,8 @@ export function UsageResponsiveShell({ children }: { children: ReactNode }) {
     <SettingsContentColumn
       theme={theme}
       className="min-w-0 overflow-x-hidden"
-      innerClassName="min-w-0 w-full max-w-none">
+      // Wider than form settings so 4-col metrics and the year heatmap fit, but still capped on ultrawide windows.
+      innerClassName="min-w-0 w-full max-w-6xl">
       <div className="@container/usage flex min-w-0 flex-col gap-6">{children}</div>
     </SettingsContentColumn>
   )

--- a/src/renderer/pages/settings/UsageSettings/__tests__/UsageSettings.test.tsx
+++ b/src/renderer/pages/settings/UsageSettings/__tests__/UsageSettings.test.tsx
@@ -113,6 +113,17 @@ describe('UsageSettings', () => {
     expect(screen.getByRole('combobox', { name: 'Top' })).toHaveTextContent('20')
   })
 
+  it('caps the dashboard column so ultrawide windows do not stretch charts', () => {
+    render(<UsageSettings />)
+
+    const overview = screen.getByRole('heading', { name: '概览' })
+    const column = overview.closest('.mx-auto')
+
+    // Layout contract: the usage dashboard is bounded (`max-w-6xl`), not full-bleed (`max-w-none`).
+    expect(column).toHaveClass('max-w-6xl')
+    expect(column).not.toHaveClass('max-w-none')
+  })
+
   it('keeps the overview insight row when usage data exists', () => {
     usageDataOverride.current = {
       overviewTotals: {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
The Usage Statistics settings page passed `max-w-none` into `SettingsContentColumn`, so overview cards, the year heatmap, and charts stretched to the full right pane on ultrawide windows.

After this PR:
The usage dashboard stays centered and capped at `max-w-6xl` (wide enough for the four-column metric strip and year heatmap, not full-bleed).

Fixes #19556

### Why we need it and why it was done in this way

Uncapped dashboard width makes metric cells, heatmap, and charts unreadable on wide displays. Other settings pages already use `SettingsContentColumn`'s `max-w-3xl` cap; usage needs more room than a form page but still needs a bound.

The following tradeoffs were made:
`max-w-6xl` (1152px) instead of the shared `max-w-3xl` (768px), because the four-column metric strip activates at a 900px container and a year heatmap is about 800px wide.

The following alternatives were considered:
Restoring `max-w-3xl` would keep the four-column strip from ever appearing. Leaving `max-w-none` keeps the original full-bleed layout.

Links to places where the discussion took place: DEV record recvqKnQMMyBAq

### Breaking changes

None

### Special notes for your reviewer

Regression test asserts the overview column has `max-w-6xl` and not `max-w-none`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Cap the Usage Statistics dashboard width so cards and charts stay readable on ultrawide windows.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout change on the usage settings page with a targeted test; no auth, data, or API impact.
> 
> **Overview**
> **Caps the Usage Statistics dashboard** so overview metrics, the year heatmap, and charts stay centered and readable on ultrawide displays instead of stretching across the full settings pane.
> 
> `UsageResponsiveShell` now passes `max-w-6xl` on `SettingsContentColumn`’s inner wrapper (replacing `max-w-none`), giving more room than the default `max-w-3xl` form layout while still bounding width for the four-column metric strip and heatmap.
> 
> A regression test locks in that layout contract: the overview column uses `max-w-6xl` and not `max-w-none`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfe305adb12464ed7276436a5e574c67323e39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->