### PR TITLE
fix(app-startup): restore launch-on-boot reconciliation

### DIFF
--- a/src/main/core/application/serviceRegistry.ts
+++ b/src/main/core/application/serviceRegistry.ts
@@ -30,6 +30,7 @@ import { KnowledgeService, KnowledgeVectorStoreService } from '@main/features/kn
 import { IpcApiService } from '@main/ipc/IpcApiService'
 import { AnalyticsService } from '@main/services/AnalyticsService'
 import { AppMenuService } from '@main/services/AppMenuService'
+import { AppService } from '@main/services/AppService'
 import { AppUpdaterService } from '@main/services/AppUpdaterService'
 import { AutoBackupService } from '@main/services/AutoBackupService'
 import { BinaryManager } from '@main/services/binaryManager'
@@ -99,6 +100,7 @@ export const services = {
   TesseractRuntimeService,
   AnalyticsService,
   AppMenuService,
+  AppService,
   CodeCliService,
   CommandService,
   ConversationNavigationService,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -11,7 +11,6 @@ import { IpcChannel } from '@shared/IpcChannel'
 import { dialog } from 'electron'
 
 import { skillService } from './ai/skills/SkillService'
-import { appService } from './services/AppService'
 import { copilotService } from './services/CopilotService'
 import { fileStorage as fileManager } from './services/FileStorage'
 import FileService from './services/FileSystemService'
@@ -37,11 +36,6 @@ export async function registerIpc() {
 
   // MainWindow_Reload handler moved into MainWindowService.registerIpcHandlers.
   // Application lifecycle handlers live in core/application/Application.ts (registerApplicationIpc).
-
-  // launch on boot
-  handleGuarded(IpcChannel.App_SetLaunchOnBoot, async (_, isLaunchOnBoot: boolean) => {
-    await appService.setAppLaunchOnBoot(isLaunchOnBoot)
-  })
 
   // // theme
   // handleGuarded(IpcChannel.App_SetTheme, (_, theme: ThemeMode) => {

--- a/src/main/services/AppService.ts
+++ b/src/main/services/AppService.ts
@@ -1,5 +1,7 @@
 import { application } from '@application'
 import { loggerService } from '@logger'
+import { createLatestReconciler, type LatestReconciler } from '@main/core/concurrency/latestReconciler'
+import { BaseService, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { isDev, isLinux, isMac, isPortable, isWin } from '@main/core/platform'
 import { app } from 'electron'
 import fs from 'fs'
@@ -7,7 +9,47 @@ import path from 'path'
 
 const logger = loggerService.withContext('AppService')
 
-export class AppService {
+@Injectable('AppService')
+@ServicePhase(Phase.WhenReady)
+export class AppService extends BaseService {
+  private acceptingPreferenceChanges = false
+  private desiredLaunchOnBoot = false
+  private appliedLaunchOnBoot: boolean | undefined
+  private readonly launchOnBootReconciler: LatestReconciler = createLatestReconciler<{
+    desired: boolean
+    applied: boolean | undefined
+  }>({
+    name: 'appLaunchOnBoot',
+    getSnapshot: () => ({ desired: this.desiredLaunchOnBoot, applied: this.appliedLaunchOnBoot }),
+    isSettled: ({ desired, applied }) => desired === applied,
+    apply: async ({ desired }) => {
+      await this.setAppLaunchOnBoot(desired)
+      this.appliedLaunchOnBoot = desired
+    },
+    onError: (error) => logger.error('Failed to reconcile launch on boot:', error as Error)
+  })
+
+  protected async onInit(): Promise<void> {
+    this.acceptingPreferenceChanges = true
+    this.appliedLaunchOnBoot = undefined
+    const preferenceService = application.get('PreferenceService')
+    this.registerDisposable(
+      preferenceService.subscribeChange('app.launch_on_boot', (isLaunchOnBoot) => {
+        if (!this.acceptingPreferenceChanges) return
+        this.desiredLaunchOnBoot = isLaunchOnBoot
+        this.launchOnBootReconciler.request()
+      })
+    )
+    this.desiredLaunchOnBoot = preferenceService.get('app.launch_on_boot')
+    this.launchOnBootReconciler.request()
+    await this.launchOnBootReconciler.flush()
+  }
+
+  protected async onStop(): Promise<void> {
+    this.acceptingPreferenceChanges = false
+    await this.launchOnBootReconciler.flush()
+  }
+
   public async setAppLaunchOnBoot(isLaunchOnBoot: boolean): Promise<void> {
     // Set login item settings for windows and mac
     // linux is not supported because it requires more file operations
@@ -23,27 +65,27 @@ export class AppService {
 
       app.setLoginItemSettings(settings)
     } else if (isLinux) {
-      try {
-        const autostartDir = application.getPath('sys.appdata.autostart')
-        const desktopFile = path.join(autostartDir, isDev ? 'cherry-studio-dev.desktop' : 'cherry-studio.desktop')
+      const autostartDir = application.getPath('sys.appdata.autostart')
+      const desktopFile = path.join(autostartDir, isDev ? 'cherry-studio-dev.desktop' : 'cherry-studio.desktop')
 
-        if (isLaunchOnBoot) {
-          // Ensure autostart directory exists
-          try {
-            await fs.promises.access(autostartDir)
-          } catch {
-            await fs.promises.mkdir(autostartDir, { recursive: true })
-          }
+      if (isLaunchOnBoot) {
+        // Ensure autostart directory exists
+        try {
+          await fs.promises.access(autostartDir)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+          await fs.promises.mkdir(autostartDir, { recursive: true })
+        }
 
-          // Get executable path
-          let executablePath = application.getPath('app.exe_file')
-          if (process.env.APPIMAGE) {
-            // For AppImage packaged apps, use APPIMAGE environment variable
-            executablePath = process.env.APPIMAGE
-          }
+        // Get executable path
+        let executablePath = application.getPath('app.exe_file')
+        if (process.env.APPIMAGE) {
+          // For AppImage packaged apps, use APPIMAGE environment variable
+          executablePath = process.env.APPIMAGE
+        }
 
-          // Create desktop file content
-          const desktopContent = `[Desktop Entry]
+        // Create desktop file content
+        const desktopContent = `[Desktop Entry]
   Type=Application
   Name=Cherry Studio
   Comment=A powerful AI assistant for producer.
@@ -55,24 +97,20 @@ export class AppService {
   X-GNOME-Autostart-enabled=true
   Hidden=false`
 
-          // Write desktop file
-          await fs.promises.writeFile(desktopFile, desktopContent)
-          logger.info('Created autostart desktop file for Linux')
-        } else {
-          // Remove desktop file
-          try {
-            await fs.promises.access(desktopFile)
-            await fs.promises.unlink(desktopFile)
-            logger.info('Removed autostart desktop file for Linux')
-          } catch {
-            // File doesn't exist, no need to remove
-          }
+        // Write desktop file
+        await fs.promises.writeFile(desktopFile, desktopContent)
+        logger.info('Created autostart desktop file for Linux')
+      } else {
+        // Remove desktop file
+        try {
+          await fs.promises.access(desktopFile)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+          throw error
         }
-      } catch (error) {
-        logger.error('Failed to set launch on boot for Linux:', error as Error)
+        await fs.promises.unlink(desktopFile)
+        logger.info('Removed autostart desktop file for Linux')
       }
     }
   }
 }
-
-export const appService = new AppService()

--- a/src/main/services/__tests__/AppService.test.ts
+++ b/src/main/services/__tests__/AppService.test.ts
@@ -1,76 +1,214 @@
+import { BaseService } from '@main/core/lifecycle'
+import path from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({
-  isDev: false,
-  isLinux: false,
-  isMac: false,
-  isPortable: true,
-  isWin: true,
-  setLoginItemSettings: vi.fn()
+const { setLoginItemSettingsMock, platform, accessMock, mkdirMock, writeFileMock, unlinkMock } = vi.hoisted(() => ({
+  setLoginItemSettingsMock: vi.fn(),
+  platform: { isDev: false, isLinux: false, isMac: false, isPortable: false, isWin: true },
+  accessMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  writeFileMock: vi.fn(),
+  unlinkMock: vi.fn()
 }))
+
+vi.mock('@application', async () => {
+  const { mockApplicationFactory } = await import('@test-mocks/main/application')
+  return mockApplicationFactory()
+})
 
 vi.mock('@main/core/platform', () => ({
   get isDev() {
-    return mocks.isDev
+    return platform.isDev
   },
   get isLinux() {
-    return mocks.isLinux
+    return platform.isLinux
   },
   get isMac() {
-    return mocks.isMac
+    return platform.isMac
   },
   get isPortable() {
-    return mocks.isPortable
+    return platform.isPortable
   },
   get isWin() {
-    return mocks.isWin
+    return platform.isWin
   }
 }))
-vi.mock('electron', () => ({
-  app: { setLoginItemSettings: mocks.setLoginItemSettings }
+
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      access: accessMock,
+      mkdir: mkdirMock,
+      writeFile: writeFileMock,
+      unlink: unlinkMock
+    }
+  }
 }))
 
-import { AppService } from '../AppService'
+vi.mock('electron', () => ({
+  app: { setLoginItemSettings: setLoginItemSettingsMock }
+}))
 
-describe('AppService.setAppLaunchOnBoot', () => {
+import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
+
+const { AppService } = await import('../AppService')
+
+const autostartDir = '/mock/sys.appdata.autostart'
+const desktopFile = path.join(autostartDir, 'cherry-studio.desktop')
+const linuxFiles = new Set<string>()
+let autostartDirExists = false
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('AppService', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
   })
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    vi.stubEnv('PORTABLE_EXECUTABLE_FILE', 'D:\\Apps\\Cherry Studio Portable.exe')
-    mocks.isLinux = false
-    mocks.isMac = false
-    mocks.isPortable = true
-    mocks.isWin = true
+    BaseService.resetInstances()
+    platform.isDev = false
+    platform.isLinux = false
+    platform.isMac = false
+    platform.isPortable = false
+    platform.isWin = true
+    autostartDirExists = false
+    linuxFiles.clear()
+    setLoginItemSettingsMock.mockReset()
+    accessMock.mockReset()
+    mkdirMock.mockReset()
+    writeFileMock.mockReset()
+    unlinkMock.mockReset()
+    accessMock.mockImplementation(async (target: string) => {
+      if ((target === autostartDir && autostartDirExists) || (target === desktopFile && linuxFiles.has(target))) return
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    mkdirMock.mockImplementation(async () => {
+      autostartDirExists = true
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      linuxFiles.add(target)
+    })
+    unlinkMock.mockImplementation(async (target: string) => {
+      linuxFiles.delete(target)
+    })
+    MockMainPreferenceServiceUtils.resetMocks()
+  })
+
+  it('reconciles the persisted launch-on-boot preference during startup', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    const service = new AppService()
+
+    await service._doInit()
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledOnce()
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
+  })
+
+  it('applies launch-on-boot preference changes to the system', async () => {
+    const service = new AppService()
+    await service._doInit()
+    setLoginItemSettingsMock.mockClear()
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    await vi.waitFor(() => expect(setLoginItemSettingsMock).toHaveBeenCalledOnce())
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    await vi.waitFor(() => expect(setLoginItemSettingsMock).toHaveBeenCalledTimes(2))
+    expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(1, { openAtLogin: true })
+    expect(setLoginItemSettingsMock).toHaveBeenNthCalledWith(2, { openAtLogin: false })
   })
 
   it('registers the stable launcher for Windows portable builds', async () => {
-    await new AppService().setAppLaunchOnBoot(true)
+    platform.isPortable = true
+    vi.stubEnv('PORTABLE_EXECUTABLE_FILE', 'D:\\Apps\\Cherry Studio Portable.exe')
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
 
-    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({
+    await new AppService()._doInit()
+
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({
       openAtLogin: true,
       path: 'D:\\Apps\\Cherry Studio Portable.exe',
       args: []
     })
   })
 
-  it('uses Electron defaults for installed Windows builds', async () => {
-    mocks.isPortable = false
-
-    await new AppService().setAppLaunchOnBoot(false)
-
-    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false })
-  })
-
   it('uses Electron defaults on macOS', async () => {
-    mocks.isMac = true
-    mocks.isPortable = false
-    mocks.isWin = false
+    platform.isMac = true
+    platform.isWin = false
 
     await new AppService().setAppLaunchOnBoot(true)
 
-    expect(mocks.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true })
+    expect(setLoginItemSettingsMock).toHaveBeenCalledWith({ openAtLogin: true })
+  })
+
+  it('serializes Linux updates and converges to the latest preference', async () => {
+    platform.isLinux = true
+    platform.isWin = false
+    const service = new AppService()
+    await service._doInit()
+
+    const writeGate = deferred()
+    let writeStarted!: () => void
+    const writeStartedPromise = new Promise<void>((resolve) => {
+      writeStarted = resolve
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      writeStarted()
+      await writeGate.promise
+      linuxFiles.add(target)
+    })
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    await writeStartedPromise
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    writeGate.resolve()
+
+    await vi.waitFor(() => expect(unlinkMock).toHaveBeenCalledOnce())
+    expect(linuxFiles.has(desktopFile)).toBe(false)
+  })
+
+  it('waits for in-flight Linux updates before stopping and resubscribes on restart', async () => {
+    platform.isLinux = true
+    platform.isWin = false
+    const service = new AppService()
+    await service._doInit()
+
+    const writeGate = deferred()
+    let writeStarted!: () => void
+    const writeStartedPromise = new Promise<void>((resolve) => {
+      writeStarted = resolve
+    })
+    writeFileMock.mockImplementation(async (target: string) => {
+      writeStarted()
+      await writeGate.promise
+      linuxFiles.add(target)
+    })
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', true)
+    await writeStartedPromise
+    let stopped = false
+    const stopPromise = service._doStop().then(() => {
+      stopped = true
+    })
+    await Promise.resolve()
+    expect(stopped).toBe(false)
+
+    writeGate.resolve()
+    await stopPromise
+    expect(linuxFiles.has(desktopFile)).toBe(true)
+
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.launch_on_boot', false)
+    expect(unlinkMock).not.toHaveBeenCalled()
+
+    await service._doInit()
+    await vi.waitFor(() => expect(unlinkMock).toHaveBeenCalledOnce())
+    expect(linuxFiles.has(desktopFile)).toBe(false)
   })
 })

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -45,7 +45,6 @@ type ShortcutRegistrationConflictPayload = {
 
 // Custom APIs for renderer
 const api = {
-  setLaunchOnBoot: (isActive: boolean) => ipcRenderer.invoke(IpcChannel.App_SetLaunchOnBoot, isActive),
   select: (options: Electron.OpenDialogOptions) => ipcRenderer.invoke(IpcChannel.App_Select, options),
   hasWritePermission: (path: string) => ipcRenderer.invoke(IpcChannel.App_HasWritePermission, path),
   resolvePath: (path: string) => ipcRenderer.invoke(IpcChannel.App_ResolvePath, path),

--- a/src/shared/IpcChannel.ts
+++ b/src/shared/IpcChannel.ts
@@ -5,7 +5,6 @@
  * LAN transfer, and a handful of micro-domains.
  */
 export enum IpcChannel {
-  App_SetLaunchOnBoot = 'app:set-launch-on-boot',
   App_Select = 'app:select',
   App_HasWritePermission = 'app:has-write-permission',
   App_ResolvePath = 'app:resolve-path',


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/pull_request_template.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The v2 Launch on Startup switch only persisted `app.launch_on_boot`. The lifecycle reconciliation from #18225 had been reverted, so startup and live preference changes did not update OS login items.

After this PR:

`AppService` is lifecycle-managed again, reconciles the saved preference during startup, subscribes to live changes, and removes the unused legacy IPC/preload path. The later stable launcher path for Windows portable builds remains intact.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19602

### Why we need it and why it was done in this way

Preference is the v2 source of truth. A WhenReady lifecycle service makes startup/migration reconciliation and live changes converge through one serialized system-side effect, while the renderer remains preference-only.

The following tradeoffs were made:

The latest-wins reconciler coalesces rapid changes and waits for in-flight Linux writes during stop. The implementation deliberately retains #19285's `PORTABLE_EXECUTABLE_FILE` path and empty argument list.

The following alternatives were considered:

Restoring only the legacy preload IPC call was rejected because it would fix live toggles but not startup reconciliation or migrated preferences. A raw cherry-pick was rejected because it would discard the portable launcher support added after #18225.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19602 and https://github.com/CherryHQ/cherry-studio/pull/18225

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

The test suite merges the startup/runtime/Linux convergence coverage from #18225 with the existing portable Windows regression.

Validation:

- `vitest run --project main src/main/services/__tests__/AppService.test.ts` (6 tests)
- changed-file Biome, Oxlint, and ESLint
- `pnpm run typecheck:node`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/everything/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Fixed Launch on Startup so Cherry Studio registers with the operating system and reapplies the saved preference during app startup.
```
