### PR TITLE
fix(composer): let long AskUserQuestion titles be read in full

### DIFF
--- a/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
+++ b/src/renderer/components/composer/variants/AskUserQuestionComposer.tsx
@@ -3,8 +3,8 @@ import { loggerService } from '@logger'
 import type { MessageToolApprovalInput } from '@renderer/components/chat/messages/types'
 import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
-import { ArrowRight, ChevronLeft, ChevronRight, Pencil, X } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { ArrowRight, ChevronLeft, ChevronRight, ChevronsDownUp, ChevronsUpDown, Pencil, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { ComposerOverride } from '../ComposerContext'
@@ -45,13 +45,32 @@ export default function AskUserQuestionComposer({ request, onRespond, className 
   const [selectedAnswers, setSelectedAnswers] = useState<AnswersByIndex>({})
   const [customAnswers, setCustomAnswers] = useState<Record<number, string>>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+  const [isQuestionClamped, setIsQuestionClamped] = useState(false)
+  const questionRef = useRef<HTMLHeadingElement>(null)
 
   const currentQuestion = questions[currentIndex]
+  const isQuestionExpanded = expandedIndex === currentIndex
   const totalQuestions = questions.length
   const isFirstQuestion = currentIndex === 0
   const isLastQuestion = currentIndex === totalQuestions - 1
   const currentCustomAnswer = customAnswers[currentIndex] ?? ''
   const currentCustomAnswerText = currentCustomAnswer.trim()
+
+  // The question is clamped to keep the dock compact; only offer the expand
+  // toggle when the clamp actually hides part of it.
+  useEffect(() => {
+    const element = questionRef.current
+    if (!element) return
+
+    const measure = () => setIsQuestionClamped(element.scrollHeight > element.clientHeight + 1)
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [currentQuestion?.question, isQuestionExpanded])
 
   const hasAnswerAt = useCallback(
     (index: number, answersByIndex: AnswersByIndex = selectedAnswers) => {
@@ -201,12 +220,35 @@ export default function AskUserQuestionComposer({ request, onRespond, className 
       <div
         className="rounded-[17px] border-[0.5px] border-border p-2.5 backdrop-blur"
         style={{ backgroundColor: 'color-mix(in srgb, var(--background) 88%, transparent)' }}>
-        <div className="flex items-center justify-between gap-3 px-1">
-          <h2 className="line-clamp-1 min-w-0 flex-1 font-semibold text-foreground text-sm leading-5">
+        <div className="flex items-start justify-between gap-3 px-1">
+          <h2
+            ref={questionRef}
+            className={cn(
+              // mt-1 keeps a single-line question centered against the 28px buttons;
+              // padding would let the clamped text bleed into it.
+              'mt-1 min-w-0 flex-1 font-semibold text-foreground text-sm leading-5',
+              isQuestionExpanded ? 'max-h-30 overflow-y-auto' : 'line-clamp-2'
+            )}>
             {currentQuestion.question}
           </h2>
 
           <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground">
+            {(isQuestionClamped || isQuestionExpanded) && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 shadow-none"
+                aria-label={
+                  isQuestionExpanded
+                    ? t('agent.askUserQuestion.collapseQuestion')
+                    : t('agent.askUserQuestion.expandQuestion')
+                }
+                aria-expanded={isQuestionExpanded}
+                onClick={() => setExpandedIndex(isQuestionExpanded ? null : currentIndex)}>
+                {isQuestionExpanded ? <ChevronsDownUp className="size-4" /> : <ChevronsUpDown className="size-4" />}
+              </Button>
+            )}
             <Button
               type="button"
               variant="ghost"

--- a/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AskUserQuestionComposer.test.tsx
@@ -13,7 +13,9 @@ vi.mock('react-i18next', async (importOriginal) => ({
       return (
         {
           'agent.askUserQuestion.close': 'Close',
+          'agent.askUserQuestion.collapseQuestion': 'Collapse question',
           'agent.askUserQuestion.customPlaceholder': 'Enter your answer...',
+          'agent.askUserQuestion.expandQuestion': 'Show full question',
           'agent.askUserQuestion.next': 'Next',
           'agent.askUserQuestion.previous': 'Previous',
           'agent.askUserQuestion.skip': 'Skip',
@@ -134,6 +136,29 @@ describe('AskUserQuestionComposer', () => {
         }
       }
     })
+  })
+
+  it('offers an expand toggle only when the question does not fit the clamped title', () => {
+    const { unmount } = render(<AskUserQuestionComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+    expect(screen.queryByRole('button', { name: 'Show full question' })).not.toBeInTheDocument()
+    unmount()
+
+    const scrollHeight = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollHeight')
+    Object.defineProperty(Element.prototype, 'scrollHeight', { configurable: true, get: () => 60 })
+
+    try {
+      render(<AskUserQuestionComposer request={makeRequest()} onRespond={vi.fn()} />)
+
+      const expand = screen.getByRole('button', { name: 'Show full question' })
+      expect(expand).toHaveAttribute('aria-expanded', 'false')
+
+      fireEvent.click(expand)
+
+      expect(screen.getByRole('button', { name: 'Collapse question' })).toHaveAttribute('aria-expanded', 'true')
+    } finally {
+      if (scrollHeight) Object.defineProperty(Element.prototype, 'scrollHeight', scrollHeight)
+    }
   })
 
   it('disables controls while the final response is submitting', async () => {

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -19,7 +19,9 @@
     "askUserQuestion": {
       "answered": "answered",
       "close": "Close",
+      "collapseQuestion": "Collapse question",
       "customPlaceholder": "Enter your answer...",
+      "expandQuestion": "Show full question",
       "loading": "Loading questions...",
       "multiSelect": "Multi-select",
       "next": "Next",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -19,7 +19,9 @@
     "askUserQuestion": {
       "answered": "已回答",
       "close": "关闭",
+      "collapseQuestion": "收起问题",
       "customPlaceholder": "输入您的回答...",
+      "expandQuestion": "展开完整问题",
       "loading": "正在加载问题...",
       "multiSelect": "多选",
       "next": "下一个",


### PR DESCRIPTION
### What this PR does

Before this PR:

The AskUserQuestion composer clamped the question title to a single line (`line-clamp-1`) with no tooltip and no way to expand it. A long question was simply unreadable — resizing the window did not help, because the clamp is one line regardless of available width.

After this PR:

- The title clamps to two lines instead of one.
- When (and only when) the clamp actually hides text, an expand toggle appears next to the header controls. Toggling it lifts the clamp and shows the full question inside a height-capped scroll area, so the dock stays compact.
- The toggle carries `aria-label` / `aria-expanded` and is localized (`en-US`, `zh-CN`).

N/A

### Why we need it and why it was done in this way

The clamp exists to keep the question dock compact; removing it would let a long question push the answer options out of view. So the fix keeps the clamp as the default and adds an explicit, opt-in escape hatch.

The following tradeoffs were made:

- Overflow is measured with `scrollHeight > clientHeight` plus a `ResizeObserver`, rather than estimating from character count — text length is a poor proxy for wrapped height across fonts, locales and window widths.
- The expanded state is tracked per question index, so paging to another question returns to the compact view instead of leaving the dock tall.

The following alternatives were considered:

- A native `title` tooltip: no keyboard access, unreliable for long multi-line text, and invisible on touch.
- Dropping the clamp entirely: a long question would dominate the dock and push the options off screen.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

The added test flips `Element.prototype.scrollHeight` to simulate overflow (jsdom reports `0` for every layout metric), and restores the original descriptor in a `finally` block. It asserts both directions: no toggle when the question fits, toggle plus `aria-expanded` transition when it does not.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Long questions in the AskUserQuestion dock are no longer cut off after one line — they now wrap to two lines and can be expanded to read in full.
```
