### PR TITLE
fix(lmstudio): preserve multi-image inputs

### DIFF
--- a/src/main/ai/provider/__tests__/lmstudio.test.ts
+++ b/src/main/ai/provider/__tests__/lmstudio.test.ts
@@ -1,0 +1,151 @@
+import { createExecutor } from '@cherrystudio/ai-core'
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import { SystemProviderIds } from '@shared/utils/systemProviderId'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { makeModel } from '../../__tests__/fixtures/model'
+import { makeProvider } from '../../__tests__/fixtures/provider'
+
+const { resolveApiKeyMock, getAuthConfigMock, getByProviderIdMock } = vi.hoisted(() => ({
+  resolveApiKeyMock: vi.fn(),
+  getAuthConfigMock: vi.fn(),
+  getByProviderIdMock: vi.fn()
+}))
+
+vi.mock('@main/data/services/ProviderService', () => ({
+  providerService: {
+    resolveApiKey: resolveApiKeyMock,
+    getAuthConfig: getAuthConfigMock,
+    getByProviderId: getByProviderIdMock
+  }
+}))
+
+const { providerToAiSdkConfig } = await import('../config')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resolveApiKeyMock.mockReturnValue({ value: '', apiKeySelection: { attribution: 'unknown' } })
+  getAuthConfigMock.mockReturnValue(null)
+})
+
+function createLmStudioProvider(id: string = SystemProviderIds.lmstudio) {
+  return makeProvider({
+    id,
+    presetProviderId: SystemProviderIds.lmstudio,
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+        baseUrl: 'http://localhost:1234/v1',
+        adapterFamily: 'openai-compatible'
+      }
+    }
+  })
+}
+
+function fakeSuccessResponse() {
+  return new Response(
+    JSON.stringify({
+      id: 'chatcmpl-fake',
+      choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+}
+
+describe('LM Studio multi-image request compatibility', () => {
+  it('strips data URI prefixes from every image while preserving count and order', async () => {
+    const provider = createLmStudioProvider('lmstudio-local')
+    const model = makeModel({
+      id: 'lmstudio-local::vision-model',
+      providerId: 'lmstudio-local',
+      apiModelId: 'vision-model',
+      endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]
+    })
+    const config = await providerToAiSdkConfig(provider, model)
+    const fetchSpy = vi.fn().mockResolvedValue(fakeSuccessResponse())
+    const executor = await createExecutor(
+      config.providerId as Parameters<typeof createExecutor>[0],
+      { ...config.providerSettings, fetch: fetchSpy } as Parameters<typeof createExecutor>[1]
+    )
+    const languageModel = await executor.languageModel('vision-model')
+
+    await languageModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Compare these images' },
+            { type: 'file', mediaType: 'image/png', data: 'AQID' },
+            { type: 'file', mediaType: 'image/jpeg', data: 'BAUG' }
+          ]
+        }
+      ]
+    })
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.messages[0].content).toEqual([
+      { type: 'text', text: 'Compare these images' },
+      { type: 'image_url', image_url: { url: 'AQID' } },
+      { type: 'image_url', image_url: { url: 'BAUG' } }
+    ])
+  })
+
+  it('keeps the existing single-image wire format', async () => {
+    const provider = createLmStudioProvider()
+    const model = makeModel({ endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS] })
+    const config = await providerToAiSdkConfig(provider, model)
+    const fetchSpy = vi.fn().mockResolvedValue(fakeSuccessResponse())
+    const executor = await createExecutor(
+      config.providerId as Parameters<typeof createExecutor>[0],
+      { ...config.providerSettings, fetch: fetchSpy } as Parameters<typeof createExecutor>[1]
+    )
+    const languageModel = await executor.languageModel('vision-model')
+
+    await languageModel.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'file', mediaType: 'image/png', data: 'AQID' }] }]
+    })
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.messages[0].content).toEqual([{ type: 'image_url', image_url: { url: 'data:image/png;base64,AQID' } }])
+  })
+
+  it('does not transform multi-image requests for other OpenAI-compatible providers', async () => {
+    const provider = makeProvider({
+      id: 'some-relay',
+      defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+      endpointConfigs: {
+        [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: {
+          baseUrl: 'https://relay.example.com/v1',
+          adapterFamily: 'openai-compatible'
+        }
+      }
+    })
+    const model = makeModel({ endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS] })
+    const config = await providerToAiSdkConfig(provider, model)
+    const fetchSpy = vi.fn().mockResolvedValue(fakeSuccessResponse())
+    const executor = await createExecutor(
+      config.providerId as Parameters<typeof createExecutor>[0],
+      { ...config.providerSettings, fetch: fetchSpy } as Parameters<typeof createExecutor>[1]
+    )
+    const languageModel = await executor.languageModel('vision-model')
+
+    await languageModel.doGenerate({
+      prompt: [
+        {
+          role: 'user',
+          content: [
+            { type: 'file', mediaType: 'image/png', data: 'AQID' },
+            { type: 'file', mediaType: 'image/jpeg', data: 'BAUG' }
+          ]
+        }
+      ]
+    })
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.messages[0].content).toEqual([
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,AQID' } },
+      { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,BAUG' } }
+    ])
+  })
+})

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -49,6 +49,7 @@ import { appendDashScopeWebExtractor } from './custom/dashscope/dashscopeWebExtr
 import { dmxapiUsesCustomTransport } from './custom/dmxapi/dmxapiImageRouting'
 import { resolveAiSdkProviderId, type ResolvedEndpoint, resolveEffectiveEndpoint } from './endpoint'
 import { buildGrokCliRequestHeaders, rewriteGrokCliResponsesBody } from './grokCli'
