### PR TITLE
fix(model-selector): improve tag filter chips spacing and overflow behavior (closes #18411)

### DIFF
--- a/src/renderer/components/ModelSelector/ModelSelector.tsx
+++ b/src/renderer/components/ModelSelector/ModelSelector.tsx
@@ -310,7 +310,7 @@ function ModelSelectorFilterTags({
       ref={scrollRef}
       onScroll={updateFadeState}
       style={maskImage ? { maskImage } : undefined}
-      className="flex min-w-0 flex-1 flex-nowrap items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      className="flex min-w-0 flex-1 flex-nowrap items-center gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       data-testid="model-selector-filter-tags">
       {tags.map((tag) => (
         <ModelTag


### PR DESCRIPTION
## Summary

Rebases #18593 onto current main (was CONFLICTING). The original PR base (08e2bb335) had accumulated two unrelated window.ts commits (`7d29b07cb`, `dcf255115`) that leaked into the diff and collided with main's current shape. This branch carries only the substantive change: the one-line tag-chip spacing fix.

Closes #18411.

## What changed

`src/renderer/components/ModelSelector/ModelSelector.tsx`: bump the tag-chip row's horizontal gap from `gap-1` (4 px) to `gap-1.5` (6 px) so adjacent filter chips have visible breathing room when several are selected. The original horizontal scroll / fade mask is preserved.

## Why a separate branch

The original PR #18593 carried 4 commits (a leftover from #18584 plus the real fix). Cherry-picking just the substantive commit onto current main gives a clean 1-commit, 1-file diff. The original PR is left open for reference.

## Verification

- 1.8 GB RAM sandbox OOMs on `pnpm install`; the change is a single Tailwind class swap. CI is the canonical validator.