### PR TITLE
fix(dsh-runtime): allow models without text modality

### DIFF
--- a/src/main/ai/runtime/dsh/__tests__/compositionBuilder.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/compositionBuilder.test.ts
@@ -429,7 +429,7 @@ describe('buildDshCompositionYaml', () => {
     expect(providerRoute(yaml, 'deepseek').models[0].reasoningEfforts).toBe(false)
   })
 
-  it('rejects models that explicitly declare no text input', () => {
-    expect(() => makeInjection({ inputModalities: [MODALITY.AUDIO] })).toThrow('text input is required')
+  it('does not reject models based on their declared input modalities', () => {
+    expect(makeInjection({ inputModalities: [MODALITY.AUDIO] }).modelConfig.input).toEqual(['text'])
   })
 })

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -15,12 +15,7 @@ import type { AiUsageCredentialReceipt } from '@data/services/AiUsageRecordServi
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
-import {
-  type DshApi,
-  hasDshTextInput,
-  mapEndpointToDshApi,
-  resolveDshEndpointType
-} from '@shared/ai/dshModelCompatibility'
+import { type DshApi, mapEndpointToDshApi, resolveDshEndpointType } from '@shared/ai/dshModelCompatibility'
 import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
@@ -58,17 +53,6 @@ export class DshMissingApiKeyError extends Error {
     super(`Provider "${providerId}" has no API key configured for dsh agents`)
     this.name = 'DshMissingApiKeyError'
     this.providerId = providerId
-  }
-}
-
-/** Thrown when a model explicitly declares no text input, which DSH rc.6 requires. */
-export class DshUnsupportedModelInputError extends Error {
-  readonly modelId: string
-
-  constructor(modelId: string) {
-    super(`Model "${modelId}" is not supported by dsh agents: text input is required`)
-    this.name = 'DshUnsupportedModelInputError'
-    this.modelId = modelId
   }
 }
 
@@ -201,7 +185,6 @@ export function buildDshProviderInjection(
   if (!api) {
     throw new DshUnsupportedProviderError(provider.id)
   }
-  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
   if (!apiKey.trim()) throw new DshMissingApiKeyError(provider.id)
 
   const baseUrl = formatDshBaseUrl(resolvedEndpoint.baseUrl, api)
@@ -262,8 +245,6 @@ export function buildDshGatewayInjection(
   reasoningEffort: ReasoningEffortOption = 'default'
 ): DshProviderInjection {
   if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(provider.id)
-  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-
   const modelId = formatGatewayModelId(provider.id, getRawModelId(model))
   const reasoning = resolveDshReasoningEffort(model, reasoningEffort)
   return {
@@ -344,13 +325,10 @@ export async function assertDshProviderUsable(uniqueModelId: UniqueModelId): Pro
   // Unsupported beats missing-credential (parity with buildDshProviderInjection).
   if (resolveDshInjectionApi(provider, model) === undefined) {
     if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(providerId)
-    if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
     // Consent only (persisted intent) — no ensureRunning/ensureValidApiKey side effects here.
     if (!application.get('ApiGatewayService').getCurrentConfig().enabled) throw new ApiGatewayNotRunningError()
     return
   }
-  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
-
   const apiKeys = providerService.getApiKeys(providerId, { enabled: true })
   if (!apiKeys.some((entry) => entry.key.trim())) throw new DshMissingApiKeyError(providerId)
 }

--- a/src/shared/ai/__tests__/agentRuntimeCapabilities.test.ts
+++ b/src/shared/ai/__tests__/agentRuntimeCapabilities.test.ts
@@ -84,20 +84,16 @@ describe('AGENT_RUNTIME_CAPABILITIES', () => {
     })
   })
 
