### PR TITLE
feat(code-mate): sync CLI skills with installed tools

### DIFF
--- a/resources/code-cli-skills/code-mate-claude-code/SKILL.md
+++ b/resources/code-cli-skills/code-mate-claude-code/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-claude-code
+description: Runs Claude Code non-interactively for code analysis and implementation tasks. Use when the user asks to delegate repository work to Claude Code or compare its result with another coding agent.
+---
+
+# Claude Code
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v claude`. If it is missing, stop and ask the user to install Claude Code in Code Mate.
+3. Run one task and exit:
+
+```bash
+claude -p "<prompt>" --output-format json
+```
+
+Pass the prompt as one quoted argument. Parse the JSON result and report stderr and the exit status on failure. Never start the interactive REPL or `/login` flow.
+
+## Authentication And Permissions
+
+If Claude reports missing login, API credentials, or provider configuration, stop and ask the user to finish Claude Code setup in Code Mate. Never request, read, print, or copy credentials.
+
+Keep tool access read-only by default. Add only the smallest necessary `--allowedTools` entries when the task explicitly requires tools, and grant edit or shell tools only when the user explicitly requested workspace changes. Do not use a permission-bypass mode.
+
+Example: for a review request, ask Claude to inspect the current repository without changing files, run the command above, then summarize the parsed JSON result.

--- a/resources/code-cli-skills/code-mate-codex/SKILL.md
+++ b/resources/code-cli-skills/code-mate-codex/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-codex
+description: Runs Codex CLI non-interactively for code analysis and implementation tasks. Use when the user asks to delegate repository work to Codex or obtain a second coding-agent result.
+---
+
+# Codex CLI
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v codex`. If it is missing, stop and ask the user to install Codex CLI in Code Mate.
+3. Run one task and exit:
+
+```bash
+codex exec "<prompt>" --json
+```
+
+Pass the prompt as one quoted argument. Parse stdout as JSONL, preserve event order, and use the final agent message as the result. Treat an error event or nonzero exit as failure. Never start interactive `codex` or `codex login`.
+
+## Authentication And Permissions
+
+If Codex reports missing login or API configuration, stop and ask the user to finish Codex setup in Code Mate. Never request, read, print, or copy credentials.
+
+Use `--sandbox read-only` unless the user explicitly requested workspace changes. For an approved edit, use only the narrowest suitable sandbox and working directory; never add `--dangerously-bypass-approvals-and-sandbox`. Add `--skip-git-repo-check` only when the user intentionally selected a non-Git directory.
+
+Example: for a review request, append `--sandbox read-only`, ask Codex not to modify files, and summarize the final JSONL message plus any reported errors.

--- a/resources/code-cli-skills/code-mate-deepseek-harness/SKILL.md
+++ b/resources/code-cli-skills/code-mate-deepseek-harness/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-deepseek-harness
+description: Runs DeepSeek Harness headlessly for bounded repository tasks. Use when the user asks to delegate analysis or implementation to DeepSeek Harness.
+---
+
+# DeepSeek Harness
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v dsh`. If it is missing, stop and ask the user to install DeepSeek Harness in Code Mate.
+3. Run one headless task:
+
+```bash
+dsh --profile headless "<prompt>"
+```
+
+Pass the prompt as one quoted argument. Treat stdout as final text, not JSON. Exit zero means success; exit one means the task failed or did not complete. Never start the interactive UI or a login flow.
+
+## Authentication And Permissions
+
+If DSH reports a missing provider, model, or API configuration, stop and ask the user to configure DeepSeek Harness in Code Mate. Never request, read, print, or copy credentials.
+
+Headless DSH can write to the workspace and creates a persistent session. For read-only work, explicitly tell it not to modify files and inspect the repository diff afterward. Allow modifications only when the user explicitly requested workspace changes, and restrict the working directory to the intended project.
+
+Example: ask DSH to diagnose a test failure without editing, run it in the repository, confirm exit zero and a clean diff, then summarize its final text.

--- a/resources/code-cli-skills/code-mate-gemini/SKILL.md
+++ b/resources/code-cli-skills/code-mate-gemini/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-gemini
+description: Runs Gemini CLI headlessly for repository analysis and coding tasks. Use when the user asks to delegate work to Gemini CLI or compare its result with another coding agent.
+---
+
+# Gemini CLI
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v gemini`. If it is missing, stop and ask the user to install Gemini CLI in Code Mate.
+3. Run one task and exit:
+
+```bash
+gemini -p "<prompt>" --output-format json
+```
+
+Pass the prompt as one quoted argument. Parse the JSON result and treat a JSON error or nonzero exit as failure. Never start interactive Gemini or an authentication flow.
+
+## Authentication And Permissions
+
+If Gemini reports missing authentication, project, or provider configuration, stop and ask the user to finish Gemini setup in Code Mate. Never request, read, print, or copy credentials.
+
+Keep headless approval policy at its read-only default. Only when the user explicitly requests workspace changes may the command use the narrowest policy and tool permissions needed; do not enable unrestricted approval.
+
+Example: ask Gemini to review a module without editing, run the command above from the repository, and summarize the parsed response and any reported error.

--- a/resources/code-cli-skills/code-mate-github-copilot/SKILL.md
+++ b/resources/code-cli-skills/code-mate-github-copilot/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-github-copilot
+description: Runs GitHub Copilot CLI programmatically for repository analysis and coding tasks. Use when the user asks to delegate work to Copilot CLI or obtain a Copilot coding-agent result.
+---
+
+# GitHub Copilot CLI
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v copilot`. If it is missing, stop and ask the user to install GitHub Copilot CLI in Code Mate.
+3. Run one non-interactive task:
+
+```bash
+copilot -p "<prompt>" -s --output-format json --no-ask-user
+```
+
+Pass the prompt as one quoted argument. Parse stdout as JSONL and treat an error event or nonzero exit as failure; the published exit-code contract is incomplete. Never start the interactive UI or an authentication flow.
+
+## Authentication And Permissions
+
+If Copilot reports a missing login, subscription, or token configuration, stop and ask the user to configure GitHub Copilot CLI in Code Mate. Never request, read, print, or copy credentials.
+
+`--no-ask-user` prevents an unattended approval prompt. Keep tools denied by default. When the user explicitly requests workspace changes, add only narrowly scoped `--allow-tool` entries; never use `--allow-all` as a shortcut.
+
+Example: ask Copilot to explain a failing test without modifying files, run the command above, and summarize the final JSONL result plus any denied tool request.

--- a/resources/code-cli-skills/code-mate-hermes/SKILL.md
+++ b/resources/code-cli-skills/code-mate-hermes/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-hermes
+description: Runs Hermes Agent in one-shot mode for bounded local tasks. Use when the user explicitly asks to delegate work to Hermes and accepts its automatic tool approval behavior.
+---
+
+# Hermes Agent
+
+## Run
+
+1. Set the Bash working directory to the smallest directory the user authorized and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v hermes`. If it is missing, stop and ask the user to install Hermes Agent in Code Mate.
+3. Run one task and exit:
+
+```bash
+hermes -z "<prompt>"
+```
+
+Pass the prompt as one quoted argument. Treat stdout as final text. Exit zero means success, exit one means failure or no response, and exit two means invalid arguments or an empty failed/partial result. Never start the interactive UI or a login flow.
+
+## Authentication And Permissions
+
+If Hermes reports missing provider, model, or API configuration, stop and ask the user to configure Hermes Agent in Code Mate. Never request, read, print, or copy credentials.
+
+One-shot mode automatically enables YOLO and hook acceptance and can load tools, memory, rules, and `AGENTS.md`. Do not run it in a writable project for read-only work. Use a disposable or read-only copy instead. Run it against the real project only when the user explicitly requests workspace changes, constrain the directory and prompt, and inspect the diff afterward.
+
+Example: for an approved edit, ask Hermes to touch only named files, run it in that project, require exit zero, and inspect the resulting diff before reporting success.

