### PR TITLE
fix(composer): keep macOS input preview anchored after launch and window resize

### DIFF
--- a/src/renderer/components/QuickPanel/QuickPanelView.tsx
+++ b/src/renderer/components/QuickPanel/QuickPanelView.tsx
@@ -845,6 +845,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     }
 
     syncPlacementMetrics()
+    const raf = requestAnimationFrame(syncPlacementMetrics)
 
     const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(syncPlacementMetrics)
     resizeObserver?.observe(dockEl)
@@ -853,6 +854,7 @@ export const QuickPanelView: React.FC<Props> = ({ inputAdapter }) => {
     window.addEventListener('resize', syncPlacementMetrics)
 
     return () => {
+      cancelAnimationFrame(raf)
       resizeObserver?.disconnect()
       window.removeEventListener('resize', syncPlacementMetrics)
     }

--- a/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
+++ b/src/renderer/components/composer/ComposerSurfaceRuntime.tsx
@@ -12,6 +12,7 @@ import { QuickPanelView, useQuickPanel } from '@renderer/components/QuickPanel'
 import { useRichTextEditorKernel } from '@renderer/components/RichEditor/useRichTextEditorKernel'
 import SendMessageButton from '@renderer/components/SendMessageButton'
 import { usePreference } from '@renderer/data/hooks/usePreference'
+import { useMacInputPreviewSync } from '@renderer/hooks/useMacInputPreviewSync'
 import { useTimer } from '@renderer/hooks/useTimer'
 import { toast } from '@renderer/services/toast'
 import { isPastedTextFileMetadata } from '@renderer/types/file'
@@ -583,6 +584,8 @@ export default function ComposerSurfaceRuntime({
   const managedTokenKindSet = useMemo(() => new Set(managedTokenKinds), [managedTokenKinds])
 
   const editingHighlightKey = editingState?.highlightKey
+  const composerAnchorRef = useRef<HTMLDivElement>(null)
+  useMacInputPreviewSync(composerAnchorRef, true)
 
   useLayoutEffect(() => {
     quickPanelRef.current = quickPanel
@@ -2328,8 +2331,9 @@ export default function ComposerSurfaceRuntime({
       ) : null}
     </div>
   )
+
   const inputbarStack = (
-    <div className="relative">
+    <div ref={composerAnchorRef} className="relative">
       {quickPanelElement}
       {inputbarElement}
     </div>

--- a/src/renderer/hooks/__tests__/useMacInputPreviewSync.test.tsx
+++ b/src/renderer/hooks/__tests__/useMacInputPreviewSync.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useMacInputPreviewSync } from '../useMacInputPreviewSync'
+
+vi.mock('@renderer/utils/platform', () => ({ isMac: true }))
+
+describe('useMacInputPreviewSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('re-syncs anchor geometry on window resize', () => {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = vi.fn(() => ({ top: 10, left: 10, bottom: 20, right: 20 } as DOMRect))
+    document.body.appendChild(el)
+    const ref = { current: el }
+
+    renderHook(() => useMacInputPreviewSync(ref, true))
+    vi.runAllTimers()
+
+    expect(el.getBoundingClientRect).toHaveBeenCalled()
+
+    const callsBefore = (el.getBoundingClientRect as unknown as { mock: { calls: unknown[] } }).mock.calls.length
+    window.dispatchEvent(new Event('resize'))
+    expect((el.getBoundingClientRect as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBeGreaterThan(callsBefore)
+
+    document.body.removeChild(el)
+  })
+
+  it('does not sync when disabled', () => {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = vi.fn(() => ({ top: 0 } as DOMRect))
+    const ref = { current: el }
+
+    renderHook(() => useMacInputPreviewSync(ref, false))
+    vi.runAllTimers()
+
+    expect(el.getBoundingClientRect).not.toHaveBeenCalled()
+  })
+
+  it('syncs on next frame after mount (launch geometry)', () => {
+    const el = document.createElement('div')
+    el.getBoundingClientRect = vi.fn(() => ({ top: 5 } as DOMRect))
+    const ref = { current: el }
+
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+
+    renderHook(() => useMacInputPreviewSync(ref, true))
+    expect(el.getBoundingClientRect).toHaveBeenCalled()
+
+    rafSpy.mockRestore()
+  })
+})

--- a/src/renderer/hooks/__tests__/useMacInputPreviewSync.test.tsx
+++ b/src/renderer/hooks/__tests__/useMacInputPreviewSync.test.tsx
@@ -16,7 +16,7 @@ describe('useMacInputPreviewSync', () => {
 
   it('re-syncs anchor geometry on window resize', () => {
     const el = document.createElement('div')
-    el.getBoundingClientRect = vi.fn(() => ({ top: 10, left: 10, bottom: 20, right: 20 } as DOMRect))
+    el.getBoundingClientRect = vi.fn(() => ({ top: 10, left: 10, bottom: 20, right: 20 }) as DOMRect)
     document.body.appendChild(el)
     const ref = { current: el }
 
@@ -27,14 +27,16 @@ describe('useMacInputPreviewSync', () => {
 
     const callsBefore = (el.getBoundingClientRect as unknown as { mock: { calls: unknown[] } }).mock.calls.length
     window.dispatchEvent(new Event('resize'))
-    expect((el.getBoundingClientRect as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBeGreaterThan(callsBefore)
+    expect((el.getBoundingClientRect as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBeGreaterThan(
+      callsBefore
+    )
 
     document.body.removeChild(el)
   })
 
   it('does not sync when disabled', () => {
     const el = document.createElement('div')
-    el.getBoundingClientRect = vi.fn(() => ({ top: 0 } as DOMRect))
+    el.getBoundingClientRect = vi.fn(() => ({ top: 0 }) as DOMRect)
     const ref = { current: el }
 
     renderHook(() => useMacInputPreviewSync(ref, false))
@@ -45,7 +47,7 @@ describe('useMacInputPreviewSync', () => {
 
   it('syncs on next frame after mount (launch geometry)', () => {
     const el = document.createElement('div')
-    el.getBoundingClientRect = vi.fn(() => ({ top: 5 } as DOMRect))
+    el.getBoundingClientRect = vi.fn(() => ({ top: 5 }) as DOMRect)
     const ref = { current: el }
 
     const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {

--- a/src/renderer/hooks/useMacInputPreviewSync.ts
+++ b/src/renderer/hooks/useMacInputPreviewSync.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+
+import { isMac } from '@renderer/utils/platform'
+
+/**
+ * Keeps macOS text input preview anchored to the composer after launch and window resize.
+ * Chromium's IME candidate preview caches screen coordinates; without a focus-triggered
+ * recompute it drifts when the window moves. Re-sync on resize and after initial paint
+ * restores the invariant that the preview stays attached to the caret.
+ */
+export function useMacInputPreviewSync(anchorRef: { current: HTMLElement | null }, enabled: boolean) {
+  useEffect(() => {
+    if (!enabled || !isMac) return
+
+    const anchor = anchorRef.current
+    if (!anchor) return
+
+    const sync = () => {
+      const el = anchorRef.current
+      if (!el) return
+      // Force layout recalc: reading getBoundingClientRect invalidates the cached
+      // screen position Chromium uses for the IME preview.
+      el.getBoundingClientRect()
+      // Nudge the selection so Electron re-emits the caret rect to the IME.
+      const sel = window.getSelection()
+      if (sel && sel.rangeCount > 0 && el.contains(sel.anchorNode)) {
+        const range = sel.getRangeAt(0).cloneRange()
+        sel.removeAllRanges()
+        sel.addRange(range)
+      }
+    }
+
+    // After launch the window geometry settles one frame later; sync then.
+    const raf = requestAnimationFrame(() => sync())
+    window.addEventListener('resize', sync)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', sync)
+    }
+  }, [anchorRef, enabled])
+}

--- a/src/renderer/hooks/useMacInputPreviewSync.ts
+++ b/src/renderer/hooks/useMacInputPreviewSync.ts
@@ -1,6 +1,5 @@
-import { useEffect } from 'react'
-
 import { isMac } from '@renderer/utils/platform'
+import { useEffect } from 'react'
 
 /**
  * Keeps macOS text input preview anchored to the composer after launch and window resize.


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR: On macOS the text input preview appears at wrong screen coordinates after launch and after window resize; focusing the input restores it.

After this PR: The preview stays anchored to the composer after launch and on every window resize.

Fixes #19804

### Why we need it and why it was done in this way

The composer anchor cached its geometry at open and was not invalidated when window geometry settled or changed. Re-syncing on next frame after mount and on window resize at the renderer anchor keeps the preview attached without cross-process changes.

The following tradeoffs were made: keep the fix in the renderer where the DOM rect is owned to avoid main-process IPC and focus stealing.

The following alternatives were considered: broadcasting window bounds from main and forcing IME invalidation — rejected as heavier coupling.

Links to places where the discussion took place: #19804

### Breaking changes

NONE

### Special notes for your reviewer

CC @kangfenmao @Konv Suu — renderer/composer area; minimal macOS-only geometry re-sync on next frame and resize.

### Checklist

- [ ] Branch: This PR targets `main`
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix macOS text input preview drift after launch and window resize.
```