### PR TITLE
fix(dsh): reject models without text input

### DIFF
--- a/src/main/ai/runtime/dsh/__tests__/compositionBuilder.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/compositionBuilder.test.ts
@@ -20,7 +20,7 @@ import {
   resolveDshPluginPath,
   toDshPluginUrl
 } from '../compositionBuilder'
-import { buildDshProviderInjection } from '../modelInjection'
+import { buildDshProviderInjection, DshUnsupportedModelInputError } from '../modelInjection'
 
 const SECRET_API_KEY = 'sk-cherry-super-secret-key'
 
@@ -273,9 +273,11 @@ describe('buildDshCompositionYaml', () => {
     const visionYml = buildDshCompositionYaml(makeInput({ modelConfig: vision.modelConfig }))
     expect(providerRoute(visionYml, 'deepseek').models[0].input).toEqual(['text', 'image'])
 
-    const audio = makeInjection({ inputModalities: [MODALITY.TEXT, MODALITY.AUDIO] })
-    const audioYml = buildDshCompositionYaml(makeInput({ modelConfig: audio.modelConfig }))
-    expect(providerRoute(audioYml, 'deepseek').models[0].input).toEqual(['text'])
+    for (const modality of [MODALITY.AUDIO, MODALITY.VIDEO]) {
+      const injection = makeInjection({ inputModalities: [MODALITY.TEXT, modality] })
+      const yml = buildDshCompositionYaml(makeInput({ modelConfig: injection.modelConfig }))
+      expect(providerRoute(yml, 'deepseek').models[0].input).toEqual(['text'])
+    }
   })
 
   it("honors Google as CherryIN's first declared route when the model supports multiple protocols", () => {
@@ -536,7 +538,7 @@ describe('buildDshCompositionYaml', () => {
     }
   })
 
-  it('does not reject models based on their declared input modalities', () => {
-    expect(makeInjection({ inputModalities: [MODALITY.AUDIO] }).modelConfig.input).toEqual(['text'])
+  it('rejects models that explicitly declare no text input', () => {
+    expect(() => makeInjection({ inputModalities: [MODALITY.VIDEO] })).toThrow(DshUnsupportedModelInputError)
   })
 })

--- a/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
+++ b/src/main/ai/runtime/dsh/__tests__/modelInjection.test.ts
@@ -1,3 +1,4 @@
+import { MODALITY } from '@cherrystudio/provider-registry'
 import { ENDPOINT_TYPE, type Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -39,6 +40,7 @@ import {
   assertDshProviderUsable,
   buildDshGatewayInjection,
   buildDshProviderInjection,
+  DshUnsupportedModelInputError,
   DshUnsupportedProviderError,
   resolveDshProviderInjectionFromSnapshot
 } from '../modelInjection'
@@ -143,6 +145,12 @@ describe('buildDshGatewayInjection', () => {
     const windowless = makeModel({ contextWindow: undefined })
     expect(buildDshGatewayInjection(vertexProvider, windowless, GATEWAY).modelConfig.contextWindow).toBe(256_000)
   })
+
+  it('rejects a gateway-routable model that explicitly cannot accept text', () => {
+    const videoOnly = makeModel({ inputModalities: [MODALITY.VIDEO] })
+
+    expect(() => buildDshGatewayInjection(vertexProvider, videoOnly, GATEWAY)).toThrow(DshUnsupportedModelInputError)
+  })
 })
 
 describe('buildDshProviderInjection', () => {
@@ -231,6 +239,29 @@ describe('resolveDshProviderInjectionFromSnapshot', () => {
       mocks.ApiGatewayNotRunningError
     )
   })
+
+  it('rejects non-text input before gateway materialization', async () => {
+    const videoOnly = makeModel({ inputModalities: [MODALITY.VIDEO] })
+
+    await expect(resolveDshProviderInjectionFromSnapshot('session-1', vertexProvider, videoOnly)).rejects.toThrow(
+      DshUnsupportedModelInputError
+    )
+    expect(mocks.resolveApiGatewayRuntime).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-text input before native credential selection', async () => {
+    const videoOnly = makeModel({
+      id: 'deepseek::active-speaker-detection',
+      providerId: 'deepseek',
+      apiModelId: 'active-speaker-detection',
+      inputModalities: [MODALITY.VIDEO]
+    })
+
+    await expect(resolveDshProviderInjectionFromSnapshot('session-1', nativeProvider, videoOnly)).rejects.toThrow(
+      DshUnsupportedModelInputError
+    )
+    expect(mocks.resolveApiKey).not.toHaveBeenCalled()
+  })
 })
 
 describe('assertDshProviderUsable', () => {
@@ -257,5 +288,30 @@ describe('assertDshProviderUsable', () => {
     mocks.getByKey.mockResolvedValue(makeModel({ endpointTypes: [ENDPOINT_TYPE.OPENAI_EMBEDDINGS] }))
 
     await expect(assertDshProviderUsable('vertexai::gemini-2.5-pro')).rejects.toThrow(DshUnsupportedProviderError)
+  })
+
+  it('rejects a gateway-routable video-only model before checking gateway consent', async () => {
+    mocks.getByProviderId.mockResolvedValue(vertexProvider)
+    mocks.getByKey.mockResolvedValue(makeModel({ inputModalities: [MODALITY.VIDEO] }))
+
+    await expect(assertDshProviderUsable('vertexai::gemini-2.5-pro')).rejects.toThrow(DshUnsupportedModelInputError)
+    expect(mocks.getCurrentConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a native video-only model before checking API keys', async () => {
+    mocks.getByProviderId.mockResolvedValue(nativeProvider)
+    mocks.getByKey.mockResolvedValue(
+      makeModel({
+        id: 'deepseek::active-speaker-detection',
+        providerId: 'deepseek',
+        apiModelId: 'active-speaker-detection',
+        inputModalities: [MODALITY.VIDEO]
+      })
+    )
+
+    await expect(assertDshProviderUsable('deepseek::active-speaker-detection')).rejects.toThrow(
+      DshUnsupportedModelInputError
+    )
+    expect(mocks.getApiKeys).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -186,6 +186,7 @@ export function resolveDshInjectionApi(provider: Provider, model: Model): DshApi
  * unit testable in isolation.
  *
  * @throws DshUnsupportedProviderError when the provider's endpoint has no dsh mapping.
+ * @throws DshUnsupportedModelInputError when the model explicitly declares no text input.
  */
 export function buildDshProviderInjection(
   provider: Provider,
@@ -266,6 +267,7 @@ export function buildDshProviderInjection(
  * agent message and apply the stable per-session prompt cache key.
  *
  * @throws DshUnsupportedProviderError when the model is not gateway-routable either.
+ * @throws DshUnsupportedModelInputError when the model explicitly declares no text input.
  */
 export function buildDshGatewayInjection(
   provider: Provider,

--- a/src/main/ai/runtime/dsh/modelInjection.ts
+++ b/src/main/ai/runtime/dsh/modelInjection.ts
@@ -15,7 +15,12 @@ import type { AiUsageCredentialReceipt } from '@data/services/AiUsageRecordServi
 import { modelService } from '@data/services/ModelService'
 import { providerService } from '@data/services/ProviderService'
 import { createAiUsagePricingSnapshot } from '@main/ai/utils/usageCapture'
-import { type DshApi, mapEndpointToDshApi, resolveDshEndpointType } from '@shared/ai/dshModelCompatibility'
+import {
+  type DshApi,
+  hasDshTextInput,
+  mapEndpointToDshApi,
+  resolveDshEndpointType
+} from '@shared/ai/dshModelCompatibility'
 import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import type { ReasoningEffortOption } from '@shared/types/aiSdk'
@@ -53,6 +58,17 @@ export class DshMissingApiKeyError extends Error {
     super(`Provider "${providerId}" has no API key configured for dsh agents`)
     this.name = 'DshMissingApiKeyError'
     this.providerId = providerId
+  }
+}
+
+/** Thrown when a model explicitly declares no text input, which DSH agents require. */
+export class DshUnsupportedModelInputError extends Error {
+  readonly modelId: string
+
+  constructor(modelId: string) {
+    super(`Model "${modelId}" is not supported by dsh agents: text input is required`)
+    this.name = 'DshUnsupportedModelInputError'
+    this.modelId = modelId
   }
 }
 
@@ -187,6 +203,7 @@ export function buildDshProviderInjection(
   if (!api) {
     throw new DshUnsupportedProviderError(provider.id)
   }
+  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
   if (!apiKey.trim()) throw new DshMissingApiKeyError(provider.id)
 
   const baseUrl = formatDshBaseUrl(resolvedEndpoint.baseUrl, api)
@@ -257,6 +274,8 @@ export function buildDshGatewayInjection(
   reasoningEffort: ReasoningEffortOption = 'default'
 ): DshProviderInjection {
   if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(provider.id)
+  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
+
   const modelId = formatGatewayModelId(provider.id, getRawModelId(model))
   const reasoning = resolveDshReasoningEffort(model, reasoningEffort)
   return {
@@ -305,10 +324,14 @@ export async function resolveDshProviderInjectionFromSnapshot(
   reasoningEffort: ReasoningEffortOption = 'default'
 ): Promise<DshProviderInjection> {
   if (resolveDshInjectionApi(provider, model) === undefined) {
+    if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(provider.id)
+    if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
     // Claude's gateway sequence: consent (ApiGatewayNotRunningError), converge, materialize key.
     const gateway = await resolveApiGatewayRuntime(sessionId)
     return buildDshGatewayInjection(provider, model, gateway, reasoningEffort)
   }
+  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
+
   const resolvedApiKey = providerService.resolveApiKey(provider.id)
   if (!resolvedApiKey.value.trim()) throw new DshMissingApiKeyError(provider.id)
   if (enabledApiKeys && !enabledApiKeys.some((entry) => entry.key === resolvedApiKey.value)) {
@@ -338,10 +361,13 @@ export async function assertDshProviderUsable(uniqueModelId: UniqueModelId): Pro
   // Unsupported beats missing-credential (parity with buildDshProviderInjection).
   if (resolveDshInjectionApi(provider, model) === undefined) {
     if (!isGatewayRoutableModel(model)) throw new DshUnsupportedProviderError(providerId)
+    if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
     // Consent only (persisted intent) — no ensureRunning/ensureValidApiKey side effects here.
     if (!application.get('ApiGatewayService').getCurrentConfig().enabled) throw new ApiGatewayNotRunningError()
     return
   }
+  if (!hasDshTextInput(model)) throw new DshUnsupportedModelInputError(model.id)
+
   const apiKeys = providerService.getApiKeys(providerId, { enabled: true })
   if (!apiKeys.some((entry) => entry.key.trim())) throw new DshMissingApiKeyError(providerId)
 }

--- a/src/shared/ai/__tests__/agentRuntimeCapabilities.test.ts
+++ b/src/shared/ai/__tests__/agentRuntimeCapabilities.test.ts
@@ -84,16 +84,18 @@ describe('AGENT_RUNTIME_CAPABILITIES', () => {
     })
   })
 
-  describe('dsh model compatibility', () => {
+  describe('dsh model input compatibility', () => {
     const isCompatible = AGENT_RUNTIME_CAPABILITIES.dsh.isModelCompatible
     const provider = makeProvider({})
 
-    it('does not filter models by their declared input modalities', () => {
+    it('accepts unknown and text-capable multimodal inputs', () => {
       expect(isCompatible(provider, makeModel({}))).toBe(true)
       expect(isCompatible(provider, makeModel({ inputModalities: [] }))).toBe(true)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.IMAGE] }))).toBe(true)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.AUDIO] }))).toBe(true)
-      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.VIDEO] }))).toBe(true)
+      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.TEXT, MODALITY.VIDEO] }))).toBe(true)
+    })
+
+    it('keeps video-only models out of the text agent picker', () => {
+      expect(isCompatible(provider, makeModel({ inputModalities: [MODALITY.VIDEO] }))).toBe(false)
     })
   })
 })

