### PR TITLE
fix(dashscope): expose all Responses reasoning tiers for Qwen3.8

### DIFF
--- a/packages/provider-registry/data/provider-models.json
+++ b/packages/provider-registry/data/provider-models.json
@@ -6985,15 +6985,11 @@
               {
                 "default": "xhigh",
                 "kind": "effort",
-                "values": ["none", "low", "medium", "xhigh"]
+                "values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
               }
             ],
             "defaultEffort": "xhigh",
-            "supportedEfforts": ["none", "low", "medium", "xhigh"],
-            "thinkingTokenLimits": {
-              "max": 262144,
-              "min": 0
-            }
+            "supportedEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "wire": {
             "auto": {
@@ -7087,15 +7083,11 @@
               {
                 "default": "xhigh",
                 "kind": "effort",
-                "values": ["none", "low", "medium", "xhigh"]
+                "values": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
               }
             ],
             "defaultEffort": "xhigh",
-            "supportedEfforts": ["none", "low", "medium", "xhigh"],
-            "thinkingTokenLimits": {
-              "max": 262144,
-              "min": 0
-            }
+            "supportedEfforts": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "wire": {
             "auto": {
@@ -7178,15 +7170,11 @@
               {
                 "default": "xhigh",
                 "kind": "effort",
-                "values": ["low", "medium", "xhigh"]
+                "values": ["minimal", "low", "medium", "high", "xhigh", "max"]
               }
             ],
             "defaultEffort": "xhigh",
-            "supportedEfforts": ["low", "medium", "xhigh"],
-            "thinkingTokenLimits": {
-              "max": 262144,
-              "min": 0
-            }
+            "supportedEfforts": ["minimal", "low", "medium", "high", "xhigh", "max"]
           },
           "wire": {
             "auto": {
@@ -38511,5 +38499,5 @@
       "providerId": "zhipu"
     }
   ],
-  "version": "e41feb80fd828236"
+  "version": "40d817144bf46fc2"
 }

--- a/packages/provider-registry/src/__tests__/alibaba-catalog.test.ts
+++ b/packages/provider-registry/src/__tests__/alibaba-catalog.test.ts
@@ -51,7 +51,9 @@ describe('Alibaba Qwen catalog', () => {
         },
         'openai-responses': {
           support: {
-            controls: [{ default: 'xhigh', kind: 'effort', values: ['none', 'low', 'medium', 'xhigh'] }]
+            controls: [
+              { default: 'xhigh', kind: 'effort', values: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] }
+            ]
           }
         }
       }

--- a/packages/provider-registry/src/providers/dashscope.ts
+++ b/packages/provider-registry/src/providers/dashscope.ts
@@ -130,6 +130,13 @@ const qwenResponsesSupport: ReasoningSupport = {
   supportedEfforts: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
 }
 
