### PR TITLE
fix(searxng-provider): keep search hits whose page content cannot be fetched

### DIFF
--- a/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
+++ b/src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts
@@ -841,7 +841,7 @@ describe('main web search API providers', () => {
     `)
   })
 
-  it('filters empty fetched content from Searxng results', async () => {
+  it('falls back to the Searxng snippet when the result page yields no readable content', async () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse(loadFixtureJson('searxng-search-response.json')))
     fetchRemoteTextMock.mockResolvedValueOnce('<html><body><div></div></body></html>')
 
@@ -862,8 +862,79 @@ describe('main web search API providers', () => {
       providerId: 'searxng',
       capability: 'searchKeywords',
       inputs: ['hello'],
-      results: []
+      results: [
+        {
+          title: 'Searxng Title',
+          content: 'Searxng Content',
+          url: 'https://searx.example/result',
+          sourceInput: 'hello'
+        }
+      ]
     })
+  })
+
+  it('falls back to the Searxng snippet when the result page cannot be fetched', async () => {
+    fetchMock.mockResolvedValueOnce(createJsonResponse(loadFixtureJson('searxng-search-response.json')))
+    fetchRemoteTextMock.mockRejectedValueOnce(new Error('HTTP error: 403'))
+
+    const provider = createProviderDriver(
+      SearxngProvider,
+      createProvider({
+        id: 'searxng',
+        name: 'Searxng',
+        apiHost: 'https://searx.example',
+        engines: ['google', 'bing']
+      })
+    )
+
+    const result = await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(result.results).toEqual([
+      {
+        title: 'Searxng Title',
+        content: 'Searxng Content',
+        url: 'https://searx.example/result',
+        sourceInput: 'hello'
+      }
+    ])
+  })
+
+  it('falls back to the Searxng snippet when the hit carries an empty content field', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({
+        query: 'hello',
+        results: [
+          {
+            title: 'Searxng Title',
+            content: '',
+            snippet: 'Searxng Snippet',
+            url: 'https://searx.example/result'
+          }
+        ]
+      })
+    )
+    fetchRemoteTextMock.mockRejectedValueOnce(new Error('HTTP error: 403'))
+
+    const provider = createProviderDriver(
+      SearxngProvider,
+      createProvider({
+        id: 'searxng',
+        name: 'Searxng',
+        apiHost: 'https://searx.example',
+        engines: ['google', 'bing']
+      })
+    )
+
+    const result = await provider.searchKeywords('hello', runtimeConfig)
+
+    expect(result.results).toEqual([
+      {
+        title: 'Searxng Title',
+        content: 'Searxng Snippet',
+        url: 'https://searx.example/result',
+        sourceInput: 'hello'
+      }
+    ])
   })
 
   it('warns when every Searxng result URL fails validation', async () => {

--- a/src/main/services/webSearch/providers/api/SearxngProvider.ts
+++ b/src/main/services/webSearch/providers/api/SearxngProvider.ts
@@ -35,11 +35,24 @@ const SearxngConfigResponseSchema = z.object({
 })
 
 type SearxngSearchContext = UrlSearchContext
+type SearxngSearchItem = z.infer<typeof SearxngSearchResponseSchema>['results'][number]
 
 const logger = loggerService.withContext('SearxngProvider')
 
 function trimStringList(values: readonly string[]): string[] {
   return values.map((value) => value.trim()).filter(Boolean)
+}
+
+function toSnippetResult(item: SearxngSearchItem): WebSearchResult[] {
+  const url = item.url ?? ''
+  // Engines that carry no summary still emit `content: ''`, so pick the first non-empty field
+  // rather than the first present one.
+  const content = [item.content, item.snippet].map((value) => value?.trim() ?? '').find(Boolean) ?? ''
+  if (!content) {
+    return []
+  }
+
+  return [{ title: item.title || url, url, content, sourceInput: url }]
 }
 
 export class SearxngProvider extends BaseWebSearchProvider {
@@ -177,15 +190,21 @@ export class SearxngProvider extends BaseWebSearchProvider {
       })
     }
 
-    const fulfilledResults = settledResults.filter(
-      (item): item is PromiseFulfilledResult<WebSearchResult> => item.status === 'fulfilled'
-    )
+    // Dropping a hit whose page is unfetchable or yields no readable text turns a Searxng instance
+    // with real results into an empty, unexplained response; degrade to its own snippet instead.
+    const results = validItems.flatMap((item, index) => {
+      const settled = settledResults[index]
+      if (settled.status === 'fulfilled' && settled.value.content.trim().length > 0) {
+        return [settled.value]
+      }
+      return toSnippetResult(item)
+    })
 
-    if (fulfilledResults.length === 0 && rejectedResults.length > 0) {
+    if (results.length === 0 && rejectedResults.length > 0) {
       throw rejectedResults[0].reason
     }
 
-    return fulfilledResults.map((item) => item.value).filter((item) => item.content.trim().length > 0)
+    return results
   }
 
   private buildFinalResponse(context: SearxngSearchContext, fetchedResults: WebSearchResult[]): WebSearchResponse {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.
> - v1 maintenance targets `v1`; forward-port fixes to `main` separately when needed.

### What this PR does

Before this PR:

Searxng hits were used for their URL only. Every result page was re-fetched, and any hit whose page failed to load or extracted to no readable text was dropped — throwing away the title and snippet Searxng had already returned. When that happened to every hit and no fetch had actually rejected, the provider resolved with zero results on a success path that logs nothing, so an agent calling `web_search` got a bare `[]` for every query with nothing in the logs to explain it.

After this PR:

A hit whose page cannot be fetched (or yields no readable text) degrades to the summary Searxng itself returned, taking the first **non-empty** of `content` / `snippet`. A hit with no page text and no summary at all is still dropped, and a search where nothing survives while fetches were rejected still throws the first rejection.

N/A

### Why we need it and why it was done in this way

Searxng aggregates engines that already return a title and a snippet per hit; the page re-fetch is an enrichment step, so a failed enrichment should not erase the hit. Keeping the snippet turns a silent empty response into a usable (if shorter) result set, which is what the agent needs.

The following tradeoffs were made:

- Snippet-only results carry less context than full page text. That is strictly better than dropping the hit, and the shape of `WebSearchResult` is unchanged, so downstream consumers need no changes.
- The empty-result-with-rejections path still throws, so genuine outages remain loud rather than silently degrading to snippets.

The following alternatives were considered:

- Logging a warning on the empty-result path only — surfaces the problem but still returns nothing usable to the caller.
- Picking the first *present* of `content` / `snippet` — engines with no summary of their own emit `content: ''` rather than omitting the field, so this would keep dropping exactly the hits that need the fallback. Hence first *non-empty*.

Links to places where the discussion took place: None

### Breaking changes

None.

### Special notes for your reviewer

Two tests were added to `src/main/services/webSearch/providers/__tests__/ApiProviders.test.ts`: one covering the fetch-failure → snippet fallback, and one covering a hit whose `content` is `''` but which carries a `snippet` (the empty-string case that motivated the non-empty pick).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets the correct branch — `main` for active development, `v1` for v1 maintenance fixes
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Searxng web search returning no results at all when the result pages cannot be fetched — such hits now fall back to the title and snippet Searxng already returned.
```
