### PR TITLE
fix(agent-session): let a started session relocate a workspace that is gone

### DIFF
--- a/src/main/data/services/AgentSessionService.ts
+++ b/src/main/data/services/AgentSessionService.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto'
+import { statSync } from 'node:fs'
 
 import { application } from '@application'
 import { notifyDataApiDataChange } from '@data/dataApiDataChange'
@@ -43,6 +44,19 @@ const logger = loggerService.withContext('AgentSessionService')
 const DEFAULT_LIMIT = 50
 const MAX_LIMIT = 200
 type SessionEntitySearchItem = Extract<EntitySearchItem, { type: 'session' }>
+
+/**
+ * A user workspace whose directory was renamed, moved, or deleted outside the app. System
+ * workspaces are app-owned and recreated on demand, so they are never "missing" in this sense.
+ */
+function boundUserWorkspaceIsMissing(workspace: AgentWorkspaceRow): boolean {
+  if (workspace.type !== AGENT_WORKSPACE_TYPE.USER) return false
+  try {
+    return !statSync(workspace.path).isDirectory()
+  } catch {
+    return true
+  }
+}
 
 function publishTaskReadModelChanges(taskIds: readonly string[]): void {
   if (taskIds.length === 0) return
@@ -531,8 +545,11 @@ export class AgentSessionService {
   /**
    * Replace a session's workspace. Only an empty session (no messages) may
    * change its workspace; once a conversation has started the binding is
-   * permanent. Lives on `PUT /agent-sessions/:id/workspace` rather than the
-   * generic PATCH because it creates/deletes the backing system workspace row.
+   * permanent — the one exception being a bound user directory that no longer
+   * exists, which would otherwise strand the session (see
+   * {@link boundUserWorkspaceIsMissing}). Lives on
+   * `PUT /agent-sessions/:id/workspace` rather than the generic PATCH because
+   * it creates/deletes the backing system workspace row.
    */
   setWorkspace(id: string, source: AgentSessionWorkspaceSource): AgentSessionEntity {
     withSqliteErrors(
@@ -545,8 +562,12 @@ export class AgentSessionService {
 
   setWorkspaceTx(tx: DbOrTx, id: string, source: AgentSessionWorkspaceSource): void {
     const current = this.getJoinedSessionRowTx(tx, id)
-    // The workspace binding is locked the moment a session has any message.
-    this.assertSessionHasNoMessagesTx(tx, id)
+    // The workspace binding is locked the moment a session has any message, unless the bound
+    // directory is gone: the session can then neither run nor be repointed, so relocating it
+    // is the only way out.
+    if (!boundUserWorkspaceIsMissing(current.workspace)) {
+      this.assertSessionHasNoMessagesTx(tx, id)
+    }
 
     if (source.type === AGENT_WORKSPACE_TYPE.USER) {
       const workspace = agentWorkspaceService.getRowByIdTx(tx, source.workspaceId)

--- a/src/main/data/services/__tests__/AgentSessionService.test.ts
+++ b/src/main/data/services/__tests__/AgentSessionService.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, renameSync, rmSync } from 'node:fs'
+
 import { application } from '@application'
 import { agentTable } from '@data/db/schemas/agent'
 import { agentSessionTable } from '@data/db/schemas/agentSession'
@@ -53,13 +55,17 @@ describe('AgentSessionService', () => {
 
   afterEach(() => {
     ;(application.get('DbService').withWriteTx as Mock).mockReset()
+    rmSync(root, { recursive: true, force: true })
   })
 
   function workspacePath(...segments: string[]) {
     return path.join(root, ...segments)
   }
 
+  // User workspaces are real folders: the service reads the directory to decide whether a
+  // messaged session may still be relocated, so the fixture has to exist on disk.
   async function createWorkspace(name: string): Promise<AgentWorkspaceEntity> {
+    mkdirSync(workspacePath(name), { recursive: true })
     return dbh.db.transaction((tx) => agentWorkspaceService.findOrCreateByPathTx(tx, workspacePath(name)))
   }
 
@@ -623,6 +629,33 @@ describe('AgentSessionService', () => {
     expect(agentSessionService.getById(session.id)).toMatchObject({
       workspaceId: firstWorkspace.id
     })
+  })
+
+  it('relocates a messaged session whose workspace directory was renamed away', async () => {
+    const renamedWorkspace = await createWorkspace('renamed-outside-the-app')
+    const relocationTarget = await createWorkspace('relocation-target')
+    const session = await createSession('Renamed workspace', renamedWorkspace.id)
+    await insertSessionMessage(session.id, 'message-before-rename')
+    renameSync(renamedWorkspace.path, workspacePath('renamed-outside-the-app-new-name'))
+
+    const updated = agentSessionService.setWorkspace(session.id, {
+      type: 'user',
+      workspaceId: relocationTarget.id
+    })
+
+    expect(updated.workspaceId).toBe(relocationTarget.id)
+    expect(updated.workspace.path).toBe(relocationTarget.path)
+  })
+
+  it('lets a messaged session with a missing workspace fall back to a system workspace', async () => {
+    const missingWorkspace = await createWorkspace('deleted-outside-the-app')
+    const session = await createSession('Deleted workspace', missingWorkspace.id)
+    await insertSessionMessage(session.id, 'message-before-delete')
+    rmSync(missingWorkspace.path, { recursive: true, force: true })
+
+    const updated = agentSessionService.setWorkspace(session.id, { type: 'system' })
+
+    expect(updated.workspace.type).toBe('system')
   })
 
   it('rejects switching a messaged system workspace session to a user workspace', async () => {

--- a/src/renderer/hooks/agent/useSession.ts
+++ b/src/renderer/hooks/agent/useSession.ts
@@ -426,7 +426,7 @@ export const useSessions = (
  * Patch session-level fields (`name`, `description`, `agentId`). Config fields
  * (model, instructions, configuration, ...) live on the parent agent — use
  * {@link import('./useAgent').useUpdateAgent} for those. The workspace binding
- * is changed separately via {@link setSessionWorkspace} (only while empty).
+ * is changed separately via {@link setSessionWorkspace}.
  */
 export const useUpdateSession = () => {
   const { t } = useTranslation()
@@ -466,8 +466,8 @@ export const useUpdateSession = () => {
 
   /**
    * Replace a session's workspace. Backend rejects this once the session has
-   * any message (only empty sessions may rebind), so callers should gate on an
-   * untouched session.
+   * any message, unless its bound directory no longer exists, so callers should
+   * gate on an untouched session or an unreachable workspace.
    */
   const setSessionWorkspace = useCallback(
     async (id: string, workspace: SetAgentSessionWorkspaceDto): Promise<AgentSessionEntity | undefined> => {

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -240,7 +240,9 @@ const AgentChat = ({
       !runtime.hasOlder &&
       runtime.uiMessages.length === 0
   )
-  const canChangeWorkspace = Boolean(onSessionWorkspaceChange && isEmptyConversation)
+  // A started conversation keeps its workspace, except when that workspace is unreachable: the
+  // session can no longer send anything, so relocating it is the only way out of the dead end.
+  const canChangeWorkspace = Boolean(onSessionWorkspaceChange && (isEmptyConversation || workspaceWarning))
   const runAfterFileNavigation = useCallback(
     (transition: () => void) => {
       if (requestFileNavigation) {

--- a/src/renderer/pages/agents/__tests__/AgentChatWorkspaceControl.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentChatWorkspaceControl.test.tsx
@@ -1,0 +1,249 @@
+import type * as ChatPrimitives from '@renderer/components/chat/primitives'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type * as MotionReact from 'motion/react'
+import type { ComponentProps, PropsWithChildren, ReactElement, ReactNode } from 'react'
+import type * as ReactI18next from 'react-i18next'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AgentChat from '../AgentChat'
+
+const workspaceWarningMock = vi.hoisted(() => ({ value: undefined as string | undefined }))
+
+vi.mock('@cherrystudio/ui', async (importOriginal) => ({
+  ...(await importOriginal()),
+  Button: ({ children, ...props }: PropsWithChildren<Record<string, unknown>>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  NormalTooltip: ({ children }: PropsWithChildren) => children,
+  Tooltip: ({ children }: PropsWithChildren) => children
+}))
+
+vi.mock('@renderer/components/chat/shell/ConversationShell', () => ({
+  default: ({ topBar, center }: { topBar?: ReactNode; center?: ReactNode }) => (
+    <div>
+      <div>{topBar}</div>
+      <div>{center}</div>
+    </div>
+  )
+}))
+
+vi.mock('@renderer/components/chat/shell/ConversationCenterState', () => ({
+  default: ({ state }: { state: string }) => <div data-testid="conversation-center-state" data-state={state} />
+}))
+
+vi.mock('@renderer/components/chat/primitives', async (importActual) => ({
+  ...(await importActual<typeof ChatPrimitives>()),
+  EmptyState: () => <div />,
+  LoadingState: () => <div />
+}))
+
+vi.mock('@renderer/components/chat/shell/RightPaneHost', () => ({
+  RightPaneHost: ({ children }: PropsWithChildren) => <section>{children}</section>,
+  PersistentRightPaneHost: ({ children }: PropsWithChildren) => <section>{children}</section>
+}))
+
+vi.mock('@renderer/components/chat/panes/ArtifactPane', () => ({
+  ARTIFACT_PANE_WIDTH: 460,
+  normalizeArtifactPaneFilePath: (_workspacePath: string, rawPath: string) => rawPath,
+  resolveArtifactPaneFileSelection: () => null,
+  ArtifactPaneView: () => <div />,
+  default: () => <div />
+}))
+
+vi.mock('@renderer/components/composer/ComposerContext', () => ({
+  ComposerContextProvider: ({ children }: PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('@renderer/components/composer/ComposerCore', () => ({
+  default: ({ fallback }: { fallback: ReactNode }) => <>{fallback}</>
+}))
+
+vi.mock('@renderer/components/composer/useToolApprovalComposerOverrides', () => ({
+  useToolApprovalComposerOverrides: () => ({})
+}))
+
+vi.mock('@renderer/components/composer/ComposerDockTransitionFrame', () => ({
+  default: ({ main, composer }: { main: ReactNode; composer: ReactNode }) => (
+    <div>
+      {main}
+      {composer}
+    </div>
+  )
+}))
+
+vi.mock('@renderer/components/composer/variants/AgentComposer', () => ({
+  default: () => <div />,
+  AgentHomeComposer: () => <div />,
+  MissingAgentHomeComposer: () => <div />
+}))
+
+vi.mock('@renderer/components/QuickPanel', () => ({
+  QuickPanelProvider: ({ children }: PropsWithChildren) => <>{children}</>
+}))
+
+vi.mock('motion/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof MotionReact>()),
+  AnimatePresence: ({ children }: PropsWithChildren) => <>{children}</>,
+  useReducedMotion: () => false
+}))
+
+vi.mock('@renderer/data/hooks/useCache', async () => {
+  const { MockUseCache } = await import('@test-mocks/renderer/useCache')
+
+  return {
+    ...MockUseCache,
+    useCache: () => [false],
+    useSharedCache: () => [null, vi.fn()],
+    useSharedCacheValue: () => undefined,
+    usePersistCache: () => [undefined, vi.fn()]
+  }
+})
+
+vi.mock('@renderer/data/hooks/usePreference', () => ({
+  usePreference: () => ['none', vi.fn()]
+}))
+
+vi.mock('@renderer/hooks/agent/useAgent', () => ({
+  useAgent: () => ({ agent: { id: 'agent-1' }, isLoading: false }),
+  useAgents: () => ({ agents: [{ id: 'agent-1' }], isLoading: false }),
+  useUpdateAgent: () => ({ updateModel: vi.fn() })
+}))
+
+vi.mock('@renderer/hooks/agent/useAgentWorkspaceWarning', () => ({
+  useAgentWorkspaceWarning: () => workspaceWarningMock.value
+}))
+
+vi.mock('@renderer/data/hooks/useDataApi', () => ({
+  useInvalidateCache: () => vi.fn()
+}))
+
+vi.mock('@renderer/hooks/agent/useSession', () => ({
+  useActiveSession: () => ({ activeSessionId: 'session-1', isLoading: false, setActiveSessionId: vi.fn() }),
+  useUpdateSession: () => ({ updateSession: vi.fn() })
+}))
+
+const agentSessionPartsMocks = vi.hoisted(() => ({
+  result: {
+    messages: [] as any[],
+    isLoading: false,
+    hasOlder: false,
+    loadOlder: vi.fn(),
+    refresh: vi.fn(),
+    deleteMessage: vi.fn()
+  }
+}))
+
+vi.mock('@renderer/hooks/useAgentSessionParts', () => ({
+  useAgentSessionParts: () => agentSessionPartsMocks.result
+}))
+
+vi.mock('@renderer/hooks/useChatWithHistory', () => ({
+  useChatWithHistory: () => ({ activeExecutions: [], sendMessage: vi.fn(), stop: vi.fn(), setMessages: vi.fn() })
+}))
+
+vi.mock('@renderer/hooks/useExecutionOverlay', () => ({
+  useExecutionOverlay: () => ({ overlay: {}, liveAssistants: [], disposeOverlay: vi.fn(), reset: vi.fn() })
+}))
+
+vi.mock('@renderer/hooks/useTopicStreamStatus', () => ({
+  useTopicStreamStatus: () => ({ isPending: false }),
+  useTopicOverlayHandoffOnTerminal: () => {}
+}))
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof ReactI18next>()),
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+vi.mock('../components/AgentChatNavbar', () => ({
+  AgentChatNavbar: ({ conversationControls }: { conversationControls?: ReactNode }) => (
+    <div data-testid="agent-chat-navbar">{conversationControls}</div>
+  )
+}))
+
+vi.mock('../AgentChatMain', () => ({ default: () => <div /> }))
+vi.mock('../AgentComposerSlot', () => ({ default: () => <div /> }))
+
+vi.mock('@renderer/components/ModelSelector', () => ({
+  ModelSelector: ({ trigger }: { trigger: ReactElement }) => trigger
+}))
+
+vi.mock('@renderer/components/Avatar/ModelAvatar', () => ({ default: () => <span /> }))
+
+// The read-only branch of the workspace control renders `OpenExternalAppButton` instead of the
+// selector — the two stubs below are what tells the locked state apart from the changeable one.
+vi.mock('@renderer/components/chat/panes/OpenExternalAppButton', () => ({
+  default: ({ menuTrigger }: { menuTrigger: ReactElement }) => (
+    <div data-testid="workspace-open-external-only">{menuTrigger}</div>
+  )
+}))
+
+vi.mock('@renderer/components/resourceCatalog/selectors', () => ({
+  AgentSelector: ({ trigger }: { trigger: ReactElement }) => trigger,
+  WorkspaceSelector: ({ trigger, onChange }: { trigger: ReactElement; onChange: (id: string | null) => void }) => (
+    <div data-testid="workspace-selector">
+      {trigger}
+      <button type="button" onClick={() => onChange('workspace-relocated')}>
+        pick-relocated-workspace
+      </button>
+    </div>
+  )
+}))
+
+describe('AgentChat workspace control', () => {
+  const conversationBootstrap = (): ComponentProps<typeof AgentChat>['conversationBootstrap'] => ({
+    session: {
+      id: 'session-1',
+      agentId: 'agent-1',
+      workspaceId: 'workspace-1',
+      workspace: { id: 'workspace-1', type: 'user', name: 'my-project', path: '/tmp/my-project' }
+    } as ComponentProps<typeof AgentChat>['conversationBootstrap']['session'],
+    sessionLoading: false,
+    sessionSource: 'query',
+    resources: {
+      agent: { id: 'agent-1', name: 'Agent' } as any,
+      agentLoading: false,
+      model: { id: 'provider::model-1', name: 'Model 1' } as any,
+      modelLoading: false
+    }
+  })
+
+  beforeEach(() => {
+    workspaceWarningMock.value = undefined
+    agentSessionPartsMocks.result = {
+      messages: [{ id: 'message-1', role: 'user', parts: [] }],
+      isLoading: false,
+      hasOlder: false,
+      loadOlder: vi.fn(),
+      refresh: vi.fn(),
+      deleteMessage: vi.fn()
+    }
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { ai: { toolApproval: { respond: vi.fn() } }, file: { getMetadata: vi.fn() } }
+    })
+  })
+
+  it('lets a started conversation relocate an unreachable workspace', async () => {
+    workspaceWarningMock.value = 'agent.session.workspace_status.inaccessible'
+    const onSessionWorkspaceChange = vi.fn()
+
+    render(
+      <AgentChat conversationBootstrap={conversationBootstrap()} onSessionWorkspaceChange={onSessionWorkspaceChange} />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'pick-relocated-workspace' }))
+
+    expect(onSessionWorkspaceChange).toHaveBeenCalledWith('workspace-relocated')
+  })
+
+  it('keeps the workspace of a started conversation that is still reachable', () => {
+    render(<AgentChat conversationBootstrap={conversationBootstrap()} onSessionWorkspaceChange={vi.fn()} />)
+
+    expect(screen.getByTestId('workspace-open-external-only')).toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-selector')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

An agent session's workspace binding locks the moment the conversation has its first message — in the UI (`canChangeWorkspace` in `AgentChat.tsx`) and again in the backend (`assertSessionHasNoMessagesTx` inside `AgentSessionService.setWorkspaceTx`). Neither lock asks whether the bound directory still exists. If the user renames, moves, or deletes that folder outside the app, the session is stranded: the workspace warning blocks sending, and nothing anywhere offers a way to repoint it. The session is permanently dead.

After this PR:

The lock stays, but only while the bound user directory is still reachable.

- Backend: `setWorkspaceTx` skips the no-messages assertion when the currently bound **user** workspace directory is gone (`statSync` on the bound path). System workspaces are app-owned and recreated on demand, so they are never treated as missing.
- Renderer: `canChangeWorkspace` also becomes true when `workspaceWarning` is set, so the top-bar control renders the workspace selector again for exactly the sessions that are stuck.

A reachable workspace stays locked exactly as before.

Fixes #

### Why we need it and why it was done in this way

The user-visible bug is a dead end with no exit: the app already detects the unreachable workspace (that is what raises `workspaceWarning` and blocks sending) but then offers no action. The fix is to make the one escape hatch — rebinding the workspace — available precisely in that state, instead of loosening the lock generally.

The following tradeoffs were made:

- **Filesystem check inside the write transaction.** `boundUserWorkspaceIsMissing` does a synchronous `statSync` in `setWorkspaceTx`. It runs once per explicit workspace-change request (a rare, user-initiated action), never on a hot path, and better-sqlite3 is synchronous anyway, so this does not introduce a new blocking pattern.
- **`statSync` throw/`isDirectory()` treated as "missing".** Anything that is not a readable directory (deleted, renamed away, replaced by a file, permission-denied mount) counts as missing. It errs toward letting the user recover rather than toward keeping them locked out.
- **Warning-driven UI gate.** The renderer reuses the existing `workspaceWarning` signal rather than introducing a parallel reachability check, so the button and the warning can never disagree.
- **System workspaces excluded.** They are app-owned and recreated on demand; treating a transiently absent system directory as "missing" would silently unlock sessions that were never broken.

The following alternatives were considered:

- **Drop the messages-based lock entirely** — rejected: the binding is intentionally permanent for started conversations (history, artifact paths, and tool state all reference the workspace).
- **Auto-recreate the missing directory** — rejected: it silently fabricates an empty workspace whose contents no longer match the conversation, hiding the fact that the user moved their files.
- **UI-only fix** — rejected: the backend assertion would still reject the request, so the button would appear and then fail.

Links to places where the discussion took place: None

### Breaking changes

None. The only behavioral change is that a previously unusable session becomes recoverable; sessions with a reachable workspace are unaffected.

### Special notes for your reviewer

- `boundUserWorkspaceIsMissing` is deliberately narrow — it answers only "may this session escape the lock", not "is this workspace healthy".
- The `AgentSessionService` test fixture now creates real directories on disk (`mkdirSync` in `createWorkspace`, `rmSync` in `afterEach`), because the service reads the filesystem to make this decision.
- New tests: two service tests (relocate after a rename-away; fall back to a system workspace after a delete) and `AgentChatWorkspaceControl.test.tsx` covering the top-bar control — selector shown for an empty conversation, hidden once messaged, and shown again when the workspace is unreachable.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix agent sessions becoming permanently unusable when their workspace folder is renamed, moved, or deleted outside the app — such sessions can now be pointed at a new workspace.
```
