### PR TITLE
feat(paintings): support mouse-wheel zoom on the artboard

### DIFF
--- a/src/renderer/pages/paintings/components/Artboard.tsx
+++ b/src/renderer/pages/paintings/components/Artboard.tsx
@@ -222,6 +222,11 @@ const Artboard: FC<ArtboardProps> = ({ painting, isLoading, imageCover }) => {
   const [displayedNaturalSize, setDisplayedNaturalSize] = useState<{ width: number; height: number } | null>(null)
   const [promptBarHeight, setPromptBarHeight] = useState(0)
   const imageDragRef = useRef<ImageDragState | null>(null)
+  // Latest scale/offset mirror for the native wheel listener, which must read the
+  // current transform synchronously without re-binding on every pan/zoom render.
+  const imageTransformRef = useRef({ scale: DEFAULT_IMAGE_SCALE, offset: DEFAULT_IMAGE_OFFSET })
+  imageTransformRef.current = { scale: imageScale, offset: imageOffset }
+  const viewerContainerRef = useRef<HTMLDivElement | null>(null)
   const awaitingRevealRef = useRef(false)
   const previousLoadingRef = useRef(isLoading)
   const paintingIdRef = useRef(painting.id)
@@ -305,6 +310,41 @@ const Artboard: FC<ArtboardProps> = ({ painting, isLoading, imageCover }) => {
     }
   }, [])
 
+  // Zoom around the pointer: with scale (and rotation) pivoting on the image
+  // center, keeping the anchor point stationary means offset' = a - (a - o)·ratio.
+  const onViewerWheel = useCallback((event: WheelEvent) => {
+    if (event.deltaY === 0) {
+      return
+    }
+    // React's synthetic onWheel registers passively, so consuming the gesture
+    // (page scroll, ctrl+wheel pinch-zoom) needs a native non-passive listener.
+    event.preventDefault()
+    const container = event.currentTarget as HTMLDivElement
+    const image = container.querySelector('img')
+    if (!image) {
+      return
+    }
+    const rect = image.getBoundingClientRect()
+    const anchorX = event.clientX - rect.left - rect.width / 2
+    const anchorY = event.clientY - rect.top - rect.height / 2
+    const { scale, offset } = imageTransformRef.current
+    const nextScale = Math.min(
+      MAX_IMAGE_SCALE,
+      Math.max(MIN_IMAGE_SCALE, scale + (event.deltaY < 0 ? IMAGE_SCALE_STEP : -IMAGE_SCALE_STEP))
+    )
+    if (nextScale === scale) {
+      return
+    }
+    const ratio = nextScale / scale
+    const nextOffset = {
+      x: anchorX - (anchorX - offset.x) * ratio,
+      y: anchorY - (anchorY - offset.y) * ratio
+    }
+    imageTransformRef.current = { scale: nextScale, offset: nextOffset }
+    setImageScale(nextScale)
+    setImageOffset(nextOffset)
+  }, [])
+
   // Explicit contain-fit box for the idle (already-generated) image, mirroring
   // PaintingImageSkeleton's lockedSize math. CSS auto-sizing a flex-col wrapper around
   // the image can't be trusted here — ImageViewer nests the `<img>` behind a
@@ -323,16 +363,22 @@ const Artboard: FC<ArtboardProps> = ({ painting, isLoading, imageCover }) => {
   // (already-generated) branch renders, which usually happens later (after a
   // generation completes) than Artboard's own mount. A callback ref re-attaches
   // the observer every time the branch swaps this node in, not just the first time.
-  const setViewerContainerRef = useCallback((el: HTMLDivElement | null) => {
-    viewerResizeObserverRef.current?.disconnect()
-    viewerResizeObserverRef.current = null
-    if (!el) return
-    const measure = () => setViewerContainer({ width: el.clientWidth, height: el.clientHeight })
-    measure()
-    const observer = new ResizeObserver(measure)
-    observer.observe(el)
-    viewerResizeObserverRef.current = observer
-  }, [])
+  const setViewerContainerRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      viewerResizeObserverRef.current?.disconnect()
+      viewerResizeObserverRef.current = null
+      viewerContainerRef.current?.removeEventListener('wheel', onViewerWheel)
+      viewerContainerRef.current = el
+      if (!el) return
+      el.addEventListener('wheel', onViewerWheel, { passive: false })
+      const measure = () => setViewerContainer({ width: el.clientWidth, height: el.clientHeight })
+      measure()
+      const observer = new ResizeObserver(measure)
+      observer.observe(el)
+      viewerResizeObserverRef.current = observer
+    },
+    [onViewerWheel]
+  )
 
   // `promptBar` renders in the fixed layout wrapper above the transformed image,
   // so its own rendered height has to come out of the space
