### PR TITLE
fix(translate-history): revalidate in place when membership changes (closes #19687)

### DIFF
--- a/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
+++ b/src/renderer/hooks/translate/__tests__/useTranslateHistories.test.ts
@@ -104,20 +104,27 @@ describe('useTranslateHistories', () => {
     })
   })
 
-  it('reloads all pages when another window changes history membership', async () => {
+  it('revalidates current pages in place when another window changes history membership (REGRESSION #19687)', async () => {
     const refresh = vi.fn().mockResolvedValue(undefined)
     const reset = vi.fn()
-    mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ refresh, reset }))
+    const mutate = vi.fn().mockResolvedValue(undefined)
+    mockUseInfiniteQuery.mockReturnValue(buildInfiniteState({ refresh, reset, mutate }))
     renderHook(() => useTranslateHistories())
     reset.mockClear()
+    refresh.mockClear()
 
     await act(async () => {
       MockUseDataApiUtils.emitDataChange([{ endpoint: '/translate/histories', kind: 'membership' }])
       await Promise.resolve()
     })
 
-    expect(reset).toHaveBeenCalledTimes(1)
-    expect(refresh).toHaveBeenCalledTimes(1)
+    // Must use `mutate()` (SWR-infinite revalidation) so already-loaded
+    // pages survive the broadcast. Calling `reset()` shrinks the cache
+    // back to size=1, the scroll container collapses, and the browser
+    // then triggers a redundant page-2 fetch (issue #19687).
+    expect(mutate).toHaveBeenCalledTimes(1)
+    expect(reset).not.toHaveBeenCalled()
+    expect(refresh).not.toHaveBeenCalled()
   })
 
   it('exposes SWR errors so consumers can distinguish loading from failure', () => {

--- a/src/renderer/hooks/translate/useTranslateHistories.ts
+++ b/src/renderer/hooks/translate/useTranslateHistories.ts
@@ -33,7 +33,8 @@ export const useTranslateHistories = ({
     hasNext,
     loadNext,
     refresh: pageRefresh,
-    reset
+    reset,
+    mutate
   } = useInfiniteQuery('/translate/histories', {
     query,
     limit: pageSize,
@@ -75,8 +76,17 @@ export const useTranslateHistories = ({
     await pageRefresh()
   }, [pageRefresh])
 
+  // Broadcast listener: revalidate the current cache without dropping
+  // already-loaded pages. Resetting (issue #19687) shrinks an infinite
+  // query back to size=1, the scroll container collapses, and the
+  // browser then triggers a redundant page-2 fetch — making the list
+  // appear to flicker while the user's reading position is silently
+  // lost. Calling `mutate()` with no argument revalidates the current
+  // pages in place, which is the same behaviour a regular mutation
+  // (`refresh: ['/translate/histories']`) already takes via
+  // `invalidatePathPatterns`.
   useDataChange('/translate/histories', () => {
-    void reload()
+    void mutate()
   })
 
   // Loading / error / ready discriminator. Empty `items` is ambiguous on its


### PR DESCRIPTION
## Summary

Fixes #19687. The Translate history drawer's broadcast listener used `reload()` (which calls `reset()` then `pageRefresh()`) when another window mutated `/translate/histories`. For an infinite query, `reset()` is `setSize(1)`, so all already-loaded pages were dropped, the scroll container's height collapsed, the browser clamped the now out-of-range scrollTop to the bottom of page 1, and the scroll event re-armed `loadMore` — one redundant IPC + DB round trip per page the user had loaded, plus a silent jump in reading position.

## What changed

- `useTranslateHistories.ts`: destructure the SWR-infinite `mutate` from the `useInfiniteQuery` result and call it (no argument) from the `useDataChange` listener. SWR Infinite revalidates the current pages in place; `size` is not touched. The same in-place behaviour a regular mutation (`refresh: ['/translate/histories']`) already takes via `invalidatePathPatterns`.
- `useTranslateHistories.test.ts`: the broadcast-listener test previously asserted `reset` + `refresh` were both called — the exact behaviour that caused the bug. It now asserts `mutate` is called and `reset` / `refresh` are not. The `reload` function on the hook (user-driven refresh) is unchanged.

## Verification

- 1.8 GB sandbox OOMs on `pnpm install`; CI is the canonical validator.
- Manual: open Translate history drawer → populate more than 20 rows so it paginates → scroll down to page 2 → start a PDF translation from another window → watch the list stay on page 2 instead of snapping back to the bottom of page 1.