### PR TITLE
fix(quick-panel): open single-select submenus on the current selection

### DIFF
--- a/src/renderer/components/QuickPanel/QuickPanelProvider.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelProvider.tsx
@@ -107,6 +107,7 @@ export const QuickPanelProvider: React.FC<React.PropsWithChildren> = ({ children
     setSortFn(undefined)
     setTitle(undefined)
     setSymbol('')
+    setDefaultIndex(-1)
     setTriggerInfo(undefined)
     setQueryAnchor(undefined)
     setTrackInputQuery(false)

--- a/src/renderer/components/QuickPanel/QuickPanelView.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelView.tsx
@@ -13,6 +13,7 @@ import {
 } from './heights'
 import {
   firstQuickPanelSelectableIndex,
+  initialQuickPanelFocusIndex,
   moveQuickPanelSelectableIndex,
   QuickPanelFooter,
   QuickPanelReadOnlyHeader,
@@ -96,6 +97,10 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
 
   // Prevent the mouse from interfering during page up/down navigation.
   const [isMouseOver, setIsMouseOver] = useState(false)
+
+  // Hover-mirroring affordances (e.g. the row tooltip) follow the cursor only after keyboard
+  // navigation, never the programmatic focus a panel opens with.
+  const [isKeyboardNavigating, setIsKeyboardNavigating] = useState(false)
 
   const scrollTriggerRef = useRef<QuickPanelScrollTrigger>('initial')
   const [activeIndex, setActiveIndex] = useState(-1)
@@ -191,10 +196,15 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       inputQueryConsumedRef.current = false
       prevPanelGenerationRef.current = undefined
       setActiveIndex(-1)
+      setIsKeyboardNavigating(false)
       return
     }
 
-    if (!ctx.isVisible) return
+    // Retire hover-mirroring state at hide time, not when the cleanup timer finally clears the symbol.
+    if (!ctx.isVisible) {
+      setIsKeyboardNavigating(false)
+      return
+    }
 
     const panelGeneration = getPanelGeneration()
     const isPanelGenerationChanged = prevPanelGenerationRef.current !== panelGeneration
@@ -206,6 +216,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
 
     if (ctx.readOnly) {
       setActiveIndex(-1)
+      setIsKeyboardNavigating(false)
       prevSearchTextRef.current = activeSearchQuery
       prevSymbolRef.current = ctx.symbol
       return
@@ -215,6 +226,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       const isSearchChanged = prevSearchTextRef.current !== activeSearchQuery
       const isSymbolChanged = prevSymbolRef.current !== ctx.symbol
       if (isSymbolChanged || (ctx.trackInputQuery && (isSearchChanged || isPanelGenerationChanged))) {
+        setIsKeyboardNavigating(false)
         setActiveIndex(firstQuickPanelSelectableIndex(list))
       } else {
         setActiveIndex((prevIndex) => (prevIndex >= list.length ? (list.length > 0 ? list.length - 1 : -1) : prevIndex))
@@ -225,12 +237,16 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       return
     }
 
-    // Reset index only when the search text or panel symbol changes.
+    // Reset on a fresh panel (open, or a same-symbol reopen inside the cleanup window) or a
+    // search change: a fresh panel honors the opener's focus request; typing starts from the top.
+    const isFreshPanel = isPanelGenerationChanged
     const isSearchChanged = prevSearchTextRef.current !== activeSearchQuery
-    const isSymbolChanged = prevSymbolRef.current !== ctx.symbol
 
-    if (isSearchChanged || isSymbolChanged) {
-      setActiveIndex(firstQuickPanelSelectableIndex(list))
+    if (isFreshPanel || isSearchChanged) {
+      setIsKeyboardNavigating(false)
+      setActiveIndex(
+        isFreshPanel ? initialQuickPanelFocusIndex(list, ctx.defaultIndex) : firstQuickPanelSelectableIndex(list)
+      )
     } else {
       // Clamp the current index into the valid range.
       setActiveIndex((prevIndex) => (prevIndex >= list.length ? (list.length > 0 ? list.length - 1 : -1) : prevIndex))
@@ -240,6 +256,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     prevSymbolRef.current = ctx.symbol
   }, [
     ctx.isVisible,
+    ctx.defaultIndex,
     ctx.manageListExternally,
     ctx.readOnly,
     ctx.symbol,
@@ -595,6 +612,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
           e.preventDefault()
           e.stopPropagation()
           setIsMouseOver(false)
+          setIsKeyboardNavigating(true)
           const dir = e.key === 'ArrowUp' || e.key === 'PageUp' ? -1 : 1
           setActiveIndex((prev) => moveQuickPanelSelectableIndex(footerNavItems, prev, dir, { wrap: true }))
           return true
@@ -624,6 +642,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
       switch (e.key) {
         case 'ArrowUp':
           scrollTriggerRef.current = 'keyboard'
+          setIsKeyboardNavigating(true)
           setActiveIndex((prev) =>
             moveQuickPanelSelectableIndex(list, prev, assistivePressed ? -ctx.pageSize : -1, { wrap: true })
           )
@@ -631,6 +650,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
 
         case 'ArrowDown':
           scrollTriggerRef.current = 'keyboard'
+          setIsKeyboardNavigating(true)
           setActiveIndex((prev) =>
             moveQuickPanelSelectableIndex(list, prev, assistivePressed ? ctx.pageSize : 1, { wrap: true })
           )
@@ -638,11 +658,13 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
 
         case 'PageUp':
           scrollTriggerRef.current = 'keyboard'
+          setIsKeyboardNavigating(true)
           setActiveIndex((prev) => moveQuickPanelSelectableIndex(list, prev, -ctx.pageSize, { wrap: false }))
           return true
 
         case 'PageDown':
           scrollTriggerRef.current = 'keyboard'
+          setIsKeyboardNavigating(true)
           setActiveIndex((prev) => moveQuickPanelSelectableIndex(list, prev, ctx.pageSize, { wrap: false }))
           return true
 
@@ -891,6 +913,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     if (!ctx.readOnly) {
       setActiveIndex((active) => (active === -1 ? active : -1))
     }
+    setIsKeyboardNavigating(false)
     setIsMouseOver((prev) => (prev ? prev : true))
   }, [ctx.readOnly])
 
@@ -907,6 +930,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
             disabled: item.disabled
           })}
           active={(!ctx.readOnly || !!item.fixedToBottom) && itemIndex === activeIndex}
+          keyboardActive={isKeyboardNavigating}
           dataId={item.id}
           hoverEnabled={isMouseOver}
           item={item}
@@ -917,7 +941,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
         />
       )
     },