-  describe('dsh model input compatibility', () => {
+  describe('dsh model compatibility', () => {
     const isCompatible = AGENT_RUNTIME_CAPABILITIES.dsh.isModelCompatible
     const provider = makeProvider({})
 
-    it('accepts undeclared and text-capable multimodal inputs', () => {
+    it('does not filter models by their declared input modalities', () => {
       expect(isCompatible(provider, makeModel({}))).toBe(true)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.TEXT, MODALITY.AUDIO] }))).toBe(true)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.TEXT, MODALITY.VIDEO] }))).toBe(true)
-    })
-
-    it('rejects models that explicitly cannot accept text', () => {
-      expect(isCompatible(provider, makeModel({ inputModalities: [] }))).toBe(false)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.AUDIO] }))).toBe(false)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.VIDEO] }))).toBe(false)
+      expect(isCompatible(provider, makeModel({ inputModalities: [] }))).toBe(true)
+      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.IMAGE] }))).toBe(true)
+      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.AUDIO] }))).toBe(true)
+      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.VIDEO] }))).toBe(true)
     })
   })
 })

--- a/src/shared/ai/__tests__/dshModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/dshModelCompatibility.test.ts
@@ -72,8 +72,10 @@ describe('isDshCompatibleModel', () => {
     ).toBe(false)
   })
 
-  it('still requires text input on the gateway route, but not a declared context window', () => {
+  it('does not use input modalities as a compatibility restriction', () => {
     expect(isDshCompatibleModel(azureProvider, makeModel({ contextWindow: undefined }))).toBe(true)
-    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: [] }))).toBe(false)
+    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: [] }))).toBe(true)
+    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: ['image'] }))).toBe(true)
+    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: ['audio'] }))).toBe(true)
   })
 })

--- a/src/shared/ai/dshModelCompatibility.ts
+++ b/src/shared/ai/dshModelCompatibility.ts
@@ -12,7 +12,6 @@
  * back to the local API Gateway when the model is gateway-routable.
  */
 
-import { MODALITY } from '@cherrystudio/provider-registry'
 import { resolveGatewayChatRoute } from '@shared/data/presets/gatewayChatRouting'
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
@@ -82,15 +81,9 @@ export function resolveDshApi(provider: Provider, model: Model): DshApi | undefi
   return mapEndpointToDshApi(endpointType, adapterFamily)
 }
 
-/** DSH rc.7 always requires text input; undeclared modalities retain the existing chat-model default. */
-export function hasDshTextInput(model: Model): boolean {
-  return model.inputModalities === undefined || model.inputModalities.includes(MODALITY.TEXT)
-}
-
 /** Whether a dsh agent can use this provider+model. Used for renderer filtering. */
 export function isDshCompatibleModel(provider: Provider, model: Model): boolean {
   // No native wire family → the local API Gateway can still front any gateway-routable
   // model as OpenAI-compatible (claude's picker rule); everything else stays fail-closed.
-  if (resolveDshApi(provider, model) === undefined && !isGatewayRoutableModel(model)) return false
-  return hasDshTextInput(model)
+  return resolveDshApi(provider, model) !== undefined || isGatewayRoutableModel(model)
 }


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: DSH agent model selection and runtime validation rejected models whose metadata did not declare text input.

After this PR: DSH follows the Claude Agent and Pi approach by relying on provider transport or gateway routability and materializing its own text-capable runtime profile.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The following tradeoffs were made: input-modality metadata is no longer a DSH compatibility gate, while provider protocol, gateway routing, managed-model, and credential checks remain unchanged.

The following alternatives were considered: rewriting custom model metadata was rejected because the restriction belongs to the DSH runtime rather than model persistence.

Links to places where the discussion took place: N/A

### Breaking changes

<!-- optional -->

If this PR introduces breaking changes, please describe the changes and the impact on users.

None.

### Special notes for your reviewer

<!-- optional -->

Validated with 41 focused tests, `pnpm lint`, and a non-isolated Electron instance; documentation changes are not required for this compatibility bug fix.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
DSH agents can now select and use compatible models even when their metadata does not declare text input.
```
