### PR TITLE
fix(huggingface): serve Agents over the router's Anthropic Messages API

### DIFF
--- a/packages/provider-registry/data/providers.json
+++ b/packages/provider-registry/data/providers.json
@@ -1910,9 +1910,17 @@
       "name": "LongCat"
     },
     {
-      "defaultChatEndpoint": "openai-responses",
+      "defaultChatEndpoint": "openai-chat-completions",
       "description": "Hugging Face - AI model provider",
       "endpointConfigs": {
+        "anthropic-messages": {
+          "adapterFamily": "anthropic",
+          "baseUrl": "https://router.huggingface.co/v1"
+        },
+        "openai-chat-completions": {
+          "adapterFamily": "openai-compatible",
+          "baseUrl": "https://router.huggingface.co/v1"
+        },
         "openai-responses": {
           "adapterFamily": "huggingface",
           "baseUrl": "https://router.huggingface.co/v1/"
@@ -2073,5 +2081,5 @@
       "presetProviderId": "minimax"
     }
   ],
-  "version": "cde3bb6539c1f8fa"
+  "version": "ba4b37746549df9a"
 }

--- a/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
+++ b/packages/provider-registry/src/__tests__/provider-endpoint-matrix.test.ts
@@ -186,3 +186,36 @@ describe('new-api single-host endpoints', () => {
     expect(provider('new-api').overrides ?? []).toEqual([])
   })
 })
+
+/**
+ * The Hugging Face router serves each of its models over three surfaces. Chat Completions is the
+ * documented general one (huggingface.co/docs/inference-providers/en/index) and Anthropic Messages
+ * is what HF documents for Claude Code (…/integrations/claude-code) — an Agent reaches it only if
+ * the provider configures a base URL for it, otherwise every turn takes the translating gateway hop.
+ * The Responses API is still labelled beta (…/guides/responses-api) and `@ai-sdk/huggingface` gets
+ * there through a converter that drops assistant `tool-call` parts and every `tool` message, so it
+ * must not lead: an Agent on it cannot see its own tool calls or their results (#18676).
+ */
+describe('huggingface (router) endpoint matrix', () => {
+  it('defaults to Chat Completions rather than the beta Responses API', () => {
+    expect(provider('huggingface').defaultChatEndpoint).toBe('openai-chat-completions')
+  })
+
+  it('configures a base URL for Anthropic Messages so Claude Code Agents can address the router', () => {
+    expect(provider('huggingface').endpointConfigs?.['anthropic-messages']).toEqual({
+      adapterFamily: 'anthropic',
+      baseUrl: 'https://router.huggingface.co/v1'
+    })
+  })
+
+  it('keeps all three router surfaces on the same host', () => {
+    expect(provider('huggingface').endpointConfigs).toEqual({
+      'anthropic-messages': { adapterFamily: 'anthropic', baseUrl: 'https://router.huggingface.co/v1' },
+      'openai-chat-completions': {
+        adapterFamily: 'openai-compatible',
+        baseUrl: 'https://router.huggingface.co/v1'
+      },
+      'openai-responses': { adapterFamily: 'huggingface', baseUrl: 'https://router.huggingface.co/v1/' }
+    })
+  })
+})

