### PR TITLE
feat(settings): carry focus intent in the URL

### DIFF
--- a/src/renderer/pages/settings/SettingsPage.tsx
+++ b/src/renderer/pages/settings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import Scrollbar from '@renderer/components/Scrollbar'
 import useMacTransparentWindow from '@renderer/hooks/useMacTransparentWindow'
 import { settingsMenu } from '@renderer/pages/settings/settingsMenu'
 import SettingsFocusScroll from '@renderer/pages/settings/settingsSearch/SettingsFocusScroll'
+import SettingsFocusUrl from '@renderer/pages/settings/settingsSearch/SettingsFocusUrl'
 import SettingsSearchBox from '@renderer/pages/settings/settingsSearch/SettingsSearchBox'
 import { SettingsSearchDomIdsProvider } from '@renderer/pages/settings/settingsSearch/SettingsSearchDomIds'
 import {
@@ -106,6 +107,7 @@ const SettingsPage: FC = () => {
               data-ui="settings.content"
               className="flex min-h-0 min-w-0 flex-1 overflow-hidden text-foreground">
               <Outlet />
+              <SettingsFocusUrl />
               <SettingsFocusScroll scopeRef={contentRef} />
             </div>
           </div>

--- a/src/renderer/pages/settings/settingsSearch/SettingsFocusUrl.tsx
+++ b/src/renderer/pages/settings/settingsSearch/SettingsFocusUrl.tsx
@@ -1,0 +1,38 @@
+import { useLocation, useNavigate, useSearch } from '@tanstack/react-router'
+import { useEffect } from 'react'
+
+import { setPendingFocus } from './store'
+
+/**
+ * URL → focus-intent translator mounted in the settings layout: reads a
+ * `?focus=<dom anchor id>` param from any settings route, forwards it into the
+ * store's pendingFocus (the same seam the search results use) and strips the
+ * one-shot param so refreshes and shared links stay clean.
+ */
+const SettingsFocusUrl = () => {
+  const search = useSearch({ strict: false })
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const focus = (search as Record<string, unknown>).focus
+    // Empty string included: a blank anchor must not reach querySelector('#')
+    if (typeof focus !== 'string' || !focus) return
+    setPendingFocus(focus)
+    void navigate({
+      to: location.pathname,
+      // Commit-time strip composes with concurrent param consumers (provider's
+      // ?id= strip); a render-time snapshot could resurrect removed params
+      search: (prev: Record<string, unknown>) => {
+        const rest = { ...prev }
+        delete rest.focus
+        return rest
+      },
+      replace: true
+    })
+  }, [search, location.pathname, navigate])
+
+  return null
+}
+
+export default SettingsFocusUrl

