### PR TITLE
fix(auto-backup): persist successful sync state

### DIFF
--- a/src/main/services/AutoBackupService.ts
+++ b/src/main/services/AutoBackupService.ts
@@ -119,7 +119,7 @@ export class AutoBackupService extends BaseService {
       preferenceService.subscribeMultipleChanges(Object.values(WATCHED_PREFERENCES).flat(), (key) => {
         const type = AUTO_BACKUP_TYPES.find((candidate) => WATCHED_PREFERENCES[candidate].includes(key))
         if (type) {
-          this.restartSchedule(type, key === 'data.backup.local.dir' ? 'immediate' : 'fromLastSyncTime')
+          this.applyConfigurationChange(type, key)
         }
       })
     )
@@ -167,6 +167,20 @@ export class AutoBackupService extends BaseService {
     const timestamp = Date.now()
     this.recordLastAttemptTime(type, timestamp)
     this.recordLastSuccessTime(type, timestamp)
+    this.clearTerminalOutcome(type)
+    if (this.active) this.restartSchedule(type, 'fromLastSyncTime')
+  }
+
+  // Not folded into `restartSchedule`: startup reaches that too and must keep the
+  // outcome it just restored. Without this, a disabled backend keeps its failure icon.
+  private applyConfigurationChange(type: AutoBackupType, key: UnifiedPreferenceKeyType): void {
+    // Rescheduling alone does not refute what the last attempt found; only switching the
+    // backend off or repointing it does.
+    if (!key.endsWith('.sync_interval')) this.clearTerminalOutcome(type)
+    this.restartSchedule(type, key === 'data.backup.local.dir' ? 'immediate' : 'fromLastSyncTime')
+  }
+
+  private clearTerminalOutcome(type: AutoBackupType): void {
     this.latestTerminalEvents.delete(type)
     this.pendingNotifications.delete(type)
     const cacheService = application.get('CacheService')
@@ -174,7 +188,6 @@ export class AutoBackupService extends BaseService {
       ...cacheService.getPersist(LATEST_TERMINAL_OUTCOMES_KEY),
       [type]: null
     })
