### PR TITLE
fix(composer): show skill suffix only in root search

### DIFF
--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -271,7 +271,6 @@ const createSkillQuickPanelItems = (
     label: skill.name,
     description: skill.description ?? undefined,
     icon: <ToolCase size={16} />,
-    suffix: options.skillLabel,
     // Skills still exclude descriptions from root-panel search; the category alias powers the persistent shortcut.
     filterText: skill.name,
     searchAliases: [options.skillLabel],
@@ -1138,18 +1137,18 @@ const AgentComposerInner = ({
     [agentId, t]
   )
 
+  const skillLabel = t('plugins.skills')
   const skillItems = useMemo<QuickPanelListItem[]>(
     () =>
       createSkillQuickPanelItems(availableSkills, {
-        skillLabel: t('plugins.skills'),
+        skillLabel,
         onInsertSkill: insertSkillToken
       }),
-    [availableSkills, insertSkillToken, t]
+    [availableSkills, insertSkillToken, skillLabel]
   )
   const skillPanelItems = useMemo(() => [...skillItems, skillManageFooterItem], [skillItems, skillManageFooterItem])
 
   const skillsLauncher = useMemo<ComposerToolLauncher>(() => {
-    const skillLabel = t('plugins.skills')
     return {
       id: AGENT_SKILLS_LAUNCHER_ID,
       kind: 'panel',
@@ -1159,7 +1158,7 @@ const AgentComposerInner = ({
       icon: <ToolCase />,
       searchAliases: [skillLabel],
       panelSymbol: AGENT_SKILLS_LAUNCHER_ID,
-      rootSearchItems: skillItems,
+      rootSearchItems: skillItems.map((item) => ({ ...item, suffix: skillLabel })),
       action: ({ parentPanel, queryAnchor, quickPanel }) => {
         void refreshAvailableSkills().catch((error) => {
           logger.warn('Failed to refresh available skills when opening the skills panel', { error })
@@ -1175,7 +1174,7 @@ const AgentComposerInner = ({
         })
       }
     }
-  }, [refreshAvailableSkills, skillItems, skillPanelItems, t])
+  }, [refreshAvailableSkills, skillItems, skillLabel, skillPanelItems])
 
   useEffect(
     () => toolsRegistry.registerLaunchers(AGENT_SKILLS_LAUNCHER_ID, [skillsLauncher]),

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3104,7 +3104,9 @@ describe('AgentComposer', () => {
     const skillsLauncher = mocks.registeredLaunchers.get('agent-skills')?.[0]
     expect(skillsLauncher?.rootPanelPlacement).toBeUndefined()
     expect(skillsLauncher?.order).toBe(40)
-    expect(skillsLauncher?.rootSearchItems).toEqual([expect.objectContaining({ id: 'skill:pdf' })])
+    expect(skillsLauncher?.rootSearchItems).toEqual([
+      expect.objectContaining({ id: 'skill:pdf', suffix: 'plugins.skills' })
+    ])
     expect(mocks.pinnedLauncherIds).toEqual(['composer:new-session', 'agent-skills'])
 
     const items = getAgentSkillsPanelItems()
@@ -3115,10 +3117,10 @@ describe('AgentComposer', () => {
         id: 'skill:pdf',
         label: 'pdf',
         description: 'Read and analyze PDFs',
-        suffix: 'plugins.skills',
         filterText: 'pdf'
       })
     )
+    expect(skillItem?.suffix).toBeUndefined()
 
     // The pinned footer opens the agent's skills config.
     const manageItem = items.at(-1)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Skill rows reused the same suffix in both root mixed search results and the dedicated skills panel, so the dedicated panel redundantly labeled every row as a skill.

![Before: the dedicated skills panel repeats the skill suffix](https://github.com/user-attachments/assets/d6292fea-a0d0-40d4-b113-8dc8c31ecfb0)

After this PR:

Skill rows show the skill suffix only when flattened into root mixed search results. The dedicated skills panel keeps the same rows without the redundant suffix.

![After: the dedicated skills panel no longer repeats the skill suffix](https://github.com/user-attachments/assets/37111e19-8f92-49f4-aae2-955057fba502)

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes N/A

### Why we need it and why it was done in this way

The suffix describes why a concrete skill appears among mixed root results, not what every row means inside a panel that is already explicitly scoped to skills. The implementation therefore keeps the shared skill items context-neutral and adds the suffix only at the existing `rootSearchItems` boundary.

The following tradeoffs were made:

- Root search items are shallow copies of the submenu items so presentation context remains explicit without changing the generic QuickPanel renderer.

The following alternatives were considered:

- Teaching the generic QuickPanel row to hide skill suffixes in a skills panel was rejected because it would move domain-specific behavior into shared UI infrastructure.
- Maintaining two independent skill-item constructors was rejected because it would duplicate filtering, aliases, icons, and actions.

Links to places where the discussion took place: N/A

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

N/A

### Special notes for your reviewer

- The regression test asserts both sides of the contract: root mixed search items include the suffix, while dedicated skills panel items do not.
- Focused renderer tests: 131 passed.
- `pnpm run typecheck:web`, Biome, and ESLint validation completed successfully. ESLint reports one unrelated pre-existing Hook dependency warning at `AgentComposer.tsx:917`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and no upgrade handling is required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered; this focused presentation correction does not require a user-guide change
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Composer] Show skill labels only in root mixed search results, avoiding redundant labels in the dedicated skills panel.
```
