### PR TITLE
fix(pi): surface max-token length truncation as error instead of success

### DIFF
--- a/src/main/ai/runtime/pi/PiRuntimeConnection.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.ts
@@ -609,8 +609,18 @@ export class PiRuntimeConnection implements AgentRuntimeConnection {
       this.session?.clearQueue()
       this.eventQueue.push({ type: 'steer-undelivered', inputs: undelivered })
     }
-    if (error || this.lastStopReason === 'error') {
-      const failure = error instanceof Error ? error : new Error(this.lastAgentError ?? 'pi agent turn failed')
+    if (error || this.lastStopReason === 'error' || this.lastStopReason === 'length') {
+      let failure: Error
+      if (error instanceof Error) {
+        failure = error
+      } else if (this.lastStopReason === 'length') {
+        failure = new Error(
+          this.lastAgentError ??
+            'Response truncated at the model output limit (stopReason: length). The reply may be incomplete or empty — try continuing the turn or retrying with a higher maximum output.'
+        )
+      } else {
+        failure = new Error(this.lastAgentError ?? 'pi agent turn failed')
+      }
       logger.error('pi prompt failed', failure)
       this.eventQueue.push({ type: 'error', error: failure })
     } else {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `PiRuntimeConnection.finishPromptRun` treated `stopReason: "length"` (provider `finish_reason: length` — max output tokens hit) as a normal `turn-complete`, persisting reasoning-only or silently truncated completions as `success`. The UI showed a blank or incomplete reply with no indication it was truncated and no path to continue/retry.

After this PR: `stopReason: "length"` is mapped to an `error` terminal with a descriptive message (`"Response truncated at the model output limit … try continuing the turn or retrying with a higher maximum output."`), so the run is stored as incomplete/error, surfaces visibly to the user, and remains continuable.

Fixes #19551

### Why we need it and why it was done in this way

`@earendil-works/pi-coding-agent` already maps `finish_reason: length` to `stopReason: length` on `turn_end`, and `PiRuntimeConnection` only treated `stopReason: error` as a failure — so a max-token truncation looked like any successful turn to the host (`AgentSessionRuntimeService` → `success` persistence → `PersistenceListener` success write).

The following tradeoffs were made:
- Reuses the existing `error` terminal (no new `ApplicationMessageStatus` / DB schema) — sufficient to satisfy the bug's contract: "must not appear as blank success" and "must indicate truncation + allow continue/retry". The error persists via `PersistenceListener.onError` (folds into `data-error` part, `status: error`), the next-turn gating treats `error` as continuable, and no silent-success path remains.
- `lastAgentError` is preferred when present, matching the existing `error` branch's preference.

The following alternatives were considered:
- Dedicated `truncated`/`incomplete` status: more faithful to the product note ("error terminal vs. dedicated incomplete state") but requires a new terminal status, persistence status value, and UI handling — deferred unless the product decision requires it. Current fix can be superseded by adding that state later.

Links to places where the discussion took place: #19551

### Breaking changes

None.

### Special notes for your reviewer

- Only file changed: `src/main/ai/runtime/pi/PiRuntimeConnection.ts` in `finishPromptRun`.
- `willRetry` path (auto-retry on API errors) intentionally does not apply to `length` — truncation is a quota/config limit, not a transient failure; retrying without changing `maxOutputTokens` would repeat the truncation. After the fix `length` still clears through `finishPromptRun`'s non-`willRetry` branch and reaches the host as `error`.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
fix(pi): surface max-token length truncations as errors instead of silent success — reasoning-only or truncated completions now show a truncation error and remain continuable (Fixes #19551)
```
