### PR TITLE
fix(agent-runtime): coerce provider extra headers for pi and dsh

### DIFF
--- a/src/main/ai/runtime/agentProviderHeaders.ts
+++ b/src/main/ai/runtime/agentProviderHeaders.ts
@@ -1,0 +1,16 @@
+/**
+ * Cherry's `extraHeaders` are user-editable and can still hold non-string values (v1 settings
+ * passthrough, API writes): coerce them to the `Record<string, string>` every agent runtime
+ * requires — pi throws inside its config resolver, dsh fails its route schema.
+ */
+export function toAgentProviderHeaders(
+  headers: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!headers) return undefined
+  const coerced: Record<string, string> = {}
+  for (const [name, value] of Object.entries(headers) as [string, unknown][]) {
+    if (value == null || typeof value === 'object') continue
+    coerced[name] = String(value)
+  }
+  return coerced
+}

--- a/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
@@ -38,6 +38,7 @@ import { buildDshCompositionYaml } from '../compositionBuilder'
 import {
   assertDshProviderUsable,
   buildDshGatewayInjection,
+  buildDshProviderInjection,
   DshUnsupportedProviderError,
   resolveDshProviderInjectionFromSnapshot
 } from '../modelInjection'
@@ -141,6 +142,20 @@ describe('buildDshGatewayInjection', () => {
 
     const windowless = makeModel({ contextWindow: undefined })
     expect(buildDshGatewayInjection(vertexProvider, windowless, GATEWAY).modelConfig.contextWindow).toBe(256_000)
+  })
+})
+
+describe('buildDshProviderInjection', () => {
+  it('coerces user headers to the strings the dsh route schema accepts', () => {
+    const provider = {
+      ...nativeProvider,
+      settings: { extraHeaders: { 'x-trace': 'on', 'x-legacy': 42, 'x-broken': { a: 1 } } }
+    } as unknown as Provider
+    const model = makeModel({ id: 'deepseek::deepseek-chat', providerId: 'deepseek', apiModelId: 'deepseek-chat' })
+
+    const injection = buildDshProviderInjection(provider, model, 'sk-native')
+
+    expect(injection.headers).toEqual({ 'x-trace': 'on', 'x-legacy': '42' })
   })
 })
 

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -32,6 +32,7 @@ import { isLoginBasedProvider } from '@shared/utils/provider'
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import { ApiGatewayNotRunningError, resolveApiGatewayRuntime } from '../agentApiGateway'
 import { resolveAgentContextWindow } from '../agentContextWindow'
+import { toAgentProviderHeaders } from '../agentProviderHeaders'
 import type { AgentSessionUsageCapture } from '../types'
 
 // dsh-llm-pi-ai uses maxTokens as a per-request output cap. Keep pi's
