### PR TITLE
fix(code-viewer): restore nested scrollbar visibility

### DIFF
--- a/src/renderer/components/CodeViewer.tsx
+++ b/src/renderer/components/CodeViewer.tsx
@@ -516,6 +516,7 @@ const CodeViewer = ({
             '--gutter-width': `${gutterDigits}ch`,
             '--line-height': `${estimateSize()}px`,
             fontSize,
+            scrollbarColor: 'auto',
             height: expanded ? undefined : height,
             maxHeight: expanded ? undefined : maxHeight,
             overflowY: expanded ? 'hidden' : 'auto'

--- a/src/renderer/components/__tests__/CodeViewer.test.tsx
+++ b/src/renderer/components/__tests__/CodeViewer.test.tsx
@@ -196,6 +196,24 @@ describe('CodeViewer', () => {
     expect(Array.from(tokenSpans).some((span) => (span as HTMLElement).style.opacity === '1')).toBe(true)
   })
 
+  it('keeps the nested horizontal scrollbar visible when an ancestor auto-hides its scrollbar', () => {
+    const { container, getByTestId } = render(
+      <div data-testid="outer-scrollbar" style={{ scrollbarColor: 'transparent transparent' }}>
+        <CodeViewer
+          value="long=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          language="text"
+          wrapped={false}
+        />
+      </div>
+    )
+
+    const outerScrollbar = getByTestId('outer-scrollbar')
+    const codeScroller = container.querySelector('.shiki-scroller') as HTMLElement
+
+    expect(outerScrollbar).toHaveStyle({ scrollbarColor: 'transparent transparent' })
+    expect(codeScroller).toHaveStyle({ scrollbarColor: 'auto' })
+  })
+
   it('lets the line-content flex item shrink so long unbreakable lines wrap instead of overflowing', () => {
     // The wrapped line-content must be able to shrink below its min-content width
     // (base64, URLs, minified JSON), otherwise long lines overflow the container


### PR DESCRIPTION
<!-- Template from https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md?-->
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/CherryHQ/cherry-studio/blob/main/CONTRIBUTING.md
-->

> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Code and text blocks nested inside an idle auto-hiding message scrollbar inherit `scrollbar-color: transparent transparent`, leaving their horizontal scrollbar thumb invisible even though the block remains scrollable.

After this PR:

`CodeViewer` resets its own scroller to `scrollbar-color: auto`, allowing the existing light and dark Shiki scrollbar theme variables and global 6px WebKit scrollbar styles to render a visible horizontal thumb without changing the outer message scrollbar's auto-hide behavior.

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->

Fixes #19798

### Why we need it and why it was done in this way

`scrollbar-color` is inherited. The surrounding message scrollbar intentionally uses a transparent standardized scrollbar color while idle, but scroll events from the nested horizontal scroller do not bubble to that ancestor. Explicitly resetting the nested scroller breaks only the unwanted inheritance and reuses the project's existing themed scrollbar styling.

The following tradeoffs were made:

The code-block horizontal thumb stays discoverable whenever horizontal overflow exists, while the outer message scrollbar continues to auto-hide independently.

The following alternatives were considered:

Adding local hover and scroll state to `CodeViewer` was considered, but it would duplicate the existing global scrollbar behavior and add event/timer state for a problem that is fully resolved by resetting the inherited property.

Links to places where the discussion took place: #19798

### Breaking changes

None.

### Special notes for your reviewer

- Added focused regression coverage for a `CodeViewer` nested under an ancestor with `scrollbar-color: transparent transparent`.
- Verified the real Chromium computed style and visible thumb in both light and dark Shiki themes.
- Focused renderer tests, Web typecheck, ESLint, Biome, and `git diff --check` pass.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
3. Only include user-facing changes (new features, bug fixes visible to users, UI changes, behavior changes). For CI, maintenance, internal refactoring, build tooling, or other non-user-facing work, write "NONE".
-->

```release-note
[Code viewer] Keep horizontal scrollbar thumbs visible for overflowing code and text blocks.
```
