### PR TITLE
perf(knowledge): lazy-load management dialogs and item detail panels

### DIFF
--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -718,7 +718,6 @@ describe('KnowledgePage', () => {
   // The four lazy-contract tests below must stay first: vi.mock factories run once per
   // module per file, so only the first test to open each dialog/panel can observe its load.
   it('does not load the management dialogs or item detail panels while the page renders', async () => {
-    const user = userEvent.setup()
     mockUseKnowledgeBases.mockReturnValue({
       bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
       isLoading: false,

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -11,6 +11,7 @@ import type {
 } from '@shared/data/types/knowledge'
 import type { PosixRelativeFilePath } from '@shared/utils/file'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -33,6 +34,14 @@ const mockDetailHeaderRender = vi.fn()
 const mockDataSourcePanelRender = vi.fn()
 const mockRagConfigPanelModuleLoad = vi.fn()
 const mockRecallTestPanelModuleLoad = vi.fn()
+const mockAddSourceDialogModuleLoad = vi.fn()
+const mockCreateBaseDialogModuleLoad = vi.fn()
+const mockCreateGroupDialogModuleLoad = vi.fn()
+const mockRenameGroupDialogModuleLoad = vi.fn()
+const mockRenameBaseDialogModuleLoad = vi.fn()
+const mockRestoreDialogModuleLoad = vi.fn()
+const mockChunkDetailPanelModuleLoad = vi.fn()
+const mockNoteContentPanelModuleLoad = vi.fn()
 
 vi.mock('@renderer/hooks/useKnowledgeBase', () => ({
   useKnowledgeBases: () => mockUseKnowledgeBases(),
@@ -245,6 +254,7 @@ vi.mock('../panels/dataSource/DataSourcePanel', () => ({
     isLoading,
     onAdd,
     onItemClick,
+    onViewNoteContent,
     onPreviewFile,
     onDrillIntoDirectory,
     currentDirectory,
@@ -258,6 +268,7 @@ vi.mock('../panels/dataSource/DataSourcePanel', () => ({
     isLoading: boolean
     onAdd: () => void
     onItemClick: (itemId: string) => void
+    onViewNoteContent: (itemId: string) => void
     onPreviewFile: (target: KnowledgeFilePreviewTarget) => void
     onDrillIntoDirectory?: (item: KnowledgeItemOf<'directory'>) => void
     currentDirectory?: KnowledgeItemOf<'directory'> | null
@@ -292,6 +303,9 @@ vi.mock('../panels/dataSource/DataSourcePanel', () => ({
             <button type="button" onClick={() => onItemClick(item.id)}>
               OpenChunks {item.id}
             </button>
+            <button type="button" onClick={() => onViewNoteContent(item.id)}>
+              ViewNoteContent {item.id}
+            </button>
             <button
               type="button"
               onClick={() =>
@@ -315,16 +329,33 @@ vi.mock('../panels/dataSource/DataSourcePanel', () => ({
   }
 }))
 
-vi.mock('../panels/dataSource/KnowledgeItemChunkDetailPanel', () => ({
-  default: ({ itemId, onBack }: { itemId: string; onBack: () => void }) => (
-    <div data-testid="chunk-detail-panel">
-      <div>{`chunks:${itemId}`}</div>
-      <button type="button" onClick={onBack}>
-        BackToSources
-      </button>
-    </div>
-  )
-}))
+vi.mock('../panels/dataSource/KnowledgeItemChunkDetailPanel', () => {
+  mockChunkDetailPanelModuleLoad()
+  return {
+    default: ({ itemId, onBack }: { itemId: string; onBack: () => void }) => (
+      <div data-testid="chunk-detail-panel">
+        <div>{`chunks:${itemId}`}</div>
+        <button type="button" onClick={onBack}>
+          BackToSources
+        </button>
+      </div>
+    )
+  }
+})
+
+vi.mock('../panels/dataSource/KnowledgeItemNoteContentPanel', () => {
+  mockNoteContentPanelModuleLoad()
+  return {
+    default: ({ itemId, onBack }: { itemId: string; onBack: () => void }) => (
+      <div data-testid="note-content-panel">
+        <div>{`note:${itemId}`}</div>
+        <button type="button" onClick={onBack}>
+          BackToSources
+        </button>
+      </div>
+    )
+  }
+})
 
 vi.mock('../panels/ragConfig/RagConfigPanel', () => {
   mockRagConfigPanelModuleLoad()
@@ -347,173 +378,191 @@ vi.mock('../panels/recallTest/RecallTestPanel', () => {
   }
 })
 
-vi.mock('../components/AddKnowledgeItemDialog', () => ({
-  default: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) =>
-    open ? (
-      <div data-testid="add-source-dialog">
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Close Add Source
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/AddKnowledgeItemDialog', () => {
+  mockAddSourceDialogModuleLoad()
+  return {
+    default: ({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) =>
+      open ? (
+        <div data-testid="add-source-dialog">
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Close Add Source
+          </button>
+        </div>
+      ) : null
+  }
+})
 
-vi.mock('../components/CreateKnowledgeBaseDialog', () => ({
-  default: ({
-    open,
-    groups,
-    initialGroupId,
-    createBase,
-    onOpenChange,
-    onCreated
-  }: {
-    open: boolean
-    groups: Array<{ id: string; name: string }>
-    initialGroupId?: string
-    createBase: (input: { name: string; groupId?: string }) => Promise<KnowledgeBase>
-    onOpenChange: (open: boolean) => void
-    onCreated: (base: KnowledgeBase) => void
-  }) =>
-    open ? (
-      <div data-testid="create-dialog">
-        <div data-testid="create-dialog-groups">{groups.map((group) => group.name).join(',')}</div>
-        <div data-testid="create-dialog-initial-group-id">{initialGroupId}</div>
-        <button
-          type="button"
-          onClick={async () => {
-            const createdBase = await createBase({
-              name: 'Base 2',
-              ...(initialGroupId ? { groupId: initialGroupId } : {})
-            })
-            onCreated(createdBase)
-            onOpenChange(false)
-          }}>
-          Submit Create
-        </button>
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Cancel Create
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/CreateKnowledgeBaseDialog', () => {
+  mockCreateBaseDialogModuleLoad()
+  return {
+    default: ({
+      open,
+      groups,
+      initialGroupId,
+      createBase,
+      onOpenChange,
+      onCreated
+    }: {
+      open: boolean
+      groups: Array<{ id: string; name: string }>
+      initialGroupId?: string
+      createBase: (input: { name: string; groupId?: string }) => Promise<KnowledgeBase>
+      onOpenChange: (open: boolean) => void
+      onCreated: (base: KnowledgeBase) => void
+    }) =>
+      open ? (
+        <div data-testid="create-dialog">
+          <div data-testid="create-dialog-groups">{groups.map((group) => group.name).join(',')}</div>
+          <div data-testid="create-dialog-initial-group-id">{initialGroupId}</div>
+          <button
+            type="button"
+            onClick={async () => {
+              const createdBase = await createBase({
+                name: 'Base 2',
+                ...(initialGroupId ? { groupId: initialGroupId } : {})
+              })
+              onCreated(createdBase)
+              onOpenChange(false)
+            }}>
+            Submit Create
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel Create
+          </button>
+        </div>
+      ) : null
+  }
+})
 
-vi.mock('../components/RestoreKnowledgeBaseDialog', () => ({
-  default: ({
-    open,
-    base,
-    restoreBase,
-    onOpenChange,
-    onRestored
-  }: {
-    open: boolean
-    base: KnowledgeBase
-    restoreBase: (input: {
-      sourceBaseId: string
-      name: string
-      embeddingModelId: string | null
-      dimensions: number
-    }) => Promise<RestoreKnowledgeBaseResult>
-    onOpenChange: (open: boolean) => void
-    onRestored: (base: KnowledgeBase) => void
-  }) =>
-    open ? (
-      <div data-testid="restore-dialog">
-        <div data-testid="restore-dialog-source-name">{base.name}</div>
-        <button
-          type="button"
-          onClick={async () => {
-            const result = await restoreBase({
-              sourceBaseId: base.id,
-              name: `${base.name}_副本`,
-              embeddingModelId: 'openai::text-embedding-3-small',
-              dimensions: 1024
-            })
-            onRestored(result.base)
-            onOpenChange(false)
-          }}>
-          Submit Restore
-        </button>
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Cancel Restore
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/RestoreKnowledgeBaseDialog', () => {
+  mockRestoreDialogModuleLoad()
+  return {
+    default: ({
+      open,
+      base,
+      restoreBase,
+      onOpenChange,
+      onRestored
+    }: {
+      open: boolean
+      base: KnowledgeBase
+      restoreBase: (input: {
+        sourceBaseId: string
+        name: string
+        embeddingModelId: string | null
+        dimensions: number
+      }) => Promise<RestoreKnowledgeBaseResult>
+      onOpenChange: (open: boolean) => void
+      onRestored: (base: KnowledgeBase) => void
+    }) =>
+      open ? (
+        <div data-testid="restore-dialog">
+          <div data-testid="restore-dialog-source-name">{base.name}</div>
+          <button
+            type="button"
+            onClick={async () => {
+              const result = await restoreBase({
+                sourceBaseId: base.id,
+                name: `${base.name}_副本`,
+                embeddingModelId: 'openai::text-embedding-3-small',
+                dimensions: 1024
+              })
+              onRestored(result.base)
+              onOpenChange(false)
+            }}>
+            Submit Restore
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel Restore
+          </button>
+        </div>
+      ) : null
+  }
+})
 
-vi.mock('../components/CreateKnowledgeGroupDialog', () => ({
-  default: ({
-    open,
-    onSubmit,
-    onOpenChange
-  }: {
-    open: boolean
-    onSubmit: (name: string) => Promise<void>
-    onOpenChange: (open: boolean) => void
-  }) =>
-    open ? (
-      <div data-testid="create-group-dialog">
-        <button type="button" onClick={() => void onSubmit('Group 2')}>
-          Submit Create Group
-        </button>
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Cancel Create Group
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/CreateKnowledgeGroupDialog', () => {
+  mockCreateGroupDialogModuleLoad()
+  return {
+    default: ({
+      open,
+      onSubmit,
+      onOpenChange
+    }: {
+      open: boolean
+      onSubmit: (name: string) => Promise<void>
+      onOpenChange: (open: boolean) => void
+    }) =>
+      open ? (
+        <div data-testid="create-group-dialog">
+          <button type="button" onClick={() => void onSubmit('Group 2')}>
+            Submit Create Group
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel Create Group
+          </button>
+        </div>
+      ) : null
+  }
+})
 
-vi.mock('../components/RenameKnowledgeGroupDialog', () => ({
-  default: ({
-    open,
-    initialName,
-    onSubmit,
-    onOpenChange
-  }: {
-    open: boolean
-    initialName: string
-    onSubmit: (name: string) => Promise<void>
-    onOpenChange: (open: boolean) => void
-  }) =>
-    open ? (
-      <div data-testid="rename-group-dialog">
-        <div data-testid="group-dialog-initial-name">{initialName}</div>
-        <button type="button" onClick={() => void onSubmit('Renamed Group')}>
-          Submit Rename Group
-        </button>
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Cancel Rename Group
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/RenameKnowledgeGroupDialog', () => {
+  mockRenameGroupDialogModuleLoad()
+  return {
+    default: ({
+      open,
+      initialName,
+      onSubmit,
+      onOpenChange
+    }: {
+      open: boolean
+      initialName: string
+      onSubmit: (name: string) => Promise<void>
+      onOpenChange: (open: boolean) => void
+    }) =>
+      open ? (
+        <div data-testid="rename-group-dialog">
+          <div data-testid="group-dialog-initial-name">{initialName}</div>
+          <button type="button" onClick={() => void onSubmit('Renamed Group')}>
+            Submit Rename Group
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel Rename Group
+          </button>
+        </div>
+      ) : null
+  }
+})
 
-vi.mock('../components/KnowledgeBaseNameDialog', () => ({
-  default: ({
-    open,
-    initialName,
-    onSubmit,
-    onOpenChange
-  }: {
-    open: boolean
-    initialName: string
-    onSubmit: (name: string) => Promise<void>
-    onOpenChange: (open: boolean) => void
-  }) =>
-    open ? (
-      <div data-testid="rename-base-dialog">
-        <div data-testid="base-dialog-initial-name">{initialName}</div>
-        <button type="button" onClick={() => void onSubmit('Renamed Base')}>
-          Submit Rename Base
-        </button>
-        <button type="button" onClick={() => void onSubmit(initialName)}>
-          Submit Same Name Base
-        </button>
-        <button type="button" onClick={() => onOpenChange(false)}>
-          Cancel Rename Base
-        </button>
-      </div>
-    ) : null
-}))
+vi.mock('../components/KnowledgeBaseNameDialog', () => {
+  mockRenameBaseDialogModuleLoad()
+  return {
+    default: ({
+      open,
+      initialName,
+      onSubmit,
+      onOpenChange
+    }: {
+      open: boolean
+      initialName: string
+      onSubmit: (name: string) => Promise<void>
+      onOpenChange: (open: boolean) => void
+    }) =>
+      open ? (
+        <div data-testid="rename-base-dialog">
+          <div data-testid="base-dialog-initial-name">{initialName}</div>
+          <button type="button" onClick={() => void onSubmit('Renamed Base')}>
+            Submit Rename Base
+          </button>
+          <button type="button" onClick={() => void onSubmit(initialName)}>
+            Submit Same Name Base
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel Rename Base
+          </button>
+        </div>
+      ) : null
+  }
+})
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -666,6 +715,127 @@ describe('KnowledgePage', () => {
     vi.restoreAllMocks()
   })
 
+  // The four lazy-contract tests below must stay first: vi.mock factories run once per
+  // module per file, so only the first test to open each dialog/panel can observe its load.
+  it('does not load the management dialogs or item detail panels while the page renders', async () => {
+    const user = userEvent.setup()
+    mockUseKnowledgeBases.mockReturnValue({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+    mockUseKnowledgeItems.mockReturnValue({
+      items: [createKnowledgeItem({ id: 'item-1' })],
+      total: 1,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+
+    render(<KnowledgePage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
+    })
+
+    expect(mockAddSourceDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockCreateBaseDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockCreateGroupDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockRenameGroupDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockRenameBaseDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockRestoreDialogModuleLoad).not.toHaveBeenCalled()
+    expect(mockChunkDetailPanelModuleLoad).not.toHaveBeenCalled()
+    expect(mockNoteContentPanelModuleLoad).not.toHaveBeenCalled()
+  })
+
+  it('loads the create-base dialog module only when the dialog opens', async () => {
+    const user = userEvent.setup()
+    mockUseKnowledgeBases.mockReturnValue({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+
+    render(<KnowledgePage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('detail-header')).toBeInTheDocument()
+    })
+    expect(mockCreateBaseDialogModuleLoad).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: '新建知识库' }))
+    expect(await screen.findByTestId('create-dialog')).toBeInTheDocument()
+    expect(mockCreateBaseDialogModuleLoad).toHaveBeenCalledOnce()
+    expect(mockAddSourceDialogModuleLoad).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Cancel Create' }))
+    await waitFor(() => {
+      expect(screen.queryByTestId('create-dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  it('loads the chunk detail panel module only when an item is opened', async () => {
+    const user = userEvent.setup()
+    mockUseKnowledgeBases.mockReturnValue({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+    mockUseKnowledgeItems.mockReturnValue({
+      items: [createKnowledgeItem({ id: 'item-1' })],
+      total: 1,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+
+    render(<KnowledgePage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
+    })
+
+    await user.click(screen.getByRole('button', { name: 'OpenChunks item-1' }))
+    expect(await screen.findByTestId('chunk-detail-panel')).toHaveTextContent('chunks:item-1')
+    expect(mockChunkDetailPanelModuleLoad).toHaveBeenCalledOnce()
+    expect(mockNoteContentPanelModuleLoad).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'BackToSources' }))
+    expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
+  })
+
+  it('loads the note content panel module only for the note view of a selected item', async () => {
+    const user = userEvent.setup()
+    mockUseKnowledgeBases.mockReturnValue({
+      bases: [createKnowledgeBase({ id: 'base-1', name: 'Base 1' })],
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+    mockUseKnowledgeItems.mockReturnValue({
+      items: [createKnowledgeItem({ id: 'item-1' })],
+      total: 1,
+      isLoading: false,
+      error: undefined,
+      refetch: vi.fn()
+    })
+
+    render(<KnowledgePage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('data-source-panel')).toHaveTextContent('1:idle')
+    })
+    expect(mockNoteContentPanelModuleLoad).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'ViewNoteContent item-1' }))
+    expect(await screen.findByTestId('note-content-panel')).toHaveTextContent('note:item-1')
+    expect(mockNoteContentPanelModuleLoad).toHaveBeenCalledOnce()
+    expect(mockChunkDetailPanelModuleLoad).not.toHaveBeenCalled()
+  })
+
   it('auto-selects the first knowledge base after bases load', async () => {
     mockUseKnowledgeBases.mockReturnValue({
       bases: [
@@ -798,7 +968,7 @@ describe('KnowledgePage', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Add Source' }))
-    expect(screen.getByTestId('add-source-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('add-source-dialog')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Close Add Source' }))
     expect(screen.queryByTestId('add-source-dialog')).not.toBeInTheDocument()
@@ -901,7 +1071,7 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenChunks item-1' }))
 
-    expect(screen.getByTestId('chunk-detail-panel')).toHaveTextContent('chunks:item-1')
+    expect(await screen.findByTestId('chunk-detail-panel')).toHaveTextContent('chunks:item-1')
     expect(screen.queryByTestId('data-source-panel')).not.toBeInTheDocument()
     expect(screen.queryByTestId('detail-header')).not.toBeInTheDocument()
 
@@ -1146,7 +1316,7 @@ describe('KnowledgePage', () => {
     expect(screen.queryByTestId('detail-header')).not.toBeInTheDocument()
   })
 
-  it('shows the empty state when no knowledge bases are available', () => {
+  it('shows the empty state when no knowledge bases are available', async () => {
     mockUseKnowledgeBases.mockReturnValue({
       bases: [],
       isLoading: false,
@@ -1165,7 +1335,7 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '创建知识库' }))
 
-    expect(screen.getByTestId('create-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('create-dialog')).toBeInTheDocument()
   })
 
   it('opens the create-group dialog and wires submission to the group mutation hook', async () => {
@@ -1186,7 +1356,7 @@ describe('KnowledgePage', () => {
     render(<KnowledgePage />)
 
     fireEvent.click(screen.getByRole('button', { name: '新建分组' }))
-    expect(screen.getByTestId('create-group-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('create-group-dialog')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Create Group' }))
 
@@ -1283,7 +1453,7 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'RenameGroup Research' }))
 
-    expect(screen.getByTestId('rename-group-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('rename-group-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('group-dialog-initial-name')).toHaveTextContent('Research')
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Rename Group' }))
@@ -1361,7 +1531,7 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'RenameBase Base 1' }))
 
-    expect(screen.getByTestId('rename-base-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('rename-base-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('base-dialog-initial-name')).toHaveTextContent('Base 1')
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Rename Base' }))
@@ -1611,7 +1781,7 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenRagConfig' }))
     fireEvent.click(screen.getByRole('button', { name: 'RagRestore Legacy KB' }))
-    expect(screen.getByTestId('restore-dialog')).toBeInTheDocument()
+    expect(await screen.findByTestId('restore-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('restore-dialog-source-name')).toHaveTextContent('Legacy KB')
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Restore' }))

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -1295,7 +1295,8 @@ describe('KnowledgePage', () => {
     })
 
     fireEvent.click(screen.getByRole('button', { name: 'OpenChunks item-1' }))
-    expect(screen.getByTestId('chunk-detail-panel')).toBeInTheDocument()
+    // The chunk panel mounts through React.lazy; await its first resolution
+    expect(await screen.findByTestId('chunk-detail-panel')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'OpenRagConfig' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'OpenRecallTest' })).not.toBeInTheDocument()
     expect(screen.queryByTestId('rag-config-panel')).not.toBeInTheDocument()

--- a/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
+++ b/src/renderer/pages/knowledge/__tests__/KnowledgePage.test.tsx
@@ -1390,7 +1390,8 @@ describe('KnowledgePage', () => {
     render(<KnowledgePage />)
 
     fireEvent.click(screen.getByRole('button', { name: 'CreateGroupForBase Base 1' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Submit Create Group' }))
+    // The create-group dialog mounts through React.lazy; await its first resolution
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Create Group' }))
 
     await waitFor(() => {
       expect(createGroupMock).toHaveBeenCalledWith('Group 2')
@@ -1424,9 +1425,10 @@ describe('KnowledgePage', () => {
     // Open from a base's context menu, cancel, then create a group the plain way:
     // the cancelled pending move must not leak into the second creation.
     fireEvent.click(screen.getByRole('button', { name: 'CreateGroupForBase Base 1' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel Create Group' }))
+    // The create-group dialog mounts through React.lazy; await its first resolution
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel Create Group' }))
     fireEvent.click(screen.getByRole('button', { name: '新建分组' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Submit Create Group' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Create Group' }))
 
     await waitFor(() => {
       expect(createGroupMock).toHaveBeenCalledTimes(1)
@@ -1584,7 +1586,8 @@ describe('KnowledgePage', () => {
     render(<KnowledgePage />)
 
     fireEvent.click(screen.getByRole('button', { name: 'RenameBase Base 1' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Submit Same Name Base' }))
+    // The rename dialog mounts through React.lazy; await its first resolution
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Same Name Base' }))
 
     await waitFor(() => {
       expect(screen.queryByTestId('rename-base-dialog')).not.toBeInTheDocument()
@@ -1648,7 +1651,8 @@ describe('KnowledgePage', () => {
     const { rerender } = render(<KnowledgePage />)
 
     fireEvent.click(screen.getByRole('button', { name: '新建知识库' }))
-    expect(screen.getByTestId('create-dialog')).toBeInTheDocument()
+    // The create dialog mounts through React.lazy; await its first resolution
+    expect(await screen.findByTestId('create-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('create-dialog-groups')).toHaveTextContent('Research,Archive')
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Create' }))
@@ -1687,7 +1691,8 @@ describe('KnowledgePage', () => {
     const { rerender } = render(<KnowledgePage />)
 
     fireEvent.click(screen.getByRole('button', { name: '新建知识库' }))
-    fireEvent.click(screen.getByRole('button', { name: 'Submit Create' }))
+    // The create dialog mounts through React.lazy; await its first resolution
+    fireEvent.click(await screen.findByRole('button', { name: 'Submit Create' }))
 
     await waitFor(() => expect(screen.getByTestId('selected-base-id')).toHaveTextContent('base-2'))
 
@@ -1719,7 +1724,8 @@ describe('KnowledgePage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'CreateBaseInGroup Archive' }))
 
-    expect(screen.getByTestId('create-dialog')).toBeInTheDocument()
+    // The create dialog mounts through React.lazy; await its first resolution
+    expect(await screen.findByTestId('create-dialog')).toBeInTheDocument()
     expect(screen.getByTestId('create-dialog-initial-group-id')).toHaveTextContent('group-2')
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit Create' }))

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDetailSection.tsx
@@ -9,8 +9,10 @@ import { useTranslation } from 'react-i18next'
 import DetailHeader from '../components/DetailHeader'
 import { useKnowledgePage } from '../KnowledgePageProvider'
 import DataSourcePanel from '../panels/dataSource/DataSourcePanel'
-import KnowledgeItemChunkDetailPanel from '../panels/dataSource/KnowledgeItemChunkDetailPanel'
-import KnowledgeItemNoteContentPanel from '../panels/dataSource/KnowledgeItemNoteContentPanel'
+
+// Item detail views are loaded when an item is opened, not with the page.
+const KnowledgeItemChunkDetailPanel = lazy(() => import('../panels/dataSource/KnowledgeItemChunkDetailPanel'))
+const KnowledgeItemNoteContentPanel = lazy(() => import('../panels/dataSource/KnowledgeItemNoteContentPanel'))
 
 const RagConfigPanel = lazy(() => import('../panels/ragConfig/RagConfigPanel'))
 const RecallTestPanel = lazy(() => import('../panels/recallTest/RecallTestPanel'))
@@ -84,11 +86,13 @@ const KnowledgePageDetailSection = () => {
 
       <div className="min-h-0 flex-1 overflow-hidden">
         {selectedItemId ? (
-          selectedItemView === 'content' ? (
-            <KnowledgeItemNoteContentPanel itemId={selectedItemId} onBack={closeItemChunks} />
-          ) : (
-            <KnowledgeItemChunkDetailPanel baseId={selectedBaseId} itemId={selectedItemId} onBack={closeItemChunks} />
-          )
+          <Suspense fallback={null}>
+            {selectedItemView === 'content' ? (
+              <KnowledgeItemNoteContentPanel itemId={selectedItemId} onBack={closeItemChunks} />
+            ) : (
+              <KnowledgeItemChunkDetailPanel baseId={selectedBaseId} itemId={selectedItemId} onBack={closeItemChunks} />
+            )}
+          </Suspense>
         ) : filePreview ? (
           <section
             aria-label={filePreview.fileName}

--- a/src/renderer/pages/knowledge/sections/KnowledgePageDialogSection.tsx
+++ b/src/renderer/pages/knowledge/sections/KnowledgePageDialogSection.tsx
@@ -1,10 +1,14 @@
-import AddKnowledgeItemDialog from '../components/AddKnowledgeItemDialog'
-import CreateKnowledgeBaseDialog from '../components/CreateKnowledgeBaseDialog'
-import CreateKnowledgeGroupDialog from '../components/CreateKnowledgeGroupDialog'
-import KnowledgeBaseNameDialog from '../components/KnowledgeBaseNameDialog'
-import RenameKnowledgeGroupDialog from '../components/RenameKnowledgeGroupDialog'
-import RestoreKnowledgeBaseDialog from '../components/RestoreKnowledgeBaseDialog'
+import { lazy, Suspense } from 'react'
+
 import { useKnowledgePage } from '../KnowledgePageProvider'
+
+// Management dialogs are loaded on first open instead of with the page.
+const AddKnowledgeItemDialog = lazy(() => import('../components/AddKnowledgeItemDialog'))
+const CreateKnowledgeBaseDialog = lazy(() => import('../components/CreateKnowledgeBaseDialog'))
+const CreateKnowledgeGroupDialog = lazy(() => import('../components/CreateKnowledgeGroupDialog'))
+const KnowledgeBaseNameDialog = lazy(() => import('../components/KnowledgeBaseNameDialog'))
+const RenameKnowledgeGroupDialog = lazy(() => import('../components/RenameKnowledgeGroupDialog'))
+const RestoreKnowledgeBaseDialog = lazy(() => import('../components/RestoreKnowledgeBaseDialog'))
 
 const KnowledgePageDialogSection = () => {
   const {
@@ -38,7 +42,7 @@ const KnowledgePageDialogSection = () => {
   } = useKnowledgePage()
 
   return (
-    <>
+    <Suspense fallback={null}>
       {isAddSourceDialogOpen ? (
         <AddKnowledgeItemDialog open={isAddSourceDialogOpen} onOpenChange={handleAddSourceDialogOpenChange} />
       ) : null}
@@ -95,7 +99,7 @@ const KnowledgePageDialogSection = () => {
           onCreated={handleCreateBaseCreated}
         />
       ) : null}
-    </>
+    </Suspense>
   )
 }
 


### PR DESCRIPTION
### What this PR does

Before this PR:

`KnowledgePageDialogSection` statically imported all six management dialogs (AddKnowledgeItemDialog, CreateKnowledgeBaseDialog, CreateKnowledgeGroupDialog, KnowledgeBaseNameDialog, RenameKnowledgeGroupDialog, RestoreKnowledgeBaseDialog — roughly a thousand lines incl. model selects) and `KnowledgePageDetailSection` statically imported the chunk/note item detail panels. Visiting the Knowledge page pulled all of it into the page graph even though none of it is rendered until a dialog opens or an item is selected.

After this PR:

Both groups use module-level `lazy(() => import(...))` with the conditional mounts that already existed (`{open ? <Dialog/> : null}`, `selectedItemId ? <panel/> : ...`), each wrapped in `<Suspense fallback={null}>` exactly like the already-lazy RagConfig/RecallTest drawers in the same file. A dialog module now loads the first time its open state activates; the chunk/note detail panels load the first time an item is opened in the matching view. Open state stays in `KnowledgePageProvider`; close callbacks and all existing loading fallbacks are untouched. The two rename dialogs share `KnowledgeEntityNameDialog`, which the bundler extracts into a shared chunk — no extra indirection module needed.

Fixes #19671

### Why we need it and why it was done in this way

The following tradeoffs were made:

- One shared `<Suspense>` wraps all six dialogs instead of one per branch. Dialogs are modal and never co-open, so a suspending sibling cannot unmount a rendered one in practice; per-branch wrappers would add churn for a theoretical case.
- The new contract tests sit at the top of the describe block: `vi.mock` factories run once per module per file, so only the first test to open each dialog/panel can observe the module load. A comment in the test file documents this ordering constraint.

The following alternatives were considered:

- A shared re-export module so the two rename dialogs share one explicit chunk — rejected: they are thin wrappers over `KnowledgeEntityNameDialog` already, and build-time shared-dependency extraction achieves the same with zero machinery.
- Lazy-loading `DataSourcePanel` as well — rejected: it is the default view once a base is selected, so laziness would only move the cost to base selection and add a blank frame; the issue only asks for the optional dialogs and item detail panels.

Links to places where the discussion took place: #19671

### Breaking changes

None. All dialog open/close/submit flows behave as before; existing tests for those flows pass with their post-click assertions converted to `findBy` (the dialog render is now asynchronous on first open).

### Special notes for your reviewer

- The four new lazy-contract tests (one negative covering all eight modules + three positive) use module-load recorders in the existing `vi.mock` factories, following the file's `mockRagConfigPanelModuleLoad` precedent, and use `userEvent` per the frontend testing guidelines.
- The `DataSourcePanel` test stub gained a `ViewNoteContent` button mirroring the real `onViewNoteContent` prop so the note-view path is drivable.
- Verified end-to-end in a tracked dev instance (CDP network capture): navigating to the Knowledge page requests none of the dialog/panel modules; opening the create dialog, the add-source dialog, and a created note each load exactly their module on demand (`CreateKnowledgeBaseDialog.tsx`, `AddKnowledgeItemDialog.tsx`, `KnowledgeItemNoteContentPanel.tsx`), with a real base + note created through the UI.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: user-guide update not required (no user-facing change; pure perf/deference)
- [x] Self-review: reviewed via two-axis code-review (standards + spec) against origin/main; the one medium finding (userEvent for new tests) and two substantive minor findings were fixed before push

### Release note

```release-note
Performance: Knowledge page management dialogs and item detail panels are now loaded on demand instead of with the page.
```
