### PR TITLE
fix(selection): inherit quickAssistant MCP for built-in quick actions

### DIFF
--- a/src/renderer/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/windows/selection/action/components/ActionGeneral.tsx
@@ -41,9 +41,15 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
   const [language] = usePreference('app.language')
   const [showOriginal, setShowOriginal] = useState(false)
 
+  const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
   const { assistant: chosenAssistant } = useAssistant(action.assistantId ?? '')
-  const chosenAssistantId = chosenAssistant?.id
-  const waitingForConfiguredAssistant = Boolean(action.assistantId) && !chosenAssistantId
+  const { assistant: fallbackAssistant } = useAssistant(
+    !action.assistantId && quickAssistantId ? (quickAssistantId as string) : ''
+  )
+  const chosenAssistantId = chosenAssistant?.id ?? fallbackAssistant?.id
+  const waitingForConfiguredAssistant =
+    (Boolean(action.assistantId) && !chosenAssistant?.id) ||
+    (!action.assistantId && Boolean(quickAssistantId) && !fallbackAssistant?.id)
 
   // Temporary in-memory topic — never touches SQLite, released on unmount.
   const { topicId: temporaryTopicId, ready } = useTemporaryTopic({

--- a/src/renderer/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/windows/selection/action/components/ActionGeneral.tsx
@@ -44,7 +44,7 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
   const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
   const { assistant: chosenAssistant } = useAssistant(action.assistantId ?? '')
   const { assistant: fallbackAssistant } = useAssistant(
-    !action.assistantId && quickAssistantId ? (quickAssistantId as string) : ''
+    !action.assistantId && quickAssistantId ? quickAssistantId : ''
   )
   const chosenAssistantId = chosenAssistant?.id ?? fallbackAssistant?.id
   const waitingForConfiguredAssistant =

--- a/src/renderer/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/windows/selection/action/components/ActionGeneral.tsx
@@ -43,9 +43,7 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
 
   const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
   const { assistant: chosenAssistant } = useAssistant(action.assistantId ?? '')
-  const { assistant: fallbackAssistant } = useAssistant(
-    !action.assistantId && quickAssistantId ? quickAssistantId : ''
-  )
+  const { assistant: fallbackAssistant } = useAssistant(!action.assistantId && quickAssistantId ? quickAssistantId : '')
   const chosenAssistantId = chosenAssistant?.id ?? fallbackAssistant?.id
   const waitingForConfiguredAssistant =
     (Boolean(action.assistantId) && !chosenAssistant?.id) ||

--- a/src/renderer/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/windows/selection/action/components/ActionGeneral.tsx
@@ -42,12 +42,15 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
   const [showOriginal, setShowOriginal] = useState(false)
 
   const [quickAssistantId] = usePreference('feature.quick_assistant.assistant_id')
-  const { assistant: chosenAssistant } = useAssistant(action.assistantId ?? '')
-  const { assistant: fallbackAssistant } = useAssistant(!action.assistantId && quickAssistantId ? quickAssistantId : '')
+  const { assistant: chosenAssistant, isLoading: isChosenLoading } = useAssistant(action.assistantId ?? '')
+  const shouldUseFallback = action.isBuiltIn && !action.assistantId && !!quickAssistantId
+  const { assistant: fallbackAssistant, isLoading: isFallbackLoading } = useAssistant(
+    shouldUseFallback ? quickAssistantId : ''
+  )
   const chosenAssistantId = chosenAssistant?.id ?? fallbackAssistant?.id
   const waitingForConfiguredAssistant =
-    (Boolean(action.assistantId) && !chosenAssistant?.id) ||
-    (!action.assistantId && Boolean(quickAssistantId) && !fallbackAssistant?.id)
+    (Boolean(action.assistantId) && isChosenLoading) ||
+    (shouldUseFallback && isFallbackLoading)
 
   // Temporary in-memory topic — never touches SQLite, released on unmount.
   const { topicId: temporaryTopicId, ready } = useTemporaryTopic({

--- a/src/renderer/windows/selection/action/components/ActionGeneral.tsx
+++ b/src/renderer/windows/selection/action/components/ActionGeneral.tsx
@@ -49,8 +49,7 @@ const ActionGeneral: FC<Props> = React.memo(({ action, scrollToBottom }) => {
   )
   const chosenAssistantId = chosenAssistant?.id ?? fallbackAssistant?.id
   const waitingForConfiguredAssistant =
-    (Boolean(action.assistantId) && isChosenLoading) ||
-    (shouldUseFallback && isFallbackLoading)
+    (Boolean(action.assistantId) && isChosenLoading) || (shouldUseFallback && isFallbackLoading)
 
   // Temporary in-memory topic — never touches SQLite, released on unmount.
   const { topicId: temporaryTopicId, ready } = useTemporaryTopic({

--- a/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
+++ b/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
@@ -46,11 +46,16 @@ vi.mock('@ai-sdk/react', () => ({
 }))
 
 vi.mock('@data/hooks/usePreference', () => ({
-  usePreference: () => ['en-US']
+  usePreference: (key: string) => {
+    if (key === 'feature.quick_assistant.assistant_id') return ['']
+    return ['en-US']
+  }
 }))
 
 vi.mock('@renderer/hooks/useAssistant', () => ({
-  useAssistant: () => ({ assistant: state.assistant })
+  useAssistant: (id: string) => ({
+    assistant: id ? state.assistant : undefined
+  })
 }))
 
 vi.mock('@renderer/hooks/useTemporaryTopic', () => ({

--- a/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
+++ b/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
@@ -9,6 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const state = vi.hoisted(() => ({
   assistant: undefined as { id: string } | undefined,
+  fallbackAssistant: undefined as { id: string } | undefined,
+  quickAssistantId: '' as string,
   sendMessage: vi.fn(),
   stopChat: vi.fn(),
   temporaryTopicOptions: [] as Array<{ enabled?: boolean; assistantId?: string }>,
@@ -47,15 +49,17 @@ vi.mock('@ai-sdk/react', () => ({
 
 vi.mock('@data/hooks/usePreference', () => ({
   usePreference: (key: string) => {
-    if (key === 'feature.quick_assistant.assistant_id') return ['']
+    if (key === 'feature.quick_assistant.assistant_id') return [state.quickAssistantId]
     return ['en-US']
   }
 }))
 
 vi.mock('@renderer/hooks/useAssistant', () => ({
-  useAssistant: (id: string) => ({
-    assistant: id ? state.assistant : undefined
-  })
+  useAssistant: (id: string) => {
+    if (!id) return { assistant: undefined }
+    if (id === state.quickAssistantId) return { assistant: state.fallbackAssistant }
+    return { assistant: state.assistant }
+  }
 }))
 
 vi.mock('@renderer/hooks/useTemporaryTopic', () => ({
@@ -133,6 +137,8 @@ function createAction(overrides: Partial<SelectionActionItem> = {}): SelectionAc
 describe('ActionGeneral', () => {
   beforeEach(() => {
     state.assistant = undefined
+    state.fallbackAssistant = undefined
+    state.quickAssistantId = ''
     state.sendMessage.mockClear()
     state.stopChat.mockClear()
     state.temporaryTopicOptions = []
@@ -191,6 +197,32 @@ describe('ActionGeneral', () => {
 
     await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
     expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: 'assistant-1' })
+  })
+
+  it('falls back to quickAssistant when built-in has no explicit assistant', async () => {
+    state.quickAssistantId = 'fallback-1'
+    state.fallbackAssistant = { id: 'fallback-1' }
+
+    render(<ActionGeneral action={createAction({ assistantId: '' })} />)
+
+    await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
+    expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: 'fallback-1' })
+  })
+
+  it('waits for fallback assistant when quickAssistant is configured but not yet loaded', async () => {
+    state.quickAssistantId = 'fallback-1'
+    state.fallbackAssistant = undefined
+
+    const { rerender } = render(<ActionGeneral action={createAction({ assistantId: '' })} />)
+
+    expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: false, assistantId: undefined })
+    expect(state.sendMessage).not.toHaveBeenCalled()
+
+    state.fallbackAssistant = { id: 'fallback-1' }
+    rerender(<ActionGeneral action={createAction({ assistantId: '' })} />)
+
+    await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
+    expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: 'fallback-1' })
   })
 
   it('localizes a known error and leaves space above it', () => {

--- a/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
+++ b/src/renderer/windows/selection/action/components/__tests__/ActionGeneral.test.tsx
@@ -11,6 +11,8 @@ const state = vi.hoisted(() => ({
   assistant: undefined as { id: string } | undefined,
   fallbackAssistant: undefined as { id: string } | undefined,
   quickAssistantId: '' as string,
+  isFallbackLoading: false as boolean,
+  isChosenLoading: false as boolean,
   sendMessage: vi.fn(),
   stopChat: vi.fn(),
   temporaryTopicOptions: [] as Array<{ enabled?: boolean; assistantId?: string }>,
@@ -56,9 +58,11 @@ vi.mock('@data/hooks/usePreference', () => ({
 
 vi.mock('@renderer/hooks/useAssistant', () => ({
   useAssistant: (id: string) => {
-    if (!id) return { assistant: undefined }
-    if (id === state.quickAssistantId) return { assistant: state.fallbackAssistant }
-    return { assistant: state.assistant }
+    if (!id) return { assistant: undefined, isLoading: false }
+    if (id === state.quickAssistantId) {
+      return { assistant: state.fallbackAssistant, isLoading: state.isFallbackLoading }
+    }
+    return { assistant: state.assistant, isLoading: state.isChosenLoading }
   }
 }))
 
@@ -139,6 +143,8 @@ describe('ActionGeneral', () => {
     state.assistant = undefined
     state.fallbackAssistant = undefined
     state.quickAssistantId = ''
+    state.isFallbackLoading = false
+    state.isChosenLoading = false
     state.sendMessage.mockClear()
     state.stopChat.mockClear()
     state.temporaryTopicOptions = []
@@ -186,12 +192,14 @@ describe('ActionGeneral', () => {
   })
 
   it('waits for a configured assistant before leasing and sending', async () => {
+    state.isChosenLoading = true
     const action = createAction({ assistantId: 'assistant-1' })
     const { rerender } = render(<ActionGeneral action={action} />)
 
     expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: false, assistantId: undefined })
     expect(state.sendMessage).not.toHaveBeenCalled()
 
+    state.isChosenLoading = false
     state.assistant = { id: 'assistant-1' }
     rerender(<ActionGeneral action={{ ...action }} />)
 
@@ -212,17 +220,44 @@ describe('ActionGeneral', () => {
   it('waits for fallback assistant when quickAssistant is configured but not yet loaded', async () => {
     state.quickAssistantId = 'fallback-1'
     state.fallbackAssistant = undefined
+    state.isFallbackLoading = true
 
     const { rerender } = render(<ActionGeneral action={createAction({ assistantId: '' })} />)
 
     expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: false, assistantId: undefined })
     expect(state.sendMessage).not.toHaveBeenCalled()
 
+    state.isFallbackLoading = false
     state.fallbackAssistant = { id: 'fallback-1' }
     rerender(<ActionGeneral action={createAction({ assistantId: '' })} />)
 
     await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
     expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: 'fallback-1' })
+  })
+
+  it('does not fall back for custom actions configured with default model', async () => {
+    state.quickAssistantId = 'fallback-1'
+    state.fallbackAssistant = { id: 'fallback-1' }
+
+    render(
+      <ActionGeneral
+        action={createAction({ id: 'custom', isBuiltIn: false, assistantId: '', prompt: 'hello', selectedText: 'hi' })}
+      />
+    )
+
+    await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
+    expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: undefined })
+  })
+
+  it('degrades to no-assistant when fallback assistant is stale (not found)', async () => {
+    state.quickAssistantId = 'deleted-id'
+    state.fallbackAssistant = undefined
+    state.isFallbackLoading = false
+
+    render(<ActionGeneral action={createAction({ assistantId: '' })} />)
+
+    await waitFor(() => expect(state.sendMessage).toHaveBeenCalledTimes(1))
+    expect(state.temporaryTopicOptions.at(-1)).toEqual({ enabled: true, assistantId: undefined })
   })
 
   it('localizes a known error and leaves space above it', () => {

--- a/src/renderer/windows/selection/action/entryPoint.tsx
+++ b/src/renderer/windows/selection/action/entryPoint.tsx
@@ -14,7 +14,8 @@ await prepareWindow({
     'ui.theme_user.color_primary',
     'feature.selection.auto_close',
     'feature.selection.auto_pin',
-    'feature.selection.action_window_opacity'
+    'feature.selection.action_window_opacity',
+    'feature.quick_assistant.assistant_id'
   ]
 })
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Built-in selection quick actions (summary, explain, translate, etc.) had no `assistantId` in `DefaultPreferences`. `ActionGeneral` leased an assistant-less temporary topic (`assistantId: undefined`), so `TemporaryChatContextProvider` created an `AiStreamRequest` with no `assistantId` and `buildAgentParams` never resolved MCP/built-in tools. Users with an MCP-enabled quickAssistant still got baked-in model responses instead of live tool calls when using quick actions.

After this PR:
When a selection action has no explicit `assistantId` but `feature.quick_assistant.assistant_id` is configured, `ActionGeneral` falls back to that assistant. The leased temporary topic now carries the correct `assistantId`, the stream provider preserves it, and `AiService.buildAgentParams` resolves MCP + built-in tools normally.

Fixes: #19740

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Fallback is only to `feature.quick_assistant.assistant_id`, not to an arbitrary assistant. This matches the existing user intent (quickAssistant is the surface where MCP is configured for transient chats) and avoids surprising users who intentionally keep quick actions assistant-less.
- No Main-process change was needed; the provider chain already handles `assistantId` correctly. The fix is a single renderer fallback, keeping the change surgical.

The following alternatives were considered:
- Make every assistant-less temporary topic auto-pick an MCP-capable assistant in `TemporaryChatContextProvider`. Rejected as too broad; it would affect home/quick-assistant model-mode and other transient surfaces that intentionally have no assistant.
- Make built-ins editable for assistant selection in settings UI. Valid follow-up, but out of scope for this bug fix.

Links to places where the discussion took place: #19740, #16203

### Breaking changes

N/A

### Special notes for your reviewer

- `ActionGeneral.test.tsx` mocks updated to be key-aware for `usePreference`/`useAssistant` so the new fallback path is exercised.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code before requesting review from others

### Release note

```release-note
Fix built-in selection quick actions (summary, explain, etc.) to call MCP tools when a quickAssistant with MCP is configured.
```