--- a/resources/code-cli-skills/code-mate-kimi-code/SKILL.md
+++ b/resources/code-cli-skills/code-mate-kimi-code/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: code-mate-kimi-code
+description: Runs Kimi Code in non-interactive prompt mode and parses its event stream. Use when the user asks to delegate a bounded repository task to Kimi Code.
+---
+
+# Kimi Code
+
+## Run
+
+1. Set the Bash working directory to the smallest directory the user authorized and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v kimi`. If it is missing, stop and ask the user to install Kimi Code in Code Mate.
+3. Run one prompt and exit:
+
+```bash
+kimi -p "<prompt>" --output-format stream-json
+```
+
+Pass the prompt as one quoted argument. Parse stdout as JSONL, preserve event order, and extract the final assistant result. Treat an error event or nonzero exit as failure. Never start the interactive UI or `kimi login`.
+
+## Authentication And Permissions
+
+If Kimi reports missing login, model, or provider configuration, stop and ask the user to configure Kimi Code in Code Mate. Never request, read, print, or copy credentials.
+
+Prompt mode automatically approves tool calls and rejects `--yolo`, `--auto`, and `--plan`; those flags cannot make it safer. Do not run it against a writable project for a read-only task. Use a disposable or read-only copy instead. Run against the real project only when the user explicitly requests workspace changes, constrain the directory, and inspect the diff afterward.
+
+Kimi writes session state under `KIMI_CODE_HOME` (normally `~/.kimi-code`) before running workspace tools. If the host Bash reports a sandbox denial there for an explicitly approved write task, retry the exact command once with the narrowest host escalation. In DSH, request `sandbox_permissions: danger-full-access` with a justification naming Kimi's session storage, then wait for approval. Keep the working directory constrained; leave Kimi's config and credential files in place.
+
+Example: for an approved implementation, ask Kimi to change only named files, run it in that project, parse the final JSONL event, and inspect the resulting diff.

--- a/resources/code-cli-skills/code-mate-openclaw/SKILL.md
+++ b/resources/code-cli-skills/code-mate-openclaw/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-openclaw
+description: Runs a local OpenClaw agent non-interactively and returns its structured response. Use when the user asks to delegate a bounded task to the OpenClaw main agent.
+---
+
+# OpenClaw
+
+## Run
+
+1. Set the Bash working directory to the exact directory the user authorized and set a finite outer timeout, normally 11 minutes.
+2. Check availability with `command -v openclaw`. If it is missing, stop and ask the user to install OpenClaw in Code Mate.
+3. Run the local main agent once:
+
+```bash
+openclaw agent --local --agent main --message "<prompt>" --json --timeout 600
+```
+
+Pass the prompt as one quoted argument. Parse the JSON payload even when the process exits zero: OpenClaw can encode failure in a successful process exit. Report payload errors and timeouts as failures. Never start onboarding, the interactive TUI, or a login flow.
+
+## Authentication And Permissions
+
+If OpenClaw reports missing onboarding, provider, model, or credentials, stop and ask the user to configure OpenClaw in Code Mate. Never request, read, print, or copy credentials.
+
+The local agent can invoke configured tools. Keep the prompt read-only by default and do not ask it to mutate files or external systems unless the user explicitly requested workspace changes or that external effect. Limit it to the selected working directory.
+
+Example: ask the main agent to explain a module without changing it, then accept the response only when the JSON payload reports success.

--- a/resources/code-cli-skills/code-mate-opencode/SKILL.md
+++ b/resources/code-cli-skills/code-mate-opencode/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-opencode
+description: Runs OpenCode non-interactively for repository analysis and coding tasks. Use when the user asks to delegate work to OpenCode or compare OpenCode with another coding agent.
+---
+
+# OpenCode
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v opencode`. If it is missing, stop and ask the user to install OpenCode in Code Mate.
+3. Run one task and exit:
+
+```bash
+opencode run "<prompt>" --format json
+```
+
+Pass the prompt as one quoted argument. Parse stdout as a JSON event stream and treat an error event or nonzero exit as failure. Never start the interactive OpenCode UI or an authentication flow.
+
+## Authentication And Permissions
+
+If OpenCode reports a missing provider or credentials, stop and ask the user to configure OpenCode in Code Mate. Never request, read, print, or copy credentials.
+
+Headless mode denies permission prompts by default; keep that behavior for analysis. Only when the user explicitly requests workspace changes may the command enable the minimum tools needed. Do not add `--auto` merely to avoid a denied permission.
+
+Example: ask OpenCode to inspect a failing test without editing, run the command above from that repository, and summarize the final content event and any tool errors.

--- a/resources/code-cli-skills/code-mate-pi/SKILL.md
+++ b/resources/code-cli-skills/code-mate-pi/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-pi
+description: Runs Pi non-interactively and parses its JSON event stream for repository tasks. Use when the user asks to delegate a bounded analysis or implementation task to Pi.
+---
+
+# Pi
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v pi`. If it is missing, stop and ask the user to install Pi in Code Mate.
+3. Run one sessionless task:
+
+```bash
+pi --mode json --no-session "<prompt>"
+```
+
+Pass the prompt as one quoted argument. Parse stdout as JSONL and inspect error events; Pi can report model or tool failure in the event stream, so process exit alone is insufficient. Never start interactive Pi or `/login`.
+
+## Authentication And Permissions
+
+If Pi reports missing login, model, provider, or API configuration, stop and ask the user to configure Pi in Code Mate. Never request, read, print, or copy credentials.
+
+Pi has no tool-approval prompt and normally exposes read, write, edit, and Bash tools. For analysis, append `--tools read,grep,find,ls`. Include write, edit, or Bash only when the user explicitly requested workspace changes, and keep the tool list and working directory as narrow as possible.
+
+Example: run a read-only diagnosis with `--tools read,grep,find,ls`, then use the final JSONL message only if no error event occurred.

--- a/resources/code-cli-skills/code-mate-qoder/SKILL.md
+++ b/resources/code-cli-skills/code-mate-qoder/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-qoder
+description: Runs the Code Mate Qoder CN CLI non-interactively with structured output. Use when the user asks to delegate a bounded coding task to Qoder.
+---
+
+# Qoder CN CLI
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v qoderclicn`. If it is missing, stop and ask the user to install Qoder CLI in Code Mate.
+3. Run one stateless task:
+
+```bash
+qoderclicn -p "<prompt>" -o json --no-session-persistence
+```
+
+Code Mate installs the CN executable `qoderclicn`, not `qoder`. Pass the prompt as one quoted argument. Parse the JSON response and check `is_error`; published exit-code behavior is incomplete, so a zero exit alone is not success. Never start the interactive UI or a login flow.
+
+## Authentication And Permissions
+
+If Qoder reports missing authentication, trust, model, or provider configuration, stop and ask the user to configure Qoder CLI in Code Mate. Never request, read, print, or copy credentials.
+
+Headless mode denies permissions that would require asking. Keep that default for analysis. Only when the user explicitly requests workspace changes may the command select the narrowest non-default permission mode, and only after the target directory is trusted through Code Mate.
+
+Example: ask Qoder to review a named file without editing, run the command above, and accept the result only when `is_error` is false.

--- a/resources/code-cli-skills/code-mate-qwen-code/SKILL.md
+++ b/resources/code-cli-skills/code-mate-qwen-code/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-mate-qwen-code
+description: Runs Qwen Code headlessly for repository analysis and coding tasks. Use when the user asks to delegate work to Qwen Code or obtain a Qwen-based coding-agent result.
+---
+
+# Qwen Code
+
+## Run
+
+1. Set the Bash working directory to the exact project the user named and set a finite timeout, normally 10 minutes.
+2. Check availability with `command -v qwen`. If it is missing, stop and ask the user to install Qwen Code in Code Mate.
+3. Run one task and exit:
+
+```bash
+qwen -p "<prompt>" --output-format json
+```
+
+Pass the prompt as one quoted argument. Parse the JSON result and treat a structured error or nonzero exit as failure. Never start the interactive UI or OAuth flow from the agent task.
+
+## Authentication And Permissions
+
+If Qwen reports missing login, API key, model, or provider configuration, stop and ask the user to configure Qwen Code in Code Mate. Never request, read, print, or copy credentials.
+
+Use the default restricted approval behavior for analysis. Add bounded turn or tool-call limits for large tasks. Only allow modification tools when the user explicitly requests workspace changes, and never use `--yolo`: it grants approval without providing a sandbox.
+
+Example: ask Qwen to identify the cause of a failing test without editing, run the command above, then summarize the parsed result within the chosen timeout.

