### PR TITLE
fix(mini-app): let the activity log wrap, and end where the dialog does

### DIFF
--- a/src/renderer/components/MiniApp/MiniAppDetailPanel.tsx
+++ b/src/renderer/components/MiniApp/MiniAppDetailPanel.tsx
@@ -373,7 +373,11 @@ const MiniAppDetailPanel: FC<Props> = ({ appId, onClose }) => {
                 />
               )}
 
-              <Tabs defaultValue="permissions" className="gap-3">
+              {/* Grows into whatever the dialog's own `min-h`/`max-h` leaves, so the activity list
+                  below ends where the dialog does instead of at a fixed 14rem. The floor is not
+                  `min-h-0`: this sits in a scrolling flex column, and a zero floor lets an update
+                  card above squash the panel instead of making that column scroll. */}
+              <Tabs defaultValue="permissions" className="min-h-56 flex-1 gap-3">
                 <TabsList className="w-full">
                   <TabsTrigger value="permissions" className="flex-1">
                     {t('miniApp.detail.permissions_title')}
@@ -426,7 +430,7 @@ const MiniAppDetailPanel: FC<Props> = ({ appId, onClose }) => {
                     </Button>
                   </div>
                 </TabsContent>
-                <TabsContent value="activity" className="flex flex-col gap-3 px-3">
+                <TabsContent value="activity" className="flex min-h-0 flex-col gap-3 px-3">
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-1.5 text-muted-foreground text-xs">
                       {activity.days > 0 && (
@@ -479,7 +483,7 @@ const MiniAppDetailPanel: FC<Props> = ({ appId, onClose }) => {
                     <p className="text-muted-foreground text-xs">{t('miniApp.activity.empty')}</p>
                   ) : (
                     <ul
-                      className="flex max-h-56 flex-col gap-1 overflow-y-auto font-mono text-xs"
+                      className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto font-mono text-xs"
                       data-testid="activity-list">
                       {activity.entries.map((entry, index) => (
                         <li
@@ -490,7 +494,9 @@ const MiniAppDetailPanel: FC<Props> = ({ appId, onClose }) => {
                               : 'flex gap-2'
                           }>
                           <span className="shrink-0 text-muted-foreground">{timeOf(entry.ts)}</span>
-                          <span className="truncate">{describeActivity(t, entry)}</span>
+                          {/* `min-w-0` as well as `break-words`: a flex item will not shrink past its
+                              longest word, and `overflow-wrap` alone does not lower that floor. */}
+                          <span className="min-w-0 break-words">{describeActivity(t, entry)}</span>
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Two display faults in the mini app detail panel's activity list, both introduced with the panel in #19475.

Before this PR:

- Entries were `truncate`d. Anything past the column width was ellipsised, with no horizontal scroll and no wrap, so the rest of the line was unreadable. #19475 made this more visible by adding a `reason` facet to failed calls, which lengthens exactly the lines a user most wants to read.
- The list capped itself at `max-h-56` inside a dialog that is at least `60vh` tall, so it scrolled internally while a band of empty space sat below it.

After this PR:

- Long entries wrap.
- The list grows into the height the dialog already has, and scrolls only once it runs out.

N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

- **Wrap rather than scroll horizontally.** A horizontal scrollbar would carry the timestamp column out of view and needs a second gesture to read one line. Wrapping is also what this repository already does for long text blocks (`BinaryInstallErrorDialog`, `MessageMetaTool`).
- **`min-w-0` alongside `break-words`.** A flex item will not shrink below its longest word, and `overflow-wrap: break-word` does not lower that floor, so a long unbroken token would still overflow without it.
- **`min-h-56` on the tabs, not `min-h-0`.** They sit in a scrolling flex column. `min-height: auto` is what makes a child overflow and let that column scroll instead of being squashed; a zero floor would let the update card above compress the panel to nothing while the column stayed unscrolled. The old fixed height becomes the floor, so a tight layout falls back to exactly today's behaviour.

The following alternatives were considered:

- Horizontal scrolling on the list, per the first reading of the report — dropped for the reason above.
- Removing the height cap entirely and letting the dialog body scroll as one. That also removes the dead space, but the filter and clear buttons scroll away with it.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

No test accompanies this change, deliberately. The truncation was CSS-only — the DOM always held the full text — so there is no behavioural difference to assert, and jsdom computes no layout. The only assertion available would be on class names, which is the behaviour-pinning shape `CLAUDE.md` rules out.

Verified by `pnpm build:check` on this branch: lint clean, 2,129 test files green.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
<!--LANG:en-->
[Mini App] The detail panel's activity log now wraps long entries and fills the dialog instead of stopping at a fixed height.
<!--LANG:zh-CN-->
[小程序] 详情面板的活动日志现在会换行显示过长条目，并跟随弹窗高度，不再固定高度留白。
<!--LANG:END-->
```
