### PR TITLE
fix(provider-registry): publish complete remote catalogs

### DIFF
--- a/.github/workflows/sync-registry-data.yml
+++ b/.github/workflows/sync-registry-data.yml
@@ -28,7 +28,9 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/sync-registry-data.yml'
       - 'packages/provider-registry/data/**'
+      - 'scripts/buildRegistrySyncRequest.js'
       # A REGISTRY_SCHEMA_VERSION bump changes the publish dir (v{N}); watch its
       # source so a version-only change still creates the new vN/ directory.
       - 'packages/provider-registry/src/registry-loader.ts'
@@ -147,25 +149,16 @@ jobs:
           REF_ID=$(jq -er '.data.repository.ref.id' <<< "$REF")
           HEAD_OID=$(jq -er '.data.repository.ref.target.oid' <<< "$REF")
 
-          ADDITIONS=$(git diff --cached --name-only --diff-filter=ACMR \
-            | while read -r f; do
-                jq -n --arg path "$f" --arg contents "$(base64 -w0 "$f")" '{path: $path, contents: $contents}'
-              done | jq -sc .)
-          DELETIONS=$(git diff --cached --name-only --diff-filter=D | jq -Rc '{path: .}' | jq -sc .)
-
-          RESP=$(jq -n \
-            --arg refId "$REF_ID" \
-            --arg oid "$HEAD_OID" \
-            --arg headline "chore(provider-registry): sync catalog to ${{ steps.ver.outputs.dir }}" \
-            --arg body "Source: ${{ github.repository }}@${{ github.sha }}
+          REQUEST_FILE=$(mktemp)
+          trap 'rm -f "$REQUEST_FILE"' EXIT
+          REGISTRY_SYNC_REF_ID="$REF_ID" \
+          REGISTRY_SYNC_EXPECTED_HEAD_OID="$HEAD_OID" \
+          REGISTRY_SYNC_HEADLINE="chore(provider-registry): sync catalog to ${{ steps.ver.outputs.dir }}" \
+          REGISTRY_SYNC_BODY="Source: ${{ github.repository }}@${{ github.sha }}
           Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            --argjson additions "$ADDITIONS" \
-            --argjson deletions "$DELETIONS" \
-            '{query: "mutation($input:CreateCommitOnBranchInput!){createCommitOnBranch(input:$input){commit{oid url}}}",
-              variables: {input: {branch: {id: $refId}, expectedHeadOid: $oid,
-                                  message: {headline: $headline, body: $body},
-                                  fileChanges: {additions: $additions, deletions: $deletions}}}}' \
-            | gh api graphql --input -)
+            node ../main/scripts/buildRegistrySyncRequest.js "$REQUEST_FILE"
+
+          RESP=$(gh api graphql --input "$REQUEST_FILE")
 
           # gh does not always exit non-zero on a GraphQL `errors` payload.
           if jq -e '.errors' <<< "$RESP" >/dev/null; then

--- a/scripts/__tests__/buildRegistrySyncRequest.test.ts
+++ b/scripts/__tests__/buildRegistrySyncRequest.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { buildRegistrySyncRequest } from '../buildRegistrySyncRequest'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('buildRegistrySyncRequest', () => {
+  it('includes catalog files larger than Linux single-argument limits without truncation', () => {
+    const rootDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-sync-request-'))
+    temporaryDirectories.push(rootDirectory)
+    const catalogPath = 'v1/provider-models.json'
+    const catalog = Buffer.alloc(200_000, 'x')
+    fs.mkdirSync(path.join(rootDirectory, 'v1'))
+    fs.writeFileSync(path.join(rootDirectory, catalogPath), catalog)
+
+    const request = buildRegistrySyncRequest({
+      rootDirectory,
+      additionPaths: [catalogPath],
+      deletionPaths: ['v1/removed.json'],
+      refId: 'branch-id',
+      expectedHeadOid: 'head-oid',
+      headline: 'sync catalog',
+      body: 'source revision'
+    })
+
+    const input = request.variables.input
+    expect(input.fileChanges.additions).toHaveLength(1)
+    expect(input.fileChanges.additions[0].path).toBe(catalogPath)
+    expect(Buffer.from(input.fileChanges.additions[0].contents, 'base64')).toEqual(catalog)
+    expect(input.fileChanges.deletions).toEqual([{ path: 'v1/removed.json' }])
+  })
+})

