### PR TITLE
fix(agent-session): make every agent reachable through a session

### DIFF
--- a/src/main/ai/agents/__tests__/createAgent.integration.test.ts
+++ b/src/main/ai/agents/__tests__/createAgent.integration.test.ts
@@ -1,0 +1,78 @@
+// Registers itself in the data service registry, which AgentService resolves lazily on create.
+import '@data/services/AgentGlobalSkillService'
+
+import { application } from '@application'
+import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionTable } from '@data/db/schemas/agentSession'
+import { agentWorkspaceTable } from '@data/db/schemas/agentWorkspace'
+import { userModelTable } from '@data/db/schemas/userModel'
+import { userProviderTable } from '@data/db/schemas/userProvider'
+import { agentSessionService } from '@data/services/AgentSessionService'
+import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
+import { setupTestDatabase } from '@test-helpers/db'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createAgentDataDirectory, removeAgentDataDirectory } = vi.hoisted(() => ({
+  createAgentDataDirectory: vi.fn(),
+  removeAgentDataDirectory: vi.fn()
+}))
+
+vi.mock('@data/dataApiDataChange', () => ({ notifyDataApiDataChange: vi.fn() }))
+vi.mock('../agentDataDirectory', () => ({ createAgentDataDirectory, removeAgentDataDirectory }))
+
+import { createAgent } from '../createAgent'
+
+describe('createAgent (database)', () => {
+  const dbh = setupTestDatabase()
+  const request = {
+    type: 'claude-code' as const,
+    name: 'Tool created agent',
+    model: 'anthropic::claude-sonnet' as const
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    vi.mocked(application.getPath).mockReturnValue('/tmp/agents')
+    createAgentDataDirectory.mockResolvedValue('/tmp/agents/agent')
+    // agent.model is an FK to user_model — seed the chain.
+    dbh.db.insert(userProviderTable).values({ providerId: 'anthropic', name: 'Anthropic', orderKey: 'a0' }).run()
+    dbh.db
+      .insert(userModelTable)
+      .values({
+        id: 'anthropic::claude-sonnet',
+        providerId: 'anthropic',
+        modelId: 'claude-sonnet',
+        presetModelId: 'claude-sonnet',
+        name: 'Claude Sonnet',
+        isEnabled: true,
+        isHidden: false,
+        orderKey: 'a0'
+      })
+      .run()
+  })
+
+  it('gives the new agent a system-workspace session to start a conversation in', async () => {
+    const agent = await createAgent(request)
+
+    const sessions = dbh.db.select().from(agentSessionTable).all()
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]).toMatchObject({ agentId: agent.id, name: '' })
+
+    const workspaces = dbh.db.select().from(agentWorkspaceTable).all()
+    expect(workspaces).toHaveLength(1)
+    expect(workspaces[0]).toMatchObject({ id: sessions[0].workspaceId, type: AGENT_WORKSPACE_TYPE.SYSTEM })
+  })
+
+  it('keeps no agent behind when its first session cannot be seeded', async () => {
+    vi.spyOn(agentSessionService, 'createTx').mockImplementation(() => {
+      throw new Error('session insert failed')
+    })
+
+    await expect(createAgent(request)).rejects.toThrow('session insert failed')
+
+    // A committed agent row without a session is the unreachable state this fix exists to prevent.
+    expect(dbh.db.select().from(agentTable).all()).toHaveLength(0)
+    expect(removeAgentDataDirectory).toHaveBeenCalled()
+  })
+})

