### PR TITLE
fix(agent-runtime): preserve attachment filenames

### DIFF
--- a/src/main/ai/runtime/__tests__/agentUserContent.test.ts
+++ b/src/main/ai/runtime/__tests__/agentUserContent.test.ts
@@ -1,0 +1,41 @@
+import { fileURLToPath } from 'node:url'
+
+import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSessionMessages'
+import type { CherryMessagePart } from '@shared/data/types/message'
+import { describe, expect, it } from 'vitest'
+
+import { buildAgentUserContent } from '../agentUserContent'
+
+function message(parts: CherryMessagePart[]): AgentSessionMessageEntity {
+  return { data: { parts } } as unknown as AgentSessionMessageEntity
+}
+
+function filePart(url: string, filename?: string): CherryMessagePart {
+  return { type: 'file', url, mediaType: 'image/jpeg', filename } as unknown as CherryMessagePart
+}
+
+describe('buildAgentUserContent', () => {
+  it('delivers original filenames alongside local attachment paths', () => {
+    const firstUrl = 'file:///C:/managed/uuid-a'
+    const secondUrl = 'file:///C:/managed/uuid-b'
+    const content = buildAgentUserContent(
+      message([
+        { type: 'text', text: 'Classify these images.' } as CherryMessagePart,
+        filePart(firstUrl, '20260406_184133 Alex Diaz.jpg'),
+        filePart(secondUrl, 'scan "final".jpg')
+      ])
+    )
+
+    expect(content).toContain('Attached files (read them with your tools using these absolute paths):')
+    expect(content).toContain(`- ${JSON.stringify('20260406_184133 Alex Diaz.jpg')}: ${fileURLToPath(firstUrl)}`)
+    expect(content).toContain(`- ${JSON.stringify('scan "final".jpg')}: ${fileURLToPath(secondUrl)}`)
+  })
+
+  it('keeps path-only output for legacy file parts without a filename', () => {
+    const url = 'file:///C:/managed/uuid-legacy'
+    const content = buildAgentUserContent(message([filePart(url)]))
+
+    expect(content).toContain(`- ${fileURLToPath(url)}`)
+    expect(content).not.toContain(`- ${JSON.stringify(fileURLToPath(url))}:`)
+  })
+})

--- a/src/main/ai/runtime/agentUserContent.ts
+++ b/src/main/ai/runtime/agentUserContent.ts
@@ -13,14 +13,22 @@ import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSe
  */
 export function buildAgentUserContent(message: AgentSessionMessageEntity): string {
   const text = extractMessageText(message)
-  const attachments = extractAttachments(message)
-  const content =
-    attachments.length === 0
-      ? text
-      : `${text.trim() ? `${text}\n\n` : ''}Attached files (read them with your tools using these absolute paths):\n${attachments
-          .map(({ filename, path }) => (filename ? `- ${JSON.stringify(filename)}: ${path}` : `- ${path}`))
-          .join('\n')}`
+  const content = appendAgentAttachmentPaths(text, extractAttachments(message))
   return wrapAgentSessionDeliveryContent(message, content)
+}
+
+/** Append original filenames beside managed paths so agents can distinguish opaque storage names. */
+export function appendAgentAttachmentPaths(
+  text: string,
+  attachments: ReadonlyArray<{ filename?: string; path: string }>
+): string {
+  if (attachments.length === 0) return text
+
+  const list = attachments
+    .map(({ filename, path }) => (filename ? `- ${JSON.stringify(filename)}: ${path}` : `- ${path}`))
+    .join('\n')
+  const section = `Attached files (read them with your tools using these absolute paths):\n${list}`
+  return text.trim() ? `${text}\n\n${section}` : section
 }
 
 /** Preserve trusted routing metadata while isolating model-authored cross-Session content. */

--- a/src/main/ai/runtime/agentUserContent.ts
+++ b/src/main/ai/runtime/agentUserContent.ts
@@ -7,17 +7,19 @@ import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSe
 /**
  * Build the user-turn content sent to an agent runtime. Agent runtimes are
  * filesystem agents (they have no native multimodal channel here), so attached
- * files are forwarded as their absolute paths appended to the text — the agent
- * reads them with its own tools. Driver-neutral: shared by the Claude Code and
- * pi drivers so they cannot drift on attachment handling.
+ * files are forwarded as their original filenames and absolute paths appended
+ * to the text — the agent reads them with its own tools. Driver-neutral: shared
+ * by the DSH and pi drivers so they cannot drift on attachment handling.
  */
 export function buildAgentUserContent(message: AgentSessionMessageEntity): string {
   const text = extractMessageText(message)
-  const paths = extractAttachmentPaths(message)
+  const attachments = extractAttachments(message)
   const content =
-    paths.length === 0
+    attachments.length === 0
       ? text
-      : `${text.trim() ? `${text}\n\n` : ''}Attached files (read them with your tools using these absolute paths):\n${paths.map((path) => `- ${path}`).join('\n')}`
+      : `${text.trim() ? `${text}\n\n` : ''}Attached files (read them with your tools using these absolute paths):\n${attachments
+          .map(({ filename, path }) => (filename ? `- ${JSON.stringify(filename)}: ${path}` : `- ${path}`))
+          .join('\n')}`
   return wrapAgentSessionDeliveryContent(message, content)
 }
 
@@ -56,13 +58,13 @@ function extractMessageText(message: AgentSessionMessageEntity): string {
   )
 }
 
