### PR TITLE
perf(files): filter types before cursor pagination

### DIFF
--- a/src/main/data/services/FileEntryService.ts
+++ b/src/main/data/services/FileEntryService.ts
@@ -41,8 +41,24 @@ import {
   InternalEntrySchema,
   SafeNameSchema
 } from '@shared/data/types/file'
-import type { CanonicalFilePath } from '@shared/utils/file'
-import { and, asc, count, eq, gt, isNotNull, isNull, lt, type SQL, sql, type SQLWrapper } from 'drizzle-orm'
+import type { FileType } from '@shared/types/file'
+import { type CanonicalFilePath, fileTypeMap } from '@shared/utils/file'
+import {
+  and,
+  asc,
+  count,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  lt,
+  notInArray,
+  or,
+  type SQL,
+  sql,
+  type SQLWrapper
+} from 'drizzle-orm'
 import { v7 as uuidv7 } from 'uuid'
 import * as z from 'zod'
 import { ZodError } from 'zod'
@@ -114,6 +130,7 @@ export type ListFilesSortBy = 'name' | 'createdAt' | 'updatedAt' | 'size' | 'ext
 export interface ListCursorQuery {
   readonly origin?: FileEntryOrigin
   readonly inTrash?: boolean
+  readonly fileType?: FileType
   readonly sortBy?: ListFilesSortBy
   readonly sortOrder?: 'asc' | 'desc'
   readonly cursor?: string
@@ -372,6 +389,21 @@ const DEFAULT_LIST_SORT_ORDER: ListSortOrder = 'asc'
 const FILE_ENTRY_SIZE_NULL_SORT_VALUE = -1
 // SafeExtSchema rejects whitespace, so this non-empty cursor key is reserved for NULL ext and sorts before real ext values.
 const FILE_ENTRY_EXT_NULL_SORT_VALUE = ' '
+const FILE_EXTENSIONS_BY_TYPE = new Map<FileType, string[]>()
+for (const [extension, fileType] of Object.entries(fileTypeMap)) {
+  const extensions = FILE_EXTENSIONS_BY_TYPE.get(fileType) ?? []
+  extensions.push(extension)
+  FILE_EXTENSIONS_BY_TYPE.set(fileType, extensions)
+}
+const KNOWN_FILE_EXTENSIONS = Object.keys(fileTypeMap)
+
+function getFileTypeFilterCondition(fileType: FileType): SQL {
+  const normalizedExtension = sql<string>`lower(${fileEntryTable.ext})`
+  if (fileType === 'other') {
+    return or(isNull(fileEntryTable.ext), notInArray(normalizedExtension, KNOWN_FILE_EXTENSIONS))!
+  }
+  return inArray(normalizedExtension, FILE_EXTENSIONS_BY_TYPE.get(fileType) ?? [])
+}
 
 function getListSortValue(row: FileEntryRow, sortBy: ListSortBy): string | number {
   switch (sortBy) {
@@ -621,6 +653,9 @@ class FileEntryServiceImpl implements FileEntryService {
       filterConditions.push(isNotNull(fileEntryTable.deletedAt))
     } else {
       filterConditions.push(isNull(fileEntryTable.deletedAt))
+    }
+    if (query.fileType) {
+      filterConditions.push(getFileTypeFilterCondition(query.fileType))
     }
 
     const sortBy = query.sortBy ?? DEFAULT_LIST_SORT_BY

--- a/src/main/data/services/__tests__/FileEntryService.test.ts
+++ b/src/main/data/services/__tests__/FileEntryService.test.ts
@@ -549,6 +549,31 @@ describe('FileEntryService', () => {
       await dbh.db.insert(fileEntryTable).values(rows)
     }
 
+    async function seedFileTypes(): Promise<void> {
+      const now = Date.now()
+      const fixtures = [
+        ['image-a', 'png'],
+        ['image-b', 'JPG'],
+        ['image-c', 'webp'],
+        ['text', 'md'],
+        ['unknown', 'blobx'],
+        ['no-ext', null]
+      ] as const
+      await dbh.db.insert(fileEntryTable).values(
+        fixtures.map(([name, ext], index) => ({
+          id: `019606a0-0000-7000-8000-0000000002a${index}`,
+          origin: 'internal' as const,
+          name,
+          ext,
+          size: 1,
+          externalPath: null,
+          deletedAt: null,
+          createdAt: now + index,
+          updatedAt: now + index
+        }))
+      )
+    }
+
     it('returns { items, total, nextCursor } with active-only filtering by default', async () => {
       const now = Date.now()
       await dbh.db.insert(fileEntryTable).values([
@@ -599,6 +624,30 @@ describe('FileEntryService', () => {
       expect(page3.items.map((e) => e.name)).toEqual(['name4'])
       expect(page3.total).toBe(5)
       expect(page3.nextCursor).toBeUndefined()
+    })
+
+    it('filters known file types before cursor pagination and total counting', async () => {
+      await seedFileTypes()
+
+      const query = { fileType: 'image' as const, sortBy: 'name' as const, sortOrder: 'asc' as const, limit: 2 }
+      const page1 = fileEntryService.listCursor(query)
+      const page2 = fileEntryService.listCursor({ ...query, cursor: page1.nextCursor })
+
+      expect(page1.items.map((item) => item.name)).toEqual(['image-a', 'image-b'])
+      expect(page1.total).toBe(3)
+      expect(page1.nextCursor).toBeDefined()
+      expect(page2.items.map((item) => item.name)).toEqual(['image-c'])
+      expect(page2.total).toBe(3)
+      expect(page2.nextCursor).toBeUndefined()
+    })
+
+    it('classifies null and unknown extensions as other', async () => {
+      await seedFileTypes()
+
+      const result = fileEntryService.listCursor({ fileType: 'other', sortBy: 'name', sortOrder: 'asc' })
+
+      expect(result.items.map((item) => item.name)).toEqual(['no-ext', 'unknown'])
+      expect(result.total).toBe(2)
     })
 
     it('sorts ascending by createdAt by default; reverses with sortOrder=desc', async () => {

--- a/src/renderer/pages/files/FileGrid.tsx
+++ b/src/renderer/pages/files/FileGrid.tsx
@@ -60,7 +60,7 @@ export const FileGrid = memo(function FileGrid({
   isTrash: boolean
   menuActions: FileContextMenuActions
   scrollRef: RefObject<HTMLDivElement | null>
-  onLayoutChange: () => void
+  onLayoutChange?: () => void
   renamingId: string | null
   onRenameConfirm: (id: string, name: string) => void
   onRenameCancel: () => void
@@ -85,7 +85,7 @@ export const FileGrid = memo(function FileGrid({
   const totalSize = rowVirtualizer.getTotalSize()
 
   useEffect(() => {
-    onLayoutChange()
+    onLayoutChange?.()
   }, [columnCount, onLayoutChange, totalSize])
 
   return (

--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -340,7 +340,15 @@ function FilesPage() {
   // renders a friendly format label derived from `ext` (e.g. `md` → Markdown).
   // Sort by raw `ext` server-side so cursor pagination stays globally stable.
   const serverSortKey: ServerSortKey = sortKey === 'type' ? 'ext' : sortKey
-  const activeFilesQuery = useMemo(() => ({ sortBy: serverSortKey, sortOrder: sortDir }), [serverSortKey, sortDir])
+  const activeFileType = filter.kind === 'type' ? filter.value : undefined
+  const activeFilesQuery = useMemo(
+    () => ({
+      sortBy: serverSortKey,
+      sortOrder: sortDir,
+      ...(activeFileType && { fileType: activeFileType })
+    }),
+    [activeFileType, serverSortKey, sortDir]
+  )
   const trashedFilesQuery = useMemo(
     () => ({ inTrash: true, sortBy: serverSortKey, sortOrder: sortDir }),
     [serverSortKey, sortDir]
@@ -527,31 +535,6 @@ function FilesPage() {
     requestLoadMore
   ])
 
-  const maybeFillClientFilteredViewport = useCallback(() => {
-    // Type filters are applied client-side over the loaded active pages.
-    // If the filtered rows do not make the container scrollable, scroll-load
-    // cannot fire, so proactively fetch another active page until scrolling can engage.
-    if (filter.kind === 'library') return
-    const el = contentScrollRef.current
-    if (!el || !hasMoreActiveFiles || isLoadingMoreActiveFiles || pendingLoadMoreRef.current) return
-    if (el.scrollHeight > el.clientHeight) return
-
-    requestLoadMore(loadMoreActiveFiles)
-  }, [filter.kind, hasMoreActiveFiles, isLoadingMoreActiveFiles, loadMoreActiveFiles, requestLoadMore])
-
-  useEffect(() => {
-    if (filter.kind === 'library') return
-    const el = contentScrollRef.current
-    if (!el) return
-
-    maybeFillClientFilteredViewport()
-    if (typeof ResizeObserver === 'undefined') return
-
-    const resizeObserver = new ResizeObserver(() => maybeFillClientFilteredViewport())
-    resizeObserver.observe(el)
-    return () => resizeObserver.disconnect()
-  }, [filter.kind, maybeFillClientFilteredViewport])
-
   const handleOpen = useCallback(
     (file: FileItem) => {
       const requestToken = ++openRequestTokenRef.current
@@ -637,10 +620,6 @@ function FilesPage() {
 
     return result
   }, [files, filter])
-
-  useEffect(() => {
-    maybeFillClientFilteredViewport()
-  }, [maybeFillClientFilteredViewport, filteredFiles.length, files.length])
 
   const fileCounts = useMemo(() => {
     const counts: Record<string, number> = {
@@ -1043,7 +1022,6 @@ function FilesPage() {
                   <FileGrid
                     files={filteredFiles}
                     scrollRef={contentScrollRef}
-                    onLayoutChange={maybeFillClientFilteredViewport}
                     onOpen={handleOpen}
                     onDelete={(id) => handleDelete(new Set([id]))}
                     isTrash={isTrash}

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -644,10 +644,10 @@ describe('FilesPage keyboard rename', () => {
     expect(screen.queryByText('files.empty.no_match_title')).not.toBeInTheDocument()
   })
 
-  it('loads another active page when a client-filtered view does not fill the viewport', async () => {
+  it('queries the selected type without scanning unrelated active pages', async () => {
     const loadNext = vi.fn()
     mockUseInfiniteQuery.mockImplementation((_path, options) => {
-      const query = options?.query as { inTrash?: boolean } | undefined
+      const query = options?.query as { fileType?: string; inTrash?: boolean } | undefined
       return {
         pages: query?.inTrash ? [] : [{ items: [entry], total: 200, nextCursor: 'next-page' }],
         isLoading: false,
@@ -665,8 +665,12 @@ describe('FilesPage keyboard rename', () => {
     fireEvent.click(screen.getByText('files.text'))
 
     await waitFor(() => {
-      expect(loadNext).toHaveBeenCalledTimes(1)
+      const activeCall = mockUseInfiniteQuery.mock.calls
+        .filter((call) => !(call[1]?.query as { inTrash?: boolean } | undefined)?.inTrash)
+        .at(-1)
+      expect(activeCall?.[1]?.query).toMatchObject({ fileType: 'text' })
     })
+    expect(loadNext).not.toHaveBeenCalled()
   })
 })
 

--- a/src/shared/data/api/schemas/__tests__/files.test.ts
+++ b/src/shared/data/api/schemas/__tests__/files.test.ts
@@ -20,6 +20,14 @@ describe('ListFilesQuerySchema', () => {
     expect(ListFilesQuerySchema.safeParse({ sortBy: 'ext', sortOrder: 'asc' }).success).toBe(true)
   })
 
+  it('accepts a supported file type filter', () => {
+    expect(ListFilesQuerySchema.safeParse({ fileType: 'image' }).success).toBe(true)
+  })
+
+  it('rejects an unknown file type filter', () => {
+    expect(ListFilesQuerySchema.safeParse({ fileType: 'archive' }).success).toBe(false)
+  })
+
   it('accepts inTrash=false with origin=external', () => {
     expect(ListFilesQuerySchema.safeParse({ inTrash: false, origin: 'external' }).success).toBe(true)
   })

--- a/src/shared/data/api/schemas/files.ts
+++ b/src/shared/data/api/schemas/files.ts
@@ -57,6 +57,7 @@ import {
   FileEntryOriginSchema,
   FileRefSourceTypeSchema
 } from '@shared/data/types/file'
+import { FileTypeSchema } from '@shared/types/file'
 import * as z from 'zod'
 
 /**
@@ -90,6 +91,7 @@ export const ListFilesQuerySchema = z
   .strictObject({
     origin: FileEntryOriginSchema.optional(),
     inTrash: z.boolean().optional(),
+    fileType: FileTypeSchema.optional(),
     sortBy: z.enum(['name', 'createdAt', 'updatedAt', 'size', 'ext']).optional(),
     sortOrder: z.enum(['asc', 'desc']).optional(),
     cursor: z.string().optional(),


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/pull_request_template.md?-->
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Files type filters ran after each cursor page reached the renderer. Sparse types could therefore serially load and hydrate unrelated pages until the viewport filled or the library was exhausted.

After this PR:

`GET /files/entries` accepts a typed `fileType` filter. `FileEntryService` applies the matching extension predicate before keyset pagination and uses the same predicate for `total`. FilesPage sends the active sidebar type and no longer runs the client-filter refill loop.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19608

### Why we need it and why it was done in this way

Filtering belongs in the SQL query that owns cursor pagination. The predicate is derived from the shared `fileTypeMap`, preserving the renderer's classification semantics, including case-insensitive known extensions and `NULL`/unknown extensions for `other`.

The following tradeoffs were made:

The renderer retains its type predicate only as a stale-data guard while SWR `keepPreviousData` transitions between query keys. FileGrid's layout callback becomes optional because the parent no longer needs viewport-driven refill work.

The following alternatives were considered:

Continuing the client-side scan was rejected because it preserves the serial request/hydration waterfall. Persisting a materialized file-type column was rejected because type is already a stable shared projection of `ext` and would require unnecessary schema migration and synchronization.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19608

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

Real-database coverage verifies known-type filtering occurs before cursor boundaries and total counting, uppercase extensions match, and `NULL`/unknown extensions map to `other`.

Validation:

- schema, main, and renderer focused suites (144 tests)
- changed-file Biome, Oxlint, and ESLint
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/everything/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
File type filters now paginate matching rows directly instead of scanning and hydrating unrelated file pages.
```
