### PR TITLE
docs(gh-pr-review): distinguish open product decisions

### DIFF
--- a/.agents/skills/gh-pr-review/SKILL.md
+++ b/.agents/skills/gh-pr-review/SKILL.md
@@ -82,28 +82,44 @@ both reference sets for stages 4–5.
 First inspect the semantics actually expressed or constrained by the change,
 then decide whether it affects **product semantics, user-visible behavior, or
 product direction**. Change labels are not sufficient evidence: internal
-refactors and non-user-facing fixes often have no product impact, while docs,
-tests, or tooling can record, lock, or alter product behavior. Skip this stage
-entirely, in both interactive and automated runs, only after semantic review
-confirms that the change is implementation-only; say nothing about the skipped
-gate.
+refactors and non-user-facing fixes often have no product impact, while
+user-facing fixes, docs, tests, or tooling can record, lock, or alter product
+behavior.
 
-When there is product impact:
+When there is product impact, determine whether the direction is already
+established in the current review context. Treat it as established only when
+the current user explicitly decided it or an authoritative project artifact
+explicitly records the accepted behavior and its approval by the responsible
+project authority, such as a specification, an ADR, or an issue containing a
+maintainer decision that settles the expected behavior. Do not infer acceptance
+from issue state, labels, milestone, assignment, or a link from the PR. A change
+label, PR body, implementation, or test demonstrates author intent or current
+behavior but does not establish product approval on its own.
 
-- **Interactive session (default)**: summarize the change's effect on product
-  functionality and semantics, and ask the current user for the product
-  decision. Do not infer automation from PR authorship, review ownership, or
-  whether the user authored the decision. If the user judges the direction
-  wrong, **stop the whole review immediately** — do not run Consumer,
-  Architecture, Implementation, or Style stages, and do not report code
-  findings. If the user approves the direction, continue with the remaining
-  stages.
-- **Automated session (explicit only)**: use this mode only when the invocation
-  prompt or workflow context explicitly identifies a headless, CI, batch, or
-  other automated run. Make **no** product decision on the user's behalf. Run
-  the remaining stages, and in the final report summarize the product impact,
-  the direction the change takes, and the points needing human confirmation.
-  Never phrase this as product approval having been obtained.
+Classify the gate into exactly one state:
+
+- **No product impact**: skip this stage entirely in both interactive and
+  automated runs; say nothing about the skipped gate.
+- **Established direction**: compare the change with the recorded decision. If
+  it aligns, continue without asking for another product decision. If it
+  conflicts, report the product-direction mismatch and **stop the whole review
+  immediately** — do not run Consumer, Architecture, Implementation, or Style
+  stages, and do not report code findings. Applying an existing decision is
+  not making a new one.
+- **Open product decision**:
+  - **Interactive session (default)**: summarize the change's effect on
+    product functionality and semantics, and ask the current user for the
+    unresolved product decision. Do not infer automation from PR authorship,
+    review ownership, or whether the user authored the change. If the user
+    rejects the direction, stop the whole review as above; if the user
+    approves it, continue with the remaining stages.
+  - **Automated session (explicit only)**: use this mode only when the
+    invocation prompt or workflow context explicitly identifies a headless,
+    CI, batch, or other automated run. Make no product decision on the user's
+    behalf. Run the remaining stages, and in the final report summarize the
+    product impact, the direction the change takes, and the points needing
+    human confirmation. Never phrase this as product approval having been
+    obtained.
 
 ## Authority model
 