--- a/src/main/ai/agents/__tests__/createAgent.test.ts
+++ b/src/main/ai/agents/__tests__/createAgent.test.ts
@@ -1,17 +1,35 @@
 import { application } from '@application'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createAgentDataDirectory, removeAgentDataDirectory, createAgentWithId } = vi.hoisted(() => ({
+const {
+  createAgentDataDirectory,
+  removeAgentDataDirectory,
+  createAgentWithIdTx,
+  emitAgentCreated,
+  createSessionTx,
+  notifyReadModelChange,
+  uuidV4
+} = vi.hoisted(() => ({
   createAgentDataDirectory: vi.fn(),
   removeAgentDataDirectory: vi.fn(),
-  createAgentWithId: vi.fn()
+  createAgentWithIdTx: vi.fn(),
+  emitAgentCreated: vi.fn(),
+  createSessionTx: vi.fn(),
+  notifyReadModelChange: vi.fn(),
+  uuidV4: vi.fn()
 }))
 
-vi.mock('@data/services/AgentService', () => ({ agentService: { createAgentWithId } }))
+vi.mock('@data/services/AgentService', () => ({ agentService: { createAgentWithIdTx, emitAgentCreated } }))
+vi.mock('@data/services/AgentSessionService', () => ({
+  agentSessionService: { createTx: createSessionTx, notifyReadModelChange }
+}))
 vi.mock('../agentDataDirectory', () => ({ createAgentDataDirectory, removeAgentDataDirectory }))
-vi.mock('uuid', () => ({ v4: () => '11111111-1111-4111-8111-111111111111' }))
+vi.mock('uuid', () => ({ v4: uuidV4 }))
 
 const { createAgent } = await import('../createAgent')
+
+const AGENT_ID = '00000000-0000-4000-8000-000000000001'
+const SESSION_ID = '00000000-0000-4000-8000-000000000002'
 
 describe('createAgent', () => {
   const request = {
@@ -22,37 +40,58 @@ describe('createAgent', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    let issued = 0
+    uuidV4.mockImplementation(() => [AGENT_ID, SESSION_ID][issued++])
     vi.mocked(application.getPath).mockReturnValue('/tmp/agents')
-    createAgentDataDirectory.mockResolvedValue('/tmp/agents/11111111-1111-4111-8111-111111111111')
+    createAgentDataDirectory.mockResolvedValue(`/tmp/agents/${AGENT_ID}`)
     removeAgentDataDirectory.mockResolvedValue(undefined)
-    createAgentWithId.mockImplementation((id: string, input: object) => ({ id, ...input }))
+    createAgentWithIdTx.mockImplementation((_tx: unknown, id: string, input: object) => ({ id, ...input }))
   })
 
   it('provisions Agent data before committing the database row', async () => {
-    await expect(createAgent(request)).resolves.toMatchObject({
-      id: '11111111-1111-4111-8111-111111111111',
-      name: 'Test'
-    })
-    expect(createAgentDataDirectory).toHaveBeenCalledWith('/tmp/agents', '11111111-1111-4111-8111-111111111111')
-    expect(createAgentWithId).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111', request)
+    await expect(createAgent(request)).resolves.toMatchObject({ id: AGENT_ID, name: 'Test' })
+    expect(createAgentDataDirectory).toHaveBeenCalledWith('/tmp/agents', AGENT_ID)
+    expect(createAgentWithIdTx).toHaveBeenCalledWith(expect.anything(), AGENT_ID, request)
     expect(createAgentDataDirectory.mock.invocationCallOrder[0]).toBeLessThan(
-      createAgentWithId.mock.invocationCallOrder[0]
+      createAgentWithIdTx.mock.invocationCallOrder[0]
     )
   })
 
+  it('seeds the first session inside the same write transaction as the agent row', async () => {
+    await createAgent(request)
+
+    const [tx, sessionId, dto] = createSessionTx.mock.calls[0]
+    expect(tx).toBe(createAgentWithIdTx.mock.calls[0][0])
+    expect(sessionId).toBe(SESSION_ID)
+    expect(dto).toEqual({ agentId: AGENT_ID, name: '', workspace: { type: 'system' } })
+    // Renderers must not be told about either row before the transaction commits.
+    expect(emitAgentCreated.mock.invocationCallOrder[0]).toBeGreaterThan(createSessionTx.mock.invocationCallOrder[0])
+    expect(notifyReadModelChange).toHaveBeenCalledWith([sessionId], 'membership')
+  })
+
   it('removes the provisioned directory when the database write fails', async () => {
-    createAgentWithId.mockImplementation(() => {
+    createAgentWithIdTx.mockImplementation(() => {
       throw new Error('database failed')
     })
 
     await expect(createAgent(request)).rejects.toThrow('database failed')
-    expect(removeAgentDataDirectory).toHaveBeenCalledWith('/tmp/agents', '11111111-1111-4111-8111-111111111111')
+    expect(removeAgentDataDirectory).toHaveBeenCalledWith('/tmp/agents', AGENT_ID)
+  })
+
+  it('does not announce the agent when its first session cannot be seeded', async () => {
+    createSessionTx.mockImplementation(() => {
+      throw new Error('session insert failed')
+    })
+
+    await expect(createAgent(request)).rejects.toThrow('session insert failed')
+    expect(removeAgentDataDirectory).toHaveBeenCalledWith('/tmp/agents', AGENT_ID)
+    expect(emitAgentCreated).not.toHaveBeenCalled()
   })
 
   it('does not write the database when directory provisioning fails', async () => {
     createAgentDataDirectory.mockRejectedValue(new Error('unsafe path'))
 
     await expect(createAgent(request)).rejects.toThrow('unsafe path')
-    expect(createAgentWithId).not.toHaveBeenCalled()
+    expect(createAgentWithIdTx).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/agents/createAgent.ts
+++ b/src/main/ai/agents/createAgent.ts
@@ -1,6 +1,9 @@
 import { application } from '@application'
+import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
 import { agentService } from '@data/services/AgentService'
+import { agentSessionService } from '@data/services/AgentSessionService'
 import { loggerService } from '@logger'
+import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
 import type { CreateAgentCommand } from '@shared/ipc/schemas/ai'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -10,11 +13,30 @@ const logger = loggerService.withContext('CreateAgent')
 
 export async function createAgent(request: CreateAgentCommand) {
   const agentId = uuidv4()
+  const sessionId = uuidv4()
   const agentsDataRoot = application.getPath('feature.agents.data')
   await createAgentDataDirectory(agentsDataRoot, agentId)
 
   try {
-    return agentService.createAgentWithId(agentId, request)
+    // Every UI entry into an agent goes through one of its sessions, so an agent with none is
+    // unreachable. The row and its first session commit together — a crash between two separate
+    // writes would leave behind exactly the unreachable agent this seeds against.
+    const agent = withSqliteErrors(
+      () =>
+        application.get('DbService').withWriteTx((tx) => {
+          const created = agentService.createAgentWithIdTx(tx, agentId, request)
+          agentSessionService.createTx(tx, sessionId, {
+            agentId,
+            name: '',
+            workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+          })
+          return created
+        }),
+      defaultHandlersFor('Agent', agentId)
+    )
+    agentService.emitAgentCreated(agent)
+    agentSessionService.notifyReadModelChange([sessionId], 'membership')
+    return agent
   } catch (error) {
     try {
       await removeAgentDataDirectory(agentsDataRoot, agentId)

--- a/src/main/data/db/seeding/seederRegistry.ts
+++ b/src/main/data/db/seeding/seederRegistry.ts
@@ -1,4 +1,5 @@
 import type { ISeeder } from '../types'
+import { AgentSessionBackfillSeeder } from './seeders/agentSessionBackfillSeeder'
 import { CherryAiDefaultModelSeeder } from './seeders/cherryaiDefaultModelSeeder'
 import { CherryAssistantSeeder } from './seeders/cherryAssistantSeeder'
 import { DefaultAssistantSeeder } from './seeders/defaultAssistantSeeder'
@@ -25,5 +26,7 @@ export const seeders: ISeeder[] = [
   new TranslateLanguageSeeder(),
   new PresetProviderSeeder(),
   new LocalModelSeeder(),
-  new MiniAppSeeder()
+  new MiniAppSeeder(),
+  // Last: it backfills whatever the seeders above just created but left session-less.
+  new AgentSessionBackfillSeeder()
 ]

--- a/src/main/data/db/seeding/seeders/__tests__/agentSessionBackfillSeeder.test.ts
+++ b/src/main/data/db/seeding/seeders/__tests__/agentSessionBackfillSeeder.test.ts
@@ -1,0 +1,87 @@
+import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionTable } from '@data/db/schemas/agentSession'
+import { agentWorkspaceTable } from '@data/db/schemas/agentWorkspace'
+import { AgentSessionBackfillSeeder } from '@data/db/seeding/seeders/agentSessionBackfillSeeder'
+import { SeedRunner } from '@data/db/seeding/SeedRunner'
+import { agentSessionService } from '@data/services/AgentSessionService'
+import { generateOrderKeyBetween } from '@data/services/utils/orderKey'
+import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
+import { setupTestDatabase } from '@test-helpers/db'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+describe('AgentSessionBackfillSeeder', () => {
+  const dbh = setupTestDatabase()
+
+  function insertAgent(id: string, { deleted = false }: { deleted?: boolean } = {}): string {
+    dbh.db
+      .insert(agentTable)
+      .values({
+        id,
+        type: 'claude-code',
+        name: id,
+        description: '',
+        instructions: 'Instructions',
+        orderKey: generateOrderKeyBetween(null, null),
+        deletedAt: deleted ? Date.now() : null
+      })
+      .run()
+    return id
+  }
+
+  function sessionsOf(agentId: string) {
+    return dbh.db.select().from(agentSessionTable).where(eq(agentSessionTable.agentId, agentId)).all()
+  }
+
+  it('gives an agent stranded without any session a system-workspace one', () => {
+    insertAgent('stranded')
+
+    new AgentSessionBackfillSeeder().run(dbh.db)
+
+    const sessions = sessionsOf('stranded')
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].name).toBe('')
+    const [workspace] = dbh.db
+      .select()
+      .from(agentWorkspaceTable)
+      .where(eq(agentWorkspaceTable.id, sessions[0].workspaceId))
+      .all()
+    expect(workspace.type).toBe(AGENT_WORKSPACE_TYPE.SYSTEM)
+  })
+
+  it('leaves an agent that already has a session alone', () => {
+    insertAgent('reachable')
+    dbh.db.transaction((tx) => {
+      agentSessionService.createTx(tx, 'existing-session', {
+        agentId: 'reachable',
+        name: 'Existing',
+        workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+      })
+    })
+
+    new AgentSessionBackfillSeeder().run(dbh.db)
+
+    expect(sessionsOf('reachable').map((s) => s.id)).toEqual(['existing-session'])
+  })
+
+  it('does not resurrect a deleted agent', () => {
+    insertAgent('deleted', { deleted: true })
+
+    new AgentSessionBackfillSeeder().run(dbh.db)
+
+    expect(sessionsOf('deleted')).toHaveLength(0)
+  })
+
+  it('backfills once, so a later user deletion of that session sticks', () => {
+    insertAgent('stranded')
+    const seeders = [new AgentSessionBackfillSeeder()]
+
+    new SeedRunner(dbh.db).runAll(seeders)
+    const [seeded] = sessionsOf('stranded')
+    dbh.db.delete(agentSessionTable).where(eq(agentSessionTable.id, seeded.id)).run()
+
+    new SeedRunner(dbh.db).runAll(seeders)
+
+    expect(sessionsOf('stranded')).toHaveLength(0)
+  })
+})

--- a/src/main/data/db/seeding/seeders/agentSessionBackfillSeeder.ts
+++ b/src/main/data/db/seeding/seeders/agentSessionBackfillSeeder.ts
@@ -1,0 +1,53 @@
+import { agentTable } from '@data/db/schemas/agent'
+import { agentSessionTable } from '@data/db/schemas/agentSession'
+import { agentSessionService } from '@data/services/AgentSessionService'
+import { AGENT_WORKSPACE_TYPE } from '@shared/data/api/schemas/agentWorkspaces'
+import { and, eq, isNull, notExists } from 'drizzle-orm'
+import { v4 as uuidv4 } from 'uuid'
+
+import type { DbType, ISeeder } from '../../types'
+
+/**
+ * Give every session-less agent a session so it is reachable again.
+ *
+ * The default sidebar derives its rows from sessions, so an agent with none is
+ * invisible there and cannot be opened. Agents created through the tool/MCP/API
+ * path used to land in exactly that state; creation now seeds the first session,
+ * but libraries written before that fix still hold the stranded rows.
+ *
+ * Runs once (seed journal). Deliberately not a permanent self-heal: deleting the
+ * last session of an agent stays a user decision.
+ */
+export class AgentSessionBackfillSeeder implements ISeeder {
+  readonly name = 'agentSessionBackfill'
+  readonly description = 'Give agents stranded without any session a system session'
+  readonly version = '1'
+
+  run(db: DbType): void {
+    db.transaction((tx) => {
+      const stranded = tx
+        .select({ id: agentTable.id })
+        .from(agentTable)
+        .where(
+          and(
+            isNull(agentTable.deletedAt),
+            notExists(
+              tx
+                .select({ id: agentSessionTable.id })
+                .from(agentSessionTable)
+                .where(eq(agentSessionTable.agentId, agentTable.id))
+            )
+          )
+        )
+        .all()
+
+      for (const agent of stranded) {
+        agentSessionService.createTx(tx, uuidv4(), {
+          agentId: agent.id,
+          name: '',
+          workspace: { type: AGENT_WORKSPACE_TYPE.SYSTEM }
+        })
+      }
+    })
+  }
+}

--- a/src/main/data/services/AgentService.ts
+++ b/src/main/data/services/AgentService.ts
@@ -231,12 +231,12 @@ export class AgentService {
   readonly onAgentDeleted: Event<AgentDeletedEvent> = this._onAgentDeleted.event
 
   /**
-   * DB-only create primitive for main-process command orchestration.
+   * DB-only create primitive for caller-owned transaction composition.
    *
-   * The caller owns non-database side effects (for example provisioning the
-   * agent data directory) and supplies the already-reserved id.
+   * The caller supplies the reserved id, owns the commit boundary, and must
+   * publish `emitAgentCreated` once it commits.
    */
-  createAgentWithId(id: string, req: AgentCreateInput): AgentEntity {
+  createAgentWithIdTx(tx: DbOrTx, id: string, req: AgentCreateInput): AgentEntity {
     // Reserved capability identity — see getBuiltinRole. Seeding writes via createAgentTx.
     if (getBuiltinRole(req.configuration) !== undefined) {
       throw DataApiErrorFactory.invalidOperation(
@@ -265,10 +265,8 @@ export class AgentService {
       configuration: req.configuration
     }
 
-    // Validate referenced skills before opening the write tx so the main path
-    // reports the missing resource as Skill, not as the Agent FK fallback. The
-    // write tx rechecks the same IDs before inserting the agent to close the
-    // delete-after-prevalidation race.
+    // Validate referenced skills before the insert so the main path reports the
+    // missing resource as Skill, not as the Agent FK fallback.
     // AgentGlobalSkillService is resolved through the registry (not a direct import)
     // to keep this service↔service edge out of the static import graph — see
     // dataServiceRegistry.
@@ -277,43 +275,33 @@ export class AgentService {
         throw DataApiErrorFactory.notFound('Skill', skillId)
       }
     }
-    this.assertKnowledgeBasesExistTx(application.get('DbService').getDb(), knowledgeBaseIds)
+    globalSkillService.assertSkillsExistTx(tx, skillIds, 'create agent')
+    this.assertKnowledgeBasesExistTx(tx, knowledgeBaseIds)
 
-    const row = withSqliteErrors(
-      () =>
-        application.get('DbService').withWriteTx((tx) => {
-          getDataService('AgentGlobalSkillService').assertSkillsExistTx(tx, skillIds, 'create agent')
-          this.assertKnowledgeBasesExistTx(tx, knowledgeBaseIds)
-          const result = this.createAgentTx(tx, id, insertData)
-          // Insert junction rows for MCP associations
-          if (mcps.length > 0) {
-            tx.insert(agentMcpServerTable)
-              .values(mcps.map((mcpId) => ({ agentId: id, mcpServerId: mcpId })))
-              .run()
-          }
-          // Insert junction rows for knowledge base associations
-          if (knowledgeBaseIds.length > 0) {
-            tx.insert(agentKnowledgeBaseTable)
-              .values(knowledgeBaseIds.map((knowledgeBaseId) => ({ agentId: id, knowledgeBaseId })))
-              .run()
-          }
-          // Enable the selected global skills for the new agent. DB-only: workspace
-          // symlinks don't exist yet (no session/workspace at create time) and get
-          // reconciled later by SkillService when a workspace appears.
-          for (const skillId of skillIds) {
-            globalSkillService.upsertJoinTx(tx, id, skillId, true)
-          }
-          return result
-        }),
-      defaultHandlersFor('Agent', id)
-    )
+    const row = this.createAgentTx(tx, id, insertData)
     if (!row) {
       throw DataApiErrorFactory.invalidOperation('create agent', 'insert succeeded but select returned no row')
     }
+    // Insert junction rows for MCP associations
+    if (mcps.length > 0) {
+      tx.insert(agentMcpServerTable)
+        .values(mcps.map((mcpId) => ({ agentId: id, mcpServerId: mcpId })))
+        .run()
+    }
+    // Insert junction rows for knowledge base associations
+    if (knowledgeBaseIds.length > 0) {
+      tx.insert(agentKnowledgeBaseTable)
+        .values(knowledgeBaseIds.map((knowledgeBaseId) => ({ agentId: id, knowledgeBaseId })))
+        .run()
+    }
+    // Enable the selected global skills for the new agent. DB-only: workspace
+    // symlinks don't exist yet (no session/workspace at create time) and get
+    // reconciled later by SkillService when a workspace appears.
+    for (const skillId of skillIds) {
+      globalSkillService.upsertJoinTx(tx, id, skillId, true)
+    }
 
-    const agent = rowToAgent(row.agent, row.modelName || null, mcps, knowledgeBaseIds)
-    this._onAgentCreated.fire({ agentId: id, agent })
-    return agent
+    return rowToAgent(row.agent, row.modelName || null, mcps, knowledgeBaseIds)
   }
 
   createAgentTx(

--- a/src/main/data/services/__tests__/AgentService.test.ts
+++ b/src/main/data/services/__tests__/AgentService.test.ts
@@ -11,6 +11,7 @@ import { knowledgeBaseTable } from '@data/db/schemas/knowledge'
 import { mcpServerTable } from '@data/db/schemas/mcpServer'
 import { userModelTable } from '@data/db/schemas/userModel'
 import { userProviderTable } from '@data/db/schemas/userProvider'
+import { defaultHandlersFor, withSqliteErrors } from '@data/db/sqliteErrors'
 // Importing the singleton loads AgentGlobalSkillService so it self-registers in the
 // data-service registry, which createAgent resolves lazily for skill validation/join.
 import { agentGlobalSkillService } from '@data/services/AgentGlobalSkillService'
@@ -42,8 +43,14 @@ function captureError(fn: () => unknown): unknown {
   throw new Error('Expected the call to throw, but it returned normally')
 }
 
-function createAgentForTest(request: Parameters<typeof agentService.createAgentWithId>[1]) {
-  return agentService.createAgentWithId(randomUUID(), request)
+// Mirrors the command boundary in main/ai/agents/createAgent.ts: one write tx around the
+// primitive, with the same SQLite error mapping.
+function createAgentForTest(request: Parameters<typeof agentService.createAgentWithIdTx>[2]) {
+  const id = randomUUID()
+  return withSqliteErrors(
+    () => application.get('DbService').withWriteTx((tx) => agentService.createAgentWithIdTx(tx, id, request)),
+    defaultHandlersFor('Agent', id)
+  )
 }
 
 vi.mock('@main/apiServer/services/mcp', () => ({

--- a/src/renderer/pages/agents/AgentPage.tsx
+++ b/src/renderer/pages/agents/AgentPage.tsx
@@ -636,9 +636,9 @@ const AgentPage = () => {
       // still visible (which reads as a black/white flash + the dialog reopening).
       setAgentCreateOpen(false)
       try {
-        // A newly created agent starts without a user workspace. Reuse only a matching system
-        // placeholder; otherwise create a fresh system-backed session below.
-        const reuseCandidates = getSessionReuseCandidates()
+        // A newly created agent starts without a user workspace, so only a system placeholder can be
+        // reused. Read from the API: main seeds that first session, and the cached list is behind it.
+        const { items: reuseCandidates } = await dataApiService.get('/agent-sessions', { query: { agentId } })
         const reusableSessions = await findReusableEmptySessions(
           reuseCandidates,
           (candidate) => candidate.agentId === agentId && isSystemWorkspaceSession(candidate)
@@ -680,14 +680,7 @@ const AgentPage = () => {
         isCreatingEmptySessionRef.current = false
       }
     },
-    [
-      activateSession,
-      deleteDuplicateEmptySystemSessions,
-      getSessionReuseCandidates,
-      invalidateCache,
-      resolveCreateWorkspaceSource,
-      t
-    ]
+    [activateSession, deleteDuplicateEmptySystemSessions, invalidateCache, resolveCreateWorkspaceSource, t]
   )
 
   const handleHistorySessionSelect = useCallback(

--- a/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
+++ b/src/renderer/pages/agents/__tests__/AgentPage.test.tsx
@@ -100,6 +100,18 @@ const agentPageMocks = vi.hoisted(() => ({
     workspaceId?: string
     workspace?: { type?: string }
   }>,
+  /** Persisted rows the cached session list has not seen yet (e.g. the session seeded with a new agent). */
+  serverOnlySessions: [] as Array<{
+    id: string
+    agentId?: string
+    name: string
+    isNameManuallyEdited?: boolean
+    lastActivityAt?: string
+    createdAt?: string
+    updatedAt: string
+    workspaceId?: string
+    workspace?: { type?: string }
+  }>,
   sessionsFirstPageLoading: false,
   sessionsLoadingAll: false,
   sessionsFullyLoaded: true
@@ -700,6 +712,7 @@ describe('AgentPage', () => {
     agentPageMocks.agents = [{ id: 'agent-a', model: 'model-a', name: 'Agent A' }]
     agentPageMocks.agentsLoading = false
     agentPageMocks.classicLayoutSessions = []
+    agentPageMocks.serverOnlySessions = []
     agentPageMocks.sessionsFirstPageLoading = false
     agentPageMocks.sessionsLoadingAll = false
     agentPageMocks.sessionsFullyLoaded = true
@@ -720,9 +733,15 @@ describe('AgentPage', () => {
     agentPageMocks.sessionPanePosition = 'right'
     agentPageMocks.showSidebar = false
     agentPageMocks.isActiveTab = false
-    agentPageMocks.dataApiGet.mockImplementation(async (path: string) => {
+    agentPageMocks.dataApiGet.mockImplementation(async (path: string, options?: { query?: { agentId?: string } }) => {
       if (path.startsWith('/agent-sessions/') && path.endsWith('/messages')) {
         return { items: [{ id: 'message-existing' }], nextCursor: undefined }
+      }
+      if (path === '/agent-sessions') {
+        // Server-side view: everything the cached list holds, plus rows it has not caught up with.
+        const agentId = options?.query?.agentId
+        const persisted = [...agentPageMocks.serverOnlySessions, ...agentPageMocks.classicLayoutSessions]
+        return { items: persisted.filter((session) => session.agentId === agentId), nextCursor: undefined }
       }
       if (path === '/agent-workspaces/workspace-next') return agentPageMocks.workspaceNext
       if (path === '/agent-workspaces/workspace-remembered') {
@@ -1438,7 +1457,7 @@ describe('AgentPage', () => {
         }
       })
     )
-    expect(agentPageMocks.dataApiGet).not.toHaveBeenCalled()
+    expect(agentPageMocks.dataApiGet).not.toHaveBeenCalledWith('/agent-workspaces/workspace-remembered')
     expect(agentPageMocks.setLastUsedWorkspaceId).not.toHaveBeenCalled()
   })
 
@@ -1477,6 +1496,35 @@ describe('AgentPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create resource agent' }))
 
     await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-empty-latest'))
+    expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
+  })
+
+  it('activates the session seeded with the new agent instead of creating a second empty one', async () => {
+    agentPageMocks.sessionDisplayMode = 'agent'
+    agentPageMocks.routeSearch = { sessionId: 'session-existing' }
+    agentPageMocks.agents = [
+      { id: 'agent-a', model: 'model-a', name: 'Agent A' },
+      { id: 'agent-b', model: 'model-b', name: 'Agent B' }
+    ]
+    // Agent creation seeds the agent's first session in the main process, so it is persisted but
+    // absent from the cached session list this render captured.
+    agentPageMocks.serverOnlySessions = [
+      {
+        id: 'session-seeded-with-agent',
+        agentId: 'agent-b',
+        name: '',
+        createdAt: '2026-01-03T00:00:00.000Z',
+        updatedAt: '2026-01-03T00:00:00.000Z',
+        workspace: { type: 'system' }
+      }
+    ]
+
+    render(<AgentPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open agent picker' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create resource agent' }))
+
+    await waitFor(() => expect(agentPageMocks.activeSessionOptions?.activeSessionId).toBe('session-seeded-with-agent'))
     expect(agentPageMocks.dataApiPost).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

An agent created through the tool/MCP/API path (`createAgent`) got an agent row but no `agent_session`. Every default-layout entry point resolves an agent through its sessions, so such an agent showed up in the agent management page but had no way to start a conversation, and never appeared in the sidebar at all — permanently unreachable, with no in-app way to recover it.

After this PR:

- `createAgent` seeds the agent row and its first system-workspace session **in the same write transaction**, so no crash window between two separate writes can reproduce the unreachable state.
- The in-app create flow in `AgentPage` now reads sessions from the API (not the stale cache) and claims the session main just seeded, instead of posting a second empty one.
- A one-shot seeder (`AgentSessionBackfillSeeder`) gives every already-stranded, non-deleted, session-less agent a system session on the next launch. Stranded agents cannot heal themselves — the sidebar they are missing from is their only way back.

Refactor that fell out of this: `createAgentWithId` was split into `createAgentWithIdTx`, a DB-only primitive that composes into a caller-owned transaction. The caller now owns the commit boundary and publishes `emitAgentCreated` after commit. That left `createAgentWithId` with no production caller, so it was removed.

N/A

### Why we need it and why it was done in this way

The invariant being restored is "every agent is reachable through at least one session". The only way to guarantee it against a crash is to write the agent and its first session atomically, which requires the create primitive to accept a caller-supplied transaction — hence `createAgentWithIdTx`.

The following tradeoffs were made:

- **Event emission moved to the caller.** `createAgentWithIdTx` no longer fires `onAgentCreated`; the caller must call `emitAgentCreated` after the transaction commits. This is correct (no events for rolled-back writes) but it is now a documented caller obligation rather than something the primitive guarantees.
- **The backfill is a one-shot seeder, not a permanent self-heal.** Deleting the last session of an agent stays a legitimate user decision, so the repair runs once via the seed journal rather than continuously reconciling.
- **The renderer now does an extra `/agent-sessions` fetch on create.** The local cache is behind main's freshly seeded session, so reusing the cached list would miss it and create a duplicate empty session.

The following alternatives were considered:

- Keeping the two writes separate and reconciling at boot — rejected: it leaves the crash window open and turns a correctness invariant into a repair loop.
- Making the backfill a permanent reconciler on every launch — rejected: it would resurrect sessions a user deliberately deleted.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- `AgentSessionBackfillSeeder` is registered **last** in `seederRegistry.ts` on purpose — it backfills whatever the seeders above it just created but left session-less.
- The seeder scopes to `deletedAt IS NULL` agents only, so soft-deleted agents are not resurrected.
- `AgentService.createAgentWithIdTx` now validates skills and knowledge bases against the caller's `tx` rather than opening its own read; the previous "recheck inside the tx" comment is gone because pre-validation and insert now share one transaction.
- Tests added: `createAgent.integration.test.ts` (agent + session commit atomically), `agentSessionBackfillSeeder.test.ts` (stranded agents backfilled, soft-deleted skipped, agents with sessions untouched), plus updated `AgentPage.test.tsx` coverage for claiming the seeded session instead of creating a duplicate.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed agents created through the tool/MCP/API path being unreachable: they appeared in agent management but had no session, so they could not be opened and never showed up in the sidebar. New agents now get their first session atomically, and agents already stranded without one are repaired on the next launch.
```
