### PR TITLE
fix(agent): show provider name in model label

### DIFF
--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -110,7 +110,8 @@ const mocks = vi.hoisted(() => ({
   sessionWorkspaceName: 'Workspace 1',
   sessionWorkspacePath: '/workspace',
   runtimeProviderMounts: 0,
-  runtimeProviderUnmounts: 0
+  runtimeProviderUnmounts: 0,
+  providerNames: {} as Record<string, string>
 }))
 
 const originalResizeObserver = globalThis.ResizeObserver
@@ -532,6 +533,10 @@ vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
   })
 }))
 
+vi.mock('@renderer/hooks/useProvider', () => ({
+  useProviderDisplayName: (providerId?: string) => (providerId ? mocks.providerNames[providerId] : '')
+}))
+
 vi.mock('@renderer/hooks/command', () => ({
   useCommandHandler: (key: string, handler: () => void, options?: Record<string, unknown>) => {
     mocks.shortcutHandlers.set(key, handler)
@@ -882,6 +887,7 @@ describe('AgentComposer', () => {
     mocks.sessionWorkspacePath = '/workspace'
     mocks.runtimeProviderMounts = 0
     mocks.runtimeProviderUnmounts = 0
+    mocks.providerNames = {}
     mocks.sessionLayout = undefined
     mocks.getDraft.mockReset()
     mocks.shortcutHandlers.clear()
@@ -1601,13 +1607,39 @@ describe('AgentComposer', () => {
       />
     )
 
-    const modelLabel = screen.getByText('Claude Sonnet 4.5')
+    const modelLabel = screen.getByText('Claude Sonnet 4.5 | Anthropic')
+    expect(modelLabel).toHaveAttribute('title', 'Claude Sonnet 4.5 | Anthropic')
     expect(modelLabel.closest('button')).toBeDisabled()
     expect(screen.getByTestId('agent-model-selector')).toHaveAttribute('data-shortcut', '')
 
     fireEvent.click(screen.getByText('select model 2'))
 
     expect(mocks.updateModel).not.toHaveBeenCalled()
+  })
+
+  it('shows the configured custom provider name in the inline model label', async () => {
+    const customModel: Model = {
+      ...model,
+      id: 'my-custom::custom-model',
+      providerId: 'my-custom',
+      apiModelId: 'custom-model',
+      name: 'Custom Model'
+    }
+    mocks.providerNames['my-custom'] = 'My Custom Provider'
+    mocks.modelResult = customModel
+
+    render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    const modelLabel = await screen.findByText('Custom Model | My Custom Provider')
+    expect(modelLabel).toHaveAttribute('title', 'Custom Model | My Custom Provider')
   })
 
   it('routes new session shortcuts through the empty session action', () => {
@@ -5184,7 +5216,7 @@ describe('AgentComposer', () => {
     )
 
     expect(screen.getByText('Agent')).not.toHaveClass('sr-only')
-    expect(screen.getByText('Claude Sonnet 4.5')).not.toHaveClass('sr-only')
+    expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).not.toHaveClass('sr-only')
     expect(screen.getByTestId('composer-below-controls')).toHaveTextContent('Workspace 1')
     expect(screen.getByTestId('composer-send-accessory')).not.toHaveTextContent('Workspace 1')
 
@@ -5192,7 +5224,7 @@ describe('AgentComposer', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Agent')).toHaveClass('sr-only')
-      expect(screen.getByText('Claude Sonnet 4.5')).toHaveClass('sr-only')
+      expect(screen.getByText('Claude Sonnet 4.5 | Anthropic')).toHaveClass('sr-only')
     })
     expect(screen.getByText('Workspace 1')).toHaveClass('sr-only')
   })

--- a/src/renderer/components/composer/variants/agent/AgentConversationControls.tsx
+++ b/src/renderer/components/composer/variants/agent/AgentConversationControls.tsx
@@ -4,6 +4,8 @@ import { ModelSelector } from '@renderer/components/ModelSelector'
 import { OpenTargetButton } from '@renderer/components/OpenTarget'
 import { type ResourceEditDialogTarget } from '@renderer/components/resourceCatalog/dialogs/edit'
 import { AgentSelector, WorkspaceSelector } from '@renderer/components/resourceCatalog/selectors'
+import { useProviderDisplayName } from '@renderer/hooks/useProvider'
+import { getProviderDisplayNameById } from '@renderer/utils/naming'
 import { cn } from '@renderer/utils/style'
 import type { AgentWorkspaceEntity } from '@shared/data/api/schemas/agentWorkspaces'
 import type { AgentEntity } from '@shared/data/types/agent'
@@ -160,7 +162,9 @@ function ModelControl({
   const baseTriggerClassName = side === 'bottom' ? COMPOSER_BELOW_SELECTOR_BUTTON_CLASS : COMPOSER_SELECTOR_BUTTON_CLASS
   const triggerClassName = cn(baseTriggerClassName, iconOnly && model && COMPOSER_ICON_ONLY_SELECTOR_BUTTON_CLASS)
   const labelClassName = cn('truncate', iconOnly && model && COMPOSER_ICON_ONLY_LABEL_CLASS)
-  const modelLabel = model ? model.name : selectModelLabel
+  const loadedProviderName = useProviderDisplayName(model?.providerId)
+  const providerName = model ? loadedProviderName || getProviderDisplayNameById(model.providerId) : undefined
+  const modelLabel = model ? `${model.name} | ${providerName}` : selectModelLabel
   const trigger = (
     <Button variant="ghost" size="sm" className={triggerClassName} disabled={!canChangeModel}>
       {model ? (
@@ -169,6 +173,7 @@ function ModelControl({
         <Sparkles size={20} aria-hidden className="text-muted-foreground" />
       )}
       <span
+        title={modelLabel}
         className={cn(
           'max-w-40 text-xs',
           canChangeModel ? (model ? 'text-foreground' : 'text-muted-foreground') : undefined,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- Chat conversations displayed `model name | provider name`, but Agent conversations still displayed only the model name.

After this PR:

- Agent conversations display `model name | provider name` in the inline model selector trigger.
- System providers keep their canonical casing, while custom providers use their configured display names.
- The complete label remains available through the trigger tooltip when the visible text is truncated.

#### Screenshots

| Before | After |
| --- | --- |
| <img width="205" height="45" alt="Before: Agent model trigger without provider name" src="https://github.com/user-attachments/assets/e6233d63-6f78-420a-815e-20280204dcf5" /> | <img width="290" height="47" alt="After: Agent model trigger with canonical provider name" src="https://github.com/user-attachments/assets/d6ec9847-b9a5-4594-92c9-e2c71c02dd83" /> |

Follow-up to #19522
Related to #19359
Related to #18339
Related to #19546
Related to #13091
Related to #18309

### Why we need it and why it was done in this way

The selected-model trigger owns the compact identity of the active model. Chat and Agent conversations share the same model selector behavior, so their trigger labels should expose the same model and provider identity.

This change reuses the existing provider display-name hook and canonical ID fallback introduced for Chat. That preserves localized casing for built-in providers and user-configured names for custom providers without changing the model dropdown or its grouping contract.

The following tradeoffs were made:

- The Agent trigger performs one provider metadata query for the selected model so custom provider names can be rendered correctly.
- Until custom provider metadata is available, the existing provider-ID fallback remains consistent with Chat behavior.

The following alternatives were considered:

- Passing the complete provider list through the Agent composer hierarchy was rejected because the trigger needs only one provider and the existing single-provider hook already owns that lookup.
- Formatting provider IDs locally was rejected because raw IDs are not reliable presentation labels and can lose canonical casing.

Links to places where the discussion took place: #19522

### Breaking changes

None.

### Special notes for your reviewer

- `AgentComposer.test.tsx`: 131 tests passed.
- `pnpm run typecheck:web` passed.
- Focused ESLint and Biome checks passed.
- `git diff --check` passed.
- The screenshots are cropped to the affected model-trigger region only.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and no upgrade changes are required
- [x] Documentation: A user-guide update was considered and is not required for this self-explanatory UI consistency fix
- [x] Self-review: I reviewed the complete diff against the latest `upstream/main`

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Show the selected model together with its provider in Agent conversations.
```
