### PR TITLE
fix(ai-diagnosis): use selected language for diagnosis output

### DIFF
--- a/src/renderer/utils/__tests__/errorDiagnosis.test.ts
+++ b/src/renderer/utils/__tests__/errorDiagnosis.test.ts
@@ -199,6 +199,18 @@ describe('ErrorDiagnosisService', () => {
       expect(callArgs.content).toContain('401')
     })
 
+    it('requires all diagnosis fields to use the language selected in settings', async () => {
+      mockFetchGenerate.mockResolvedValue(
+        JSON.stringify({ summary: 'summary', category: 'category', explanation: 'explanation', steps: [] })
+      )
+
+      await diagnoseError(makeError(), 'preferred-language')
+
+      expect(mockFetchGenerate.mock.calls[0][0].prompt).toContain(
+        'Write all values for summary, category, explanation, and steps[].text in preferred-language'
+      )
+    })
+
     it('defaults category to unknown when missing', async () => {
       mockFetchGenerate.mockResolvedValue(
         JSON.stringify({

--- a/src/renderer/utils/errorDiagnosis.ts
+++ b/src/renderer/utils/errorDiagnosis.ts
@@ -228,9 +228,10 @@ Analyze the error and return a JSON diagnosis in ${language}.
 ${contextHint}
 ## Output
 Return ONLY valid JSON (no markdown, no code blocks):
-{"summary":"one-line","category":"auth|permission|region|quota|rate_limit|model|network|proxy|content|server|context_length|payload|stream|parse|mcp|knowledge|ocr|deprecated|unknown","explanation":"2-3 sentences why this happened","steps":[{"text":"step 1"},{"text":"step 2"}]}
+{"summary":"one-line","category":"short error category","explanation":"2-3 sentences why this happened","steps":[{"text":"step 1"},{"text":"step 2"}]}
 
 ## Rules
+- Write all values for summary, category, explanation, and steps[].text in ${language}, the user's language selected in settings
 - 2-4 concrete steps, reference actual provider/model name from error
 - No URLs, no links, no restart suggestion, plain text only
 - Distinguish rate_limit (too many requests, transient, retry soon) from quota (billing/balance exhausted, not transient, must top up)
@@ -246,7 +247,9 @@ Input: {"name":"APICallError","message":"Rate limit exceeded","status":429,"prov
 Output: {"summary":"OpenAI rate limit hit due to too many requests","category":"rate_limit","explanation":"The OpenAI server is throttling because the request rate exceeded the allowed limit for this model. This is not a billing issue.","steps":[{"text":"Wait a few seconds before sending the next request"},{"text":"Slow down concurrent or repeated requests to gpt-4"},{"text":"Switch to a model with a higher rate limit if this happens often"}]}
 
 Input: {"name":"APICallError","message":"insufficient_quota: You exceeded your current quota","status":429,"provider":"openai"}
-Output: {"summary":"OpenAI account balance is exhausted","category":"quota","explanation":"The OpenAI account has run out of available credit or quota, so further requests are rejected until the balance is topped up.","steps":[{"text":"Check the billing page of your OpenAI account and top up credit"},{"text":"Switch to another provider with available quota in provider settings"}]}`
+Output: {"summary":"OpenAI account balance is exhausted","category":"quota","explanation":"The OpenAI account has run out of available credit or quota, so further requests are rejected until the balance is topped up.","steps":[{"text":"Check the billing page of your OpenAI account and top up credit"},{"text":"Switch to another provider with available quota in provider settings"}]}
+
+The examples above demonstrate structure only. Write all four diagnosis fields in ${language}.`
 
   const content = JSON.stringify(errorInfo)
 


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The AI error diagnosis prompt used English-only category values and examples, and did not explicitly require all four diagnosis fields to follow the language selected in settings.

After this PR:

The prompt requires `summary`, `category`, `explanation`, and `steps` text to use the selected language variable. It also identifies the English examples as structure-only guidance.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

English examples could anchor the model to English output even when Cherry Studio passed another configured language. The language requirement now names every output field and is repeated after the examples.

The following tradeoffs were made:

The generated `category` is localized instead of constrained to an English enum. This is safe because the persisted diagnosis contract stores it as a string and no diagnosis consumer uses it as a machine-readable enum.

The following alternatives were considered:

Keeping `category` in English while localizing only visible text was considered, but it would not satisfy the requirement that all four diagnosis fields use the selected language.

Links to places where the discussion took place: None

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

The regression test uses a language-neutral sentinel to verify that the configured language is interpolated dynamically rather than targeting a specific locale.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
AI error diagnosis results now use the language selected in settings for all four output fields.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the diagnosis LLM prompt and tests; localized category strings remain opaque to UI logic and are stored as plain text.
> 
> **Overview**
> AI error diagnosis was often returning English **category** values and mixed-language text even when settings specified another language, because the prompt showed an English category enum and English examples without a clear “all fields” language rule.
> 
> The **`diagnoseError`** prompt now requires **summary**, **category**, **explanation**, and **steps[].text** in the configured language, replaces the fixed category token list with a generic “short error category” shape, and states that the English examples are **structure-only** with a follow-up reminder to write all four fields in that language. A regression test asserts the language string is interpolated into those instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee3207f932be209bc9a3ec32df263a85a2f3ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->