### PR TITLE
perf(code-style): defer CodeMirror theme resolution to active editor boundaries

### DIFF
--- a/src/renderer/components/CodeBlockView/CodeBlockView.tsx
+++ b/src/renderer/components/CodeBlockView/CodeBlockView.tsx
@@ -17,7 +17,7 @@ import {
 import CodeViewer from '@renderer/components/CodeViewer'
 import ImageViewer from '@renderer/components/ImageViewer'
 import type { BasicPreviewHandles } from '@renderer/components/Preview/types'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { pyodideService } from '@renderer/services/PyodideService'
 import { toast } from '@renderer/services/toast'
 import { getExtensionByLanguage } from '@renderer/utils/codeLanguage'
@@ -104,7 +104,6 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
     themeDark: 'chat.code.editor.theme_dark'
   })
 
-  const { activeCmTheme } = useCodeStyle()
   const canEdit = codeEditor.enabled && editable
   const hasSpecialView = useMemo(() => SPECIAL_VIEWS.includes(language), [language])
   const startedStreamingRef = useRef(isStreaming)
@@ -159,6 +158,7 @@ export const CodeBlockView: React.FC<Props> = memo((props) => {
     return hasSpecialView && viewMode === 'special'
   }, [hasSpecialView, viewMode])
   const isEditing = canEdit && (viewMode === 'edit' || (viewMode === 'split' && viewState.previousMode === 'edit'))
+  const activeCmTheme = useCmTheme(isEditing)
 
   const [expandOverride, setExpandOverride] = useState(!codeCollapsible)
   const [wrapOverride, setWrapOverride] = useState(codeWrappable)

--- a/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
+++ b/src/renderer/components/CodeBlockView/HtmlArtifactsPopup.tsx
@@ -22,7 +22,7 @@ import { loggerService } from '@logger'
 import CodeViewer from '@renderer/components/CodeViewer'
 import CopyIcon from '@renderer/components/icons/CopyIcon'
 import { FilePngIcon } from '@renderer/components/icons/FileIcons'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { useTemporaryValue } from '@renderer/hooks/useTemporaryValue'
 import { toast } from '@renderer/services/toast'
 import { extractHtmlTitle, getFileNameFromHtmlTitle } from '@renderer/utils/formats'
