### PR TITLE
fix(chat-citations): drop citation markers the message cannot resolve

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
+++ b/src/renderer/components/chat/messages/blocks/MainTextBlock.tsx
@@ -9,6 +9,7 @@ import { isComposerInputTokenKind } from '@renderer/utils/composerTokenPolicy'
 import {
   type MessageCitations,
   type ResolvedCitationMarkers,
+  stripCitationMarkers,
   withToolCitationTags
 } from '@renderer/utils/message/citations'
 import { readComposerFileTokenIdSuffix } from '@renderer/utils/message/composerFileTokenSource'
@@ -398,9 +399,12 @@ const MainTextBlock: React.FC<Props> = ({
       if (toolCitations) {
         return withToolCitationTags(rawText, toolCitations.citations, toolCitations.projection.byMarker).content
       }
-      return rawText
+      // No citation at all in this message, so no marker in it can resolve — a model reusing an id
+      // minted by an earlier turn is the usual way here (#19771). Drop them rather than printing
+      // internal ids. User text is left alone: a literal `[cite:…]` there is the author's own.
+      return role === 'assistant' ? stripCitationMarkers(rawText) : rawText
     },
-    [citationReferences, citations, toolCitations]
+    [citationReferences, citations, role, toolCitations]
   )
   const toolCitedCitations = toolCitations?.projection.cited ?? EMPTY_CITATIONS
   const footerCitations = citations.length > 0 ? citations : toolCitedCitations

--- a/src/renderer/components/chat/messages/blocks/__tests__/MainTextBlock.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MainTextBlock.test.tsx
@@ -3,6 +3,7 @@ import type { ReadOnlyComposerFileTokenPreview } from '@renderer/components/comp
 import type { Citation } from '@renderer/types/message'
 import type { Model } from '@renderer/types/model'
 import { WEB_SEARCH_SOURCE } from '@renderer/types/webSearchProvider'
+import type * as CitationUtils from '@renderer/utils/citation'
 import type { ComposerMessageSnapshot } from '@shared/data/types/uiParts'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -207,8 +208,10 @@ vi.mock('react-i18next', () => ({
   })
 }))
 
