### PR TITLE
fix(agents): keep the progress capsule on the main agent's plan

### DIFF
--- a/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/__tests__/agentRightPaneProjection.test.ts
@@ -276,6 +276,52 @@ describe('agent right pane projections', () => {
     expect(snapshotWins.totalTaskCount).toBe(1)
   })
 
+  it('keeps the plan owned by the main agent when spawned runs write todos or tasks', () => {
+    const parts = [
+      toolPart('todos-main', 'TodoWrite', undefined, 'output-available', {
+        todos: [
+          { content: 'Design pane', activeForm: 'Designing pane', status: 'completed' },
+          { content: 'Wire flow', activeForm: 'Wiring flow', status: 'in_progress' }
+        ]
+      }),
+      // Spawned-run parts arrive parented under their Task tool call and must not own the plan.
+      toolPart('child-todos', 'TodoWrite', 'parent-task-call', 'output-available', {
+        todos: [{ content: 'Subagent todo', status: 'in_progress' }]
+      }),
+      toolPart(
+        'child-task-create',
+        'TaskCreate',
+        'parent-task-call',
+        'output-available',
+        { subject: 'Subagent ledger row' },
+        {
+          task: { id: '1', subject: 'Subagent ledger row' }
+        }
+      ),
+      // The dsh runtime parents spawned-run parts through its own metadata namespace.
+      {
+        type: 'dynamic-tool',
+        toolCallId: 'dsh-child-todos',
+        toolName: 'todo_write',
+        state: 'output-available',
+        input: { todos: [{ content: 'Dsh child todo', status: 'in_progress' }] },
+        callProviderMetadata: {
+          cherry: {
+            transport: 'dsh-agent',
+            parentToolCallId: 'dsh-parent-task-call',
+            tool: { type: 'builtin', name: 'todo_write' }
+          }
+        }
+      } as unknown as CherryMessagePart
+    ]
+
+    const status = buildAgentRightPaneStatus([message('m1', parts)], { m1: parts })
+
+    expect(status.tasks.map((task) => task.title)).toEqual(['Design pane', 'Wire flow'])
+    expect(status.completedTaskCount).toBe(1)
+    expect(status.totalTaskCount).toBe(2)
+  })
+
   it('projects the latest successful dsh todo_write snapshot into status tasks', () => {
     const parts = [
       dshToolPart('dsh-todos-1', 'todo_write', 'output-available', {

--- a/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
+++ b/src/renderer/pages/agents/components/AgentRightPane/agentRightPaneProjection.ts
@@ -12,6 +12,7 @@ import {
 } from '@renderer/components/chat/messages/tools/shared/agentToolTypes'
 import {
   getPartParentToolCallId,
+  hasPartParentToolCallId,
   stripPartParentToolMetadata
 } from '@renderer/components/chat/messages/tools/toolParentMetadata'
 import { getCanonicalToolName } from '@renderer/components/chat/messages/tools/toolResponse'
@@ -560,9 +561,12 @@ export function buildAgentRightPaneStatus(
       const fallbackId = getToolCallId(part) ?? `${message.id}-${partIndex}`
       // The plan has two writers — the incremental task ledger and full-list todo snapshots —
       // and the most recent writer owns it: a later ledger write invalidates an earlier snapshot.
-      if (applyTaskToolPart(taskPlanState, part, fallbackId, toolName)) todoSnapshotTasks = undefined
-      const todoSnapshot = getTodoSnapshot(part)
-      if (todoSnapshot !== undefined) todoSnapshotTasks = todoSnapshot
+      // Both writers are main-agent-only: spawned-run parts are parented under their Task call.
+      if (!hasPartParentToolCallId(part)) {
+        if (applyTaskToolPart(taskPlanState, part, fallbackId, toolName)) todoSnapshotTasks = undefined
+        const todoSnapshot = getTodoSnapshot(part)
+        if (todoSnapshot !== undefined) todoSnapshotTasks = todoSnapshot
+      }
 
       if (isReportArtifactsTool(toolName)) {
         const parsed = reportArtifactsInputSchema.safeParse(getToolPartInput(part))


### PR DESCRIPTION
### What this PR does

Before this PR:

When the main agent spawned a subagent and that subagent called `TodoWrite` (or the task tools), the floating progress capsule and its hover card switched to tracking the **subagent's** private checklist: the main plan's items disappeared, the "step n/m" count restarted over subagent-internal steps, and a subagent's later snapshot always won over the main plan.

After this PR:

The progress capsule always tracks the **main agent's own task plan**. Plan-writing parts (`TaskCreate`/`TaskUpdate`/`TaskList` ledger and full-list `TodoWrite` snapshots) are only applied when the part is owned by the main agent — i.e. it carries no parent tool-call linkage. Spawned-run parts are always parented under their `Task` tool call in both runtimes (claude-code provider metadata and the dsh `cherry` transport tag), so one ownership check covers both writers and both runtimes.

None

### Why we need it and why it was done in this way

The capsule is the session's primary progress signal, and it is documented (in `agentRightPaneProjection.ts` itself) to represent the main agent's plan. The projection, which owns that fact, was feeding every tool part in the session stream into the plan regardless of owner; because the plan follows a "most recent writer wins" rule, any later subagent todo write silently replaced the main plan.

The following tradeoffs were made:

- Fixing at the projection (the owner of the "which plan does the session show" fact) instead of at each renderer: one guard covers both plan writers and both runtimes' parent-stamping schemes, with no per-runtime special-casing.
- Subagent capability is deliberately untouched: subagents keep calling `TodoWrite`/task tools; their calls still persist and still render inside their own flow view. This changes display ownership only.

The following alternatives were considered:

- Threading an explicit `owner` field through the task data model (a discarded earlier attempt): a data-model change with the same observable outcome; the parent-tool-call linkage already encodes ownership, so it is reused instead.
- Hiding subagent todos in the subagent flow view too: rejected — that view is the spawned run's own transcript and its todo list is legitimate content there.

Links to places where the discussion took place: N/A

### Breaking changes

None

### Special notes for your reviewer

- Regression test reproduces the bug red (a spawned `TaskCreate` wiping the main snapshot) and covers both parent-stamping namespaces; right-pane + tool-renderer suites 275/275, typecheck/biome/eslint clean.
- Verified in the real Electron app over CDP: a seeded session with a main-agent `TodoWrite` plus parented subagent `TodoWrite`/`TaskCreate` renders a capsule listing only the main agent's todos.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g. via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agents: the task progress capsule now always tracks the main agent's task plan; todo lists written by spawned subagents no longer replace it.
```
