### PR TITLE
fix(composer): persist atomic agent draft snapshots

### DIFF
--- a/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
+++ b/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
@@ -269,6 +269,17 @@ function addMissingToken(
   insertComposerTokenAtCursor(editor, token)
 }
 
+/** Sole write path for `emitUpdate: false` content: keeps the last-serialized-draft ref in step
+ *  with the document, so a torn-down `getDraft()` serves an atomic current pair, not a stale one. */
+function setComposerEditorContent(
+  editor: Editor,
+  lastSerializedDraftRef: { current: ComposerSerializedDraft | null },
+  content: JSONContent
+) {
+  lastSerializedDraftRef.current = serializeComposerDocument(content)
+  editor.commands.setContent(content, { emitUpdate: false })
+}
+
 function hasComposerTokenBeforeSelection(editor: Editor) {
   const selection = editor.state.selection
   const selectedNode = (selection as { node?: { type?: { name?: string } } }).node
@@ -536,6 +547,8 @@ export default function ComposerSurfaceRuntime({
   const editorRef = useRef<Editor | null>(null)
   const textRef = useRef(text)
   const pendingLocalTextEchoRef = useRef<string | null>(null)
+  // The most recent full document serialization; served by getDraft() once the editor is gone.
+  const lastSerializedDraftRef = useRef<ComposerSerializedDraft | null>(null)
   const inputListenersRef = useRef(new Set<(event?: QuickPanelInputEvent) => void>())
   const isSyncingTokensRef = useRef(false)
   const trackedTokenSignatureRef = useRef('')
@@ -643,7 +656,8 @@ export default function ComposerSurfaceRuntime({
       textRef.current = limitedText
       pendingLocalTextEchoRef.current = limitedText
       onTextChange(limitedText)
-      editor?.commands.setContent(createPromptVariableContent(limitedText), { emitUpdate: false })
+      const nextContent = createPromptVariableContent(limitedText)
+      if (editor) setComposerEditorContent(editor, lastSerializedDraftRef, nextContent)
     },
     [onTextChange]
   )
@@ -867,7 +881,11 @@ export default function ComposerSurfaceRuntime({
 
   const getDraft = useCallback((): ComposerSerializedDraft => {
     const editor = editorRef.current
-    if (!editor || editor.isDestroyed) return { text: textRef.current, tokens: [] }
+    if (!editor || editor.isDestroyed) {
+      // Callers persist the returned pair verbatim; a fabricated { text, tokens: [] } would strand
+      // managed chips' prompt sentences as visible prose on the next restore.
+      return lastSerializedDraftRef.current ?? { text: textRef.current, tokens: [] }
+    }
 
     return serializeComposerDocument(editor)
   }, [])
@@ -878,7 +896,7 @@ export default function ComposerSurfaceRuntime({
 
     textRef.current = draft.text
     pendingLocalTextEchoRef.current = null
-    editor.commands.setContent(createComposerDraftContent(draft), { emitUpdate: false })
+    setComposerEditorContent(editor, lastSerializedDraftRef, createComposerDraftContent(draft))
     trackedTokenSignatureRef.current = getTrackedTokenSignature(draft.tokens)
   }, [])
 
@@ -1719,6 +1737,7 @@ export default function ComposerSurfaceRuntime({
       if (tokenizePromptVariablesInEditor(updatedEditor)) return
 
       const draft = serializeComposerDocument(updatedEditor)
+      lastSerializedDraftRef.current = draft
       const nextText = draft.text
       textRef.current = nextText
       pendingLocalTextEchoRef.current = nextText
@@ -1738,7 +1757,8 @@ export default function ComposerSurfaceRuntime({
         trackedTokenSignatureRef.current = nextTrackedTokenSignature
       }
     },
-    onCreate: () => {
+    onCreate: ({ editor: createdEditor }) => {
+      lastSerializedDraftRef.current = serializeComposerDocument(createdEditor)
       window.requestAnimationFrame(() => {
         startTransition(() => setEditorReady(true))
       })
@@ -1789,7 +1809,11 @@ export default function ComposerSurfaceRuntime({
       return
     }
     pendingLocalTextEchoRef.current = null
-    editor.commands.setContent(createComposerDraftContent({ text, tokens: draftTokens ?? [] }), { emitUpdate: false })
+    setComposerEditorContent(
+      editor,
+      lastSerializedDraftRef,
+      createComposerDraftContent({ text, tokens: draftTokens ?? [] })
+    )
   }, [draftTokens, editor, text])
 
   useEffect(() => {

--- a/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
+++ b/src/renderer/components/composer/__tests__/ComposerSurface.test.tsx
@@ -1278,6 +1278,76 @@ describe('ComposerSurface', () => {
     )
   })
 
+  it('serves the last serialized draft after the editor is destroyed instead of a text-only pair', async () => {
+    // A destroyed-editor getDraft() must never fabricate { text, tokens: [] }: callers persist that
+    // pair verbatim, and text without its tokens strands managed chips' prompt sentences as prose.
+    mocks.stabilizeEditor = true
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'composerToken',
+              attrs: { id: 'knowledge:kb-1', kind: 'knowledge', label: 'KB One', promptText: 'kb sentence' }
+            },
+            { type: 'text', text: ' tail' }
+          ]
+        }
+      ]
+    })
+
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    act(() => {
+      mocks.editorOptions?.onUpdate({ editor: mocks.editorInstance })
+    })
+
+    const liveDraft = mocks.actions?.getDraft()
+    expect(liveDraft?.tokens).toHaveLength(1)
+
+    // After teardown a fresh serialization is impossible; the last serialized pair is the draft.
+    mocks.getJSON.mockReturnValue({ type: 'doc', content: [{ type: 'paragraph' }] })
+    if (mocks.editorInstance) mocks.editorInstance.isDestroyed = true
+
+    expect(mocks.actions?.getDraft()).toEqual(liveDraft)
+  })
+
+  it('seeds the last serialized draft at editor creation, so a torn-down getDraft is still paired', async () => {
+    // Initial content never fires onUpdate, so creation itself must record the serialization —
+    // otherwise a getDraft() before the first keystroke still fabricates a text-only pair.
+    mocks.stabilizeEditor = true
+    mocks.getJSON.mockReturnValue({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'composerToken',
+              attrs: { id: 'knowledge:kb-1', kind: 'knowledge', label: 'KB One', promptText: 'kb sentence' }
+            }
+          ]
+        }
+      ]
+    })
+
+    render(<Harness />)
+
+    await waitFor(() => expect(mocks.actions).toBeDefined())
+    act(() => {
+      mocks.editorOptions?.onCreate({ editor: mocks.editorInstance })
+    })
+    const seededDraft = mocks.actions?.getDraft()
+    expect(seededDraft?.tokens).toHaveLength(1)
+
+    if (mocks.editorInstance) mocks.editorInstance.isDestroyed = true
+
+    expect(mocks.actions?.getDraft()).toEqual(seededDraft)
+  })
+
   it('keeps token structure when an external text update matches the current content', async () => {
     // Reproduces the long-text paste flow: the editor holds a quote token, PasteService converts
     // the pasted text into a file and re-applies the unchanged serialized text. The rebuild only

--- a/src/renderer/components/composer/variants/AgentComposer.tsx
+++ b/src/renderer/components/composer/variants/AgentComposer.tsx
@@ -1031,7 +1031,7 @@ const AgentComposerInner = ({
     }
     const draft = actionsRef.current.getDraft()
     writeAgentDraftCache(draftCacheKey, {
-      text,
+      text: draft.text,
       tokens: draft.tokens,
       files,
       knowledgeBaseIds: knowledgeBaseIdsRef.current,
@@ -1057,9 +1057,12 @@ const AgentComposerInner = ({
 
   const persistFinalDraft = useEffectEvent(() => {
     if (!draftPersistenceEnabled || isInputHistoryActive) return
+    // Managed-sync token changes never reach `draftTokens` (isSyncingTokensRef suppresses
+    // onTokensChange), so the cache must come from one surface serialization, not the shadow state.
+    const draft = actionsRef.current.getDraft()
     writeAgentDraftCache(draftCacheKey, {
-      text,
-      tokens: draftTokensRef.current,
+      text: draft.text,
+      tokens: draft.tokens,
       files: filesRef.current,
       knowledgeBaseIds: knowledgeBaseIdsRef.current,
       workspaceKey,

--- a/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
+++ b/src/renderer/components/composer/variants/__tests__/AgentComposer.test.tsx
@@ -3769,6 +3769,62 @@ describe('AgentComposer', () => {
     })
   })
 
+  it('persists the surface-serialized draft on unmount, not the shadow token state', async () => {
+    // A managed-sync dispatch (panel pick / hydration) inserts the chip while onTokensChange is
+    // suppressed, so persisting the shadow token state would strand its sentence as visible prose.
+    const draftCacheKey = 'agent.composer_draft.session_session-1'
+    const knowledgePrompt =
+      'The user attached knowledge base "Knowledge One" (id: kb-1). Include "kb-1" in kb_search baseIds before answering questions that may depend on this knowledge base, and cite relevant kb_search or kb_read results. Use kb_list only to browse its structure; kb_list output is not retrieved evidence.'
+    const chipToken: ComposerSerializedToken = {
+      ...knowledgeBaseToken(knowledgeBaseOne),
+      promptText: knowledgePrompt,
+      textOffset: 'hello '.length
+    }
+    const drafts = new Map<string, unknown>()
+    vi.mocked(cacheService.get).mockImplementation((key: string) => drafts.get(key))
+    vi.mocked(cacheService.set).mockImplementation((key: string, value: unknown) => {
+      drafts.set(key, value)
+    })
+    const serializedText = `hello ${knowledgePrompt} tail`
+    mocks.getDraft.mockImplementation(() => ({
+      text: serializedText,
+      tokens: [chipToken]
+    }))
+
+    const view = render(
+      <AgentComposer
+        agentId="agent-1"
+        sessionId="session-1"
+        sendMessage={mocks.sendMessage}
+        stop={mocks.stop}
+        isStreaming={false}
+      />
+    )
+
+    // The managed-sync upward propagation: editor text changes, tokens never reported.
+    await act(async () => {
+      mocks.surfaceProps?.onTextChange(`hello ${knowledgePrompt}`)
+    })
+
+    // Every writer — periodic and unmount — must store the serialized pair, even where the text
+    // state has fallen behind the editor serialization the pair was captured from.
+    expect(drafts.get(draftCacheKey)).toEqual(
+      expect.objectContaining({
+        text: serializedText,
+        tokens: [chipToken]
+      })
+    )
+
+    view.unmount()
+
+    expect(drafts.get(draftCacheKey)).toEqual(
+      expect.objectContaining({
+        text: serializedText,
+        tokens: [chipToken]
+      })
+    )
+  })
+
   it('seeds cached files before managed file tokens reconcile', () => {
     const cachedFileToken = {
       id: `file:${file.fileTokenSourceId}`,


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Switching away from an agent session whose composer had a knowledge base chip (added via the panel picker, or restored by draft hydration) could poison the persisted draft: switching back showed the chip's hidden model-facing instruction sentence as plain text in the input box, followed by the chip being re-inserted at the caret - a stable broken `[chip][raw sentence]` state. Screenshot of the broken state (input box at the bottom shows the raw English prompt next to the re-inserted chip):

![Before: knowledge base prompt sentence leaked into the agent composer input](https://github.com/user-attachments/assets/f7238859-86ca-4482-8fdb-9a2c6f367f72)

After this PR:

A persisted composer draft is always an atomic `{ text, tokens }` pair from a single serialization of the live editor surface. Switching away and back restores the chip without ever stranding its prompt sentence as visible prose.

- `AgentComposer`'s periodic persist effect and `persistFinalDraft` both read text and tokens from one `actionsRef.current.getDraft()` call instead of pairing live text with the shadow `draftTokens` state.
- `ComposerSurfaceRuntime.getDraft`'s destroyed-editor branch serves the last full serialization (`lastSerializedDraftRef`, maintained at every write path including the `emitUpdate: false` `setContent` sites and seeded at `onCreate`) instead of fabricating `{ text, tokens: [] }`.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #

### Why we need it and why it was done in this way

Root cause: a knowledge chip inserted through the managed token sync never reaches the composer's shadow `draftTokens` state, because the sync dispatch runs with `isSyncingTokensRef` set and the editor's `onUpdate` deliberately suppresses `onTokensChange` there (to avoid render loops - the `tokens` prop is itself derived from the selection state). The unmount-time persist read text from React state but tokens from that shadow ref, so the cache held a text/token pair captured from two different sources. On restore, `createComposerDraftContent` could not match the token's `promptText` at its recorded offset, dropped the chip and left the sentence as prose.

The following tradeoffs were made:

- The editor serialization is the single source of truth for persistence. The shadow token state still exists, but only for UI derivation (skill/knowledge data fetching, reconciliation) - never for persistence.
- The destroyed-editor branch of `getDraft` serves the last known serialization rather than a fabricated text-only pair, so the invariant "one serialization per persisted pair" holds even if the editor is torn down before the persist runs.

The following alternatives were considered:

- Keeping the shadow state fresh by reporting tokens during managed sync: rejected - `isSyncingTokensRef` suppression is deliberate anti-feedback design; the `tokens` prop is derived from selection state, so echoing tokens back would close a loop.
- Healing already-poisoned caches on restore: rejected - a stranded sentence is indistinguishable from deliberately pasted text, so automatic removal is unsafe. Fixing the writer stops new corruption; an existing corrupted draft is repaired by deleting the sentence once.

Links to places where the discussion took place: N/A

### Breaking changes

None. The draft cache format (fields and serialization protocol) is unchanged.

### Special notes for your reviewer

- `ChatComposer`'s periodic/final persist writers pair React-state text with editor tokens too - same defect class, but with no reachable production divergence (its final persist already serializes from the live surface, text state and editor serialization are held in lockstep, and TipTap defers editor destruction past unmount cleanup). Fixing it faithfully requires migrating the chat test harness's phantom `getDraft` default plus several tests that implicitly depend on it; deferred to a separate change.
- Draft caches already corrupted before this fix are not auto-healed (see rejected alternative above).
- Regression tests: agent unmount + periodic persist (managed-sync simulation where `onTextChange` fires but `onTokensChange` is suppressed), destroyed-editor `getDraft`, and `onCreate` seeding.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
<!--LANG:en-->
[Composer] Fixed the agent input box sometimes showing a raw knowledge-base prompt sentence after switching back to a session with an attached knowledge base.
<!--LANG:zh-CN-->
[输入框] 修复切回已挂载知识库的智能体会话时，输入框偶尔显示知识库提示词原文的问题。
<!--LANG:END-->
```
