### PR TITLE
fix(provider-settings): send extraHeaders: null when the list is cleared (closes #19695)

### DIFF
--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderCustomHeaderDrawer.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/ProviderCustomHeaderDrawer.tsx
@@ -312,10 +312,16 @@ export default function ProviderCustomHeaderDrawer({ providerId, open, onClose }
     }
 
     try {
+      // The main process applies providerSettings as an RFC 7396 JSON Merge
+      // Patch, so an empty object would re-merge into the existing
+      // `extraHeaders` and silently keep every key. Emit `null` when the
+      // user has cleared the list so the stored entry is actually removed
+      // (issue #19695).
+      const nextExtraHeaders = isEmpty(parsedHeaders) ? null : parsedHeaders
       await updateProvider({
         endpointConfigs: nextEndpointConfigs,
         defaultChatEndpoint,
-        providerSettings: { ...provider.settings, extraHeaders: parsedHeaders }
+        providerSettings: { ...provider.settings, extraHeaders: nextExtraHeaders }
       })
     } catch (error) {
       // Surface the failure and keep the drawer open so the user can retry

--- a/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderCustomHeaderDrawer.test.tsx
+++ b/src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderCustomHeaderDrawer.test.tsx
@@ -110,7 +110,7 @@ describe('ProviderCustomHeaderDrawer', () => {
       expect(updateProviderMock).toHaveBeenCalledWith({
         endpointConfigs: provider.endpointConfigs,
         defaultChatEndpoint: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
-        providerSettings: { extraHeaders: {} }
+        providerSettings: { extraHeaders: null }
       })
     })
     expect(syncProviderModelsMock).toHaveBeenCalledWith(
@@ -120,5 +120,63 @@ describe('ProviderCustomHeaderDrawer', () => {
       })
     )
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends extraHeaders: null when the user clears the list (REGRESSION #19695)', async () => {
+    // Renderer must emit `null`, not `{}`, when the user empties the headers
+    // list. The main process patches providerSettings as RFC 7396 JSON
+    // Merge Patch, so `{}` re-merges into the stored `extraHeaders` and
+    // silently keeps every prior key. `null` is the merge-patch signal that
+    // removes the property (issue #19695).
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    useProviderMock.mockReturnValue({
+      provider: {
+        ...provider,
+        settings: { extraHeaders: { 'X-Stale': 'old' } }
+      },
+      updateProvider: updateProviderMock
+    })
+
+    render(<ProviderCustomHeaderDrawer providerId={provider.id} open onClose={onClose} />)
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'common.delete' })
+    for (const btn of deleteButtons) {
+      await user.click(btn)
+    }
+
+    await user.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      expect(updateProviderMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerSettings: expect.objectContaining({ extraHeaders: null })
+        })
+      )
+    })
+  })
+
+  it('sends the populated extraHeaders object as-is when the user keeps entries', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    useProviderMock.mockReturnValue({
+      provider: {
+        ...provider,
+        settings: { extraHeaders: { 'X-Stale': 'old' } }
+      },
+      updateProvider: updateProviderMock
+    })
+
+    render(<ProviderCustomHeaderDrawer providerId={provider.id} open onClose={onClose} />)
+
+    // Default render seeds the rows from the stored `extraHeaders`, so the
+    // save below would normally still transmit the populated object — no
+    // clicks needed.
+    await user.click(screen.getByRole('button', { name: 'common.save' }))
+
+    await waitFor(() => {
+      const lastCall = updateProviderMock.mock.calls.at(-1)
+      expect(lastCall?.[0]?.providerSettings?.extraHeaders).toEqual({ 'X-Stale': 'old' })
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes #19695.

`ProviderCustomHeaderDrawer` built its PATCH body from the visible rows via `rowsToHeadersObject`, which returns `{}` when the user removes every header. The main-side update path applies `providerSettings` as an RFC 7396 JSON Merge Patch, where an empty object re-merges into the stored value and silently preserves every prior key. Result: deleting a custom request header saved nothing, and reopening the drawer showed the old headers again.

## What changes

- `ProviderCustomHeaderDrawer.tsx`: when `parsedHeaders` is empty, send `extraHeaders: null` (the merge-patch signal that removes the key) instead of `extraHeaders: {}`.
- `ProviderCustomHeaderDrawer.test.tsx`:
  - Update the existing `persists a configured endpoint` assertion to expect `null` on the cleared-drawer path.
  - Add a focused regression test for the deletion case (`REGRESSION #19695`).
  - Add a sibling test that keeps a populated draft and saves, to guard against an over-correction that would null out populated drafts.

## Why null and not stripping the field

The schema already allows `extraHeaders.nullable().optional()`, and the main process's `applyJsonMergePatch` treats `null` as 'delete this key' (RFC 7396). Stripping the field client-side would not survive the spread `{ ...provider.settings, extraHeaders: undefined }` (`undefined` is filtered by JSON.stringify, so the patch would still pass an empty object through). Sending the explicit `null` is the only signal that reaches the merge as 'remove'.

## Test plan

- `pnpm test:renderer src/renderer/pages/settings/ProviderSettings/ConnectionSettings/__tests__/ProviderCustomHeaderDrawer.test.tsx` (CI will run; 1.8G sandbox OOM prevents local vitest).
- Manual: Settings → Model Service → Configure API Host and Custom Request Headers → set a header → save → reopen → delete the header → save → reopen → header is gone.