### PR TITLE
fix(mini-app): treat null bridge options like an absent argument

### DIFF
--- a/src/preload/__tests__/miniAppBridge.test.ts
+++ b/src/preload/__tests__/miniAppBridge.test.ts
@@ -249,4 +249,17 @@ describe('null arguments', () => {
   ])('%s treats null like an absent argument', async (_name, call) => {
     await expect(call()).resolves.toBeDefined()
   })
+
+  it.each([
+    ['ai.chat', () => cherry.ai.chat({ messages: [] }, null as never)],
+    ['file.export', () => cherry.file.export('export.txt', null as never)]
+  ])('%s rejects null options through the public error contract', async (_name, call) => {
+    const reason = await call().then(
+      () => expect.fail('resolved'),
+      (error: unknown) => error
+    )
+
+    expect(reason).toEqual({ name: 'InvalidArgument', message: expect.any(String) })
+    expect(Object.getPrototypeOf(reason)).toBe(Object.prototype)
+  })
 })

--- a/src/preload/__tests__/miniAppBridge.test.ts
+++ b/src/preload/__tests__/miniAppBridge.test.ts
@@ -245,21 +245,10 @@ describe('null arguments', () => {
     ['network.fetch', () => cherry.network.fetch(null as never)],
     ['clipboard.write', () => cherry.clipboard.write(null as never)],
     ['notification.show', () => cherry.notification.show(null as never)],
-    ['ai.chat', () => cherry.ai.chat(null as never, {})]
+    ['ai.chat', () => cherry.ai.chat(null as never, {})],
+    ['ai.chat options', () => cherry.ai.chat({ messages: [] }, null as never)],
+    ['file.export options', () => cherry.file.export('export.txt', null as never)]
   ])('%s treats null like an absent argument', async (_name, call) => {
     await expect(call()).resolves.toBeDefined()
-  })
-
-  it.each([
-    ['ai.chat', () => cherry.ai.chat({ messages: [] }, null as never)],
-    ['file.export', () => cherry.file.export('export.txt', null as never)]
-  ])('%s rejects null options through the public error contract', async (_name, call) => {
-    const reason = await call().then(
-      () => expect.fail('resolved'),
-      (error: unknown) => error
-    )
-
-    expect(reason).toEqual({ name: 'InvalidArgument', message: expect.any(String) })
-    expect(Object.getPrototypeOf(reason)).toBe(Object.prototype)
   })
 })

