### PR TITLE
fix(mcp-browser): restore tab bar actions on Windows

### DIFF
--- a/src/main/ai/mcp/servers/__tests__/browser.test.ts
+++ b/src/main/ai/mcp/servers/__tests__/browser.test.ts
@@ -118,9 +118,11 @@ vi.mock('electron', () => {
 
 import { application } from '@application'
 import { BrowserWindow, nativeTheme } from 'electron'
+import { JSDOM } from 'jsdom'
 import { beforeEach } from 'vitest'
 
 import { CdpBrowserController } from '../browser'
+import { TAB_BAR_HTML } from '../browser/tabbarHtml'
 
 // WindowManager stub: hands out instances of the mocked BrowserWindow class
 // above, mirroring open()/getWindow()/close() used by the controller.
@@ -152,6 +154,35 @@ describe('CdpBrowserController', () => {
       }
       throw new Error(`Unexpected application.get(${name})`)
     })
+  })
+
+  it('forwards tab-bar actions from window messages to the console bridge', async () => {
+    const dom = new JSDOM(TAB_BAR_HTML, { runScripts: 'dangerously' })
+    const executeJavaScript = vi.fn((script: string) => {
+      dom.window.eval(script)
+      return Promise.resolve(null)
+    })
+    const controller = new CdpBrowserController()
+    ;(
+      controller as unknown as {
+        setupTabBarMessageHandler: (windowInfo: { tabBarView: unknown }) => void
+      }
+    ).setupTabBarMessageHandler({
+      tabBarView: { webContents: { on: vi.fn(), executeJavaScript } }
+    })
+
+    const consoleLog = vi.fn()
+    dom.window.console.log = consoleLog
+
+    dom.window.document.getElementById('minimize-btn')?.dispatchEvent(new dom.window.MouseEvent('click'))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      JSON.stringify({ channel: 'tabbar-action', payload: { type: 'window-minimize' } })
+    )
+
+    dom.window.close()
+    await controller.dispose()
   })
 
   it('executes single-line code via Runtime.evaluate', async () => {

--- a/src/main/ai/mcp/servers/browser/controller.ts
+++ b/src/main/ai/mcp/servers/browser/controller.ts
@@ -271,7 +271,7 @@ export class CdpBrowserController {
       (function() {
         window.addEventListener('message', function(e) {
           if (e.data && e.data.channel === 'tabbar-action') {
-            // Tab bar action received
+            console.log(JSON.stringify(e.data));
           }
         });
       })();


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

The MCP browser tab bar posted renderer actions with `window.postMessage`, but the injected listener did not forward them to the main process. As a result, the custom Windows minimize, maximize/restore, and close controls did nothing.

After this PR:

The injected listener serializes `tabbar-action` messages through the existing `console-message` bridge, allowing `CdpBrowserController.handleTabBarAction()` to process window and tab-bar actions. A regression test exercises a real minimize-button click through the injected bridge.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when merged)*: -->

Fixes #19737

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Reuse the existing message bridge and action handler so the fix remains focused and restores all actions that use the same path.
- Keep the change limited to the missing forwarding step instead of changing the established window-management flow.

The following alternatives were considered:

- A dedicated preload/IPC bridge would be a more robust long-term design, but it would be a broader change than required for this regression.

Links to places where the discussion took place: [Issue #19737](https://github.com/CherryHQ/cherry-studio/issues/19737)

### Breaking changes

None.

### Special notes for your reviewer

- The regression test runs the real tab-bar HTML and injected message bridge, then verifies that a window-control click reaches the console bridge.
- Validation completed with `pnpm lint`, Node type checking, and `pnpm exec vitest run --project main src/main/ai/mcp/servers/__tests__/browser.test.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: The targeted change avoids unrelated refactoring and keeps the existing controller flow intact
- [x] Upgrade: Impact of this change on upgrade flows was considered; no upgrade changes are required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required because this restores existing controls without adding a new workflow
- [x] Self-review: I have reviewed my own code via the branch diff and targeted tests

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
Restore MCP browser window controls and tab-bar actions on Windows.
```
