### PR TITLE
feat(files): support Ctrl+A select-all in the file list

### DIFF
--- a/src/renderer/pages/files/FilesPage.tsx
+++ b/src/renderer/pages/files/FilesPage.tsx
@@ -878,10 +878,31 @@ function FilesPage() {
 
         startInlineRename(selectedFile.id)
       }
+      if (
+        (isMac ? e.metaKey : e.ctrlKey) &&
+        !e.shiftKey &&
+        !e.altKey &&
+        e.key.toLowerCase() === 'a' &&
+        !isImageGrid &&
+        filteredFiles.length > 0
+      ) {
+        e.preventDefault()
+        handleSelectAllVisible(true)
+      }
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [embeddedPreview, files, selectedIds, handleDelete, renamingId, startInlineRename])
+  }, [
+    embeddedPreview,
+    files,
+    selectedIds,
+    handleDelete,
+    renamingId,
+    startInlineRename,
+    isImageGrid,
+    filteredFiles,
+    handleSelectAllVisible
+  ])
 
   return (
     <div data-ui="files.view" className="relative flex min-h-0 flex-1 overflow-hidden">

--- a/src/renderer/pages/files/__tests__/FilesPage.test.tsx
+++ b/src/renderer/pages/files/__tests__/FilesPage.test.tsx
@@ -674,6 +674,68 @@ describe('FilesPage keyboard rename', () => {
   })
 })
 
+describe('FilesPage keyboard select all', () => {
+  it('selects all visible files with Cmd+A on macOS', async () => {
+    const secondEntry = { ...entry, id: 'file-2', name: 'notes' } as unknown as FileEntry
+    renderFilesPage([entry, secondEntry])
+    const user = userEvent.setup()
+
+    await user.keyboard('{Meta>}a{/Meta}')
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: 'files.select_file' })
+    expect(checkboxes).toHaveLength(2)
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toBeChecked()
+    }
+  })
+
+  it('selects all visible files with Ctrl+A outside macOS', async () => {
+    platformState.isMac = false
+    const secondEntry = { ...entry, id: 'file-2', name: 'notes' } as unknown as FileEntry
+    renderFilesPage([entry, secondEntry])
+    const user = userEvent.setup()
+
+    await user.keyboard('{Control>}a{/Control}')
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: 'files.select_file' })
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toBeChecked()
+    }
+  })
+
+  it('ignores select-all shortcuts from interactive controls', async () => {
+    renderFilesPage()
+    const user = userEvent.setup()
+
+    const typeHeader = screen.getByRole('button', { name: 'files.type' })
+    typeHeader.focus()
+    await user.keyboard('{Meta>}a{/Meta}')
+
+    expect(screen.getByRole('checkbox', { name: 'files.select_file' })).not.toBeChecked()
+  })
+
+  it('does not batch-delete files via select-all and delete shortcuts in the image grid', async () => {
+    ipcMocks.request.mockImplementation((route: string) => {
+      if (route === 'file.batch_get_metadata') return Promise.resolve({})
+      if (route === 'file.batch_get_physical_paths') return Promise.resolve({ [imageEntry.id]: '/tmp/photo.png' })
+      if (route === 'file.batch_get_dangling_states') return Promise.resolve({})
+      return Promise.resolve({})
+    })
+    renderFilesPage([imageEntry])
+    const user = userEvent.setup()
+
+    const imageFilterButton = screen.getByRole('button', { name: /^files\.image/ })
+    await user.click(imageFilterButton)
+    imageFilterButton.blur()
+    await screen.findByAltText('photo.png')
+
+    await user.keyboard('{Meta>}a{/Meta}')
+    await user.keyboard('{Delete}')
+
+    expect(ipcMocks.request).not.toHaveBeenCalledWith('file.batch_trash', expect.anything())
+  })
+})
+
 describe('FilesPage file operations', () => {
   beforeEach(() => {
     ipcMocks.request.mockImplementation((route: string, input?: unknown) => {


### PR DESCRIPTION
### What this PR does

Before this PR:

- The Files page offers select-all only through the header checkbox; there is no keyboard shortcut for it.

After this PR:

- Pressing `Ctrl+A` (`Cmd+A` on macOS) in the Files page list view selects every file in the current filtered view, with the same effect as checking the header select-all checkbox.
- The shortcut is guarded the same way as the page's existing Delete/F2 shortcuts: it does nothing while an input, text field, or other interactive control has focus (native text select-all is preserved), and it stays inert in the image grid view, which has no selection model.

Related to #9616 (file-management batch operations, closed as completed when the batch-selection UI shipped — this PR completes it with a keyboard select-all entry point).

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Reused the existing select-all logic behind the header checkbox (`handleSelectAllVisible`) instead of adding a new selection path, so the checkbox and the keyboard shortcut share one owner for select-all semantics.
- The shortcut always selects (never toggles), matching standard file-manager behavior; deselection remains available through the header checkbox.

The following alternatives were considered:

- Handling the shortcut in the list component: rejected because selection state and the page's existing keyboard shortcuts already live on the page, making the page-level keydown handler the single owner.
- Adding the shortcut to the image grid view: rejected for now because that view has no selection model; the branch explicitly keeps the shortcut inert there to avoid invisible selections.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Regression tests cover Cmd+A on macOS, Ctrl+A outside macOS, the interactive-control guard, and the image-grid no-op path, written with `userEvent.keyboard` and role-based queries per `docs/references/testing/frontend-testing.md`.
- The image-grid no-op test is mutation-verified: removing the `!isImageGrid` clause makes it fail (`file.batch_trash` gets called), so the guard clause is genuinely pinned.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Files: You can now press Ctrl+A (Cmd+A on macOS) in the file list to select all files in the current view.
```
