### PR TITLE
fix(model-parameters): omit fixed Kimi sampling settings

### DIFF
--- a/src/main/ai/utils/__tests__/modelParameters.test.ts
+++ b/src/main/ai/utils/__tests__/modelParameters.test.ts
@@ -85,6 +85,14 @@ describe('getTemperature', () => {
     expect(getTemperature(a, model, OMIT_REASONING)).toBeUndefined()
   })
 
+  it.each(['kimi-k2.5', 'kimi-k2.7-code', 'kimi-k3'])(
+    'omits fixed temperature for a custom %s model without registry metadata',
+    (id) => {
+      const a = makeAssistant({ temperature: 0.7 })
+      expect(getTemperature(a, makeModel({ id: `custom::${id}` }), OMIT_REASONING)).toBeUndefined()
+    }
+  )
+
   it('disables temperature for Gemini 3.x models', () => {
     const a = makeAssistant({ temperature: 0.8 })
     const model = makeModel({ id: 'gemini::gemini-3-pro' })
@@ -124,6 +132,14 @@ describe('getTopP', () => {
 
     expect(getTopP(a, model, OMIT_REASONING)).toBeUndefined()
   })
+
+  it.each(['kimi-k2.5', 'kimi-k2.7-code', 'kimi-k3'])(
+    'omits fixed topP for a custom %s model without registry metadata',
+    (id) => {
+      const a = makeAssistant({ enableTopP: true, topP: 1 })
+      expect(getTopP(a, makeModel({ id: `custom::${id}` }), OMIT_REASONING)).toBeUndefined()
+    }
+  )
 
   it('clamps topP to [0.95, 1] from the resolved request reasoning', () => {
     // `enableTemperature: false` — Claude 4.5 has mutually-exclusive

--- a/src/shared/utils/model.ts
+++ b/src/shared/utils/model.ts
@@ -136,12 +136,22 @@ export const getModelSupportedReasoningEffortOptions = (model: Model | undefined
 // Parameter support checks
 // ---------------------------------------------------------------------------
 
+const isKimiFixedSamplingModel = (model: Model): boolean => {
+  const id = getLowerBaseModelName(getRawModelId(model))
+  return /^kimi-k(?:2[.-][5-9]\d*|[3-9]\d*)(?:[-_.]|$)/i.test(id)
+}
+
 /** Check if model supports temperature parameter */
-export const isSupportTemperatureModel = (model: Model): boolean =>
-  model.parameterSupport?.temperature?.supported !== false
+export const isSupportTemperatureModel = (model: Model): boolean => {
+  if (model.parameterSupport?.temperature) return model.parameterSupport.temperature.supported !== false
+  return !isKimiFixedSamplingModel(model)
+}
 
 /** Check if model supports top_p parameter */
-export const isSupportTopPModel = (model: Model): boolean => model.parameterSupport?.topP?.supported !== false
+export const isSupportTopPModel = (model: Model): boolean => {
+  if (model.parameterSupport?.topP) return model.parameterSupport.topP.supported !== false
+  return !isKimiFixedSamplingModel(model)
+}
 
 /** Whether temperature and top_p are mutually exclusive for this model */
 export const isTemperatureTopPMutuallyExclusiveModel = (model: Model): boolean => {


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Custom Kimi K2.5, K2.7, and K3 model entries had no registry metadata, so assistant temperature and top-p settings were sent even though these models require fixed sampling values. Moonshot then rejected requests whose values differed from those fixed settings.

After this PR:

The model-parameter fallback recognizes Kimi K2.5 and newer IDs and omits temperature and top-p unless explicit provider metadata says the parameter is supported. Explicit registry metadata remains authoritative.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19601

### Why we need it and why it was done in this way

Custom providers bypass the built-in model registry, so the existing `parameterSupport` flags are unavailable for those model entries. A narrow ID fallback in the shared support helpers keeps both request-parameter paths consistent while preserving explicit metadata when it exists.

The following tradeoffs were made:

The fallback intentionally covers only Kimi K2.5 and newer model IDs, matching the affected fixed-sampling model family without changing older Kimi behavior.

The following alternatives were considered:

Adding custom-provider registry metadata was considered, but custom models are user-defined and do not pass through the built-in registry.

Links to places where the discussion took place: #19601

### Breaking changes

None.

### Special notes for your reviewer

Focused coverage exercises custom-provider IDs for Kimi K2.5, K2.7-code, and K3 in both temperature and top-p paths.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
<!--LANG:en-->
[Models] Fixed Kimi K2.5 and newer requests failing when assistant sampling settings were enabled.
<!--LANG:zh-CN-->
[模型] 修复启用助手采样设置时 Kimi K2.5 及更新版本请求失败的问题。
<!--LANG:END-->
```