@@ -497,6 +543,7 @@ const Artboard: FC<ArtboardProps> = ({ painting, isLoading, imageCover }) => {
         ) : painting.files.length > 0 && currentImageUrl ? (
           <div
             ref={setViewerContainerRef}
+            data-testid="artboard-viewer"
             className="relative flex min-h-0 w-full flex-1 items-center justify-center overflow-hidden">
             {/* The prompt bar is a flex-col sibling of the transformed image so it stays
                 fixed while the image pans, zooms, or rotates. The layout wrapper is

--- a/src/renderer/pages/paintings/components/__tests__/Artboard.test.tsx
+++ b/src/renderer/pages/paintings/components/__tests__/Artboard.test.tsx
@@ -143,6 +143,17 @@ const firePointer = (element: Element, type: string, init: Record<string, number
   fireEvent(element, event)
 }
 
+const fireWheel = (element: Element, init: Record<string, number>) => {
+  const event = new Event('wheel', { bubbles: true, cancelable: true })
+
+  for (const [key, value] of Object.entries(init)) {
+    Object.defineProperty(event, key, { value })
+  }
+
+  fireEvent(element, event)
+  return event
+}
+
 describe('Artboard', () => {
   beforeAll(() => {
     HTMLElement.prototype.setPointerCapture ??= vi.fn()
@@ -693,5 +704,81 @@ describe('Artboard', () => {
     expect(transformTarget.style.transform).toBe('translate(0px, 0px) scale(4) rotate(0deg)')
     expect(zoomInButton).toBeDisabled()
     expect(zoomOutButton).not.toBeDisabled()
+  })
+
+  describe('wheel zoom', () => {
+    // Image box centered at (200, 100) — wheel events aim at this box unless the
+    // test says otherwise, so a pointer at the center anchors zoom at (0, 0).
+    const mockImageRect = (image: Element) =>
+      vi
+        .spyOn(image, 'getBoundingClientRect')
+        .mockReturnValue({ left: 100, top: 50, width: 200, height: 100 } as DOMRect)
+
+    it('zooms in on wheel-up and out on wheel-down around the pointer', () => {
+      render(<Artboard painting={makePainting()} isLoading={false} />)
+
+      const viewer = screen.getByTestId('artboard-viewer')
+      const image = screen.getByTestId('artboard-image-transform')
+      mockImageRect(image)
+
+      // Pointer at (300, 150) anchors 100px right / 50px below the image center;
+      // zooming 1 → 1.25 pulls the offset to keep that point under the cursor.
+      const zoomEvent = fireWheel(viewer, { deltaY: -100, clientX: 300, clientY: 150 })
+      expect(zoomEvent.defaultPrevented).toBe(true)
+      expect(image.style.transform).toBe('translate(-25px, -12.5px) scale(1.25) rotate(0deg)')
+
+      fireWheel(viewer, { deltaY: 100, clientX: 300, clientY: 150 })
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+    })
+
+    it('clamps wheel zoom at the 0.25–4 boundaries without shifting the image', () => {
+      render(<Artboard painting={makePainting()} isLoading={false} />)
+
+      const viewer = screen.getByTestId('artboard-viewer')
+      const image = screen.getByTestId('artboard-image-transform')
+      mockImageRect(image)
+      const zoomOutButton = screen.getByRole('button', { name: 'preview.zoom_out' })
+      const zoomInButton = screen.getByRole('button', { name: 'preview.zoom_in' })
+
+      for (let i = 0; i < 3; i++) {
+        fireWheel(viewer, { deltaY: 100, clientX: 200, clientY: 100 })
+      }
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(0.25) rotate(0deg)')
+      expect(zoomOutButton).toBeDisabled()
+
+      // Extra wheel-downs at the floor stay consumed (no ancestor scroll) and
+      // must not nudge the clamped transform.
+      const clampedEvent = fireWheel(viewer, { deltaY: 100, clientX: 200, clientY: 100 })
+      expect(clampedEvent.defaultPrevented).toBe(true)
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(0.25) rotate(0deg)')
+
+      for (let i = 0; i < 15; i++) {
+        fireWheel(viewer, { deltaY: -100, clientX: 200, clientY: 100 })
+      }
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(4) rotate(0deg)')
+      expect(zoomInButton).toBeDisabled()
+
+      const ceilingEvent = fireWheel(viewer, { deltaY: -100, clientX: 200, clientY: 100 })
+      expect(ceilingEvent.defaultPrevented).toBe(true)
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(4) rotate(0deg)')
+      expect(zoomOutButton).not.toBeDisabled()
+
+      fireEvent.click(screen.getByRole('button', { name: 'preview.reset' }))
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+    })
+
+    it('leaves wheel events originating outside the artboard surface untouched', () => {
+      const { container: outside } = render(<Artboard painting={makePainting()} isLoading={false} />)
+
+      const image = screen.getByTestId('artboard-image-transform')
+      mockImageRect(image)
+
+      // Dispatching on the render wrapper bypasses the artboard surface entirely —
+      // the wheel must stay default (history strip and other scrollable UI keep
+      // working) and the image must not move.
+      const outsideEvent = fireWheel(outside, { deltaY: -100, clientX: 300, clientY: 150 })
+      expect(outsideEvent.defaultPrevented).toBe(false)
+      expect(image.style.transform).toBe('translate(0px, 0px) scale(1) rotate(0deg)')
+    })
   })
 })


### PR DESCRIPTION
### What this PR does

Before this PR:

On the Paintings page, a generated image could only be zoomed by repeatedly clicking the Zoom In / Zoom Out buttons in the left-side toolbar; the mouse wheel did nothing over the artboard.

After this PR:

Scrolling the mouse wheel (or trackpad scroll gesture) over the generated-image artboard zooms the image — wheel up zooms in, wheel down zooms out — anchored at the pointer position so the detail under inspection stays in view. The existing 0.25x–4x scale bounds and 0.25 step are reused, so wheel zoom and the toolbar buttons stay in sync (either input can reach a boundary and disable its button).

Fixes #19654

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The handler is a native non-passive `wheel` listener bound to the artboard surface instead of a React `onWheel` prop: React registers synthetic `wheel` events passively, so `preventDefault()` — needed to consume the gesture and block ancestor scrolling / ctrl+wheel pinch-zoom — would be a no-op. This matches the existing patterns in `useImageTools` and `PdfFilePreview`.
- One discrete `IMAGE_SCALE_STEP` per wheel event instead of continuous multiplicative zoom: it keeps every reachable scale aligned with the toolbar's step model and makes the boundary/disabled-state contract deterministic, as planned on the issue.

The following alternatives were considered:

- Ctrl+wheel-only zoom (raised in the issue): rejected because the artboard is a dedicated non-scrolling surface, so plain wheel zoom with `preventDefault` is safe and more convenient.
- Continuous `exp(-deltaY)` zoom like the image preview dialog: rejected to preserve the existing 0.25-step scale state shared with the toolbar buttons.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19654

### Breaking changes

None.

### Special notes for your reviewer

- The listener is bound in the existing `setViewerContainerRef` callback ref, for the same reason the ResizeObserver is: the container only exists once the idle (already-generated) branch renders, so a mount-only effect would never attach.
- Wheel events outside the artboard surface (history strip, composer, other scrollable UI) are untouched; wheel events inside are always consumed, even at the scale boundaries.
- Rotation co-exists with pointer anchoring because uniform scaling commutes with rotation about the same center pivot.
- Focused component tests cover wheel direction + pointer anchoring, boundary clamping without offset drift, and scroll isolation for events originating outside the surface.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Paintings] The generated-image artboard now supports mouse-wheel zoom (wheel up to zoom in, wheel down to zoom out) anchored at the pointer, within the existing 0.25x–4x scale bounds.
```
