### PR TITLE
perf(resource-selector): defer data reads until opened

### DIFF
--- a/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AgentSelector.tsx
@@ -83,7 +83,10 @@ export function AgentSelector(props: AgentSelectorProps) {
 
   // Keep in lockstep with TasksSettings' agents query — they share one SWR
   // cache entry only while path + query serialize identically.
-  const { data, isLoading, refetch } = useQuery('/agents', { query: { limit: AGENTS_MAX_LIMIT } })
+  const { data, isLoading, refetch } = useQuery('/agents', {
+    enabled: selectorOpen,
+    query: { limit: AGENTS_MAX_LIMIT }
+  })
   const { createAgent, isCreatingAgent } = useAgentMutations()
   const {
     isLoading: isPinnedLoading,
@@ -92,7 +95,7 @@ export function AgentSelector(props: AgentSelectorProps) {
     pinnedIds,
     refetch: refetchPins,
     togglePin
-  } = usePins('agent')
+  } = usePins('agent', { enabled: selectorOpen })
   const isPinActionDisabled = isPinnedLoading || isPinsRefreshing || isPinsMutating
 
   const items: AgentSelectorItem[] = useMemo(

--- a/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/AssistantSelector.tsx
@@ -112,8 +112,11 @@ export function AssistantSelector(props: AssistantSelectorProps) {
 
   // `limit: 500` matches ListAssistantsQuerySchema's max; realistic libraries sit well under it.
   // If a user ever exceeds this we should move to usePaginatedQuery + scroll-load inside the popover.
-  const { data, isLoading, refetch } = useQuery('/assistants', { query: { limit: 500 } })
-  const { groups, isLoading: isGroupsLoading } = useGroups('assistant')
+  const { data, isLoading, refetch } = useQuery('/assistants', {
+    enabled: selectorOpen,
+    query: { limit: 500 }
+  })
+  const { groups, isLoading: isGroupsLoading } = useGroups('assistant', { enabled: selectorOpen })
   const { trigger: createAssistant, isLoading: isCreatingAssistant } = useMutation('POST', '/assistants', {
     refresh: ['/assistants']
   })
@@ -124,7 +127,7 @@ export function AssistantSelector(props: AssistantSelectorProps) {
     pinnedIds,
     refetch: refetchPins,
     togglePin
-  } = usePins('assistant')
+  } = usePins('assistant', { enabled: selectorOpen })
   const isPinActionDisabled = isPinnedLoading || isPinsRefreshing || isPinsMutating
 
   const groupById = useMemo(() => new Map(groups.map((group) => [group.id, group] as const)), [groups])

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -8,6 +8,8 @@ import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  agentPinReadMock,
+  agentReadMock,
   createAgentMock,
   refetchAgentsMock,
   refetchPinsMock,
@@ -18,6 +20,8 @@ const {
   useProvidersMock,
   useQueryMock
 } = vi.hoisted(() => ({
+  agentPinReadMock: vi.fn(),
+  agentReadMock: vi.fn(),
   createAgentMock: vi.fn(),
   refetchAgentsMock: vi.fn(),
   refetchPinsMock: vi.fn(),
@@ -273,8 +277,10 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  useQueryMock.mockImplementation((path: string) => {
-    const data = path === '/agents/:agentId' ? AGENTS_RESPONSE.items[0] : AGENTS_RESPONSE
+  useQueryMock.mockImplementation((path: string, options?: { enabled?: boolean }) => {
+    const enabled = path !== '/agents' || options?.enabled !== false
+    if (path === '/agents' && enabled) agentReadMock()
+    const data = enabled ? (path === '/agents/:agentId' ? AGENTS_RESPONSE.items[0] : AGENTS_RESPONSE) : undefined
     return {
       data,
       isLoading: false,
@@ -310,14 +316,17 @@ beforeEach(() => {
     ...AGENTS_RESPONSE.items[0],
     name: 'Renamed Agent'
   })
-  usePinsMock.mockReturnValue({
-    isLoading: false,
-    isRefreshing: false,
-    isMutating: false,
-    error: undefined,
-    pinnedIds: [],
-    refetch: refetchPinsMock,
-    togglePin: togglePinMock
+  usePinsMock.mockImplementation((_entityType: string, options?: { enabled?: boolean }) => {
+    if (options?.enabled !== false) agentPinReadMock()
+    return {
+      isLoading: false,
+      isRefreshing: false,
+      isMutating: false,
+      error: undefined,
+      pinnedIds: [],
+      refetch: refetchPinsMock,
+      togglePin: togglePinMock
+    }
   })
   useProvidersMock.mockReturnValue({
     providers: [{ id: 'provider', endpointConfigs: { 'anthropic-messages': {} } }]
@@ -346,11 +355,23 @@ async function openCreateDialog() {
 }
 
 describe('AgentSelector', () => {
+  it('defers selector reads until the popover opens', () => {
+    renderSelector()
+
+    expect(agentReadMock).not.toHaveBeenCalled()
+    expect(agentPinReadMock).not.toHaveBeenCalled()
+
+    openPopover()
+
+    expect(agentReadMock).toHaveBeenCalled()
+    expect(agentPinReadMock).toHaveBeenCalled()
+    expect(screen.getByRole('option', { name: /Alpha Agent/ })).toBeInTheDocument()
+  })
+
   it('fetches agents from DataApi and renders returned rows', () => {
     renderSelector()
     openPopover()
 
-    expect(useQueryMock).toHaveBeenCalledWith('/agents', { query: { limit: 500 } })
     expect(screen.getByRole('option', { name: /Alpha Agent/ })).toBeInTheDocument()
     expect(screen.getByRole('option', { name: /Beta Agent/ })).toBeInTheDocument()
     const options = screen.getAllByRole('option')
@@ -449,7 +470,6 @@ describe('AgentSelector', () => {
     renderSelector()
     openPopover()
 
-    expect(usePinsMock).toHaveBeenCalledWith('agent')
     expect(screen.getByText('Pinned')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Unpin' }))

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -8,21 +8,29 @@ import type * as ReactI18next from 'react-i18next'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  assistantGroupReadMock,
+  assistantPinReadMock,
+  assistantReadMock,
   createAssistantMock,
   refetchAssistantsMock,
   refetchPinsMock,
   togglePinMock,
   updateAssistantMock,
   useMutationMock,
+  useGroupsMock,
   usePinsMock,
   useQueryMock
 } = vi.hoisted(() => ({
+  assistantGroupReadMock: vi.fn(),
+  assistantPinReadMock: vi.fn(),
+  assistantReadMock: vi.fn(),
   createAssistantMock: vi.fn(),
   refetchAssistantsMock: vi.fn(),
   refetchPinsMock: vi.fn(),
   togglePinMock: vi.fn(),
   updateAssistantMock: vi.fn(),
   useMutationMock: vi.fn(),
+  useGroupsMock: vi.fn(),
   usePinsMock: vi.fn(),
   useQueryMock: vi.fn()
 }))
@@ -87,35 +95,7 @@ vi.mock('@renderer/hooks/usePins', () => ({
 }))
 
 vi.mock('@renderer/hooks/useGroups', () => ({
-  useGroups: () => ({
-    groups: [
-      {
-        id: '33333333-3333-4333-8333-333333333333',
-        entityType: 'assistant',
-        name: 'work',
-        orderKey: 'a0',
-        createdAt: '2024-01-01T00:00:00.000Z',
-        updatedAt: '2024-01-01T00:00:00.000Z'
-      },
-      {
-        id: '44444444-4444-4444-8444-444444444444',
-        entityType: 'assistant',
-        name: 'personal',
-        orderKey: 'a1',
-        createdAt: '2024-01-01T00:00:00.000Z',
-        updatedAt: '2024-01-01T00:00:00.000Z'
-      },
-      {
-        id: '55555555-5555-4555-8555-555555555555',
-        entityType: 'assistant',
-        name: 'empty',
-        orderKey: 'a2',
-        createdAt: '2024-01-01T00:00:00.000Z',
-        updatedAt: '2024-01-01T00:00:00.000Z'
-      }
-    ],
-    isLoading: false
-  }),
+  useGroups: useGroupsMock,
   useGroupMutations: () => ({
     createGroup: vi.fn()
   })
@@ -289,8 +269,10 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  useQueryMock.mockImplementation((path: string) => {
-    const data = path === '/assistants/:id' ? ASSISTANTS_RESPONSE.items[0] : ASSISTANTS_RESPONSE
+  useQueryMock.mockImplementation((path: string, options?: { enabled?: boolean }) => {
+    const enabled = path !== '/assistants' || options?.enabled !== false
+    if (path === '/assistants' && enabled) assistantReadMock()
+    const data = enabled ? (path === '/assistants/:id' ? ASSISTANTS_RESPONSE.items[0] : ASSISTANTS_RESPONSE) : undefined
     return {
       data,
       isLoading: false,
@@ -325,14 +307,52 @@ beforeEach(() => {
     ...ASSISTANTS_RESPONSE.items[0],
     name: 'Renamed Assistant'
   })
-  usePinsMock.mockReturnValue({
-    isLoading: false,
-    isRefreshing: false,
-    isMutating: false,
-    error: undefined,
-    pinnedIds: [],
-    refetch: refetchPinsMock,
-    togglePin: togglePinMock
+  useGroupsMock.mockImplementation((_entityType: string, options?: { enabled?: boolean }) => {
+    const enabled = options?.enabled !== false
+    if (enabled) assistantGroupReadMock()
+    return {
+      groups: enabled
+        ? [
+            {
+              id: '33333333-3333-4333-8333-333333333333',
+              entityType: 'assistant',
+              name: 'work',
+              orderKey: 'a0',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              updatedAt: '2024-01-01T00:00:00.000Z'
+            },
+            {
+              id: '44444444-4444-4444-8444-444444444444',
+              entityType: 'assistant',
+              name: 'personal',
+              orderKey: 'a1',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              updatedAt: '2024-01-01T00:00:00.000Z'
+            },
+            {
+              id: '55555555-5555-4555-8555-555555555555',
+              entityType: 'assistant',
+              name: 'empty',
+              orderKey: 'a2',
+              createdAt: '2024-01-01T00:00:00.000Z',
+              updatedAt: '2024-01-01T00:00:00.000Z'
+            }
+          ]
+        : [],
+      isLoading: false
+    }
+  })
+  usePinsMock.mockImplementation((_entityType: string, options?: { enabled?: boolean }) => {
+    if (options?.enabled !== false) assistantPinReadMock()
+    return {
+      isLoading: false,
+      isRefreshing: false,
+      isMutating: false,
+      error: undefined,
+      pinnedIds: [],
+      refetch: refetchPinsMock,
+      togglePin: togglePinMock
+    }
   })
 })
 
@@ -359,6 +379,21 @@ async function openCreateDialog() {
 }
 
 describe('AssistantSelector', () => {
+  it('defers selector reads until the popover opens', () => {
+    renderSelector()
+
+    expect(assistantReadMock).not.toHaveBeenCalled()
+    expect(assistantGroupReadMock).not.toHaveBeenCalled()
+    expect(assistantPinReadMock).not.toHaveBeenCalled()
+
+    openPopover()
+
+    expect(assistantReadMock).toHaveBeenCalled()
+    expect(assistantGroupReadMock).toHaveBeenCalled()
+    expect(assistantPinReadMock).toHaveBeenCalled()
+    expect(screen.getByRole('option', { name: /Alpha Assistant/ })).toBeInTheDocument()
+  })
+
   it('renders rows in DataApi order and shows group filters without sort controls', () => {
     renderSelector()
     openPopover()

--- a/src/renderer/hooks/__tests__/usePins.test.ts
+++ b/src/renderer/hooks/__tests__/usePins.test.ts
@@ -1,4 +1,5 @@
 import type { Pin } from '@shared/data/types/pin'
+import { MockDataApiUtils } from '@test-mocks/renderer/DataApiService'
 import { MockUseDataApiUtils, mockUseMutation, mockUseQuery } from '@test-mocks/renderer/useDataApi'
 import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -96,6 +97,7 @@ function wireMutations(overrides?: {
 describe('usePins', () => {
   beforeEach(() => {
     MockUseDataApiUtils.resetMocks()
+    MockDataApiUtils.resetMocks()
   })
 
   it('passes the configured entityType through to the /pins query', () => {
@@ -119,7 +121,7 @@ describe('usePins', () => {
     expect(refetch).toHaveBeenCalledTimes(1)
   })
 
-  it('disables the /pins query and toggle when enabled is false', async () => {
+  it('disables the /pins query, subscription, and toggle when enabled is false', async () => {
     const consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
     wirePins([MODEL_PIN_A])
     const { postTrigger, deleteTrigger } = wireMutations()
@@ -127,6 +129,7 @@ describe('usePins', () => {
     const { result } = renderHook(() => usePins('model', { enabled: false }))
 
     expect(mockUseQuery).toHaveBeenCalledWith('/pins', { enabled: false, query: { entityType: 'model' } })
+    expect(MockDataApiUtils.getCurrentState().dataChangeListeners.has('/pins')).toBe(false)
     expect(result.current.pinnedIds).toEqual([])
 
     await act(async () => {

--- a/src/renderer/hooks/usePins.ts
+++ b/src/renderer/hooks/usePins.ts
@@ -43,9 +43,7 @@ export function usePins(entityType: EntityType, options: UsePinsOptions = {}): U
     refetch
   } = useQuery('/pins', { enabled, query: { entityType } })
 
-  useDataChange('/pins', () => {
-    if (enabled) void refetch()
-  })
+  useDataChange(enabled ? '/pins' : [], () => void refetch())
 
   const {
     trigger: createPin,


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/pull_request_template.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Closed Assistant and Agent selectors queried up to 500 rows and activated their group and pin reads as soon as the persistent conversation controls mounted.

After this PR:

Selector-owned DataApi, group, and pin reads remain disabled until the selector opens. Opening still performs the existing pin refresh and cached data remains reusable on later opens.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19607

### Why we need it and why it was done in this way

The selectors are optional surfaces on the normal composer path, and all three existing hooks already expose an `enabled` option. Gating at those owning call sites avoids SQLite work, subscriptions, and large-array mapping without changing selector lifecycle or UX.

The following tradeoffs were made:

The existing 500-row limit and pin refresh-on-open behavior are unchanged; pagination changes remain outside this focused fix.

The following alternatives were considered:

Unmounting the complete selector controls was rejected because it would broaden the change into trigger/dialog lifecycle behavior. Relying only on SWR caching was rejected because the first closed mount would still perform the unwanted reads.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19607

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Focused renderer regressions prove Assistant DataApi/group/pin reads and Agent DataApi/pin reads remain inactive while closed, then load and render normally after opening.

Validation:

- `pnpm test:renderer src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx` (29 tests)
- changed-file Biome, Oxlint, and ESLint
- `pnpm run typecheck:web`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/everything/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
