### PR TITLE
fix(message-translation): hide inline translation delete in read-only embeds

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessagePartsRenderer.tsx
@@ -1356,6 +1356,7 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
   const activeTurnStatus = useMessageListActiveTurnStatus()
   const { removeMessageTranslation, notifySuccess } = useMessageListActions()
   const { t } = useTranslation()
+  const canRemoveTranslation = !!removeMessageTranslation
   const removeTranslationRef = React.useRef({ removeMessageTranslation, notifySuccess, t })
   removeTranslationRef.current = { removeMessageTranslation, notifySuccess, t }
   const handleRemoveTranslation = React.useCallback(async () => {
@@ -1455,9 +1456,10 @@ const MessagePartsRendererContent = React.memo(function MessagePartsRendererCont
       readOnlyFilePreviews,
       onTextPlayoutSettledChange: handleTextPlayoutSettledChange,
       onTextPartExpandedChange: handleTextPartExpandedChange,
-      onRemoveTranslation: handleRemoveTranslation
+      onRemoveTranslation: canRemoveTranslation ? handleRemoveTranslation : undefined
     }),
     [
+      canRemoveTranslation,
       expandedTextPartIds,
       citationProjectionByPart,
       handleTextPartExpandedChange,

--- a/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
+++ b/src/renderer/components/chat/messages/blocks/__tests__/MessagePartsRenderer.test.tsx
@@ -352,7 +352,8 @@ vi.mock('../TranslationBlock', () => ({
     <div
       data-testid="mock-translation-block"
       data-streaming={String(!!isStreaming)}
-      data-has-delete={String(!!onDelete)}>
+      data-has-delete={String(!!onDelete)}
+      onClick={onDelete}>
       {content}
     </div>
   )
@@ -2051,11 +2052,25 @@ describe('MessagePartsRenderer', () => {
       expect(screen.getByTestId('completed-process-trigger')).toHaveAttribute('aria-expanded', 'false')
     })
 
-    it('threads onRemoveTranslation to the translation block', () => {
+    it('removes this message translation through the inline delete when the action is available', () => {
+      const removeMessageTranslation = vi.fn()
+      renderParts(
+        [{ type: 'data-translation', data: { content: 'translated answer' } }] as unknown as CherryMessagePart[],
+        msg({ id: 'msg-translated' }),
+        { removeMessageTranslation }
+      )
+
+      const block = screen.getByTestId('mock-translation-block')
+      expect(block).toHaveAttribute('data-has-delete', 'true')
+      fireEvent.click(block)
+      expect(removeMessageTranslation).toHaveBeenCalledWith('msg-translated')
+    })
+
+    it('hides the inline translation delete in read-only embeds without removeMessageTranslation', () => {
       renderParts([
         { type: 'data-translation', data: { content: 'translated answer' } }
       ] as unknown as CherryMessagePart[])
-      expect(screen.getByTestId('mock-translation-block')).toHaveAttribute('data-has-delete', 'true')
+      expect(screen.getByTestId('mock-translation-block')).toHaveAttribute('data-has-delete', 'false')
     })
   })
 })


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`MessagePartsRenderer` always passed an `onRemoveTranslation` callback to `TranslationBlock`, so every message embed rendered the inline trash button on translation blocks — including embeds whose `MessageListActions` do not provide `removeMessageTranslation` (global search message preview, topic flow node, quick assistant, selection action). In those surfaces the button was a silent no-op: the handler swallowed the missing action with `removeMessageTranslation?.()`. Where `notifySuccess` was available (quick assistant, selection action) it would even toast "translation closed" without removing anything.

After this PR:

The inline delete callback is only passed when `removeMessageTranslation` is present in the current `MessageListActions`. Read-only embeds render the translation block with no delete affordance; the home chat keeps the working button. This matches how the message menu bar (`messageMenuBarActions.tsx`) and `ErrorBlock` already gate their optional actions.

Fixes N/A

<table>
<tr>
 <td>
 Before
 <td>
 After
<tr>
 <td>
<img width="2224" height="1812" alt="CleanShot 2026-09-01 at 16 18 11@2x" src="https://github.com/user-attachments/assets/a28ea917-6f31-4523-9bc4-f44f2c7fd937" />

 <td>
<img width="2228" height="1774" alt="CleanShot 2026-09-01 at 16 19 31@2x" src="https://github.com/user-attachments/assets/90597b1f-9cfd-4f90-9248-e9fc47c8eb1a" />

</table>

### Why we need it and why it was done in this way

The following tradeoffs were made:

The gate lives at the single site where `renderOptions` is built, so one check covers every consumer of `MessagePartsRenderer` instead of patching each embed. The stable-identity `removeTranslationRef` pattern is kept unchanged; only the presence of the callback flips with the capability.

The following alternatives were considered:

- Provide `removeMessageTranslation` in `GlobalSearchMessagePreviewPanel`: rejected — the preview is a read-only surface with no other edit or delete actions, and the same bug exists in the other action-less embeds.
- Early-return inside `handleRemoveTranslation`: rejected — `MessageTranslate` decides whether to render the button from the truthiness of `onDelete`, so a defined-but-inert handler would still show a dead button.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- The existing test `threads onRemoveTranslation to the translation block` rendered with `actions = {}` and asserted the delete was present, i.e. it certified the bug. It is replaced by two contract tests: no action → no delete (fails on `main` with `data-has-delete="true"`), action present → delete shown and clicking calls `removeMessageTranslation` with the message id.
- The inline delete button itself landed in #19705 (2026-08-31) and has not shipped in any release tag, so no released user has seen the dead button.
- Manual check: translate an assistant message in a home topic, then `Cmd/Ctrl+Shift+F` → "Messages" → open a result into the preview pane; the translation block should show no trash icon there, while the home chat still shows a working one.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
NONE
```
