### PR TITLE
feat(files): support shift-click range selection

### DIFF
--- a/src/renderer/pages/files/FileList.tsx
+++ b/src/renderer/pages/files/FileList.tsx
@@ -123,7 +123,7 @@ export const FileList = memo(function FileList({
 }: {
   files: FileItem[]
   selectedIds: Set<string>
-  onSelect: (id: string) => void
+  onSelect: (id: string, isChecked: boolean, shouldSelectRange: boolean) => void
   onOpen: (file: FileItem) => void
   onDelete: (id: string) => void
   onRestore: (id: string) => void
@@ -188,8 +188,10 @@ export const FileList = memo(function FileList({
                     size="sm"
                     className={FILE_LIST_CHECKBOX_CLASS_NAME}
                     checked={selected}
-                    onCheckedChange={() => onSelect(file.id)}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onSelect(file.id, !selected, e.shiftKey)
+                    }}
                     data-file-selection-checkbox
                     aria-label={t('files.select_file', { name: file.name })}
                   />

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -326,6 +326,7 @@ function FilesPage() {
   const [filter, setFilter] = useState<SidebarFilter>({ kind: 'library', value: 'all' })
   const isTrash = filter.kind === 'library' && filter.value === 'trash'
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const selectionAnchorIdRef = useRef<string | null>(null)
 
   const [sortKey, setSortKey] = useState<SortKey>('updatedAt')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
@@ -669,13 +670,35 @@ function FilesPage() {
     return t('files.delete.label')
   }, [isTrash, selectedFiles, t])
 
-  const handleSelect = useCallback((id: string) => {
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      next.has(id) ? next.delete(id) : next.add(id)
-      return next
-    })
-  }, [])
+  const handleSelect = useCallback(
+    (id: string, isChecked: boolean, shouldSelectRange: boolean) => {
+      const anchorIndex = selectionAnchorIdRef.current
+        ? filteredFiles.findIndex((file) => file.id === selectionAnchorIdRef.current)
+        : -1
+      const targetIndex = filteredFiles.findIndex((file) => file.id === id)
+      const isRangeSelection = shouldSelectRange && anchorIndex >= 0
+      const selectionIds = isRangeSelection
+        ? filteredFiles
+            .slice(Math.min(anchorIndex, targetIndex), Math.max(anchorIndex, targetIndex) + 1)
+            .map((file) => file.id)
+        : [id]
+
+      if (!isRangeSelection) selectionAnchorIdRef.current = id
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        for (const selectionId of selectionIds) {
+          if (isChecked) next.add(selectionId)
+          else next.delete(selectionId)
+        }
+        return next
+      })
+    },
+    [filteredFiles]
+  )
+
+  useEffect(() => {
+    if (selectedIds.size === 0) selectionAnchorIdRef.current = null
+  }, [selectedIds])
 
   const handleSelectAllVisible = useCallback(
     (checked: boolean) => {

--- a/src/renderer/pages/files/__tests__/FileList.test.tsx
+++ b/src/renderer/pages/files/__tests__/FileList.test.tsx
@@ -1,9 +1,13 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest'
 
+import type * as CherryStudioUi from '@cherrystudio/ui'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ComponentProps } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => importOriginal<typeof CherryStudioUi>())
 
 import type { FileContextMenuActions } from '../FileContextMenu'
 import type { FileItem } from '../fileDisplay'
@@ -153,18 +157,21 @@ describe('FileList', () => {
     expect(virtualizerMocks.scrollToIndex).toHaveBeenCalledWith(37, { align: 'auto' })
   })
 