-// Mock citation utilities
-vi.mock('@renderer/utils/citation', () => ({
+// Mock citation utilities. Only the tag-emitting entry points are stubbed — the marker pattern and
+// the code-block-aware walker stay real so the strip path under test behaves like production.
+vi.mock('@renderer/utils/citation', async (importOriginal) => ({
+  ...(await importOriginal<typeof CitationUtils>()),
   toTooltipCitation: vi.fn((citation: Citation) => citation),
   withCitationTags: vi.fn((content: string, citations: any[]) => {
     if (citations.length > 0) {
@@ -1196,6 +1199,24 @@ Hidden answer
 
       expect(screen.getByText('Markdown: Content [1]')).toBeInTheDocument()
       expect(mockWithCitationTags).not.toHaveBeenCalled()
+    })
+
+    // #19771: the reported answer reused a `[cite:…]` id minted by an earlier turn, so this
+    // message resolved no citation of its own and the internal id was printed verbatim.
+    it('drops [cite:id] markers from an assistant message that resolved no citation', () => {
+      renderMainTextBlock({
+        content: '1. 工程立项审计；[cite:2598d0ab-1]\n2. 工程采购审计；[cite:2598d0ab-1]',
+        role: 'assistant'
+      })
+
+      expect(getRenderedMarkdown()).toHaveAttribute('data-content', '1. 工程立项审计；\n2. 工程采购审计；')
+    })
+
+    it('keeps a literal [cite:id] typed by the user', () => {
+      mockRenderConfig.renderInputMessageAsMarkdown = true
+      renderMainTextBlock({ content: 'What does [cite:2598d0ab-1] mean?', role: 'user' })
+
+      expect(getRenderedMarkdown()).toHaveAttribute('data-content', 'What does [cite:2598d0ab-1] mean?')
     })
   })
 

--- a/src/renderer/utils/__tests__/citation.test.ts
+++ b/src/renderer/utils/__tests__/citation.test.ts
@@ -445,7 +445,7 @@ Numbered list:
       expect(result).toContain('3</sup>](https://example3.com) citations')
     })
 
-    it('should preserve non-matching cite marks', () => {
+    it('should drop non-matching cite marks instead of exposing the internal id', () => {
       const content = 'Text with [cite:1] and [cite:3] citations'
       const citations: Citation[] = [{ number: 1, url: 'https://example1.com', title: 'Test 1' }]
       const citationMap = createCitationMap(citations)
@@ -453,7 +453,7 @@ Numbered list:
       const result = mapCitationMarksToTags(content, citationMap)
 
       expect(result).toContain('1</sup>](https://example1.com)')
-      expect(result).toContain('[cite:3]') // Should remain unchanged
+      expect(result).toBe("Text with [<sup data-citation='1'>1</sup>](https://example1.com) and citations")
     })
 
     it('should handle nested cite marks', () => {
@@ -480,13 +480,13 @@ Numbered list:
       expect(result).toBe('Text without citations')
     })
 
-    it('should handle malformed citation numbers', () => {
+    it('drops an id-shaped mark it cannot resolve but leaves an empty bracket alone', () => {
       const content = 'Text with [cite:abc] and [cite:] marks'
       const citationMap = new Map()
 
       const result = mapCitationMarksToTags(content, citationMap)
 
-      expect(result).toBe('Text with [cite:abc] and [cite:] marks')
+      expect(result).toBe('Text with and [cite:] marks')
     })
   })
 

--- a/src/renderer/utils/citation.ts
+++ b/src/renderer/utils/citation.ts
@@ -197,15 +197,28 @@ export function normalizeCitationMarks(
 }
 
 /**
+ * A `[cite:id]` marker together with the space that separates it from the
+ * preceding sentence, so a dropped marker takes that space with it instead of
+ * leaving `Claim .` behind. Shared with the export/strip paths in
+ * `utils/message/citations.ts`.
+ */
+export const CITATION_MARKER_PATTERN = /([ \t]?)\[cite:([\w-]+)\]/g
+
+/**
  * Map every `[cite:<id>]` mark to a rendered `[<sup>…</sup>](url)` tag. Keys
  * are wire ids as strings: legacy numeric marks stringify to their number,
  * tool-result ids keep their `<prefix>-<n>` form.
+ *
+ * An id that resolves to nothing is dropped rather than echoed: the id is an
+ * internal, message-scoped handle, so printing it puts implementation detail on
+ * screen (#19771). A model that reuses an id minted in an earlier turn is the
+ * common way to get here, and its markers cannot be resolved from this message.
  */
 export function mapCitationMarksToTags(content: string, citationMap: Map<string, Citation>): string {
   return mapMarkdownOutsideCode(content, (text) =>
-    text.replace(/\[cite:([\w-]+)\]/g, (match, id) => {
+    text.replace(CITATION_MARKER_PATTERN, (_match, space: string, id: string) => {
       const citation = citationMap.get(id)
-      return citation ? generateCitationTag(citation) : match
+      return citation ? `${space}${generateCitationTag(citation)}` : ''
     })
   )
 }

--- a/src/renderer/utils/message/__tests__/citations.test.ts
+++ b/src/renderer/utils/message/__tests__/citations.test.ts
@@ -393,10 +393,23 @@ describe('withToolCitationTags', () => {
     expect(content).toContain('[cite: ]')
   })
 
-  it('leaves unknown ids literal', () => {
+  it('drops an unknown id instead of printing it, taking its separating space with it', () => {
     const mc = resolveMessageCitations([webToolPart(webResults('abc'))])
-    const { content, cited } = withToolCitationTags('Fact. [cite:zzz-9]', mc)
-    expect(content).toContain('[cite:zzz-9]')
+    const { content, cited } = withToolCitationTags('Fact. [cite:zzz-9] Next.', mc)
+    expect(content).toBe('Fact. Next.')
+    expect(cited).toHaveLength(0)
+  })
+
+  // #19771: a model that reuses an id minted by an earlier turn leaves this message with markers
+  // nothing can resolve. Printing them puts an internal id on screen; the export path already
+  // drops such markers, so rendering has to agree.
+  it('drops every marker when the message carries no citation at all', () => {
+    const mc = resolveMessageCitations([textPart('no tool ran in this message')])
+    const { content, cited } = withToolCitationTags(
+      '1. 工程立项审计；[cite:2598d0ab-1]\n2. 工程采购审计；[cite:2598d0ab-1]',
+      mc
+    )
+    expect(content).toBe('1. 工程立项审计；\n2. 工程采购审计；')
     expect(cited).toHaveLength(0)
   })
 

--- a/src/renderer/utils/message/citations.ts
+++ b/src/renderer/utils/message/citations.ts
@@ -24,7 +24,12 @@
 
 import type { Citation } from '@renderer/types/message'
 import { WEB_SEARCH_SOURCE } from '@renderer/types/webSearchProvider'
-import { mapCitationMarksToTags, mapMarkdownOutsideCode, normalizeCitationMarks } from '@renderer/utils/citation'
+import {
+  CITATION_MARKER_PATTERN,
+  mapCitationMarksToTags,
+  mapMarkdownOutsideCode,
+  normalizeCitationMarks
+} from '@renderer/utils/citation'
 import { cleanMarkdownContent } from '@renderer/utils/formats'
 import {
   CITATION_SNIPPET_MAX_CHARS,
@@ -466,20 +471,13 @@ export function resolveCitationMarkers(content: string, citations: MessageCitati
 }
 
 /**
- * A `[cite:id]` marker together with the space that separates it from the
- * preceding sentence, so a dropped marker takes that space with it instead of
- * leaving `Claim .` behind.
- */
-const CITATION_MARKER_PATTERN = /([ \t]?)\[cite:([\w-]+)\]/g
-
-/**
  * Export / copy view: every resolved `[cite:id]` marker becomes a plain `[N]`,
  * and an id that resolves to nothing is dropped — an internal marker must never
  * escape into exported text or the clipboard. Also returns the cited sources in
  * display order so the caller can render a sources list.
  *
- * Rendering deliberately leaves an unresolved id visible (it is a model mistake
- * worth seeing on screen); an export is a finished document, so it is removed.
+ * Rendering drops unresolved ids too (`mapCitationMarksToTags`), so screen,
+ * export and clipboard agree that the internal id never reaches the user.
  */
 export function toExportableCitations(
   content: string,


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

`[cite:id]` ids are minted per lookup call (`citationIds.ts`) and resolved only against the citing message's own tool parts (`resolveMessageCitations`). A model that reuses an id minted in an earlier turn therefore leaves markers that nothing in this message can resolve.

Before this PR: an unresolved marker was echoed back verbatim, printing an internal handle on screen. The reported answer showed `[cite:2598d0ab-1]` three times with no reachable source. Two render paths did this:
- `mapCitationMarksToTags` returned the raw match on a lookup miss.
- `MainTextBlock.processContent` returned the text untouched when the message resolved no citation at all — the path the report actually took.

After this PR: an unresolved marker is dropped, taking its separating space with it so no `Claim .` artifact is left behind, on both paths. Export (`toExportableCitations`) and clipboard already dropped them, so screen, export and clipboard now agree. User-authored text is untouched: a literal `[cite:…]` a user typed is their own content.

Fixes #19771

### Why we need it and why it was done in this way

The previous behavior was deliberate — the doc comment on `toExportableCitations` stated that rendering leaves an unresolved id visible because "it is a model mistake worth seeing on screen". Issue #19771 rejects that tradeoff explicitly: "Internal citation identifiers must never be exposed as user-facing text." This PR flips that one decision and records why in the code.

The following tradeoffs were made:
- **Drop rather than render a placeholder badge.** An id that resolves to nothing has no source, title or URL, so there is no citation UI to show and no tooltip to fill. Dropping matches what export and clipboard have always done; a placeholder would have introduced a fourth, inconsistent rendering of the same marker.
- **Silent removal.** The sentence loses its visual "this came from a source" hint. That signal was already false — the marker pointed at nothing reachable — and the alternative was leaking the internal id.
- **`role === 'assistant'` guard on the no-citation path.** `processContent` also runs for user messages, where a literal `[cite:…]` is author content and must survive.
- **Moved `CITATION_MARKER_PATTERN` into `utils/citation.ts`** so both render and export share one space-aware pattern instead of two copies. `utils/message/citations.ts` already imports from that module, so this direction avoids a cycle.

The following alternatives were considered:
- Making `resolveMessageCitations` resolve ids across the whole conversation. Rejected: ids are only intra-message unique by design (`citationIds.ts`), so cross-message resolution can silently mis-attribute a marker to the wrong source.
- Fixing only `mapCitationMarksToTags`. Rejected: it does not reach the reported case, where the message has zero citations and `processContent` never calls it.

Links to places where the discussion took place: #19771. Sibling report #19756 covers the same symptom for web search and is not otherwise addressed here.

### Breaking changes

None. This changes rendering of markers that never resolved to a source; every resolvable marker renders byte-identically (covered by the existing assertions in `citation.test.ts` and `citations.test.ts`).

### Special notes for your reviewer

Root cause was confirmed by replaying the reported answer text through the resolver:
- with the message's own `kb_search` part present, all three markers render as `<sup data-citation='1'>` badges;
- without it, the output is character-for-character the reported screenshot.

That repro is the new test `drops every marker when the message carries no citation at all` in `citations.test.ts`, plus the component-level pair in `MainTextBlock.test.tsx`.

Two pre-existing tests pinned the old "leave it visible" contract and were rewritten to the new one — `should preserve non-matching cite marks` and `should handle malformed citation numbers` in `citation.test.ts`, and `leaves unknown ids literal` in `citations.test.ts`. An empty bracket (`[cite:]`, `[cite: ]`) still passes through untouched, and markers inside inline/fenced code are still protected.

This does not address the upstream question of *why* the citing turn ran no knowledge-base lookup. The reporter also filed "binding a knowledge base to a new assistant does not take effect", which would leave later turns without `kb_search` (`KnowledgeSearchTool.applies` requires a non-empty scope) and is the likely trigger. That is a separate defect and is not in this PR.

Targeted local verification (per `cherry-bug-diagnose`; full suite deferred to CI):
- `vitest run` on `citation.test.ts`, `citations.test.ts`, `MainTextBlock.test.tsx` — 136 passed
- `vitest run` on the downstream consumers (`markdown/__tests__`, `blocks/__tests__`, `ExportService.test.ts`, `utils/__tests__/export.test.ts`) — 447 passed
- `pnpm run typecheck:web` — clean
- `oxlint` + `biome format` on the six changed files — clean

Deferred to remote CI: full `pnpm test`, repo-wide lint, `i18n:check`, `docs:check`, build.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
[Chat] Citation markers that cannot be matched to a source are no longer shown as raw `[cite:...]` text in answers.
```
