### PR TITLE
fix(main-network-devtools): ship the Main Network panel in release builds behind developer mode

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -71,10 +71,10 @@ files:
   - "!node_modules/onnxruntime-node/bin/**" # native binary is downloaded on first use (Toolchain/onnxruntime), never bundled — see OnnxRuntimeBinaryService
   - "!**/*.{h,iobj,ipdb,tlog,recipe,vcxproj,vcxproj.filters,Makefile,*.Makefile}" # filter .node build files
   - "resources/**/*" # include all files in resources, and unpack them from asar for runtime access
-  - "!resources/devtools/**" # dev-only extensions are loaded from source in development
+  - "!resources/devtools/data-api/**" # dev-only panel; main-network ships so developer mode can inspect main-process traffic
 asarUnpack:
   - resources/**
-  - "!resources/devtools/**"
+  - "!resources/devtools/data-api/**"
   - "**/*.{metal,exp,lib}"
   - "node_modules/@img/sharp-*/**"
   - "node_modules/@anthropic-ai/claude-agent-sdk-*/**" # native CLI binary must live on disk to be spawned

--- a/src/main/core/__tests__/devtools.test.ts
+++ b/src/main/core/__tests__/devtools.test.ts
@@ -1,20 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { applicationMock, loggerMock, loadExtensionMock, installExtensionMock, platformMock } = vi.hoisted(() => {
-  const applicationMock = {
-    getPath: vi.fn((key: string) => `/mock/${key}`)
+const { applicationMock, loggerMock, loadExtensionMock, installExtensionMock, platformMock, appMock } = vi.hoisted(
+  () => {
+    const applicationMock = {
+      getPath: vi.fn((key: string) => `/mock/${key}`)
+    }
+    const loggerMock = {
+      error: vi.fn(),
+      info: vi.fn()
+    }
+    const loadExtensionMock = vi.fn()
+    const installExtensionMock = vi.fn()
+    // Mutable so individual tests can toggle dev/non-dev. Read via a getter in the
+    // mock below, since `isDev` is a module-load-time constant otherwise.
+    const platformMock = { isDev: true }
+    const appMock = { isPackaged: false, appPath: '/repo' }
+    return { applicationMock, loggerMock, loadExtensionMock, installExtensionMock, platformMock, appMock }
   }
-  const loggerMock = {
-    error: vi.fn(),
-    info: vi.fn()
-  }
-  const loadExtensionMock = vi.fn()
-  const installExtensionMock = vi.fn()
-  // Mutable so individual tests can toggle dev/non-dev. Read via a getter in the
-  // mock below, since `isDev` is a module-load-time constant otherwise.
-  const platformMock = { isDev: true }
-  return { applicationMock, loggerMock, loadExtensionMock, installExtensionMock, platformMock }
-})
+)
 
 vi.mock('@application', () => ({
   application: applicationMock
@@ -33,6 +36,12 @@ vi.mock('@main/core/platform', () => ({
 }))
 
 vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return appMock.isPackaged
+    },
+    getAppPath: () => appMock.appPath
+  },
   session: {
     defaultSession: {
       extensions: {
@@ -47,12 +56,15 @@ vi.mock('electron-devtools-installer', () => ({
   REACT_DEVELOPER_TOOLS: 'react-devtools'
 }))
 
-import { installDevtoolsExtensions } from '../devtools'
+import { installBundledDevtools, installDevtoolsExtensions } from '../devtools'
 
 describe('installDevtoolsExtensions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     platformMock.isDev = true
+    appMock.isPackaged = false
+    appMock.appPath = '/repo'
+    applicationMock.getPath.mockImplementation((key: string) => `/mock/${key}`)
     installExtensionMock.mockResolvedValue('React Developer Tools')
     loadExtensionMock.mockResolvedValue({ id: 'data-api-extension-id', name: 'DataApi DevTools' })
   })
@@ -87,5 +99,41 @@ describe('installDevtoolsExtensions', () => {
 
     expect(installExtensionMock).not.toHaveBeenCalled()
     expect(loadExtensionMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('installBundledDevtools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    appMock.isPackaged = false
+    appMock.appPath = '/repo'
+    applicationMock.getPath.mockImplementation((key: string) => `/mock/${key}`)
+    loadExtensionMock.mockResolvedValue({ id: 'main-network-extension-id', name: 'Main Network' })
+  })
+
+  it('loads a packaged panel from app.asar.unpacked, which Chromium can read off disk', async () => {
+    appMock.isPackaged = true
+    appMock.appPath = '/Applications/Cherry Studio.app/Contents/Resources/app.asar'
+    applicationMock.getPath.mockImplementation(() => `${appMock.appPath}/resources`)
+
+    await installBundledDevtools('main-network', 'Main Network')
+
+    expect(loadExtensionMock).toHaveBeenCalledWith(
+      '/Applications/Cherry Studio.app/Contents/Resources/app.asar.unpacked/resources/devtools/main-network'
+    )
+  })
+
+  it('loads an unpackaged panel straight from the source tree', async () => {
+    await installBundledDevtools('main-network', 'Main Network')
+
+    expect(loadExtensionMock).toHaveBeenCalledWith('/mock/app.root.resources/devtools/main-network')
+  })
+
+  it('reports the resolved extension to its caller so the origin can be allowlisted', async () => {
+    const onInstalled = vi.fn()
+
+    await installBundledDevtools('main-network', 'Main Network', onInstalled)
+
+    expect(onInstalled).toHaveBeenCalledWith({ id: 'main-network-extension-id', name: 'Main Network' })
   })
 })

--- a/src/main/core/devtools.ts
+++ b/src/main/core/devtools.ts
@@ -1,6 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { isDev } from '@main/core/platform'
+import { toAsarUnpackedPath } from '@main/utils/asar'
 import { session } from 'electron'
 import { join } from 'path'
 
@@ -48,7 +49,9 @@ export async function installBundledDevtools(
   onInstalled?: (extension: { id: string; name: string }) => void
 ) {
   try {
-    const devtoolsPath = join(application.getPath('app.root.resources'), 'devtools', directoryName)
+    // Chromium reads the unpacked extension straight off disk, so a packaged build
+    // must point at app.asar.unpacked rather than the virtual path inside the asar.
+    const devtoolsPath = toAsarUnpackedPath(join(application.getPath('app.root.resources'), 'devtools', directoryName))
     // Loads into the default session, so every default-session BrowserWindow can inspect bundled panels.
     const extension = await session.defaultSession.extensions.loadExtension(devtoolsPath)
     onInstalled?.({ id: extension.id, name: extension.name })

--- a/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
+++ b/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
@@ -3,9 +3,10 @@ import http, { type ClientRequest, type IncomingMessage, type RequestOptions } f
 import https from 'node:https'
 import type { AddressInfo } from 'node:net'
 
+import { application } from '@application'
 import { loggerService } from '@logger'
 import { installBundledDevtools } from '@main/core/devtools'
-import { BaseService, Conditional, Injectable, Phase, Priority, ServicePhase, when } from '@main/core/lifecycle'
+import { BaseService, Injectable, Phase, Priority, ServicePhase } from '@main/core/lifecycle'
 import { isDev } from '@main/core/platform'
 import { net } from 'electron'
 import type WebSocket from 'ws'
@@ -165,8 +166,11 @@ export function describeHttpRequest(source: 'http' | 'https', args: unknown[]): 
 }
 
 /**
- * Development-only monitor for network requests initiated by this main-process
- * JavaScript runtime (`fetch`, Electron `net.fetch`, and Node `http`/`https`).
+ * Monitor for network requests initiated by this main-process JavaScript runtime
+ * (`fetch`, Electron `net.fetch`, and Node `http`/`https`). Always on in development;
+ * in packaged builds it runs only when the user enables developer mode, since V2
+ * issues model traffic from the main process where the renderer DevTools Network
+ * panel cannot see it.
  *
  * Known limitations: traffic emitted by native binaries or child processes is
  * not visible to these in-process monkey patches. In particular, Claude agent SDK
@@ -177,8 +181,8 @@ export function describeHttpRequest(source: 'http' | 'https', args: unknown[]): 
 @Injectable('MainNetworkDevtoolsService')
 @ServicePhase(Phase.Background)
 @Priority(0)
-@Conditional(when(() => isDev, 'development mode'))
 export class MainNetworkDevtoolsService extends BaseService {
+  private started = false
   private readonly events: MainNetworkDevtoolsEvent[] = []
   private readonly clients = new Set<WebSocket>()
   private readonly allowedOrigins = new Set<string>()
@@ -193,7 +197,38 @@ export class MainNetworkDevtoolsService extends BaseService {
   private monitoredHttpsGet: typeof https.get | null = null
   private monitoredHttpsRequest: typeof https.request | null = null
 
+  /**
+   * Development starts monitoring here so the patches cover requests made during
+   * early boot. Packaged builds cannot decide yet: the developer-mode preference is
+   * loaded by PreferenceService in the BeforeReady phase, which Application.bootstrap
+   * runs *alongside* this Background phase, so reading it now would always yield the
+   * default. That path starts from onAllReady instead.
+   */
   protected async onInit(): Promise<void> {
+    if (isDev) await this.start()
+  }
+
+  /**
+   * Install the panel here rather than in onInit: this service runs in the Background
+   * phase, which Application.bootstrap starts *before* awaiting app.whenReady(), so
+   * onInit would hit `session.defaultSession` too early and throw "Session can only be
+   * received when app is ready". onAllReady fires after every phase completes, by which
+   * point the app is ready — and the developer-mode preference is readable.
+   *
+   * Disabling developer mode takes effect on the next launch; the patches installed
+   * for this session stay in place, matching NodeTraceService.
+   */
+  protected async onAllReady(): Promise<void> {
+    if (!this.started && application.get('PreferenceService').get('app.developer_mode.enabled')) {
+      await this.start()
+    }
+    if (!this.started) return
+
+    await this.installPanel()
+  }
+
+  private async start(): Promise<void> {
+    this.started = true
     this.patchFetch()
     this.patchNetFetch()
     this.patchHttpModules()
@@ -203,20 +238,6 @@ export class MainNetworkDevtoolsService extends BaseService {
     } catch (error) {
       logger.error('Failed to start Main Network DevTools websocket server', error as Error)
     }
-  }
-
-  /**
-   * Install the panel here rather than in onInit: this service runs in the Background
-   * phase, which Application.bootstrap starts *before* awaiting app.whenReady(), so
-   * onInit would hit `session.defaultSession` too early and throw "Session can only be
-   * received when app is ready". onAllReady fires after every phase completes, by which
-   * point the app is ready. Registering the panel only has to precede the user opening
-   * DevTools, so the extra wait costs nothing.
-   *
-   * Patching stays in onInit — it must cover requests made during early boot.
-   */
-  protected async onAllReady(): Promise<void> {
-    await this.installPanel()
   }
 
   /**

--- a/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
+++ b/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
@@ -183,6 +183,7 @@ export function describeHttpRequest(source: 'http' | 'https', args: unknown[]): 
 @Priority(0)
 export class MainNetworkDevtoolsService extends BaseService {
   private capturing = false
+  private serving = false
   private enabled = false
   private setupDone = false
   /** Bumped on every stop so work still in flight from the previous run can tell it was abandoned. */
@@ -231,6 +232,7 @@ export class MainNetworkDevtoolsService extends BaseService {
   protected onStop(): void {
     this.generation++
     this.capturing = false
+    this.serving = false
     this.enabled = false
     this.setupDone = false
   }
@@ -263,25 +265,50 @@ export class MainNetworkDevtoolsService extends BaseService {
 
     const generation = this.generation
     this.enabled = true
-    await this.startCapture()
+
+    const monitoring = await this.startCapture()
     if (generation !== this.generation) return
+
+    // The panel only ever talks to the fixed port. Installing it with nothing behind
+    // that port would show the user an empty panel — the very symptom this feature
+    // exists to remove. Stay off instead, and let the next attempt bind again.
+    if (!monitoring) {
+      this.enabled = false
+      return
+    }
 
     await this.installPanel()
   }
 
-  private async startCapture(): Promise<void> {
-    if (this.capturing) return
+  /**
+   * Patch the request APIs and bring the monitor port up.
+   *
+   * @returns whether the monitor is live. A port already held by another instance or a
+   * leftover process leaves it false; the patches stay and the next call retries the bind.
+   */
+  private async startCapture(): Promise<boolean> {
+    const generation = this.generation
 
-    this.capturing = true
-    this.patchFetch()
-    this.patchNetFetch()
-    this.patchHttpModules()
+    if (!this.capturing) {
+      this.capturing = true
+      this.patchFetch()
+      this.patchNetFetch()
+      this.patchHttpModules()
+    }
+
+    if (this.serving) return true
 
     try {
       await this.startWebSocketServer()
     } catch (error) {
-      logger.error('Failed to start Main Network DevTools websocket server', error as Error)
+      logger.error('Failed to start Main Network DevTools websocket server; the panel stays hidden', error as Error)
+      return false
     }
+
+    if (generation !== this.generation) return false
+
+    this.serving = true
+    return true
   }
 
   /**

--- a/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
+++ b/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
@@ -182,7 +182,8 @@ export function describeHttpRequest(source: 'http' | 'https', args: unknown[]): 
 @ServicePhase(Phase.Background)
 @Priority(0)
 export class MainNetworkDevtoolsService extends BaseService {
-  private started = false
+  private capturing = false
+  private enabled = false
   private readonly events: MainNetworkDevtoolsEvent[] = []
   private readonly clients = new Set<WebSocket>()
   private readonly allowedOrigins = new Set<string>()
@@ -205,7 +206,7 @@ export class MainNetworkDevtoolsService extends BaseService {
    * default. That path starts from onAllReady instead.
    */
   protected async onInit(): Promise<void> {
-    if (isDev) await this.start()
+    if (isDev) await this.startCapture()
   }
 
   /**
@@ -215,20 +216,35 @@ export class MainNetworkDevtoolsService extends BaseService {
    * received when app is ready". onAllReady fires after every phase completes, by which
    * point the app is ready — and the developer-mode preference is readable.
    *
-   * Disabling developer mode takes effect on the next launch; the patches installed
-   * for this session stay in place, matching NodeTraceService.
+   * Enabling developer mode later takes effect immediately (the user only has to reopen
+   * DevTools to see the panel); it is not captured retroactively. Disabling it stops at
+   * the next launch — the patches installed for this session stay in place, matching
+   * NodeTraceService, rather than being pulled out from under in-flight requests.
    */
   protected async onAllReady(): Promise<void> {
-    if (!this.started && application.get('PreferenceService').get('app.developer_mode.enabled')) {
-      await this.start()
-    }
-    if (!this.started) return
+    const preferences = application.get('PreferenceService')
+    this.registerDisposable(
+      preferences.subscribeChange('app.developer_mode.enabled', (enabled) => {
+        if (enabled) void this.enable()
+      })
+    )
 
+    if (isDev || preferences.get('app.developer_mode.enabled')) await this.enable()
+  }
+
+  /** Start monitoring and expose the panel. Idempotent — enabling twice is a no-op. */
+  private async enable(): Promise<void> {
+    if (this.enabled) return
+
+    this.enabled = true
+    await this.startCapture()
     await this.installPanel()
   }
 
-  private async start(): Promise<void> {
-    this.started = true
+  private async startCapture(): Promise<void> {
+    if (this.capturing) return
+
+    this.capturing = true
     this.patchFetch()
     this.patchNetFetch()
     this.patchHttpModules()

--- a/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
+++ b/src/main/services/mainNetworkDevtools/MainNetworkDevtoolsService.ts
@@ -8,7 +8,7 @@ import { loggerService } from '@logger'
 import { installBundledDevtools } from '@main/core/devtools'
 import { BaseService, Injectable, Phase, Priority, ServicePhase } from '@main/core/lifecycle'
 import { isDev } from '@main/core/platform'
-import { net } from 'electron'
+import { app, net } from 'electron'
 import type WebSocket from 'ws'
 import type { WebSocketServer } from 'ws'
 
@@ -184,6 +184,9 @@ export function describeHttpRequest(source: 'http' | 'https', args: unknown[]): 
 export class MainNetworkDevtoolsService extends BaseService {
   private capturing = false
   private enabled = false
+  private setupDone = false
+  /** Bumped on every stop so work still in flight from the previous run can tell it was abandoned. */
+  private generation = 0
   private readonly events: MainNetworkDevtoolsEvent[] = []
   private readonly clients = new Set<WebSocket>()
   private readonly allowedOrigins = new Set<string>()
@@ -207,6 +210,10 @@ export class MainNetworkDevtoolsService extends BaseService {
    */
   protected async onInit(): Promise<void> {
     if (isDev) await this.startCapture()
+    // onAllReady only ever fires once per instance, so a restart has to pick the
+    // preference up here. app.isReady() is exactly that signal: false during the
+    // first bootstrap (Background runs before app.whenReady()), true afterwards.
+    if (app.isReady()) await this.setup()
   }
 
   /**
@@ -215,13 +222,31 @@ export class MainNetworkDevtoolsService extends BaseService {
    * onInit would hit `session.defaultSession` too early and throw "Session can only be
    * received when app is ready". onAllReady fires after every phase completes, by which
    * point the app is ready — and the developer-mode preference is readable.
+   */
+  protected async onAllReady(): Promise<void> {
+    await this.setup()
+  }
+
+  /** Reset to the "never started" state; BaseService has already released the patches, server and subscription. */
+  protected onStop(): void {
+    this.generation++
+    this.capturing = false
+    this.enabled = false
+    this.setupDone = false
+  }
+
+  /**
+   * Watch the developer-mode preference and honour its current value.
    *
    * Enabling developer mode later takes effect immediately (the user only has to reopen
    * DevTools to see the panel); it is not captured retroactively. Disabling it stops at
    * the next launch — the patches installed for this session stay in place, matching
    * NodeTraceService, rather than being pulled out from under in-flight requests.
    */
-  protected async onAllReady(): Promise<void> {
+  private async setup(): Promise<void> {
+    if (this.setupDone) return
+
+    this.setupDone = true
     const preferences = application.get('PreferenceService')
     this.registerDisposable(
       preferences.subscribeChange('app.developer_mode.enabled', (enabled) => {
@@ -236,8 +261,11 @@ export class MainNetworkDevtoolsService extends BaseService {
   private async enable(): Promise<void> {
     if (this.enabled) return
 
+    const generation = this.generation
     this.enabled = true
     await this.startCapture()
+    if (generation !== this.generation) return
+
     await this.installPanel()
   }
 
@@ -571,6 +599,7 @@ export class MainNetworkDevtoolsService extends BaseService {
   }
 
   private async startWebSocketServer(port = MAIN_NETWORK_DEVTOOLS_DEFAULT_PORT): Promise<number> {
+    const generation = this.generation
     const { WebSocketServer } = await import('ws')
     const server = new WebSocketServer({ host: '127.0.0.1', port })
 
@@ -604,6 +633,14 @@ export class MainNetworkDevtoolsService extends BaseService {
     }
 
     const listeningPort = (address as AddressInfo).port
+
+    // Stopped while binding: the disposable list has already been flushed, so a
+    // close-disposable registered now would never run and the port would leak.
+    if (generation !== this.generation) {
+      server.close()
+      return listeningPort
+    }
+
     logger.info(`Main Network DevTools websocket server listening on 127.0.0.1:${listeningPort}`)
 
     this.registerDisposable(() => {

--- a/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
+++ b/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
@@ -378,6 +378,46 @@ describe('MainNetworkDevtoolsService gating', () => {
     expect(net.fetch).toBe(originalNetFetch)
   })
 
+  it('starts capturing as soon as the user enables developer mode, without an app restart', async () => {
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    try {
+      await service._doInit()
+      await service._doAllReady()
+      expect(net.fetch).toBe(originalNetFetch)
+
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+      await vi.waitFor(() => expect(installBundledDevtools).toHaveBeenCalled())
+
+      await net.fetch('https://api.test/v1/models')
+      expect(readEvents(service)[0]).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+    } finally {
+      await service._doStop()
+    }
+
+    expect(net.fetch).toBe(originalNetFetch)
+  })
+
+  it('does not re-install the panel when developer mode is toggled again', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const service = createStartedService()
+
+    try {
+      await service._doInit()
+      await service._doAllReady()
+      expect(installBundledDevtools).toHaveBeenCalledTimes(1)
+
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', false)
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+      await flushMicrotasks()
+
+      expect(installBundledDevtools).toHaveBeenCalledTimes(1)
+    } finally {
+      await service._doStop()
+    }
+  })
+
   it('captures boot-time requests in development regardless of the developer mode preference', async () => {
     platformState.isDev = true
     const originalNetFetch = net.fetch
@@ -413,6 +453,10 @@ function readEvents(service: MainNetworkDevtoolsService): MainNetworkDevtoolsEve
 
 function isOriginAllowed(service: MainNetworkDevtoolsService, origin: string): boolean {
   return (service as unknown as { isOriginAllowed: (origin: string) => boolean }).isOriginAllowed(origin)
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let tick = 0; tick < 5; tick++) await Promise.resolve()
 }
 
 function openSocketWithMessage(port: number, origin: string): Promise<{ socket: WebSocket; message: unknown }> {

--- a/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
+++ b/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
@@ -509,6 +509,88 @@ describe('MainNetworkDevtoolsService gating', () => {
     }
   })
 
+  it('does not install the panel when the service stops after capture was already live', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const service = new MainNetworkDevtoolsService()
+    let releaseCapture: ((live: boolean) => void) | undefined
+    vi.spyOn(service as unknown as { startCapture: () => Promise<boolean> }, 'startCapture').mockImplementation(
+      () => new Promise<boolean>((resolve) => (releaseCapture = resolve))
+    )
+
+    await service._doInit()
+    const allReady = service._doAllReady()
+    await service._doStop()
+    // Capture reports success only after the stop — the panel must not follow it into a dead session.
+    releaseCapture?.(true)
+    await allReady
+
+    expect(installBundledDevtools).not.toHaveBeenCalled()
+  })
+
+  it('reports a busy monitor port as a failure instead of resolving', async () => {
+    const service = new MainNetworkDevtoolsService()
+    const serviceState = service as unknown as { startWebSocketServer: (port?: number) => Promise<number> }
+    const squatter = createServer()
+    const port = await listenOnAnyPort(squatter)
+
+    try {
+      await expect(serviceState.startWebSocketServer(port)).rejects.toThrow(/EADDRINUSE/)
+    } finally {
+      await new Promise<void>((resolve) => squatter.close(() => resolve()))
+      await service._doStop()
+    }
+  })
+
+  it('does not install the panel when the monitor port is taken, and binds again once it frees up', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const originalNetFetch = net.fetch
+    const service = new MainNetworkDevtoolsService()
+    const startWebSocketServer = vi
+      .spyOn(service as unknown as { startWebSocketServer: () => Promise<number> }, 'startWebSocketServer')
+      .mockRejectedValue(Object.assign(new Error('listen EADDRINUSE 127.0.0.1:38997'), { code: 'EADDRINUSE' }))
+
+    try {
+      await service._doInit()
+      await service._doAllReady()
+
+      // A panel with no monitor behind it shows zero requests — the bug being fixed.
+      expect(installBundledDevtools).not.toHaveBeenCalled()
+
+      startWebSocketServer.mockResolvedValue(38997)
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', false)
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+      await vi.waitFor(() => expect(installBundledDevtools).toHaveBeenCalledTimes(1))
+
+      await net.fetch('https://api.test/v1/models')
+      expect(readEvents(service).at(-1)).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+    } finally {
+      await service._doStop()
+    }
+
+    expect(net.fetch).toBe(originalNetFetch)
+  })
+
+  it('takes the monitor port again after a restart released it', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const service = new MainNetworkDevtoolsService()
+    const startWebSocketServer = vi
+      .spyOn(service as unknown as { startWebSocketServer: () => Promise<number> }, 'startWebSocketServer')
+      .mockResolvedValue(38997)
+
+    await service._doInit()
+    await service._doAllReady()
+    expect(startWebSocketServer).toHaveBeenCalledTimes(1)
+    await service._doStop()
+
+    vi.mocked(app.isReady).mockReturnValue(true)
+    try {
+      await service._doInit()
+      expect(startWebSocketServer).toHaveBeenCalledTimes(2)
+    } finally {
+      await service._doStop()
+    }
+  })
+
   it('captures boot-time requests in development regardless of the developer mode preference', async () => {
     platformState.isDev = true
     const originalNetFetch = net.fetch
@@ -544,6 +626,17 @@ function readEvents(service: MainNetworkDevtoolsService): MainNetworkDevtoolsEve
 
 function isOriginAllowed(service: MainNetworkDevtoolsService, origin: string): boolean {
   return (service as unknown as { isOriginAllowed: (origin: string) => boolean }).isOriginAllowed(origin)
+}
+
+/** Listen on a free localhost port and report which one, so tests never fight over 38997. */
+async function listenOnAnyPort(server: ReturnType<typeof createServer>): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ host: '127.0.0.1', port: 0 }, resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Server did not expose a TCP port')
+  return address.port
 }
 
 /** Bind and release a localhost port; rejects while something else still holds it. */

--- a/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
+++ b/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 
 import { BaseService } from '@main/core/lifecycle'
+import type * as PlatformModule from '@main/core/platform'
 import { net } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import WebSocket from 'ws'
@@ -35,7 +36,16 @@ vi.mock('@main/core/devtools', () => ({
   installBundledDevtools: vi.fn()
 }))
 
+const platformState = { isDev: false }
+vi.mock('@main/core/platform', async (importOriginal) => ({
+  ...(await importOriginal<typeof PlatformModule>()),
+  get isDev() {
+    return platformState.isDev
+  }
+}))
+
 import { installBundledDevtools } from '@main/core/devtools'
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 
 import {
   captureRequestBody,
@@ -226,21 +236,6 @@ describe('MainNetworkDevtoolsService helpers', () => {
     expect(serviceState.isOriginAllowed('chrome-extension://other-id')).toBe(false)
   })
 
-  it('installs its own bundled panel once the app is ready and allowlists the resolved extension origin', async () => {
-    vi.mocked(installBundledDevtools).mockImplementation(async (_directoryName, _displayName, onInstalled) => {
-      onInstalled?.({ id: 'main-network-id', name: 'Main Network' })
-    })
-
-    const service = new MainNetworkDevtoolsService()
-    // Panel install must hang off onAllReady, not onInit: this service runs in the
-    // Background phase, which starts before app.whenReady() resolves.
-    await service._doAllReady()
-
-    expect(installBundledDevtools).toHaveBeenCalledWith('main-network', 'Main Network', expect.any(Function))
-    const serviceState = service as unknown as { isOriginAllowed: (origin: string | undefined) => boolean }
-    expect(serviceState.isOriginAllowed('chrome-extension://main-network-id')).toBe(true)
-  })
-
   it('enforces the registered DevTools extension origin on live websocket connections', async () => {
     const service = new MainNetworkDevtoolsService()
     const serviceState = service as unknown as {
@@ -320,6 +315,105 @@ describe('MainNetworkDevtoolsService helpers', () => {
     })
   })
 })
+
+describe('MainNetworkDevtoolsService gating', () => {
+  beforeEach(() => {
+    BaseService.resetInstances()
+    platformState.isDev = false
+    MockMainPreferenceServiceUtils.resetMocks()
+    vi.mocked(installBundledDevtools)
+      .mockReset()
+      .mockImplementation(async (_directoryName, _displayName, onInstalled) => {
+        onInstalled?.({ id: 'main-network-id', name: 'Main Network' })
+      })
+    vi.mocked(net.fetch)
+      .mockReset()
+      .mockImplementation(async () => new Response('{}', { status: 200 }))
+  })
+
+  afterEach(() => {
+    BaseService.resetInstances()
+    platformState.isDev = false
+  })
+
+  it('leaves main-process requests untouched in a packaged build with developer mode off', async () => {
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    try {
+      await service._doInit()
+      await service._doAllReady()
+
+      expect(net.fetch).toBe(originalNetFetch)
+      await net.fetch('https://api.test/v1/models')
+
+      expect(readEvents(service)).toHaveLength(0)
+      expect(installBundledDevtools).not.toHaveBeenCalled()
+    } finally {
+      await service._doStop()
+    }
+  })
+
+  it('captures main-process requests and installs the panel in a packaged build with developer mode on', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    try {
+      // The Background phase runs alongside BeforeReady, so the preference is not
+      // readable yet — nothing may be patched before onAllReady.
+      await service._doInit()
+      expect(net.fetch).toBe(originalNetFetch)
+
+      await service._doAllReady()
+      await net.fetch('https://api.test/v1/models')
+
+      expect(readEvents(service)[0]).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+      expect(installBundledDevtools).toHaveBeenCalledWith('main-network', 'Main Network', expect.any(Function))
+      expect(isOriginAllowed(service, 'chrome-extension://main-network-id')).toBe(true)
+    } finally {
+      await service._doStop()
+    }
+
+    expect(net.fetch).toBe(originalNetFetch)
+  })
+
+  it('captures boot-time requests in development regardless of the developer mode preference', async () => {
+    platformState.isDev = true
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    try {
+      await service._doInit()
+
+      expect(net.fetch).not.toBe(originalNetFetch)
+      await net.fetch('https://api.test/v1/models')
+      expect(readEvents(service)).toHaveLength(1)
+    } finally {
+      await service._doStop()
+    }
+
+    expect(net.fetch).toBe(originalNetFetch)
+  })
+})
+
+/** Build a service whose websocket server is stubbed out so tests never bind the fixed port. */
+function createStartedService(): MainNetworkDevtoolsService {
+  const service = new MainNetworkDevtoolsService()
+  vi.spyOn(
+    service as unknown as { startWebSocketServer: () => Promise<number> },
+    'startWebSocketServer'
+  ).mockResolvedValue(38997)
+  return service
+}
+
+function readEvents(service: MainNetworkDevtoolsService): MainNetworkDevtoolsEvent[] {
+  return (service as unknown as { events: MainNetworkDevtoolsEvent[] }).events
+}
+
+function isOriginAllowed(service: MainNetworkDevtoolsService, origin: string): boolean {
+  return (service as unknown as { isOriginAllowed: (origin: string) => boolean }).isOriginAllowed(origin)
+}
 
 function openSocketWithMessage(port: number, origin: string): Promise<{ socket: WebSocket; message: unknown }> {
   return new Promise((resolve, reject) => {

--- a/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
+++ b/src/main/services/mainNetworkDevtools/__tests__/MainNetworkDevtoolsService.test.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from 'node:events'
+import { createServer } from 'node:net'
 
 import { BaseService } from '@main/core/lifecycle'
 import type * as PlatformModule from '@main/core/platform'
-import { net } from 'electron'
+import { app, net } from 'electron'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import WebSocket from 'ws'
 
@@ -320,6 +321,7 @@ describe('MainNetworkDevtoolsService gating', () => {
   beforeEach(() => {
     BaseService.resetInstances()
     platformState.isDev = false
+    vi.mocked(app.isReady).mockReturnValue(false)
     MockMainPreferenceServiceUtils.resetMocks()
     vi.mocked(installBundledDevtools)
       .mockReset()
@@ -418,6 +420,95 @@ describe('MainNetworkDevtoolsService gating', () => {
     }
   })
 
+  it('captures again after a restart, even though onAllReady only fires once', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    await service._doInit()
+    await service._doAllReady()
+    await service._doStop()
+    expect(net.fetch).toBe(originalNetFetch)
+
+    // A restart only replays _doInit(); it always happens after the app is ready.
+    vi.mocked(app.isReady).mockReturnValue(true)
+    try {
+      await service._doInit()
+      await net.fetch('https://api.test/v1/models')
+
+      expect(readEvents(service).at(-1)).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+    } finally {
+      await service._doStop()
+    }
+
+    expect(net.fetch).toBe(originalNetFetch)
+  })
+
+  it('watches the developer mode preference again after a restart', async () => {
+    const originalNetFetch = net.fetch
+    const service = createStartedService()
+
+    await service._doInit()
+    await service._doAllReady()
+    await service._doStop()
+
+    vi.mocked(app.isReady).mockReturnValue(true)
+    try {
+      await service._doInit()
+      expect(net.fetch).toBe(originalNetFetch)
+
+      MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+      await vi.waitFor(() => expect(installBundledDevtools).toHaveBeenCalled())
+
+      await net.fetch('https://api.test/v1/models')
+      expect(readEvents(service).at(-1)).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+    } finally {
+      await service._doStop()
+    }
+  })
+
+  it('releases the websocket port when the service stops while the server is still binding', async () => {
+    const service = new MainNetworkDevtoolsService()
+    const serviceState = service as unknown as { startWebSocketServer: (port?: number) => Promise<number> }
+
+    // Binding completes on an I/O turn, so the stop below always lands inside the await window.
+    const listening = serviceState.startWebSocketServer(0)
+    await service._doStop()
+    const port = await listening
+
+    // server.close() is asynchronous, so poll until the port is free again.
+    await vi.waitFor(() => bindPort(port))
+  })
+
+  it('does not install the panel when the service stops while capture is still starting', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.developer_mode.enabled', true)
+    const service = new MainNetworkDevtoolsService()
+    let releaseServer: ((port: number) => void) | undefined
+    const startWebSocketServer = vi
+      .spyOn(service as unknown as { startWebSocketServer: () => Promise<number> }, 'startWebSocketServer')
+      .mockImplementation(() => new Promise<number>((resolve) => (releaseServer = resolve)))
+
+    await service._doInit()
+    const allReady = service._doAllReady()
+    await service._doStop()
+    releaseServer?.(38997)
+    await allReady
+
+    expect(installBundledDevtools).not.toHaveBeenCalled()
+
+    startWebSocketServer.mockResolvedValue(38997)
+    vi.mocked(app.isReady).mockReturnValue(true)
+    try {
+      await service._doInit()
+      await net.fetch('https://api.test/v1/models')
+
+      expect(installBundledDevtools).toHaveBeenCalledTimes(1)
+      expect(readEvents(service).at(-1)).toMatchObject({ method: 'GET', url: 'https://api.test/v1/models' })
+    } finally {
+      await service._doStop()
+    }
+  })
+
   it('captures boot-time requests in development regardless of the developer mode preference', async () => {
     platformState.isDev = true
     const originalNetFetch = net.fetch
@@ -453,6 +544,16 @@ function readEvents(service: MainNetworkDevtoolsService): MainNetworkDevtoolsEve
 
 function isOriginAllowed(service: MainNetworkDevtoolsService, origin: string): boolean {
   return (service as unknown as { isOriginAllowed: (origin: string) => boolean }).isOriginAllowed(origin)
+}
+
+/** Bind and release a localhost port; rejects while something else still holds it. */
+async function bindPort(port: number): Promise<void> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ host: '127.0.0.1', port }, resolve)
+  })
+  await new Promise<void>((resolve) => server.close(() => resolve()))
 }
 
 async function flushMicrotasks(): Promise<void> {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

- V2 issues model traffic from the main process, which the renderer DevTools Network tab cannot see. The **Main Network** panel exists for exactly this, but it was unreachable in release builds: `MainNetworkDevtoolsService` was `@Conditional(when(() => isDev))`, and `electron-builder.yml` excluded `resources/devtools/**` from the package, so the extension was never shipped.
- The service also had latent restart/port bugs that a dev-only service could hide: `capturing` / `enabled` never reset on stop, `onAllReady` fires only once per instance, the websocket close-disposable was registered after the list had already been flushed on stop (leaking the listener and making later restarts fail with `EADDRINUSE`), and a failed bind on `127.0.0.1:38997` still installed the panel — showing the user an empty Main Network tab, the exact symptom the feature exists to remove.

After this PR:

- The service is registered unconditionally and decides per environment. `isDev` still starts monitoring in `onInit`, keeping boot-time coverage; packaged builds read `app.developer_mode.enabled` in `onAllReady` (the `Background` phase runs alongside the `BeforeReady` phase that loads `PreferenceService`, so the preference is not readable any earlier).
- Toggling developer mode **on** takes effect immediately via `preferences.subscribeChange` — no restart. Toggling it **off** stops at the next launch rather than pulling `globalThis.fetch` / `net.fetch` / `http.request` out from under in-flight requests, matching `NodeTraceService`.
- The main-network panel is packaged (`resources/devtools/data-api/**` stays dev-only) and resolved through `app.asar.unpacked`, since Chromium reads an unpacked extension off disk and cannot load one from a virtual asar path.
- "Patches installed" is split from "monitor is live": `startCapture()` reports whether it holds the port, `enable()` rolls back and installs nothing when it does not, and `onStop()` resets the flags so a restart re-acquires the port. A generation counter bumped on stop lets an in-flight start notice it was abandoned and close its own server.

Fixes # N/A

### Why we need it and why it was done in this way

Main-process network traffic is invisible in the renderer DevTools Network tab, so users reporting model-request problems on a release build have no way to show what actually went over the wire. The panel already existed and was already written; the only thing missing was shipping it and gating it on a switch the user has to deliberately flip.

The following tradeoffs were made:

- **Enable is live, disable is next-launch.** Un-patching `globalThis.fetch` / `net.fetch` / `http.request` mid-session would strand in-flight requests on a patched-then-restored call path. `NodeTraceService` already draws this line; this follows it rather than inventing a second convention.
- **Failed port bind means the panel stays hidden.** Installing the panel with nothing behind port 38997 yields an empty tab that reads as "the feature is broken". Staying off is honest and the next toggle/restart retries the bind.
- **`onInit` re-runs setup when `app.isReady()`.** `onAllReady` is guarded by `BaseService._allReadyCalled`, which never resets, so a `restart()` would otherwise leave the service permanently silent. `app.isReady()` is precisely the "this is not first bootstrap" signal.

The following alternatives were considered:

- **A dynamic monitor port.** Rejected: the panel pins `connect-src` to `ws://127.0.0.1:38997` in its manifest, so a dynamic port means widening that to any localhost websocket — the wrong direction for a diagnostic surface now shipping in release builds.
- **Leaving the service `@Conditional(isDev)` and shipping nothing.** Rejected: that is the status quo that leaves release-build main-process traffic uninspectable.

Links to places where the discussion took place: None

### Breaking changes

None. The panel is off by default in packaged builds and only appears once the user enables developer mode. Development behavior is unchanged.

### Special notes for your reviewer

- `electron-builder.yml` now flips from excluding all of `resources/devtools/**` to excluding only `resources/devtools/data-api/**`, in both `files` and `asarUnpack`. The data-api panel stays dev-only.
- `installBundledDevtools` now routes the extension path through `toAsarUnpackedPath`; this is a no-op in development and required in packaged builds.
- Tests cover the new paths: restart re-acquiring the port, stop-during-start closing its own server, a failed bind leaving the panel uninstalled, and the developer-mode toggle enabling without a restart.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Release builds can now inspect main-process network traffic: enable developer mode to get the Main Network DevTools panel, which shows the model requests the renderer Network tab cannot see. Turning developer mode on applies immediately; turning it off takes effect on the next launch.
```
