### PR TITLE
fix(agent-heartbeat): honor the heartbeat toggle on migration-renamed schedules

### DIFF
--- a/src/main/ai/agents/AgentJobsService.ts
+++ b/src/main/ai/agents/AgentJobsService.ts
@@ -4,6 +4,7 @@ import { agentService } from '@data/services/AgentService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import {
   agentTaskService,
+  HEARTBEAT_PROMPT_SENTINEL,
   normalizeTaskSessionReuseRevision,
   readTaskSessionReuse,
   writeTaskSessionReuse
@@ -75,6 +76,7 @@ export class AgentJobsService extends BaseService {
 
   createTask(agentId: string, form: AgentTaskForm): ScheduledTaskEntity {
     this.assertAgentExists(agentId)
+    this.assertPromptNotReserved(form.prompt)
     const channelIds = form.channelIds ?? []
     this.assertChannelsBelongToAgent(agentId, channelIds)
 
@@ -115,6 +117,7 @@ export class AgentJobsService extends BaseService {
   updateTask(agentId: string, taskId: string, patch: AgentTaskPatch): ScheduledTaskEntity | null {
     const existing = agentTaskService.getTask(agentId, taskId)
     if (!existing) return null
+    this.assertPromptNotReserved(patch.prompt)
     if (patch.channelIds !== undefined) {
       this.assertChannelsBelongToAgent(agentId, patch.channelIds)
     }
@@ -267,6 +270,19 @@ export class AgentJobsService extends BaseService {
   private assertAgentExists(agentId: string): void {
     if (!agentService.getAgent(agentId)) {
       throw new Error(`Agent not found: ${agentId}`)
+    }
+  }
+
+  /**
+   * The heartbeat sentinel is what identifies a heartbeat run, so a user task
+   * must never carry it: `AgentTaskService` would hide the task and
+   * `runAgentTask` would run `heartbeat.md` under the heartbeat toggle instead
+   * of the task's own prompt. Guarded here rather than in `agentTaskFormSchema`
+   * because MCP's `cherryAutonomyTools` calls this service directly.
+   */
+  private assertPromptNotReserved(prompt: string | undefined): void {
+    if (prompt === HEARTBEAT_PROMPT_SENTINEL) {
+      throw new Error(`Prompt is reserved for the agent heartbeat: ${HEARTBEAT_PROMPT_SENTINEL}`)
     }
   }
 

--- a/src/main/ai/agents/__tests__/AgentJobsService.test.ts
+++ b/src/main/ai/agents/__tests__/AgentJobsService.test.ts
@@ -215,6 +215,13 @@ describe('AgentJobsService', () => {
       spy.mockRestore()
     })
 
+    it('refuses the reserved heartbeat prompt — nothing is written', () => {
+      expect(() => service.createTask(AGENT_ID, { ...form, prompt: '__heartbeat__' })).toThrow(
+        'reserved for the agent heartbeat'
+      )
+      expect(jobScheduleService.listAll({ type: 'agent.task' })).toHaveLength(0)
+    })
+
     it('rejects an invalid cron trigger up front — no row, no subscriptions, no timer', () => {
       seedChannel(CHANNEL_ID, AGENT_ID)
 
@@ -252,6 +259,15 @@ describe('AgentJobsService', () => {
       expect(updated?.prompt).toBe('new prompt')
       expect(jobScheduleService.getById(task.id)?.jobInputTemplate).toMatchObject({ prompt: 'new prompt' })
       expect(getIntervalEntry(task.id)).toBe(originalEntry)
+    })
+
+    it('refuses to repoint an existing task at the reserved heartbeat prompt', () => {
+      const task = service.createTask(AGENT_ID, form)
+
+      expect(() => service.updateTask(AGENT_ID, task.id, { prompt: '__heartbeat__' })).toThrow(
+        'reserved for the agent heartbeat'
+      )
+      expect(jobScheduleService.getById(task.id)?.jobInputTemplate).toMatchObject({ prompt: form.prompt })
     })
 
     it('drops a semantically-equal trigger from the patch — the interval phase is not reset', () => {

--- a/src/main/ai/agents/__tests__/runAgentTask.test.ts
+++ b/src/main/ai/agents/__tests__/runAgentTask.test.ts
@@ -248,6 +248,45 @@ describe('runAgentTask', () => {
     expect(readHeartbeat).not.toHaveBeenCalled()
   })
 
+  // v1 gave every agent a `heartbeat` task; v2's job_schedule is UNIQUE on (type, name), so
+  // the migration renames all but the first to `task_<v1Id>` — still heartbeats, still gated.
+  it('skips a disabled heartbeat whose schedule name the migration disambiguated', async () => {
+    vi.mocked(jobService.getById).mockReturnValueOnce(makeJobSnapshot())
+    vi.mocked(jobScheduleService.getById).mockReturnValueOnce(makeSchedule('task_hb-2'))
+    vi.mocked(agentService.getAgent).mockReturnValueOnce(makeAgent({ heartbeat_enabled: false }))
+
+    const out = await runAgentTask(makeCtx())
+
+    expect(out).toEqual({ sessionId: null, result: 'Skipped (disabled)' })
+    expect(agentSessionService.create).not.toHaveBeenCalled()
+    expect(mockStartRun).not.toHaveBeenCalled()
+  })
+
+  // Same renamed schedule, heartbeat on: it must run heartbeat.md, not hand the raw
+  // sentinel to the model (whose reply then reached every subscribed channel).
+  it('runs a disambiguated heartbeat from heartbeat.md rather than the raw sentinel', async () => {
+    vi.mocked(jobService.getById).mockReturnValueOnce(makeJobSnapshot())
+    vi.mocked(jobScheduleService.getById).mockReturnValueOnce(makeSchedule('task_hb-2'))
+    vi.mocked(agentService.getAgent).mockReturnValueOnce(makeAgent({ heartbeat_enabled: true }))
+    vi.mocked(agentWorkspaceService.getById).mockReturnValueOnce({ id: 'ws-1', type: 'user', path: '/ws/a' } as never)
+    vi.mocked(readHeartbeat).mockResolvedValueOnce('check the inbox')
+    vi.mocked(agentSessionService.create).mockReturnValueOnce(makeSession('/ws/a'))
+
+    const promise = runAgentTask(makeCtx())
+    await vi.waitFor(() => expect(mockStartRun).toHaveBeenCalled())
+    captured.listeners[0].onDone({ status: 'completed' })
+    await promise
+
+    expect(mockStartRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userParts: [{ type: 'text', text: expect.stringContaining('check the inbox') }]
+      })
+    )
+    expect(mockStartRun).not.toHaveBeenCalledWith(
+      expect.objectContaining({ userParts: [{ type: 'text', text: '__heartbeat__' }] })
+    )
+  })
+
   it('treats a built-in Assistant heartbeat like any other Agent heartbeat', async () => {
     vi.mocked(jobService.getById).mockReturnValueOnce(makeJobSnapshot())
     vi.mocked(jobScheduleService.getById).mockReturnValueOnce(makeSchedule('heartbeat'))

--- a/src/main/ai/agents/runAgentTask.ts
+++ b/src/main/ai/agents/runAgentTask.ts
@@ -27,6 +27,7 @@ import { agentChannelService } from '@data/services/AgentChannelService'
 import { agentService } from '@data/services/AgentService'
 import { agentSessionService } from '@data/services/AgentSessionService'
 import {
+  HEARTBEAT_PROMPT_SENTINEL,
   normalizeTaskSessionReuseRevision,
   readTaskSessionReuse,
   type TaskSessionReuse
@@ -43,9 +44,6 @@ import { ErrorCode, isDataApiError } from '@shared/data/api/errors'
 import { AGENT_WORKSPACE_TYPE, type AgentSessionWorkspaceSource } from '@shared/data/api/schemas/agentWorkspaces'
 
 const logger = loggerService.withContext('runAgentTask')
-
-const HEARTBEAT_PROMPT_SENTINEL = '__heartbeat__'
-const HEARTBEAT_TASK_NAME = 'heartbeat'
 
 export type AgentTaskInput = {
   agentId: string
@@ -157,7 +155,8 @@ export async function runAgentTask(ctx: JobContext<AgentTaskInput>): Promise<Age
 
   const config = agent.configuration ?? {}
 
-  const isHeartbeat = taskName === HEARTBEAT_TASK_NAME && prompt === HEARTBEAT_PROMPT_SENTINEL
+  // Identity is the reserved prompt, not the schedule name — see HEARTBEAT_PROMPT_SENTINEL.
+  const isHeartbeat = prompt === HEARTBEAT_PROMPT_SENTINEL
 
   let effectivePrompt = prompt
 

--- a/src/main/data/services/AgentTaskService.ts
+++ b/src/main/data/services/AgentTaskService.ts
@@ -25,7 +25,15 @@ import type { JobScheduleSnapshot, JobSnapshot } from '@shared/data/api/schemas/
 import type { ListOptions } from '@shared/data/api/types'
 
 const AGENT_TASK_TYPE = 'agent.task' as const
-const HEARTBEAT_TASK_NAME = 'heartbeat'
+
+/**
+ * Reserved prompt marking a schedule as an agent heartbeat rather than a
+ * user-authored task. It is the only heartbeat marker that survives the v1→v2
+ * migration intact — the schedule name does not, because `job_schedule` is
+ * UNIQUE on (type, name) while v1 gave every agent its own `heartbeat` row, so
+ * all but the first are renamed to `task_<v1Id>`.
+ */
+export const HEARTBEAT_PROMPT_SENTINEL = '__heartbeat__'
 
 type AgentTaskJobInputTemplate = {
   agentId: string
@@ -208,7 +216,7 @@ export class AgentTaskService {
       const template = normalizeAgentTaskTemplate(s.jobInputTemplate)
       if (!template) return false
       if (agentId !== undefined && template.agentId !== agentId) return false
-      if (!includeHeartbeat && s.name === HEARTBEAT_TASK_NAME) return false
+      if (!includeHeartbeat && template.prompt === HEARTBEAT_PROMPT_SENTINEL) return false
       return true
     })
 

--- a/src/main/data/services/__tests__/AgentTaskService.test.ts
+++ b/src/main/data/services/__tests__/AgentTaskService.test.ts
@@ -58,6 +58,20 @@ function makeSnapshot(overrides: Partial<JobScheduleSnapshot> = {}): JobSchedule
   }
 }
 
+/**
+ * What the v1→v2 migration actually writes for an agent heartbeat: the reserved
+ * prompt survives verbatim, the `heartbeat` name does not — `job_schedule` is
+ * UNIQUE on (type, name), so every agent past the first is renamed `task_<v1Id>`.
+ */
+function makeHeartbeatSnapshot(overrides: Partial<JobScheduleSnapshot> = {}): JobScheduleSnapshot {
+  return makeSnapshot({
+    name: 'task_v1-7',
+    jobInputTemplate: { agentId: AGENT_ID, prompt: '__heartbeat__', timeoutMinutes: 2, workspace: taskWorkspace },
+    metadata: { migratedFrom: 'v1.agentTask', v1Id: 'v1-7' },
+    ...overrides
+  })
+}
+
 function makeJobSnapshot(overrides: Partial<JobSnapshot> = {}): JobSnapshot {
   return {
     id: 'job-1',
@@ -210,7 +224,7 @@ describe('AgentTaskService (read side)', () => {
           name: 'b',
           jobInputTemplate: { agentId: 'other', prompt: 'x', timeoutMinutes: 2, workspace: taskWorkspace }
         }),
-        makeSnapshot({ id: 's3', name: 'heartbeat' })
+        makeHeartbeatSnapshot({ id: 's3' })
       ])
 
       const result = agentTaskService.listTasks(AGENT_ID)
@@ -220,10 +234,18 @@ describe('AgentTaskService (read side)', () => {
       expect(result.tasks[0].id).toBe('s1')
     })
 
+    it('lists a user task that merely happens to be named heartbeat', () => {
+      vi.mocked(jobScheduleService.listAll).mockReturnValueOnce([makeSnapshot({ id: 's1', name: 'heartbeat' })])
+
+      const result = agentTaskService.listTasks(AGENT_ID)
+
+      expect(result.tasks.map((t) => t.id)).toEqual(['s1'])
+    })
+
     it('returns heartbeat tasks when includeHeartbeat=true', () => {
       vi.mocked(jobScheduleService.listAll).mockReturnValueOnce([
         makeSnapshot({ id: 's1', name: 'a' }),
-        makeSnapshot({ id: 's3', name: 'heartbeat' })
+        makeHeartbeatSnapshot({ id: 's3' })
       ])
 
       const result = agentTaskService.listTasks(AGENT_ID, { includeHeartbeat: true })
@@ -241,7 +263,7 @@ describe('AgentTaskService (read side)', () => {
           createdAt: '2026-05-22T00:00:00.000Z',
           jobInputTemplate: { agentId: 'other', prompt: 'x', timeoutMinutes: 2, workspace: taskWorkspace }
         }),
-        makeSnapshot({ id: 'heartbeat', name: 'heartbeat', createdAt: '2026-05-23T00:00:00.000Z' })
+        makeHeartbeatSnapshot({ id: 'heartbeat', createdAt: '2026-05-23T00:00:00.000Z' })
       ])
 
       const result = agentTaskService.listAllTasks({ limit: 1, offset: 0 })


### PR DESCRIPTION
### What this PR does

Before this PR:

A schedule counted as an agent heartbeat only when `schedule.name === 'heartbeat'` **and** its prompt was the reserved `__heartbeat__` sentinel. v2 never creates heartbeat schedules itself — every one of them arrives through the v1 → v2 migration, and that migration cannot keep the `heartbeat` name: `job_schedule` is UNIQUE on `(type, name)` while v1 gave *each* agent its own `heartbeat` row, so all but the first are renamed to `task_<v1Id>`.

For those renamed schedules the name check never matched, with two user-visible consequences:

- `runAgentTask` ignored `heartbeat_enabled: false` and ran the schedule as an ordinary task, handing the raw `__heartbeat__` sentinel to the model as the user prompt — and the model's reply then fanned out to every channel the task is subscribed to. Turning the heartbeat off did nothing.
- `AgentTaskService.listTasks` showed those heartbeats in the Scheduled Tasks list as if the user had authored them, while *hiding* a genuine user task that merely happened to be named `heartbeat`.

After this PR:

A heartbeat is identified by the reserved prompt alone — the one marker the migration preserves verbatim — at both sites, from a single exported `HEARTBEAT_PROMPT_SENTINEL` constant in `AgentTaskService`. The disabled toggle is honored for renamed schedules, an enabled one runs `heartbeat.md` instead of the raw sentinel, and a user task named `heartbeat` is listed normally.

Because the sentinel is now the *sole* marker, `AgentJobsService` — the single write path shared by the renderer (IpcApi) and MCP's `cherryAutonomyTools` — rejects it as a user task's prompt on both create and update, so no ordinary task can be mistaken for a heartbeat.

N/A

### Why we need it and why it was done in this way

The name and the prompt were two markers for one fact, and the migration can only guarantee one of them. Dropping the unreliable half is the root fix; the alternative — teaching the migration to preserve the name — is impossible under the UNIQUE constraint, and a metadata flag would be a third marker to keep in sync.

The following tradeoffs were made:

- The prompt becomes a reserved value, so it needs a guard on the write path. That guard lives in `AgentJobsService` rather than in `agentTaskFormSchema`, because MCP calls the service directly and would otherwise bypass a schema-level check.
- A pre-existing task carrying `__heartbeat__` (only reachable by hand-editing the DB) is not migrated or rewritten; it is simply treated as a heartbeat from now on, which is what the old code intended for it anyway.

The following alternatives were considered:

- Match on either the name or the prompt (keep both markers) — leaves the name half able to misclassify a user task named `heartbeat`, which is the second half of this bug.
- Add a `metadata.isHeartbeat` flag — a third source of truth that the already-shipped migration would have to backfill.

Links to places where the discussion took place: N/A

### Breaking changes

None. A user task whose prompt is literally `__heartbeat__` can no longer be created or updated to that value; such a task is not creatable through the UI in normal use.

### Special notes for your reviewer

The two new `runAgentTask` tests use a schedule named `task_hb-2` — that is exactly what the migration writes for the second and later agents, which is the case the old gate missed. `AgentTaskService.test.ts` grew a `makeHeartbeatSnapshot()` helper that mirrors the migration's real output (renamed schedule + `migratedFrom` metadata) so the read-side tests stop asserting against a shape the migration never produces.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the agent heartbeat toggle being ignored for agents migrated from v1: turning the heartbeat off now stops it, an enabled heartbeat no longer sends the internal `__heartbeat__` marker to the model (whose reply reached the task's subscribed channels), and a scheduled task you named "heartbeat" is no longer hidden from the Scheduled Tasks list.
```