--- a/src/shared/ai/__tests__/dshModelCompatibility.test.ts
+++ b/src/shared/ai/__tests__/dshModelCompatibility.test.ts
@@ -1,3 +1,4 @@
+import { MODALITY } from '@cherrystudio/provider-registry'
 import type { Model } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
 import { describe, expect, it } from 'vitest'
@@ -27,6 +28,18 @@ const azureProvider = makeProvider({
   defaultChatEndpoint: 'openai-chat-completions',
   endpointConfigs: { 'openai-chat-completions': { adapterFamily: 'azure' } }
 })
+
+const inputModalityCases: Array<[string, Model['inputModalities'], boolean]> = [
+  ['accepts undeclared input modalities', undefined, true],
+  ['accepts empty input modalities', [], true],
+  ['accepts text input', [MODALITY.TEXT], true],
+  ['accepts text and image input', [MODALITY.TEXT, MODALITY.IMAGE], true],
+  ['accepts text and audio input', [MODALITY.TEXT, MODALITY.AUDIO], true],
+  ['accepts text and video input', [MODALITY.TEXT, MODALITY.VIDEO], true],
+  ['rejects video-only input', [MODALITY.VIDEO], false],
+  ['rejects image-only input', [MODALITY.IMAGE], false],
+  ['rejects audio-only input', [MODALITY.AUDIO], false]
+]
 
 describe('isDshCompatibleModel', () => {
   it('accepts native wire families directly', () => {
@@ -72,10 +85,11 @@ describe('isDshCompatibleModel', () => {
     ).toBe(false)
   })
 
-  it('does not use input modalities as a compatibility restriction', () => {
+  it('does not require a declared context window', () => {
     expect(isDshCompatibleModel(azureProvider, makeModel({ contextWindow: undefined }))).toBe(true)
-    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: [] }))).toBe(true)
-    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: ['image'] }))).toBe(true)
-    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities: ['audio'] }))).toBe(true)
+  })
+
+  it.each(inputModalityCases)('%s', (_name, inputModalities, expected) => {
+    expect(isDshCompatibleModel(azureProvider, makeModel({ inputModalities }))).toBe(expected)
   })
 })

