### PR TITLE
fix(moonshot): omit fixed temperature and top_p for all Kimi models

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -17651,6 +17651,9 @@
       "apiModelId": "kimi-k2.5",
       "modelId": "kimi-k2-5",
       "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
         "topP": {
           "supported": false
         }
@@ -17660,6 +17663,14 @@
     {
       "apiModelId": "kimi-k2.6",
       "modelId": "kimi-k2-6",
+      "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
+        "topP": {
+          "supported": false
+        }
+      },
       "providerId": "moonshot",
       "reasoningContracts": {
         "openai-chat-completions": {
@@ -17705,6 +17716,9 @@
     {
       "modelId": "kimi-k3",
       "parameterSupport": {
+        "temperature": {
+          "supported": false
+        },
         "topP": {
           "supported": false
         }

--- a/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-parameter-support.test.ts
@@ -18,7 +18,12 @@ const overrideOf = (providerId: string, modelId: string) => {
 }
 
 describe('moonshot parameter support', () => {
-  it.each(['kimi-k2-5', 'kimi-k3'])('omits the fixed top_p parameter for %s', (modelId) => {
-    expect(overrideOf('moonshot', modelId).parameterSupport?.topP).toEqual({ supported: false })
-  })
+  it.each(['kimi-k2-5', 'kimi-k2-6', 'kimi-k3'])(
+    'omits the fixed temperature and top_p parameters for %s',
+    (modelId) => {
+      const { parameterSupport } = overrideOf('moonshot', modelId)
+      expect(parameterSupport?.temperature).toEqual({ supported: false })
+      expect(parameterSupport?.topP).toEqual({ supported: false })
+    }
+  )
 })

--- a/packages/provider-registry/src/providers/moonshot.ts
+++ b/packages/provider-registry/src/providers/moonshot.ts
@@ -3,7 +3,10 @@ import { EFFORT, modeWire } from './wires'
 
 const effortWire = modeWire('reasoningEffort', { off: 'none', auto: EFFORT, effort: EFFORT }, { autoEffort: 'medium' })
 
-const fixedTopPParameterSupport = { topP: { supported: false } } as const
+const fixedSamplingParameterSupport = {
+  temperature: { supported: false },
+  topP: { supported: false }
+} as const
 
 export default openaiCompatible({
   id: 'moonshot',
@@ -35,12 +38,12 @@ export default openaiCompatible({
     official: 'https://www.moonshot.cn/'
   },
   overrides: [
-    // Moonshot fixes top_p at 0.95 for these models. Omitting the non-configurable
-    // parameter uses that server default; sending Cherry's default of 1 is rejected.
-    { modelId: 'kimi-k2.5', parameterSupport: fixedTopPParameterSupport },
+    // Moonshot fixes temperature and top_p (0.95) for these models and rejects other
+    // values with HTTP 400; omitting the non-configurable parameters uses the server defaults.
+    { modelId: 'kimi-k2.5', parameterSupport: fixedSamplingParameterSupport },
     ...['kimi-k2.6', 'kimi-k3'].map((modelId) => ({
       modelId,
-      ...(modelId === 'kimi-k3' ? { parameterSupport: fixedTopPParameterSupport } : {}),
+      parameterSupport: fixedSamplingParameterSupport,
       reasoningContracts: {
         'openai-chat-completions': { wire: effortWire }
       }

--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -69,6 +69,22 @@ describe('getTemperature', () => {
     expect(getTemperature(a, model, OMIT_REASONING)).toBe(1)
   })
 
+  it('omits temperature when the resolved provider-model marks it unsupported', () => {
+    const a = makeAssistant({ temperature: 0.7 })
+    const model = makeModel({
+      id: 'moonshot::kimi-k2-6',
+      providerId: 'moonshot',
+      parameterSupport: {
+        temperature: { supported: false, min: 0, max: 1 },
+        maxTokens: true,
+        stopSequences: true,
+        systemMessage: true
+      }
+    })
+
+    expect(getTemperature(a, model, OMIT_REASONING)).toBeUndefined()
+  })
+
   it('disables temperature for Gemini 3.x models', () => {
     const a = makeAssistant({ temperature: 0.8 })
     const model = makeModel({ id: 'gemini::gemini-3-pro' })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

#19431 marked `top_p` unsupported only for Kimi K2.5 and K3 on the official Moonshot provider. Kimi K2.6 still received the assistant default `top_p=1`, which the official Moonshot API rejects with HTTP 400 — the official K2.6 quickstart states the k2.6/k2.5 series fixes `top_p` at 0.95 and errors on any other value. The same documentation also fixes `temperature` (1.0 thinking / 0.6 instant for the K2.5/K2.6 series, 1.0 for K3), so a custom assistant temperature could trigger the same HTTP 400 on all three models.

After this PR:

Moonshot's Kimi K2.5, K2.6, and K3 catalog entries mark both `temperature` and `topP` unsupported, so the request builder omits both fixed parameters and the official API uses its accepted server-side defaults.

Follow-up to #19431 (#12691 is already closed, so no issue is auto-closed here).

### Why we need it and why it was done in this way

Same mechanism as #19431: the constraint is expressed as provider-scoped parameter-support metadata and flows through the existing parameter-omission path in the request builder, with no request-time model-name conditionals.

The following tradeoffs were made:

The change applies only to the official `moonshot` provider. Other providers hosting the open-weight Kimi models run their own inference and keep their own parameter behavior. The official docs also fix `n` and both penalties server-side, but Cherry's default chat flow never sends those, so no metadata was added for them.

The following alternatives were considered:

Forcing the documented fixed values client-side was rejected — the API owns the accepted defaults and a hardcoded value could become stale (consistent with #19431).

Links to places where the discussion took place:

- https://github.com/CherryHQ/cherry-studio/issues/12691
- Official parameter docs: https://platform.kimi.com/docs/guide/kimi-k2-6-quickstart and https://platform.kimi.com/docs/guide/kimi-k3-quickstart ("若指定其他值，将会报错" / fixed-value list for K3)

### Breaking changes

None.

### Special notes for your reviewer

The regenerated `provider-models.json` diff is scoped to the three Moonshot rows; unrelated live-upstream drift from the models.dev pull was excluded. Note the current models.dev state trips two pre-existing catalog invariants unrelated to this change (a dangling `deepseek/deepseek-reasoner` override and three unpinned OpenCode Go models) — the next PR that regenerates the catalog will hit them; worth a separate issue.

`isMaxTemperatureOneModel` now returns false for these models (previously matched via the id-based fallback). Its only live consumer is the temperature clamp in `getTemperature`, which sits after the unsupported-parameter early return, so there is no behavioral impact.

Verified with `vitest run --project provider-registry` (345 tests, includes schema conformance, catalog invariants, and catalog↔source sync) and `vitest run --project main src/main/ai/utils/__tests__/modelParameters.test.ts` (22 tests); oxlint / Biome / tsgo clean on the touched files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix HTTP 400 errors from the official Moonshot API by omitting the fixed `temperature` and `top_p` parameters for Kimi K2.5, K2.6, and K3 models.
```
