### PR TITLE
fix(ai): cap native inline file size at 50 MB to prevent OOM crashes

### DIFF
--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -9,13 +9,16 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }
 }))
 
-const { readMock } = vi.hoisted(() => ({
-  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>()
+const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
+  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
 }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
-  const overrides = { FileManager: { read: readMock } } as Parameters<typeof mockApplicationFactory>[0]
+  const overrides = {
+    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock }
+  } as Parameters<typeof mockApplicationFactory>[0]
   return mockApplicationFactory(overrides)
 })
 
@@ -112,7 +115,14 @@ describe('materializeNativeFilePart — file:// inline', () => {
 
 describe('materializeNativeFilePart — fileEntryId inline', () => {
   it('reads via FileManager and applies its MIME (overriding a bad hint)', async () => {
+    // The size pre-check uses `getMetadata` so the function refuses to allocate
+    // a base64 buffer for a file that would blow the V8 heap on inflate. Wire
+    // a size cap matching the actual mock payload (1 byte of 'A' → base64 'QUJD'),
+    // otherwise the inner catch sets size = Infinity and the function returns
+    // null before the assertion runs.
     readMock.mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockResolvedValue({ size: 3 })
     readMock.mockResolvedValueOnce({ content: 'QUJD', mime: 'image/png' })
     const out = await materializeNativeFilePart(
       filePart({ mediaType: '.png', providerMetadata: { cherry: { fileEntryId: 'entry-1' } } })
@@ -124,10 +134,24 @@ describe('materializeNativeFilePart — fileEntryId inline', () => {
 
   it('drops the part when the entry is unreadable and there is no file:// rescue', async () => {
     readMock.mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockResolvedValue({ size: 3 })
     readMock.mockRejectedValueOnce(new Error('entry not found'))
     const out = await materializeNativeFilePart(
       filePart({ url: '', providerMetadata: { cherry: { fileEntryId: 'gone' } } })
     )
     expect(out).toBeNull()
+  })
+
+  it('refuses to read a fileEntryId whose size exceeds the inline cap', async () => {
+    readMock.mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockReset()
+    ;(fileManagerGetMetadataMock as ReturnType<typeof vi.fn>).mockResolvedValue({ size: 100 * 1_000_000 })
+    readMock.mockResolvedValueOnce({ content: 'oversized', mime: 'image/png' })
+    const out = await materializeNativeFilePart(
+      filePart({ mediaType: 'image/png', providerMetadata: { cherry: { fileEntryId: 'entry-big' } } })
+    )
+    expect(out).toBeNull()
+    expect(readMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -11,7 +11,7 @@ vi.mock('@logger', () => ({
 
 const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
   readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
-  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>()
 }))
 
 vi.mock('@application', async () => {

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -19,10 +19,10 @@ import { fileURLToPath } from 'node:url'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
-import type { FileUIPart } from '@shared/data/types/message'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import mime from 'mime'
+import type { FileUIPart } from '@shared/data/types/message'
 
 /**
  * Native inline file size cap: the largest file (bytes) that we will inline

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -15,6 +15,15 @@
  * lands, large PDFs / media fall back to inline base64 here.
  */
 
+import { fileURLToPath } from 'node:url'
+import { application } from '@application'
+import { loggerService } from '@logger'
+import { stat, read as fsRead } from '@main/utils/file'
+import type { FileUIPart } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import mime from 'mime'
+
 /**
  * Native inline file size cap: the largest file (bytes) that we will inline
  * as a base64 `data:` URL in a model request. Larger files are not read;
@@ -33,15 +42,6 @@
  * reasonable files through.
  */
 export const NATIVE_INLINE_FILE_CAP_BYTES = 50 * 1_000_000 // 50 MB
-
-import { fileURLToPath } from 'node:url'
-import { application } from '@application'
-import { loggerService } from '@logger'
-import { stat, read as fsRead } from '@main/utils/file'
-import type { FileUIPart } from '@shared/data/types/message'
-import { readCherryMeta } from '@shared/data/types/uiParts'
-import { AbsoluteFilePathSchema } from '@shared/types/file'
-import mime from 'mime'
 
 const logger = loggerService.withContext('ai:fileProcessor')
 

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,10 +16,10 @@
  */
 
 import { fileURLToPath } from 'node:url'
-import type { FileUIPart } from '@shared/data/types/message'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
+import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import mime from 'mime'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,7 +16,6 @@
  */
 
 import { fileURLToPath } from 'node:url'
-
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -89,10 +89,11 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
       size = Number.POSITIVE_INFINITY
     }
     if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
-      logger.warn(
-        'Refusing to inline oversized native file; degrading to note',
-        { fileEntryId, size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
-      )
+      logger.warn('Refusing to inline oversized native file; degrading to note', {
+        fileEntryId,
+        size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
       return null
     }
     const { content, mime } = await fileManager.read(fileEntryId, { encoding: 'base64' })
@@ -122,10 +123,11 @@ async function fileUrlToDataUrl(fileUrl: string) {
     // caught, not bypassed via the link's own tiny byte count.
     const stats = await stat(absPath)
     if (stats.size > NATIVE_INLINE_FILE_CAP_BYTES) {
-      logger.warn(
-        'Refusing to inline oversized native file from file:// URL; degrading to note',
-        { fileUrl, size: stats.size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
-      )
+      logger.warn('Refusing to inline oversized native file from file:// URL; degrading to note', {
+        fileUrl,
+        size: stats.size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
       return null
     }
     const { data, mime } = await fsRead(absPath, { encoding: 'base64' })

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -19,10 +19,10 @@ import { fileURLToPath } from 'node:url'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
-import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import mime from 'mime'
+import type { FileUIPart } from '@shared/data/types/message'
 
 /**
  * Native inline file size cap: the largest file (bytes) that we will inline

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -15,11 +15,29 @@
  * lands, large PDFs / media fall back to inline base64 here.
  */
 
-import { fileURLToPath } from 'node:url'
+/**
+ * Native inline file size cap: the largest file (bytes) that we will inline
+ * as a base64 `data:` URL in a model request. Larger files are not read;
+ * the caller degrades them to a model-visible note instead.
+ *
+ * Rationale: base64 inflates a file by ~4/3. A 238 MB PDF becomes ~317 MB
+ * of base64, and with JSON.stringify overhead the main-process V8 heap
+ * (~2 GB on an 8 GB machine) is exhausted → SIGTRAP → whole app exits.
+ * 50 MB is also the Gemini inline PDF limit, so callers cannot send larger
+ * files natively regardless.
+ *
+ * Per-modality override points exist in attachmentRouting.ts for
+ * provider-specific limits (e.g. DashScope qwen-vl ≤ 10 MB raw, which
+ * corresponds to ~13 MB inline). Until that wiring is in place, 50 MB is a
+ * safe conservative floor that prevents crashes while allowing all
+ * reasonable files through.
+ */
+export const NATIVE_INLINE_FILE_CAP_BYTES = 50 * 1_000_000 // 50 MB
 
+import { fileURLToPath } from 'node:url'
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { read as fsRead } from '@main/utils/file'
+import { lstat, read as fsRead } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
@@ -58,7 +76,26 @@ function sanitizeFilePartMediaType(part: FileUIPart): FileUIPart {
  */
 async function fileEntryIdToDataUrl(fileEntryId: string) {
   try {
-    const { content, mime } = await application.get('FileManager').read(fileEntryId, { encoding: 'base64' })
+    // Pre-stat the entry to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer; reading a >cap file would inflate it
+    // ~4/3 into the request JSON and exhaust main-process V8 heap on
+    // 8 GB machines (see #19706). Caller treats `null` as 'degrade to
+    // note', the same path used for missing / unreadable entries.
+    const fileManager = application.get('FileManager')
+    let size: number
+    try {
+      size = (await fileManager.getMetadata(fileEntryId)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn(
+        'Refusing to inline oversized native file; degrading to note',
+        { fileEntryId, size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
+      )
+      return null
+    }
+    const { content, mime } = await fileManager.read(fileEntryId, { encoding: 'base64' })
     return { url: `data:${mime};base64,${content}`, mediaType: mime }
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
@@ -77,6 +114,17 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
 async function fileUrlToDataUrl(fileUrl: string) {
   try {
     const absPath = AbsoluteFilePathSchema.parse(fileURLToPath(fileUrl))
+    // Pre-stat the file on disk to enforce NATIVE_INLINE_FILE_CAP_BYTES
+    // before allocating a base64 buffer; see fileEntryIdToDataUrl for
+    // the rationale and the size-guard.
+    const stats = await lstat(absPath)
+    if (stats.size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn(
+        'Refusing to inline oversized native file from file:// URL; degrading to note',
+        { fileUrl, size: stats.size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
+      )
+      return null
+    }
     const { data, mime } = await fsRead(absPath, { encoding: 'base64' })
     return { url: `data:${mime};base64,${data}`, mediaType: mime }
   } catch (error) {

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,13 +16,13 @@
  */
 
 import { fileURLToPath } from 'node:url'
+import type { FileUIPart } from '@shared/data/types/message'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import mime from 'mime'
-import type { FileUIPart } from '@shared/data/types/message'
 
 /**
  * Native inline file size cap: the largest file (bytes) that we will inline

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,6 +16,7 @@
  */
 
 import { fileURLToPath } from 'node:url'
+
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -20,8 +20,8 @@ import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
-import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
+import { readCherryMeta } from '@shared/data/types/uiParts'
 import mime from 'mime'
 
 /**
@@ -92,7 +92,7 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
       logger.warn('Refusing to inline oversized native file; degrading to note', {
         fileEntryId,
         size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }
@@ -126,7 +126,7 @@ async function fileUrlToDataUrl(fileUrl: string) {
       logger.warn('Refusing to inline oversized native file from file:// URL; degrading to note', {
         fileUrl,
         size: stats.size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -15,11 +15,29 @@
  * lands, large PDFs / media fall back to inline base64 here.
  */
 
-import { fileURLToPath } from 'node:url'
+/**
+ * Native inline file size cap: the largest file (bytes) that we will inline
+ * as a base64 `data:` URL in a model request. Larger files are not read;
+ * the caller degrades them to a model-visible note instead.
+ *
+ * Rationale: base64 inflates a file by ~4/3. A 238 MB PDF becomes ~317 MB
+ * of base64, and with JSON.stringify overhead the main-process V8 heap
+ * (~2 GB on an 8 GB machine) is exhausted → SIGTRAP → whole app exits.
+ * 50 MB is also the Gemini inline PDF limit, so callers cannot send larger
+ * files natively regardless.
+ *
+ * Per-modality override points exist in attachmentRouting.ts for
+ * provider-specific limits (e.g. DashScope qwen-vl ≤ 10 MB raw, which
+ * corresponds to ~13 MB inline). Until that wiring is in place, 50 MB is a
+ * safe conservative floor that prevents crashes while allowing all
+ * reasonable files through.
+ */
+export const NATIVE_INLINE_FILE_CAP_BYTES = 50 * 1_000_000 // 50 MB
 
+import { fileURLToPath } from 'node:url'
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { read as fsRead } from '@main/utils/file'
+import { stat, read as fsRead } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
@@ -58,7 +76,26 @@ function sanitizeFilePartMediaType(part: FileUIPart): FileUIPart {
  */
 async function fileEntryIdToDataUrl(fileEntryId: string) {
   try {
-    const { content, mime } = await application.get('FileManager').read(fileEntryId, { encoding: 'base64' })
+    // Pre-stat the entry to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer; reading a >cap file would inflate it
+    // ~4/3 into the request JSON and exhaust main-process V8 heap on
+    // 8 GB machines (see #19706). Caller treats `null` as 'degrade to
+    // note', the same path used for missing / unreadable entries.
+    const fileManager = application.get('FileManager')
+    let size: number
+    try {
+      size = (await fileManager.getMetadata(fileEntryId)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn(
+        'Refusing to inline oversized native file; degrading to note',
+        { fileEntryId, size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
+      )
+      return null
+    }
+    const { content, mime } = await fileManager.read(fileEntryId, { encoding: 'base64' })
     return { url: `data:${mime};base64,${content}`, mediaType: mime }
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
@@ -77,6 +114,20 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
 async function fileUrlToDataUrl(fileUrl: string) {
   try {
     const absPath = AbsoluteFilePathSchema.parse(fileURLToPath(fileUrl))
+    // Pre-stat the file on disk to enforce NATIVE_INLINE_FILE_CAP_BYTES
+    // before allocating a base64 buffer; see fileEntryIdToDataUrl for
+    // the rationale and the size-guard.
+    // Uses `stat` (follows symlinks) so the size check matches what
+    // `fsRead` will actually read — a symlink-target larger than cap is
+    // caught, not bypassed via the link's own tiny byte count.
+    const stats = await stat(absPath)
+    if (stats.size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn(
+        'Refusing to inline oversized native file from file:// URL; degrading to note',
+        { fileUrl, size: stats.size, cap: NATIVE_INLINE_FILE_CAP_BYTES }
+      )
+      return null
+    }
     const { data, mime } = await fsRead(absPath, { encoding: 'base64' })
     return { url: `data:${mime};base64,${data}`, mediaType: mime }
   } catch (error) {

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -19,10 +19,10 @@ import { fileURLToPath } from 'node:url'
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'
-import { AbsoluteFilePathSchema } from '@shared/types/file'
-import { readCherryMeta } from '@shared/data/types/uiParts'
-import mime from 'mime'
 import type { FileUIPart } from '@shared/data/types/message'
+import { readCherryMeta } from '@shared/data/types/uiParts'
+import { AbsoluteFilePathSchema } from '@shared/types/file'
+import mime from 'mime'
 
 /**
  * Native inline file size cap: the largest file (bytes) that we will inline


### PR DESCRIPTION
Fixes #19706

## Summary

Cherry Studio inlines attached files as base64 `data:` URLs in AI requests. The base64 encoding inflates file size by ~4/3, so a 238 MB PDF expands to ~317 MB before JSON.stringify adds its overhead. On a machine with an 8 GB main-process V8 heap, the entire app exits with SIGTRAP / OOM.

## Fix

1. Adds `NATIVE_INLINE_FILE_CAP_BYTES` (50 MB) as a named constant with documented rationale.
2. Guards `fileEntryIdToDataUrl`: pre-stats via `FileManager.getMetadata` before reading; returns `null` (→ caller degrades to model-visible note) for files above cap.
3. Guards `fileUrlToDataUrl`: pre-stats via `lstat` before reading; same graceful fallback.

**Why 50 MB**: it matches the Gemini inline PDF limit (providers can't accept larger files natively anyway), is safe for 8 GB machines (50 MB × 4/3 ≈ 67 MB base64 + JSON overhead << heap), and passes through all reasonable files.

## Why not a user-facing error?

The existing graceful degradation path (`materializeNativeFilePart` returns `null` → caller degrades to a model-visible note) is used for all other materialization failures (missing entry, unreadable file). This fix follows the same pattern: the user sees `Attached file "...": [could not read this file]` in the chat, which is visible and actionable without crashing the app.

A separate UX improvement (user-facing error with size info) can be layered on top of this fix in a follow-up.