--- a/src/main/ai/mcp/servers/__tests__/cherryCliTools.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/cherryCliTools.test.ts
@@ -6,11 +6,13 @@ const binaryManager = {
   installByName: vi.fn(),
   addCustomTool: vi.fn()
 }
+const codeCliService = { installCli: vi.fn() }
 
 vi.mock('@application', () => ({
   application: {
     get: (name: string) => {
       if (name === 'BinaryManager') return binaryManager
+      if (name === 'CodeCliService') return codeCliService
       throw new Error(`Unexpected service: ${name}`)
     }
   }
@@ -37,6 +39,7 @@ describe('CherryCliTools', () => {
     binaryManager.searchRegistry.mockResolvedValue([])
     binaryManager.installByName.mockResolvedValue(undefined)
     binaryManager.addCustomTool.mockResolvedValue(undefined)
+    codeCliService.installCli.mockResolvedValue(undefined)
   })
 
   it('advertises the thin list/search/install surface', () => {
@@ -84,6 +87,22 @@ describe('CherryCliTools', () => {
     expect(json(result)).toEqual({
       tool: { name: 'fd', recipe: 'aqua:sharkdp/fd', status: 'ready', version: '10.2.0' }
     })
+  })
+
+  it('routes a canonical Code CLI install through CodeCliService', async () => {
+    binaryManager.getToolInventory
+      .mockResolvedValueOnce([{ name: 'codex', recipe: 'codex', status: 'not_installed' }])
+      .mockResolvedValueOnce([{ name: 'codex', recipe: 'codex', status: 'ready', version: '1.2.3' }])
+
+    const result = await new CherryCliTools().call(CLI_INSTALL_TOOL_NAME, {
+      name: 'codex',
+      tool: 'codex',
+      requestedVersion: '1.2.3'
+    })
+
+    expect(codeCliService.installCli).toHaveBeenCalledWith({ name: 'codex', targetVersion: '1.2.3' })
+    expect(binaryManager.installByName).not.toHaveBeenCalled()
+    expect(result.isError).toBeFalsy()
   })
 
   it('persists an arbitrary valid mise backend through BinaryManager', async () => {

--- a/src/main/ai/mcp/servers/cherryCliTools.ts
+++ b/src/main/ai/mcp/servers/cherryCliTools.ts
@@ -1,6 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
+import { CODE_CLI_TOOL_PRESET_BY_EXECUTABLE } from '@shared/data/presets/codeCliTools'
 import * as z from 'zod'
 
 const logger = loggerService.withContext('McpServer:CherryCliTools')
@@ -83,10 +84,15 @@ export class CherryCliTools {
         const existing = (await binaryManager.getToolInventory()).find((entry) => entry.name === definition.name)
 
         if (existing?.recipe === definition.tool) {
-          await binaryManager.installByName({
+          const request = {
             name: definition.name,
             ...(definition.requestedVersion ? { targetVersion: definition.requestedVersion } : {})
-          })
+          }
+          if (CODE_CLI_TOOL_PRESET_BY_EXECUTABLE[definition.name]) {
+            await application.get('CodeCliService').installCli(request)
+          } else {
+            await binaryManager.installByName(request)
+          }
         } else {
           await binaryManager.addCustomTool({
             name: definition.name,

--- a/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
+++ b/src/main/ai/runtime/claudeCode/__tests__/settingsBuilder.test.ts
@@ -343,6 +343,35 @@ describe('buildClaudeCodeSessionSettings', () => {
     mocks.loadBuiltinAgentDefinition.mockReturnValue(undefined)
   })
 
+  it('preserves managed CLI paths from the login-shell environment', async () => {
+    mocks.getShellEnv.mockResolvedValue({
+      PATH: '/managed/shims:/usr/bin',
+      MISE_DATA_DIR: '/managed',
+      MISE_CONFIG_DIR: '/managed/config',
+      MISE_CACHE_DIR: '/managed/cache',
+      MISE_STATE_DIR: '/managed/state',
+      MISE_SHIMS_DIR: '/managed/shims'
+    })
+
+    const settings = await buildClaudeCodeSessionSettings(
+      {
+        id: 'session-1',
+        agentId: 'agent-1',
+        workspace: { type: 'user', path: '/workspace/project' }
+      } as never,
+      {} as never
+    )
+
+    expect(settings.env).toMatchObject({
+      PATH: '/managed/shims:/usr/bin',
+      MISE_DATA_DIR: '/managed',
+      MISE_CONFIG_DIR: '/managed/config',
+      MISE_CACHE_DIR: '/managed/cache',
+      MISE_STATE_DIR: '/managed/state',
+      MISE_SHIMS_DIR: '/managed/shims'
+    })
+  })
+
   it.each(['PostToolUse', 'PostToolUseFailure'] as const)(
     'captures %s duration through the live Agent runtime owner',
     async (hookEventName) => {

--- a/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
+++ b/src/main/ai/runtime/dsh/DshRuntimeConnection.ts
@@ -22,6 +22,7 @@ import { buildCitationsGuidance } from '@main/ai/runtime/citationsGuidance'
 import { wrapSteerReminder } from '@main/ai/steerReminder'
 import { toolApprovalRegistry } from '@main/ai/toolApproval/ToolApprovalRegistry'
 import { resolveKnowledgeBaseScope } from '@main/ai/utils/knowledgeScope'
+import { mergeBinaryExecutionEnv } from '@main/utils/binaryEnv'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
 import {
   KB_READ_TOOL_NAME,
@@ -347,14 +348,17 @@ export class DshRuntimeConnection implements AgentRuntimeConnection {
       await this.bridge.listen()
 
       const sdk = await loadDshSdk()
+      const binaryExecutionEnv = mergeBinaryExecutionEnv(
+        process.env.PATH !== undefined ? { PATH: process.env.PATH } : {}
+      )
       // Complete replacement env — deliberate credential scope: the child sees
-      // only the routed API key and the bridge socket, never Cherry's own env.
+      // only managed binary locations, the routed API key, and the bridge socket.
       const client = new sdk.HarnessClient({
         command: process.execPath,
         args: [resolveDshRuntimeBinPath(), this.compositionPath],
         cwd: workspacePath,
         env: {
-          ...(process.env.PATH !== undefined ? { PATH: process.env.PATH } : {}),
+          ...binaryExecutionEnv,
           ...(process.env.HOME !== undefined ? { HOME: process.env.HOME } : {}),
           ELECTRON_RUN_AS_NODE: '1',
           CHERRY_DSH_API_KEY: injection.apiKey,

--- a/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/DshRuntimeConnection.trace.test.ts
@@ -1,5 +1,5 @@
 import { trace } from '@opentelemetry/api'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { AgentRuntimeConnectInput, AgentRuntimeTraceContext } from '../../types'
 
@@ -29,7 +29,8 @@ vi.spyOn(trace, 'getTracer').mockReturnValue({ startSpan } as never)
 
 const runtimeMocks = vi.hoisted(() => ({
   snapshot: undefined as any,
-  bridgeRequest: vi.fn().mockResolvedValue(undefined)
+  bridgeRequest: vi.fn().mockResolvedValue(undefined),
+  harnessOptions: undefined as Record<string, any> | undefined
 }))
 
 const baseSnapshot = () => ({
@@ -128,12 +129,15 @@ vi.mock('../DshCherryToolBridge', () => ({
 }))
 vi.mock('../dshSdk', () => ({
   loadDshSdk: vi.fn().mockResolvedValue({
-    HarnessClient: vi.fn(() => ({
-      start: vi.fn(),
-      initialize: vi.fn().mockResolvedValue(undefined),
-      subscribe: vi.fn(() => (subscription = new FakeSubscription())),
-      close: vi.fn().mockResolvedValue(undefined)
-    }))
+    HarnessClient: vi.fn((options: Record<string, unknown>) => {
+      runtimeMocks.harnessOptions = options
+      return {
+        start: vi.fn(),
+        initialize: vi.fn().mockResolvedValue(undefined),
+        subscribe: vi.fn(() => (subscription = new FakeSubscription())),
+        close: vi.fn().mockResolvedValue(undefined)
+      }
+    })
   })
 }))
 vi.mock('@main/ai/agents/agentDataDirectory', () => ({
@@ -170,12 +174,36 @@ const drain = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
 beforeEach(() => {
   runtimeMocks.snapshot = baseSnapshot()
   runtimeMocks.bridgeRequest.mockReset().mockResolvedValue(undefined)
+  runtimeMocks.harnessOptions = undefined
   vi.mocked(DshBridgeServer).mockClear()
   spans.length = 0
   startSpan.mockClear()
 })
 
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('DshRuntimeConnection tracing', () => {
+  it('exposes managed CLIs without leaking the main-process environment', async () => {
+    vi.stubEnv('PATH', '/usr/bin')
+    vi.stubEnv('CHERRY_TEST_SECRET', 'do-not-copy')
+
+    const connection = await new DshRuntimeConnection(connectInput).start()
+    const env = runtimeMocks.harnessOptions?.env as NodeJS.ProcessEnv
+
+    expect(env.PATH?.split(':')).toEqual(['/mock/feature.binary.data/shims', '/usr/bin'])
+    expect(env).toMatchObject({
+      MISE_DATA_DIR: '/mock/feature.binary.data',
+      MISE_CONFIG_DIR: '/mock/feature.binary.data/config',
+      MISE_CACHE_DIR: '/mock/feature.binary.data/cache',
+      MISE_STATE_DIR: '/mock/feature.binary.data/state',
+      MISE_SHIMS_DIR: '/mock/feature.binary.data/shims'
+    })
+    expect(env).not.toHaveProperty('CHERRY_TEST_SECRET')
+    await connection.close()
+  })
+
   it('feeds runtime session events to the trace recorder', async () => {
     const connection = await new DshRuntimeConnection(connectInput).start()
     subscription.push({

--- a/src/main/ai/skills/SkillService.ts
+++ b/src/main/ai/skills/SkillService.ts
@@ -177,12 +177,22 @@ export class SkillService {
       if (!skill) {
         throw new Error(`Skill not found: ${skillId}`)
       }
+      await this.uninstallLocked(skill)
+    })
+  }
 
-      const skillPath = this.getSkillStoragePath(skill.folderName)
-      await this.installer.uninstall(skillPath)
-      await this.unlinkMirror(skill.folderName)
-      agentGlobalSkillService.deleteById(skillId)
-      logger.info('Skill uninstalled', { skillId, folderName: skill.folderName })
+  /** Remove an app-owned conditional builtin without touching a colliding user skill. */
+  async uninstallBuiltinSkill(folderName: string, namespace: string): Promise<boolean> {
+    return this.mutationLock.runExclusive(async () => {
+      const skill = this.findCatalogSkillCaseInsensitive(sanitizeFolderName(folderName))
+      if (!skill) return false
+      if (skill.source !== 'builtin' || skill.namespace !== namespace) {
+        throw new Error(
+          `Skill folder "${folderName}" is not owned by builtin namespace "${namespace}"; refusing to remove it.`
+        )
+      }
+      await this.uninstallLocked(skill)
+      return true
     })
   }
 
@@ -1075,12 +1085,23 @@ export class SkillService {
    * toggles it off, so a fresh `agent_global_skill` row is enabled everywhere —
    * for existing and future agents alike — without any `agent_skill` rows.
    */
-  async syncBuiltinSkill(folderName: string, sourcePath: string, appVersion: string): Promise<boolean> {
+  async syncBuiltinSkill(
+    folderName: string,
+    sourcePath: string,
+    appVersion: string,
+    namespace: string | null = null
+  ): Promise<boolean> {
     return this.mutationLock.runExclusive(async () => {
       const existing = this.findCatalogSkillCaseInsensitive(folderName)
       if (existing && existing.source !== 'builtin') {
         throw new Error(
           `Folder name "${folderName}" is already used by a ${existing.source} skill; refusing to overwrite it with a builtin.`
+        )
+      }
+      if (existing && existing.namespace !== namespace) {
+        throw new Error(
+          `Folder name "${folderName}" belongs to builtin namespace "${existing.namespace ?? 'default'}"; ` +
+            `refusing to overwrite it with "${namespace ?? 'default'}".`
         )
       }
 
@@ -1130,7 +1151,8 @@ export class SkillService {
           author: metadata.author ?? null,
           version: metadata.version ?? null,
           tags,
-          contentHash: sourceHash
+          contentHash: sourceHash,
+          namespace
         })
       } else {
         agentGlobalSkillService.insert({
@@ -1139,7 +1161,7 @@ export class SkillService {
           folderName: destFolderName,
           source: 'builtin',
           sourceUrl: null,
-          namespace: null,
+          namespace,
           author: metadata.author ?? null,
           version: metadata.version ?? null,
           tags,
@@ -1151,6 +1173,14 @@ export class SkillService {
       logger.info('Built-in skill synced to DB', { folderName: destFolderName, firstInstall: !existing, filesUpdated })
       return filesUpdated
     })
+  }
+
+  private async uninstallLocked(skill: InstalledSkill): Promise<void> {
+    const skillPath = this.getSkillStoragePath(skill.folderName)
+    await this.installer.uninstall(skillPath)
+    await this.unlinkMirror(skill.folderName)
+    agentGlobalSkillService.deleteById(skill.id)
+    logger.info('Skill uninstalled', { skillId: skill.id, folderName: skill.folderName })
   }
 }
 

--- a/src/main/ai/skills/__tests__/SkillService.test.ts
+++ b/src/main/ai/skills/__tests__/SkillService.test.ts
@@ -1535,6 +1535,40 @@ describe('SkillService', () => {
       expect(installed?.isEnabled).toBe(true)
     })
 
+    it('records conditional builtin ownership and preserves it across updates', async () => {
+      const skillService = new SkillService()
+
+      await skillService.syncBuiltinSkill(FOLDER_NAME, sourcePath, APP_VERSION, 'code-cli:test')
+      const initial = await skillService.getByFolderName(FOLDER_NAME)
+      await fs.promises.writeFile(path.join(sourcePath, 'SKILL.md'), '# Updated Builtin')
+      await skillService.syncBuiltinSkill(FOLDER_NAME, sourcePath, APP_VERSION, 'code-cli:test')
+      const updated = await skillService.getByFolderName(FOLDER_NAME)
+
+      expect(updated).toMatchObject({ id: initial?.id, namespace: 'code-cli:test', source: 'builtin' })
+    })
+
+    it('refuses to replace a builtin owned by another namespace', async () => {
+      const skillService = new SkillService()
+      await skillService.syncBuiltinSkill(FOLDER_NAME, sourcePath, APP_VERSION, 'code-cli:first')
+
+      await expect(
+        skillService.syncBuiltinSkill(FOLDER_NAME, sourcePath, APP_VERSION, 'code-cli:second')
+      ).rejects.toThrow(/belongs to builtin namespace/)
+    })
+
+    it('only uninstalls a conditional builtin for its owning namespace', async () => {
+      const skillService = new SkillService()
+      await skillService.syncBuiltinSkill(FOLDER_NAME, sourcePath, APP_VERSION, 'code-cli:test')
+
+      await expect(skillService.uninstallBuiltinSkill(FOLDER_NAME, 'code-cli:other')).rejects.toThrow(
+        /not owned by builtin namespace/
+      )
+      await expect(skillService.getByFolderName(FOLDER_NAME)).resolves.not.toBeNull()
+
+      await expect(skillService.uninstallBuiltinSkill(FOLDER_NAME, 'code-cli:test')).resolves.toBe(true)
+      await expect(skillService.getByFolderName(FOLDER_NAME)).resolves.toBeNull()
+    })
+
     it('rejects a cross-source builtin collision before overwriting user content', async () => {
       const skillService = new SkillService()
       await fs.promises.mkdir(destPath, { recursive: true })

--- a/src/main/core/paths/__tests__/pathRegistry.test.ts
+++ b/src/main/core/paths/__tests__/pathRegistry.test.ts
@@ -46,6 +46,15 @@ describe('buildPathRegistry', () => {
     expect(registry['feature.agents.claude.skills']).toBe(path.join(claudeRoot, 'skills'))
   })
 
+  it('keeps conditional Code Mate skill templates in read-only app resources', () => {
+    const registry = buildPathRegistry()
+
+    expect(registry['feature.code_cli.skills.builtin']).toBe(
+      path.join(registry['app.root.resources'], 'code-cli-skills')
+    )
+    expect(shouldAutoEnsure('feature.code_cli.skills.builtin')).toBe(false)
+  })
+
   it('keeps pi runtime state under the Agents data directory', () => {
     const registry = buildPathRegistry()
     const piRoot = path.join('/mock/userData', 'Data', 'Agents', '.pi')

--- a/src/main/core/paths/pathRegistry.ts
+++ b/src/main/core/paths/pathRegistry.ts
@@ -159,6 +159,7 @@ export function buildPathRegistry() {
     'feature.ovms.ovocr': path.join(CHERRY_HOME, 'ovms', 'ovocr'),
 
     // Agents
+    'feature.code_cli.skills.builtin': path.join(appRootResources, 'code-cli-skills'), // conditional Code Mate skill templates (read-only)
     'feature.agents.skills.builtin': path.join(appRootResources, 'skills'), // bundled skill templates (read-only)
     'feature.agents.skills': path.join(appUserDataData, 'Skills'), // installed skills storage
     'feature.agents.skills.install.temp': path.join(appTemp, 'skill-install'),
@@ -282,6 +283,7 @@ const NO_ENSURE = [
   'app.session.webview',
   'app.database.migrations',
   'feature.provider_registry.data',
+  'feature.code_cli.skills.builtin',
   'feature.agents.builtin',
   'feature.agents.assistant.manifest.file',
   'feature.agents.skills.builtin',

--- a/src/main/ipc/handlers/__tests__/binary.test.ts
+++ b/src/main/ipc/handlers/__tests__/binary.test.ts
@@ -13,11 +13,16 @@ const binaryManager = {
   searchRegistry: vi.fn(),
   getLatestVersions: vi.fn()
 }
+const codeCliService = {
+  installCli: vi.fn(),
+  removeCli: vi.fn()
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
   appGetMock.mockImplementation((name: string) => {
     if (name === 'BinaryManager') return binaryManager
+    if (name === 'CodeCliService') return codeCliService
     throw new Error(`Unexpected application.get(${name})`)
   })
 })
@@ -30,6 +35,16 @@ describe('binaryHandlers', () => {
     const request = { name: 'fd', targetVersion: '10.0.0' }
     await binaryHandlers['binary.install_tool'](request, ctx)
     expect(binaryManager.installByName).toHaveBeenCalledWith(request)
+  })
+
+  it('install_tool delegates canonical Code CLI names to CodeCliService', async () => {
+    codeCliService.installCli.mockResolvedValue(undefined)
+    const request = { name: 'codex', targetVersion: '1.2.3' }
+
+    await binaryHandlers['binary.install_tool'](request, ctx)
+
+    expect(codeCliService.installCli).toHaveBeenCalledWith(request)
+    expect(binaryManager.installByName).not.toHaveBeenCalled()
   })
 
   it('add_custom_tool forwards the full recipe to the manager', async () => {
@@ -45,6 +60,16 @@ describe('binaryHandlers', () => {
     const result = await binaryHandlers['binary.remove_tool'](request, ctx)
     expect(binaryManager.removeTool).toHaveBeenCalledWith(request)
     expect(result).toEqual({ status: 'removed' })
+  })
+
+  it('remove_tool delegates canonical Code CLI names to CodeCliService', async () => {
+    codeCliService.removeCli.mockResolvedValue({ status: 'removed' })
+    const request = { name: 'codex' }
+
+    await expect(binaryHandlers['binary.remove_tool'](request, ctx)).resolves.toEqual({ status: 'removed' })
+
+    expect(codeCliService.removeCli).toHaveBeenCalledWith(request)
+    expect(binaryManager.removeTool).not.toHaveBeenCalled()
   })
 
   it('get_tool_snapshots forwards names and returns the manager snapshots', async () => {

--- a/src/main/ipc/handlers/binary.ts
+++ b/src/main/ipc/handlers/binary.ts
@@ -1,4 +1,5 @@
 import { application } from '@application'
+import { CODE_CLI_TOOL_PRESET_BY_EXECUTABLE } from '@shared/data/presets/codeCliTools'
 import type { binaryRequestSchemas } from '@shared/ipc/schemas/binary'
 import type { IpcHandlersFor } from '@shared/ipc/types'
 
@@ -9,9 +10,15 @@ import type { IpcHandlersFor } from '@shared/ipc/types'
  * route schema; the source-trust gate (validateSender) runs before dispatch.
  */
 export const binaryHandlers: IpcHandlersFor<typeof binaryRequestSchemas> = {
-  'binary.install_tool': async (request) => application.get('BinaryManager').installByName(request),
+  'binary.install_tool': async (request) =>
+    CODE_CLI_TOOL_PRESET_BY_EXECUTABLE[request.name]
+      ? application.get('CodeCliService').installCli(request)
+      : application.get('BinaryManager').installByName(request),
   'binary.add_custom_tool': async (definition) => application.get('BinaryManager').addCustomTool(definition),
-  'binary.remove_tool': async (request) => application.get('BinaryManager').removeTool(request),
+  'binary.remove_tool': async (request) =>
+    CODE_CLI_TOOL_PRESET_BY_EXECUTABLE[request.name]
+      ? application.get('CodeCliService').removeCli(request)
+      : application.get('BinaryManager').removeTool(request),
   'binary.get_tool_snapshots': async (names) => application.get('BinaryManager').getToolSnapshots(names),
   'binary.search_registry': async (query) => application.get('BinaryManager').searchRegistry(query),
   'binary.get_latest_versions': async (force) => application.get('BinaryManager').getLatestVersions(force)

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -3,14 +3,27 @@ import path from 'node:path'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
+import { skillService } from '@main/ai/skills/SkillService'
+import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isMac, isWin } from '@main/core/platform'
+import { toAsarUnpackedPath } from '@main/utils/asar'
 import { dedupePathSegments, mergeBinaryExecutionEnv } from '@main/utils/binaryEnv'
 import { getBundledGitDir } from '@main/utils/bundledGit'
 import { removeEnvProxy } from '@main/utils/processRunner'
 import { getRawShellEnv, getShellEnv } from '@main/utils/shellEnv'
-import { CODE_CLI_TOOL_PRESET_MAP } from '@shared/data/presets/codeCliTools'
+import {
+  CODE_CLI_TOOL_PRESET_BY_EXECUTABLE,
+  CODE_CLI_TOOL_PRESET_MAP,
+  CODE_CLI_TOOL_PRESETS,
+  type CodeCliToolPreset
+} from '@shared/data/presets/codeCliTools'
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
+import type {
+  BinaryInstallByNameRequest,
+  BinaryRemoveRequest,
+  BinaryRemoveResult,
+  BinaryToolSnapshot
+} from '@shared/types/binary'
 import {
   CodeCli,
   LOGIN_CAPABLE_CLI_TOOLS,
@@ -23,6 +36,7 @@ import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import type { CliConfigTarget, CliConfigWriteFile, FileConfiguredCli } from '@shared/utils/cliConfig'
 import { REDACTED, redactRecord } from '@shared/utils/redaction'
 import { execFile, spawn } from 'child_process'
+import { app } from 'electron'
 import { promisify } from 'util'
 
 import { type CliConfigReadFile, readCliConfigFiles, writeCliConfigFiles } from './configWriter'
@@ -63,6 +77,7 @@ const MACOS_APPLICATION_LOOKUP_SCRIPT = [
 
 @Injectable('CodeCliService')
 @ServicePhase(Phase.Background)
+@DependsOn(['BinaryManager'])
 export class CodeCliService extends BaseService {
   // Static properties for cleanup management (avoid listener accumulation)
   private static pendingBatCleanups = new Set<string>()
@@ -77,6 +92,75 @@ export class CodeCliService extends BaseService {
   protected async onInit(): Promise<void> {
     if (isMac || isWin) {
       void this.preloadTerminals()
+    }
+  }
+
+  protected override async onAllReady(): Promise<void> {
+    await this.reconcileCliSkills().catch((error) => {
+      logger.error('Failed to reconcile Code CLI skills', error as Error)
+    })
+  }
+
+  async installCli(request: BinaryInstallByNameRequest): Promise<void> {
+    const preset = this.requirePreset(request.name)
+    await application.get('BinaryManager').installByName(request)
+    const snapshot = (await application.get('BinaryManager').getToolSnapshots([preset.executable]))[preset.executable]
+    if (!snapshot || snapshot.availability.source === 'none') {
+      throw new Error(`${preset.executable} is unavailable after installation`)
+    }
+    await this.installCliSkill(preset)
+  }
+
+  async removeCli(request: BinaryRemoveRequest): Promise<BinaryRemoveResult> {
+    const preset = this.requirePreset(request.name)
+    const result = await application.get('BinaryManager').removeTool(request)
+    if (result.status === 'cleanup_blocked') return result
+
+    const snapshot = (await application.get('BinaryManager').getToolSnapshots([preset.executable]))[preset.executable]
+    if (snapshot) await this.reconcileCliSkill(preset, snapshot)
+    return result
+  }
+
+  async reconcileCliSkills(): Promise<void> {
+    const snapshots = await application
+      .get('BinaryManager')
+      .getToolSnapshots(CODE_CLI_TOOL_PRESETS.map((preset) => preset.executable))
+
+    for (const preset of CODE_CLI_TOOL_PRESETS) {
+      const snapshot = snapshots[preset.executable]
+      if (!snapshot) continue
+      try {
+        await this.reconcileCliSkill(preset, snapshot)
+      } catch (error) {
+        logger.warn('Failed to reconcile Code CLI skill', {
+          cliTool: preset.id,
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+  }
+
+  private requirePreset(executable: string): CodeCliToolPreset {
+    const preset = CODE_CLI_TOOL_PRESET_BY_EXECUTABLE[executable]
+    if (!preset) throw new Error(`Unknown Code CLI: ${executable}`)
+    return preset
+  }
+
+  private async installCliSkill(preset: CodeCliToolPreset): Promise<void> {
+    const sourcePath = path.join(
+      toAsarUnpackedPath(application.getPath('feature.code_cli.skills.builtin')),
+      preset.skillFolderName
+    )
+    await skillService.syncBuiltinSkill(preset.skillFolderName, sourcePath, app.getVersion(), preset.skillNamespace)
+  }
+
+  private async reconcileCliSkill(preset: CodeCliToolPreset, snapshot: BinaryToolSnapshot): Promise<void> {
+    if (snapshot.availability.source !== 'none') {
+      await this.installCliSkill(preset)
+      return
+    }
+    if (snapshot.application?.status === 'absent') {
+      await skillService.uninstallBuiltinSkill(preset.skillFolderName, preset.skillNamespace)
     }
   }
 
@@ -429,7 +513,7 @@ export class CodeCliService extends BaseService {
         // Name-only lazy install: BinaryManager resolves the Code CLI's fixed
         // recipe itself and writes no Preference — the CLI is a code-owned tool,
         // not a user-added custom one.
-        await binaryManager.installByName({ name: executableName })
+        await this.installCli({ name: executableName })
         logger.info(`${cliTool} installed successfully`)
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
@@ -443,6 +527,15 @@ export class CodeCliService extends BaseService {
         const message = `${cliTool} is not available after install`
         logger.error(message)
         return { success: false, message }
+      }
+    } else {
+      try {
+        await this.installCliSkill(preset)
+      } catch (error) {
+        logger.warn('Failed to sync an available Code CLI skill before launch', {
+          cliTool,
+          error: error instanceof Error ? error.message : String(error)
+        })
       }
     }
 

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
 import type { BinaryRemoveRequest, BinaryRemoveResult } from '@shared/types/binary'
 import { CodeCli, TerminalApp } from '@shared/types/codeCli'
@@ -192,7 +194,7 @@ describe('CodeCliService', () => {
     expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledTimes(12)
     expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledWith(
       'code-mate-codex',
-      '/mock/binary-data/code-mate-codex',
+      path.join('/mock/binary-data', 'code-mate-codex'),
       '2.0.9',
       'code-cli:openai-codex'
     )
@@ -221,7 +223,7 @@ describe('CodeCliService', () => {
       expect(binaryManagerMock.installByName).toHaveBeenCalledWith({ name: 'codex' })
       expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledWith(
         'code-mate-codex',
-        '/mock/binary-data/code-mate-codex',
+        path.join('/mock/binary-data', 'code-mate-codex'),
         '2.0.9',
         'code-cli:openai-codex'
       )

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -1,13 +1,28 @@
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
+import type { BinaryRemoveRequest, BinaryRemoveResult } from '@shared/types/binary'
 import { CodeCli, TerminalApp } from '@shared/types/codeCli'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const binaryManagerMock = vi.hoisted(() => ({
   installByName: vi.fn(() => Promise.resolve()),
-  removeTool: vi.fn(() => Promise.resolve()),
+  removeTool: vi.fn<(_request: BinaryRemoveRequest) => Promise<BinaryRemoveResult>>(),
   getToolSnapshots: vi.fn()
 }))
 const hermesDashboardMock = vi.hoisted(() => ({ writeConfigFiles: vi.fn() }))
+const skillServiceMock = vi.hoisted(() => ({
+  syncBuiltinSkill: vi.fn(() => Promise.resolve(false)),
+  uninstallBuiltinSkill: vi.fn(() => Promise.resolve(false))
+}))
+
+vi.mock('@main/ai/skills/SkillService', () => ({ skillService: skillServiceMock }))
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '2.0.9'),
+    getAppPath: vi.fn(() => '/mock/app'),
+    isPackaged: false
+  }
+}))
 
 vi.mock('@application', () => ({
   application: {
@@ -148,6 +163,9 @@ describe('CodeCliService', () => {
       )
     )
     binaryManagerMock.installByName.mockResolvedValue(undefined)
+    binaryManagerMock.removeTool.mockResolvedValue({ status: 'removed' })
+    skillServiceMock.syncBuiltinSkill.mockResolvedValue(false)
+    skillServiceMock.uninstallBuiltinSkill.mockResolvedValue(false)
     hermesDashboardMock.writeConfigFiles.mockResolvedValue(undefined)
     childProcessMock.execAsync.mockResolvedValue({ stdout: '' })
     childProcessMock.execFileAsync.mockResolvedValue({ stdout: '' })
@@ -164,6 +182,22 @@ describe('CodeCliService', () => {
     expect(codeCliService.isReady).toBe(true)
   })
 
+  it('reconciles available CLI skills only after every service is ready', async () => {
+    const { codeCliService } = await loadModules()
+
+    await codeCliService._doInit()
+    expect(skillServiceMock.syncBuiltinSkill).not.toHaveBeenCalled()
+
+    await codeCliService._doAllReady()
+    expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledTimes(12)
+    expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledWith(
+      'code-mate-codex',
+      '/mock/binary-data/code-mate-codex',
+      '2.0.9',
+      'code-cli:openai-codex'
+    )
+  })
+
   it('should clean up timers on stop', async () => {
     const { codeCliService } = await loadModules()
     await codeCliService._doInit()
@@ -176,6 +210,83 @@ describe('CodeCliService', () => {
     // loadModules() already created one instance,
     // so creating another should throw
     expect(() => new CodeCliService()).toThrow(/already been instantiated/)
+  })
+
+  describe('CLI skill lifecycle', () => {
+    it('installs the bundled skill only after the CLI install succeeds', async () => {
+      const { codeCliService } = await loadModules()
+
+      await codeCliService.installCli({ name: 'codex' })
+
+      expect(binaryManagerMock.installByName).toHaveBeenCalledWith({ name: 'codex' })
+      expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalledWith(
+        'code-mate-codex',
+        '/mock/binary-data/code-mate-codex',
+        '2.0.9',
+        'code-cli:openai-codex'
+      )
+    })
+
+    it('does not install a skill when the CLI install fails', async () => {
+      binaryManagerMock.installByName.mockRejectedValue(new Error('install failed'))
+      const { codeCliService } = await loadModules()
+
+      await expect(codeCliService.installCli({ name: 'codex' })).rejects.toThrow('install failed')
+
+      expect(skillServiceMock.syncBuiltinSkill).not.toHaveBeenCalled()
+    })
+
+    it('does not change the skill when binary removal is blocked', async () => {
+      binaryManagerMock.removeTool.mockResolvedValue({ status: 'cleanup_blocked', reason: 'conflict' })
+      const { codeCliService } = await loadModules()
+
+      await expect(codeCliService.removeCli({ name: 'codex' })).resolves.toEqual({
+        status: 'cleanup_blocked',
+        reason: 'conflict'
+      })
+
+      expect(skillServiceMock.syncBuiltinSkill).not.toHaveBeenCalled()
+      expect(skillServiceMock.uninstallBuiltinSkill).not.toHaveBeenCalled()
+    })
+
+    it('removes the owned skill when no CLI remains after removal', async () => {
+      binaryManagerMock.getToolSnapshots.mockResolvedValue({
+        codex: { name: 'codex', availability: { source: 'none' }, application: { status: 'absent' } }
+      })
+      const { codeCliService } = await loadModules()
+
+      await expect(codeCliService.removeCli({ name: 'codex' })).resolves.toEqual({ status: 'removed' })
+
+      expect(skillServiceMock.uninstallBuiltinSkill).toHaveBeenCalledWith('code-mate-codex', 'code-cli:openai-codex')
+    })
+
+    it('keeps the skill when a system CLI remains after managed removal', async () => {
+      binaryManagerMock.getToolSnapshots.mockResolvedValue({
+        codex: { name: 'codex', availability: { source: 'system', path: '/usr/local/bin/codex' } }
+      })
+      const { codeCliService } = await loadModules()
+
+      await codeCliService.removeCli({ name: 'codex' })
+
+      expect(skillServiceMock.syncBuiltinSkill).toHaveBeenCalled()
+      expect(skillServiceMock.uninstallBuiltinSkill).not.toHaveBeenCalled()
+    })
+
+    it('preserves the skill when CLI state is unknown', async () => {
+      binaryManagerMock.getToolSnapshots.mockResolvedValue({
+        codex: {
+          name: 'codex',
+          availability: { source: 'none' },
+          application: { status: 'unknown', reason: 'backend_unavailable' }
+        }
+      })
+      const { codeCliService } = await loadModules()
+
+      await codeCliService.reconcileCliSkills()
+
+      expect(skillServiceMock.syncBuiltinSkill).not.toHaveBeenCalled()
+      expect(skillServiceMock.uninstallBuiltinSkill).not.toHaveBeenCalled()
+    })
   })
 
   describe('getAvailableTerminalsForPlatform (macOS)', () => {

--- a/src/shared/data/presets/__tests__/codeCliTools.test.ts
+++ b/src/shared/data/presets/__tests__/codeCliTools.test.ts
@@ -1,5 +1,13 @@
-import { CODE_CLI_TOOL_PRESET_MAP, CODE_CLI_TOOL_PRESETS } from '@shared/data/presets/codeCliTools'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  CODE_CLI_TOOL_PRESET_BY_EXECUTABLE,
+  CODE_CLI_TOOL_PRESET_MAP,
+  CODE_CLI_TOOL_PRESETS
+} from '@shared/data/presets/codeCliTools'
 import { CodeCli } from '@shared/types/codeCli'
+import matter from 'gray-matter'
 import { describe, expect, it } from 'vitest'
 
 const EXPECTED_ACQUISITION_FACTS = [
@@ -16,6 +24,30 @@ const EXPECTED_ACQUISITION_FACTS = [
   ['pi', 'pi', '@earendil-works/pi-coding-agent', 'npm', 'npm:@earendil-works/pi-coding-agent'],
   ['hermes', 'hermes', 'hermes-agent', 'pipx', 'pipx:hermes-agent[extras=web]']
 ]
+
+const EXPECTED_SKILL_COMMANDS: Record<CodeCli, string> = {
+  [CodeCli.CLAUDE_CODE]: 'claude -p "<prompt>" --output-format json',
+  [CodeCli.OPENAI_CODEX]: 'codex exec "<prompt>" --json',
+  [CodeCli.OPEN_CODE]: 'opencode run "<prompt>" --format json',
+  [CodeCli.OPENCLAW]: 'openclaw agent --local --agent main --message "<prompt>" --json --timeout 600',
+  [CodeCli.DEEPSEEK_HARNESS]: 'dsh --profile headless "<prompt>"',
+  [CodeCli.GEMINI_CLI]: 'gemini -p "<prompt>" --output-format json',
+  [CodeCli.QWEN_CODE]: 'qwen -p "<prompt>" --output-format json',
+  [CodeCli.KIMI_CODE]: 'kimi -p "<prompt>" --output-format stream-json',
+  [CodeCli.QODER_CLI]: 'qoderclicn -p "<prompt>" -o json --no-session-persistence',
+  [CodeCli.GITHUB_COPILOT_CLI]: 'copilot -p "<prompt>" -s --output-format json --no-ask-user',
+  [CodeCli.PI]: 'pi --mode json --no-session "<prompt>"',
+  [CodeCli.HERMES]: 'hermes -z "<prompt>"'
+}
+
+const EXPECTED_SKILL_CAVEATS: Partial<Record<CodeCli, string[]>> = {
+  [CodeCli.OPENCLAW]: ['exits zero', 'payload'],
+  [CodeCli.DEEPSEEK_HARNESS]: ['persistent session', 'write to the workspace'],
+  [CodeCli.KIMI_CODE]: ['automatically approves', 'read-only copy', 'KIMI_CODE_HOME', 'sandbox_permissions'],
+  [CodeCli.QODER_CLI]: ['qoderclicn', 'is_error'],
+  [CodeCli.PI]: ['no tool-approval prompt', '--tools read,grep,find,ls'],
+  [CodeCli.HERMES]: ['YOLO', 'exit two']
+}
 
 describe('Code CLI acquisition catalog', () => {
   it('preserves every pre-migration acquisition fact', () => {
@@ -34,13 +66,55 @@ describe('Code CLI acquisition catalog', () => {
     expect(new Set(CODE_CLI_TOOL_PRESETS.map((preset) => preset.id))).toEqual(new Set(Object.values(CodeCli)))
   })
 
+  it('assigns every CLI a unique bundled skill folder', () => {
+    const folderNames = CODE_CLI_TOOL_PRESETS.map((preset) => preset.skillFolderName)
+    expect(new Set(folderNames).size).toBe(CODE_CLI_TOOL_PRESETS.length)
+    expect(folderNames.every((folderName) => /^code-mate-[a-z0-9-]+$/.test(folderName))).toBe(true)
+    expect(new Set(CODE_CLI_TOOL_PRESETS.map((preset) => preset.skillNamespace)).size).toBe(
+      CODE_CLI_TOOL_PRESETS.length
+    )
+  })
+
   it('keeps the catalog and lookup map immutable', () => {
     expect(Object.isFrozen(CODE_CLI_TOOL_PRESETS)).toBe(true)
     expect(CODE_CLI_TOOL_PRESETS.every((preset) => Object.isFrozen(preset))).toBe(true)
     expect(Object.isFrozen(CODE_CLI_TOOL_PRESET_MAP)).toBe(true)
+    expect(Object.isFrozen(CODE_CLI_TOOL_PRESET_BY_EXECUTABLE)).toBe(true)
   })
 
   it.each(CODE_CLI_TOOL_PRESETS)('$id: indexes the canonical preset', (preset) => {
     expect(CODE_CLI_TOOL_PRESET_MAP[preset.id]).toBe(preset)
+    expect(CODE_CLI_TOOL_PRESET_BY_EXECUTABLE[preset.executable]).toBe(preset)
+  })
+
+  it('bundles exactly one valid skill for every CLI preset', () => {
+    const skillsRoot = path.resolve(process.cwd(), 'resources/code-cli-skills')
+    const bundledFolders = fs
+      .readdirSync(skillsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+    expect(bundledFolders).toEqual(CODE_CLI_TOOL_PRESETS.map((preset) => preset.skillFolderName).sort())
+
+    for (const preset of CODE_CLI_TOOL_PRESETS) {
+      const skillPath = path.join(skillsRoot, preset.skillFolderName, 'SKILL.md')
+      const source = fs.readFileSync(skillPath, 'utf8')
+      const parsed = matter(source)
+
+      expect(parsed.data.name, preset.id).toBe(preset.skillFolderName)
+      expect(parsed.data.description, preset.id).toMatch(/\. Use when /)
+      expect(source.split(/\r?\n/).length, preset.id).toBeLessThan(100)
+      expect(source, preset.id).toContain(`command -v ${preset.executable}`)
+      expect(source, preset.id).toContain(EXPECTED_SKILL_COMMANDS[preset.id])
+      expect(source, preset.id).toContain('Code Mate')
+      expect(source, preset.id).toContain('Never request, read, print, or copy credentials.')
+      expect(source, preset.id).toContain('timeout')
+      expect(source, preset.id).toMatch(/explicitly request(?:s|ed)? workspace changes/)
+      expect(source, preset.id).toContain('Example:')
+
+      for (const caveat of EXPECTED_SKILL_CAVEATS[preset.id] ?? []) {
+        expect(source, preset.id).toContain(caveat)
+      }
+    }
   })
 })

--- a/src/shared/data/presets/codeCliTools.ts
+++ b/src/shared/data/presets/codeCliTools.ts
@@ -4,6 +4,8 @@ import { CodeCli } from '@shared/types/codeCli'
 export interface CodeCliToolPreset {
   id: CodeCli
   executable: string
+  skillFolderName: string
+  skillNamespace: `code-cli:${CodeCli}`
   packageName: string
   install: 'registry' | 'npm' | 'pipx'
   miseTool: string
@@ -19,7 +21,7 @@ export interface CodeCliToolPreset {
   requiredPeer?: { host: string; peer: string }
 }
 
-type CodeCliToolDefinition = Omit<CodeCliToolPreset, 'miseTool'> & {
+type CodeCliToolDefinition = Omit<CodeCliToolPreset, 'miseTool' | 'skillNamespace'> & {
   /** pipx extras required to install this tool's built-in capabilities. */
   pipxExtras?: readonly string[]
 }
@@ -30,6 +32,7 @@ function defineCodeCliTool({ pipxExtras, ...definition }: CodeCliToolDefinition)
   const extras = definition.install === 'pipx' && pipxExtras?.length ? pipxExtras.join(',') : ''
   return Object.freeze({
     ...definition,
+    skillNamespace: `code-cli:${definition.id}` as const,
     miseTool: extras ? `${packageTool}[extras=${extras}]` : packageTool
   })
 }
@@ -42,20 +45,35 @@ export const CODE_CLI_TOOL_PRESETS = Object.freeze([
   defineCodeCliTool({
     id: CodeCli.CLAUDE_CODE,
     executable: 'claude',
+    skillFolderName: 'code-mate-claude-code',
     packageName: '@anthropic-ai/claude-code',
     install: 'registry'
   }),
   defineCodeCliTool({
     id: CodeCli.OPENAI_CODEX,
     executable: 'codex',
+    skillFolderName: 'code-mate-codex',
     packageName: '@openai/codex',
     install: 'registry'
   }),
-  defineCodeCliTool({ id: CodeCli.OPEN_CODE, executable: 'opencode', packageName: 'opencode-ai', install: 'registry' }),
-  defineCodeCliTool({ id: CodeCli.OPENCLAW, executable: 'openclaw', packageName: 'openclaw', install: 'npm' }),
+  defineCodeCliTool({
+    id: CodeCli.OPEN_CODE,
+    executable: 'opencode',
+    skillFolderName: 'code-mate-opencode',
+    packageName: 'opencode-ai',
+    install: 'registry'
+  }),
+  defineCodeCliTool({
+    id: CodeCli.OPENCLAW,
+    executable: 'openclaw',
+    skillFolderName: 'code-mate-openclaw',
+    packageName: 'openclaw',
+    install: 'npm'
+  }),
   defineCodeCliTool({
     id: CodeCli.DEEPSEEK_HARNESS,
     executable: 'dsh',
+    skillFolderName: 'code-mate-deepseek-harness',
     packageName: '@deepseek-ai/dsh',
     install: 'npm',
     misePrerelease: true,
@@ -68,37 +86,49 @@ export const CODE_CLI_TOOL_PRESETS = Object.freeze([
   defineCodeCliTool({
     id: CodeCli.GEMINI_CLI,
     executable: 'gemini',
+    skillFolderName: 'code-mate-gemini',
     packageName: '@google/gemini-cli',
     install: 'npm'
   }),
-  defineCodeCliTool({ id: CodeCli.QWEN_CODE, executable: 'qwen', packageName: '@qwen-code/qwen-code', install: 'npm' }),
+  defineCodeCliTool({
+    id: CodeCli.QWEN_CODE,
+    executable: 'qwen',
+    skillFolderName: 'code-mate-qwen-code',
+    packageName: '@qwen-code/qwen-code',
+    install: 'npm'
+  }),
   defineCodeCliTool({
     id: CodeCli.KIMI_CODE,
     executable: 'kimi',
+    skillFolderName: 'code-mate-kimi-code',
     packageName: '@moonshot-ai/kimi-code',
     install: 'npm'
   }),
   defineCodeCliTool({
     id: CodeCli.QODER_CLI,
     executable: 'qoderclicn',
+    skillFolderName: 'code-mate-qoder',
     packageName: '@qodercn-ai/qoderclicn',
     install: 'npm'
   }),
   defineCodeCliTool({
     id: CodeCli.GITHUB_COPILOT_CLI,
     executable: 'copilot',
+    skillFolderName: 'code-mate-github-copilot',
     packageName: '@github/copilot',
     install: 'npm'
   }),
   defineCodeCliTool({
     id: CodeCli.PI,
     executable: 'pi',
+    skillFolderName: 'code-mate-pi',
     packageName: '@earendil-works/pi-coding-agent',
     install: 'npm'
   }),
   defineCodeCliTool({
     id: CodeCli.HERMES,
     executable: 'hermes',
+    skillFolderName: 'code-mate-hermes',
     packageName: 'hermes-agent',
     install: 'pipx',
     pipxExtras: ['web']
@@ -109,5 +139,11 @@ export const CODE_CLI_TOOL_PRESET_MAP = Object.freeze(
   Object.fromEntries(CODE_CLI_TOOL_PRESETS.map((preset) => [preset.id, preset])) as Record<
     CodeCli,
     Readonly<CodeCliToolPreset>
+  >
+)
+
+export const CODE_CLI_TOOL_PRESET_BY_EXECUTABLE = Object.freeze(
+  Object.fromEntries(CODE_CLI_TOOL_PRESETS.map((preset) => [preset.executable, preset])) as Readonly<
+    Record<string, (typeof CODE_CLI_TOOL_PRESETS)[number] | undefined>
   >
 )


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: Code Mate CLI availability and Agent Skills were managed independently.

After this PR: Each of the 12 supported CLIs owns a bundled non-interactive Skill that is reconciled on install, removal, launch, and startup, while system fallbacks preserve the Skill.

<img width="2440" height="1196" alt="CleanShot 2026-08-27 at 18 20 37@2x" src="https://github.com/user-attachments/assets/d7f5119f-bdb1-4fb6-83f1-ce98710ba6d9" />


<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19550

### Why we need it and why it was done in this way

The following tradeoffs were made: CLI availability is not rolled back if Skill synchronization fails; startup reconciliation retries failures, and uncertain binary states retain existing Skills.

The following alternatives were considered: Manual Skill installation and a new persistence schema were rejected because the existing builtin source, namespace ownership, and Agent enablement state cover the lifecycle.

Links to places where the discussion took place: #19550

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

Pi managed Bash support is already present on `main` via #19428; this change adds equivalent managed environment coverage for DSH and regression coverage for Claude Code. No external user-guide update is required because each installed Skill contains its command, authentication, output, and permission guidance.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Code Mate now automatically adds a dedicated Agent Skill for each available coding CLI and removes it when the CLI is no longer available.
```
