### PR TITLE
fix(renderer): make code block horizontal scrollbar thumb visible (fixes #19798)

### DIFF
--- a/src/renderer/assets/styles/scrollbar.css
+++ b/src/renderer/assets/styles/scrollbar.css
@@ -55,15 +55,3 @@ pre:not(.shiki)::-webkit-scrollbar-thumb:hover {
   --scrollbar-thumb: var(--scrollbar-thumb-light);
   --scrollbar-thumb-hover: var(--scrollbar-thumb-light-hover);
 }
-
-/**
- * Override the inherited `scrollbar-color: transparent transparent` from the
- * app's auto-hiding Scrollbar wrapper (see packages/ui/src/components/composites/scrollbar/index.tsx).
- * Without this, a CodeViewer inside an idle Scrollbar ancestor shows an invisible
- * horizontal thumb even though its content overflows.
- * `auto` lets the browser/platform default apply, which the existing
- * ::-webkit-scrollbar rules already theme.
- */
-.scrollbar-color-auto {
-  scrollbar-color: auto;
-}

--- a/src/renderer/assets/styles/scrollbar.css
+++ b/src/renderer/assets/styles/scrollbar.css
@@ -55,3 +55,15 @@ pre:not(.shiki)::-webkit-scrollbar-thumb:hover {
   --scrollbar-thumb: var(--scrollbar-thumb-light);
   --scrollbar-thumb-hover: var(--scrollbar-thumb-light-hover);
 }
+
+/**
+ * Override the inherited `scrollbar-color: transparent transparent` from the
+ * app's auto-hiding Scrollbar wrapper (see packages/ui/src/components/composites/scrollbar/index.tsx).
+ * Without this, a CodeViewer inside an idle Scrollbar ancestor shows an invisible
+ * horizontal thumb even though its content overflows.
+ * `auto` lets the browser/platform default apply, which the existing
+ * ::-webkit-scrollbar rules already theme.
+ */
+.scrollbar-color-auto {
+  scrollbar-color: auto;
+}

--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -509,7 +509,7 @@ const CodeViewer = ({
     <div ref={shikiThemeRef} style={expanded ? undefined : { height }}>
       <div
         ref={scrollerRef}
-        className="shiki-scroller relative block overflow-x-auto rounded-[inherit] py-[0.5em] pr-0 pl-[1em] scrollbar-color-auto"
+        className="shiki-scroller relative block overflow-x-auto rounded-[inherit] py-[0.5em] pr-0 pl-[1em] [scrollbar-color:auto]"
         onScroll={handleScroll}
         style={
           {

--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -509,7 +509,7 @@ const CodeViewer = ({
     <div ref={shikiThemeRef} style={expanded ? undefined : { height }}>
       <div
         ref={scrollerRef}
-        className="shiki-scroller relative block overflow-x-auto rounded-[inherit] py-[0.5em] pr-0 pl-[1em]"
+        className="shiki-scroller relative block overflow-x-auto rounded-[inherit] py-[0.5em] pr-0 pl-[1em] scrollbar-color-auto"
         onScroll={handleScroll}
         style={
           {


### PR DESCRIPTION
## Summary

Fixes CherryHQ/cherry-studio#19798: Horizontal scrollbar thumb is invisible in code and text blocks on Windows and potentially other platforms.

## Problem

- The app's auto-hiding  component sets  when idle.
-  renders  inside a  ancestor.
- The inherited  scrollbar-color prevents the browser from showing the themed 6px thumb even when content overflows horizontally.
- Users cannot discover or use the horizontal scroll position.

## Root cause

The nested scroller inherits  from an ancestor  wrapper that is not scrolling (auto-hide idle state). Scroll events from  do not bubble to the ancestor's scroll handler, so the parent never exits its idle state. Meanwhile, the non-  value overrides WebKit's built-in scrollbar styling.

## Fix

1. Add  CSS rule to  that sets , breaking the inherited transparent value.
2. Apply the  class to  in .
3. The existing  rules already theme the thumb at 6px;  lets those rules take effect.

## Testing

- Manual: Open a code block with unwrapped long lines, observe that the horizontal scrollbar thumb is visible in both light and dark themes.
- This is the minimal fix: it does not change the outer message list's auto-hide behavior and does not introduce a visible scrollbar when content is wrapped.