### PR TITLE
fix(markdown): preserve single-tilde text

### DIFF
--- a/packages/ui/src/components/composites/markdown/__tests__/markdown.test.tsx
+++ b/packages/ui/src/components/composites/markdown/__tests__/markdown.test.tsx
@@ -35,6 +35,21 @@ describe('Markdown (static)', () => {
     expect(container.querySelector('pre')).not.toBeNull()
   })
 
+  it('keeps single tildes literal while retaining double-tilde strikethrough', () => {
+    const { container } = render(
+      <Markdown id="tilde-markdown" plugins={withChatPlugins()}>
+        {'~literal~ and ~~deleted~~\n\n`~inline~`\n\n```text\n~fenced~\n```\n\n$$\n\\tilde{x}\n$$'}
+      </Markdown>
+    )
+
+    expect(container.textContent).toContain('~literal~ and deleted')
+    expect(container.querySelectorAll('del')).toHaveLength(1)
+    expect(container.querySelector('del')?.textContent).toBe('deleted')
+    expect(container.querySelector('code')?.textContent).toBe('~inline~')
+    expect(container.querySelector('pre code')?.textContent).toBe('~fenced~')
+    expect(container.querySelector('math')).not.toBeNull()
+  })
+
   it('renders all GitHub alert types with their semantic classes', () => {
     const alertTypes = ['note', 'tip', 'important', 'warning', 'caution']
     const source = alertTypes.map((type) => `> [!${type.toUpperCase()}]\n> ${type} content`).join('\n\n')

--- a/packages/ui/src/components/composites/markdown/internal.tsx
+++ b/packages/ui/src/components/composites/markdown/internal.tsx
@@ -33,7 +33,13 @@ import {
   SVG_ELEMENT_REGEX
 } from './utils'
 
-const STREAMDOWN_DEFAULT_REMARK_PLUGINS = Object.values(defaultRemarkPlugins)
+const STREAMDOWN_DEFAULT_REMARK_PLUGINS = Object.entries(defaultRemarkPlugins).map(([name, plugin]) => {
+  if (name !== 'gfm' || !Array.isArray(plugin)) return plugin
+
+  // Keep GFM extensions while treating single tildes as literal chat text.
+  const [gfmPlugin, options] = plugin
+  return [gfmPlugin, { ...(options as Record<string, unknown>), singleTilde: false }] as Pluggable
+})
 
 function MarkdownBlock({ content, ...props }: BlockProps): ReactElement {
   const markdownCtx = useMemo(() => ({ content }), [content])

--- a/packages/ui/src/components/composites/markdown/presets.ts
+++ b/packages/ui/src/components/composites/markdown/presets.ts
@@ -7,11 +7,12 @@
  * their tree-shaken build.
  */
 
-import { cjk } from '@streamdown/cjk'
+import { cjk, type CjkPlugin } from '@streamdown/cjk'
 import { code } from '@streamdown/code'
 import { createMathPlugin } from '@streamdown/math'
 import { mermaid } from '@streamdown/mermaid'
 import type { PluginConfig } from 'streamdown'
+import type { Pluggable } from 'unified'
 
 export interface WithMathOptions {
   singleDollar?: boolean
@@ -21,10 +22,22 @@ export interface WithFullMarkdownOptions {
   singleDollarMath?: boolean
 }
 
+const cjkWithLiteralTildes: CjkPlugin = (() => {
+  const remarkPluginsAfter = cjk.remarkPluginsAfter.map((plugin, index, plugins) =>
+    index === plugins.length - 1 ? ([plugin, { singleTilde: false }] as Pluggable) : plugin
+  )
+
+  return {
+    ...cjk,
+    remarkPluginsAfter,
+    remarkPlugins: [...cjk.remarkPluginsBefore, ...remarkPluginsAfter]
+  }
+})()
+
 /** Code (Shiki highlighting) + CJK line-break tweaks. */
 export const defaultMarkdownPlugins: PluginConfig = {
   code,
-  cjk
+  cjk: cjkWithLiteralTildes
 }
 
 /** KaTeX math plugin. `singleDollar` enables `$x$` inline math (off by default). */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Single-tilde text such as `~example~` was rendered as strikethrough in the shared Markdown renderer.

After this PR:
Single tildes remain literal text, while double-tilde strikethrough continues to work. Tildes inside inline code, fenced code, and math content remain unaffected.

Fixes #19757

### Why we need it and why it was done in this way

The following tradeoffs were made:

The shared Markdown pipeline now configures Streamdown's GFM plugin and its CJK strikethrough extension with `singleTilde: false`. This keeps the existing GFM feature set and CJK-aware double-tilde behavior while matching chat users' expected literal-text semantics.

The following alternatives were considered:

A compatibility setting would add new product surface for a behavior that is currently unexpected. A custom AST post-processing workaround would be more fragile than configuring the existing remark plugins at their supported option boundary.

Links to places where the discussion took place: [Issue #19757](https://github.com/CherryHQ/cherry-studio/issues/19757)

### Breaking changes

This changes the rendering of single-tilde pairs from strikethrough to literal text. Double-tilde strikethrough remains unchanged, and no user migration or configuration change is required.

### Special notes for your reviewer

The regression test uses the production `withChatPlugins()` preset and verifies single tilde, double tilde, inline/fenced code, and math rendering. No documentation update is required because this is a correction of unexpected rendering behavior and introduces no new user workflow or setting.

### Checklist

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/Keep_it_simple)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is not required for this bug fix.
- [x] Self-review: I have reviewed my own code via the local diff, focused tests, lint, and typecheck

### Release note

```release-note
Fixed single-tilde text such as `~example~` being rendered as strikethrough; double-tilde strikethrough remains supported.
```
