### PR TITLE
feat(agent): mount ApiGatewayRequiredDialog at AppShell level (Fixes #18556)

### DIFF
--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -227,6 +227,7 @@ export const AppShell = () => {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       {tabBar}
       {contentArea}
+      <ApiGatewayRequiredDialog />
     </div>
   )
 

--- a/src/renderer/components/layout/AppShell.tsx
+++ b/src/renderer/components/layout/AppShell.tsx
@@ -18,6 +18,7 @@ import GlobalSearchPopup from '../GlobalSearch/GlobalSearchPopup'
 import MiniAppTabsPool from '../MiniApp/MiniAppTabsPool'
 import { ResourceViewSourceProvider } from '../ResourceViewSourceProvider'
 import { AppShellTabBar } from './AppShellTabBar'
+import { ApiGatewayRequiredDialog } from './feedback/ApiGatewayRequiredDialog'
 import { TabRouter } from './TabRouter'
 
 // Routes whose pages stay usable below the global minimum window width.

--- a/src/renderer/components/layout/feedback/ApiGatewayRequiredDialog.tsx
+++ b/src/renderer/components/layout/feedback/ApiGatewayRequiredDialog.tsx
@@ -4,10 +4,6 @@ import { useIpcOn } from '@renderer/ipc'
 import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-interface Props {
-  sessionId: string
-}
-
 /**
  * Main refuses to bridge an agent through a disabled API gateway (it never starts it implicitly),
  * so it asks here instead. Enabling persists the preference, which is also what makes the gateway
@@ -16,16 +12,20 @@ interface Props {
  * Enabling is ALL this does. Resending the failed message would be a request the user never
  * approved, rebuilt from text alone — dropping attachments, knowledge scope and the reasoning /
  * fast-mode selection frozen with the original turn.
+ *
+ * Mounted globally in AppShell: it listens for every 'api_gateway.required' event regardless
+ * of which tab is active, ensuring the prompt is always shown even if the triggering session
+ * is in a background tab or dormant.
  */
-export function ApiGatewayRequiredDialog({ sessionId }: Props) {
+export function ApiGatewayRequiredDialog() {
   const [open, setOpen] = useState(false)
 
-  useIpcOn('api_gateway.required', (payload) => {
-    if (payload.sessionId === sessionId) setOpen(true)
+  useIpcOn('api_gateway.required', () => {
+    setOpen(true)
   })
 
-  // Every agent chat renders this, but the prompt is rare — keep the gateway preference and
-  // shared-cache subscriptions out of the common path until it actually fires.
+  // The prompt is rare — keep the gateway preference and shared-cache subscriptions
+  // out of the common path until it actually fires.
   if (!open) return null
   return <GatewayPrompt onOpenChange={setOpen} />
 }

--- a/src/renderer/pages/agents/AgentChat.tsx
+++ b/src/renderer/pages/agents/AgentChat.tsx
@@ -48,7 +48,6 @@ import AgentChatMain from './AgentChatMain'
 import AgentComposerSlot from './AgentComposerSlot'
 import { AgentChatNavbar } from './components/AgentChatNavbar'
 import { type AgentFileNavigationRequest, AgentRightPane, AgentTaskProgressCapsule } from './components/AgentRightPane'
-import { ApiGatewayRequiredDialog } from './components/ApiGatewayRequiredDialog'
 import { locateAgentMessageInList } from './messages/agentMessageListAdapter'
 import type { CreateAgentSessionDefaults } from './types'
 import { type AgentChatRuntimeState, useAgentChatRuntimeState } from './useAgentChatRuntimeState'
@@ -671,7 +670,6 @@ const AgentChatSessionCenter = ({
         </div>
       )}
       {messageList}
-      <ApiGatewayRequiredDialog sessionId={runtime.sessionId} />
     </div>
   )
 


### PR DESCRIPTION
## Summary

Rebases #18598 onto current main (the original was CONFLICTING because main has moved).

Fixes #18556. The original `api_gateway.required` IPC fires from `ClaudeCodeRuntimeDriver` regardless of tab state, but the dialog was only mounted in active agent-chat tabs. When the originating session sat in a background or dormant tab, the prompt was silently dropped.

## What changes

- `src/renderer/pages/agents/components/ApiGatewayRequiredDialog.tsx` → `src/renderer/components/layout/feedback/ApiGatewayRequiredDialog.tsx` (moved to the shared layout area).
- `AppShell.tsx`: import + mount `<ApiGatewayRequiredDialog />` at the top-level content column.
- `ApiGatewayRequiredDialog` itself: drop the `sessionId` prop and its `payload.sessionId === sessionId` filter so the listener fires for every `api_gateway.required` event regardless of which session triggered it.
- `AgentChat.tsx`: stop mounting the per-session dialog in the agent-tab component.

## Why two commits

The original PR carried two commits (feat + path-correction). Both are preserved here so the final history matches the upstream-style change shape. The path correction is the file move from `components/feedback/` to `components/layout/feedback/` so the AppShell relative import `./feedback/ApiGatewayRequiredDialog` resolves correctly.

## Verification

- 1.8 GB RAM sandbox OOMs on `pnpm install`; the diff is mechanical (3 files, no logic additions beyond removing the sessionId filter).
- CI is the canonical validator.