--- a/scripts/buildRegistrySyncRequest.js
+++ b/scripts/buildRegistrySyncRequest.js
@@ -1,0 +1,69 @@
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const CREATE_COMMIT_MUTATION =
+  'mutation($input:CreateCommitOnBranchInput!){createCommitOnBranch(input:$input){commit{oid url}}}'
+
+function listStagedPaths(diffFilter) {
+  return execFileSync('git', ['diff', '--cached', '--name-only', '-z', `--diff-filter=${diffFilter}`])
+    .toString()
+    .split('\0')
+    .filter(Boolean)
+}
+
+function buildRegistrySyncRequest({
+  rootDirectory,
+  additionPaths,
+  deletionPaths,
+  refId,
+  expectedHeadOid,
+  headline,
+  body
+}) {
+  const additions = additionPaths.map((filePath) => ({
+    path: filePath,
+    contents: fs.readFileSync(path.resolve(rootDirectory, filePath)).toString('base64')
+  }))
+  const deletions = deletionPaths.map((filePath) => ({ path: filePath }))
+
+  return {
+    query: CREATE_COMMIT_MUTATION,
+    variables: {
+      input: {
+        branch: { id: refId },
+        expectedHeadOid,
+        message: { headline, body },
+        fileChanges: { additions, deletions }
+      }
+    }
+  }
+}
+
+function requiredEnvironment(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+function main() {
+  const [outputPath] = process.argv.slice(2)
+  if (!outputPath) throw new Error('output path is required')
+
+  const rootDirectory = process.cwd()
+  const request = buildRegistrySyncRequest({
+    rootDirectory,
+    additionPaths: listStagedPaths('ACMR'),
+    deletionPaths: listStagedPaths('D'),
+    refId: requiredEnvironment('REGISTRY_SYNC_REF_ID'),
+    expectedHeadOid: requiredEnvironment('REGISTRY_SYNC_EXPECTED_HEAD_OID'),
+    headline: requiredEnvironment('REGISTRY_SYNC_HEADLINE'),
+    body: requiredEnvironment('REGISTRY_SYNC_BODY')
+  })
+
+  fs.writeFileSync(outputPath, JSON.stringify(request))
+}
+
+if (require.main === module) main()
+
+exports.buildRegistrySyncRequest = buildRegistrySyncRequest


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The provider-registry sync workflow passed each Base64-encoded catalog through a single command-line argument. `models.json` and `provider-models.json` exceeded Linux's per-argument limit, so both `jq` processes failed inside a pipeline while the workflow still published a manifest-only commit and reported success.

After this PR:

The workflow builds its GraphQL request in a file through a tested Node helper, preserving every staged catalog file without using large argv values. Changes to the workflow or helper also trigger a sync, so merging this PR republishes a complete snapshot.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The helper reads the staged catalog files into memory while constructing the request. The current request is about 2 MB, which is small enough for the workflow and avoids shell argument limits.

The following alternatives were considered:

Publishing each file in a separate commit was rejected because the catalog contract requires the manifest to bind one atomic snapshot. A normal Git push was rejected because the branch requires GitHub-verified signatures; `createCommitOnBranch` preserves the existing signed publication path.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/actions/runs/33060064566

### Breaking changes

None.

### Special notes for your reviewer

The failed sync left the remote manifest newer than the two large JSON files. Merging this PR triggers the repaired workflow and republishes them together. The regression test uses a 200 KB catalog fixture, above Linux's single-argument limit, and verifies lossless Base64 round-tripping.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
