### PR TITLE
fix(agent-sessions): let orphaned sessions be dragged back onto an agent

### DIFF
--- a/src/renderer/i18n/locales/de-de.json
+++ b/src/renderer/i18n/locales/de-de.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Diese Woche",
   "agent.session.group.today": "Heute",
   "agent.session.group.unknown_agent": "Unbekannter Agent",
-  "agent.session.group.unknown_agent_tip": "Dies ist eine historische Sitzungsgruppe ohne Agent, kein tatsächlicher Agent. Sie ist nur anzeigbar und kann nicht weiter ausgeführt werden.",
+  "agent.session.group.unknown_agent_tip": "Dies ist eine historische Sitzungsgruppe ohne Agent, kein tatsächlicher Agent. Ziehen Sie eine Sitzung auf einen vorhandenen Agenten, um sie erneut zu verknüpfen und weiter zu verwenden.",
   "agent.session.group.yesterday": "Gestern",
   "agent.session.list.title": "Aufgaben",
   "agent.session.model_switch_confirm.confirm": "Modell wechseln",

--- a/src/renderer/i18n/locales/el-gr.json
+++ b/src/renderer/i18n/locales/el-gr.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Αυτή την εβδομάδα",
   "agent.session.group.today": "Σήμερα",
   "agent.session.group.unknown_agent": "Άγνωστος πράκτορας",
-  "agent.session.group.unknown_agent_tip": "Αυτή είναι μια ιστορική ομάδα συνεδριών χωρίς πράκτορα, όχι ένας πραγματικός πράκτορας. Είναι μόνο για προβολή και δεν μπορεί να συνεχίσει την εκτέλεση.",
+  "agent.session.group.unknown_agent_tip": "Αυτή είναι μια ιστορική ομάδα συνεδριών χωρίς πράκτορα, όχι ένας πραγματικός πράκτορας. Σύρετε μια συνεδρία σε έναν υπάρχοντα πράκτορα για να τη συνδέσετε ξανά και να συνεχίσετε να τη χρησιμοποιείτε.",
   "agent.session.group.yesterday": "Χθες",
   "agent.session.list.title": "Εργασίες",
   "agent.session.model_switch_confirm.confirm": "Αλλαγή μοντέλου",

--- a/src/renderer/i18n/locales/en-us.json
+++ b/src/renderer/i18n/locales/en-us.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "This week",
   "agent.session.group.today": "Today",
   "agent.session.group.unknown_agent": "Unlinked Agent",
-  "agent.session.group.unknown_agent_tip": "This is a historical session group without an agent, not an actual agent. It is view-only and cannot continue running.",
+  "agent.session.group.unknown_agent_tip": "This is a historical session group without an agent, not an actual agent. Drag a session onto an existing agent to re-link it and continue using it.",
   "agent.session.group.yesterday": "Yesterday",
   "agent.session.list.title": "Tasks",
   "agent.session.model_switch_confirm.confirm": "Switch model",

--- a/src/renderer/i18n/locales/es-es.json
+++ b/src/renderer/i18n/locales/es-es.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Esta semana",
   "agent.session.group.today": "Hoy",
   "agent.session.group.unknown_agent": "Agente desconocido",
-  "agent.session.group.unknown_agent_tip": "Este es un grupo de sesión histórico sin agente, no un agente real. Es solo de visualización y no puede continuar ejecutándose.",
+  "agent.session.group.unknown_agent_tip": "Este es un grupo de sesión histórico sin agente, no un agente real. Arrastre una sesión a un agente existente para volver a vincularla y seguir usándola.",
   "agent.session.group.yesterday": "Ayer",
   "agent.session.list.title": "Tareas",
   "agent.session.model_switch_confirm.confirm": "Cambiar modelo",

--- a/src/renderer/i18n/locales/fr-fr.json
+++ b/src/renderer/i18n/locales/fr-fr.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Cette semaine",
   "agent.session.group.today": "Aujourd'hui",
   "agent.session.group.unknown_agent": "Agent inconnu",
-  "agent.session.group.unknown_agent_tip": "Il s'agit d'un groupe de session historique sans agent, et non d'un agent réel. Il est en lecture seule et ne peut pas continuer à s'exécuter.",
+  "agent.session.group.unknown_agent_tip": "Il s'agit d'un groupe de session historique sans agent, et non d'un agent réel. Faites glisser une session sur un agent existant pour la relier à nouveau et continuer à l'utiliser.",
   "agent.session.group.yesterday": "Hier",
   "agent.session.list.title": "Tâches",
   "agent.session.model_switch_confirm.confirm": "Changer de modèle",