--- a/packages/provider-registry/src/providers/huggingface.ts
+++ b/packages/provider-registry/src/providers/huggingface.ts
@@ -3,8 +3,20 @@ import { defineProvider } from './types'
 export default defineProvider({
   id: 'huggingface',
   name: 'Hugging Face',
-  defaultChatEndpoint: 'openai-responses',
+  defaultChatEndpoint: 'openai-chat-completions',
   endpointConfigs: {
+    // The router serves every model it lists over Anthropic Messages too, which is how HF documents
+    // running Claude Code on it (huggingface.co/docs/inference-providers/en/integrations/claude-code).
+    'anthropic-messages': {
+      adapterFamily: 'anthropic',
+      baseUrl: 'https://router.huggingface.co/v1'
+    },
+    'openai-chat-completions': {
+      adapterFamily: 'openai-compatible',
+      baseUrl: 'https://router.huggingface.co/v1'
+    },
+    // Trails the two general surfaces: the router's Responses API is still beta, and the adapter that
+    // reaches it drops assistant tool calls and every tool result, which breaks Agent tool loops.
     'openai-responses': {
       adapterFamily: 'huggingface',
       baseUrl: 'https://router.huggingface.co/v1/'

--- a/src/main/ai/provider/__tests__/listModels.test.ts
+++ b/src/main/ai/provider/__tests__/listModels.test.ts
@@ -1048,3 +1048,52 @@ describe('listModels — openAICompatibleFetcher display names', () => {
     expect(models.map((model) => model.name)).toEqual(['Named Model', 'unnamed-model'])
   })
 })
+
+describe('listModels — huggingFaceFetcher (router dialects)', () => {
+  // The listing carries no endpoint field, so without this the models fall back to the provider
+  // default and a Claude Code Agent can only reach the router through the translating gateway.
+  it('declares both router dialects on every model, Chat Completions leading', async () => {
+    aiSdkGetFromApiMock.mockResolvedValue({
+      value: {
+        data: [
+          { id: 'deepseek-ai/DeepSeek-V4-Pro-0813', owned_by: 'deepseek-ai' },
+          { id: 'zai-org/GLM-5.1', owned_by: 'zai-org' }
+        ]
+      }
+    })
+
+    const models = await listModels(
+      makeProvider({
+        id: 'huggingface',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://router.huggingface.co/v1' }
+        }
+      })
+    )
+
+    const call = aiSdkGetFromApiMock.mock.calls[0][0] as { url: string }
+    expect(call.url).toBe('https://router.huggingface.co/v1/models')
+    expect(models.map((model) => model.apiModelId)).toEqual(['deepseek-ai/DeepSeek-V4-Pro-0813', 'zai-org/GLM-5.1'])
+    for (const model of models) {
+      expect(model.endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
+    }
+  })
+
+  it('routes a copied Hugging Face provider (uuid id + presetProviderId) through the same fetcher', async () => {
+    aiSdkGetFromApiMock.mockResolvedValue({ value: { data: [{ id: 'zai-org/GLM-5.1' }] } })
+
+    const models = await listModels(
+      makeProvider({
+        id: 'a4f1e6c0-0d2b-4f0e-9d1a-2b3c4d5e6f70',
+        presetProviderId: 'huggingface',
+        defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+        endpointConfigs: {
+          [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://router.huggingface.co/v1' }
+        }
+      })
+    )
+
+    expect(models[0].endpointTypes).toEqual([ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES])
+  })
+})

--- a/src/main/ai/provider/listModels.ts
+++ b/src/main/ai/provider/listModels.ts
@@ -701,6 +701,31 @@ const jinaFetcher: ModelFetcher = {
   }
 }
 
+/**
+ * The router lists chat models only and serves each of them over both `/v1/chat/completions` and
+ * `/v1/messages`, but its listing carries no endpoint field. Declare both, because routing asks the
+ * MODEL for a dialect: with Chat Completions alone a Claude Code Agent is pushed onto the API
+ * gateway, which translates every turn instead of speaking Anthropic Messages to the router.
+ */
+const huggingFaceFetcher: ModelFetcher = {
+  match: (p) => matchesPreset(p, SystemProviderIds.huggingface),
+  fetch: async (provider, signal) => {
+    const baseUrl = formatApiHost(getBaseUrl(provider))
+    const response = await getFromApi({
+      url: `${baseUrl}/models`,
+      headers: defaultHeaders(provider),
+      responseSchema: OpenAIModelsResponseSchema,
+      abortSignal: signal
+    })
+    return dedup(response.data, (m) => m.id).map((m) =>
+      toModel(m.id, provider, {
+        ownedBy: m.owned_by,
+        endpointTypes: [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS, ENDPOINT_TYPE.ANTHROPIC_MESSAGES]
+      })
+    )
+  }
+}
+
 const openAIFetcher: ModelFetcher = {
   match: (p) => matchesPreset(p, SystemProviderIds.openai),
   fetch: async (provider, signal) => {
@@ -753,6 +778,7 @@ const fetchers: ModelFetcher[] = [
   gatewayFetcher,
   anthropicFetcher,
   jinaFetcher,
+  huggingFaceFetcher,
   openAIFetcher,
   openAICompatibleFetcher // always-match fallback, must be last
 ]


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

A `claude-code` Agent on **any** Hugging Face model fails every request with `API Error: Request too large for claude-code (max 32MB)` — the Claude Code CLI's canned text for any upstream 413, images or not (#18676). Two things are wrong at once:

- Hugging Face defaults to the router's **Responses API** (`openai-responses`, still labelled beta), the one surface the reporter never tested. The two they did test answered `200` at several hundred KB, and size is not the variable either: serialising the same prompt yields 84,471 bytes on Responses against 85,038 bytes on Chat Completions, so the *rejected* body is the smaller one.
- That endpoint is structurally wrong for an Agent regardless of the 413: `@ai-sdk/huggingface` reaches it through a converter that drops assistant `tool-call` parts and every `tool` message, so an Agent cannot see the tools it just called or what they returned.

After this PR:

- `huggingface` declares the router's **Anthropic Messages** surface (`https://router.huggingface.co/v1`, `adapterFamily: 'anthropic'`) — the surface Hugging Face documents for running Claude Code — plus an explicit `openai-chat-completions` config, and `defaultChatEndpoint` moves from `openai-responses` to `openai-chat-completions`. All three surfaces stay on the same host; Responses is kept, just no longer leading.
- A dedicated `huggingFaceFetcher` in `src/main/ai/provider/listModels.ts` stamps `[OPENAI_CHAT_COMPLETIONS, ANTHROPIC_MESSAGES]` on every model the router lists. A Claude Code Agent then talks to the router directly instead of being translated by the API gateway.

Fixes #18676

### Why we need it and why it was done in this way

Routing asks the **model** for a dialect, and Hugging Face models carry no `endpointTypes` — the router's `/v1/models` listing has no endpoint field at all. So the model fetcher is where the dialect has to be stamped: the live listing wins over the shipped catalog and is the only place that covers models the catalog never had, the reported one among them.

The following tradeoffs were made:

- **Chat Completions leads, not Anthropic Messages.** Chat Completions is HF's documented general surface and keeps working for in-app chat and for models the router no longer serves; Anthropic Messages is what an Agent picks up. Making Anthropic lead would have changed the default transport for ordinary chat too.
- **`openai-responses` is kept, just demoted.** Users who explicitly selected it are not broken; it simply stops being the default that silently lands Agents on a beta endpoint with a lossy tool-call converter.
- **A provider-specific fetcher instead of catalog data.** The catalog cannot enumerate router models (they change with HF's provider mix), so a static `endpointTypes` list in `provider-models.json` would miss exactly the model in the report.

The following alternatives were considered:

- Raising a request-size limit / stripping images — ruled out by measurement: the rejected body is the *smaller* one, and the error text is the CLI's generic 413 string, not an actual 32MB payload.
- Fixing the `@ai-sdk/huggingface` Responses converter to preserve tool calls — a much larger upstream change that still leaves Agents on a beta endpoint; addressing the surface choice is the root fix.

Links to places where the discussion took place: https://github.com/CherryHQ/cherry-studio/issues/18676

### Breaking changes

No user-visible breaking change. The Hugging Face provider's default chat endpoint changes from `openai-responses` to `openai-chat-completions`; both are served by the same router host, and existing explicit per-model endpoint selections are untouched.

### Special notes for your reviewer

- `packages/provider-registry/data/providers.json` is the generated catalog; the hand-edited source is `packages/provider-registry/src/providers/huggingface.ts` (the `version` hash change is the regenerated checksum).
- `@cherrystudio/provider-registry` is in the changesets `ignore` list, so no changeset accompanies this PR.
- New coverage: `provider-endpoint-matrix.test.ts` pins the three router surfaces and the non-beta default; `listModels.test.ts` covers both the preset provider and a copied provider (uuid id + `presetProviderId`) reaching the same fetcher.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Claude Code Agents on Hugging Face models failing every request with "Request too large (max 32MB)": the Hugging Face router is now addressed over its Anthropic Messages API for Agents and Chat Completions for chat, instead of the beta Responses API.
```