-/** Absolute local paths of `file://`-backed attachment parts (composer attachments). */
-function extractAttachmentPaths(message: AgentSessionMessageEntity): string[] {
-  const paths: string[] = []
+/** Original names and absolute local paths of composer attachments. */
+function extractAttachments(message: AgentSessionMessageEntity): Array<{ filename?: string; path: string }> {
+  const attachments: Array<{ filename?: string; path: string }> = []
   for (const part of message.data?.parts ?? []) {
     // `parts` is a typed `CherryMessagePart[]`, so `type === 'file'` narrows to `FileUIPart`.
     if (part.type !== 'file' || !part.url.startsWith('file://')) continue
-    paths.push(fileURLToPath(part.url))
+    attachments.push({ filename: part.filename, path: fileURLToPath(part.url) })
   }
-  return paths
+  return attachments
 }

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -19,7 +19,11 @@ import { loggerService } from '@logger'
 import { collectAssistantFileAttachments } from '@main/ai/messages/assistantFileAttachments'
 import { collectFileAttachments, prepareChatMessages } from '@main/ai/messages/attachmentRouting'
 import { materializeNativeFilePart } from '@main/ai/messages/fileProcessor'
-import { buildAgentUserContent, wrapAgentSessionDeliveryContent } from '@main/ai/runtime/agentUserContent'
+import {
+  appendAgentAttachmentPaths,
+  buildAgentUserContent,
+  wrapAgentSessionDeliveryContent
+} from '@main/ai/runtime/agentUserContent'
 import { wrapSteerReminder } from '@main/ai/steerReminder'
 import type { ClaudeAgentToolPolicySnapshot } from '@main/ai/tools/adapters/claudeCode/agentTools'
 import {
@@ -1238,7 +1242,7 @@ async function materializeUserContent(
 
   const resolvedPaths = await extractAttachmentPaths(fallbackParts)
   unavailableParts.push(...resolvedPaths.unavailable)
-  let textContent = appendAttachmentPaths(text, resolvedPaths.files)
+  let textContent = appendAgentAttachmentPaths(text, resolvedPaths.files)
   if (supportsAttachmentReads) textContent = appendAttachmentManifest(textContent, turnAttachments)
   if (unavailableParts.length > 0) {
     const names = unavailableParts.map((part) => part.filename || 'attachment')
@@ -1262,18 +1266,6 @@ function appendAttachmentManifest(
     .map(({ displayName, handle }) => `- ${JSON.stringify(displayName)} (handle: ${handle})`)
     .join('\n')
   const section = `Attachment manifest:\n${list}`
-  return text.trim() ? `${text}\n\n${section}` : section
-}
-
-function appendAttachmentPaths(text: string, files: ResolvedAttachmentPath[]): string {
-  if (files.length === 0) return text
-
-  // Managed copies are stored under a UUID filename, so the display name has to travel
-  // with the path — otherwise multiple attachments are indistinguishable to the model.
-  const list = files
-    .map(({ filename, path }) => (filename ? `- ${JSON.stringify(filename)}: ${path}` : `- ${path}`))
-    .join('\n')
-  const section = `Attached files (read them with your tools using these absolute paths):\n${list}`
   return text.trim() ? `${text}\n\n${section}` : section
 }
 

--- a/src/main/ai/runtime/pi/PiRuntimeConnection.ts
+++ b/src/main/ai/runtime/pi/PiRuntimeConnection.ts
@@ -457,8 +457,9 @@ export class PiRuntimeConnection implements AgentRuntimeConnection {
     const session = this.session
     if (!session?.isStreaming) return false
 
-    // buildAgentUserContent intentionally flattens attachments to absolute paths for filesystem agents;
-    // pi's native image channel stays unused until Cherry models multimodal agent attachments end-to-end.
+    // buildAgentUserContent intentionally flattens attachments to filenames and absolute paths for
+    // filesystem agents; pi's native image channel stays unused until Cherry models multimodal agent
+    // attachments end-to-end.
     const wrappedText = wrapSteerReminder(buildAgentUserContent(input.message))
     const pending: PendingSteer = { input }
     this.pendingSteers.push(pending)


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Agent-session runtimes received only absolute paths for local attachments. Managed attachments use opaque storage names, so agents could not reliably map an uploaded file to its original filename.

After this PR:
The shared agent-session content builder includes each attachment's original filename beside its absolute path, with JSON escaping for special characters. Filename-less legacy parts remain path-only. DSH and Pi therefore receive the same filename-to-path mapping.

Fixes #19676

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Reuse the existing driver-neutral `buildAgentUserContent` path so DSH and Pi stay consistent.
- Keep the existing managed absolute path for filesystem access and add only the already-persisted filename as prompt metadata.
- Preserve the current runtime model: agent sessions use text instructions and filesystem tools rather than changing native multimodal transport or persisting duplicate files.

The following alternatives were considered:
- Sending a separate native image metadata block: these agent-session drivers currently consume a text content block with file paths, so it would not reach their runtime.
- Adding a persistence layer or per-agent setting: this is broader than the reported metadata loss and unnecessary because filenames already exist in each file part.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/19676

### Breaking changes

None. Existing path-only handling remains unchanged for filename-less parts; named attachments now expose their original name in the agent runtime input.

### Special notes for your reviewer

- Filenames are encoded with `JSON.stringify` so quotes and control characters do not corrupt the mapping.
- No user-guide update is required: this fixes agent runtime attachment context without adding a setting or changing the upload workflow.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this runtime-context fix.
- [x] Self-review: I have reviewed my own code (focused tests, lint/format checks, and static review against the project architecture guidance)

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Agent sessions now preserve original attachment filenames in runtime context, allowing agents to identify and associate uploaded files with their source names.
```