-  it('opens rows while checkbox interactions only select', () => {
+  it('forwards checkbox state and the Shift modifier without opening the row', async () => {
     const onSelect = vi.fn()
     const onOpen = vi.fn()
+    const user = userEvent.setup()
 
     render(<FileList {...fileListProps(null)} onSelect={onSelect} onOpen={onOpen} />)
 
     const checkbox = screen.getByRole('checkbox', { name: 'files.select_file' })
-    fireEvent.click(checkbox)
-    expect(onSelect).toHaveBeenCalledWith(file.id)
+    await user.keyboard('{Shift>}')
+    await user.click(checkbox)
+    await user.keyboard('{/Shift}')
+    expect(onSelect).toHaveBeenCalledWith(file.id, true, true)
     expect(onOpen).not.toHaveBeenCalled()
 
-    fireEvent.click(screen.getByText(file.name))
+    await user.click(screen.getByText(file.name))
     expect(onOpen).toHaveBeenCalledWith(file)
     expect(onSelect).toHaveBeenCalledOnce()
   })

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -7,6 +7,7 @@ import type { FileEntryStats } from '@shared/data/api/schemas/files'
 import type { FileEntry } from '@shared/data/types/file'
 import { mockUseInfiniteQuery, mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { act, cleanup, createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -897,6 +898,41 @@ describe('FilesPage file operations', () => {
     await waitFor(() => {
       expect(ipcMocks.request).toHaveBeenCalledWith('file.batch_trash', { ids: [entry.id, secondEntry.id] })
     })
+  })
+
+  it('selects the visible range when Shift-clicking a file checkbox', async () => {
+    const secondEntry = { ...entry, id: 'file-2', name: 'notes' } as unknown as FileEntry
+    const thirdEntry = { ...entry, id: 'file-3', name: 'summary' } as unknown as FileEntry
+    renderFilesPage([entry, secondEntry, thirdEntry])
+    const user = userEvent.setup()
+    const checkboxes = screen.getAllByRole('checkbox', { name: 'files.select_file' })
+
+    await user.click(checkboxes[0])
+    await user.keyboard('{Shift>}')
+    await user.click(checkboxes[2])
+    await user.keyboard('{/Shift}')
+
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toBeChecked()
+    }
+  })
+
+  it('starts a new selection anchor after clearing the previous selection', async () => {
+    const secondEntry = { ...entry, id: 'file-2', name: 'notes' } as unknown as FileEntry
+    const thirdEntry = { ...entry, id: 'file-3', name: 'summary' } as unknown as FileEntry
+    renderFilesPage([entry, secondEntry, thirdEntry])
+    const user = userEvent.setup()
+    const checkboxes = screen.getAllByRole('checkbox', { name: 'files.select_file' })
+
+    await user.click(checkboxes[0])
+    await user.click(checkboxes[0])
+    await user.keyboard('{Shift>}')
+    await user.click(checkboxes[2])
+    await user.keyboard('{/Shift}')
+
+    expect(checkboxes[0]).not.toBeChecked()
+    expect(checkboxes[1]).not.toBeChecked()
+    expect(checkboxes[2]).toBeChecked()
   })
 
   it('does not change selection when opening a row context menu', () => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

File checkboxes could only toggle individual files.

After this PR:

Holding Shift while clicking a file checkbox selects or deselects the contiguous range from the most recent selection anchor, based on the currently visible file order.
<img width="2348" height="1530" alt="PixPin_2026-08-27_21-44-28" src="https://github.com/user-attachments/assets/1da428c2-8c21-4581-b3c0-94a4c6461baa" />

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

N/A

### Why we need it and why it was done in this way

The files page already owns both the selected IDs and the current visible ordering, so it also owns the range-selection anchor and interval calculation. The checkbox forwards its next state and Shift modifier without exposing DOM events to the page.

The following tradeoffs were made:

- The anchor is transient and stored in a ref to avoid an extra render.
- Selections outside the clicked interval are preserved.
- Clearing all selections invalidates the previous anchor.

The following alternatives were considered:

- A shared range-selection abstraction was not introduced because this behavior currently has one domain-local consumer.
- Reusing the active/open file state as the anchor was rejected because opening and multi-selection have different lifecycles.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

Validation completed locally:

- `pnpm exec vitest run --project renderer src/renderer/pages/files/__tests__/FileList.test.tsx src/renderer/pages/files/__tests__/FilesPage.test.tsx` (65 tests passed)
- `pnpm typecheck:web`
- Biome check for the four changed files
- ESLint for the four changed files
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Files] Added Shift-click range selection for file checkboxes.
```