--- a/src/shared/ai/dshModelCompatibility.ts
+++ b/src/shared/ai/dshModelCompatibility.ts
@@ -12,6 +12,7 @@
  * back to the local API Gateway when the model is gateway-routable.
  */
 
+import { MODALITY } from '@cherrystudio/provider-registry'
 import { resolveGatewayChatRoute } from '@shared/data/presets/gatewayChatRouting'
 import type { Model } from '@shared/data/types/model'
 import { ENDPOINT_TYPE, type EndpointType } from '@shared/data/types/model'
@@ -81,9 +82,15 @@ export function resolveDshApi(provider: Provider, model: Model): DshApi | undefi
   return mapEndpointToDshApi(endpointType, adapterFamily)
 }
 
+/** DSH agents require text input; missing or empty metadata retains the chat-model default. */
+export function hasDshTextInput(model: Model): boolean {
+  return !model.inputModalities?.length || model.inputModalities.includes(MODALITY.TEXT)
+}
+
 /** Whether a dsh agent can use this provider+model. Used for renderer filtering. */
 export function isDshCompatibleModel(provider: Provider, model: Model): boolean {
   // No native wire family → the local API Gateway can still front any gateway-routable
   // model as OpenAI-compatible (claude's picker rule); everything else stays fail-closed.
-  return resolveDshApi(provider, model) !== undefined || isGatewayRoutableModel(model)
+  if (resolveDshApi(provider, model) === undefined && !isGatewayRoutableModel(model)) return false
+  return hasDshTextInput(model)
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

DSH Agent selection admitted models whose declared input modalities were video-only, image-only, or audio-only. Runtime injection then forced `input: ['text']`, producing an unusable Agent configuration.

After this PR:

The shared picker filter and all DSH runtime injection paths use the same text-input compatibility rule. Models with explicit modality metadata must include text; explicitly non-text-only models are rejected before gateway or credential side effects. Text-capable multimodal models remain supported, and composition metadata declares only the inputs DSH can actually send.

Fixes: N/A (no linked issue).

### Why we need it and why it was done in this way

Selection-time and runtime compatibility must agree. A shared predicate prevents the picker, native runtime, gateway runtime, snapshots, and assertions from drifting into different interpretations of the same model metadata.

The following tradeoffs were made:

- Missing or empty modality metadata remains fail-open because several providers do not publish complete metadata.
- Text-plus-audio or text-plus-video models remain eligible because they can accept text, but DSH does not advertise fabricated audio or video input.
- Vision-capable text models continue to declare image input alongside text.

The following alternatives were considered:

- Inferring compatibility from model names was rejected because provider naming is not a stable contract.
- Requiring every model to declare modalities was rejected because it would hide otherwise usable models with incomplete metadata.
- Filtering only in the picker was rejected because persisted or injected configurations also require a runtime guard.

Links to places where the discussion took place: N/A.

### Breaking changes

None. Explicitly non-text-only models are intentionally removed from DSH Agent selection and rejected at runtime.

### Special notes for your reviewer

- Shared focused tests: 21 passed.
- Main-process focused tests: 47 passed.
- `pnpm lint`: passed with the repository's existing ESLint warnings.
- `pnpm test:lint`: passed.
- Coverage includes video-only, image-only, audio-only, text-plus-image, text-plus-audio, text-plus-video, and missing/empty modality metadata.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because the picker now prevents an invalid configuration.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Agents] Prevent models that cannot accept text from being selected for DSH agents.
```

