### PR TITLE
fix(topic-naming): use explicit language names in prompts

### DIFF
--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -7,6 +7,7 @@ import { loggerService } from '@logger'
 import type { AiGenerateRequest } from '@main/ai/AiService'
 import { WindowType } from '@main/core/window/types'
 import { messageService } from '@main/data/services/MessageService'
+import { getAppLanguage } from '@main/i18n'
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import type { Message, MessageData, UIMessage } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId, UniqueModelIdSchema } from '@shared/data/types/model'
@@ -17,7 +18,7 @@ import {
   sanitizeConversationTitle,
   truncateFirstUserMessageTitleSource
 } from '@shared/utils/conversationTitle'
-import { defaultLanguage, languageEnglishNameMap } from '@shared/utils/languages'
+import { languageEnglishNameMap } from '@shared/utils/languages'
 import { isExternalCliProvider } from '@shared/utils/provider'
 
 const logger = loggerService.withContext('TopicNamingService')
@@ -389,8 +390,7 @@ export class TopicNamingService {
   private resolveNamingPrompt(): string {
     const preferenceService = application.get('PreferenceService')
     const configuredPrompt = preferenceService.get('topic.naming_prompt')
-    const locale = preferenceService.get('app.language') || defaultLanguage
-    const language = languageEnglishNameMap[locale]
+    const language = languageEnglishNameMap[getAppLanguage()]
     return (configuredPrompt || FALLBACK_PROMPT).replaceAll('{{language}}', language)
   }
 

--- a/src/main/services/TopicNamingService.ts
+++ b/src/main/services/TopicNamingService.ts
@@ -17,6 +17,7 @@ import {
   sanitizeConversationTitle,
   truncateFirstUserMessageTitleSource
 } from '@shared/utils/conversationTitle'
+import { defaultLanguage, languageEnglishNameMap } from '@shared/utils/languages'
 import { isExternalCliProvider } from '@shared/utils/provider'
 
 const logger = loggerService.withContext('TopicNamingService')
@@ -388,7 +389,8 @@ export class TopicNamingService {
   private resolveNamingPrompt(): string {
     const preferenceService = application.get('PreferenceService')
     const configuredPrompt = preferenceService.get('topic.naming_prompt')
-    const language = preferenceService.get('app.language') || 'en-us'
+    const locale = preferenceService.get('app.language') || defaultLanguage
+    const language = languageEnglishNameMap[locale]
     return (configuredPrompt || FALLBACK_PROMPT).replaceAll('{{language}}', language)
   }
 

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -5,6 +5,7 @@ import { WindowType } from '@main/core/window/types'
 import { CHERRYAI_DEFAULT_UNIQUE_MODEL_ID } from '@shared/data/presets/cherryai'
 import { MockMainPreferenceServiceUtils } from '@test-mocks/main/PreferenceService'
 import { mockMainLoggerService } from '@test-mocks/MainLoggerService'
+import { app } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
@@ -143,6 +144,22 @@ describe('TopicNamingService', () => {
 
   it('requests a title in the language selected in system settings', async () => {
     MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
+
+    await createService().maybeRenameFromConversationSummary('topic-1', 'assistant-1', 'message-1', {
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Assistant response' }]
+    } as never)
+
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('Chinese (Simplified)')
+      })
+    )
+  })
+
+  it('follows the system locale when app.language is null', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.language', null)
+    vi.mocked(app.getLocale).mockReturnValueOnce('zh-CN')
 
     await createService().maybeRenameFromConversationSummary('topic-1', 'assistant-1', 'message-1', {
       role: 'assistant',

--- a/src/main/services/__tests__/TopicNamingService.test.ts
+++ b/src/main/services/__tests__/TopicNamingService.test.ts
@@ -141,6 +141,21 @@ describe('TopicNamingService', () => {
     expect(mocks.broadcast).toHaveBeenCalledWith('ai.topic.auto_renamed', { topicId: 'topic-1' })
   })
 
+  it('requests a title in the language selected in system settings', async () => {
+    MockMainPreferenceServiceUtils.setPreferenceValue('app.language', 'zh-CN')
+
+    await createService().maybeRenameFromConversationSummary('topic-1', 'assistant-1', 'message-1', {
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Assistant response' }]
+    } as never)
+
+    expect(mocks.generateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('Chinese (Simplified)')
+      })
+    )
+  })
+
   it('sends a naming-failed toast event to the main window when summary generation throws', async () => {
     mocks.generateText.mockRejectedValue(new Error('Invalid signature'))
 


### PR DESCRIPTION
### What this PR does

Before this PR:

The topic naming prompt substituted the selected locale code, such as `zh-CN`, for `{{language}}`. Some providers did not reliably interpret that code as an instruction to generate the title in the selected language.

After this PR:

Topic naming uses the existing shared locale map to substitute an explicit language name, such as `Chinese (Simplified)`, while preserving custom prompt handling.

Fixes #19623

### Why we need it and why it was done in this way

The selected app language already reaches the main-process naming service. Converting that locale at the prompt boundary makes the instruction clearer without adding settings, output post-processing, or provider-specific behavior.

The following tradeoffs were made:

- This improves the language instruction but cannot guarantee that every model will follow it.
- Custom prompts that omit `{{language}}` remain unchanged.

The following alternatives were considered:

- Detecting, translating, or retrying non-matching output was rejected because it would add model calls and product behavior beyond this bug.
- Adding a separate topic-language preference was rejected because the existing app language is already the intended source.

Links to places where the discussion took place: #19623

### Breaking changes

None.

### Special notes for your reviewer

The regression test sets `app.language` to `zh-CN` and verifies that the generated system prompt requests `Chinese (Simplified)`. It fails against the previous raw-locale implementation.

Validation:

- `pnpm install`
- `pnpm test:main src/main/services/__tests__/TopicNamingService.test.ts` (43/43)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

The lint commands only reported the 46 warnings already present on `main`; neither changed file adds a warning.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Improved automatic conversation titles by requesting them in the selected language using an explicit language name.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to auto-title prompt text only; no auth, persistence, or API contract changes.
> 
> **Overview**
> Auto-generated conversation titles now put a **human-readable language name** (e.g. `Chinese (Simplified)`) into the `{{language}}` slot of the naming prompt instead of a raw locale code like `zh-CN`, so models get a clearer instruction to title in the user’s language.
> 
> **`resolveNamingPrompt`** no longer reads `app.language` directly; it uses **`getAppLanguage()`** (preference with system-locale fallback) and **`languageEnglishNameMap`**, matching how other main-process prompts resolve language. Custom `topic.naming_prompt` values are unchanged when they omit `{{language}}`.
> 
> Tests assert the system prompt contains the mapped name when `app.language` is `zh-CN` and when `app.language` is null and Electron’s locale is `zh-CN`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd5acc6d33f967463324018f59c57d766fc0bc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->