--- a/src/preload/miniAppBridge.ts
+++ b/src/preload/miniAppBridge.ts
@@ -176,8 +176,10 @@ contextBridge.exposeInMainWorld('cherry', {
   ai: {
     // The APP's own label. Attaching an id to the returned promise would depend on
     // contextBridge preserving custom properties across worlds — unverified.
-    chat: async (params: unknown, opts: { onChunk?: (c: string) => void; callId?: string } = {}) =>
-      callStreaming('ai.chat', gateChat(params), opts.onChunk ?? (() => {}), gateCallId(opts.callId)),
+    chat: async (params: unknown, opts: { onChunk?: (c: string) => void; callId?: string } | null = {}) => {
+      if (opts === null) throw guestRefusal('Mini app ai.chat options must be an object')
+      return callStreaming('ai.chat', gateChat(params), opts.onChunk ?? (() => {}), gateCallId(opts.callId))
+    },
     cancel: async (callId: string) => call('ai.cancel', { callId: gateCallId(callId) }),
     getCapabilities: async (params?: { model?: unknown } | null) => {
       // `?? {}`, not a default parameter or an `=== undefined` test: a default fills in for
@@ -206,11 +208,13 @@ contextBridge.exposeInMainWorld('cherry', {
     list: async () => call('file.list'),
     delete: async (name: string) => call('file.delete', { name: gateName(name) }),
     usage: async () => call('file.usage'),
-    export: async (name: string, opts: { suggestedName?: string } = {}) =>
-      call('file.export', {
+    export: async (name: string, opts: { suggestedName?: string } | null = {}) => {
+      if (opts === null) throw guestRefusal('Mini app file.export options must be an object')
+      return call('file.export', {
         name: gateName(name),
         ...(opts.suggestedName === undefined ? {} : { suggestedName: gateName(opts.suggestedName) })
       })
+    }
   },
   app: {
     getInfo: async () => call('app.getInfo'),

--- a/src/preload/miniAppBridge.ts
+++ b/src/preload/miniAppBridge.ts
@@ -176,9 +176,9 @@ contextBridge.exposeInMainWorld('cherry', {
   ai: {
     // The APP's own label. Attaching an id to the returned promise would depend on
     // contextBridge preserving custom properties across worlds — unverified.
-    chat: async (params: unknown, opts: { onChunk?: (c: string) => void; callId?: string } | null = {}) => {
-      if (opts === null) throw guestRefusal('Mini app ai.chat options must be an object')
-      return callStreaming('ai.chat', gateChat(params), opts.onChunk ?? (() => {}), gateCallId(opts.callId))
+    chat: async (params: unknown, opts?: { onChunk?: (c: string) => void; callId?: string } | null) => {
+      const { onChunk, callId } = opts ?? {}
+      return callStreaming('ai.chat', gateChat(params), onChunk ?? (() => {}), gateCallId(callId))
     },
     cancel: async (callId: string) => call('ai.cancel', { callId: gateCallId(callId) }),
     getCapabilities: async (params?: { model?: unknown } | null) => {
@@ -208,11 +208,11 @@ contextBridge.exposeInMainWorld('cherry', {
     list: async () => call('file.list'),
     delete: async (name: string) => call('file.delete', { name: gateName(name) }),
     usage: async () => call('file.usage'),
-    export: async (name: string, opts: { suggestedName?: string } | null = {}) => {
-      if (opts === null) throw guestRefusal('Mini app file.export options must be an object')
+    export: async (name: string, opts?: { suggestedName?: string } | null) => {
+      const { suggestedName } = opts ?? {}
       return call('file.export', {
         name: gateName(name),
-        ...(opts.suggestedName === undefined ? {} : { suggestedName: gateName(opts.suggestedName) })
+        ...(suggestedName === undefined ? {} : { suggestedName: gateName(suggestedName) })
       })
     }
   },


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`cherry.ai.chat(validRequest, null)` and `cherry.file.export(name, null)` reached a property read on `null` and rejected with a native `TypeError`. A default parameter fills in for `undefined` alone, so an explicit `null` from a plain-JavaScript Mini App bypassed the bridge's documented plain `{ name, message }` error contract.

After this PR:

Both boundaries resolve their options with `?? {}`, so `null` is treated like an absent argument and the call proceeds with its normal defaults. This matches the five bridge entry points that already behave this way — `ai.getCapabilities`, `network.fetch`, `clipboard.write`, `notification.show`, and `ai.chat`'s first parameter. Omitted and `undefined` options are unaffected.

Fixes: N/A (no linked issue).

### Why we need it and why it was done in this way

Mini Apps depend on a stable cross-context error shape: `cherry.d.ts` promises that every rejection is one of seven named plain objects, and a native `TypeError` is invisible to the `catch (e) { e.name }` handling the documentation tells authors to write.

Treating `null` as absent is the smaller of the two available fixes and the only one that keeps a single policy across the whole bridge surface. Rejecting `null` with `InvalidArgument` closes the same hole, but it would leave `ai.chat` accepting `null` for its first parameter while refusing it for its second, and it would contradict the five entry points whose `null`-as-absent behavior is already asserted by tests.

The following tradeoffs were made:

- Internal boundary types accept `null` so the runtime behavior for JavaScript callers can be expressed; the public declarations in `docs/references/mini-app/cherry.d.ts` are unchanged and still exclude it.
- A `null` options argument now succeeds instead of failing loudly. That is consistent with the rest of the bridge, and the documented signatures still do not offer `null` as a supported value.

The following alternatives were considered:

- Rejecting `null` with `InvalidArgument`: closes the same contract hole, but splits the bridge into two opposing policies for the same input shape and would require rewriting the existing `null`-as-absent tests.
- Catching and translating every native exception around the bridge: rejected because it could mask unrelated implementation errors.

Links to places where the discussion took place: N/A.

### Breaking changes

None.

### Special notes for your reviewer

- Focused preload tests: 26 passed (`npx vitest run src/preload/__tests__/miniAppBridge.test.ts`).
- The two `null`-options cases now live in the existing "treats null like an absent argument" table rather than in a separate error-contract test, so one table states the whole bridge policy.
- A sweep of the file found no other entry point with this defect shape; the remaining methods already resolve their arguments with `?? {}`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because the documented API contract is unchanged.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Mini Apps] Passing null options to chat or file export no longer rejects with an unexpected error.
```
