### PR TITLE
fix(topics): keep selection stable on delete race

### DIFF
--- a/src/main/data/services/AssistantService.ts
+++ b/src/main/data/services/AssistantService.ts
@@ -617,7 +617,7 @@ export class AssistantDataService {
     if (!deleted) {
       throw DataApiErrorFactory.notFound('Assistant', id)
     }
-    topicService.notifyReadModelChange(deletedTopicIds ?? [], 'membership')
+    topicService.notifyReadModelChange(deletedTopicIds ?? [], 'membership', { deleted: true })
     pinService.notifyPurged()
 
     logger.info('Soft-deleted assistant', { id, deleteTopics: options.deleteTopics === true })

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -119,7 +119,11 @@ function assertActiveAssistantTx(tx: Pick<DbOrTx, 'select'>, assistantId: string
 }
 
 export class TopicService {
-  notifyReadModelChange(topicIds: readonly string[], kind: 'membership' | 'projection', options: { deleted?: boolean } = {}): void {
+  notifyReadModelChange(
+    topicIds: readonly string[],
+    kind: 'membership' | 'projection',
+    options: { deleted?: boolean } = {}
+  ): void {
     if (topicIds.length === 0) return
     const entityIds = [...new Set(topicIds)]
     // Deleted ids are terminal: scope each by-id effect to that exact id so only its

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -25,7 +25,7 @@ import type {
   ReuseOrCreateTopicDto,
   UpdateTopicDto
 } from '@shared/data/api/schemas/topics'
-import type { CursorPaginationResponse } from '@shared/data/api/types'
+import type { CursorPaginationResponse, DataApiDataChangeEffect } from '@shared/data/api/types'
 import type { Topic } from '@shared/data/types/topic'
 import type { SQL } from 'drizzle-orm'
 import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, or, sql } from 'drizzle-orm'
@@ -119,13 +119,18 @@ function assertActiveAssistantTx(tx: Pick<DbOrTx, 'select'>, assistantId: string
 }
 
 export class TopicService {
-  notifyReadModelChange(topicIds: readonly string[], kind: 'membership' | 'projection'): void {
+  notifyReadModelChange(topicIds: readonly string[], kind: 'membership' | 'projection', options: { deleted?: boolean } = {}): void {
     if (topicIds.length === 0) return
     const entityIds = [...new Set(topicIds)]
+    // Deleted ids are terminal: scope each by-id effect to that exact id so only its
+    // subscribers revalidate; live-topic paths keep the broadcast-wide effect.
+    const byIdEffects: DataApiDataChangeEffect[] = options.deleted
+      ? entityIds.map((id) => ({ endpoint: '/topics/:id', routeParams: { id }, entityIds: [id] }))
+      : [{ endpoint: '/topics/:id', entityIds }]
     notifyDataApiDataChange([
       { endpoint: '/topics', kind, entityIds },
       { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds },
-      { endpoint: '/topics/:id', entityIds },
+      ...byIdEffects,
       { endpoint: '/topics/latest' }
     ])
   }
@@ -448,7 +453,7 @@ export class TopicService {
   delete(id: string): void {
     const dbService = application.get('DbService')
     const deletedIds = dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, [id], { requireAll: true }))
-    this.notifyReadModelChange(deletedIds, 'membership')
+    this.notifyReadModelChange(deletedIds, 'membership', { deleted: true })
     pinService.notifyPurged()
 
     logger.info('Deleted topic', { id })
@@ -457,7 +462,7 @@ export class TopicService {
   deleteByIds(ids: string[]): DeleteTopicsResult {
     const dbService = application.get('DbService')
     const deletedIds = dbService.withWriteTx((tx) => this.deleteManyByIdsTx(tx, ids, { requireAll: true }))
-    this.notifyReadModelChange(deletedIds, 'membership')
+    this.notifyReadModelChange(deletedIds, 'membership', { deleted: true })
     if (deletedIds.length > 0) pinService.notifyPurged()
 
     logger.info('Deleted topics', { count: deletedIds.length })
@@ -718,7 +723,7 @@ export class TopicService {
   deleteByAssistantId(assistantId: string): DeleteTopicsResult {
     const dbService = application.get('DbService')
     const deletedIds = dbService.withWriteTx((tx) => this.deleteByAssistantIdTx(tx, assistantId))
-    this.notifyReadModelChange(deletedIds, 'membership')
+    this.notifyReadModelChange(deletedIds, 'membership', { deleted: true })
     if (deletedIds.length > 0) pinService.notifyPurged()
 
     logger.info('Deleted assistant topics', { assistantId, count: deletedIds.length })

--- a/src/main/data/services/TopicService.ts
+++ b/src/main/data/services/TopicService.ts
@@ -126,11 +126,13 @@ export class TopicService {
   ): void {
     if (topicIds.length === 0) return
     const entityIds = [...new Set(topicIds)]
-    // Deleted ids are terminal: scope each by-id effect to that exact id so only its
-    // subscribers revalidate; live-topic paths keep the broadcast-wide effect.
-    const byIdEffects: DataApiDataChangeEffect[] = options.deleted
-      ? entityIds.map((id) => ({ endpoint: '/topics/:id', routeParams: { id }, entityIds: [id] }))
-      : [{ endpoint: '/topics/:id', entityIds }]
+    // A terminal single delete scopes its by-id effect to that exact id; batches keep
+    // one broadcast-wide entry per the shared data-change contract (batch = one entry,
+    // and one entry can carry only one routeParams).
+    const byIdEffects: DataApiDataChangeEffect[] =
+      options.deleted && entityIds.length === 1
+        ? [{ endpoint: '/topics/:id', routeParams: { id: entityIds[0] }, entityIds }]
+        : [{ endpoint: '/topics/:id', entityIds }]
     notifyDataApiDataChange([
       { endpoint: '/topics', kind, entityIds },
       { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds },

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -509,11 +509,29 @@ describe('TopicService', () => {
       expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(1, [
         { endpoint: '/topics', kind: 'membership', entityIds: ['topic-1'] },
         { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds: ['topic-1'] },
-        { endpoint: '/topics/:id', entityIds: ['topic-1'] },
+        { endpoint: '/topics/:id', routeParams: { id: 'topic-1' }, entityIds: ['topic-1'] },
         { endpoint: '/topics/latest' }
       ])
       expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(2, [{ endpoint: '/pins', kind: 'membership' }])
       expect(notifyDataApiDataChangeMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('scopes batch-delete by-id effects per deleted id', async () => {
+      await dbh.db.insert(topicTable).values([
+        { id: 'topic-1', name: 'Topic 1', orderKey: 'a0', createdAt: 1, updatedAt: 1 },
+        { id: 'topic-2', name: 'Topic 2', orderKey: 'a1', createdAt: 1, updatedAt: 1 }
+      ])
+
+      notifyDataApiDataChangeMock.mockClear()
+      topicService.deleteByIds(['topic-1', 'topic-2'])
+
+      expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(1, [
+        { endpoint: '/topics', kind: 'membership', entityIds: ['topic-1', 'topic-2'] },
+        { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds: ['topic-1', 'topic-2'] },
+        { endpoint: '/topics/:id', routeParams: { id: 'topic-1' }, entityIds: ['topic-1'] },
+        { endpoint: '/topics/:id', routeParams: { id: 'topic-2' }, entityIds: ['topic-2'] },
+        { endpoint: '/topics/latest' }
+      ])
     })
 
     it('deletes a topic containing a multi-model sibling group without a unique-index crash', async () => {

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -516,7 +516,7 @@ describe('TopicService', () => {
       expect(notifyDataApiDataChangeMock).toHaveBeenCalledTimes(2)
     })
 
-    it('scopes batch-delete by-id effects per deleted id', async () => {
+    it('emits one broadcast-wide by-id effect for batch deletes and a scoped one for single deletes', async () => {
       await dbh.db.insert(topicTable).values([
         { id: 'topic-1', name: 'Topic 1', orderKey: 'a0', createdAt: 1, updatedAt: 1 },
         { id: 'topic-2', name: 'Topic 2', orderKey: 'a1', createdAt: 1, updatedAt: 1 }
@@ -524,12 +524,20 @@ describe('TopicService', () => {
 
       notifyDataApiDataChangeMock.mockClear()
       topicService.deleteByIds(['topic-1', 'topic-2'])
-
       expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(1, [
         { endpoint: '/topics', kind: 'membership', entityIds: ['topic-1', 'topic-2'] },
         { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds: ['topic-1', 'topic-2'] },
-        { endpoint: '/topics/:id', routeParams: { id: 'topic-1' }, entityIds: ['topic-1'] },
-        { endpoint: '/topics/:id', routeParams: { id: 'topic-2' }, entityIds: ['topic-2'] },
+        { endpoint: '/topics/:id', entityIds: ['topic-1', 'topic-2'] },
+        { endpoint: '/topics/latest' }
+      ])
+
+      await dbh.db.insert(topicTable).values({ id: 'topic-3', name: 'Topic 3', orderKey: 'a2', createdAt: 1, updatedAt: 1 })
+      notifyDataApiDataChangeMock.mockClear()
+      topicService.deleteByIds(['topic-3'])
+      expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(1, [
+        { endpoint: '/topics', kind: 'membership', entityIds: ['topic-3'] },
+        { endpoint: '/topics', kind: 'order', dimension: 'lastActivityAt', entityIds: ['topic-3'] },
+        { endpoint: '/topics/:id', routeParams: { id: 'topic-3' }, entityIds: ['topic-3'] },
         { endpoint: '/topics/latest' }
       ])
     })

--- a/src/main/data/services/__tests__/TopicService.test.ts
+++ b/src/main/data/services/__tests__/TopicService.test.ts
@@ -531,7 +531,9 @@ describe('TopicService', () => {
         { endpoint: '/topics/latest' }
       ])
 
-      await dbh.db.insert(topicTable).values({ id: 'topic-3', name: 'Topic 3', orderKey: 'a2', createdAt: 1, updatedAt: 1 })
+      await dbh.db
+        .insert(topicTable)
+        .values({ id: 'topic-3', name: 'Topic 3', orderKey: 'a2', createdAt: 1, updatedAt: 1 })
       notifyDataApiDataChangeMock.mockClear()
       topicService.deleteByIds(['topic-3'])
       expect(notifyDataApiDataChangeMock).toHaveBeenNthCalledWith(1, [

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -959,9 +959,10 @@ export function Topics({
 
         const result = await deleteTopicsByAssistantId(assistantId)
         await refreshTopics()
-        // Same broadcast race as single-topic delete (#19583): a collapsed ('') mirror
-        // means the selection was nuked mid-delete — reselect instead of skipping.
-        if (deletedActiveTopicId && (!activeTopicIdRef.current || activeTopicIdRef.current === deletedActiveTopicId)) {
+        // Reselect while the current selection is dead — empty, or switched mid-delete to
+        // another topic of the same deleted set (it strands otherwise, #19583).
+        const currentActiveTopicId = activeTopicIdRef.current
+        if (deletedActiveTopicId && (!currentActiveTopicId || latestTargetTopicIds.has(currentActiveTopicId))) {
           if (replacement) setActiveTopic(replacement)
           else clearActiveTopic()
         }

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -958,10 +958,7 @@ export function Topics({
         await refreshTopics()
         // Same broadcast race as single-topic delete (#19583): a collapsed ('') mirror
         // means the selection was nuked mid-delete — reselect instead of skipping.
-        if (
-          deletedActiveTopicId &&
-          (!activeTopicIdRef.current || activeTopicIdRef.current === deletedActiveTopicId)
-        ) {
+        if (deletedActiveTopicId && (!activeTopicIdRef.current || activeTopicIdRef.current === deletedActiveTopicId)) {
           if (replacement) setActiveTopic(replacement)
           else clearActiveTopic()
         }

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -639,6 +639,7 @@ export function Topics({
 
   const handleDeleteTopicFromMenu = useCallback(
     async (topic: Topic) => {
+      const wasActiveAtStart = topic.id === activeTopicIdRef.current
       const assistantTopicsBeforeDelete = topicsRef.current.filter(
         (candidate) => candidate.assistantId === topic.assistantId
       )
@@ -655,10 +656,12 @@ export function Topics({
         return
       }
 
-      // A mid-delete switch to another topic must win. An empty ('') mirror — e.g. the
-      // broadcast race wiping the selection mid-delete (#19583) — reselects the replacement.
+      // A mid-delete switch to another topic must win. An empty ('') mirror only reselects
+      // when the deleted topic was active at delete start (#19583 race collapse); deleting
+      // with no selection at all stays a no-op.
       const currentActiveTopicId = activeTopicIdRef.current
       if (currentActiveTopicId && currentActiveTopicId !== topic.id) return
+      if (!currentActiveTopicId && !wasActiveAtStart) return
 
       if (replacement) {
         setActiveTopic(replacement)

--- a/src/renderer/pages/home/Tabs/components/Topics.tsx
+++ b/src/renderer/pages/home/Tabs/components/Topics.tsx
@@ -655,7 +655,10 @@ export function Topics({
         return
       }
 
-      if (topic.id !== activeTopicIdRef.current) return
+      // A mid-delete switch to another topic must win. An empty ('') mirror — e.g. the
+      // broadcast race wiping the selection mid-delete (#19583) — reselects the replacement.
+      const currentActiveTopicId = activeTopicIdRef.current
+      if (currentActiveTopicId && currentActiveTopicId !== topic.id) return
 
       if (replacement) {
         setActiveTopic(replacement)
@@ -953,7 +956,12 @@ export function Topics({
 
         const result = await deleteTopicsByAssistantId(assistantId)
         await refreshTopics()
-        if (deletedActiveTopicId && activeTopicIdRef.current === deletedActiveTopicId) {
+        // Same broadcast race as single-topic delete (#19583): a collapsed ('') mirror
+        // means the selection was nuked mid-delete — reselect instead of skipping.
+        if (
+          deletedActiveTopicId &&
+          (!activeTopicIdRef.current || activeTopicIdRef.current === deletedActiveTopicId)
+        ) {
           if (replacement) setActiveTopic(replacement)
           else clearActiveTopic()
         }

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2240,6 +2240,81 @@ describe('Topics', () => {
     expect(onNewTopic).not.toHaveBeenCalled()
   })
 
+  it('reselects a live replacement when the selection switches into the assistant delete set mid-delete', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('topic.tab.display_mode' as never, 'assistant')
+    mockUseInfiniteQuery.mockReturnValue({
+      pages: [
+        {
+          items: [
+            createApiTopic({
+              id: 'topic-a1-first',
+              name: 'A1 First',
+              assistantId: 'assistant-1',
+              orderKey: 'a',
+              createdAt: '2026-01-02T01:00:00.000Z',
+              updatedAt: '2026-01-02T01:00:00.000Z'
+            }),
+            createApiTopic({
+              id: 'topic-a1-second',
+              name: 'A1 Second',
+              assistantId: 'assistant-1',
+              orderKey: 'b',
+              createdAt: '2026-01-03T01:00:00.000Z',
+              updatedAt: '2026-01-03T01:00:00.000Z'
+            }),
+            createApiTopic({
+              id: 'topic-b-live',
+              name: 'B Live',
+              assistantId: 'assistant-2',
+              orderKey: 'c',
+              createdAt: '2026-01-04T01:00:00.000Z',
+              updatedAt: '2026-01-04T01:00:00.000Z'
+            })
+          ]
+        }
+      ],
+      isLoading: false,
+      isRefreshing: false,
+      error: undefined,
+      hasNext: false,
+      loadNext: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+      mutate: vi.fn()
+    })
+    let resolveDelete!: (value: { deletedIds: string[]; deletedCount: number }) => void
+    topicDataMocks.deleteTopicsByAssistantId.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDelete = resolve
+        })
+    )
+
+    const { rerenderTopicList, setActiveTopic } = renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-a1-second', assistantId: 'assistant-1', name: 'A1 Second' })
+    })
+
+    const assistantHeader = screen.getByRole('button', { name: 'Alpha Assistant' }).closest('div')
+    fireEvent.click(within(assistantHeader as HTMLElement).getByRole('button', { name: 'More' }))
+    fireEvent.click(
+      within(assistantHeader as HTMLElement).getByRole('button', { name: 'Delete all assistant conversations' })
+    )
+    await vi.waitFor(() => expect(topicDataMocks.deleteTopicsByAssistantId).toHaveBeenCalledWith('assistant-1'))
+
+    // Mid-delete switch to another topic of the same (deleted) set — it dies with the batch.
+    rerenderTopicList(
+      undefined,
+      createRendererTopic({ id: 'topic-a1-first', assistantId: 'assistant-1', name: 'A1 First' })
+    )
+    await act(async () => {
+      resolveDelete({ deletedIds: ['topic-a1-first', 'topic-a1-second'], deletedCount: 2 })
+    })
+
+    await vi.waitFor(() =>
+      expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-b-live' }))
+    )
+  })
+
   it('switches to another assistant latest topic after deleting the active assistant last topic in the right panel', async () => {
     mockUseInfiniteQuery.mockReturnValue({
       pages: [

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -678,9 +678,9 @@ function renderTopicList({
   revealRequest?: ResourceListRevealRequest
 } = {}) {
   const setActiveTopic = vi.fn()
-  const renderNode = (nextRevealRequest = revealRequest, nextActiveTopic = activeTopic) => (
+  const renderNode = (nextRevealRequest = revealRequest, nextActiveTopic = activeTopic, collapseActiveTopic = false) => (
     <Topics
-      activeTopic={nextActiveTopic}
+      activeTopic={collapseActiveTopic ? undefined : nextActiveTopic}
       assistantTopicsSource={assistantTopicsSource ?? createAssistantTopicsSource()}
       assistantIdFilter={assistantIdFilter}
       clearActiveTopic={clearActiveTopic}
@@ -705,8 +705,11 @@ function renderTopicList({
     onAddAssistant,
     onNewTopic,
     onOpenHistoryRecords,
-    rerenderTopicList: (nextRevealRequest = revealRequest, nextActiveTopic = activeTopic) =>
-      view.rerender(renderNode(nextRevealRequest, nextActiveTopic)),
+    rerenderTopicList: (
+      nextRevealRequest = revealRequest,
+      nextActiveTopic = activeTopic,
+      options?: { collapseActiveTopic?: boolean }
+    ) => view.rerender(renderNode(nextRevealRequest, nextActiveTopic, options?.collapseActiveTopic)),
     setActiveTopic
   }
 }
@@ -2073,6 +2076,60 @@ describe('Topics', () => {
       expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a1-first' }))
     )
     expect(onNewTopic).not.toHaveBeenCalled()
+  })
+
+  it('reselects the pre-delete neighbour when the active topic collapses while deletion is in flight', async () => {
+    // #19583: the deleted topic's broadcast-triggered by-id refetch 404s while DELETE is
+    // still resolving, activeTopic collapses to undefined and the ref mirror becomes ''.
+    // The post-delete guard must judge with the selection captured at delete start, not
+    // with the mid-race mirror value, otherwise the selection strands on the deleted id
+    // and the 404 recovery chain redirects to another assistant.
+    const topics = [
+      createApiTopic({
+        id: 'topic-a1-first',
+        name: 'A1 First',
+        assistantId: 'assistant-1',
+        orderKey: 'a'
+      }),
+      createApiTopic({
+        id: 'topic-a1-second',
+        name: 'A1 Second',
+        assistantId: 'assistant-1',
+        orderKey: 'b'
+      })
+    ]
+    const assistantTopicsSource = createAssistantTopicsSource(topics)
+    let resolveDelete: (() => void) | undefined
+    topicDataMocks.deleteTopic.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve
+        })
+    )
+    const { rerenderTopicList, setActiveTopic } = renderTopicList({
+      activeTopic: createRendererTopic({ id: 'topic-a1-second', assistantId: 'assistant-1', name: 'A1 Second' }),
+      assistantTopicsSource
+    })
+
+    const topicRow = screen.getByText('A1 Second').closest('[role="option"]')
+    const deleteButton = within(topicRow as HTMLElement).getByLabelText('Delete')
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    await vi.waitFor(() => expect(topicDataMocks.deleteTopic).toHaveBeenCalledWith('topic-a1-second'))
+
+    // Simulate the broadcast-race: by-id refetch 404s → activeTopic collapses mid-delete.
+    rerenderTopicList(undefined, undefined, { collapseActiveTopic: true })
+    await act(async () => {
+      resolveDelete?.()
+    })
+
+    await vi.waitFor(() =>
+      expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a1-first' }))
+    )
   })
 
   it('switches to the latest topic from another assistant after deleting an assistant last topic', async () => {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -678,7 +678,11 @@ function renderTopicList({
   revealRequest?: ResourceListRevealRequest
 } = {}) {
   const setActiveTopic = vi.fn()
-  const renderNode = (nextRevealRequest = revealRequest, nextActiveTopic = activeTopic, collapseActiveTopic = false) => (
+  const renderNode = (
+    nextRevealRequest = revealRequest,
+    nextActiveTopic = activeTopic,
+    collapseActiveTopic = false
+  ) => (
     <Topics
       activeTopic={collapseActiveTopic ? undefined : nextActiveTopic}
       assistantTopicsSource={assistantTopicsSource ?? createAssistantTopicsSource()}

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -649,6 +649,7 @@ function renderTopicList({
   assistantTopicsSource,
   assistantIdFilter,
   clearActiveTopic = vi.fn(),
+  initiallyCollapsed = false,
   onActiveAssistantDeleted,
   onAddAssistant = vi.fn(),
   historyRecordsActive,
@@ -665,6 +666,7 @@ function renderTopicList({
   assistantTopicsSource?: AssistantTopicsSource
   assistantIdFilter?: string | null
   clearActiveTopic?: Mock<() => void>
+  initiallyCollapsed?: boolean
   onActiveAssistantDeleted?: ComponentProps<typeof Topics>['onActiveAssistantDeleted']
   onAddAssistant?: ComponentProps<typeof Topics>['onAddAssistant']
   historyRecordsActive?: ComponentProps<typeof Topics>['historyRecordsActive']
@@ -702,7 +704,7 @@ function renderTopicList({
       revealRequest={nextRevealRequest}
     />
   )
-  const view = render(renderNode())
+  const view = render(renderNode(revealRequest, activeTopic, initiallyCollapsed))
   return {
     ...view,
     clearActiveTopic,
@@ -2134,6 +2136,46 @@ describe('Topics', () => {
     await vi.waitFor(() =>
       expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-a1-first' }))
     )
+  })
+
+  it('keeps the empty selection a no-op when deleting an inactive topic', async () => {
+    // No selection at all (e.g. a cross-window deletion collapsed the active topic):
+    // deleting a background topic must not navigate anywhere.
+    const topics = [
+      createApiTopic({
+        id: 'topic-a1-first',
+        name: 'A1 First',
+        assistantId: 'assistant-1',
+        orderKey: 'a'
+      }),
+      createApiTopic({
+        id: 'topic-a1-second',
+        name: 'A1 Second',
+        assistantId: 'assistant-1',
+        orderKey: 'b'
+      })
+    ]
+    const { clearActiveTopic, setActiveTopic } = renderTopicList({
+      assistantTopicsSource: createAssistantTopicsSource(topics),
+      initiallyCollapsed: true
+    })
+
+    const topicRow = screen.getByText('A1 First').closest('[role="option"]')
+    const deleteButton = within(topicRow as HTMLElement).getByLabelText('Delete')
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+    act(() => {
+      fireEvent.click(deleteButton)
+    })
+
+    await vi.waitFor(() => expect(topicDataMocks.deleteTopic).toHaveBeenCalledWith('topic-a1-first'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(setActiveTopic).not.toHaveBeenCalled()
+    expect(clearActiveTopic).not.toHaveBeenCalled()
   })
 
   it('switches to the latest topic from another assistant after deleting an assistant last topic', async () => {

--- a/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
+++ b/src/renderer/pages/home/Tabs/components/__tests__/Topics.test.tsx
@@ -2310,9 +2310,7 @@ describe('Topics', () => {
       resolveDelete({ deletedIds: ['topic-a1-first', 'topic-a1-second'], deletedCount: 2 })
     })
 
-    await vi.waitFor(() =>
-      expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-b-live' }))
-    )
+    await vi.waitFor(() => expect(setActiveTopic).toHaveBeenCalledWith(expect.objectContaining({ id: 'topic-b-live' })))
   })
 
   it('switches to another assistant latest topic after deleting the active assistant last topic in the right panel', async () => {


### PR DESCRIPTION
fix(topics): keep selection stable on delete race

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Deleting the active topic from the topics list raced the main-process data-change broadcast: the deleted topic's by-id refetch 404ed while DELETE was still resolving, `activeTopic` collapsed, and the post-delete guard early-returned on the emptied ref mirror. Selection stayed stranded on the dead id until the 404 recovery chain redirected to a globally-latest topic — often from another assistant — with repeated 404s targeting the deleted id.

After this PR:

- The delete guard reselects the pre-delete neighbour when the active-topic mirror is empty **and the deleted topic was active when the delete started** (race collapse); it still respects mid-delete switches to a different topic, and deleting with no selection at all stays a no-op. Applied to both the single-topic delete path and the assistant batch-delete path.
- Delete broadcasts (`TopicService.delete`/`deleteByIds`/`deleteByAssistantId`, plus the assistant-cascade path) now scope each `/topics/:id` effect with `routeParams`, so only subscribers of the deleted ids revalidate. Live-topic update/create broadcasts are unchanged, as is the by-id refetch of the deleted id itself (that 404 is the NOT_FOUND authority cross-window deletion relies on).

Fixes #19583

### Why we need it and why it was done in this way

The guard reads the ref mirror that an in-flight broadcast can invalidate between `await removeTopic(topic)` and the check; comparing against the mirror value conflated "the race wiped the selection" with "the user switched topics". An empty mirror now means "reselect", a non-empty different id means "respect the user".

Broadcast scoping follows the existing `setActiveNode` precedent (`routeParams` on by-id effects) and keeps the DataApi fence intact: notify still happens only after the write transaction commits, best-effort, describing endpoint changes only.

The following alternatives were considered:
- Clamping or suppressing the deleted id's own refetch: rejected — that 404 is the mechanism that lets a window learn its active topic vanished (e.g. deleted from another window); the race is handled at the guard instead.
- Always awaiting a list refresh before deciding the replacement in the single-delete path: rejected — the mutation's `refresh: ['/topics']` already converges the list; the race probe showed no snapshot freeze once the guard is fixed.

### Breaking changes

None.

### Special notes for your reviewer

- The failing-first regression test simulates the race at the component boundary: it collapses the `activeTopic` prop while DELETE is deferred, then resolves it; the old guard fails the assertion, the new one reselects the neighbour.
- The by-id broadcast shape (per-id `routeParams`) is pinned in `TopicService.test.ts` for both single and batch deletes; the update path is asserted to keep the legacy broadcast-wide effect.
- Follow-up to a review round: the empty-mirror reselect initially also fired with no selection at delete start (navigating on a background delete); the guard now snapshots `wasActiveAtStart` before awaiting the delete, and a regression test pins the no-op.
- Verified locally: `pnpm typecheck` (node/web/aicore) green; TopicService+AssistantService 168 tests, Topics 105 tests green; CDP smoke against a dev instance confirmed on both delete paths: row removed immediately, selection lands on the same-assistant neighbour, dead-id requests bounded (2, from the intended by-id notification) with zero in the following 5s stability window.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (no schema or preference changes)
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) is not required (bug fix, no user-visible setting change)
- [x] Self-review: reviewed via local diff + two adversarial review rounds (0 major findings outstanding)

### Release note

```release-note
Fixed a race where deleting the active conversation from the topics list could leave the UI stuck on the deleted conversation, bounce to another assistant, and repeatedly request the deleted topic.
```