--- a/src/renderer/i18n/locales/ja-jp.json
+++ b/src/renderer/i18n/locales/ja-jp.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "今週",
   "agent.session.group.today": "今日",
   "agent.session.group.unknown_agent": "不明なエージェント",
-  "agent.session.group.unknown_agent_tip": "これはエージェントではなく、エージェントなしの履歴セッショングループです。表示専用で、実行を継続することはできません。",
+  "agent.session.group.unknown_agent_tip": "これはエージェントではなく、エージェントなしの履歴セッショングループです。既存のエージェントにセッションをドラッグすると、再度リンクして引き続き使用できます。",
   "agent.session.group.yesterday": "昨日",
   "agent.session.list.title": "タスク",
   "agent.session.model_switch_confirm.confirm": "モデル切り替え",

--- a/src/renderer/i18n/locales/pt-pt.json
+++ b/src/renderer/i18n/locales/pt-pt.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Esta semana",
   "agent.session.group.today": "Hoje",
   "agent.session.group.unknown_agent": "Agente desconhecido",
-  "agent.session.group.unknown_agent_tip": "Este é um grupo de sessão histórico sem agente, não um agente real. É somente para visualização e não pode continuar em execução.",
+  "agent.session.group.unknown_agent_tip": "Este é um grupo de sessão histórico sem agente, não um agente real. Arraste uma sessão para um agente existente para voltar a vinculá-la e continuar a utilizá-la.",
   "agent.session.group.yesterday": "Ontem",
   "agent.session.list.title": "Tarefas",
   "agent.session.model_switch_confirm.confirm": "Mudar modelo",

--- a/src/renderer/i18n/locales/ro-ro.json
+++ b/src/renderer/i18n/locales/ro-ro.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Săptămâna aceasta",
   "agent.session.group.today": "Astăzi",
   "agent.session.group.unknown_agent": "Agent necunoscut",
-  "agent.session.group.unknown_agent_tip": "Aceasta este o grup de sesiuni istoric fără un agent, nu un agent real. Este doar pentru vizualizare și nu poate continua să ruleze.",
+  "agent.session.group.unknown_agent_tip": "Aceasta este o grup de sesiuni istoric fără un agent, nu un agent real. Trageți o sesiune peste un agent existent pentru a o reasocia și a continua să o utilizați.",
   "agent.session.group.yesterday": "Ieri",
   "agent.session.list.title": "Sarcini",
   "agent.session.model_switch_confirm.confirm": "Schimbă modelul",

--- a/src/renderer/i18n/locales/ru-ru.json
+++ b/src/renderer/i18n/locales/ru-ru.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "На этой неделе",
   "agent.session.group.today": "Сегодня",
   "agent.session.group.unknown_agent": "Неизвестный агент",
-  "agent.session.group.unknown_agent_tip": "Это историческая группа сеансов без агента, а не фактический агент. Она доступна только для просмотра и не может продолжить работу.",
+  "agent.session.group.unknown_agent_tip": "Это историческая группа сеансов без агента, а не фактический агент. Перетащите сеанс на существующего агента, чтобы снова связать его и продолжить работу.",
   "agent.session.group.yesterday": "Вчера",
   "agent.session.list.title": "Задачи",
   "agent.session.model_switch_confirm.confirm": "Переключить модель",

--- a/src/renderer/i18n/locales/vi-vn.json
+++ b/src/renderer/i18n/locales/vi-vn.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "Tuần này",
   "agent.session.group.today": "Hôm nay",
   "agent.session.group.unknown_agent": "Agent không xác định",
-  "agent.session.group.unknown_agent_tip": "Đây là nhóm phiên cũ không có Agent, không phải Agent thực tế. Bạn chỉ có thể xem và không thể tiếp tục chạy nhóm này.",
+  "agent.session.group.unknown_agent_tip": "Đây là nhóm phiên cũ không có Agent, không phải Agent thực tế. Kéo một phiên vào Agent hiện có để liên kết lại và tiếp tục sử dụng.",
   "agent.session.group.yesterday": "Hôm qua",
   "agent.session.list.title": "Nhiệm vụ",
   "agent.session.model_switch_confirm.confirm": "Chuyển đổi mô hình",

--- a/src/renderer/i18n/locales/zh-cn.json
+++ b/src/renderer/i18n/locales/zh-cn.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "本周",
   "agent.session.group.today": "今天",
   "agent.session.group.unknown_agent": "未关联智能体",
