### PR TITLE
fix(release-workflow): allow preview validation from branches

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -33,12 +33,6 @@ jobs:
       short_sha: ${{ steps.source.outputs.short_sha }}
       source_sha: ${{ steps.source.outputs.source_sha }}
     steps:
-      - name: Require the workflow from main
-        if: github.ref != 'refs/heads/main'
-        run: |
-          echo "Preview Release must be dispatched from main; choose the source branch with the branch input" >&2
-          exit 1
-
       - name: Resolve source branch
         id: source
         shell: bash


### PR DESCRIPTION
### What this PR does

Before this PR:

Preview Release could only use the workflow definition from `main`, so changes to the workflow itself could not be validated from a topic branch without temporarily removing and later restoring the guard.

After this PR:

Preview Release can be dispatched using the workflow definition from any branch in the official repository. The `branch` input continues to select the application source commit to package.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes # N/A

### Why we need it and why it was done in this way

The main-only dispatch guard prevented the preview workflow from validating its own changes. Removing only that guard keeps the existing official-repository restriction and source-branch resolution intact.

The following tradeoffs were made:

Authorized maintainers can dispatch a branch version of the workflow with its existing draft-release permission.

The following alternatives were considered:

Temporarily removing and restoring the guard for every workflow validation was rejected because it requires extra commits and duplicate runs.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

To validate a workflow change, select the topic branch under **Use workflow from**, then select the application source with the `branch` input.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
NONE
```
