### PR TITLE
fix(portable): preserve provider resources across relaunches

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -126,6 +126,8 @@ nsis:
 portable:
   artifactName: ${productName}-${version}-${arch}-portable.${ext}
   buildUniversalInstaller: false
+  # electron-builder 26.15.6 uses true for a unique $PLUGINSDIR on every launch.
+  unpackDirName: true
 mac:
   entitlementsInherit: build/entitlements.mac.plist
   notarize: false

--- a/scripts/__tests__/portable-packaging.test.ts
+++ b/scripts/__tests__/portable-packaging.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectRoot = path.join(import.meta.dirname, '..', '..')
+
+describe('Windows portable packaging', () => {
+  it('isolates extracted resources for each launcher invocation', () => {
+    const config = parse(readFileSync(path.join(projectRoot, 'electron-builder.yml'), 'utf8')) as {
+      portable?: { unpackDirName?: boolean | string }
+    }
+
+    expect(config.portable?.unpackDirName).toBe(true)
+  })
+})

--- a/scripts/__tests__/portable-packaging.test.ts
+++ b/scripts/__tests__/portable-packaging.test.ts
@@ -7,11 +7,20 @@ import { parse } from 'yaml'
 const projectRoot = path.join(import.meta.dirname, '..', '..')
 
 describe('Windows portable packaging', () => {
-  it('isolates extracted resources for each launcher invocation', () => {
+  it('pins the audited electron-builder portable unpack contract', () => {
     const config = parse(readFileSync(path.join(projectRoot, 'electron-builder.yml'), 'utf8')) as {
       portable?: { unpackDirName?: boolean | string }
     }
+    const packageManifest = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf8')) as {
+      devDependencies?: Record<string, string>
+    }
 
-    expect(config.portable?.unpackDirName).toBe(true)
+    expect({
+      electronBuilder: packageManifest.devDependencies?.['electron-builder'],
+      unpackDirName: config.portable?.unpackDirName
+    }).toEqual({
+      electronBuilder: '26.15.6',
+      unpackDirName: true
+    })
   })
 })

--- a/src/renderer/hooks/__tests__/useProvider.test.ts
+++ b/src/renderer/hooks/__tests__/useProvider.test.ts
@@ -94,6 +94,23 @@ describe('useProviders', () => {
     expect(result.current.providers).toBe(firstProviders)
   })
 
+  it('exposes a provider list read failure instead of presenting only an empty list', () => {
+    const error = new Error('Provider registry unavailable')
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isRefreshing: false,
+      error,
+      refetch: vi.fn().mockResolvedValue(undefined),
+      mutate: vi.fn()
+    })
+
+    const { result } = renderHook(() => useProviders())
+
+    expect(result.current.providers).toEqual([])
+    expect(result.current.error).toBe(error)
+  })
+
   it('should call useQuery with /providers path', () => {
     renderHook(() => useProviders())
 

--- a/src/renderer/hooks/__tests__/useProvider.test.ts
+++ b/src/renderer/hooks/__tests__/useProvider.test.ts
@@ -108,6 +108,25 @@ describe('useProviders', () => {
     const { result } = renderHook(() => useProviders())
 
     expect(result.current.providers).toEqual([])
+    expect(result.current.hasLoaded).toBe(false)
+    expect(result.current.error).toBe(error)
+  })
+
+  it('marks stale provider data as loaded when background revalidation fails', () => {
+    const error = new Error('Provider registry unavailable')
+    mockUseQuery.mockReturnValue({
+      data: mockProviderList,
+      isLoading: false,
+      isRefreshing: false,
+      error,
+      refetch: vi.fn().mockResolvedValue(undefined),
+      mutate: vi.fn()
+    })
+
+    const { result } = renderHook(() => useProviders())
+
+    expect(result.current.providers).toBe(mockProviderList)
+    expect(result.current.hasLoaded).toBe(true)
     expect(result.current.error).toBe(error)
   })
 

--- a/src/renderer/hooks/useProvider.ts
+++ b/src/renderer/hooks/useProvider.ts
@@ -53,7 +53,7 @@ export function useProviders(
         }
       : undefined
 
-  const { data, isLoading, refetch } = useQuery('/providers', queryOptions)
+  const { data, isLoading, error, refetch } = useQuery('/providers', queryOptions)
 
   const {
     trigger: createTrigger,
@@ -80,6 +80,7 @@ export function useProviders(
   return {
     providers,
     isLoading,
+    error,
     createProvider,
     isCreating,
     createError,

--- a/src/renderer/hooks/useProvider.ts
+++ b/src/renderer/hooks/useProvider.ts
@@ -79,6 +79,7 @@ export function useProviders(
 
   return {
     providers,
+    hasLoaded: data !== undefined,
     isLoading,
     error,
     createProvider,

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
@@ -110,9 +110,9 @@ function ProviderSettingsContent({ isOnboarding = false, rawProviders }: Provide
 
 export default function ProviderSettingsPage({ isOnboarding = false }: ProviderSettingsPageProps) {
   const { t } = useTranslation()
-  const { providers, isLoading, error, refetch } = useProviders()
+  const { providers, hasLoaded, isLoading, error, refetch } = useProviders()
 
-  if (error) {
+  if (error && !hasLoaded) {
     return (
       <div className="flex h-full w-full items-center justify-center p-6">
         <Alert

--- a/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ProviderSettingsPage.tsx
@@ -1,8 +1,11 @@
+import { Alert, Button, Spinner } from '@cherrystudio/ui'
 import { usePersistCache } from '@data/hooks/useCache'
 import { useProviders } from '@renderer/hooks/useProvider'
+import type { Provider } from '@shared/data/types/provider'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import { omit } from 'es-toolkit/compat'
 import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { useProviderDeepLinkImport } from './hooks/useProviderDeepLinkImport'
 import { ProviderList } from './ProviderList'
@@ -19,10 +22,13 @@ interface ProviderSettingsSearch {
   id?: string
 }
 
-export default function ProviderSettingsPage({ isOnboarding = false }: ProviderSettingsPageProps) {
+interface ProviderSettingsContentProps extends ProviderSettingsPageProps {
+  rawProviders: Provider[]
+}
+
+function ProviderSettingsContent({ isOnboarding = false, rawProviders }: ProviderSettingsContentProps) {
   const search = useSearch({ strict: false }) as ProviderSettingsSearch
   const navigate = useNavigate()
-  const { providers: rawProviders } = useProviders()
   const [lastSelectedProviderId, setLastSelectedProviderId] = usePersistCache(
     'settings.provider.last_selected_provider_id'
   )
@@ -100,4 +106,38 @@ export default function ProviderSettingsPage({ isOnboarding = false }: ProviderS
       )}
     </div>
   )
+}
+
+export default function ProviderSettingsPage({ isOnboarding = false }: ProviderSettingsPageProps) {
+  const { t } = useTranslation()
+  const { providers, isLoading, error, refetch } = useProviders()
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <Alert
+          type="error"
+          showIcon
+          message={t('common.error')}
+          description={error.message}
+          action={
+            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+              {t('common.retry')}
+            </Button>
+          }
+          className="max-w-lg rounded-md px-4 py-3 shadow-none"
+        />
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center p-6">
+        <Spinner text={t('common.loading')} />
+      </div>
+    )
+  }
+
+  return <ProviderSettingsContent isOnboarding={isOnboarding} rawProviders={providers} />
 }

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
@@ -1,5 +1,7 @@
+import i18n from '@renderer/i18n/resolver'
 import { MockUseCacheUtils } from '@test-mocks/renderer/useCache'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useProviderDeepLinkImport } from '../hooks/useProviderDeepLinkImport'
@@ -50,7 +52,68 @@ describe('ProviderSettingsPage', () => {
     vi.clearAllMocks()
     MockUseCacheUtils.resetMocks()
     searchMock = {}
-    useProvidersMock.mockReturnValue({ providers })
+    useProvidersMock.mockReturnValue({
+      providers,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    })
+  })
+
+  it('shows loading state without mounting the provider list', () => {
+    useProvidersMock.mockReturnValue({
+      providers: [],
+      isLoading: true,
+      error: undefined,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    })
+
+    render(<ProviderSettingsPage />)
+
+    expect(screen.getByText(i18n.t('common.loading'))).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'select-openai' })).not.toBeInTheDocument()
+  })
+
+  it('shows a provider read failure and lets the user retry', async () => {
+    const user = userEvent.setup()
+    const refetch = vi.fn().mockResolvedValue(undefined)
+    useProvidersMock.mockReturnValue({
+      providers: [],
+      isLoading: false,
+      error: new Error('Provider registry unavailable'),
+      refetch
+    })
+
+    render(<ProviderSettingsPage />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(i18n.t('common.error'))
+    expect(screen.getByRole('alert')).toHaveTextContent('Provider registry unavailable')
+    expect(screen.queryByRole('button', { name: 'select-openai' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: i18n.t('common.retry') }))
+    expect(refetch).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the remembered provider while an initial read fails', async () => {
+    MockUseCacheUtils.setPersistCacheValue('settings.provider.last_selected_provider_id', 'anthropic')
+    useProvidersMock.mockReturnValue({
+      providers: [],
+      isLoading: false,
+      error: new Error('Provider registry unavailable'),
+      refetch: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const { rerender } = render(<ProviderSettingsPage />)
+
+    useProvidersMock.mockReturnValue({
+      providers,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn().mockResolvedValue(undefined)
+    })
+    rerender(<ProviderSettingsPage />)
+
+    expect(await screen.findByText('provider-setting-anthropic')).toBeInTheDocument()
   })
 
   it('restores the last selected provider after leaving and returning to the page', async () => {

--- a/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/__tests__/ProviderSettingsPage.test.tsx
@@ -54,6 +54,7 @@ describe('ProviderSettingsPage', () => {
     searchMock = {}
     useProvidersMock.mockReturnValue({
       providers,
+      hasLoaded: true,
       isLoading: false,
       error: undefined,
       refetch: vi.fn().mockResolvedValue(undefined)
@@ -63,6 +64,7 @@ describe('ProviderSettingsPage', () => {
   it('shows loading state without mounting the provider list', () => {
     useProvidersMock.mockReturnValue({
       providers: [],
+      hasLoaded: false,
       isLoading: true,
       error: undefined,
       refetch: vi.fn().mockResolvedValue(undefined)
@@ -79,6 +81,7 @@ describe('ProviderSettingsPage', () => {
     const refetch = vi.fn().mockResolvedValue(undefined)
     useProvidersMock.mockReturnValue({
       providers: [],
+      hasLoaded: false,
       isLoading: false,
       error: new Error('Provider registry unavailable'),
       refetch
@@ -94,10 +97,26 @@ describe('ProviderSettingsPage', () => {
     expect(refetch).toHaveBeenCalledOnce()
   })
 
+  it('keeps stale provider data visible when background revalidation fails', async () => {
+    useProvidersMock.mockReturnValue({
+      providers,
+      hasLoaded: true,
+      isLoading: false,
+      error: new Error('Provider registry unavailable'),
+      refetch: vi.fn().mockResolvedValue(undefined)
+    })
+
+    render(<ProviderSettingsPage />)
+
+    expect(await screen.findByText('provider-setting-openai')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
   it('preserves the remembered provider while an initial read fails', async () => {
     MockUseCacheUtils.setPersistCacheValue('settings.provider.last_selected_provider_id', 'anthropic')
     useProvidersMock.mockReturnValue({
       providers: [],
+      hasLoaded: false,
       isLoading: false,
       error: new Error('Provider registry unavailable'),
       refetch: vi.fn().mockResolvedValue(undefined)
@@ -107,6 +126,7 @@ describe('ProviderSettingsPage', () => {
 
     useProvidersMock.mockReturnValue({
       providers,
+      hasLoaded: true,
       isLoading: false,
       error: undefined,
       refetch: vi.fn().mockResolvedValue(undefined)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Relaunching a Windows portable build could reuse and delete the live instance's extracted resources, while provider read failures appeared as an empty list.

After this PR: Portable launches use independent extraction directories, and Provider settings distinguishes loading, retryable errors, and successful data without clearing the saved selection.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes: None

### Why we need it and why it was done in this way

The following tradeoffs were made: The fix is limited to electron-builder's portable extraction contract and the existing renderer query boundary, leaving Provider Registry, GitCode updates, and database schemas unchanged.

The following alternatives were considered: Moving registry JSON into userData, adding a custom NSIS script, or introducing compatibility migrations would only mask part of the resource lifecycle problem or add unnecessary maintenance.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Windows x64 portable dual-launch acceptance remains to be run on a packaged artifact; focused tests and repository lint gates pass on macOS.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix provider and model lists disappearing after relaunching the Windows portable app, and show retryable errors when provider data cannot be loaded.
```
