### PR TITLE
feat(agent-chat): add global search action

### DIFF
--- a/src/renderer/pages/agents/components/AgentChatNavbar/Tools.tsx
+++ b/src/renderer/pages/agents/components/AgentChatNavbar/Tools.tsx
@@ -1,14 +1,30 @@
+import { CommandTooltip } from '@renderer/components/command'
+import GlobalSearchPopup from '@renderer/components/GlobalSearch/GlobalSearchPopup'
+import NavbarIcon from '@renderer/components/NavbarIcon'
+import { Search } from 'lucide-react'
 import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   children?: ReactNode
 }
 
 const Tools = ({ children }: Props) => {
+  const { t } = useTranslation()
+  const searchLabel = t('globalSearch.open')
+
+  const openGlobalSearch = () => {
+    void GlobalSearchPopup.show()
+  }
+
   return (
     <div className="flex items-center gap-0.5">
       {children}
-      {/* TODO: Add search button back when global search supports agent messages */}
+      <CommandTooltip command="app.search" label={searchLabel} placement="bottom" delay={800}>
+        <NavbarIcon tone="conversation" aria-label={searchLabel} onClick={openGlobalSearch}>
+          <Search size={16} strokeWidth={1.8} />
+        </NavbarIcon>
+      </CommandTooltip>
     </div>
   )
 }

--- a/src/renderer/pages/agents/components/AgentChatNavbar/__tests__/Tools.test.tsx
+++ b/src/renderer/pages/agents/components/AgentChatNavbar/__tests__/Tools.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  showGlobalSearch: vi.fn()
+}))
+
+vi.mock('@renderer/components/command', () => ({
+  CommandTooltip: ({ children }: { children: ReactNode }) => children
+}))
+
+vi.mock('@renderer/components/GlobalSearch/GlobalSearchPopup', () => ({
+  default: {
+    show: mocks.showGlobalSearch
+  }
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({ 'globalSearch.open': 'Open global search' })[key] ?? key
+  })
+}))
+
+import Tools from '../Tools'
+
+describe('Agent navbar tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens global search from the agent navbar', async () => {
+    const user = userEvent.setup()
+
+    render(<Tools />)
+
+    await user.click(screen.getByRole('button', { name: 'Open global search' }))
+
+    expect(mocks.showGlobalSearch).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The Agent conversation navbar had no search action even though global search already supports Agent sessions and messages.

After this PR:

The active Agent navbar exposes the existing global search popup with the shared shortcut tooltip, conversation toolbar styling, and an accessible label.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

N/A — tracked from user feedback in DEV; no public GitHub issue exists.

### Why we need it and why it was done in this way

Agent users need a discoverable way to search their sessions and messages from the surface where they work. Reusing `GlobalSearchPopup` keeps one search implementation and preserves the existing Agent result and navigation behavior.

The following tradeoffs were made:

- The action opens the existing all-sources search instead of applying an Agent-only filter, matching the application-wide search command.
- The action appears only when an Agent is active, matching the existing lifetime of Agent-scoped navbar tools.

The following alternatives were considered:

- A separate Agent search popup was rejected because it would duplicate query, keyboard, and navigation behavior already owned by global search.

Links to places where the discussion took place: N/A — internal DEV user-feedback record.

### Breaking changes

None.

If this PR introduces breaking changes, please describe the changes and the impact on users.

### Special notes for your reviewer

The regression test proves that the Agent navbar action has an accessible name and opens the external global-search surface. Global search result behavior remains covered by its existing tests.

Runtime validation used an isolated Electron profile and the exact worktree target. From the Agent navbar, the action opened global search and a query for `Cherry Support` returned the built-in Agent result.

Validation:

- `pnpm test:renderer src/renderer/pages/agents/components/AgentChatNavbar/__tests__/Tools.test.tsx src/renderer/pages/agents/components/AgentChatNavbar/__tests__/AgentContent.test.tsx` (8/8)
- `pnpm lint`
- `pnpm test:lint`
- `git diff --check`

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Added a global search action to the Agent conversation toolbar.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reuse of existing global search entry points; no auth, data, or search logic changes.
> 
> **Overview**
> Re-enables global search on the **Agent conversation toolbar** by replacing a TODO comment with a search control that matches other shell surfaces.
> 
> The button uses the shared **`app.search`** command tooltip, **`globalSearch.open`** label, conversation **`NavbarIcon`** styling, and calls **`GlobalSearchPopup.show()`** on click—same wiring as the main tab bar, without an Agent-only filter.
> 
> Adds a focused unit test that the control is an accessible button and invokes the global search popup when clicked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e85186c501f4502e934b0752032b6c57e8073a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->