### PR TITLE
fix(command-resolver): accept existing absolute MCP stdio commands

### DIFF
--- a/src/main/ai/mcp/__tests__/mcpLaunch.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpLaunch.test.ts
@@ -98,4 +98,16 @@ describe('resolveLaunchCommand', () => {
     expect(unresolved.command).toBe('my-server')
     expect(logger.warn).toHaveBeenCalled()
   })
+
+  it('normalizes surrounding whitespace before resolving or falling back', async () => {
+    const launch = await resolve('  my-server  ', ['--stdio'])
+
+    expect(commandMock.findCommandInShellEnv).toHaveBeenCalledWith('my-server', { PATH: '/usr/bin' })
+    expect(launch.command).toBe('my-server')
+  })
+
+  it('rejects a command that is empty after normalization', async () => {
+    await expect(resolve('   ')).rejects.toThrow(/MCP stdio command cannot be empty/)
+    expect(commandMock.findCommandInShellEnv).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ai/mcp/__tests__/mcpStdio.windows.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpStdio.windows.test.ts
@@ -1,0 +1,130 @@
+import type { LoggerService } from '@logger'
+import type { McpClientSdk, McpTransport } from '@main/ai/mcp/mcpClientSdk'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import type { McpServer } from '@shared/data/types/mcpServer'
+import type { McpServerLogEntry } from '@shared/types/mcp'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory({} as Record<string, unknown>)
+})
+vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
+vi.mock('@main/ai/mcp/servers/factory', () => ({
+  createInMemoryMcpServer: vi.fn(),
+  getBuiltinHttpHeaders: () => ({}),
+  getBuiltinRegistryEnv: () => ({}),
+  hasInMemoryImplementation: () => false
+}))
+vi.mock('@main/utils/shellEnv', () => ({
+  getShellEnv: async () => ({ PATH: process.env.PATH ?? '' })
+}))
+
+const { createTransport } = await import('../mcpTransport')
+
+const sdk = { Client, StdioClientTransport } as unknown as McpClientSdk
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as LoggerService
+const authProvider = { config: {} } as any
+
+describe.skipIf(process.platform !== 'win32')('Windows MCP stdio absolute commands', () => {
+  let fixtureDir: string
+  let commandPath: string
+  let client: Client | undefined
+  let transport: McpTransport | undefined
+
+  beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cherry-mcp-stdio path-'))
+    const serverPath = path.join(fixtureDir, 'server.mjs')
+    commandPath = path.join(fixtureDir, 'server.cmd')
+
+    fs.writeFileSync(
+      serverPath,
+      [
+        "import readline from 'node:readline'",
+        'const lines = readline.createInterface({ input: process.stdin })',
+        'for await (const line of lines) {',
+        '  const request = JSON.parse(line)',
+        "  if (!Object.hasOwn(request, 'id')) continue",
+        "  const result = request.method === 'initialize'",
+        '    ? {',
+        '        protocolVersion: request.params.protocolVersion,',
+        '        capabilities: { tools: {} },',
+        "        serverInfo: { name: 'absolute-command-fixture', version: '1.0.0' }",
+        '      }',
+        "    : request.method === 'tools/list' ? { tools: [] } : {}",
+        "  process.stdout.write(`${JSON.stringify({ jsonrpc: '2.0', id: request.id, result })}\\n`)",
+        '}'
+      ].join('\n'),
+      'utf8'
+    )
+    fs.writeFileSync(commandPath, `@echo off\r\n"${process.execPath}" "%~dp0server.mjs"\r\n`, 'utf8')
+  })
+
+  afterEach(async () => {
+    await client?.close().catch(() => undefined)
+    if (!client) await transport?.close().catch(() => undefined)
+    fs.rmSync(fixtureDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it.each([
+    ['an exact path', (value: string) => value],
+    ['surrounding whitespace', (value: string) => `  ${value}  `]
+  ])('connects, initializes, and lists tools through %s', async (_case, configureCommand) => {
+    const serverLogs: McpServerLogEntry[] = []
+    transport = await createTransport({
+      sdk,
+      server: {
+        id: 'absolute-command-test',
+        name: 'absolute-command-test',
+        type: 'stdio',
+        command: configureCommand(commandPath),
+        isActive: true
+      } as McpServer,
+      args: [],
+      authProvider,
+      logger,
+      onServerLog: (entry) => serverLogs.push(entry)
+    })
+
+    client = new Client({ name: 'cherry-test-client', version: '1.0.0' }, { capabilities: {} })
+    await client.connect(transport)
+
+    await expect(client.listTools()).resolves.toEqual({ tools: [] })
+    expect(serverLogs).toEqual([])
+  })
+
+  it('surfaces the underlying spawn error for a missing absolute command', async () => {
+    const missingCommand = path.join(fixtureDir, 'missing.cmd')
+    const serverLogs: McpServerLogEntry[] = []
+    transport = await createTransport({
+      sdk,
+      server: {
+        id: 'missing-command-test',
+        name: 'missing-command-test',
+        type: 'stdio',
+        command: missingCommand,
+        isActive: true
+      } as McpServer,
+      args: [],
+      authProvider,
+      logger,
+      onServerLog: (entry) => serverLogs.push(entry)
+    })
+
+    client = new Client({ name: 'cherry-test-client', version: '1.0.0' }, { capabilities: {} })
+    await expect(client.connect(transport)).rejects.toThrow(/Connection closed/)
+
+    const spawnLog = serverLogs.find((entry) => entry.level === 'error')
+    expect(spawnLog).toMatchObject({
+      data: { code: 'ENOENT', path: missingCommand },
+      source: 'stdio'
+    })
+    expect(spawnLog?.message).toContain('code=ENOENT')
+    expect(spawnLog?.message).toContain(`path=${missingCommand}`)
+  })
+})

--- a/src/main/ai/mcp/__tests__/mcpTransport.test.ts
+++ b/src/main/ai/mcp/__tests__/mcpTransport.test.ts
@@ -38,6 +38,7 @@ class FakeTransport {
 }
 class FakeStdioTransport {
   stderr = { on: vi.fn() }
+  onerror?: (error: Error) => void
   constructor(public params: any) {}
 }
 const sdk = {
@@ -163,6 +164,36 @@ describe('createTransport', () => {
 
     expect(entries).toHaveLength(1)
     expect(entries[0]).toMatchObject({ level: 'stderr', message: 'server crashed', source: 'stdio' })
+  })
+
+  it('forwards the underlying spawn error details to app and server logs', async () => {
+    const entries: McpServerLogEntry[] = []
+    const transport = (await create(
+      { type: 'stdio', command: 'C:\\missing\\uvx.exe' },
+      { onServerLog: (entry) => entries.push(entry) }
+    )) as unknown as FakeStdioTransport
+    const error = Object.assign(new Error('spawn C:\\missing\\uvx.exe ENOENT'), {
+      code: 'ENOENT',
+      errno: -4058,
+      syscall: 'spawn C:\\missing\\uvx.exe',
+      path: 'C:\\missing\\uvx.exe'
+    })
+
+    transport.onerror?.(error)
+
+    expect(logger.error).toHaveBeenCalledWith('Stdio transport error', error, {
+      code: 'ENOENT',
+      errno: -4058,
+      syscall: 'spawn C:\\missing\\uvx.exe',
+      path: 'C:\\missing\\uvx.exe'
+    })
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      level: 'error',
+      message: expect.stringContaining('code=ENOENT'),
+      data: expect.objectContaining({ code: 'ENOENT', path: 'C:\\missing\\uvx.exe' }),
+      source: 'stdio'
+    })
   })
 
   it('runs an in-memory row we cannot start in-process through the connection it declares', async () => {

--- a/src/main/ai/mcp/mcpLaunch.ts
+++ b/src/main/ai/mcp/mcpLaunch.ts
@@ -63,36 +63,43 @@ export async function resolveLaunchCommand({
   loginShellEnv: Record<string, string>
   logger: LoggerService
 }): Promise<LaunchCommand> {
-  const runner = RUNNERS[command]
+  const normalizedCommand = command.trim()
+  if (!normalizedCommand) {
+    throw new Error('MCP stdio command cannot be empty')
+  }
+
+  const runner = RUNNERS[normalizedCommand]
   const env = runner?.registryEnv && registryUrl ? runner.registryEnv(registryUrl) : {}
 
   if (!runner) {
-    const resolved = await findCommandInShellEnv(command, loginShellEnv)
+    const resolved = await findCommandInShellEnv(normalizedCommand, loginShellEnv)
     if (!resolved) {
       logger.warn(
-        `Could not resolve command '${command}' to a full path. ` +
+        `Could not resolve command '${normalizedCommand}' to a full path. ` +
           `If the server fails to start, try providing the full path in the command field.`
       )
-      return { command, args, env }
+      return { command: normalizedCommand, args, env }
     }
     logger.debug(`Resolved command to full path`, { command: resolved })
     return { command: resolved, args, env }
   }
 
-  const systemPath = await findExecutableInEnv(command)
+  const systemPath = await findExecutableInEnv(normalizedCommand)
   if (systemPath) {
-    logger.debug(`Using system ${command}`, { command: systemPath })
+    logger.debug(`Using system ${normalizedCommand}`, { command: systemPath })
     return { command: systemPath, args, env }
   }
 
-  const bundled = runner.bundled ?? command
-  logger.debug(`System ${command} not found, checking for bundled ${bundled}`)
+  const bundled = runner.bundled ?? normalizedCommand
+  logger.debug(`System ${normalizedCommand} not found, checking for bundled ${bundled}`)
   if (!(await isBinaryExists(bundled))) {
-    throw new Error(runner.notFound(command))
+    throw new Error(runner.notFound(normalizedCommand))
   }
 
   const bundledPath = await getBinaryPath(bundled)
-  logger.info(`Using bundled ${bundled} as fallback (${command} not found in PATH)`, { command: bundledPath })
+  logger.info(`Using bundled ${bundled} as fallback (${normalizedCommand} not found in PATH)`, {
+    command: bundledPath
+  })
   return { command: bundledPath, args: runner.transformArgs?.(args) ?? args, env }
 }
 

--- a/src/main/ai/mcp/mcpTransport.ts
+++ b/src/main/ai/mcp/mcpTransport.ts
@@ -85,6 +85,25 @@ function buildHttpOptions(server: McpServer, authProvider: McpOAuthClientProvide
   }
 }
 
+function getStdioTransportErrorDetails(error: Error): Record<string, number | string> {
+  const spawnError = error as NodeJS.ErrnoException
+  return Object.fromEntries(
+    Object.entries({
+      code: spawnError.code,
+      errno: spawnError.errno,
+      syscall: spawnError.syscall,
+      path: spawnError.path
+    }).filter((entry): entry is [string, number | string] => entry[1] !== undefined)
+  )
+}
+
+function formatStdioTransportError(error: Error, details: Record<string, number | string>): string {
+  const diagnostic = Object.entries(details)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(', ')
+  return diagnostic ? `${error.message} (${diagnostic})` : error.message
+}
+
 async function createInMemory({ sdk, server, args, logger }: CreateTransportInput): Promise<McpTransport> {
   logger.debug(`Using in-memory transport`)
   const [clientTransport, serverTransport] = sdk.InMemoryTransport.createLinkedPair()
@@ -187,6 +206,17 @@ async function createStdio(
   }
 
   const transport = new sdk.StdioClientTransport(transportOptions)
+  transport.onerror = (error) => {
+    const details = getStdioTransportErrorDetails(error)
+    logger.error(`Stdio transport error`, error, details)
+    onServerLog({
+      timestamp: Date.now(),
+      level: 'error',
+      message: formatStdioTransportError(error, details),
+      data: details,
+      source: 'stdio'
+    })
+  }
   const stderrDecoder = new TextDecoder('utf-8', { fatal: false })
   const emitStderr = (message: string) => {
     if (!message.trim()) return

--- a/src/main/utils/__tests__/commandResolver.test.ts
+++ b/src/main/utils/__tests__/commandResolver.test.ts
@@ -872,6 +872,7 @@ describe('findCommandInShellEnv', () => {
       .mockReturnValue(null as never)
     // Reset path.isAbsolute to real implementation for these tests
     vi.mocked(path.isAbsolute).mockImplementation((p) => p.startsWith('/') || /^[A-Z]:/i.test(p))
+    vi.mocked(path.resolve).mockImplementation((p: string) => p)
     vi.mocked(path.win32.resolve).mockImplementation(resolveWindowsPath)
     vi.mocked(path.win32.extname).mockImplementation((p) => p.match(/\.[^\\/.]+$/)?.[0] ?? '')
     vi.mocked(path.win32.relative).mockImplementation((from, to) => {
@@ -925,6 +926,38 @@ describe('findCommandInShellEnv', () => {
         expect(result).toBeNull()
         expect(commandLookup()).not.toHaveBeenCalled()
       }
+    })
+
+    it('should return an existing absolute executable without shell lookup', async () => {
+      const absolute = 'C:\\Program Files\\nodejs\\npx.cmd'
+      vi.mocked(path.isAbsolute).mockReturnValue(true)
+      vi.mocked(path.resolve).mockReturnValue(absolute)
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as fs.Stats)
+
+      await expect(findCommandInShellEnv(absolute, {})).resolves.toBe(absolute)
+      expect(commandLookup()).not.toHaveBeenCalled()
+    })
+
+    it('should reject an absolute path that does not exist', async () => {
+      const absolute = 'C:\\missing\\uvx.exe'
+      vi.mocked(path.isAbsolute).mockReturnValue(true)
+      vi.mocked(path.resolve).mockReturnValue(absolute)
+      vi.mocked(fs.existsSync).mockReturnValue(false)
+
+      await expect(findCommandInShellEnv(absolute, {})).resolves.toBeNull()
+      expect(commandLookup()).not.toHaveBeenCalled()
+    })
+
+    it('should reject an absolute path that is a directory', async () => {
+      const absolute = '/usr/local/bin'
+      vi.mocked(path.isAbsolute).mockReturnValue(true)
+      vi.mocked(path.resolve).mockReturnValue(absolute)
+      vi.mocked(fs.existsSync).mockReturnValue(true)
+      vi.mocked(fs.statSync).mockReturnValue({ isFile: () => false } as fs.Stats)
+
+      await expect(findCommandInShellEnv(absolute, {})).resolves.toBeNull()
+      expect(commandLookup()).not.toHaveBeenCalled()
     })
 
     it('should reject command names exceeding max length', async () => {

--- a/src/main/utils/commandResolver.ts
+++ b/src/main/utils/commandResolver.ts
@@ -126,6 +126,30 @@ function findWindowsCommandCandidatesSync(
   }
 }
 
+/** Absolute MCP stdio commands skip the bare-name regex and `command -v`. */
+function resolveExistingAbsoluteCommand(command: string): string | null {
+  const trimmed = command.trim()
+  if (!trimmed || !path.isAbsolute(trimmed)) {
+    return null
+  }
+
+  const resolved = path.resolve(trimmed)
+  if (!path.isAbsolute(resolved)) {
+    return null
+  }
+
+  try {
+    if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+      return null
+    }
+  } catch (error) {
+    logger.debug(`Absolute command path is not readable '${resolved}'`, { error })
+    return null
+  }
+
+  return resolved
+}
+
 /**
  * Check if a command is available in the user's login shell environment
  * @param command - Command name to check (e.g., 'npx', 'uvx')
@@ -136,6 +160,11 @@ export async function findCommandInShellEnv(
   command: string,
   loginShellEnv: Record<string, string>
 ): Promise<string | null> {
+  const absoluteCommand = resolveExistingAbsoluteCommand(command)
+  if (absoluteCommand) {
+    return absoluteCommand
+  }
+
   // Validate command name to prevent command injection
   if (!VALID_COMMAND_NAME_REGEX.test(command)) {
     logger.warn(`Invalid command name '${command}' - must only contain alphanumeric characters, underscore, or hyphen`)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`findCommandInShellEnv` only accepted bare command names matching `[A-Za-z0-9_-]`. An MCP stdio `command` that was already an absolute executable path, such as `C:\Program Files\nodejs\npx.cmd`, was logged as `Invalid command name` and treated as unresolved. Migrated v1 configs that stored the full path then failed to start, and the follow-up warning incorrectly told users to provide a full path.

After this PR:

If `command` is already an absolute path to an existing file, the resolver returns that path and does not run `command -v` / `which`. Bare names still go through PATH lookup. Relative paths, `..` traversal, and shell metacharacters remain rejected.

Fixes #19557

### Why we need it and why it was done in this way

Users with stdio MCP servers configured as full executable paths cannot use those servers after v1 → v2 migration. The launch helper already tells callers to provide a full path when lookup fails, so accepting an existing absolute file is the contract the rest of MCP launch already assumes.

The following tradeoffs were made:

The resolver still does not accept relative paths. Relative `./` commands are a different, directory-scoped case and are not needed to restore migrated full-path configs.

The following alternatives were considered:

Rewriting stored MCP `command` values during v2 migration was rejected because that is schema/migration work and would not help configs that are already on disk as absolute paths. Expanding the bare-name regex to allow slashes was rejected because it would re-open shell lookup for relative and traversal-like strings.

Links to places where the discussion took place: GitHub #19557.

### Breaking changes

None.

### Special notes for your reviewer

- Focused tests: `pnpm exec vitest run src/main/utils/__tests__/commandResolver.test.ts src/main/utils/__tests__/commandResolver.windows.test.ts src/main/ai/mcp/__tests__/mcpLaunch.test.ts` — 33 passed, 57 skipped (Windows-only cases on macOS).
- `pnpm lint` exit 0. `pnpm test:lint` oxlint 0 warnings / 0 errors (pre-existing ESLint warnings only, 0 errors).
- The Windows `C:\Program Files\nodejs\npx.cmd` case is the regression: that string fails the bare-name regex and previously returned null without checking the filesystem.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Allow stdio MCP servers to use an existing absolute executable path as `command`, so migrated full-path configs start instead of being rejected as invalid command names.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how MCP-related executables are resolved before spawn; scope is limited to verified absolute files and skips shell lookup, but it still alters a security-sensitive code path.
> 
> **Overview**
> **`findCommandInShellEnv`** now short-circuits when the input is an **absolute path to an existing regular file**, returning the resolved path without running the bare-name regex or shell/`which` lookup. That restores stdio MCP configs (including migrated v1 entries) that store full executables such as `C:\Program Files\nodejs\npx.cmd`, which previously failed validation as “invalid command name.”
> 
> The new **`resolveExistingAbsoluteCommand`** helper trims the string, requires `path.isAbsolute` before and after `path.resolve`, and rejects missing paths, directories, and unreadable files. **Bare names** still use PATH lookup; **relative paths, traversal, and metacharacters** are unchanged because they never pass the absolute-path branch.
> 
> Tests cover success, missing absolute paths, and directory rejection, with **`path.resolve`** mocked in the shared `beforeEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 017ae428d0b9fd1e4dfc43504617794a200ab8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->