--- a/src/renderer/pages/settings/settingsSearch/SettingsFocusUrl.tsx
+++ b/src/renderer/pages/settings/settingsSearch/SettingsFocusUrl.tsx
@@ -5,9 +5,11 @@ import { setPendingFocus } from './store'
 
 /**
  * URL → focus-intent translator mounted in the settings layout: reads a
- * `?focus=<dom anchor id>` param from any settings route, forwards it into the
- * store's pendingFocus (the same seam the search results use) and strips the
- * one-shot param so refreshes and shared links stay clean.
+ * `?focusId=<dom anchor id>` param from any settings route, forwards it into
+ * the store's pendingFocus (the same seam the search results use) and strips
+ * the one-shot param so refreshes and shared links stay clean. The key is
+ * `focusId`, not `focus`: /settings/model already owns `?focus=default|translate`
+ * to select its default/translate rows.
  */
 const SettingsFocusUrl = () => {
   const search = useSearch({ strict: false })
@@ -15,17 +17,17 @@ const SettingsFocusUrl = () => {
   const navigate = useNavigate()
 
   useEffect(() => {
-    const focus = (search as Record<string, unknown>).focus
+    const focusId = (search as Record<string, unknown>).focusId
     // Empty string included: a blank anchor must not reach querySelector('#')
-    if (typeof focus !== 'string' || !focus) return
-    setPendingFocus(focus)
+    if (typeof focusId !== 'string' || !focusId) return
+    setPendingFocus(focusId)
     void navigate({
       to: location.pathname,
       // Commit-time strip composes with concurrent param consumers (provider's
       // ?id= strip); a render-time snapshot could resurrect removed params
       search: (prev: Record<string, unknown>) => {
         const rest = { ...prev }
-        delete rest.focus
+        delete rest.focusId
         return rest
       },
       replace: true

--- a/src/renderer/pages/settings/settingsSearch/__tests__/SettingsFocusUrl.test.tsx
+++ b/src/renderer/pages/settings/settingsSearch/__tests__/SettingsFocusUrl.test.tsx
@@ -23,6 +23,7 @@ describe('SettingsFocusUrl', () => {
   beforeEach(() => {
     locationMock.pathname = '/settings/general'
     searchMock.q = undefined
+    searchMock.focusId = undefined
     searchMock.focus = undefined
     navigateMock.mockReset()
     setPendingFocus(undefined)
@@ -30,8 +31,8 @@ describe('SettingsFocusUrl', () => {
 
   const pendingFocusOf = () => renderHook(() => useSettingsSearchKeyboard()).result.current.pendingFocusId
 
-  it('forwards a ?focus= anchor into the store and strips only that key', () => {
-    searchMock.focus = 'setting-general-proxy'
+  it('forwards a ?focusId= anchor into the store and strips only that key', () => {
+    searchMock.focusId = 'setting-general-proxy'
     render(<SettingsFocusUrl />)
 
     expect(pendingFocusOf()).toBe('setting-general-proxy')
@@ -39,7 +40,17 @@ describe('SettingsFocusUrl', () => {
     const call = navigateMock.mock.calls[0][0]
     expect(call.to).toBe('/settings/general')
     expect(call.replace).toBe(true)
-    expect(call.search({ focus: 'setting-general-proxy', panel: 'data' })).toEqual({ panel: 'data' })
+    expect(call.search({ focusId: 'setting-general-proxy', panel: 'data' })).toEqual({ panel: 'data' })
+  })
+
+  it('leaves the model page legacy ?focus=default|translate param untouched', () => {
+    // /settings/model owns `focus` for its default/translate rows — the
+    // translator must not read, forward, or strip that key
+    searchMock.focus = 'default'
+    render(<SettingsFocusUrl />)
+
+    expect(pendingFocusOf()).toBeUndefined()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 
   it('does nothing without a focus param', () => {
@@ -50,7 +61,7 @@ describe('SettingsFocusUrl', () => {
   })
 
   it('ignores a non-string focus value', () => {
-    searchMock.focus = 42
+    searchMock.focusId = 42
     render(<SettingsFocusUrl />)
 
     expect(pendingFocusOf()).toBeUndefined()
@@ -58,7 +69,7 @@ describe('SettingsFocusUrl', () => {
   })
 
   it('ignores an empty-string focus (blank anchor must not reach the selector)', () => {
-    searchMock.focus = ''
+    searchMock.focusId = ''
     render(<SettingsFocusUrl />)
 
     expect(pendingFocusOf()).toBeUndefined()
@@ -66,18 +77,18 @@ describe('SettingsFocusUrl', () => {
   })
 
   it('re-injects when focus reappears (second agent deep link into the same tab)', () => {
-    searchMock.focus = 'setting-general-proxy'
+    searchMock.focusId = 'setting-general-proxy'
     const view = render(<SettingsFocusUrl />)
     expect(navigateMock).toHaveBeenCalledTimes(1)
     expect(pendingFocusOf()).toBe('setting-general-proxy')
 
     // Strip landed; the next render sees a search without focus
-    delete searchMock.focus
+    delete searchMock.focusId
     view.rerender(<SettingsFocusUrl />)
     expect(navigateMock).toHaveBeenCalledTimes(1)
 
     // A second deep link reintroduces focus — one more injection
-    searchMock.focus = 'setting-general-totray'
+    searchMock.focusId = 'setting-general-totray'
     view.rerender(<SettingsFocusUrl />)
     expect(navigateMock).toHaveBeenCalledTimes(2)
     expect(pendingFocusOf()).toBe('setting-general-totray')
@@ -85,11 +96,11 @@ describe('SettingsFocusUrl', () => {
 
   it('strips focus while preserving other params (q coexistence)', () => {
     searchMock.q = 'proxy'
-    searchMock.focus = 'setting-general-proxy'
+    searchMock.focusId = 'setting-general-proxy'
     render(<SettingsFocusUrl />)
 
     const call = navigateMock.mock.calls[0][0]
-    expect(call.search({ q: 'proxy', focus: 'setting-general-proxy' })).toEqual({ q: 'proxy' })
+    expect(call.search({ q: 'proxy', focusId: 'setting-general-proxy' })).toEqual({ q: 'proxy' })
   })
 
   it('drives the scroll pipeline end to end from a URL focus', () => {
@@ -100,7 +111,7 @@ describe('SettingsFocusUrl', () => {
     scope.appendChild(target)
     Element.prototype.scrollIntoView = vi.fn()
 
-    searchMock.focus = 'setting-general-proxy'
+    searchMock.focusId = 'setting-general-proxy'
     render(
       <>
         <SettingsFocusUrl />

--- a/src/renderer/pages/settings/settingsSearch/__tests__/SettingsFocusUrl.test.tsx
+++ b/src/renderer/pages/settings/settingsSearch/__tests__/SettingsFocusUrl.test.tsx
@@ -1,0 +1,118 @@
+import { render, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SettingsFocusScroll from '../SettingsFocusScroll'
+import SettingsFocusUrl from '../SettingsFocusUrl'
+import { setPendingFocus, useSettingsSearchKeyboard } from '../store'
+
+const { locationMock, navigateMock, searchMock } = vi.hoisted(() => ({
+  locationMock: { pathname: '/settings/general' },
+  navigateMock: vi.fn(),
+  searchMock: {} as Record<string, unknown>
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => locationMock,
+  useNavigate: () => navigateMock,
+  // Fresh object per render (pessimistic vs TanStack structural sharing):
+  // effect deps must survive reference changes and re-run safely
+  useSearch: () => ({ ...searchMock })
+}))
+
+describe('SettingsFocusUrl', () => {
+  beforeEach(() => {
+    locationMock.pathname = '/settings/general'
+    searchMock.q = undefined
+    searchMock.focus = undefined
+    navigateMock.mockReset()
+    setPendingFocus(undefined)
+  })
+
+  const pendingFocusOf = () => renderHook(() => useSettingsSearchKeyboard()).result.current.pendingFocusId
+
+  it('forwards a ?focus= anchor into the store and strips only that key', () => {
+    searchMock.focus = 'setting-general-proxy'
+    render(<SettingsFocusUrl />)
+
+    expect(pendingFocusOf()).toBe('setting-general-proxy')
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    const call = navigateMock.mock.calls[0][0]
+    expect(call.to).toBe('/settings/general')
+    expect(call.replace).toBe(true)
+    expect(call.search({ focus: 'setting-general-proxy', panel: 'data' })).toEqual({ panel: 'data' })
+  })
+
+  it('does nothing without a focus param', () => {
+    render(<SettingsFocusUrl />)
+
+    expect(pendingFocusOf()).toBeUndefined()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores a non-string focus value', () => {
+    searchMock.focus = 42
+    render(<SettingsFocusUrl />)
+
+    expect(pendingFocusOf()).toBeUndefined()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores an empty-string focus (blank anchor must not reach the selector)', () => {
+    searchMock.focus = ''
+    render(<SettingsFocusUrl />)
+
+    expect(pendingFocusOf()).toBeUndefined()
+    expect(navigateMock).not.toHaveBeenCalled()
+  })
+
+  it('re-injects when focus reappears (second agent deep link into the same tab)', () => {
+    searchMock.focus = 'setting-general-proxy'
+    const view = render(<SettingsFocusUrl />)
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+    expect(pendingFocusOf()).toBe('setting-general-proxy')
+
+    // Strip landed; the next render sees a search without focus
+    delete searchMock.focus
+    view.rerender(<SettingsFocusUrl />)
+    expect(navigateMock).toHaveBeenCalledTimes(1)
+
+    // A second deep link reintroduces focus — one more injection
+    searchMock.focus = 'setting-general-totray'
+    view.rerender(<SettingsFocusUrl />)
+    expect(navigateMock).toHaveBeenCalledTimes(2)
+    expect(pendingFocusOf()).toBe('setting-general-totray')
+  })
+
+  it('strips focus while preserving other params (q coexistence)', () => {
+    searchMock.q = 'proxy'
+    searchMock.focus = 'setting-general-proxy'
+    render(<SettingsFocusUrl />)
+
+    const call = navigateMock.mock.calls[0][0]
+    expect(call.search({ q: 'proxy', focus: 'setting-general-proxy' })).toEqual({ q: 'proxy' })
+  })
+
+  it('drives the scroll pipeline end to end from a URL focus', () => {
+    const scope = document.createElement('div')
+    document.body.appendChild(scope)
+    const target = document.createElement('div')
+    target.id = 'setting-general-proxy'
+    scope.appendChild(target)
+    Element.prototype.scrollIntoView = vi.fn()
+
+    searchMock.focus = 'setting-general-proxy'
+    render(
+      <>
+        <SettingsFocusUrl />
+        <SettingsFocusScroll scopeRef={{ current: scope }} />
+      </>
+    )
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(target.classList.contains('search-hit-highlight')).toBe(true)
+    expect(pendingFocusOf()).toBeUndefined()
+
+    delete (Element.prototype as Partial<Element>).scrollIntoView
+    document.body.innerHTML = ''
+  })
+})

--- a/src/renderer/pages/settings/settingsSearch/store.ts
+++ b/src/renderer/pages/settings/settingsSearch/store.ts
@@ -8,8 +8,11 @@
  * other's selection/jump/highlight intent. Accepted as low-risk: every field
  * is recoverable ephemeral UI state, and <Activity> hide runs unmount
  * cleanups, so a hidden tab releases liveQuery and its jump handler instead
- * of leaking them. EXIT CONDITION: once tab session identity/ownership is
- * unified (the per-tab session class of bugs, e.g. #18885 / #18879), delete
+ * of leaking them. The recognized pendingFocus intent writers are the search
+ * results page's goTo and the URL translator (SettingsFocusUrl) —
+ * SettingsFocusScroll only consumes/clears it, and more writers do not
+ * extend the protocol. EXIT CONDITION: once tab session identity/ownership
+ * is unified (the per-tab session class of bugs, e.g. #18885 / #18879), delete
  * this module and move the state to the owning tab's context/provider.
  */
 import { useSyncExternalStore } from 'react'


### PR DESCRIPTION
## What

> **Review revision (kangfenmao, P1):** the param is `?focusId=`, not `?focus=` — `/settings/model` already owns `?focus=default|translate` for its default/translate rows, so the anchor contract took a separate key. The legacy param is never read, forwarded, or stripped (pinned by an ownership test).

Implements the URL focus contract proposed by @EurFelux in #19345 (discussion 3889116717): any settings route now accepts `?focusId=<dom anchor id>`, scrolls to and flashes the target row (identical behavior to clicking a search result), then strips the one-shot param.

- New headless `SettingsFocusUrl` mounted in the settings layout: reads `?focusId=` → forwards into the store's `pendingFocus` (the same seam the results page's `goTo` uses) → strips the param with a commit-time search updater that composes with concurrent param consumers (e.g. provider's `?id=` strip)
- `SettingsFocusScroll` / `store` / route schemas: zero behavior change (the store header documents the recognized intent writers per the legacy-module contract note)
- Loose validation + consumer-side fallback: unknown/blank anchors degrade silently through the existing retry-exhaustion path

## Why now

Anchors are deterministic and CI-audited already; exposing them as URLs is cheap today and expensive later (URL-shape migration once links exist). Enables in-app Agents to hand users direct URLs to specific settings items, and documentation-site deeplinks.

## Deliberate deviation from the review suggestion

The suggestion said "SettingsFocusScroll consume focus intent from the URL". This PR keeps FocusScroll URL-agnostic and adds a small translator at the store seam instead — same intent (URL is the source of focus intent), but FocusScroll's interface (scopeRef + pendingFocusId) stays minimal and both intent sources (result clicks, deep links) converge in the store.

## Testing

- 7 unit tests: inject+strip-only-that-key / no param no-op / non-string ignored / empty-string guarded / idempotent re-run + second-deep-link re-injection / q coexistence / end-to-end pipeline into the scoped scroll
- CDP on-device 5/5: in-tab deep link, cross-tab Agent path (settings-tab singleton retarget + query passthrough), `?panel=` coexistence, reload idempotency (strip proof via persisted tab url), provider `?id=` + `?focusId=` combo
- Full settings suite green (133 files / 1029 tests), typecheck/oxlint/biome clean

Stacked on #19346 (merge order: #19345 → #19346 → this). Draft until the stack underneath merges.
