### PR TITLE
docs: add DeepSeek Harness Handbook reference

### DIFF
--- a/docs/references/ai/README.md
+++ b/docs/references/ai/README.md
@@ -20,6 +20,7 @@ renderer-side transport that connects to them.
 | [Core Architecture](./core-architecture.md) | End-to-end call flow: `ai.stream.open` IpcApi route → context provider → AiStreamManager → runtime → broadcast / persist |
 | [Stream Manager](./stream-manager.md) | Active-stream registry, listeners, reconnect, abort, queue/yield/continuation steering, persistence backends |
 | [Agent Session Runtime](./agent-session-runtime.md) | Agent-session host/driver split, follow-up admission, resume persistence, and the registered Claude Code, Pi, and DSH drivers |
+| [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) | Independent, source-backed Agent/runtime field guides for DSH plugins, MCP, tools, Sessions, sandboxes, approvals, evaluation, and troubleshooting |
 | [Adding an Agent Runtime](./adding-a-runtime.md) | Operational checklist for a new runtime: capability descriptor, driver package, registration points, design rules |
 | [Adapter Family](./adapter-family.md) | How `provider.endpointConfigs[ep].adapterFamily` picks the right `@ai-sdk/*` package per request |
 | [Provider State Ownership](./provider-state-ownership.md) | Where provider facts, endpoint dialects, connection overrides, and per-request controls belong |


### PR DESCRIPTION
## Summary

- Add the independent DeepSeek Harness Handbook to Cherry Studio's AI reference navigation.
- The handbook complements Cherry Studio's DSH runtime implementation docs with source-backed Agent/runtime field guides and troubleshooting runbooks.

## Link

https://github.com/sandbaseai/deepseek-harness-handbook

This is a single documentation-table row; no application code or behavior changes.