@@ -254,4 +270,3 @@ Print this list when the resolved scope is empty:
 /gh-pr-review checklist            adopt this session's proposed checklist items
 /gh-pr-review diag                 diagnose gaps in this skill
 ```
-

--- a/.agents/skills/gh-pr-review/references/local-review.md
+++ b/.agents/skills/gh-pr-review/references/local-review.md
@@ -45,14 +45,11 @@ resolved scope is empty. Do not restate the derivation here.
 Run the review stages defined in `SKILL.md` § Review Stages in order.
 
 1. **Product Demand gate** — follow `SKILL.md` § Review Stages, stage 1 for
-   the skip test and mode rules: skip silently only after inspecting the
-   semantics the change expresses or constrains, never from its change type;
-   interactive is the default (ask the current user for the product decision
-   and stop the whole review if the direction is rejected), and record-only
-   automated behavior applies only when the invocation or workflow context
-   explicitly identifies an automated run, carrying the product-impact
-   summary into Step 4's report. Skip this step when the PR wrapper already
-   ran the gate.
+   the semantic-impact, decision-evidence, and mode rules. Preserve its three
+   states: no product impact, established direction, and open product decision.
+   Only an open product decision may prompt in an interactive run or use
+   record-only behavior in an explicitly automated run. Skip this step when
+   the PR wrapper already ran the gate.
 2. **Consumer review** — whenever the diff adds or expands shared surface,
    judged by diff semantics rather than change label. Follow
    `consumer-review.md`; only surviving surfaces continue to the stages below.
@@ -112,9 +109,9 @@ with their fix guidance or "no issues found". If
 `LIMITED_SINGLE_AGENT = true`, explicitly state that the scope was non-small
 but the runtime had no subagent capability, so the review was single-agent and
 did not include independent adversarial verification. In an automated session
-with product impact, include the Product Demand summary — impact, direction,
-and points needing human confirmation — explicitly marked as awaiting a
-product decision, never as approved.
+with an open product decision, include the Product Demand summary — impact,
+direction, and points needing human confirmation — explicitly marked as
+awaiting a product decision, never as approved.
 
 Validation: when fixes were applied, the session is a coding task — run the
 validation selected per `SKILL.md` § Validation after applied fixes and report

--- a/.agents/skills/gh-pr-review/references/pr-review.md
+++ b/.agents/skills/gh-pr-review/references/pr-review.md
@@ -200,15 +200,14 @@ submission packaging for either engine.
 Coordinator duties around the selected engine:
 
 0. Run the **Product Demand gate** (`SKILL.md` § Review Stages, stage 1)
-   before implementation review, using `PR_BODY` and the diff. First inspect
-   the actual semantics; skip silently only when they have no product impact.
-   Interactive mode is the default regardless of PR authorship or decision
-   ownership: explain the semantic effect and ask the current user for the
-   product decision. A rejected direction stops the review before code findings
-   are produced. Use record-only automated behavior only when the invocation
-   prompt or workflow context explicitly identifies an automated run; then
-   carry impact, direction, and open product questions into the Step 4 report
-   and, when submitting, the review body as awaiting human confirmation.
+   before implementation review, using `PR_BODY`, the diff, and authoritative
+   decision artifacts they reference. Apply its no-impact,
+   established-direction, and open-decision states exactly; the PR body alone
+   demonstrates author intent, not product approval. Only an open decision may
+   prompt in an interactive run or use record-only behavior in an explicitly
+   automated run; carry the latter's impact, direction, and open product
+   questions into the Step 4 report and, when submitting, the review body as
+   awaiting human confirmation.
    This coordinator gate satisfies stage 1 for the selected engine; do not run
    it a second time inside local-review or teams-review.
 1. Read `PR_BODY` to understand the stated motivation and include it in
@@ -259,6 +258,9 @@ Present results to user:
 - When `LIMITED_SINGLE_AGENT = true`: explicitly disclose that a non-small PR
   received single-agent review without independent adversarial verification
   because the runtime has no subagent capability.
+- In an automated session with an open product decision: include the Product
+  Demand summary — impact, direction, and points needing human confirmation —
+  explicitly marked as awaiting a product decision, never as approved.
 - Checklist candidates: include any valid recurring-pattern candidates as
   `proposed`; regular PR review never accepts, inserts, or claims to persist
   checklist rules.

--- a/.agents/skills/gh-pr-review/references/teams-review.md
+++ b/.agents/skills/gh-pr-review/references/teams-review.md
@@ -54,14 +54,12 @@ Report-only (default): Scope → Product gate → Review → Filter → Report
 ```
 
 The **Product gate** is stage 1 of `SKILL.md` § Review Stages, run by the
-coordinator before dispatching any reviewer: inspect the semantics actually
-expressed or constrained, then skip silently only when the change has no
-product impact. Interactive is the default: summarize the product effect, ask
-the current user for the product decision, and abort the entire review (no
-reviewers dispatched) if the direction is rejected. Use record-only automated
-behavior only when the invocation or workflow explicitly identifies an
-automated run; then decide nothing and carry the product-impact summary into
-the Report. Reviewers cover stages 2–5.
+coordinator before dispatching any reviewer. Apply its semantic-impact and
+decision-evidence rules without collapsing the no-impact,
+established-direction, and open-decision states. Only an open product decision
+may prompt in an interactive run or use record-only behavior in an explicitly
+automated run; carry the latter's product-impact summary into the Report.
+Reviewers cover stages 2–5.
 
 - **Filter** routes issues per `judgment-matrix.md` § Handling by Risk Level,
   which owns the risk-to-action mapping. If nothing is fixable, skip directly
@@ -387,9 +385,10 @@ fixer edit.
 ## Phase 5: Report
 
 Summary:
-- Product Demand summary when the change has product impact and the session
-  was automated: impact, direction, and points needing human confirmation,
-  explicitly marked as awaiting a product decision — never as approved
+- Product Demand summary when the product decision remains open and the
+  session was automated: impact, direction, and points needing human
+  confirmation, explicitly marked as awaiting a product decision — never as
+  approved
 - Consumer review decisions per surface, when the diff added or expanded shared surface
 - Issues found / fixed (authorized fix only) / reported / failed
 - Reported issues listed with risk, `file:line`, and at-altitude fix guidance


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR, any user-visible impact forced an interactive product-direction prompt even when an authoritative decision already existed.

After this PR, the gate distinguishes no impact, established direction, and open decisions while all review engines share the same reporting contract.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #N/A

### Why we need it and why it was done in this way

This avoids redundant confirmation for refactors and bug fixes while requiring explicit user or authoritative-artifact evidence, so PR text, issue metadata, implementation, and tests cannot impersonate product approval.

The following tradeoffs were made:

A conflict with an established direction still stops review.

The following alternatives were considered:

Label-based skipping — rejected because labels do not prove semantic equivalence

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

None

### Special notes for your reviewer

<!-- optional -->

Docs-only skill workflow change; validated with the skill validator, two isolated scenario passes, `pnpm docs:check`, and `pnpm skills:check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
