### PR TITLE
fix(chat): allow switching model conversations during active streaming

### DIFF
--- a/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
+++ b/src/renderer/components/chat/messages/__tests__/MessageGroup.test.tsx
@@ -277,6 +277,9 @@ const expectEveryMessageHeaderToShowModelIdentity = (expected: boolean) => {
   expect(mocks.MessageHeader.mock.calls.every(([props]) => props.showModelIdentity === expected)).toBe(true)
 }
 
+const getLatestMessageGroupMenuProps = () =>
+  (mocks.MessageGroupMenuBar.mock.calls as unknown as [{ selectMessageId: string }][]).at(-1)?.[0]
+
 describe('MessageGroup', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -1110,6 +1113,57 @@ describe('MessageGroup', () => {
     expect(updateMessageUiState).toHaveBeenCalledWith('model-b', { foldSelected: true })
   })
 
+  it('keeps a newer model selection pending until its branch request settles', async () => {
+    const firstSelection = createDeferred()
+    const secondSelection = createDeferred()
+    const setActiveBranch = vi.fn((messageId: string) =>
+      messageId === 'model-b' ? firstSelection.promise : secondSelection.promise
+    )
+    mocks.messageListActions.mockReturnValue({
+      setActiveBranch,
+      updateMessageUiState: vi.fn()
+    })
+    const messages = [
+      { ...createMessage('model-a', 0, 'fold'), isActiveBranch: true },
+      { ...createMessage('model-b', 1, 'fold'), isActiveBranch: false },
+      { ...createMessage('model-c', 2, 'fold'), isActiveBranch: false }
+    ]
+
+    const { rerender } = render(<MessageGroup messages={messages} />)
+    const menuProps = (
+      mocks.MessageGroupMenuBar.mock.calls.at(-1) as unknown as [
+        {
+          selectMessageId: string
+          setSelectedMessage: (message: MessageListItem) => void
+        }
+      ]
+    )[0]
+
+    act(() => {
+      menuProps.setSelectedMessage(messages[1])
+      menuProps.setSelectedMessage(messages[2])
+    })
+
+    await waitFor(() => expect(setActiveBranch).toHaveBeenCalledTimes(2))
+    await act(async () => firstSelection.resolve())
+
+    rerender(
+      <MessageGroup
+        messages={[
+          { ...messages[0], isActiveBranch: false },
+          { ...messages[1], isActiveBranch: true },
+          { ...messages[2], isActiveBranch: false }
+        ]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getLatestMessageGroupMenuProps()).toEqual(expect.objectContaining({ selectMessageId: 'model-c' }))
+    })
+
+    await act(async () => secondSelection.resolve())
+  })
+
   it('shows the context indicator on the active branch instead of stale useful UI state', () => {
     mocks.settings.mockReturnValue({
       multiModelMessageStyle: 'grid',
@@ -1194,5 +1248,50 @@ describe('MessageGroup', () => {
     await waitFor(() => {
       expect(setActiveBranch).toHaveBeenNthCalledWith(2, 'model-a')
     })
+  })
+
+  it('keeps a queued context selection pending until its branch request settles', async () => {
+    const firstSelection = createDeferred()
+    const secondSelection = createDeferred()
+    const setActiveBranch = vi.fn((messageId: string) =>
+      messageId === 'model-b' ? firstSelection.promise : secondSelection.promise
+    )
+    mocks.messageListActions.mockReturnValue({
+      setActiveBranch,
+      updateMessageUiState: vi.fn()
+    })
+    const messages = [
+      { ...createMessage('model-a', 0, 'grid'), isActiveBranch: true },
+      { ...createMessage('model-b', 1, 'grid'), isActiveBranch: false }
+    ]
+
+    const { rerender } = render(<MessageGroup messages={messages} />)
+    const menuPropsByMessageId = new Map(
+      mocks.MessageMenuBar.mock.calls.map(([props]) => [props.message.id, props] as const)
+    )
+
+    act(() => menuPropsByMessageId.get('model-b')?.onSelectContext?.('model-b'))
+    act(() => menuPropsByMessageId.get('model-a')?.onSelectContext?.('model-a'))
+
+    await waitFor(() => {
+      expect(setActiveBranch).toHaveBeenCalledTimes(1)
+      expect(setActiveBranch).toHaveBeenLastCalledWith('model-b')
+    })
+    await act(async () => firstSelection.resolve())
+
+    rerender(
+      <MessageGroup
+        messages={[
+          { ...messages[0], isActiveBranch: false },
+          { ...messages[1], isActiveBranch: true }
+        ]}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getLatestMessageGroupMenuProps()).toEqual(expect.objectContaining({ selectMessageId: 'model-a' }))
+    })
+
+    await act(async () => secondSelection.resolve())
   })
 })

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -177,7 +177,7 @@ const MessageGroup = ({
             actions.notifyError?.(error instanceof Error ? error.message : String(error))
           })
           .finally(() => {
-            pendingBranchTargetRef.current = null
+            if (pendingBranchTargetRef.current === message.id) pendingBranchTargetRef.current = null
           })
       }
 