-    [activeIndex, ctx.readOnly, handleItemAction, isMouseOver]
+    [activeIndex, ctx.readOnly, handleItemAction, isKeyboardNavigating, isMouseOver]
   )
 
   return (

--- a/src/renderer/components/QuickPanel/__tests__/list.test.ts
+++ b/src/renderer/components/QuickPanel/__tests__/list.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { firstQuickPanelSelectableIndex, moveQuickPanelSelectableIndex } from '../list'
+import { firstQuickPanelSelectableIndex, initialQuickPanelFocusIndex, moveQuickPanelSelectableIndex } from '../list'
 
 const createItems = (): { id: string; disabled?: boolean }[] => [
   { id: 'one' },
@@ -13,6 +13,22 @@ const createItems = (): { id: string; disabled?: boolean }[] => [
 describe('QuickPanel list primitives', () => {
   it('finds the first selectable item', () => {
     expect(firstQuickPanelSelectableIndex([{ id: 'disabled', disabled: true }, ...createItems()])).toBe(1)
+  })
+
+  describe('initialQuickPanelFocusIndex', () => {
+    it('honors the opener focus request when the row is selectable', () => {
+      const items: { id: string; disabled?: boolean }[] = [{ id: 'one' }, { id: 'two' }, { id: 'three' }]
+
+      expect(initialQuickPanelFocusIndex(items, 2)).toBe(2)
+    })
+
+    it('falls back to the first selectable item for a disabled, negative, or out-of-range request', () => {
+      const items: { id: string; disabled?: boolean }[] = [{ id: 'disabled', disabled: true }, { id: 'one' }]
+
+      expect(initialQuickPanelFocusIndex(items, 0)).toBe(1)
+      expect(initialQuickPanelFocusIndex(items, -1)).toBe(1)
+      expect(initialQuickPanelFocusIndex(items, 9)).toBe(1)
+    })
   })
 
   it('moves by one with wrapping while skipping disabled items', () => {

--- a/src/renderer/components/QuickPanel/__tests__/view.test.tsx
+++ b/src/renderer/components/QuickPanel/__tests__/view.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
-import React, { Activity, useEffect, useRef, useState } from 'react'
+import React, { Activity, type ReactNode, useEffect, useRef, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getQuickPanelHeights, QUICK_PANEL_ITEM_HEIGHT, QUICK_PANEL_SAFE_MARGIN } from '../heights'
@@ -14,10 +14,41 @@ import type {
 } from '../types'
 import { useQuickPanel } from '../useQuickPanel'
 
+// The renderer setup stubs the whole UI kit with content-dropped tooltips; restore a minimal
+// NormalTooltip that exposes the controlled `open` flag so row tooltip gating stays observable.
+vi.mock('@cherrystudio/ui', () => ({
+  Kbd: ({ children }: { children?: ReactNode }) => <kbd>{children}</kbd>,
+  NormalTooltip: ({ open = false, children }: { open?: boolean; children?: ReactNode }) => (
+    <div data-open={String(open)}>{children}</div>
+  )
+}))
+
 const virtualListMocks = vi.hoisted(() => ({
   scrollToIndex: vi.fn(),
   scrollToOffset: vi.fn()
 }))
+
+// 单选子菜单夹具：当前值行带警告 tooltip，模拟权限模式弹层。
+const singleSelectSubmenuItems: QuickPanelListItem[] = [
+  { id: 'default', label: 'Ask every time', icon: '1', action: vi.fn() },
+  {
+    id: 'plan',
+    label: 'Plan only',
+    icon: '2',
+    tooltip: 'Plan tip',
+    tooltipAnchor: <span aria-label="plan-warning" />,
+    action: vi.fn()
+  },
+  {
+    id: 'smart',
+    label: 'Smart approval',
+    icon: '3',
+    isSelected: true,
+    tooltip: 'Smart tip',
+    tooltipAnchor: <span aria-label="smart-warning" />,
+    action: vi.fn()
+  }
+]
 
 vi.mock('i18next', () => ({
   t: (key: string, fallback?: string) => fallback ?? key
@@ -94,6 +125,8 @@ function PanelHarness({
   trackInputQuery,
   initialSearchText,
   queryAnchor,
+  defaultIndex,
+  openNonce = 0,
   onClose,
   fill = false
 }: {
@@ -108,6 +141,9 @@ function PanelHarness({
   trackInputQuery?: boolean
   initialSearchText?: string
   queryAnchor?: number
+  defaultIndex?: number
+  /** Bumping re-calls open() with the same symbol, like a reopen inside the cleanup window. */
+  openNonce?: number
   onClose?: QuickPanelOpenOptions['onClose']
   /** Drives the ambient fill flag the composer would push for home placement. */
   fill?: boolean
@@ -129,6 +165,7 @@ function PanelHarness({
       readOnly,
       symbol,
       title,
+      defaultIndex,
       triggerInfo:
         triggerInfo ??
         (inputAdapter
@@ -152,7 +189,9 @@ function PanelHarness({
     symbol,
     title,
     trackInputQuery,
-    triggerInfo
+    triggerInfo,
+    defaultIndex,
+    openNonce
   ])
 
   return <QuickPanelView inputAdapter={inputAdapter} />
@@ -999,6 +1038,78 @@ describe('QuickPanelView', () => {
     expect(unselectedAction).toHaveBeenCalledTimes(1)
     expect(selectedAction).toHaveBeenCalledTimes(1)
     expect(disabledAction).not.toHaveBeenCalled()
+  })
+
+  // 双高亮回归防护：单选子菜单打开时键盘焦点应落在当前值上，选中行不再铺与焦点同色的灰底，
+  // 且打开即聚焦不触发行 tooltip（tooltip 只跟随悬停或键盘导航）。
+  it('opens on the opener-requested row without a second highlight or an auto tooltip', async () => {
+    const captureDispatch = vi.fn()
+
+    render(
+      <QuickPanelProvider>
+        <PanelHarness captureDispatch={captureDispatch} items={singleSelectSubmenuItems} defaultIndex={2} />
+      </QuickPanelProvider>
+    )
+
+    const smartRow = (await screen.findByText('Smart approval')).closest('[data-id="smart"]')
+    const defaultRow = screen.getByText('Ask every time').closest('[data-id="default"]')
+
+    expect(smartRow).toHaveAttribute('data-active', 'true')
+    expect(smartRow).toHaveAttribute('aria-pressed', 'true')
+    expect(defaultRow).toHaveAttribute('data-active', 'false')
+    expect(smartRow?.className).not.toContain('bg-muted')
+    expect(smartRow?.className).toContain('bg-accent')
+    // 打开即聚焦（defaultIndex）不触发行 tooltip。
+    expect(screen.getByLabelText('smart-warning').closest('[data-open]')).toHaveAttribute('data-open', 'false')
+
+    const dispatchKeyDown = captureDispatch.mock.calls.at(-1)?.[0] as QuickPanelContextType['dispatchKeyDown']
+    act(() => {
+      dispatchKeyDown(createKeyDownEvent('ArrowUp').event)
+    })
+
+    // 键盘导航到达的行恢复 tooltip 供查看，离开的行收回。
+    expect(screen.getByLabelText('plan-warning').closest('[data-open]')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByLabelText('smart-warning').closest('[data-open]')).toHaveAttribute('data-open', 'false')
+  })
+
+  it('treats a same-symbol reopen as a fresh panel for focus and tooltip state', async () => {
+    const captureDispatch = vi.fn()
+    let quickPanel: QuickPanelContextType | undefined
+
+    const harness = (nonce: number) => (
+      <QuickPanelProvider>
+        <CaptureQuickPanel onCapture={(context) => (quickPanel = context)} />
+        <PanelHarness
+          captureDispatch={captureDispatch}
+          items={singleSelectSubmenuItems}
+          defaultIndex={2}
+          openNonce={nonce}
+        />
+      </QuickPanelProvider>
+    )
+    const { rerender } = render(harness(0))
+
+    await screen.findByText('Smart approval')
+    const dispatchKeyDown = captureDispatch.mock.calls.at(-1)?.[0] as QuickPanelContextType['dispatchKeyDown']
+    act(() => {
+      dispatchKeyDown(createKeyDownEvent('ArrowUp').event)
+    })
+    expect(screen.getByLabelText('plan-warning').closest('[data-open]')).toHaveAttribute('data-open', 'true')
+
+    // 关闭后在清理窗口内以同一 symbol 重开：不得恢复旧光标与其 tooltip。
+    act(() => {
+      quickPanel?.close('esc')
+    })
+    // 面板隐藏瞬间 tooltip 就应收回，不等清理窗口结束。
+    expect(screen.getByLabelText('plan-warning').closest('[data-open]')).toHaveAttribute('data-open', 'false')
+    rerender(harness(1))
+
+    const smartRow = (await screen.findByText('Smart approval')).closest('[data-id="smart"]')
+    const planRow = screen.getByText('Plan only').closest('[data-id="plan"]')
+    expect(smartRow).toHaveAttribute('data-active', 'true')
+    expect(planRow).toHaveAttribute('data-active', 'false')
+    expect(screen.getByLabelText('plan-warning').closest('[data-open]')).toHaveAttribute('data-open', 'false')
+    expect(screen.getByLabelText('smart-warning').closest('[data-open]')).toHaveAttribute('data-open', 'false')
   })
 
   it('keeps rendered row height aligned with the virtual-list item contract', async () => {

--- a/src/renderer/components/QuickPanel/index.ts
+++ b/src/renderer/components/QuickPanel/index.ts
@@ -1,6 +1,7 @@
 export { defaultFilterFn, defaultSortFn } from './defaultStrategies'
 export {
   firstQuickPanelSelectableIndex,
+  initialQuickPanelFocusIndex,
   moveQuickPanelSelectableIndex,
   QuickPanelFooter,
   QuickPanelReadOnlyHeader,

--- a/src/renderer/components/QuickPanel/list.tsx
+++ b/src/renderer/components/QuickPanel/list.tsx
@@ -43,6 +43,8 @@ interface QuickPanelRowProps<T extends QuickPanelRowData> {
   active: boolean
   className?: string
   dataId?: string
+  /** The cursor reached this row through keyboard navigation, so the anchored tooltip mirrors hover. */
+  keyboardActive?: boolean
   hoverEnabled?: boolean
   item: T
   onSelect: () => void
@@ -54,6 +56,15 @@ interface QuickPanelRowProps<T extends QuickPanelRowData> {
 
 export function firstQuickPanelSelectableIndex(items: readonly { disabled?: boolean }[]) {
   return items.findIndex((item) => !item.disabled)
+}
+
+export function initialQuickPanelFocusIndex(items: readonly { disabled?: boolean }[], preferredIndex: number) {
+  const preferred = items[preferredIndex]
+  if (preferredIndex >= 0 && preferred && !preferred.disabled) {
+    return preferredIndex
+  }
+
+  return firstQuickPanelSelectableIndex(items)
 }
 
 function selectableIndexes(items: readonly { disabled?: boolean }[]) {
@@ -155,6 +166,7 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
   active,
   className,
   dataId,
+  keyboardActive = false,
   hoverEnabled = true,
   item,
   onSelect,
@@ -183,7 +195,7 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
         content={item.tooltip}
         side="top"
         sideOffset={6}
-        open={active || tooltipOpen}
+        open={(active && keyboardActive) || tooltipOpen}
         onOpenChange={setTooltipOpen}>
         <span className="inline-flex shrink-0">{item.tooltipAnchor}</span>
       </NormalTooltip>
@@ -203,9 +215,9 @@ export function QuickPanelRow<T extends QuickPanelRowData>({
       className={cn(
         'mx-[5px] mb-px flex items-center justify-between gap-3 rounded-md px-2 py-1 transition-colors duration-100',
         isReadOnlyLocked ? 'cursor-default' : item.disabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
-        !isReadOnlyLocked && selected && 'bg-muted',
-        !isReadOnlyLocked && selected && active && 'bg-accent',
-        !isReadOnlyLocked && !selected && active && 'bg-accent',
+        // Selection is marked by the check suffix alone: bg-accent and bg-muted share the same
+        // token value, so a selected tint would read as a second keyboard cursor on the row.
+        !isReadOnlyLocked && active && 'bg-accent',
         canHover && 'hover:bg-accent',
         className
       )}

--- a/src/renderer/components/__tests__/PermissionModeOption.test.tsx
+++ b/src/renderer/components/__tests__/PermissionModeOption.test.tsx
@@ -178,21 +178,21 @@ describe('PermissionModeWarning', () => {
     expect(screen.getByRole('button', { name: /Needs a model that supports it\./ })).toBeInTheDocument()
   })
 
-  it('anchors the active QuickPanel warning Tooltip to its icon', async () => {
-    render(
-      <QuickPanelRow
-        active
-        item={{
-          id: 'permission-mode-auto',
-          label: 'Approve for Me',
-          description: 'Runs without routine prompts.',
-          icon: '!',
-          tooltip: 'Needs a model that supports it.',
-          tooltipAnchor: <PermissionModeWarning card={withWarning} showTooltip={false} t={t} />
-        }}
-        onSelect={vi.fn()}
-      />
-    )
+  it('anchors the keyboard-active QuickPanel warning Tooltip to its icon', async () => {
+    const item = {
+      id: 'permission-mode-auto',
+      label: 'Approve for Me',
+      description: 'Runs without routine prompts.',
+      icon: '!',
+      tooltip: 'Needs a model that supports it.',
+      tooltipAnchor: <PermissionModeWarning card={withWarning} showTooltip={false} t={t} />
+    }
+    const { rerender } = render(<QuickPanelRow active item={item} onSelect={vi.fn()} />)
+
+    // Programmatic focus (e.g. the panel opens on the current value) does not surface the tooltip.
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+    rerender(<QuickPanelRow active keyboardActive item={item} onSelect={vi.fn()} />)
 
     const tooltip = await screen.findByRole('tooltip')
     const icon = screen.getByLabelText('Needs a model that supports it.')

--- a/src/renderer/components/composer/quickPanel/__tests__/unifiedPanel.test.ts
+++ b/src/renderer/components/composer/quickPanel/__tests__/unifiedPanel.test.ts
@@ -573,6 +573,56 @@ describe('createUnifiedQuickPanelOpenOptions', () => {
     )
   })
 
+  it('opens a single-select submenu with the keyboard on the active child', () => {
+    const options = createUnifiedQuickPanelOpenOptions(
+      [
+        {
+          id: 'permission-mode',
+          kind: 'panel',
+          label: 'Permission Mode',
+          icon: 'shield',
+          sources: ['popover'],
+          submenu: [
+            { id: 'mode-default', kind: 'command', label: 'Ask Every Time', icon: 'a', sources: ['popover'] },
+            {
+              id: 'mode-smart',
+              kind: 'command',
+              label: 'Smart Approval',
+              icon: 's',
+              active: true,
+              sources: ['popover']
+            },
+            { id: 'mode-full', kind: 'command', label: 'Full Access', icon: 'f', sources: ['popover'] }
+          ]
+        }
+      ],
+      { quickPanel, triggerInfo: { type: 'button' } }
+    )
+    const submenuLauncher = options.list[0]
+    const actionContext = { ...quickPanel, triggerInfo: options.triggerInfo } satisfies QuickPanelContextType
+
+    submenuLauncher.action?.({
+      action: 'enter',
+      context: actionContext,
+      item: submenuLauncher,
+      parentPanel: options,
+      queryAnchor: 0,
+      searchText: ''
+    })
+
+    expect(quickPanel.open).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: 'permission-mode',
+        defaultIndex: 1,
+        list: [
+          expect.objectContaining({ label: 'Ask Every Time' }),
+          expect.objectContaining({ label: 'Smart Approval', isSelected: true }),
+          expect.objectContaining({ label: 'Full Access' })
+        ]
+      })
+    )
+  })
+
   it('preserves tooltip metadata for submenu rows', () => {
     const tooltipAnchor = createElement('span', { 'aria-label': 'warning' })
     const options = createUnifiedQuickPanelOpenOptions(

--- a/src/renderer/components/composer/quickPanel/unifiedPanel.ts
+++ b/src/renderer/components/composer/quickPanel/unifiedPanel.ts
@@ -370,6 +370,9 @@ function openUnifiedPanelSubmenu(
     title: typeof launcher.label === 'string' ? launcher.label : undefined,
     list: childItems,
     symbol: launcher.id,
+    // A single-select submenu opens with the keyboard on the current value (active child), so
+    // the focused row and the selection check never land on two different rows.
+    defaultIndex: childItems.findIndex((child) => child.isSelected && !child.disabled),
     parentPanel: options.parentPanel,
     queryAnchor: options.queryAnchor,
     // A submenu is opened by a selection, so its query starts empty and is typed, not triggered.


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Single-select quick-panel submenus such as the agent permission-mode picker opened with the keyboard cursor on the first row, while the current-selection row carried its own gray tint. `bg-muted` and `bg-accent` share the same token value, so the panel showed two identically gray rows that read as "two selected items" and could only be told apart by a small check mark. Pressing Enter at that point also activated the first row instead of confirming the current mode. Additionally, a row tooltip (e.g. the permission-mode warning) was force-opened whenever its row was the cursor target, so any programmatic focus popped the tooltip without pointer or keyboard intent.
<img width="1224" height="596" alt="PixPin_2026-08-29_18-02-56" src="https://github.com/user-attachments/assets/1e792174-02b9-4262-a385-88dc030b77e2" />

After this PR:

Single-select submenus open with the keyboard cursor on the current value, so the highlighted row and the check mark land on the same row and Enter confirms the current mode. Selected rows are marked by the check alone; the row tint stays reserved for the keyboard cursor and hover, which removes the double-highlight in the open, hover, and keyboard-navigation states. Row tooltips now mirror only hover or keyboard navigation — programmatic focus (panel open, or a same-symbol reopen inside the provider's cleanup window) never triggers them, and they retract immediately when the panel hides instead of floating through the 200ms cleanup window.

Implementation: the previously unused `QuickPanelOpenOptions.defaultIndex` contract now has a consumer — `QuickPanelView` honors it on a fresh panel (generation-based, so same-symbol reopens reset too), and `openUnifiedPanelSubmenu` proposes the first non-disabled selected child. `QuickPanelRow` drops the `bg-muted` selected tint and gains a `keyboardActive` flag that gates the anchored tooltip. Root panels, read-only panels, multi-select checks, and search-filter focus behavior are unchanged.
<img width="1224" height="596" alt="PixPin_2026-08-29_17-55-43" src="https://github.com/user-attachments/assets/3bc33808-d483-4828-99ce-87d24926ff93" />

Fixes #

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The fix reuses the existing but previously dead `defaultIndex` open-option contract instead of adding a new one, and scopes "focus follows selection" to submenu opens — root-panel rows use `active` as a toggle-on state (web search, knowledge base, image generation), so preferring selected rows globally would have jumped root-panel focus to mid-list toggle rows.
- Tooltip gating lives on the generic row (`keyboardActive`) rather than the permission-mode tool, so every current and future tooltip-carrying row gets the same semantics.

The following alternatives were considered:

- Keeping the `bg-muted` selected tint and differentiating the cursor with a stronger color: rejected because the two tokens are deliberately equal in this design system, and inventing a new highlight token for one popup would fork the row contract.
- Gating tooltips only inside the permission-mode tool: rejected because it would fork the shared row contract per surface.

Links to places where the discussion took place: N/A

### Breaking changes

None. Behavior changes are confined to the open/focus/highlight/tooltip semantics described above; public component props are additive (`keyboardActive` is optional).

### Special notes for your reviewer

- `initialQuickPanelFocusIndex` (list.tsx) validates the opener-proposed index (disabled/out-of-range falls back to the first selectable row); `openUnifiedPanelSubmenu` proposes, the view validates — deliberately split ownership.
- The fresh-panel reset keys on `panelGeneration`, which also fixes a latent stale-cursor bug: reopening the same submenu symbol inside the provider's 200ms cleanup window previously restored the old cursor position.
- Tests: `view.test.tsx` covers open-on-selection, no auto tooltip, tooltip retract at hide, and same-symbol reopen; `unifiedPanel.test.ts` covers the submenu `defaultIndex` proposal; `list.test.ts` covers the fallback rules.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Agent] Fixed the permission-mode popup showing two highlighted rows at once, and tooltips no longer pop up on their own when the panel opens.
```