-    if (this.active) this.restartSchedule(type, 'fromLastSyncTime')
   }
 
   private recordLastAttemptTime(type: AutoBackupType, timestamp: number): void {

--- a/src/main/services/AutoBackupService.ts
+++ b/src/main/services/AutoBackupService.ts
@@ -5,13 +5,16 @@ import { loggerService } from '@logger'
 import { BaseService, DependsOn, Injectable, Phase, ServicePhase } from '@main/core/lifecycle'
 import { WindowType } from '@main/core/window/types'
 import { hasWritePermission, isPathInside, untildify } from '@main/utils/legacyFile'
+import type { CacheAutoBackupTerminalOutcome } from '@shared/data/cache/cacheValueTypes'
 import type { UnifiedPreferenceKeyType } from '@shared/data/preference/preferenceTypes'
 import {
   AUTO_BACKUP_TYPES,
   type AutoBackupEvent,
   type AutoBackupEventInput,
+  type AutoBackupLastSuccessTimes,
   type AutoBackupSnapshot,
   type AutoBackupType,
+  BACKUP_ACTIVE_WRITERS_ERROR_CODE,
   type S3Config,
   type WebDavConfig
 } from '@shared/types/backup'
@@ -24,6 +27,8 @@ const logger = loggerService.withContext('AutoBackupService')
 
 const SCHEDULE_ID_PREFIX = 'auto-backup:'
 const LAST_ATTEMPT_TIMES_KEY = 'backup.auto_sync.last_attempt_times'
+const LAST_SUCCESS_TIMES_KEY = 'backup.auto_sync.last_success_times'
+const LATEST_TERMINAL_OUTCOMES_KEY = 'backup.auto_sync.latest_terminal_outcomes'
 const MAX_ATTEMPTS = 4
 const INITIAL_DELAY_MS = 1_000
 const STARTUP_GRACE_PERIOD_MS = 60_000
@@ -56,6 +61,13 @@ const createScheduleState = (): ScheduleState => ({
   running: false
 })
 
+const createLastSuccessTimes = (): AutoBackupLastSuccessTimes => ({
+  webdav: null,
+  s3: null,
+  local: null,
+  nutstore: null
+})
+
 @Injectable('AutoBackupService')
 @ServicePhase(Phase.WhenReady)
 @DependsOn([
@@ -76,6 +88,7 @@ export class AutoBackupService extends BaseService {
   private readonly latestTransientEvents = new Map<AutoBackupType, AutoBackupEvent>()
   private readonly pendingNotifications = new Map<AutoBackupType, AutoBackupEvent>()
   private readonly pendingRuns = new Map<AutoBackupType, number>()
+  private lastSuccessTimes = createLastSuccessTimes()
   private readonly schedules: Record<AutoBackupType, ScheduleState> = {
     webdav: createScheduleState(),
     s3: createScheduleState(),
@@ -84,9 +97,21 @@ export class AutoBackupService extends BaseService {
   }
 
   protected override onInit(): void {
-    const lastAttemptTimes = application.get('CacheService').getPersist(LAST_ATTEMPT_TIMES_KEY)
+    const cacheService = application.get('CacheService')
+    const lastAttemptTimes = cacheService.getPersist(LAST_ATTEMPT_TIMES_KEY)
+    this.lastSuccessTimes = { ...cacheService.getPersist(LAST_SUCCESS_TIMES_KEY) }
+    this.nextEventId = 0
+    this.latestTerminalEvents.clear()
+    this.latestTransientEvents.clear()
+    this.pendingNotifications.clear()
+
+    const terminalOutcomes = cacheService.getPersist(LATEST_TERMINAL_OUTCOMES_KEY)
     for (const type of AUTO_BACKUP_TYPES) {
       this.schedules[type].lastSyncTime = lastAttemptTimes[type]
+      const outcome = terminalOutcomes[type]
+      if (outcome) {
+        this.latestTerminalEvents.set(type, this.createEvent(this.restoreTerminalOutcome(type, outcome)))
+      }
     }
 
     const preferenceService = application.get('PreferenceService')
@@ -124,6 +149,7 @@ export class AutoBackupService extends BaseService {
 
   getStateSnapshot(): AutoBackupSnapshot {
     return {
+      lastSuccessTimes: { ...this.lastSuccessTimes },
       events: [...this.latestTerminalEvents.values(), ...this.latestTransientEvents.values()].sort(
         (first, second) => first.id - second.id
       ),
@@ -138,7 +164,16 @@ export class AutoBackupService extends BaseService {
   }
 
   recordManualBackupCompletion(type: AutoBackupType): void {
-    this.recordLastAttemptTime(type, Date.now())
+    const timestamp = Date.now()
+    this.recordLastAttemptTime(type, timestamp)
+    this.recordLastSuccessTime(type, timestamp)
+    this.latestTerminalEvents.delete(type)
+    this.pendingNotifications.delete(type)
+    const cacheService = application.get('CacheService')
+    cacheService.setPersist(LATEST_TERMINAL_OUTCOMES_KEY, {
+      ...cacheService.getPersist(LATEST_TERMINAL_OUTCOMES_KEY),
+      [type]: null
+    })
     if (this.active) this.restartSchedule(type, 'fromLastSyncTime')
   }
 
@@ -149,6 +184,50 @@ export class AutoBackupService extends BaseService {
       ...cacheService.getPersist(LAST_ATTEMPT_TIMES_KEY),
       [type]: timestamp
     })
+  }
+
+  private recordLastSuccessTime(type: AutoBackupType, timestamp: number): void {
+    this.lastSuccessTimes = { ...this.lastSuccessTimes, [type]: timestamp }
+    application.get('CacheService').setPersist(LAST_SUCCESS_TIMES_KEY, this.lastSuccessTimes)
+  }
+
+  private recordTerminalOutcome(event: AutoBackupEvent): void {
+    if (event.status === 'running' || event.status === 'stopped') return
+
+    const outcome: CacheAutoBackupTerminalOutcome =
+      event.status === 'failed'
+        ? {
+            status: 'failed',
+            timestamp: event.timestamp,
+            failureKind: event.errorMessage.includes(BACKUP_ACTIVE_WRITERS_ERROR_CODE)
+              ? 'active_data_writers'
+              : 'unknown'
+          }
+        : event.status === 'warning'
+          ? { status: 'warning', timestamp: event.timestamp, reason: event.reason }
+          : { status: 'succeeded', timestamp: event.timestamp }
+
+    const cacheService = application.get('CacheService')
+    cacheService.setPersist(LATEST_TERMINAL_OUTCOMES_KEY, {
+      ...cacheService.getPersist(LATEST_TERMINAL_OUTCOMES_KEY),
+      [event.type]: outcome
+    })
+  }
+
+  private restoreTerminalOutcome(type: AutoBackupType, outcome: CacheAutoBackupTerminalOutcome): AutoBackupEventInput {
+    if (outcome.status === 'failed') {
+      return {
+        type,
+        status: 'failed',
+        timestamp: outcome.timestamp,
+        errorMessage: outcome.failureKind === 'active_data_writers' ? BACKUP_ACTIVE_WRITERS_ERROR_CODE : ''
+      }
+    }
+    return { type, ...outcome }
+  }
+
+  private createEvent(event: AutoBackupEventInput): AutoBackupEvent {
+    return { ...event, id: ++this.nextEventId } as AutoBackupEvent
   }
 
   private restartSchedule(type: AutoBackupType, mode: ScheduleMode): void {
@@ -245,6 +324,7 @@ export class AutoBackupService extends BaseService {
 
       const timestamp = Date.now()
       this.recordLastAttemptTime(type, timestamp)
+      this.recordLastSuccessTime(type, timestamp)
       state.retryCount = 0
       state.running = false
       if (cleanupError) {
@@ -423,17 +503,20 @@ export class AutoBackupService extends BaseService {
 
   private emit(event: AutoBackupEventInput): void {
     if (!this.active) return
-    const emittedEvent = { ...event, id: ++this.nextEventId } as AutoBackupEvent
+    const emittedEvent = this.createEvent(event)
     if (event.status === 'running' || event.status === 'stopped') {
       this.latestTransientEvents.set(event.type, emittedEvent)
     } else {
       this.latestTerminalEvents.set(event.type, emittedEvent)
       this.latestTransientEvents.delete(event.type)
+      this.recordTerminalOutcome(emittedEvent)
     }
     if (event.status === 'warning' || event.status === 'failed') {
       this.pendingNotifications.set(event.type, emittedEvent)
     }
-    application.get('IpcApiService').broadcastToType(WindowType.Main, 'backup.auto_sync_state_changed', emittedEvent)
+    const ipcApiService = application.get('IpcApiService')
+    ipcApiService.broadcastToType(WindowType.Main, 'backup.auto_sync_state_changed', emittedEvent)
+    ipcApiService.broadcastToType(WindowType.SubWindow, 'backup.auto_sync_state_changed', emittedEvent)
   }
 
   private unregisterAllSchedules(): void {

--- a/src/main/services/LegacyBackupManager.ts
+++ b/src/main/services/LegacyBackupManager.ts
@@ -31,6 +31,7 @@ import { IdleTimeoutController } from '@main/utils/IdleTimeoutController'
 import { isPathInside, resolveAndValidatePath } from '@main/utils/legacyFile'
 import { getDeviceType, getHostname } from '@main/utils/system'
 import { assertZipEntriesWithin } from '@main/utils/zipSafety'
+import { DEVICE_LOCAL_MAIN_PERSIST_KEYS } from '@shared/data/cache/cacheSchemas'
 import { IpcChannel } from '@shared/IpcChannel'
 import {
   BACKUP_ACTIVE_WRITERS_ERROR_CODE,
@@ -212,6 +213,16 @@ class BackupManager {
     }
   }
 
+  // Restore writes cache.json straight back to the live path, so device-local keys
+  // would make machine B replay machine A's sync times and backup failure banners.
+  private async writeArchiveCache(source: string, destination: string): Promise<void> {
+    const archived: Record<string, unknown> = { ...(await fs.readJson(source)) }
+    for (const key of DEVICE_LOCAL_MAIN_PERSIST_KEYS) {
+      delete archived[key]
+    }
+    await fs.writeJson(destination, archived, { spaces: 2 })
+  }
+
   /**
    * Direct backup method - copies Data (excluding transient SQLite sidecars
    * and the internal restore journal) plus cache.json, IndexedDB, and Local Storage.
@@ -353,7 +364,7 @@ class BackupManager {
           if (!(await fs.pathExists(cacheSource))) {
             throw new Error('Failed to persist cache.json for backup')
           }
-          await fs.copy(cacheSource, path.join(workDir, 'cache.json'))
+          await this.writeArchiveCache(cacheSource, path.join(workDir, 'cache.json'))
 
           if (!slimBackup) {
             await this.copyDirectoryOrCreate(

--- a/src/main/services/__tests__/AutoBackupService.test.ts
+++ b/src/main/services/__tests__/AutoBackupService.test.ts
@@ -2,6 +2,7 @@ import { tmpdir } from 'node:os'
 
 import { BaseService } from '@main/core/lifecycle/BaseService'
 import { SchedulerService } from '@main/core/scheduler/SchedulerService'
+import { WindowType } from '@main/core/window/types'
 import type * as LegacyFile from '@main/utils/legacyFile'
 import { BACKUP_ACTIVE_WRITERS_ERROR_CODE } from '@shared/types/backup'
 import { MockMainCacheServiceExport, MockMainCacheServiceUtils } from '@test-mocks/main/CacheService'
@@ -326,6 +327,21 @@ describe('AutoBackupService', () => {
       'backup.auto_sync_state_changed',
       expect.objectContaining({ type: 'local', status: 'succeeded' })
     )
+
+    const warning = service
+      .getStateSnapshot()
+      .events.find((event) => event.type === 'local' && event.status === 'warning')
+    expect(warning).toMatchObject({ type: 'local', status: 'warning', timestamp: expect.any(Number) })
+    if (!warning || warning.status !== 'warning') throw new Error('Missing local backup warning event')
+    expect(service.getStateSnapshot().lastSuccessTimes.local).toBe(warning.timestamp)
+
+    await recreateService()
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { local: warning.timestamp },
+      events: [expect.objectContaining({ type: 'local', status: 'warning', reason: 'cleanup_failed' })],
+      pendingNotifications: []
+    })
   })
 
   it('aborts an active automatic backup while stopping', async () => {
@@ -356,6 +372,10 @@ describe('AutoBackupService', () => {
 
     await vi.advanceTimersByTimeAsync(60_000)
     expect(mocks.backupToWebdav).toHaveBeenCalledOnce()
+    expect(service.getStateSnapshot().lastSuccessTimes.webdav).toBeNull()
+    expect(service.getStateSnapshot().events.some((event) => event.type === 'webdav' && 'timestamp' in event)).toBe(
+      false
+    )
 
     await vi.advanceTimersByTimeAsync(30_000)
     await recreateService()
@@ -387,6 +407,108 @@ describe('AutoBackupService', () => {
     expect(failure).toMatchObject({ type: 'webdav', status: 'failed' })
     service.acknowledgeNotification(failure.type, failure.id)
     expect(service.getStateSnapshot().pendingNotifications).toEqual([])
+  })
+
+  it('restores the last successful automatic backup and terminal outcome after restart', async () => {
+    setPreference('data.backup.s3.auto_sync', false)
+    setPreference('data.backup.local.auto_sync', false)
+    setPreference('data.backup.nutstore.auto_sync', false)
+    mocks.backupToWebdav.mockResolvedValue({ result: true, cleanupError: null })
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    const succeeded = service
+      .getStateSnapshot()
+      .events.find((event) => event.type === 'webdav' && event.status === 'succeeded')
+    expect(succeeded).toMatchObject({ type: 'webdav', status: 'succeeded', timestamp: expect.any(Number) })
+    if (!succeeded || succeeded.status !== 'succeeded') throw new Error('Missing successful WebDAV backup event')
+
+    await recreateService()
+
+    const snapshot = service.getStateSnapshot()
+    expect(snapshot.lastSuccessTimes.webdav).toBe(succeeded.timestamp)
+    expect(snapshot.events).toContainEqual(
+      expect.objectContaining({ type: 'webdav', status: 'succeeded', timestamp: succeeded.timestamp })
+    )
+    expect(snapshot.pendingNotifications).toEqual([])
+  })
+
+  it('keeps a manual success when a later automatic backup fails', async () => {
+    setPreference('data.backup.s3.auto_sync', false)
+    setPreference('data.backup.local.auto_sync', false)
+    setPreference('data.backup.nutstore.auto_sync', false)
+    service.recordManualBackupCompletion('webdav')
+    const lastSuccessTime = service.getStateSnapshot().lastSuccessTimes.webdav
+    expect(lastSuccessTime).toEqual(expect.any(Number))
+
+    mocks.backupToWebdav.mockRejectedValue(
+      new Error(`${BACKUP_ACTIVE_WRITERS_ERROR_CODE}: A conversation is still running.`)
+    )
+    await vi.advanceTimersByTimeAsync(60_000 + 7_000 + 17_000 + 37_000)
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { webdav: lastSuccessTime },
+      events: [
+        expect.objectContaining({
+          type: 'webdav',
+          status: 'failed',
+          timestamp: expect.any(Number),
+          errorMessage: expect.stringContaining(BACKUP_ACTIVE_WRITERS_ERROR_CODE)
+        })
+      ]
+    })
+
+    await recreateService()
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { webdav: lastSuccessTime },
+      events: [
+        expect.objectContaining({
+          type: 'webdav',
+          status: 'failed',
+          errorMessage: expect.stringContaining(BACKUP_ACTIVE_WRITERS_ERROR_CODE)
+        })
+      ],
+      pendingNotifications: []
+    })
+  })
+
+  it.each([
+    {
+      name: 'failure',
+      event: { type: 'webdav', status: 'failed', timestamp: 100, errorMessage: 'upload failed' } as const
+    },
+    {
+      name: 'warning',
+      event: { type: 'webdav', status: 'warning', timestamp: 100, reason: 'cleanup_failed' } as const
+    }
+  ])('does not restore an older automatic $name after a manual success', async ({ event }) => {
+    ;(service as any).emit(event)
+    expect(service.getStateSnapshot().events).toContainEqual(expect.objectContaining(event))
+
+    service.recordManualBackupCompletion('webdav')
+    const lastSuccessTime = service.getStateSnapshot().lastSuccessTimes.webdav
+    expect(lastSuccessTime).toEqual(expect.any(Number))
+    expect(service.getStateSnapshot().events).not.toContainEqual(expect.objectContaining({ type: 'webdav' }))
+    expect(service.getStateSnapshot().pendingNotifications).toEqual([])
+
+    await recreateService()
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { webdav: lastSuccessTime },
+      events: [],
+      pendingNotifications: []
+    })
+  })
+
+  it('delivers automatic backup events to main and detached settings windows', () => {
+    mocks.broadcastToType.mockClear()
+
+    ;(service as any).emit({ type: 's3', status: 'succeeded', timestamp: 123 })
+
+    const event = service.getStateSnapshot().events.find((candidate) => candidate.type === 's3')
+    expect(mocks.broadcastToType).toHaveBeenCalledWith(WindowType.Main, 'backup.auto_sync_state_changed', event)
+    expect(mocks.broadcastToType).toHaveBeenCalledWith(WindowType.SubWindow, 'backup.auto_sync_state_changed', event)
   })
 
   it('keeps the last result in snapshots while the next backup is running', () => {

--- a/src/main/services/__tests__/AutoBackupService.test.ts
+++ b/src/main/services/__tests__/AutoBackupService.test.ts
@@ -501,6 +501,39 @@ describe('AutoBackupService', () => {
     })
   })
 
+  it('drops a persisted failure when the backend configuration changes', async () => {
+    service.recordManualBackupCompletion('s3')
+    const lastSuccessTime = service.getStateSnapshot().lastSuccessTimes.s3
+    expect(lastSuccessTime).toEqual(expect.any(Number))
+    ;(service as any).emit({ type: 's3', status: 'failed', timestamp: Date.now(), errorMessage: 'upload failed' })
+    expect(service.getStateSnapshot().pendingNotifications).toHaveLength(1)
+
+    setPreference('data.backup.s3.auto_sync', false)
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { s3: lastSuccessTime },
+      events: [],
+      pendingNotifications: []
+    })
+
+    await recreateService()
+
+    expect(service.getStateSnapshot()).toMatchObject({
+      lastSuccessTimes: { s3: lastSuccessTime },
+      events: [],
+      pendingNotifications: []
+    })
+  })
+
+  it('keeps a persisted failure when only the schedule interval changes', async () => {
+    ;(service as any).emit({ type: 's3', status: 'failed', timestamp: Date.now(), errorMessage: 'upload failed' })
+
+    setPreference('data.backup.s3.sync_interval', 120)
+    await recreateService()
+
+    expect(service.getStateSnapshot().events).toMatchObject([{ type: 's3', status: 'failed' }])
+  })
+
   it('delivers automatic backup events to main and detached settings windows', () => {
     mocks.broadcastToType.mockClear()
 

--- a/src/main/services/__tests__/LegacyBackupManager.test.ts
+++ b/src/main/services/__tests__/LegacyBackupManager.test.ts
@@ -494,10 +494,9 @@ describe('BackupManager direct v2 data compatibility', () => {
     expect(mockDbService.checkpointTruncate).toHaveBeenCalledTimes(2)
     expect(mockDbService.createSnapshot).not.toHaveBeenCalled()
     expect(mockCacheService.flushPersistForBackup).toHaveBeenCalledOnce()
-    expect(fs.copy).toHaveBeenCalledWith(
-      '/mock/userData/cache.json',
-      '/mock/temp/backup/create-operation-id/cache.json'
-    )
+    expect(fs.writeJson).toHaveBeenCalledWith('/mock/temp/backup/create-operation-id/cache.json', expect.any(Object), {
+      spaces: 2
+    })
     expect(copyDirectories).toHaveBeenCalledTimes(2)
     expect(fs.writeJson).toHaveBeenCalledWith(
       '/mock/temp/backup/create-operation-id/metadata.json',
@@ -524,6 +523,39 @@ describe('BackupManager direct v2 data compatibility', () => {
     expect(mockAiStreamHold.dispose).toHaveBeenCalledOnce()
     expect(mockAgentSessionHold.dispose).toHaveBeenCalledOnce()
     expect(mockJobHold.dispose).toHaveBeenCalledOnce()
+  })
+
+  it('keeps device-local backup state out of the archived cache.json', async () => {
+    const windowBounds = { main: { x: 0, y: 0, width: 800, height: 600, isMaximized: false } }
+    vi.mocked(fs.pathExists).mockImplementation(async (entryPath) => {
+      return ['/mock/userData/cache.json', '/mock/userData/Data'].includes(String(entryPath))
+    })
+    vi.mocked(fs.readJson).mockResolvedValue({
+      'backup.auto_sync.last_attempt_times': { webdav: 1000, s3: null, local: null, nutstore: null },
+      'backup.auto_sync.last_success_times': { webdav: 2000, s3: null, local: null, nutstore: null },
+      'backup.auto_sync.latest_terminal_outcomes': {
+        webdav: { status: 'failed', timestamp: 3000, failureKind: 'unknown' },
+        s3: null,
+        local: null,
+        nutstore: null
+      },
+      'internal.persist_probe': 7,
+      'window.bounds': windowBounds
+    } as never)
+    vi.spyOn(backupManager as any, 'copyDirectoryOrCreate').mockResolvedValue(undefined)
+    vi.spyOn(backupManager as any, 'getDirSize').mockResolvedValue(42)
+    vi.spyOn(backupManager as any, 'copyDirWithProgress').mockResolvedValue(undefined)
+    mockArchiveClose()
+
+    await backupManager.backup({} as Electron.IpcMainInvokeEvent, 'backup.zip', '/backups')
+
+    expect(fs.readJson).toHaveBeenCalledWith('/mock/userData/cache.json')
+    const archivedCache = vi
+      .mocked(fs.writeJson)
+      .mock.calls.find(([target]) => target === '/mock/temp/backup/create-operation-id/cache.json')?.[1]
+    expect(archivedCache).toEqual({ 'internal.persist_probe': 7, 'window.bounds': windowBounds })
+    expect(fs.writeJson).not.toHaveBeenCalledWith('/mock/userData/cache.json', expect.anything(), expect.anything())
+    expect(fs.copy).not.toHaveBeenCalledWith('/mock/userData/cache.json', expect.anything())
   })
 
   it('rejects remote backup file names containing path separators', async () => {

--- a/src/renderer/hooks/__tests__/useAutoBackupEvents.test.tsx
+++ b/src/renderer/hooks/__tests__/useAutoBackupEvents.test.tsx
@@ -1,0 +1,152 @@
+import type { BackupEventSchemas } from '@shared/ipc/schemas/backup'
+import type { AutoBackupSnapshot, AutoBackupType } from '@shared/types/backup'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (payload: unknown) => void>(),
+  loggerError: vi.fn(),
+  notificationSend: vi.fn(),
+  request: vi.fn(),
+  states: {
+    webdav: { lastSyncTime: null, syncing: false, lastSyncError: null },
+    s3: { lastSyncTime: null, syncing: false, lastSyncError: null },
+    local: { lastSyncTime: null, syncing: false, lastSyncError: null },
+    nutstore: { lastSyncTime: null, syncing: false, lastSyncError: null }
+  } as Record<AutoBackupType, { lastSyncTime: number | null; syncing: boolean; lastSyncError: string | null }>,
+  toastError: vi.fn(),
+  toastWarning: vi.fn()
+}))
+
+vi.mock('@logger', () => ({
+  loggerService: { withContext: () => ({ error: mocks.loggerError }) }
+}))
+
+vi.mock('@renderer/ipc', () => ({
+  ipcApi: { request: mocks.request },
+  useIpcOn: (event: string, handler: (payload: unknown) => void) => {
+    mocks.handlers.set(event, handler)
+  }
+}))
+
+vi.mock('@renderer/services/BackupService', () => ({
+  getBackupSyncState: () => mocks.states,
+  setBackupSyncState: (
+    type: AutoBackupType,
+    patch: Partial<{ lastSyncTime: number | null; syncing: boolean; lastSyncError: string | null }>
+  ) => {
+    mocks.states[type] = { ...mocks.states[type], ...patch }
+  }
+}))
+
+vi.mock('@renderer/services/notification', () => ({
+  notificationService: { send: mocks.notificationSend }
+}))
+
+vi.mock('@renderer/services/toast', () => ({
+  toast: { error: mocks.toastError, warning: mocks.toastWarning }
+}))
+
+vi.mock('@renderer/utils/backup', () => ({
+  getLocalizedBackupErrorMessage: (error: Error) => `localized:${error.message}`
+}))
+
+vi.mock('@renderer/utils/uuid', () => ({ uuid: () => 'notification-id' }))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}))
+
+import { useAutoBackupEvents } from '../useAutoBackupEvents'
+
+const emptySuccessTimes = { webdav: null, s3: null, local: null, nutstore: null }
+
+function emit<E extends keyof BackupEventSchemas>(event: E, payload: BackupEventSchemas[E]) {
+  const handler = mocks.handlers.get(event)
+  if (!handler) throw new Error(`Missing handler for ${event}`)
+  act(() => handler(payload))
+}
+
+describe('useAutoBackupEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.handlers.clear()
+    for (const type of ['webdav', 's3', 'local', 'nutstore'] as const) {
+      mocks.states[type] = { lastSyncTime: null, syncing: false, lastSyncError: null }
+    }
+  })
+
+  it('hydrates the last success without turning a later failure into a success', async () => {
+    const snapshot: AutoBackupSnapshot = {
+      lastSuccessTimes: { ...emptySuccessTimes, webdav: 100 },
+      events: [{ id: 100, type: 'webdav', status: 'failed', timestamp: 200, errorMessage: 'upload failed' }],
+      pendingNotifications: []
+    }
+    mocks.request.mockResolvedValue(snapshot)
+
+    renderHook(() => useAutoBackupEvents({ notificationsEnabled: true }))
+    await waitFor(() => expect(mocks.states.webdav.lastSyncError).toBe('localized:upload failed'))
+
+    expect(mocks.states.webdav).toEqual({
+      lastSyncTime: 100,
+      syncing: false,
+      lastSyncError: 'localized:upload failed'
+    })
+  })
+
+  it('updates detached-window state without duplicating notifications or acknowledgements', async () => {
+    const snapshot: AutoBackupSnapshot = {
+      lastSuccessTimes: emptySuccessTimes,
+      events: [],
+      pendingNotifications: []
+    }
+    mocks.request.mockResolvedValue(snapshot)
+
+    renderHook(() => useAutoBackupEvents({ notificationsEnabled: false }))
+    await waitFor(() => expect(mocks.request).toHaveBeenCalledWith('backup.get_auto_sync_state'))
+
+    emit('backup.auto_sync_state_changed', { id: 200, type: 's3', status: 'succeeded', timestamp: 300 })
+    emit('backup.auto_sync_state_changed', {
+      id: 201,
+      type: 'local',
+      status: 'warning',
+      timestamp: 301,
+      reason: 'cleanup_failed'
+    })
+
+    expect(mocks.states.s3.lastSyncTime).toBe(300)
+    expect(mocks.states.local).toEqual({
+      lastSyncTime: 301,
+      syncing: false,
+      lastSyncError: 'message.backup.cleanup_failed'
+    })
+    expect(mocks.notificationSend).not.toHaveBeenCalled()
+    expect(mocks.toastWarning).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalled()
+    expect(mocks.request).not.toHaveBeenCalledWith('backup.acknowledge_auto_sync_notification', expect.anything())
+  })
+
+  it('leaves warning notification ownership with the main window', async () => {
+    const warning = {
+      id: 300,
+      type: 'nutstore',
+      status: 'warning',
+      timestamp: 400,
+      reason: 'cleanup_failed'
+    } as const
+    const snapshot: AutoBackupSnapshot = {
+      lastSuccessTimes: { ...emptySuccessTimes, nutstore: 400 },
+      events: [warning],
+      pendingNotifications: [warning]
+    }
+    mocks.request.mockResolvedValue(snapshot)
+
+    renderHook(() => useAutoBackupEvents({ notificationsEnabled: true }))
+    await waitFor(() => expect(mocks.toastWarning).toHaveBeenCalledOnce())
+
+    expect(mocks.request).toHaveBeenCalledWith('backup.acknowledge_auto_sync_notification', {
+      type: 'nutstore',
+      id: 300
+    })
+  })
+})

--- a/src/renderer/hooks/useAutoBackupEvents.ts
+++ b/src/renderer/hooks/useAutoBackupEvents.ts
@@ -1,11 +1,11 @@
 import { loggerService } from '@logger'
 import { ipcApi, useIpcOn } from '@renderer/ipc'
-import { setBackupSyncState } from '@renderer/services/BackupService'
+import { getBackupSyncState, setBackupSyncState } from '@renderer/services/BackupService'
 import { notificationService } from '@renderer/services/notification'
 import { toast } from '@renderer/services/toast'
 import { getLocalizedBackupErrorMessage } from '@renderer/utils/backup'
 import { uuid } from '@renderer/utils/uuid'
-import type { AutoBackupEvent, AutoBackupType } from '@shared/types/backup'
+import { AUTO_BACKUP_TYPES, type AutoBackupEvent, type AutoBackupType } from '@shared/types/backup'
 import { useEffect, useEffectEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -13,7 +13,11 @@ const logger = loggerService.withContext('useAutoBackupEvents')
 const latestEventIds = new Map<AutoBackupType, number>()
 const notifiedEventIds = new Map<AutoBackupType, number>()
 
-export function useAutoBackupEvents(): void {
+type AutoBackupEventOptions = {
+  notificationsEnabled: boolean
+}
+
+export function useAutoBackupEvents({ notificationsEnabled }: AutoBackupEventOptions): void {
   const { t } = useTranslation()
 
   const handleEvent = useEffectEvent((event: AutoBackupEvent, notify: boolean) => {
@@ -33,7 +37,6 @@ export function useAutoBackupEvents(): void {
       } else if (event.status === 'failed') {
         setBackupSyncState(event.type, {
           syncing: false,
-          lastSyncTime: event.timestamp,
           lastSyncError: getLocalizedBackupErrorMessage(new Error(event.errorMessage))
         })
       } else {
@@ -66,14 +69,21 @@ export function useAutoBackupEvents(): void {
     }
   })
 
-  useIpcOn('backup.auto_sync_state_changed', (event) => handleEvent(event, true))
+  useIpcOn('backup.auto_sync_state_changed', (event) => handleEvent(event, notificationsEnabled))
 
   useEffect(() => {
     void ipcApi
       .request('backup.get_auto_sync_state')
-      .then(({ events, pendingNotifications }) => {
+      .then(({ lastSuccessTimes, events, pendingNotifications }) => {
+        for (const type of AUTO_BACKUP_TYPES) {
+          const timestamp = lastSuccessTimes[type]
+          const currentTimestamp = getBackupSyncState()[type].lastSyncTime
+          if (timestamp !== null && (currentTimestamp === null || timestamp > currentTimestamp)) {
+            setBackupSyncState(type, { lastSyncTime: timestamp })
+          }
+        }
         events.forEach((event) => handleEvent(event, false))
-        pendingNotifications.forEach((event) => handleEvent(event, true))
+        pendingNotifications.forEach((event) => handleEvent(event, notificationsEnabled))
       })
       .catch((error) => logger.error('Failed to load automatic backup state', error as Error))
     // `handleEvent` is an Effect Event and must not be a dependency.

--- a/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/LocalBackupSettings.tsx
@@ -17,7 +17,7 @@ import { useTheme } from '@renderer/hooks/useTheme'
 import { ipcApi } from '@renderer/ipc'
 import { toast } from '@renderer/services/toast'
 import type { AppInfo } from '@renderer/types/app'
-import dayjs from 'dayjs'
+import { formatBackupSyncTime } from '@renderer/utils/backup'
 import { FolderOpen, RefreshCw, Save, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -167,7 +167,7 @@ const LocalBackupSettings: React.FC = () => {
         )}
         {localBackupSync.lastSyncTime && (
           <span style={{ color: SYNC_STATUS_COLOR }}>
-            {t('settings.data.local.lastSync')}: {dayjs(localBackupSync.lastSyncTime).format('HH:mm:ss')}
+            {t('settings.data.local.lastSync')}: {formatBackupSyncTime(localBackupSync.lastSyncTime)}
           </span>
         )}
       </RowFlex>

--- a/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/NutstoreSettings.tsx
@@ -23,8 +23,8 @@ import {
 } from '@renderer/services/NutstoreService'
 import { popup } from '@renderer/services/popup'
 import { toast } from '@renderer/services/toast'
+import { formatBackupSyncTime } from '@renderer/utils/backup'
 import { NUTSTORE_HOST } from '@shared/utils/nutstore'
-import dayjs from 'dayjs'
 import { Check, ExternalLink, FolderOpen, Loader2, RefreshCw } from 'lucide-react'
 import type { FC } from 'react'
 import { useCallback, useEffect, useState } from 'react'
@@ -188,7 +188,7 @@ const NutstoreSettings: FC = () => {
         )}
         {nutstoreSyncState.lastSyncTime && (
           <span style={{ color: SYNC_STATUS_COLOR }}>
-            {t('settings.data.webdav.lastSync')}: {dayjs(nutstoreSyncState.lastSyncTime).format('HH:mm:ss')}
+            {t('settings.data.webdav.lastSync')}: {formatBackupSyncTime(nutstoreSyncState.lastSyncTime)}
           </span>
         )}
       </RowFlex>

--- a/src/renderer/pages/settings/DataSettings/S3Settings.tsx
+++ b/src/renderer/pages/settings/DataSettings/S3Settings.tsx
@@ -15,7 +15,7 @@ import {
 import { useBackupSyncState } from '@renderer/hooks/useBackupSyncState'
 import { useMiniAppPopup } from '@renderer/hooks/useMiniAppPopup'
 import { useTheme } from '@renderer/hooks/useTheme'
-import dayjs from 'dayjs'
+import { formatBackupSyncTime } from '@renderer/utils/backup'
 import { FolderOpen, RefreshCw, Save } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
@@ -84,7 +84,7 @@ const S3Settings: FC = () => {
         )}
         {s3Sync?.lastSyncTime && (
           <span style={{ color: SYNC_STATUS_COLOR }}>
-            {t('settings.data.s3.syncStatus.lastSync', { time: dayjs(s3Sync.lastSyncTime).format('HH:mm:ss') })}
+            {t('settings.data.s3.syncStatus.lastSync', { time: formatBackupSyncTime(s3Sync.lastSyncTime) })}
           </span>
         )}
       </RowFlex>

--- a/src/renderer/pages/settings/DataSettings/WebDavSettings.tsx
+++ b/src/renderer/pages/settings/DataSettings/WebDavSettings.tsx
@@ -13,7 +13,7 @@ import { WebdavBackupManager } from '@renderer/components/WebdavBackupManager'
 import { useWebdavBackupModal, WebdavBackupModal } from '@renderer/components/WebdavModals'
 import { useBackupSyncState } from '@renderer/hooks/useBackupSyncState'
 import { useTheme } from '@renderer/hooks/useTheme'
-import dayjs from 'dayjs'
+import { formatBackupSyncTime } from '@renderer/utils/backup'
 import { FolderOpen, RefreshCw, Save } from 'lucide-react'
 import type { FC } from 'react'
 import { useState } from 'react'
@@ -75,7 +75,7 @@ const WebDavSettings: FC = () => {
         )}
         {webdavSync.lastSyncTime && (
           <span style={{ color: SYNC_STATUS_COLOR }}>
-            {t('settings.data.webdav.lastSync')}: {dayjs(webdavSync.lastSyncTime).format('HH:mm:ss')}
+            {t('settings.data.webdav.lastSync')}: {formatBackupSyncTime(webdavSync.lastSyncTime)}
           </span>
         )}
       </RowFlex>

--- a/src/renderer/utils/__tests__/backup.test.ts
+++ b/src/renderer/utils/__tests__/backup.test.ts
@@ -1,7 +1,7 @@
 import { BACKUP_ACTIVE_WRITERS_ERROR_CODE } from '@shared/types/backup'
 import { describe, expect, it, vi } from 'vitest'
 
-import { getLocalizedBackupErrorMessage } from '../backup'
+import { formatBackupSyncTime, getLocalizedBackupErrorMessage } from '../backup'
 
 const mocks = vi.hoisted(() => ({
   t: vi.fn((key: string) => `localized:${key}`)
@@ -26,5 +26,17 @@ describe('getLocalizedBackupErrorMessage', () => {
     expect(getLocalizedBackupErrorMessage(new Error('Disk is full'), 'message.restore.failed')).toBe(
       'localized:message.restore.failed'
     )
+  })
+})
+
+describe('formatBackupSyncTime', () => {
+  const at = (value: string) => new Date(value).getTime()
+
+  it('keeps a same-day sync to the clock time', () => {
+    expect(formatBackupSyncTime(at('2026-08-30T10:51:03'), at('2026-08-30T21:00:00'))).toBe('10:51:03')
+  })
+
+  it('dates a sync from an earlier day even when it is minutes old', () => {
+    expect(formatBackupSyncTime(at('2026-08-29T23:51:03'), at('2026-08-30T00:05:00'))).toBe('2026-08-29 23:51:03')
   })
 })

--- a/src/renderer/utils/backup.ts
+++ b/src/renderer/utils/backup.ts
@@ -1,5 +1,6 @@
 import i18n from '@renderer/i18n/resolver'
 import { BACKUP_ACTIVE_WRITERS_ERROR_CODE } from '@shared/types/backup'
+import dayjs from 'dayjs'
 
 type BackupErrorFallbackKey =
   | 'error.backup.file_format'
@@ -18,4 +19,15 @@ export function getLocalizedBackupErrorMessage(
       : fallbackKey
 
   return i18n.t(messageKey)
+}
+
+/**
+ * Format a last-sync timestamp for the backup settings panels.
+ *
+ * The timestamp survives restarts, so a bare clock time would read as "today"
+ * for a sync that happened days ago. Only same-day values drop the date.
+ */
+export function formatBackupSyncTime(timestamp: number, now: number = Date.now()): string {
+  const time = dayjs(timestamp)
+  return time.isSame(now, 'day') ? time.format('HH:mm:ss') : time.format('YYYY-MM-DD HH:mm:ss')
 }

--- a/src/renderer/windows/main/MainApp.tsx
+++ b/src/renderer/windows/main/MainApp.tsx
@@ -12,13 +12,13 @@ import { ThemeProvider } from '@renderer/components/ThemeProvider'
 import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
 import { useMainWindowNavigation } from '@renderer/hooks/tab'
+import { useAutoBackupEvents } from '@renderer/hooks/useAutoBackupEvents'
 import { useStorageMonitorNotification } from '@renderer/hooks/useStorageMonitorNotification'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
 import { registerImageModeChooser } from '@renderer/services/imageExportModeChooser'
 import { lazy, Suspense, useEffect } from 'react'
 
 import { useAppUpdateHandler } from './hooks/useAppUpdateHandler'
-import { useAutoBackupEvents } from './hooks/useAutoBackupEvents'
 import { useTopicNamingErrorNotification } from './hooks/useTopicNamingErrorNotification'
 import { PrivacyPolicyUpdateGate } from './privacy/PrivacyPolicyUpdateGate'
 
@@ -39,7 +39,7 @@ function BootFallback(): React.ReactElement {
 // TabRouter/<Activity>, so these window-scoped subscriptions and DOM sync are never
 // torn down when a background tab hides.
 //
-// useAppUpdateHandler / useAutoBackupEvents / useStorageMonitorNotification / useTopicNamingErrorNotification are
+// useAppUpdateHandler / useStorageMonitorNotification / useTopicNamingErrorNotification are
 // intentionally main-only (update events only reach the main window; the storage warning and
 // topic-naming-failed toast must not duplicate across windows) and intentionally React hooks:
 // they depend on React-visible
@@ -73,7 +73,7 @@ function MainWindowRuntime(): null {
   }, [])
 
   useAppUpdateHandler()
-  useAutoBackupEvents()
+  useAutoBackupEvents({ notificationsEnabled: true })
   useStorageMonitorNotification()
   useTopicNamingErrorNotification()
 

--- a/src/renderer/windows/main/__tests__/MainApp.test.tsx
+++ b/src/renderer/windows/main/__tests__/MainApp.test.tsx
@@ -25,12 +25,12 @@ vi.mock('@renderer/components/layout/AppShell', () => ({
 }))
 
 vi.mock('@renderer/hooks/useWindowRuntime', () => ({ useWindowRuntime: () => {} }))
+vi.mock('@renderer/hooks/useAutoBackupEvents', () => ({ useAutoBackupEvents: () => {} }))
 vi.mock('@renderer/hooks/tab', () => ({ useMainWindowNavigation: () => {} }))
 vi.mock('@renderer/hooks/useStorageMonitorNotification', () => ({ useStorageMonitorNotification: () => {} }))
 vi.mock('@renderer/components/ConversationNotificationRuntime', () => ({
   ConversationNotificationRuntime: () => null
 }))
-vi.mock('../hooks/useAutoBackupEvents', () => ({ useAutoBackupEvents: () => {} }))
 vi.mock('../hooks/useTopicNamingErrorNotification', () => ({ useTopicNamingErrorNotification: () => {} }))
 vi.mock('../hooks/useAppUpdateHandler', () => ({ useAppUpdateHandler: () => {} }))
 vi.mock('@renderer/components/PopupHost', () => ({ PopupHost: () => null }))

--- a/src/renderer/windows/subWindow/SubWindowApp.tsx
+++ b/src/renderer/windows/subWindow/SubWindowApp.tsx
@@ -7,6 +7,7 @@ import { PopupHost } from '@renderer/components/PopupHost'
 import { ThemeProvider } from '@renderer/components/ThemeProvider'
 import ToastHost from '@renderer/components/ToastHost'
 import { WindowFatalFallback } from '@renderer/components/WindowFatalFallback'
+import { useAutoBackupEvents } from '@renderer/hooks/useAutoBackupEvents'
 import { useWindowRuntime } from '@renderer/hooks/useWindowRuntime'
 import { registerImageModeChooser } from '@renderer/services/imageExportModeChooser'
 import { SubWindowAppShell } from '@renderer/windows/subWindow/SubWindowAppShell'
@@ -18,6 +19,7 @@ import { useEffect } from 'react'
 // none of the main-only concerns (boot spinner/timer, update/storage notification).
 function SubWindowRuntime(): null {
   useWindowRuntime()
+  useAutoBackupEvents({ notificationsEnabled: false })
 
   // Same route tree as main, so topic/message exports run here too — register the
   // image-mode popup behind the services seam like MainApp does.

--- a/src/renderer/windows/subWindow/__tests__/SubWindowApp.test.tsx
+++ b/src/renderer/windows/subWindow/__tests__/SubWindowApp.test.tsx
@@ -1,20 +1,43 @@
 import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import SubWindowApp from '../SubWindowApp'
+
+const mocks = vi.hoisted(() => ({
+  themeProviderThrows: true,
+  useAutoBackupEvents: vi.fn()
+}))
 
 // Cut the heavy shell import graph (SubWindowAppShell → TabRouter → routeTree.gen);
 // the wiring under test is the boundary around the providers.
 vi.mock('../SubWindowAppShell', () => ({ SubWindowAppShell: () => null }))
 
 vi.mock('@renderer/components/ThemeProvider', () => ({
-  ThemeProvider: () => {
-    throw new Error('theme provider boom')
+  ThemeProvider: ({ children }: { children: ReactNode }) => {
+    if (mocks.themeProviderThrows) throw new Error('theme provider boom')
+    return children
   }
 }))
 
+vi.mock('@renderer/components/CodeStyleProvider', () => ({
+  CodeStyleProvider: ({ children }: { children: ReactNode }) => children
+}))
+vi.mock('@renderer/components/layout/TabsProvider', () => ({
+  TabsProvider: ({ children }: { children: ReactNode }) => children
+}))
+vi.mock('@renderer/components/ConversationNotificationRuntime', () => ({
+  ConversationNotificationRuntime: () => null
+}))
+vi.mock('@renderer/components/PopupHost', () => ({ PopupHost: () => null }))
+vi.mock('@renderer/components/ToastHost', () => ({ default: () => null }))
+vi.mock('@renderer/hooks/useWindowRuntime', () => ({ useWindowRuntime: () => {} }))
+vi.mock('@renderer/hooks/useAutoBackupEvents', () => ({ useAutoBackupEvents: mocks.useAutoBackupEvents }))
+vi.mock('@renderer/services/imageExportModeChooser', () => ({ registerImageModeChooser: () => {} }))
+
 describe('SubWindowApp top-level error boundary', () => {
   beforeEach(() => {
+    mocks.themeProviderThrows = true
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -26,5 +49,21 @@ describe('SubWindowApp top-level error boundary', () => {
     render(<SubWindowApp />)
 
     expect(screen.getByRole('alert')).toHaveTextContent('theme provider boom')
+  })
+})
+
+describe('SubWindowApp automatic backup wiring', () => {
+  beforeEach(() => {
+    mocks.themeProviderThrows = false
+    mocks.useAutoBackupEvents.mockClear()
+  })
+
+  // A detached window renders the same settings panels as main, so it must track
+  // automatic backup state — but the toast/notification for one backup belongs to
+  // exactly one window, so only main may notify.
+  it('tracks automatic backup state without duplicating the main window notifications', () => {
+    render(<SubWindowApp />)
+
+    expect(mocks.useAutoBackupEvents).toHaveBeenCalledWith({ notificationsEnabled: false })
   })
 })

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -486,6 +486,11 @@ export type MainPersistCacheSchema = {
   // Last completed automatic-backup attempt (or manual backup) per backend.
   // AutoBackupService owns this restart-safe scheduling baseline.
   'backup.auto_sync.last_attempt_times': Record<AutoBackupType, number | null>
+  'backup.auto_sync.last_success_times': Record<AutoBackupType, number | null>
+  'backup.auto_sync.latest_terminal_outcomes': Record<
+    AutoBackupType,
+    CacheValueTypes.CacheAutoBackupTerminalOutcome | null
+  >
   // Persist-layer self-test key: exercises the typed persist API and round-trip
   // tests for the generic mechanism, independent of any real consumer.
   'internal.persist_probe': number
@@ -498,6 +503,8 @@ export type MainPersistCacheSchema = {
 
 export const DefaultMainPersistCache: MainPersistCacheSchema = {
   'backup.auto_sync.last_attempt_times': { webdav: null, s3: null, local: null, nutstore: null },
+  'backup.auto_sync.last_success_times': { webdav: null, s3: null, local: null, nutstore: null },
+  'backup.auto_sync.latest_terminal_outcomes': { webdav: null, s3: null, local: null, nutstore: null },
   'internal.persist_probe': 0,
   'window.bounds': {}
 }

--- a/src/shared/data/cache/cacheSchemas.ts
+++ b/src/shared/data/cache/cacheSchemas.ts
@@ -509,6 +509,17 @@ export const DefaultMainPersistCache: MainPersistCacheSchema = {
   'window.bounds': {}
 }
 
+/**
+ * Main persist keys that describe **this machine's** state and are meaningless
+ * on another one. The backup archive drops them, so restoring machine A's
+ * backup on machine B never makes B replay A's sync times or failure banners.
+ */
+export const DEVICE_LOCAL_MAIN_PERSIST_KEYS: readonly (keyof MainPersistCacheSchema)[] = [
+  'backup.auto_sync.last_attempt_times',
+  'backup.auto_sync.last_success_times',
+  'backup.auto_sync.latest_terminal_outcomes'
+]
+
 // ============================================================================
 // Cache Key Types
 // ============================================================================

--- a/src/shared/data/cache/cacheValueTypes.ts
+++ b/src/shared/data/cache/cacheValueTypes.ts
@@ -190,6 +190,11 @@ export type CacheAgentSessionBackgroundTasks = AgentSessionBackgroundTasks
 export type CacheAgentSessionTaskEvents = AgentSessionTaskEvents
 export type CacheAgentSessionFlowParts = AgentSessionFlowParts
 
+export type CacheAutoBackupTerminalOutcome =
+  | { status: 'succeeded'; timestamp: number }
+  | { status: 'warning'; timestamp: number; reason: 'cleanup_failed' }
+  | { status: 'failed'; timestamp: number; failureKind: 'active_data_writers' | 'unknown' }
+
 /**
  * Persisted window geometry for the WindowManager "remember bounds" capability.
  *

--- a/src/shared/ipc/schemas/__tests__/backup.test.ts
+++ b/src/shared/ipc/schemas/__tests__/backup.test.ts
@@ -1,0 +1,31 @@
+import { AUTO_BACKUP_TYPES } from '@shared/types/backup'
+import { describe, expect, it } from 'vitest'
+
+import { backupRequestSchemas } from '../backup'
+
+describe('backup.get_auto_sync_state', () => {
+  it('carries a last success time for every declared backend', () => {
+    const lastSuccessTimes = Object.fromEntries(AUTO_BACKUP_TYPES.map((type, index) => [type, index * 1000]))
+
+    const parsed = backupRequestSchemas['backup.get_auto_sync_state'].output.parse({
+      lastSuccessTimes,
+      events: [],
+      pendingNotifications: []
+    })
+
+    expect(parsed).toMatchObject({ lastSuccessTimes })
+  })
+
+  it('rejects a snapshot missing a backend instead of dropping it silently', () => {
+    const [omitted, ...rest] = AUTO_BACKUP_TYPES
+
+    const result = backupRequestSchemas['backup.get_auto_sync_state'].output.safeParse({
+      lastSuccessTimes: Object.fromEntries(rest.map((type) => [type, null])),
+      events: [],
+      pendingNotifications: []
+    })
+
+    expect(result.success).toBe(false)
+    expect(JSON.stringify(result.error)).toContain(omitted)
+  })
+})

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -4,6 +4,12 @@ import * as z from 'zod'
 import { defineRoute } from '../define'
 
 const autoBackupTypeSchema = z.enum(AUTO_BACKUP_TYPES)
+const autoBackupLastSuccessTimesSchema = z.object({
+  webdav: z.number().nullable(),
+  s3: z.number().nullable(),
+  local: z.number().nullable(),
+  nutstore: z.number().nullable()
+})
 const eventFields = { id: z.number().int().positive(), type: autoBackupTypeSchema }
 const autoBackupEventSchema = z.discriminatedUnion('status', [
   z.object({ ...eventFields, status: z.literal('running') }),
@@ -21,7 +27,11 @@ const autoBackupEventSchema = z.discriminatedUnion('status', [
 export const backupRequestSchemas = {
   'backup.get_auto_sync_state': defineRoute({
     input: z.void(),
-    output: z.object({ events: z.array(autoBackupEventSchema), pendingNotifications: z.array(autoBackupEventSchema) })
+    output: z.object({
+      lastSuccessTimes: autoBackupLastSuccessTimesSchema,
+      events: z.array(autoBackupEventSchema),
+      pendingNotifications: z.array(autoBackupEventSchema)
+    })
   }),
   'backup.acknowledge_auto_sync_notification': defineRoute({
     input: z.object({ type: autoBackupTypeSchema, id: z.number().int().positive() }),

--- a/src/shared/ipc/schemas/backup.ts
+++ b/src/shared/ipc/schemas/backup.ts
@@ -1,15 +1,16 @@
-import { AUTO_BACKUP_TYPES, type AutoBackupEvent } from '@shared/types/backup'
+import { AUTO_BACKUP_TYPES, type AutoBackupEvent, type AutoBackupLastSuccessTimes } from '@shared/types/backup'
 import * as z from 'zod'
 
 import { defineRoute } from '../define'
 
 const autoBackupTypeSchema = z.enum(AUTO_BACKUP_TYPES)
-const autoBackupLastSuccessTimesSchema = z.object({
-  webdav: z.number().nullable(),
-  s3: z.number().nullable(),
-  local: z.number().nullable(),
-  nutstore: z.number().nullable()
-})
+// `z.record(enum, value)` in zod 4 requires every enum key, so a new AUTO_BACKUP_TYPES
+// member widens this route instead of being silently stripped at the boundary while
+// AutoBackupSnapshot still declares it.
+const autoBackupLastSuccessTimesSchema = z.record(
+  autoBackupTypeSchema,
+  z.number().nullable()
+) satisfies z.ZodType<AutoBackupLastSuccessTimes>
 const eventFields = { id: z.number().int().positive(), type: autoBackupTypeSchema }
 const autoBackupEventSchema = z.discriminatedUnion('status', [
   z.object({ ...eventFields, status: z.literal('running') }),

--- a/src/shared/types/backup.ts
+++ b/src/shared/types/backup.ts
@@ -52,7 +52,10 @@ export type AutoBackupEventInput =
 
 export type AutoBackupEvent = AutoBackupEventInput & { id: number }
 
+export type AutoBackupLastSuccessTimes = Record<AutoBackupType, number | null>
+
 export type AutoBackupSnapshot = {
+  lastSuccessTimes: AutoBackupLastSuccessTimes
   events: AutoBackupEvent[]
   pendingNotifications: AutoBackupEvent[]
 }


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Automatic backup persisted only the last-attempt timestamp. The last successful backup and latest terminal outcome lived in memory, so restarting the app reset a successful cloud backup to "Not synced." Detached settings windows also did not mount the shared automatic-backup event state.

After this PR:

Automatic backup persists separate last-attempt, last-success, and stable terminal-outcome fields, restores them on startup, and mounts the shared event hook in both main and detached settings windows. Busy or failed attempts no longer overwrite the last successful timestamp, warnings retain successful upload time, and a later manual success clears stale automatic warning or failure state.

Because that state describes one machine, it is excluded from backup archives: restoring machine A's backup on machine B no longer makes B display A's sync times or replay A's failure banner. A persisted failure is also cleared when the backend it describes is switched off or repointed, and a restored timestamp from an earlier day is rendered with its date instead of a bare clock time.

Fixes #19670

### Why we need it and why it was done in this way

Backup status is device-local operational state: it must survive a restart to be useful, but it is meaningless on a different machine and has no home in the database or in user settings. The existing main-process persist cache is the right store for it, provided the one boundary where that file leaves the machine — the backup archive — drops the device-local keys. `DEVICE_LOCAL_MAIN_PERSIST_KEYS` states that set once, and the archive writer filters against it; the live cache file and the restore path are unchanged.

The following tradeoffs were made:

- Persisted failures are normalized to `active_data_writers` or `unknown`; raw exception details are not stored.
- The new cache fields are optional, so existing installations require no migration and naturally fall back to the previous empty state.
- Only the main window owns notifications and acknowledgement; detached windows consume status events without duplicating notifications.
- After restoring an archive, the receiving machine starts from empty backup status rather than inheriting the source machine's. That is the intended outcome, and a restore is followed by a restart anyway.
- Clearing a persisted outcome is deliberately not folded into the schedule restart: startup restarts every schedule too and must keep the outcome it just restored. Changing only the schedule interval does not clear it either, because rescheduling does not refute what the last attempt found.

The following alternatives were considered:

- Preference storage was rejected because backup outcome is not a user setting.
- DataApi storage was rejected because this status has no SQLite business-data table.
- Reusing last-attempt as last-success was rejected because failures and busy skips would make the UI claim a sync that did not happen.
- Filtering the device-local keys on restore instead of on archive write was rejected because it would leave one machine's state inside archives that travel between machines.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19670

### Breaking changes

None.

### Special notes for your reviewer

- Focused tests: 130 passed across AutoBackupService, LegacyBackupManager, CacheService, the backup IPC schema, the renderer backup util, `useAutoBackupEvents`, `MainApp`, `SubWindowApp`, and `LocalBackupSettings`.
- Restart coverage includes success, warning, failure, busy attempts, and failure/warning followed by manual success. Added coverage: the archive omits the device-local keys while keeping the rest of the persist cache; a configuration change drops a persisted failure while keeping the last-success time; a schedule-interval change keeps it; a cross-midnight timestamp renders with its date.
- The timestamp change adds no i18n key — only the formatted string passed into the existing interpolation changed, via one shared helper used by all four panels.
- `window.bounds` is arguably device-local for the same reason and is the next candidate for `DEVICE_LOCAL_MAIN_PERSIST_KEYS`; it is deliberately left out here because it changes existing restore behavior and deserves its own decision.
- Clearing an outcome does not broadcast an event, so an already-open settings window refreshes on remount. This matches the existing manual-backup path.
- An already-open secondary window still does not receive live manual-backup completion; this PR addresses automatic-backup persistence and detached-window event handling from #19670.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because this restores the documented backup status behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Backup] Preserve automatic backup success and terminal status across restarts and detached settings windows, and keep one machine's backup status out of restores on another.
```