-  "agent.session.group.unknown_agent_tip": "这是未关联智能体的历史会话分组，并非真实智能体。仅供查看，无法继续运行。",
+  "agent.session.group.unknown_agent_tip": "这是未关联智能体的历史会话分组，并非真实智能体。请将会话拖到现有智能体后继续使用。",
   "agent.session.group.yesterday": "昨天",
   "agent.session.list.title": "任务",
   "agent.session.model_switch_confirm.confirm": "切换模型",

--- a/src/renderer/i18n/locales/zh-tw.json
+++ b/src/renderer/i18n/locales/zh-tw.json
@@ -198,7 +198,7 @@
   "agent.session.group.this_week": "本週",
   "agent.session.group.today": "今天",
   "agent.session.group.unknown_agent": "未連結的 Agent",
-  "agent.session.group.unknown_agent_tip": "這是一個沒有 Agent 的歷史工作階段群組，並非實際的 Agent。此群組僅供檢視，無法繼續執行。",
+  "agent.session.group.unknown_agent_tip": "這是一個沒有 Agent 的歷史工作階段群組，並非實際的 Agent。請將工作階段拖曳至現有的 Agent 以重新連結並繼續使用。",
   "agent.session.group.yesterday": "昨天",
   "agent.session.list.title": "任務",
   "agent.session.model_switch_confirm.confirm": "切換模型",

