### PR TITLE
fix(renderer): refresh time bucket reference for session/topic lists

### DIFF
--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -354,7 +354,23 @@ const Sessions = ({
   const isRightPanel = presentation === 'right-panel'
   const conversationNav = useConversationNavigation('agents')
   const isWindowFrame = useWindowFrame().mode === 'window'
-  const [groupNow] = useState(() => new Date())
+  const [groupNow, setGroupNow] = useState(() => new Date())
+
+  useEffect(() => {
+    const updateGroupNow = () => setGroupNow(new Date())
+    const intervalId = window.setInterval(updateGroupNow, 60_000)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') updateGroupNow()
+    }
+    window.addEventListener('focus', updateGroupNow)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      window.clearInterval(intervalId)
+      window.removeEventListener('focus', updateGroupNow)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
   const { notesPath } = useNotesSettings()
   const [exportMenuOptions] = useMultiplePreferences({
     docx: 'data.export.menus.docx',

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -275,7 +275,23 @@ export function Topics({
   const tabs = useOptionalTabsContext()
   const conversationNav = useConversationNavigation('assistants')
   const isWindowFrame = useWindowFrame().mode === 'window'
-  const [groupNow] = useState(() => dayjs())
+  const [groupNow, setGroupNow] = useState(() => dayjs())
+
+  useEffect(() => {
+    const updateGroupNow = () => setGroupNow(dayjs())
+    const intervalId = window.setInterval(updateGroupNow, 60_000)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') updateGroupNow()
+    }
+    window.addEventListener('focus', updateGroupNow)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      window.clearInterval(intervalId)
+      window.removeEventListener('focus', updateGroupNow)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
   const { notesPath } = useNotesSettings()
   const {
     updateTopic: patchTopic,


### PR DESCRIPTION
### What this PR does

Before this PR: time grouping in the Sessions and Topics lists used a mount-time frozen `now` value (`const [groupNow] = useState(() => new Date()/dayjs())`). Once the component stayed mounted across midnight (long-lived right-side panel), newly created sessions/topics landed in "Earlier" instead of "Today". Switching the panel left↔right briefly fixed it by remounting.

After this PR: the grouping reference refreshes every 60s and on window `focus` / `visibilitychange`, so `getResourceTimeBucket(..., now)` tracks wall-clock days without waiting for a remount. Applied to both `Sessions.tsx` and `Topics.tsx`.

Fixes #19536

### Why we need it and why it was done in this way

The lightest fix is to make `groupNow` live — no schema, preference, or helper changes. A 60s poll is cheap (triggers two small re-renders) and covers the "app left open overnight" case; focus/visibility handlers recover immediately on resume.

Alternatives considered: recomputing with `dayjs()` on every render (heavier/more churn), or adding a "disable grouping" toggle for the right panel (separate UX decision — out of scope for the correctness fix).

Links: #19536, #19026 / #19032 (prior fix was scoped to `reuseOrCreatePlaceholderForDelivery` only)

### Breaking changes

NONE

### Release note

```release-note
Fixed sessions/topics in the right-side panel showing new items under "Earlier" instead of "Today" after staying open across days.
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>