@@ -233,11 +233,15 @@ const MessageGroup = ({
       const setActiveBranch = actions.setActiveBranch
       if (!setActiveBranch) return
 
+      pendingBranchTargetRef.current = message.id
       activeBranchSelectionQueueRef.current = activeBranchSelectionQueueRef.current
         .then(() => setActiveBranch(message.id))
         .catch((error) => {
           logger.error('Failed to set active branch from context selection', error as Error, { messageId: message.id })
           actions.notifyError?.(error instanceof Error ? error.message : String(error))
+        })
+        .finally(() => {
+          if (pendingBranchTargetRef.current === message.id) pendingBranchTargetRef.current = null
         })
     },
     [actions, messages]

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -138,10 +138,14 @@ const MessageGroup = ({
     const activeBranchMessage = messages.find((message) => message.isActiveBranch)
     let nextSelectedMessage: MessageListItem | undefined
 
-    if (
+    if (pendingBranchTargetRef.current !== null) {
+      // A branch switch is in flight — suppress all auto-sync so streaming
+      // updates and newly added assistant messages cannot override the user's
+      // model selection.  The pending ref is cleared in setSelectedMessage's
+      // finally block once the switch settles.
+    } else if (
       activeBranchMessage &&
-      activeBranchMessage.id !== selectedMessageId &&
-      pendingBranchTargetRef.current === null
+      activeBranchMessage.id !== selectedMessageId
     ) {
       nextSelectedMessage = activeBranchMessage
     } else if (!hasSelected) {

--- a/src/renderer/components/chat/messages/list/MessageGroup.tsx
+++ b/src/renderer/components/chat/messages/list/MessageGroup.tsx
@@ -94,6 +94,7 @@ const MessageGroup = ({
   )
   const previousMessageIdsRef = useRef(messages.map((message) => message.id))
   const activeBranchSelectionQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const pendingBranchTargetRef = useRef<string | null>(null)
   const messageElementsRef = useRef<Map<string, HTMLElement>>(new Map())
 
   const registerRenderedMessageElement = useCallback(
@@ -137,7 +138,11 @@ const MessageGroup = ({
     const activeBranchMessage = messages.find((message) => message.isActiveBranch)
     let nextSelectedMessage: MessageListItem | undefined
 
-    if (activeBranchMessage && activeBranchMessage.id !== selectedMessageId) {
+    if (
+      activeBranchMessage &&
+      activeBranchMessage.id !== selectedMessageId &&
+      pendingBranchTargetRef.current === null
+    ) {
       nextSelectedMessage = activeBranchMessage
     } else if (!hasSelected) {
       nextSelectedMessage = pickPreferredSelectedMessage(messages, getMessageUiState) ?? messages.at(-1) ?? messages[0]
@@ -165,10 +170,15 @@ const MessageGroup = ({
       setSelectedMessageIdState(message.id)
 
       if (message.role === 'assistant' && message.id !== selectedMessageId) {
-        void Promise.resolve(actions.setActiveBranch?.(message.id)).catch((error) => {
-          logger.error('Failed to set active branch from message group', error as Error, { messageId: message.id })
-          actions.notifyError?.(error instanceof Error ? error.message : String(error))
-        })
+        pendingBranchTargetRef.current = message.id
+        void Promise.resolve(actions.setActiveBranch?.(message.id))
+          .catch((error) => {
+            logger.error('Failed to set active branch from message group', error as Error, { messageId: message.id })
+            actions.notifyError?.(error instanceof Error ? error.message : String(error))
+          })
+          .finally(() => {
+            pendingBranchTargetRef.current = null
+          })
       }
 
       setTimeoutTimer(


### PR DESCRIPTION
## Summary

Fixes #19659 — users cannot switch between model conversations while one model is still streaming a reply.

**Root cause:** The active-branch sync effect in `MessageGroup` (`src/renderer/components/chat/messages/list/MessageGroup.tsx`) re-runs on every `messages` change. During streaming, message content updates trigger frequent re-renders. When a user clicks a different model tab, `setSelectedMessageId` updates synchronously but `setActiveBranch()` is async (DataApi round-trip). Before it resolves, the effect sees `activeBranchMessage.id !== selectedMessageId` and snaps the selection back to the streaming model — overriding the user's click on every render cycle.

**Fix:** Track the in-flight branch switch target in a ref (`pendingBranchTargetRef`). While a switch is pending, the sync effect skips the snap-back, letting the user's selection hold until the async operation completes.

## Changed files

- `src/renderer/components/chat/messages/list/MessageGroup.tsx` — add `pendingBranchTargetRef` to suppress re-render snap-back during in-flight branch switches (+15 -5 lines)

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] 205 existing tests pass (`vitest run`)
- [x] Production build succeeds (`electron-vite build`)
- [ ] Manual: start a multi-model conversation (mention 2+ models), while one model is streaming, click the other model's tab — selection should hold
- [ ] Manual: after streaming completes, switching between models should still work normally
- [ ] Manual: fold/horizontal/grid multi-model display modes all allow switching during streaming