@@ -129,9 +129,9 @@ const HtmlArtifactsPopup: React.FC<HtmlArtifactsPopupProps> = ({
   onClose
 }) => {
   const { t } = useTranslation()
-  const { activeCmTheme } = useCodeStyle()
   const [fontSize] = usePreference('chat.message.font_size')
   const [viewMode, setViewMode] = useState<ViewMode>('preview')
+  const activeCmTheme = useCmTheme(viewMode !== 'preview')
   const [isFullscreen, setIsFullscreen] = useState(true)
   const [saved, setSaved] = useTemporaryValue(false, 2000)
   const [splitSizes, setSplitSizes] = useState<[number, number]>([50, 50])

--- a/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/CodeBlockView.test.tsx
@@ -28,7 +28,8 @@ vi.mock('@renderer/components/CodeViewer', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/services/PyodideService', () => ({

--- a/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
+++ b/src/renderer/components/CodeBlockView/__tests__/HtmlArtifactsPopup.test.tsx
@@ -26,7 +26,8 @@ vi.mock('@renderer/components/CodeViewer', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('react-i18next', () => ({

--- a/src/renderer/components/CodeStyleProvider.tsx
+++ b/src/renderer/components/CodeStyleProvider.tsx
@@ -73,7 +73,13 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
     theme === ThemeMode.light ? 'light' : 'dark'
   )
 
+  // The themes-all catalog is only resolved after an editor boundary demands a theme, so
+  // windows that never render a CodeMirror editor never load it.
+  const [cmThemeRequested, setCmThemeRequested] = useState(false)
+  const requestCmTheme = useCallback(() => setCmThemeRequested(true), [])
+
   useEffect(() => {
+    if (!cmThemeRequested) return
     // Every CodeMirror consumer (Notes, MCP editors, ArtifactPane, previews) reads this, so it must
     // not depend on the chat-editor flag. getCmThemeByName already falls back for unknown names.
     const codeStyle = theme === ThemeMode.light ? codeEditorThemeLight : codeEditorThemeDark
@@ -91,7 +97,7 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
     return () => {
       cancelled = true
     }
-  }, [theme, codeEditorThemeLight, codeEditorThemeDark])
+  }, [cmThemeRequested, theme, codeEditorThemeLight, codeEditorThemeDark])
 
   // 自定义 shiki 语言别名
   const languageAliases = useMemo(() => {
@@ -179,7 +185,8 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
       shikiMarkdownIt,
       activeShikiTheme,
       isShikiThemeDark,
-      activeCmTheme
+      activeCmTheme,
+      requestCmTheme
     }),
     [
       highlightCodeChunk,
@@ -190,7 +197,8 @@ export const CodeStyleProvider: React.FC<PropsWithChildren> = ({ children }) => 
       shikiMarkdownIt,
       activeShikiTheme,
       isShikiThemeDark,
-      activeCmTheme
+      activeCmTheme,
+      requestCmTheme
     ]
   )
 

--- a/src/renderer/components/FilePreview/plugins/markdown/__tests__/MarkdownFilePreview.links.test.tsx
+++ b/src/renderer/components/FilePreview/plugins/markdown/__tests__/MarkdownFilePreview.links.test.tsx
@@ -23,7 +23,8 @@ vi.mock('@renderer/components/CodeViewer', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/services/PyodideService', () => ({

--- a/src/renderer/components/TextFilePreviewPopup.tsx
+++ b/src/renderer/components/TextFilePreviewPopup.tsx
@@ -1,6 +1,6 @@
 import { CodeEditor, Dialog, DialogContent, DialogHeader, DialogTitle } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { createPopup, type PopupInjectedProps } from '@renderer/services/popup'
 
 interface OwnProps {
@@ -13,7 +13,7 @@ type Props = OwnProps & PopupInjectedProps<void>
 
 const PopupContainer: React.FC<Props> = ({ text, title, extension, open, resolve }) => {
   const [fontSize] = usePreference('chat.message.font_size')
-  const { activeCmTheme } = useCodeStyle()
+  const activeCmTheme = useCmTheme(open && extension !== undefined)
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && resolve()}>

--- a/src/renderer/components/__tests__/CodeStyleProvider.test.tsx
+++ b/src/renderer/components/__tests__/CodeStyleProvider.test.tsx
@@ -1,6 +1,7 @@
+import { getCmThemeByName } from '@cherrystudio/ui'
 import type * as codeEditorUtils from '@cherrystudio/ui/components/composites/code-editor/utils'
 import { CodeStyleProvider } from '@renderer/components/CodeStyleProvider'
-import { useCodeStyle, useCodeStyleThemeCatalog } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme, useCodeStyle, useCodeStyleThemeCatalog } from '@renderer/hooks/useCodeStyle'
 import { shikiStreamService } from '@renderer/services/ShikiStreamService'
 import { getShiki } from '@renderer/utils/shiki'
 import { MockUsePreferenceUtils } from '@test-mocks/renderer/usePreference'
@@ -15,12 +16,14 @@ vi.mock('@cherrystudio/ui', async () => {
   )
   return {
     getCmThemeNames: utils.getCmThemeNames,
-    getCmThemeByName: utils.getCmThemeByName
+    getCmThemeByName: vi.fn((name: string) => utils.getCmThemeByName(name))
   }
 })
 
+const themeState = vi.hoisted(() => ({ theme: 'light' as 'light' | 'dark' }))
+
 vi.mock('@renderer/hooks/useTheme', () => ({
-  useTheme: () => ({ theme: 'light' })
+  useTheme: () => ({ theme: themeState.theme })
 }))
 
 vi.mock('@renderer/hooks/useMermaid', () => ({
@@ -51,13 +54,11 @@ vi.mock('@renderer/utils/shiki', () => ({
 }))
 
 const Probe = () => {
-  const { highlightCode, activeCmTheme, activeShikiTheme } = useCodeStyle()
+  const { highlightCode, activeShikiTheme } = useCodeStyle()
   const { loadThemeNames, themeNames } = useCodeStyleThemeCatalog()
   return (
     <>
       <span data-testid="has-dracula">{String(themeNames.includes('dracula'))}</span>
-      <span data-testid="cm-theme-type">{typeof activeCmTheme}</span>
-      <span data-testid="cm-theme-string">{typeof activeCmTheme === 'string' ? activeCmTheme : ''}</span>
       <span data-testid="shiki-theme">{activeShikiTheme}</span>
       <button type="button" onClick={() => void loadThemeNames()}>
         Load themes
@@ -69,28 +70,67 @@ const Probe = () => {
   )
 }
 
-const renderProvider = () =>
-  render(
-    <CodeStyleProvider>
-      <Probe />
-    </CodeStyleProvider>
+// Stands in for any CodeMirror consumer boundary (Notes, MCP editors, ArtifactPane, previews).
+const EditorBoundary = ({ active = true }: { active?: boolean }) => {
+  const theme = useCmTheme(active)
+  return (
+    <>
+      <span data-testid="cm-theme-type">{typeof theme}</span>
+      <span data-testid="cm-theme-string">{typeof theme === 'string' ? theme : ''}</span>
+    </>
   )
+}
+
+const renderProvider = (children: React.ReactNode = <Probe />) =>
+  render(<CodeStyleProvider>{children}</CodeStyleProvider>)
 
 describe('CodeStyleProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     MockUsePreferenceUtils.resetMocks()
+    themeState.theme = 'light'
   })
 
   it('throws when useCodeStyle is used outside CodeStyleProvider', () => {
     expect(() => render(<Probe />)).toThrow('useCodeStyle must be used within a CodeStyleProvider')
   })
 
-  it('provides cm theme names and resolves the saved cm theme when code editor is enabled', async () => {
+  it('does not resolve the cm theme while no editor boundary is mounted', () => {
     MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.enabled', true)
     MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
 
     renderProvider()
+
+    // Mounting the provider alone must not pull the themes-all catalog; only an
+    // editor boundary (useCmTheme) may trigger resolution.
+    expect(vi.mocked(getCmThemeByName)).not.toHaveBeenCalled()
+  })
+
+  it('does not demand the theme while the editor boundary is inactive', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
+
+    const { rerender } = renderProvider(<EditorBoundary active={false} />)
+    expect(vi.mocked(getCmThemeByName)).not.toHaveBeenCalled()
+
+    rerender(
+      <CodeStyleProvider>
+        <EditorBoundary />
+      </CodeStyleProvider>
+    )
+
+    await waitFor(() => expect(vi.mocked(getCmThemeByName)).toHaveBeenCalledWith('dracula'))
+  })
+
+  it('resolves the saved cm theme once an editor boundary demands it', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.enabled', true)
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
+
+    renderProvider(
+      <>
+        <Probe />
+        <EditorBoundary />
+      </>
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Load themes' }))
 
     // The first waitFor in this file pays the real (cold) dynamic import of
@@ -110,11 +150,47 @@ describe('CodeStyleProvider', () => {
     MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.enabled', true)
     MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dark')
 
-    renderProvider()
+    renderProvider(<EditorBoundary />)
 
     await waitFor(() => {
       expect(screen.getByTestId('cm-theme-string').textContent).toBe('dark')
     })
+  })
+
+  // Notes, MCP editors, ArtifactPane and the previews all read the cm theme; gating its
+  // resolution on the chat-only flag left them on the bare light/dark theme.
+  it('resolves a real cm theme for non-chat editors while the chat code editor is disabled', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.enabled', false)
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
+
+    renderProvider(<EditorBoundary />)
+
+    await waitFor(() => expect(screen.getByTestId('cm-theme-type').textContent).toBe('object'), { timeout: 15000 })
+  })
+
+  it('falls back to the base material light theme when the stored name is auto', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'auto')
+
+    renderProvider(<EditorBoundary />)
+
+    await waitFor(() => expect(vi.mocked(getCmThemeByName)).toHaveBeenCalledWith('materialLight'))
+  })
+
+  it('re-resolves with the dark-side theme when the window theme flips', async () => {
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
+    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_dark', 'githubDark')
+
+    const { rerender } = renderProvider(<EditorBoundary />)
+    await waitFor(() => expect(vi.mocked(getCmThemeByName)).toHaveBeenCalledWith('dracula'))
+
+    themeState.theme = 'dark'
+    rerender(
+      <CodeStyleProvider>
+        <EditorBoundary />
+      </CodeStyleProvider>
+    )
+
+    await waitFor(() => expect(vi.mocked(getCmThemeByName)).toHaveBeenCalledWith('githubDark'))
   })
 
   it('does not load shiki until its theme catalog is requested', async () => {
@@ -126,17 +202,6 @@ describe('CodeStyleProvider', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load themes' }))
     await waitFor(() => expect(vi.mocked(getShiki)).toHaveBeenCalledOnce())
-  })
-
-  // Notes, MCP editors, ArtifactPane and the previews all read activeCmTheme; gating its
-  // resolution on the chat-only flag left them on the bare light/dark theme.
-  it('resolves a real cm theme for non-chat editors while the chat code editor is disabled', async () => {
-    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.enabled', false)
-    MockUsePreferenceUtils.setPreferenceValue('chat.code.editor.theme_light', 'dracula')
-
-    renderProvider()
-
-    await waitFor(() => expect(screen.getByTestId('cm-theme-type').textContent).toBe('object'), { timeout: 15000 })
   })
 
   // AgentFileDiffRenderer reads activeShikiTheme synchronously and hands it to a resolver that

--- a/src/renderer/components/chat/panes/ArtifactPane.tsx
+++ b/src/renderer/components/chat/panes/ArtifactPane.tsx
@@ -6,7 +6,7 @@ import { CommandContextMenu, type CommandContextMenuExtraItem } from '@renderer/
 import { FilePreview } from '@renderer/components/FilePreview'
 import { FileTree, type FileTreeNode } from '@renderer/components/FileTree'
 import { loadOpenTargetMenuItems, OpenTargetButton } from '@renderer/components/OpenTarget'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import {
   FILE_EDIT_MAX_SIZE_BYTES as ARTIFACT_PREVIEW_MAX_SIZE_BYTES,
   type FileEditSession
@@ -154,7 +154,7 @@ export function ArtifactPaneView(props: ArtifactPaneViewProps) {
     onEditModeChange
   } = props
   const { t } = useTranslation()
-  const { activeCmTheme } = useCodeStyle()
+  const activeCmTheme = useCmTheme(editMode === 'edit')
   const artifactPaneRef = useRef<HTMLDivElement>(null)
   const overlayRef = useRef<HTMLDivElement>(null)
   const [contentRefreshToken, setContentRefreshToken] = useState(0)

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPane.test.tsx
@@ -249,7 +249,8 @@ function binaryReadResult(content: Uint8Array) {
 }
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@cherrystudio/ui', async (importActual) => {

--- a/src/renderer/components/chat/panes/__tests__/ArtifactPaneContextMenu.integration.test.tsx
+++ b/src/renderer/components/chat/panes/__tests__/ArtifactPaneContextMenu.integration.test.tsx
@@ -47,7 +47,8 @@ vi.mock('@renderer/services/externalOpenTargetService', async (importOriginal) =
 })
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: null })
+  useCodeStyle: () => ({ activeCmTheme: null }),
+  useCmTheme: () => null
 }))
 
 vi.mock('@renderer/components/FilePreview', () => ({

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AgentSelector.test.tsx
@@ -110,7 +110,8 @@ vi.mock('@renderer/hooks/useModel', async (importOriginal) => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/hooks/useProvider', () => ({

--- a/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
+++ b/src/renderer/components/resourceCatalog/selectors/__tests__/AssistantSelector.test.tsx
@@ -111,7 +111,8 @@ vi.mock('@renderer/hooks/tab', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('react-i18next', async (importOriginal) => {

--- a/src/renderer/hooks/useCodeStyle.ts
+++ b/src/renderer/hooks/useCodeStyle.ts
@@ -1,6 +1,6 @@
 import type { CodeMirrorTheme } from '@cherrystudio/ui'
 import type { HighlightChunkResult, ShikiPreProperties } from '@renderer/services/ShikiStreamService'
-import { createContext, use } from 'react'
+import { createContext, use, useEffect } from 'react'
 
 interface CodeStyleContextType {
   highlightCodeChunk: (trunk: string, language: string, callerId: string) => Promise<HighlightChunkResult>
@@ -12,6 +12,7 @@ interface CodeStyleContextType {
   activeShikiTheme: string
   isShikiThemeDark: boolean
   activeCmTheme: CodeMirrorTheme
+  requestCmTheme: () => void
 }
 
 interface CodeStyleThemeCatalogContextType {
@@ -36,4 +37,17 @@ export const useCodeStyleThemeCatalog = () => {
     throw new Error('useCodeStyleThemeCatalog must be used within a CodeStyleProvider')
   }
   return context
+}
+
+/**
+ * Reads the active CodeMirror theme for an editor boundary being rendered (`active`).
+ * Demanding the theme is what triggers catalog resolution, so windows without editors
+ * never load it; the base light/dark string is returned until resolution lands.
+ */
+export const useCmTheme = (active = true): CodeMirrorTheme => {
+  const { activeCmTheme, requestCmTheme } = useCodeStyle()
+  useEffect(() => {
+    if (active) requestCmTheme()
+  }, [active, requestCmTheme])
+  return activeCmTheme
 }

--- a/src/renderer/pages/code/components/configEditPanel/CliConfigEditor.tsx
+++ b/src/renderer/pages/code/components/configEditPanel/CliConfigEditor.tsx
@@ -1,6 +1,6 @@
 import { Button, CodeEditor, Tabs, TabsContent, TabsList, TabsTrigger, Tooltip } from '@cherrystudio/ui'
 import { usePreference } from '@data/hooks/usePreference'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { type CliConfigFileDraft, formatCliConfigDraftFile } from '@renderer/pages/code/cliConfig'
 import { toast } from '@renderer/services/toast'
 import { cn } from '@renderer/utils/style'
@@ -18,7 +18,6 @@ interface CliConfigEditorProps {
 export const CliConfigEditor: FC<CliConfigEditorProps> = ({ files, error, onChange }) => {
   const { t } = useTranslation()
   const [fontSize] = usePreference('chat.message.font_size')
-  const { activeCmTheme } = useCodeStyle()
   const [requestedTarget, setRequestedTarget] = useState<string>(files[0]?.target ?? '')
   const activeTarget = files.some((file) => file.target === requestedTarget)
     ? requestedTarget
@@ -28,6 +27,7 @@ export const CliConfigEditor: FC<CliConfigEditorProps> = ({ files, error, onChan
     () => files.find((file) => file.target === activeTarget) ?? files[0],
     [activeTarget, files]
   )
+  const activeCmTheme = useCmTheme(!!activeFile)
 
   if (!files.length) return null
 

--- a/src/renderer/pages/code/components/configEditPanel/__tests__/CliConfigEditor.test.tsx
+++ b/src/renderer/pages/code/components/configEditPanel/__tests__/CliConfigEditor.test.tsx
@@ -38,7 +38,8 @@ vi.mock('@data/hooks/usePreference', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 const files: CliConfigFileDraft[] = [

--- a/src/renderer/pages/notes/NotesEditor.tsx
+++ b/src/renderer/pages/notes/NotesEditor.tsx
@@ -5,7 +5,7 @@ import ActionIconButton from '@renderer/components/ActionIconButton'
 import { ErrorBoundary } from '@renderer/components/ErrorBoundary'
 import type { RichEditorRef } from '@renderer/components/RichEditor/types'
 import Selector from '@renderer/components/Selector'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { useNotesSettings } from '@renderer/hooks/useNotesSettings'
 import { toast } from '@renderer/services/toast'
 import type { EditorView } from '@renderer/types/app'
@@ -58,7 +58,6 @@ const NotesEditor: FC<NotesEditorProps> = memo(
   }) => {
     const { t } = useTranslation()
     const { settings } = useNotesSettings()
-    const { activeCmTheme } = useCodeStyle()
     const [enableSpellCheck, setEnableSpellCheck] = usePreference('app.spell_check.enabled')
     const currentViewMode = useMemo(() => {
       if (settings.defaultViewMode === 'edit') {
@@ -68,6 +67,7 @@ const NotesEditor: FC<NotesEditorProps> = memo(
       }
     }, [settings.defaultEditMode, settings.defaultViewMode])
     const [tmpViewMode, setTmpViewMode] = useState(currentViewMode)
+    const activeCmTheme = useCmTheme(tmpViewMode === 'source')
     const currentViewModeRef = useRef(currentViewMode)
     const userViewModeOverrideRef = useRef(false)
 

--- a/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesEditor.test.tsx
@@ -46,7 +46,8 @@ vi.mock('@renderer/components/Selector', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/hooks/useNotesSettings', () => ({

--- a/src/renderer/pages/notes/__tests__/NotesEditor.transactions.test.tsx
+++ b/src/renderer/pages/notes/__tests__/NotesEditor.transactions.test.tsx
@@ -10,7 +10,8 @@ vi.mock('@renderer/data/hooks/usePreference', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light', activeShikiTheme: 'one-light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light', activeShikiTheme: 'one-light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/hooks/useNotesSettings', () => ({

--- a/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/AppearanceSettings.tsx
@@ -28,7 +28,7 @@ import {
   SettingsContentColumn,
   SettingTitle
 } from '@renderer/components/SettingsPrimitives'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { useSidebarFavorites } from '@renderer/hooks/useSidebarFavorites'
 import { useTheme } from '@renderer/hooks/useTheme'
 import { useTimer } from '@renderer/hooks/useTimer'
@@ -121,7 +121,7 @@ const AppearanceSettings: FC = () => {
   const { theme, settedTheme, setTheme } = useTheme()
   const { setTimeoutTimer } = useTimer()
   const { userTheme, setUserTheme } = useUserTheme()
-  const { activeCmTheme } = useCodeStyle()
+  const activeCmTheme = useCmTheme()
   const { appFavorites, setAppPinned } = useSidebarFavorites()
   const isChatAssistantVisible = appFavorites.includes('assistants')
 

--- a/src/renderer/pages/settings/AppearanceSettings/__tests__/AppearanceSettings.test.tsx
+++ b/src/renderer/pages/settings/AppearanceSettings/__tests__/AppearanceSettings.test.tsx
@@ -153,7 +153,8 @@ vi.mock('@renderer/hooks/useTheme', () => ({
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
   useCodeStyle: () => ({
     activeCmTheme: 'light'
-  })
+  }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/hooks/useUserTheme', () => ({

--- a/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
+++ b/src/renderer/pages/settings/McpSettings/AddMcpServerModal.tsx
@@ -19,7 +19,7 @@ import { dataApiService } from '@data/DataApiService'
 import { usePreference } from '@data/hooks/usePreference'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { loggerService } from '@logger'
-import { useCodeStyle } from '@renderer/hooks/useCodeStyle'
+import { useCmTheme } from '@renderer/hooks/useCodeStyle'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { ipcApi } from '@renderer/ipc'
 import { toast } from '@renderer/services/toast'
@@ -103,9 +103,9 @@ const AddMcpServerModal: FC<AddMcpServerModalProps> = ({
 }) => {
   const { t } = useTranslation()
   const [fontSize] = usePreference('chat.message.font_size')
-  const { activeCmTheme } = useCodeStyle()
   const [loading, setLoading] = useState(false)
   const [importMethod, setImportMethod] = useState<'json' | 'dxt' | 'mcpb'>(initialImportMethod)
+  const activeCmTheme = useCmTheme(visible && importMethod === 'json')
   const [packageFile, setPackageFile] = useState<File | null>(null)
   const { setTimeoutTimer } = useTimer()
 

--- a/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
+++ b/src/renderer/pages/settings/McpSettings/__tests__/AddMcpServerModal.test.tsx
@@ -34,7 +34,8 @@ vi.mock('@data/hooks/usePreference', () => ({
 }))
 
 vi.mock('@renderer/hooks/useCodeStyle', () => ({
-  useCodeStyle: () => ({ activeCmTheme: 'light' })
+  useCodeStyle: () => ({ activeCmTheme: 'light' }),
+  useCmTheme: () => 'light'
 }))
 
 vi.mock('@renderer/hooks/useTimer', () => ({


### PR DESCRIPTION
### What this PR does

Before this PR:

`CodeStyleProvider` resolved the selected CodeMirror theme in a mount-time effect, so every window that mounts the provider (main, sub windows, Quick Assistant, selection action) eagerly pulled the `@uiw/codemirror-themes-all` catalog — even when no CodeMirror editor was ever rendered in that window.

After this PR:

Resolution is deferred to the moment a CodeMirror boundary actually renders. The provider exposes an idempotent `requestCmTheme()` demand plus a `useCmTheme(active = true)` hook; each consumer passes its own editor-render condition (`isEditing`, `visible && importMethod === 'json'`, `tmpViewMode === 'source'`, …). Until resolution lands the hook returns the base `light`/`dark` string — bit-for-bit the same first-frame value as before. Resolution itself (auto → `materialLight`/`dark` fallback, unknown-name fallback, light/dark re-resolution, the shared `cmThemesPromise` cache) is unchanged and still independent of `chat.code.editor.enabled`, so Notes, MCP editors, ArtifactPane and previews keep the exact theme behavior they had.

Fixes #19715

### Why we need it and why it was done in this way

The following tradeoffs were made:

- The demand signal lives at the consumer boundary instead of the provider mount. A window that never opens an editor now never loads the catalog; the one-time cost is that the first editor activation in a cold window renders the base theme for one frame before the resolved extension lands (equivalent to today's startup-time async window, just later).
- The provider latches the demand (never un-latches). Releasing it when the last editor closes would save nothing — the module-level `cmThemesPromise` cache retains the catalog anyway, and the issue asks for resolve-and-cache semantics.

The following alternatives were considered:

- Exposing the theme *name* plus an async resolver on the context and letting each of the 8 consumers resolve locally — rejected: duplicates resolution logic 8× for no behavioral gain.
- Triggering resolution inside `@cherrystudio/ui`'s `CodeEditor` via a prop callback — rejected: packages/ui would call back into renderer context wiring.

Links to places where the discussion took place: #19715 (also related bundle-governance issues #17016, #19067, #19208)

### Breaking changes

None. All consumers read the same resolved theme through the new hook; the catalog path used by the settings theme picker (`loadThemeNames`/`getCmThemeNames`) is untouched.

### Special notes for your reviewer

- The 8 consumer predicates were each checked against the component's actual `<CodeEditor theme=...>` render condition (see `useCmTheme` call sites). Predicates err on the eager side where a condition is imminent (e.g. ArtifactPane demands on `editMode === 'edit'` while the file session is still loading) — over-requesting only, never an unthemed editor.
- 11 existing test files stub `@renderer/hooks/useCodeStyle` with a module factory; each gained a one-line `useCmTheme` stub of the same shape (per-file stubbing is the established pattern for renderer hooks).
- Focused tests: provider mount with a stored custom theme and no editor boundary asserts `getCmThemeByName` is never called; demand-predicate flip, auto→`materialLight` fallback, and window-theme re-resolution are each locked by a dedicated test.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: user-guide update not required (no user-facing change; pure perf/deference)
- [x] Self-review: reviewed via two-axis code-review (standards + spec) against origin/main; no medium+ findings remain (one judged-duplicated test-stub pattern documented above)

### Release note

```release-note
Performance: CodeMirror theme catalog is now loaded only when a code editor is actually opened, reducing startup work for editor-less windows.
```

