### PR TITLE
fix(ci): serialize typecheck inside basic-checks to stop runner OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,13 @@ jobs:
         run: |
           # Share one checkout/install while keeping independent checks parallel.
           # Do not kill sibling checks on failure so every failure is reported.
+          # `--max-processes 1` lands on the typecheck script's trailing concurrently call and
+          # serializes it: eslint plus two concurrent tsgo runs OOM the runner mid-job.
           pnpm exec concurrently \
             --names "Lint,Type and Hardcoded Strings,Format and Repository,Docs" \
             --prefix-colors "blue,yellow,cyan,green" \
             "pnpm test:lint" \
-            "pnpm typecheck && pnpm i18n:hardcoded:strict" \
+            "pnpm typecheck --max-processes 1 && pnpm i18n:hardcoded:strict" \
             "pnpm format:check && pnpm build:builtin-knowledge:check && pnpm skills:check" \
             "pnpm docs:check"
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`basic-checks` fails intermittently across unrelated PRs and on `main` itself (4 of 8 `main` push runs failed on 2026-08-29, e.g. [33251990426](https://github.com/CherryHQ/cherry-studio/actions/runs/33251990426), [33245995674](https://github.com/CherryHQ/cherry-studio/actions/runs/33245995674); PR examples: [33263161932](https://github.com/CherryHQ/cherry-studio/actions/runs/33263161932) — failed twice with the same signature — and [33266304318](https://github.com/CherryHQ/cherry-studio/actions/runs/33266304318)). The signature is always the same: every check that finishes passes, then ~1–2 minutes after the `aicore` typecheck completes — the exact window where eslint and the two `tsgo` processes (`typecheck:node`, `typecheck:web`) run concurrently at full tilt — the whole job is killed externally (`The runner has received a shutdown signal` / `##[error]The operation was canceled.`), with every in-flight process getting SIGTERM. No check ever reports an actual error. Reruns pass or fail by luck.

After this PR:

The `Type and Hardcoded Strings` lane of `Read-only Checks` runs `pnpm typecheck --max-processes 1`: pnpm appends the flag to the end of the script, where it lands on the `typecheck` script's trailing `concurrently` call and serializes the three typechecks (still reporting every failure instead of stopping at the first, matching this step's philosophy). Peak memory drops from {eslint + tsgo + tsgo} to {eslint + one tsgo}, which is the load the job carried back when it was reliably green. `package.json` stays the single source of truth — editing the `typecheck` script needs no ci.yml follow-up.

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The flag rides on pnpm's append-to-end behavior, so it assumes `concurrently` remains the last command in the `typecheck` script — a far smaller coupling than the rejected alternative of inlining the whole script composition into ci.yml. Verified locally: `pnpm typecheck --max-processes 1` resolves to `… && concurrently … "pnpm --filter @cherrystudio/ai-core typecheck" --max-processes 1`, and `concurrently` with a trailing `--max-processes 1` runs its commands strictly in order, keeps going past a failing one, and still exits non-zero. (Note: `pnpm typecheck -- --max-processes 1` with the `--` separator does NOT work — pnpm forwards the `--` literally and concurrently would treat the flag as a command.)
- The typecheck lane gets slower (sequential ~3–4 min vs parallel ~2.5 min), but the job's wall clock is dominated by eslint anyway, so the practical impact is small — and far smaller than the reruns these cancellations cost today.
- Cancellation cause is diagnosed from the runs' evidence, not guessed from one flake: no `concurrency`/`cancel-in-progress` group and no `timeout-minutes` exist in ci.yml (ruling out configured cancellation), the three failures died at different job durations (ruling out a fixed timeout), one failure shows the runner shutdown signal explicitly, and the kill always lands in the same eslint+tsgo×2 window while runs whose peak fits pass unchanged.

The following alternatives were considered:

- Inlining the serialized `pnpm typecheck` composition into ci.yml: works, but duplicates the script and silently drifts when `package.json` changes.
- Splitting `basic-checks` into separate lint/typecheck jobs: cleaner isolation and full memory per job, but duplicates checkout+install (~2 min each) and defeats this step's stated "share one checkout/install" design.
- `--max-processes 2`: any scheduling order eventually pairs the two tsgo processes, so it does not remove the worst-case peak.

Links to places where the discussion took place:

### Breaking changes

None.

### Special notes for your reviewer

- This PR's own `basic-checks` run executes the modified workflow (pull_request runs use the merge ref's workflow file), so its CI result is itself the verification of the fix under the new lane layout.
- Recent CI-heavy additions on `main` (e.g. the mini-app sandbox) grew the lint/typecheck working set; that is why a load that used to fit started tipping the runner over this week — PRs green on 08-28 began dying on 08-29 with no relevant changes of their own.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