+/** `qwen3.8-max-preview` serves thinking mode only, so its Responses contract drops the `'none'` tier. */
+const qwenResponsesThinkingOnlySupport: ReasoningSupport = {
+  controls: [{ kind: 'effort', values: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'], default: 'xhigh' }],
+  defaultEffort: 'xhigh',
+  supportedEfforts: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+}
+
 const qwen38Support: ReasoningSupport = {
   controls: [{ kind: 'effort', values: ['none', 'low', 'medium', 'xhigh'], default: 'xhigh' }],
   defaultEffort: 'xhigh',
@@ -279,7 +286,7 @@ const endpointReasoningOverrides: Partial<ProviderModelOverride>[] = [
     ...endpointPin('qwen3.8-flash'),
     reasoningContracts: {
       'openai-chat-completions': { support: qwen38Support, wire: qwen38ChatWire },
-      'openai-responses': { support: qwen38Support, wire: responsesEffortWire }
+      'openai-responses': { support: qwenResponsesSupport, wire: responsesEffortWire }
     }
   },
   {
@@ -289,7 +296,7 @@ const endpointReasoningOverrides: Partial<ProviderModelOverride>[] = [
     ...endpointPin('qwen3.8-max'),
     reasoningContracts: {
       'openai-chat-completions': { support: qwen38Support, wire: qwen38ChatWire },
-      'openai-responses': { support: qwen38Support, wire: responsesEffortWire }
+      'openai-responses': { support: qwenResponsesSupport, wire: responsesEffortWire }
     }
   },
   {
@@ -299,7 +306,7 @@ const endpointReasoningOverrides: Partial<ProviderModelOverride>[] = [
     ...endpointPin('qwen3.8-max-preview'),
     reasoningContracts: {
       'openai-chat-completions': { support: qwen38PreviewSupport, wire: qwen38PreviewChatWire },
-      'openai-responses': { support: qwen38PreviewSupport, wire: qwen38PreviewResponsesWire }
+      'openai-responses': { support: qwenResponsesThinkingOnlySupport, wire: qwen38PreviewResponsesWire }
     }
   },
   {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

On the DashScope `openai-responses` endpoint, Qwen3.8 Flash and Qwen3.8 Max exposed only four reasoning tiers (`none / low / medium / xhigh`), and Qwen3.8 Max Preview only three. The Responses contract for these three SKUs reused `qwen38Support`, which is the Chat Completions contract, so `minimal`, `high` and `max` were missing from the reasoning picker even though Bailian's Responses API serves them.

After this PR:

- `qwen3.8-flash` and `qwen3.8-max` use the existing seven-tier `qwenResponsesSupport` on `openai-responses` (`none / minimal / low / medium / high / xhigh / max`, default `xhigh`), the same contract every other Qwen SKU already has there.
- `qwen3.8-max-preview` (thinking-only) gets a six-tier variant without `none`.
- Chat Completions contracts are unchanged: Bailian's Chat doc lists only `low / medium / xhigh` for Qwen3.8, so the narrow list stays correct there.
- `data/provider-models.json` is updated for these three rows only, and its content-hash `version` is restamped.

Fixes #N/A

### Why we need it and why it was done in this way

Bailian's Responses reference (help.aliyun.com/zh/model-studio/qwen-api-via-openai-responses) documents `reasoning.effort` as seven tiers for the Qwen line with no per-model carve-out (only a regional note that `xhigh`/`max` are served from Beijing and Singapore; this provider's base URL is the Beijing host). The four-tier list was copy-pasted from the Chat contract when Qwen3.8 was added in #19667. Reusing the already-defined `qwenResponsesSupport` keeps Qwen3.8 consistent with `qwen3.7-max`, `qwen3.6-*`, etc.

The following tradeoffs were made:

- The Responses contract for Qwen3.8 no longer carries `thinkingTokenLimits`. That matches the Responses doc (`thinking_budget` is not supported on that endpoint) and the shape of every other Qwen Responses contract. The only consumer is the API-gateway budget reverse-mapping, which falls back to `high` — now a valid tier.
- `pnpm generate` pulls models.dev live and drags in unrelated catalog drift (new gateway/groq/openrouter rows, pricing changes). Only the three Qwen3.8 rows were kept, and `version` was recomputed with the generator's own `sortKeys` + sha256 scheme so the seeder journal sees a real change.

The following alternatives were considered:

- Hand-writing a new seven-tier const for Qwen3.8: rejected, `qwenResponsesSupport` already exists and is the shared contract.
- Committing the full `pnpm generate` output: rejected, it would ship unrelated upstream drift in the same PR.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Upstream #19730 changed `provider-models.json` content but left `version` at `e41feb80fd828236`; that value no longer matches the file's content on `main` (computed `6e284b68d19c5bc9`). This PR restamps to `40d817144bf46fc2`, the correct hash for the merged content, so the preset seeder will re-run once — picking up both this change and #19730's rows.
- Whether Bailian actually honors `minimal` / `high` / `max` for Qwen3.8 on Responses was verified against the docs, not against a live key. The change only brings Qwen3.8 to parity with the other Qwen SKUs' existing Responses contract.
- Two Chat-side discrepancies were noticed and left alone: Bailian's Chat doc now lists `thinking_budget` as applicable to Qwen3.8 (the comment on `qwen38Support` says otherwise), and it does not list `none` for Qwen3.8's `reasoning_effort` while `qwen38ChatWire` sends it for the off mode.
- Verified with `npx vitest run` on `alibaba-catalog`, `provider-endpoint-matrix`, `provider-reasoning-contracts`, `upstream-reasoning` (66/66) and `biome check` on the three changed files.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
<!--LANG:en-->
[Models] Qwen3.8 Flash and Qwen3.8 Max on the DashScope Responses endpoint now offer all seven reasoning tiers, adding minimal, high, and max.
<!--LANG:zh-CN-->
[模型] 百炼 Responses 接口下的 Qwen3.8 Flash 与 Qwen3.8 Max 现在提供全部七档推理强度，新增 minimal、high、max。
<!--LANG:END-->
```