@@ -205,7 +206,7 @@ export function buildDshProviderInjection(
 
   const baseUrl = formatDshBaseUrl(resolvedEndpoint.baseUrl, api)
   const modelId = getRawModelId(model)
-  const headers = provider.settings?.extraHeaders
+  const headers = toAgentProviderHeaders(provider.settings?.extraHeaders)
   const reasoning = resolveDshReasoningEffort(model, reasoningEffort)
 
   return {

--- a/src/main/ai/runtime/pi/modelInjection.test.ts
+++ b/src/main/ai/runtime/pi/modelInjection.test.ts
@@ -277,6 +277,35 @@ describe('buildPiProviderInjection', () => {
     expect(injection.requestEnvironment).toEqual({ AZURE_OPENAI_API_VERSION: '2025-04-01-preview' })
   })
 
+  it('hands pi header values it resolves back to the literals the user typed', async () => {
+    const { AuthStorage, ModelRegistry } = await import('@earendil-works/pi-coding-agent')
+    const provider = makeProvider({
+      id: 'p',
+      defaultChatEndpoint: 'openai-chat-completions',
+      endpointConfigs: { 'openai-chat-completions': { baseUrl: 'https://example.com/v1' } },
+      settings: {
+        extraHeaders: {
+          'x-token': 'a$b${HOME}',
+          'x-command': '!echo pwned',
+          // A non-string survives from v1 settings and from `String()`-less API writes.
+          'x-legacy': 42 as unknown as string
+        }
+      }
+    })
+    const injection = buildPiProviderInjection(provider, makeModel({ apiModelId: 'm' }), REAL_KEY)
+
+    const authStorage = AuthStorage.inMemory()
+    authStorage.setRuntimeApiKey('p', injection.apiKey)
+    const registry = ModelRegistry.inMemory(authStorage)
+    registry.registerProvider('p', injection.providerConfig)
+    const auth = await registry.getApiKeyAndHeaders(registry.find('p', injection.modelId)!)
+
+    expect(auth).toMatchObject({
+      ok: true,
+      headers: { 'x-token': 'a$b${HOME}', 'x-command': '!echo pwned', 'x-legacy': '42' }
+    })
+  })
+
   it('uses the gateway per-model route for both API family and base URL', () => {
     const provider = makeProvider({
       id: 'aihubmix',

--- a/src/main/ai/runtime/pi/modelInjection.ts
+++ b/src/main/ai/runtime/pi/modelInjection.ts
@@ -36,6 +36,7 @@ import { isLoginBasedProvider, resolveEndpointDialect } from '@shared/utils/prov
 import { resolveEffectiveEndpoint } from '../../provider/endpoint'
 import { getProviderTransportAdapter, type ProviderTransportAdapter } from '../../provider/runtimeTransport'
 import { resolveAgentContextWindow } from '../agentContextWindow'
+import { toAgentProviderHeaders } from '../agentProviderHeaders'
 import type { AgentSessionUsageCapture } from '../types'
 import { loadPiAnthropicMessagesApi, loadPiApiStreamSimple } from './piSdk'
 import { withCherryInThinkingReplay } from './piThinkingReplay'
@@ -165,7 +166,7 @@ export function buildPiProviderInjection(
     baseUrl,
     apiKey: PI_PLACEHOLDER_API_KEY,
     api,
-    headers: provider.settings?.extraHeaders,
+    headers: toPiHeaders(provider.settings?.extraHeaders),
     models: [modelConfig]
   }
 
@@ -197,6 +198,18 @@ export function buildPiProviderInjection(
       ? { requestEnvironment: { AZURE_OPENAI_API_VERSION: provider.settings.apiVersion.trim() } }
       : {})
   }
+}
+
+/**
+ * Cherry header values are literals, but pi resolves each one as a `$ENV` / `!command`
+ * template — the same interpolation the `apiKey` placeholder dodges.
+ */
+function toPiHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+  const coerced = toAgentProviderHeaders(headers)
+  if (!coerced) return undefined
+  return Object.fromEntries(
+    Object.entries(coerced).map(([name, value]) => [name, value.replaceAll('$', '$$$$').replace(/^!/, '$!')])
+  )
 }
 
 function formatPiBaseUrl(baseUrl: string, api: PiApi): string {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: `provider.settings.extraHeaders` was handed to the agent runtimes verbatim. A non-string value (v1 settings passthrough, or an API write that skipped coercion) made pi's config-value resolver throw `config.startsWith is not a function`; pi turned that into a request-auth failure, and `PiRuntimeConnection.finishPromptRun` re-wrapped it into a fresh `Error`, so every turn on that provider died with an opaque message whose stack pointed at Cherry instead of the header. dsh hit the same data through its route schema (`z.dict(z.string())`). pi also resolves each header value as a `$ENV` / `!command` template, so a literal value containing `$` was interpolated away or made the turn fail.

After this PR: both runtimes coerce user headers through one shared `toAgentProviderHeaders()` helper (non-strings stringified, object/null values dropped), and the pi injection additionally escapes pi's `$` / leading `!` sigils so header literals survive resolution. dsh gets coercion only — `dsh-llm-pi-ai` passes headers through untouched, so escaping there would put `$$` on the wire.

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: the fix lives at the runtime injection boundary rather than in the persisted data, so existing bad values stay in the database but can no longer break a session; the escaping stays pi-local because it is pi config-template semantics, not HTTP semantics, and must not leak into `mergeHeaders`/`utils/http.ts` where it would reach the wire.

The following alternatives were considered: putting the whole helper in `src/main/utils/http.ts` (rejected — it would apply pi's escaping to ordinary provider requests); sanitizing on write in the DataApi provider schema (rejected — it does not repair already-migrated v1 rows); dropping non-string values instead of stringifying them (rejected — it silently discards a header the user meant to send).

Links to places where the discussion took place: N/A

### Breaking changes

None. Header values containing `$` are now sent literally to pi-backed agents instead of being interpolated as environment variables — that interpolation was an accidental leak of pi's config semantics, never a documented Cherry feature.

### Special notes for your reviewer

The pi test drives the real `ModelRegistry`/`AuthStorage` from `@earendil-works/pi-coding-agent` and asserts the round-trip, so it fails on the actual defect rather than on our own escaping helper. Unverified adjacent risk, left alone: dsh's cordis render treats `{{var}}` strictly (`compositionBuilder.ts` guards only `persona`), so a header value containing `{{` may still fail composition rendering.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed agent sessions failing every turn with "config.startsWith is not a function" when the provider had custom request headers, and stopped header values containing `$` from being mangled.
```
