### PR TITLE
fix(window-manager): block content-initiated subframe navigation

### DIFF
--- a/src/main/core/window/WindowManager.ts
+++ b/src/main/core/window/WindowManager.ts
@@ -1383,6 +1383,16 @@ export class WindowManager extends BaseService {
       }
     })
 
+    // A script-less sandboxed subframe still follows <a href>: deny (fail-closed) unless the
+    // app's own main frame initiated it (by frameTreeNodeId — wrapper identity isn't stable).
+    window.webContents.on('will-frame-navigate', (event) => {
+      if (event.isMainFrame) return
+      const initiatorId = event.initiator?.frameTreeNodeId
+      if (initiatorId !== undefined && initiatorId === window.webContents.mainFrame.frameTreeNodeId) return
+      event.preventDefault()
+      logger.warn(`Blocked subframe navigation to: ${event.url}`)
+    })
+
     // 2. Setup event listeners
     this.setupWindowListeners(windowId, window)
 

--- a/src/main/core/window/__tests__/WindowManager.test.ts
+++ b/src/main/core/window/__tests__/WindowManager.test.ts
@@ -70,6 +70,7 @@ interface MockBrowserWindow {
     setWindowOpenHandler: ReturnType<typeof vi.fn>
     on: ReturnType<typeof vi.fn>
     getURL: ReturnType<typeof vi.fn>
+    mainFrame: { frameTreeNodeId: number }
   }
 }
 
@@ -136,7 +137,8 @@ function createMockBrowserWindow(): MockBrowserWindow {
       isCrashed: vi.fn(() => false),
       setWindowOpenHandler: vi.fn(),
       on: vi.fn(),
-      getURL: vi.fn(() => '')
+      getURL: vi.fn(() => ''),
+      mainFrame: { frameTreeNodeId: 1 }
     }
   }
   return win
