### PR TITLE
fix(ci): shard preload with the main forks pool

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -132,6 +132,10 @@ export default defineConfig({
         test: {
           name: 'preload',
           environment: 'node',
+          // vitest shards per (groupOrder, pool) bucket and rejects buckets smaller
+          // than the shard count; preload's single test file must share main's forks
+          // pool (CI always runs it alongside main) instead of crashing --shard=i/3.
+          pool: 'forks',
           include: ['src/preload/**/*.{test,spec}.ts', 'src/preload/**/__tests__/**/*.{test,spec}.ts']
         }
       },


### PR DESCRIPTION
### What this PR does

Before this PR: any PR that only touches `src/main/**` (plus renderer/etc. but **not** `src/shared`, `packages/**`, `scripts/**`, or other threads-pool areas) fails `main-test (ubuntu-latest i/3)` with:

```
Error: --shard <count> must be a smaller than count of test files. Resolved 1 test files for --shard=1/3.
```

After this PR: the `preload` project joins `main` in the forks pool, so CI's `--project main --project preload --shard=i/3` has a single large pool bucket and never hits the 1-file-bucket rejection.

### Why we need it and why it was done this way

Vitest 3 shards per `(sequence.groupOrder, pool)` bucket and **throws when any bucket has fewer files than the shard count** (the guard inside `sortSpecs` in vitest's dist). Our pool layout:

- `main` → `pool: 'forks'` (~300 test files)
- every other project → global `pool: 'threads'`
- **`preload` has exactly one test file** (`src/preload/__tests__/miniAppBridge.test.ts`)

CI's paths-filter folds `src/preload/**` into the `main` filter, so on PR events `projects=(--project main --project preload)` — preload alone forms a 1-file threads bucket while main lives in forks, and `--shard=1/3` (3 > 1) aborts the whole job. Reproduced locally:

```bash
$ pnpm exec vitest list --project preload --shard=1/3
Error: --shard <count> must be a smaller than count of test files. Resolved 1 test files for --shard=1/3.
```

Why PRs that also touch `src/shared` pass (e.g. #18793): `shared` joins the threads bucket (97 files), so the bucket is 1+97 ≥ 3. Why pushes to `main` pass: push events open **all** projects, so the threads bucket is huge.

**Regression window**: `--project preload` entered `ci.yml` in #19475 (merged 2026-08-28 23:13 +0800). PRs whose last CI run predates it (e.g. #19652, #19663) ran the old workflow without preload and still show green — but they will fail the same way on their next push, since PR runs use the workflow file from their own merge ref. #19613 was the first hit because its CI ran right after that merge.

The following alternatives were considered:
- Dynamically lowering the shard count in ci.yml — rejected: needs an extra full collection pass per job and complicates the workflow script.
- `passWithNoTests: true` — rejected: globally masks genuine "collected 0 tests" regressions.
- Merging preload's tests into the `main` project — rejected: larger config/CI surface change for the same effect.
- Upgrading to vitest 4 (whose `shard()` no longer throws on small buckets) — a valid long-term path, but too large to bundle with this fix.

The following tradeoffs were made: preload tests (pure bridge logic, node environment) now run in fork workers instead of threads — verified identical results, no measurable overhead for a single file.

Links to places where the discussion took place: N/A

### Breaking changes

None. Local runs without `--shard` are unaffected; the pool only changes which worker kind executes the file.

### Special notes for your reviewer

Verification on this branch:
- `pnpm exec vitest list --project main --project preload --shard=1/3` — collects and shards cleanly (4727 cases in shard 1/3), no error.
- `pnpm exec vitest run --project preload` — 24/24 passed (~200 ms).
- File counts that keep every other single-project bucket safe: aiCore 31, ui 69, provider-registry 24, scripts 28, shared 97 test files — preload (1) was the only sub-shard-count bucket.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough
- [x] Code: Write code that humans can understand & Keep it simple
- [x] Refactor: Left the code cleaner than I found it
- [x] Upgrade: No upgrade impact (test infra only)
- [x] Documentation: Not required (no user-facing change)
- [x] Self-review: Done via `gh pr diff`

### Release note

```release-note
NONE
```
