### PR TITLE
fix(message-translation): split the translation divider around its icons

### DIFF
--- a/src/renderer/components/chat/messages/blocks/MessageTranslate.tsx
+++ b/src/renderer/components/chat/messages/blocks/MessageTranslate.tsx
@@ -26,21 +26,22 @@ const MessageTranslate: FC<Props> = ({ block, onDelete }) => {
 
   return (
     <Fragment>
-      <div className="relative mb-2.5">
-        <Divider />
-        <div className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-1/2 bg-background px-2">
-          <Languages size={14} className="text-muted-foreground" />
+      <div className="my-2.5 grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+        <Divider className="my-0" aria-hidden />
+        <Languages size={14} className="text-muted-foreground" />
+        <div className="flex items-center">
+          <Divider className="my-0 flex-1" aria-hidden />
+          {onDelete && (
+            <NormalTooltip content={t('translate.close')} side="top">
+              <button
+                type="button"
+                onClick={onDelete}
+                className="flex items-center px-2 text-muted-foreground transition-colors hover:text-foreground">
+                <Trash size={14} />
+              </button>
+            </NormalTooltip>
+          )}
         </div>
-        {onDelete && (
-          <NormalTooltip content={t('translate.close')} side="top">
-            <button
-              type="button"
-              onClick={onDelete}
-              className="-translate-y-1/2 absolute top-1/2 right-0 flex items-center bg-background px-2 text-muted-foreground transition-colors hover:text-foreground">
-              <Trash size={14} />
-            </button>
-          </NormalTooltip>
-        )}
       </div>
       {isAwaitingFirstChunk && (
         <div className="-mt-1.25 mb-1.25 flex h-8 flex-row items-center">


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

`MessageTranslate` drew one full-width `Divider` and placed the language icon (and, since #19705, the delete button) absolutely on top of it, hiding the line underneath each icon with a `bg-background px-2` patch. That patch is the page's base color, so it only blends in when the message sits directly on the page background. On any tinted surface — the global search message preview's selected row (`bg-accent/55`) or hovered row (`bg-muted/35`), the quick assistant and selection windows, the topic flow node — the patch rendered as a darker square around each icon that looked like a hole punched through the row.

After this PR:

The row is laid out as line / icon / line: a three-column grid (`1fr auto 1fr`) with a `Divider` segment on each side of the language icon, and the delete button appended after the right segment. No background mask is needed, so the icons render correctly on every container, and the equal `1fr` columns keep the language icon centered whether or not the delete button is present. Spacing matches the previous rendering (10px above/below the line, 8px around each icon).

Fixes N/A

### Why we need it and why it was done in this way

The following tradeoffs were made:

The two line segments reuse the `Divider` primitive from `@cherrystudio/ui` so the hairline weight and `--color-border` token stay identical to before; they are marked `aria-hidden` as decorative lines. The change is confined to the divider row — the markdown body and the streaming loader below it are untouched.

The following alternatives were considered:

- Change the mask to a color that matches the tinted row: rejected — the component is embedded in several surfaces with different backgrounds and cannot know which one it is on.
- Reuse `DividerWithText`: rejected — it is a left-aligned text-only divider with hard-coded gray colors.

Links to places where the discussion took place: N/A

### Breaking changes

None.

### Special notes for your reviewer

- Pure layout change; `MessageTranslate.test.tsx` still passes (4/4). There is no honest unit-test seam for a background-mask mismatch, so no test was added rather than pinning class names.
- Where to look: translate an assistant message in a home topic, then `Cmd/Ctrl+Shift+F` → "Messages" → open a result into the preview pane. The selected row and hovered rows should show the divider icons without a darker square behind them; the home chat should look the same as before.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix the translation divider icons showing a mismatched background square on tinted message surfaces such as the global search preview.
```
