### PR TITLE
feat(knowledge): support dropped file uploads

### DIFF
--- a/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/DataSourcePanel.tsx
@@ -1,4 +1,5 @@
 import { Button, CircularProgress, ConfirmDialog } from '@cherrystudio/ui'
+import { useDrag } from '@renderer/hooks/useDrag'
 import { useLocalModel } from '@renderer/hooks/useLocalModel'
 import { openSettingsTab } from '@renderer/services/mainWindowNavigation'
 import { toast } from '@renderer/services/toast'
@@ -8,7 +9,7 @@ import type { LocalModelStatus } from '@shared/data/presets/localModel'
 import type { KnowledgeItem, KnowledgeItemOf, KnowledgeItemType } from '@shared/data/types/knowledge'
 import type { TFunction } from 'i18next'
 import { ChevronLeft, Settings2 } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { type DragEvent, useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { KNOWLEDGE_DATA_SOURCE_TYPES } from '../../components/addKnowledgeItemDialog/constants'
@@ -283,6 +284,18 @@ const DataSourcePanelContent = ({
   }
 
   const handleAddSource = useCallback((source: KnowledgeItemType) => onAdd(source), [onAdd])
+  const handleFileDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      const files = Array.from(event.dataTransfer.files)
+      if (files.length > 0) {
+        onAdd('file', files)
+      }
+    },
+    [onAdd]
+  )
+  const { isDragging, handleDragEnter, handleDragLeave, handleDragOver, handleDrop } =
+    useDrag<HTMLDivElement>(handleFileDrop)
+  const canAddSource = !currentDirectory && !localEmbeddingState
   const localModelStatus =
     localEmbeddingState && (items.length > 0 || Boolean(currentDirectory))
       ? {
@@ -307,12 +320,24 @@ const DataSourcePanelContent = ({
             onBulkReindex={handleBulkReindex}
             onBulkDelete={() => setIsBulkDeleteOpen(true)}
             onAdd={handleAddSource}
-            canAddSource={!currentDirectory && !localEmbeddingState}
+            canAddSource={canAddSource}
             localModelStatus={localModelStatus}
           />
         </div>
       }>
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div
+        className="relative flex min-h-0 flex-1 flex-col"
+        onDragEnter={canAddSource ? handleDragEnter : undefined}
+        onDragLeave={canAddSource ? handleDragLeave : undefined}
+        onDragOver={canAddSource ? handleDragOver : undefined}
+        onDrop={canAddSource ? handleDrop : undefined}>
+        {isDragging && canAddSource ? (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-3 z-10 flex items-center justify-center rounded-lg border border-primary border-dashed bg-background/90 text-foreground shadow-sm">
+            <span className="font-medium text-sm">{t('files.drag_upload')}</span>
+          </div>
+        ) : null}
         {currentDirectory && onNavigateUp && (
           <div className="flex shrink-0 items-center gap-2 px-3 py-2">
             {/* Flat text button (no chrome): the `px-2.5` matches the row's own inset so the chevron

--- a/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
+++ b/src/renderer/pages/knowledge/panels/dataSource/__tests__/DataSourcePanel.test.tsx
@@ -331,6 +331,7 @@ vi.mock('react-i18next', () => ({
             'common.more': '更多',
             'common.no_results': '暂无结果',
             'common.go_to_settings': '前往设置',
+            'files.drag_upload': '拖拽文件到此处上传',
             'knowledge.data_source.actions.preview_source': '预览原文',
             'knowledge.data_source.actions.view_chunks': '查看 Chunks',
             'knowledge.data_source.actions.reindex': '重新索引',
@@ -555,6 +556,37 @@ describe('DataSourcePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: '链接' }))
 
     expect(onAdd).toHaveBeenCalledWith('url')
+  })
+
+  it('sends dropped files through the existing file add flow while preserving the picker entry', () => {
+    const onAdd = vi.fn()
+    const files = [
+      new File(['report'], 'report.pdf', { type: 'application/pdf' }),
+      new File(['unsupported'], 'unsupported.exe', { type: 'application/octet-stream' })
+    ]
+
+    render(
+      <DataSourcePanel
+        updatedAt="2026-04-15T09:00:00+08:00"
+        items={[]}
+        isLoading={false}
+        onAdd={onAdd}
+        onDelete={vi.fn()}
+        onReindex={vi.fn()}
+      />
+    )
+
+    const dropTarget = screen.getByText('上传第一个数据源')
+    expect(screen.getByRole('button', { name: '文件' })).toBeInTheDocument()
+
+    fireEvent.dragEnter(dropTarget, { dataTransfer: { files } })
+    expect(screen.getByText('拖拽文件到此处上传')).toBeInTheDocument()
+
+    fireEvent.drop(dropTarget, { dataTransfer: { files } })
+
+    expect(onAdd).toHaveBeenCalledWith('file', files)
+    expect(screen.queryByText('拖拽文件到此处上传')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '文件' })).toBeInTheDocument()
   })
 
   it('uses the first non-empty note line as the title and leaves blank notes without the old fallback label', () => {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Files dragged over a knowledge base had no drop target and did not enter the add-file flow. Users had to discover and use the existing picker.

After this PR:

The data-source area shows a localized drop target while files are dragged over it. Dropped files enter the same `onAdd('file', files)` flow as picker uploads, so existing type, limit, duplicate, processing, and error handling remains authoritative. The picker remains available as the keyboard- and screen-reader-accessible path.

Fixes #19639

### Why we need it and why it was done in this way

The page already has one complete file-ingestion path through `pendingAddFiles` and `AddKnowledgeItemDialog`. Reusing it keeps drag-and-drop behavior aligned with picker uploads and avoids a second validation or ingestion implementation.

The following tradeoffs were made:

- Drag-and-drop is enabled only at the knowledge-base root and only when the existing add-source action is available.
- The drop target is a transient visual overlay; the existing picker remains the equivalent accessible control.

The following alternatives were considered:

- A separate drag uploader with independent validation and progress state was rejected because it would duplicate the existing add-item contract.

Links to places where the discussion took place: #19639

### Breaking changes

None.

### Special notes for your reviewer

- The runtime check used the exact tracked development instance. A synthetic CDP `File` displayed the drop target, preserved the picker, and reached the existing local-path error handling after drop.
- The focused regression test passes both supported and unsupported files through unchanged, ensuring validation stays in the existing dialog flow.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things/every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Knowledge Base] Files can now be dragged into a knowledge base to start the existing upload flow.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change that delegates file handling to the existing `onAdd` contract; no new ingestion or auth paths.
> 
> **Overview**
> Users can **drag files onto the knowledge base data-source panel** to start uploads instead of relying only on the file picker.
> 
> `DataSourcePanel` wires the main content area to **`useDrag`**: while dragging (and when add-source is allowed), it shows a dashed overlay with **`files.drag_upload`**. On drop it calls **`onAdd('file', files)`**, so validation and ingestion stay in the existing add-item dialog path. Drag-and-drop is **gated the same way as the header add action**—only at the knowledge-base root and not while viewing a directory or when local embedding is blocking adds.
> 
> A regression test covers the overlay, **`onAdd('file', files)`** with mixed file types, and that the picker button remains available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20813fb4088d8e479ba19cf3157f48d38b28428b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->