### PR TITLE
fix(custom-fetch): preserve auth on safe redirects

### DIFF
--- a/src/main/ai/observability/__tests__/httpTraceFetch.test.ts
+++ b/src/main/ai/observability/__tests__/httpTraceFetch.test.ts
@@ -98,6 +98,23 @@ describe('createHttpTraceFetch', () => {
     })
   })
 
+  it('clears inputs when the inner fetch drops the request body', async () => {
+    const { tracer, attributes, state } = fakeTracer()
+    const innerFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const slot = (init as { [HTTP_TRACE_FINAL_BODY_SLOT]?: HttpTraceFinalBodySlot } | undefined)?.[
+        HTTP_TRACE_FINAL_BODY_SLOT
+      ]
+      if (slot) slot.body = null
+      return new Response(null, { status: 204 })
+    })
+
+    const f = createHttpTraceFetch(innerFetch as never, { topicId: 't1', tracer })
+    await f('https://api.example.com/v1/responses', { method: 'POST', body: '{"before":true}' })
+    await vi.waitFor(() => expect(state.ended).toBe(true))
+
+    expect(attributes.inputs).toBe('')
+  })
+
   it('truncates a request body larger than maxBodyBytes', async () => {
     const { tracer, attributes, state } = fakeTracer()
     const innerFetch = vi.fn(async () => new Response(null, { status: 204 }))

--- a/src/main/ai/observability/httpTraceFetch.ts
+++ b/src/main/ai/observability/httpTraceFetch.ts
@@ -188,14 +188,18 @@ async function accumulateBody(
 
 /**
  * Overwrite the span's `inputs` with the body the innermost fetch actually sent,
- * when a provider transform rewrote it via the trace slot. No-op when the slot is
- * absent (no transform in the chain) or carries no string body.
+ * when a provider transform rewrote it via the trace slot. A `null` body clears
+ * stale inputs after redirect handling changed the request to GET.
  */
 function applyFinalBodyInputs(span: Span, init: RequestInit | undefined, maxBodyBytes: number): void {
   const slot = (init as { [HTTP_TRACE_FINAL_BODY_SLOT]?: HttpTraceFinalBodySlot } | undefined)?.[
     HTTP_TRACE_FINAL_BODY_SLOT
   ]
   const finalBody = slot?.body
+  if (finalBody === null) {
+    span.setAttribute('inputs', '')
+    return
+  }
   if (typeof finalBody !== 'string') return
   const parsed = readRequestBody(finalBody, maxBodyBytes)
   if (parsed !== undefined) span.setAttribute('inputs', stringifyBody(parsed))

--- a/src/main/ai/utils/__tests__/customFetch.test.ts
+++ b/src/main/ai/utils/__tests__/customFetch.test.ts
@@ -22,7 +22,7 @@ describe('customFetch', () => {
     const init: RequestInit = { method: 'POST', body: '{}' }
     const result = await customFetch('https://api.test/v1/chat', init)
 
-    expect(net.fetch).toHaveBeenCalledWith('https://api.test/v1/chat', init)
+    expect(net.fetch).toHaveBeenCalledWith('https://api.test/v1/chat', { ...init, redirect: 'manual' })
     expect(result).toBe(response)
   })
 
@@ -31,7 +31,7 @@ describe('customFetch', () => {
 
     await customFetch(new URL('https://api.test/v1/models'))
 
-    expect(net.fetch).toHaveBeenCalledWith('https://api.test/v1/models', undefined)
+    expect(net.fetch).toHaveBeenCalledWith('https://api.test/v1/models', { redirect: 'manual' })
   })
 
   it('passes a Request input through unchanged', async () => {
@@ -87,14 +87,104 @@ describe('customFetch', () => {
     expect(slot.body).toBe(JSON.stringify({ tools: [{ type: 'web_extractor' }] }))
   })
 
-  it('leaves requests without a User-Agent untouched', async () => {
+  it('does not add a User-Agent sentinel when none was provided', async () => {
     vi.mocked(net.fetch).mockResolvedValue(new Response())
 
     const init: RequestInit = { method: 'POST', headers: { Authorization: 'Bearer k' } }
     await customFetch('https://api.test/v1/chat', init)
 
-    // Same init object forwarded — no sentinel header added.
-    expect(net.fetch).toHaveBeenCalledWith('https://api.test/v1/chat', init)
+    const [, forwardedInit] = vi.mocked(net.fetch).mock.calls[0]
+    expect(new Headers(forwardedInit?.headers).has(SENTINEL_HEADER)).toBe(false)
+  })
+
+  it('preserves authentication across a same-host HTTP-to-HTTPS redirect', async () => {
+    vi.mocked(net.fetch)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { Location: 'https://api.test/v1/chat' }
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok'))
+
+    const response = await customFetch('http://api.test/v1/chat', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer secret',
+        'Content-Type': 'application/json',
+        'X-Custom': 'custom'
+      },
+      body: '{"message":"hello"}'
+    })
+
+    expect(await response.text()).toBe('ok')
+    expect(net.fetch).toHaveBeenCalledTimes(2)
+    const [redirectUrl, redirectInit] = vi.mocked(net.fetch).mock.calls[1]
+    const redirectHeaders = new Headers(redirectInit?.headers)
+    expect(redirectUrl).toBe('https://api.test/v1/chat')
+    expect(redirectInit).toMatchObject({ method: 'POST', redirect: 'manual' })
+    expect(redirectInit?.body).toBe('{"message":"hello"}')
+    expect(redirectHeaders.get('Authorization')).toBe('Bearer secret')
+    expect(redirectHeaders.get('X-Custom')).toBe('custom')
+  })
+
+  it('strips authentication when a redirect changes host', async () => {
+    vi.mocked(net.fetch)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 307,
+          headers: { Location: 'https://other.test/v1/chat' }
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok'))
+
+    await customFetch('https://api.test/v1/chat', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer secret',
+        'X-Api-Key': 'secret-key',
+        'X-Custom': 'custom'
+      },
+      body: '{}'
+    })
+
+    const [, redirectInit] = vi.mocked(net.fetch).mock.calls[1]
+    const redirectHeaders = new Headers(redirectInit?.headers)
+    expect(redirectHeaders.get('Authorization')).toBeNull()
+    expect(redirectHeaders.get('X-Api-Key')).toBeNull()
+    expect(redirectHeaders.get('X-Custom')).toBe('custom')
+  })
+
+  it.each([
+    { method: 'POST', status: 302 },
+    { method: 'PUT', status: 303 }
+  ])('switches $method to GET without content headers for $status', async ({ method, status }) => {
+    vi.mocked(net.fetch)
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status,
+          headers: { Location: '/result' }
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok'))
+
+    await customFetch('https://api.test/v1/chat', {
+      method,
+      headers: {
+        Authorization: 'Bearer secret',
+        'Content-Encoding': 'gzip',
+        'Content-Type': 'application/json'
+      },
+      body: '{}'
+    })
+
+    const [redirectUrl, redirectInit] = vi.mocked(net.fetch).mock.calls[1]
+    const redirectHeaders = new Headers(redirectInit?.headers)
+    expect(redirectUrl).toBe('https://api.test/result')
+    expect(redirectInit?.method).toBe('GET')
+    expect(redirectInit?.body).toBeUndefined()
+    expect(redirectHeaders.get('Authorization')).toBe('Bearer secret')
+    expect([...redirectHeaders.keys()].some((key) => key.startsWith('content-'))).toBe(false)
   })
 })
 

--- a/src/main/ai/utils/__tests__/customFetch.test.ts
+++ b/src/main/ai/utils/__tests__/customFetch.test.ts
@@ -155,6 +155,43 @@ describe('customFetch', () => {
     expect(redirectHeaders.get('X-Custom')).toBe('custom')
   })
 
+  it.each(['file:///etc/passwd', 'cherry-media://files/private'])(
+    'rejects redirects to non-HTTP(S) protocol %s',
+    async (location) => {
+      vi.mocked(net.fetch).mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { Location: location }
+        })
+      )
+
+      await expect(customFetch('https://api.test/v1/chat')).rejects.toThrow('unsupported redirect protocol')
+      expect(net.fetch).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('allows 20 redirects before fetching the successful destination', async () => {
+    let requestCount = 0
+    vi.mocked(net.fetch).mockImplementation(async () => {
+      requestCount++
+      return requestCount <= 20
+        ? new Response(null, { status: 302, headers: { Location: `/hop-${requestCount}` } })
+        : new Response('ok')
+    })
+
+    const response = await customFetch('https://api.test/start')
+
+    expect(await response.text()).toBe('ok')
+    expect(net.fetch).toHaveBeenCalledTimes(21)
+  })
+
+  it('rejects when the successful destination would require a 21st redirect', async () => {
+    vi.mocked(net.fetch).mockResolvedValue(new Response(null, { status: 302, headers: { Location: '/next' } }))
+
+    await expect(customFetch('https://api.test/start')).rejects.toThrow('too many redirects')
+    expect(net.fetch).toHaveBeenCalledTimes(21)
+  })
+
   it.each([
     { method: 'POST', status: 302 },
     { method: 'PUT', status: 303 }
@@ -168,15 +205,18 @@ describe('customFetch', () => {
       )
       .mockResolvedValueOnce(new Response('ok'))
 
-    await customFetch('https://api.test/v1/chat', {
+    const slot: HttpTraceFinalBodySlot = {}
+    const init: RequestInit & { [HTTP_TRACE_FINAL_BODY_SLOT]?: HttpTraceFinalBodySlot } = {
       method,
       headers: {
         Authorization: 'Bearer secret',
         'Content-Encoding': 'gzip',
         'Content-Type': 'application/json'
       },
-      body: '{}'
-    })
+      body: '{}',
+      [HTTP_TRACE_FINAL_BODY_SLOT]: slot
+    }
+    await customFetch('https://api.test/v1/chat', init)
 
     const [redirectUrl, redirectInit] = vi.mocked(net.fetch).mock.calls[1]
     const redirectHeaders = new Headers(redirectInit?.headers)
@@ -185,6 +225,7 @@ describe('customFetch', () => {
     expect(redirectInit?.body).toBeUndefined()
     expect(redirectHeaders.get('Authorization')).toBe('Bearer secret')
     expect([...redirectHeaders.keys()].some((key) => key.startsWith('content-'))).toBe(false)
+    expect(slot.body).toBeNull()
   })
 })
 

--- a/src/main/ai/utils/__tests__/customFetch.test.ts
+++ b/src/main/ai/utils/__tests__/customFetch.test.ts
@@ -102,12 +102,12 @@ describe('customFetch', () => {
       .mockResolvedValueOnce(
         new Response(null, {
           status: 307,
-          headers: { Location: 'https://api.test/v1/chat' }
+          headers: { Location: 'https://api.test:443/v1/chat' }
         })
       )
       .mockResolvedValueOnce(new Response('ok'))
 
-    const response = await customFetch('http://api.test/v1/chat', {
+    const response = await customFetch('http://api.test:80/v1/chat', {
       method: 'POST',
       headers: {
         Authorization: 'Bearer secret',

--- a/src/main/ai/utils/customFetch.ts
+++ b/src/main/ai/utils/customFetch.ts
@@ -15,6 +15,9 @@ import { net, session } from 'electron'
  * (mirrors `WebviewService.initSessionUserAgent`).
  */
 const PROVIDER_USER_AGENT_HEADER = 'x-cherry-studio-user-agent'
+const MAX_REDIRECTS = 20
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308])
+const SENSITIVE_REDIRECT_HEADERS = new Set(['authorization', 'cookie', 'cookie2', 'proxy-authorization'])
 
 /**
  * Symbol-keyed slot carried on a `RequestInit` between the HTTP-trace wrapper
@@ -52,6 +55,64 @@ function resolveUserAgent(headers: HeadersInit): string | null {
   return userAgent
 }
 
+function canPreserveSensitiveHeaders(from: URL, to: URL): boolean {
+  if (from.origin === to.origin) return true
+
+  return (
+    from.protocol === 'http:' &&
+    to.protocol === 'https:' &&
+    from.hostname === to.hostname &&
+    (from.port === to.port || (from.port === '' && to.port === ''))
+  )
+}
+
+function redirectHeaders(headersInit: HeadersInit | undefined, preserveSensitive: boolean, dropBody: boolean) {
+  const headers = new Headers(headersInit)
+  for (const key of [...headers.keys()]) {
+    const normalizedKey = key.toLowerCase()
+    const isSensitive = SENSITIVE_REDIRECT_HEADERS.has(normalizedKey) || normalizedKey.endsWith('api-key')
+    if ((!preserveSensitive && isSensitive) || (dropBody && normalizedKey.startsWith('content-'))) {
+      headers.delete(key)
+    }
+  }
+  return headers
+}
+
+function shouldRedirectWithGet(status: number, method: string): boolean {
+  return (
+    ((status === 301 || status === 302) && method === 'POST') ||
+    (status === 303 && method !== 'GET' && method !== 'HEAD')
+  )
+}
+
+async function fetchFollowingRedirects(target: string, initialInit?: RequestInit): Promise<Response> {
+  let url = target
+  let requestInit = initialInit
+
+  for (let redirectCount = 0; redirectCount < MAX_REDIRECTS; redirectCount++) {
+    const response = await net.fetch(url, { ...requestInit, redirect: 'manual' })
+    if (!REDIRECT_STATUSES.has(response.status)) return response
+
+    const location = response.headers.get('location')
+    if (!location) return response
+
+    const currentUrl = new URL(url)
+    const nextUrl = new URL(location, currentUrl)
+    const method = (requestInit?.method ?? 'GET').toUpperCase()
+    const dropBody = shouldRedirectWithGet(response.status, method)
+    requestInit = {
+      ...requestInit,
+      body: dropBody ? undefined : requestInit?.body,
+      headers: redirectHeaders(requestInit?.headers, canPreserveSensitiveHeaders(currentUrl, nextUrl), dropBody),
+      method: dropBody ? 'GET' : method
+    }
+    url = nextUrl.href
+    await response.body?.cancel()
+  }
+
+  throw new Error('fetch: too many redirects')
+}
+
 /**
  * Base `fetch` for AI provider HTTP calls.
  *
@@ -87,10 +148,15 @@ export const customFetch: FetchFunction = (input: RequestInfo | URL, init?: Requ
   if (userAgent) {
     const headers = new Headers(init?.headers)
     headers.set(PROVIDER_USER_AGENT_HEADER, userAgent)
-    return net.fetch(target, { ...init, headers })
+    const requestInit = { ...init, headers }
+    return typeof target === 'string' && (!init?.redirect || init.redirect === 'follow')
+      ? fetchFollowingRedirects(target, requestInit)
+      : net.fetch(target, requestInit)
   }
 
-  return net.fetch(target, init)
+  return typeof target === 'string' && (!init?.redirect || init.redirect === 'follow')
+    ? fetchFollowingRedirects(target, init)
+    : net.fetch(target, init)
 }
 
 /**

--- a/src/main/ai/utils/customFetch.ts
+++ b/src/main/ai/utils/customFetch.ts
@@ -85,21 +85,36 @@ function shouldRedirectWithGet(status: number, method: string): boolean {
   )
 }
 
-async function fetchFollowingRedirects(target: string, initialInit?: RequestInit): Promise<Response> {
+async function fetchFollowingRedirects(
+  target: string,
+  initialInit: RequestInit | undefined,
+  sendRequest: (target: string, init: RequestInit) => Promise<Response>
+): Promise<Response> {
   let url = target
   let requestInit = initialInit
+  let redirectCount = 0
 
-  for (let redirectCount = 0; redirectCount < MAX_REDIRECTS; redirectCount++) {
-    const response = await net.fetch(url, { ...requestInit, redirect: 'manual' })
+  while (true) {
+    const response = await sendRequest(url, { ...requestInit, redirect: 'manual' })
     if (!REDIRECT_STATUSES.has(response.status)) return response
 
     const location = response.headers.get('location')
     if (!location) return response
+    if (redirectCount === MAX_REDIRECTS) {
+      await response.body?.cancel()
+      throw new Error('fetch: too many redirects')
+    }
 
     const currentUrl = new URL(url)
     const nextUrl = new URL(location, currentUrl)
+    if (nextUrl.protocol !== 'http:' && nextUrl.protocol !== 'https:') {
+      await response.body?.cancel()
+      throw new TypeError(`fetch: unsupported redirect protocol "${nextUrl.protocol}"`)
+    }
+
     const method = (requestInit?.method ?? 'GET').toUpperCase()
     const dropBody = shouldRedirectWithGet(response.status, method)
+
     requestInit = {
       ...requestInit,
       body: dropBody ? undefined : requestInit?.body,
@@ -107,10 +122,9 @@ async function fetchFollowingRedirects(target: string, initialInit?: RequestInit
       method: dropBody ? 'GET' : method
     }
     url = nextUrl.href
+    redirectCount++
     await response.body?.cancel()
   }
-
-  throw new Error('fetch: too many redirects')
 }
 
 /**
@@ -138,7 +152,10 @@ export const customFetch: FetchFunction = (input: RequestInfo | URL, init?: Requ
   const finalBodySlot = (init as { [HTTP_TRACE_FINAL_BODY_SLOT]?: HttpTraceFinalBodySlot } | undefined)?.[
     HTTP_TRACE_FINAL_BODY_SLOT
   ]
-  if (finalBodySlot) finalBodySlot.body = init?.body
+  const sendRequest = (requestTarget: string | Request, requestInit?: RequestInit) => {
+    if (finalBodySlot) finalBodySlot.body = requestInit?.body ?? null
+    return net.fetch(requestTarget, requestInit)
+  }
 
   // A custom `User-Agent` in the request headers is overwritten by Chromium's net
   // stack, so smuggle it through PROVIDER_USER_AGENT_HEADER and let the default-session
@@ -150,13 +167,13 @@ export const customFetch: FetchFunction = (input: RequestInfo | URL, init?: Requ
     headers.set(PROVIDER_USER_AGENT_HEADER, userAgent)
     const requestInit = { ...init, headers }
     return typeof target === 'string' && (!init?.redirect || init.redirect === 'follow')
-      ? fetchFollowingRedirects(target, requestInit)
-      : net.fetch(target, requestInit)
+      ? fetchFollowingRedirects(target, requestInit, sendRequest)
+      : sendRequest(target, requestInit)
   }
 
   return typeof target === 'string' && (!init?.redirect || init.redirect === 'follow')
-    ? fetchFollowingRedirects(target, init)
-    : net.fetch(target, init)
+    ? fetchFollowingRedirects(target, init, sendRequest)
+    : sendRequest(target, init)
 }
 
 /**


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Provider requests that followed an HTTP redirect through Chromium's network stack could lose authentication headers, causing otherwise valid provider checks and API calls to fail.

After this PR:

The shared provider `customFetch` follows redirects manually. It preserves sensitive headers for same-origin redirects and same-host HTTP-to-HTTPS upgrades, strips authentication and API-key headers for other cross-origin redirects, and retains standard 301/302/303 method and body semantics.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*: -->

Fixes #13236

### Why we need it and why it was done in this way

The v2 architecture routes provider traffic through Electron `net.fetch` in the main process so requests use the proxy-aware Chromium network stack. Chromium intentionally strips sensitive headers on cross-origin redirects, including the common case where a configured HTTP endpoint upgrades to HTTPS on the same host.

The following tradeoffs were made:

Manual redirect handling is limited to the string/URL request shape used by the AI SDK and only when redirect mode is omitted or set to `follow`. Explicit `manual`/`error` modes and `Request` inputs retain their native behavior. Redirects are capped at 20 hops.

The following alternatives were considered:

Reusing the renderer implementation from #13652 was rejected because v2 moved provider networking into the main process. Rewriting configured HTTP URLs to HTTPS was also rejected because it would break intentional HTTP and local endpoints.

Links to places where the discussion took place: #13652

### Breaking changes

<!-- optional -->

None.

### Special notes for your reviewer

The regression tests cover safe same-host HTTP-to-HTTPS authentication preservation, cross-host credential stripping, and POST/PUT conversion for 302/303 redirects with all `Content-*` headers removed when the body is dropped.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Provider requests now retain authentication headers across safe same-host HTTP-to-HTTPS redirects.
```