@@ -487,6 +489,84 @@ describe('WindowManager', () => {
 
       expect(preventDefault).toHaveBeenCalledTimes(1)
       expect(shell.openExternal).toHaveBeenCalledWith('https://evil.example.com')
+    })
+  })
+
+  // ─── will-frame-navigate subframe guard ────────────────
+
+  describe('will-frame-navigate subframe guard', () => {
+    /** The guard WindowManager registers via webContents.on('will-frame-navigate', …). */
+    function getWillFrameNavigateHandler(
+      win: MockBrowserWindow
+    ): (event: {
+      preventDefault: () => void
+      url: string
+      isMainFrame: boolean
+      initiator?: { frameTreeNodeId?: number } | null
+    }) => void {
+      const call = win.webContents.on.mock.calls.find(([event]) => event === 'will-frame-navigate')
+      if (!call) throw new Error('will-frame-navigate handler was not registered')
+      return call[1] as never
+    }
+
+    it('blocks subframe navigation initiated from inside a frame (link click)', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      const handler = getWillFrameNavigateHandler(win)
+
+      const preventDefault = vi.fn()
+      handler({
+        preventDefault,
+        url: 'https://evil.example.com/?exfil',
+        isMainFrame: false,
+        initiator: { frameTreeNodeId: 42 }
+      })
+
+      expect(preventDefault).toHaveBeenCalledTimes(1)
+    })
+
+    it('blocks subframe navigation with no initiator identity (fail-closed)', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      const handler = getWillFrameNavigateHandler(win)
+
+      for (const initiator of [null, undefined, {}]) {
+        const preventDefault = vi.fn()
+        handler({ preventDefault, url: 'https://evil.example.com', isMainFrame: false, initiator })
+        expect(
+          preventDefault,
+          `expected navigation with initiator ${JSON.stringify(initiator)} to be blocked`
+        ).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    it('allows subframe loads the app main frame itself initiated (iframe src/srcdoc)', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      const handler = getWillFrameNavigateHandler(win)
+
+      // A distinct wrapper instance with the main frame's id: Electron does not
+      // guarantee stable WebFrameMain object identity, only stable frameTreeNodeId.
+      const preventDefault = vi.fn()
+      handler({
+        preventDefault,
+        url: 'file:///resources/privacy-policy.html',
+        isMainFrame: false,
+        initiator: { frameTreeNodeId: win.webContents.mainFrame.frameTreeNodeId }
+      })
+
+      expect(preventDefault).not.toHaveBeenCalled()
+    })
+
+    it('leaves main-frame navigation to the will-navigate guard', () => {
+      const id = wm.open('default' as never)
+      const win = wm.getWindow(id) as unknown as MockBrowserWindow
+      const handler = getWillFrameNavigateHandler(win)
+
+      const preventDefault = vi.fn()
+      handler({ preventDefault, url: 'https://evil.example.com', isMainFrame: true, initiator: null })
+
+      expect(preventDefault).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The HTML artifact consent gate could be bypassed with a plain link. The static (unauthorized) preview tier renders in a script-less sandboxed iframe with a strict CSP, but neither sandbox nor CSP governs frame self-navigation: clicking `<a href="https://…">` inside the preview navigated the iframe to an arbitrary external URL — issuing a network request before any "View webpage" consent and rendering remote content inside the chat UI. The existing `will-navigate` guards cover main-frame navigation only; subframe navigation had no interception at all.

After this PR:

`WindowManager` registers a `will-frame-navigate` guard on every managed window, next to the existing `will-navigate` guard. Subframe navigations are denied fail-closed unless initiated by the window's own main frame (app code setting iframe `src`/`srcdoc`), comparing `frameTreeNodeId` rather than `WebFrameMain` object identity, which Electron does not guarantee to be stable. A content-initiated link click inside any preview iframe is cancelled and logged; app-driven loads (srcdoc previews and their streaming re-renders, the local `file://` privacy-policy page) proceed unchanged.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Blocked navigations are silently cancelled (plus a main-process warn log) instead of being forwarded to `shell.openExternal`: auto-opening would keep a click-triggered exfiltration channel (the visible link text can differ from the href, and a transparent link can cover the whole preview). This also matches the authorized interactive tier, which already denies external navigation.
- The initiator is allowlisted (main frame only) rather than blocking just self-navigation, so nested-frame tricks such as a nested srcdoc iframe navigating its parent via `target=_parent` are covered by the same rule.
- Missing initiator or missing `frameTreeNodeId` is treated as hostile (fail-closed).

The following alternatives were considered:

- Stripping/neutralizing `href` attributes in the static preview tier (like the existing meta-refresh strip): rewriting content is a whack-a-mole (`area`, `ping`, SVG `xlink:href`, nested srcdoc frames) and is not an enforced boundary; the main-process guard is.
- Attaching the guard per-surface in `MainWindowService`: placing it in `WindowManager.createWindow` protects every managed window (main, quick assistant, …) uniformly.

Verified at runtime via CDP probes against a dev instance: parent-initiated srcdoc and `file://` loads proceed (real `initiator.frameTreeNodeId` matches the main frame), a link click inside a sandbox="allow-same-origin" iframe is cancelled with exactly one warn log, and the frame stays on `about:srcdoc`. Same-document (`#hash`) navigation inside previews is unaffected (the event does not fire for it), and `<webview>` guests (mini-apps, the authorized interactive artifact tier) are separate webContents with their own guards, untouched by this listener.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

- The three utility windows created outside `WindowManager` (`PowerService` shutdown hook, migration window, user-data relocation window) only load app-owned UI and never render model-generated HTML, so they are intentionally left out.
- Scoped verification: `npx vitest run src/main/core/window/__tests__/WindowManager.test.ts` (124 passed, 4 new contract tests — the allow case uses a distinct wrapper object with a matching `frameTreeNodeId`, which fails on an object-identity implementation), `tsgo --noEmit -p tsconfig.node.json`, oxlint `--deny-warnings`, biome.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Links inside unauthorized HTML artifact previews can no longer navigate the preview frame to external pages; the consent gate ("View webpage") is now enforced for link clicks as well.
```