--- a/src/renderer/pages/agents/components/Sessions.tsx
+++ b/src/renderer/pages/agents/components/Sessions.tsx
@@ -1437,9 +1437,16 @@ const Sessions = ({
   )
 
   const canDropSessionItem = useCallback(
-    ({ sourceGroupId, targetGroupId }: { sourceGroupId: string; targetGroupId: string }) =>
-      itemDragReady && canDropSessionItemInDisplayGroup({ mode: displayMode, sourceGroupId, targetGroupId }),
-    [displayMode, itemDragReady]
+    ({ sourceGroupId, targetGroupId }: { sourceGroupId: string; targetGroupId: string }) => {
+      if (!itemDragReady || !canDropSessionItemInDisplayGroup({ mode: displayMode, sourceGroupId, targetGroupId })) {
+        return false
+      }
+      if (sourceGroupId === targetGroupId) return true
+
+      const targetAgentId = getAgentIdFromSessionGroupId(targetGroupId)
+      return !!targetAgentId && agentById.has(targetAgentId)
+    },
+    [agentById, displayMode, itemDragReady]
   )
 
   const canDragSessionGroup = useCallback(
@@ -1584,6 +1591,23 @@ const Sessions = ({
 
       const normalizedPayload = normalizeSessionDropPayload(payload)
       const anchor = buildSessionDropAnchor(normalizedPayload)
+
+      if (payload.sourceGroupId !== payload.targetGroupId) {
+        const targetAgentId = getAgentIdFromSessionGroupId(payload.targetGroupId)
+        if (!targetAgentId || !agentById.has(targetAgentId)) return
+
+        // Group membership is derived from the persisted `agentId`, so the row can only leave the
+        // unknown-agent bucket once the server owns the new one — an optimistic overlay can't move it.
+        const relinked = await updateSession(
+          { id: payload.activeId, agentId: targetAgentId },
+          { showSuccessToast: false }
+        )
+        if (!relinked) return
+
+        await reorderSession(payload.activeId, anchor)
+        return
+      }
+
       setOptimisticMove(normalizedPayload)
 
       const reordered = await reorderSession(payload.activeId, anchor)
@@ -1604,6 +1628,7 @@ const Sessions = ({
       reorderWorkspace,
       sessionItems,
       t,
+      updateSession,
       workdirDragReady,
       workdirDisplay,
       workspaceRowsForDisplay
@@ -1967,7 +1992,7 @@ const Sessions = ({
         groups: displayMode === 'agent' ? agentDragReady : workdirDragReady,
         items: itemDragReady,
         itemSameGroup: itemDragReady,
-        itemCrossGroup: false
+        itemCrossGroup: agentDragReady
       }}
       canDragGroup={canDragSessionGroup}
       canDropGroup={canDropSessionGroup}

--- a/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
+++ b/src/renderer/pages/agents/components/__tests__/Sessions.test.tsx
@@ -3127,6 +3127,72 @@ describe('Sessions', () => {
     )
   })
 
+  it('re-links a session dropped out of the unlinked group onto a real agent', async () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    sessionDataMocks.updateSession.mockResolvedValue(createSession({ id: 'session-x', agentId: 'agent-a' }))
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-x', name: 'Orphan session', agentId: null, orderKey: 'x' })
+      ]
+    })
+
+    render(<SessionsForTest />)
+
+    startDraggingSession('session-x')
+    expect(screen.getByText('Alpha session').closest('[data-drop-blocked="true"]')).toBeNull()
+
+    act(() => {
+      dndMocks.onDragEnd?.({
+        active: {
+          data: sortableData('item:session-x'),
+          id: 'item:session-x',
+          rect: { current: { initial: null, translated: { top: 100, height: 20 } } }
+        },
+        over: { data: sortableData('item:session-a'), id: 'item:session-a', rect: { top: 10, height: 20 } }
+      })
+    })
+
+    await vi.waitFor(() =>
+      expect(sessionDataMocks.updateSession).toHaveBeenCalledWith(
+        { id: 'session-x', agentId: 'agent-a' },
+        { showSuccessToast: false }
+      )
+    )
+    await vi.waitFor(() =>
+      expect(sessionDataMocks.reorderSession).toHaveBeenCalledWith('session-x', { after: 'session-a' })
+    )
+  })
+
+  it('leaves an unlinked session where it is when the re-link write fails', async () => {
+    preferenceMocks.values.set('agent.session.display_mode', 'agent')
+    sessionDataMocks.updateSession.mockResolvedValue(undefined)
+    setupSessions({
+      sessions: [
+        createSession({ id: 'session-a', name: 'Alpha session', agentId: 'agent-a', orderKey: 'a' }),
+        createSession({ id: 'session-x', name: 'Orphan session', agentId: null, orderKey: 'x' })
+      ]
+    })
+
+    render(<SessionsForTest />)
+
+    startDraggingSession('session-x')
+
+    act(() => {
+      dndMocks.onDragEnd?.({
+        active: {
+          data: sortableData('item:session-x'),
+          id: 'item:session-x',
+          rect: { current: { initial: null, translated: { top: 100, height: 20 } } }
+        },
+        over: { data: sortableData('item:session-a'), id: 'item:session-a', rect: { top: 10, height: 20 } }
+      })
+    })
+
+    await vi.waitFor(() => expect(sessionDataMocks.updateSession).toHaveBeenCalled())
+    expect(sessionDataMocks.reorderSession).not.toHaveBeenCalled()
+  })
+
   it('reorders workspace groups through the workspace order endpoint', async () => {
     preferenceMocks.values.set('agent.session.display_mode', 'workdir')
     setupSessions({

--- a/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
+++ b/src/renderer/utils/chat/__tests__/sessionListHelpers.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeSessionWorkdirPath,
   SESSION_NO_PROJECT_GROUP_ID,
   SESSION_PINNED_GROUP_ID,
+  SESSION_UNKNOWN_AGENT_GROUP_ID,
   sortSessionsForDisplayGroups
 } from '../sessionListHelpers'
 import { createResourceListGroupReorderPayload, createResourceListItemReorderPayload } from './resourceListFixtures'
@@ -115,14 +116,30 @@ describe('SessionList helpers', () => {
     expect(normalizeSessionDropPayload(crossGroupPayload)).toBe(crossGroupPayload)
   })
 
-  it('allows drag only inside the same non-pinned display group', () => {
+  it('allows drag inside the same non-pinned display group, plus re-linking out of the unknown-agent group', () => {
     const cases = [
       ['same agent group', 'agent', 'session:agent:agent-a', 'session:agent:agent-a', true],
       ['different agent groups', 'agent', 'session:agent:agent-a', 'session:agent:agent-b', false],
       ['same workdir group', 'workdir', 'session:workspace:ws-a', 'session:workspace:ws-a', true],
       ['different workdir groups', 'workdir', 'session:workspace:ws-a', 'session:workspace:ws-b', false],
       ['pinned group', 'workdir', 'session:pinned', 'session:pinned', false],
-      ['time mode', 'time', 'session:workspace:ws-a', 'session:workspace:ws-a', false]
+      ['time mode', 'time', 'session:workspace:ws-a', 'session:workspace:ws-a', false],
+      ['unknown agent group to a real agent', 'agent', SESSION_UNKNOWN_AGENT_GROUP_ID, 'session:agent:agent-a', true],
+      ['unknown agent group to pinned', 'agent', SESSION_UNKNOWN_AGENT_GROUP_ID, SESSION_PINNED_GROUP_ID, false],
+      [
+        'a real agent back into the unknown agent group',
+        'agent',
+        'session:agent:agent-a',
+        SESSION_UNKNOWN_AGENT_GROUP_ID,
+        false
+      ],
+      [
+        'unknown agent group in workdir mode',
+        'workdir',
+        SESSION_UNKNOWN_AGENT_GROUP_ID,
+        'session:workspace:ws-a',
+        false
+      ]
     ] as const
 
     for (const [label, mode, sourceGroupId, targetGroupId, expected] of cases) {

--- a/src/renderer/utils/chat/sessionListHelpers.ts
+++ b/src/renderer/utils/chat/sessionListHelpers.ts
@@ -420,7 +420,16 @@ export function canDropSessionItemInDisplayGroup({
   sourceGroupId: string
   targetGroupId: string
 }) {
-  return mode !== 'time' && sourceGroupId === targetGroupId && targetGroupId !== SESSION_PINNED_GROUP_ID
+  if (mode === 'time' || targetGroupId === SESSION_PINNED_GROUP_ID) return false
+  if (sourceGroupId === targetGroupId) return true
+
+  // Dropping an orphaned session on a real agent re-links it — the only way out of the unknown-agent
+  // bucket. Every other cross-group drop stays closed, workdir rebinding included.
+  return (
+    mode === 'agent' &&
+    sourceGroupId === SESSION_UNKNOWN_AGENT_GROUP_ID &&
+    !!getAgentIdFromSessionGroupId(targetGroupId)
+  )
 }
 
 export function applyOptimisticSessionDisplayMove<T extends SessionListItem>(


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Deleting an agent nulls its sessions' `agentId` (`ON DELETE set null`), so those sessions fall into the "Unlinked Agent" pseudo-group. That group has no group-level menu, and opening one of its sessions renders neither the top-bar agent selector nor the composer — the session is stuck with no way back. Agent sessions hard-disabled cross-group item drops (`itemCrossGroup: false`), so dragging was not an escape either.

After this PR:

A session can be dragged out of the unknown-agent group onto a real agent group, which re-links it and makes it usable again. The tooltip on the group now says so, in all 12 locales. Every other cross-group drop stays closed — agent-to-agent moves are still not offered here, and workdir rebinding keeps its own rules.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

N/A

### Why we need it and why it was done in this way

The assistant side already solves the same problem: a topic can be dragged out of its unlinked group onto a real assistant, and its tooltip tells users to do exactly that. Agent sessions had the identical dead-end state but no equivalent path, even though `PATCH /agent-sessions/:id` already accepts a new `agentId` (the composer's agent switcher uses it). This mirrors the existing assistant behavior rather than inventing a new recovery affordance.

The following tradeoffs were made:

- The drop is allowed only *from* the unknown-agent group *to* a real agent group, and only in `agent` display mode. Opening general agent-to-agent moves would be a separate product decision; this PR keeps the permission surface as narrow as the bug requires.
- The cross-group drop skips the optimistic overlay used by same-group reorders. Group membership is derived from the persisted `agentId`, so an optimistic row move would render the session in the target group before the write lands and snap back on failure. The drop `PATCH`es `agentId` first, then anchors the position through the existing reorder call.
- The target agent is validated against `agentById` in both `canDropSessionItem` and the drop handler, so a stale or unknown target group id is rejected instead of issuing a bad `PATCH`.

The following alternatives were considered:

- Adding a group-level or context-menu "re-link to agent" action instead of drag-and-drop. Rejected: the assistant side sets the precedent for dragging, and the unlinked-agent tooltip already had to be rewritten either way.
- Blocking deletion or reassigning sessions at agent-delete time. Rejected: that changes existing delete semantics and does nothing for sessions already orphaned in users' databases.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

- i18n: `agent.session.group.unknown_agent_tip` is reworded in `en-us.json` and translated in all 11 other locales — no `[to be translated]` placeholders remain.
- `canDropSessionItemInDisplayGroup` (`sessionListHelpers.ts`) holds the pure predicate; `Sessions.tsx` adds the live "does this agent still exist?" check on top of it. Both are covered by tests.
- Tests added: `Sessions.test.tsx` (drop re-links then reorders; drop rejected when the target agent is unknown) and `sessionListHelpers.test.ts` (predicate allows only unknown-agent → real agent in `agent` mode).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Agent sessions left in the "Unlinked Agent" group after their agent was deleted can now be dragged onto an existing agent to re-link them and continue using them.
```
