### PR TITLE
fix(chat): keep thinking elapsed stable across tab switches

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessageProcessGroup.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessageProcessGroup.tsx
@@ -69,13 +69,21 @@ const LazyCompletedProcessContent = React.memo(function LazyCompletedProcessCont
 
 const ActiveProcessHeader = React.memo(function ActiveProcessHeader({
   createdAt,
+  startedAtMs,
   toolItems
 }: {
   createdAt: string
+  startedAtMs?: number
   toolItems: ToolRenderItem[]
 }) {
   const { t } = useTranslation()
-  const elapsedMs = usePlaceholderElapsedMs(true, createdAt, 1000)
+  const effectiveCreatedAt = useMemo(() => {
+    if (startedAtMs !== undefined && Number.isFinite(startedAtMs)) {
+      return new Date(startedAtMs).toISOString()
+    }
+    return createdAt
+  }, [createdAt, startedAtMs])
+  const elapsedMs = usePlaceholderElapsedMs(true, effectiveCreatedAt, 1000)
   const elapsedText = formatPlaceholderElapsed(elapsedMs, t)
   const summary = t('message.processing').replace(/(?:\.{3}|…)\s*$/u, '')
 
@@ -111,7 +119,11 @@ const MessageProcessGroup = React.memo(function MessageProcessGroup(props: Props
           data-testid="live-tool-group-header"
           className="flex min-h-7 w-full select-none items-center py-0.5 text-left">
           <div className="min-w-0 flex-1 overflow-hidden">
-            <ActiveProcessHeader createdAt={message.createdAt} toolItems={toolItems} />
+            <ActiveProcessHeader
+              createdAt={message.createdAt}
+              startedAtMs={runtimeTiming?.startedAt}
+              toolItems={toolItems}
+            />
           </div>
         </div>
         <div data-testid="live-tool-group-content" className={`${PROCESS_CONTENT_CLASS_NAME} pt-2`}>

--- a/src/renderer/components/chat/messages/blocks/PlaceholderBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/PlaceholderBlock.tsx
@@ -35,7 +35,23 @@ export function usePlaceholderElapsedMs(isProcessing: boolean, createdAt: string
     updateElapsed()
 
     const timer = setInterval(updateElapsed, updateIntervalMs)
-    return () => clearInterval(timer)
+
+    const handleVisibilityChange = () => {
+      if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+        updateElapsed()
+      }
+    }
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', handleVisibilityChange)
+    }
+
+    return () => {
+      clearInterval(timer)
+      if (typeof document !== 'undefined') {
+        document.removeEventListener('visibilitychange', handleVisibilityChange)
+      }
+    }
   }, [createdAt, isProcessing, updateIntervalMs])
 
   return elapsedMs


### PR DESCRIPTION
### What this PR does

Before this PR:
When a model is thinking and the user switches AppShell/Browser tabs, the thinking time counter restarts from 0 after switching back (reported on VLLM 0.19.0 / Qwen3 27B-FP8, Windows V1.9.13).

After this PR:
Thinking/processing elapsed time stays continuous across tab switches and visibility changes.

Fixes #19742

### Why we need it and why it was done in this way

`usePlaceholderElapsedMs` computed elapsed as `Date.now() - Date.parse(createdAt)` on a `setInterval(1000)`. Background tabs throttle intervals, so the next tick after returning is delayed and shows a stale/0s value. Added a `visibilitychange` listener to recalc immediately when `document.visibilityState === 'visible'`.

`ActiveProcessHeader` used `message.createdAt` for active elapsed, while completed elapsed used `runtimeTiming.startedAt`. Now it prefers `runtimeTiming.startedAt` when available (fallback to `createdAt`), so the displayed duration tracks the actual processing window and survives remounts.

The following tradeoffs were made:
- Kept `Date.now()`-based calc (self-correcting) instead of an incremental counter or global store.
- Minimal scope: only `PlaceholderBlock` hook + `MessageProcessGroup` header, no tab infrastructure changes.

The following alternatives were considered:
- Persisting elapsed in store/localStorage — unnecessary, `Date.now() - startedAt` is pure.
- Using `performance.now()` anchored at stream start — fragile across reloads.

Links to places where the discussion took place: #19742

### Breaking changes

NONE

### Special notes for your reviewer

Verified via `vitest run` for `PlaceholderBlock.test.tsx` + `MessageProcessGroup.test.tsx` (6 tests passed). The visible timer is the process header `elapsedText` (`ToolBlockGroupHeaderContent`), not `ThinkingBlock` itself (which intentionally shows only "Thinking"/"Deep reasoning").

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: left the code cleaner than found
- [x] Upgrade: no upgrade impact
- [x] Documentation: not required (bug fix, no user-facing doc change)
- [x] Self-review: reviewed via `gh pr diff`

### Release note

```release-note
Fix thinking time restarting from 0 when switching tabs during streaming.
```

Fixes: #19742