+import { transformLmStudioRequestBody } from './lmstudio'
 import { isVertexMaasModelId, normalizeVertexCredentials } from './vertex'
 import { transformZhipuRequestBody } from './zhipuWebSearch'
 
@@ -248,6 +249,17 @@ export async function resolveProviderAiSdkConfig(
       build: withSelectedApiKey((ctx) => {
         const config = buildOpenAICompatibleConfig(ctx)
         config.providerSettings.transformRequestBody = transformZhipuRequestBody
+        return config
+      })
+    },
+    // LM Studio's OpenAI-compatible endpoint expects bare base64 for images when
+    // a message contains multiple image blocks. Keep single-image requests on
+    // the unchanged OpenAI data-URI format (lmstudio.ts).
+    {
+      match: (p, id) => id === 'openai-compatible' && matchesPreset(p, SystemProviderIds.lmstudio),
+      build: withSelectedApiKey((ctx) => {
+        const config = buildOpenAICompatibleConfig(ctx)
+        config.providerSettings.transformRequestBody = transformLmStudioRequestBody
         return config
       })
     },

--- a/src/main/ai/provider/lmstudio.ts
+++ b/src/main/ai/provider/lmstudio.ts
@@ -1,0 +1,34 @@
+/**
+ * LM Studio's OpenAI-compatible endpoint expects image data as bare base64 when
+ * more than one image is present in a message, while the OpenAI format uses a
+ * data URI. Keep the workaround scoped to multi-image messages so single-image
+ * requests retain their existing wire format.
+ */
+export function transformLmStudioRequestBody(args: Record<string, any>): Record<string, any> {
+  if (!Array.isArray(args.messages)) return args
+
+  let changed = false
+  const messages = args.messages.map((message: any) => {
+    if (!Array.isArray(message?.content)) return message
+
+    const imageCount = message.content.filter((part: any) => part?.type === 'image_url').length
+    if (imageCount < 2) return message
+
+    let messageChanged = false
+    const content = message.content.map((part: any) => {
+      const url = part?.image_url?.url
+      if (part?.type !== 'image_url' || typeof url !== 'string') return part
+
+      const match = url.match(/^data:image\/[^;,]+;base64,(.*)$/is)
+      if (!match) return part
+
+      messageChanged = true
+      changed = true
+      return { ...part, image_url: { ...part.image_url, url: match[1] } }
+    })
+
+    return messageChanged ? { ...message, content } : message
+  })
+
+  return changed ? { ...args, messages } : args
+}

--- a/src/main/ai/provider/lmstudio.ts
+++ b/src/main/ai/provider/lmstudio.ts
@@ -1,3 +1,5 @@
+import { parseDataUrl } from '@shared/utils/dataUrl'
+
 /**
  * LM Studio's OpenAI-compatible endpoint expects image data as bare base64 when
  * more than one image is present in a message, while the OpenAI format uses a
@@ -19,12 +21,12 @@ export function transformLmStudioRequestBody(args: Record<string, any>): Record<
       const url = part?.image_url?.url
       if (part?.type !== 'image_url' || typeof url !== 'string') return part
 
-      const match = url.match(/^data:image\/[^;,]+;base64,(.*)$/is)
-      if (!match) return part
+      const parsed = parseDataUrl(url)
+      if (!parsed?.isBase64 || !parsed.mediaType?.toLowerCase().startsWith('image/')) return part
 
       messageChanged = true
       changed = true
-      return { ...part, image_url: { ...part.image_url, url: match[1] } }
+      return { ...part, image_url: { ...part.image_url, url: parsed.data } }
     })
 
     return messageChanged ? { ...message, content } : message


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Cherry Studio sent multiple images in one LM Studio vision message as OpenAI data-URI URLs, and LM Studio processed only the first image.

After this PR:

LM Studio requests containing multiple images in one message strip the data-URI prefix from every image while preserving the original count and order. Single-image requests and other OpenAI-compatible providers keep their existing wire format.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19449

### Why we need it and why it was done in this way

LM Studio's OpenAI-compatible endpoint needs bare base64 image data for multi-image messages. The provider-specific request-body transform is applied only to the LM Studio preset and only when a message contains at least two images, keeping the workaround isolated from other providers.

The following tradeoffs were made:

- Multi-image LM Studio messages use a provider-specific wire-format adjustment.
- Single-image LM Studio messages remain unchanged to preserve their existing behavior.

The following alternatives were considered:

- Changing the shared AI SDK converter would alter requests for every OpenAI-compatible provider.
- Matching model names would be less reliable than routing from the LM Studio provider preset.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

https://github.com/CherryHQ/cherry-studio/issues/19449

### Breaking changes

None.

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The focused LM Studio provider regression tests cover multi-image count/order preservation, unchanged single-image formatting, and isolation from other OpenAI-compatible providers. No user-guide update is required for this compatibility fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this provider compatibility fix.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fix LM Studio vision requests so multiple images in one message are forwarded in order.
```
