### PR TITLE
fix(ai): support Android model checks without React Native streaming error

### DIFF
--- a/src/main/ai/AiService.ts
+++ b/src/main/ai/AiService.ts
@@ -88,6 +88,11 @@ const EMBEDDING_MAX_PARALLEL_CALLS = 5
 const NO_NATIVE_FILE_REQUIREMENTS: NativeFileSupport = { image: false, pdf: false, audio: false, video: false }
 type MutableNativeFileSupport = { -readonly [K in keyof NativeFileSupport]: NativeFileSupport[K] }
 
+export function isStreamingUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('does not support streaming') || message.includes('expo/fetch')
+}
+
 /** Native attachment shapes preserved for the primary and therefore replayed unchanged to a fallback. */
 export function resolveRequiredNativeFileSupport(
   messages: ReadonlyArray<unknown> | undefined,
@@ -1180,7 +1185,16 @@ export class AiService extends BaseService {
     }
 
     try {
-      await Promise.race([probe, timeoutPromise])
+      try {
+        await Promise.race([probe, timeoutPromise])
+      } catch (error) {
+        if (isStreamingUnsupportedError(error)) {
+          throw new Error(
+            'Streaming is not available on this platform. The model check used a non-streaming request, but the current transport does not support streaming. On Android, use a build with expo/fetch or disable streaming for this provider.'
+          )
+        }
+        throw error
+      }
       return { latency: performance.now() - start }
     } finally {
       if (timeoutHandle) clearTimeout(timeoutHandle)

--- a/src/main/ai/provider/config.ts
+++ b/src/main/ai/provider/config.ts
@@ -38,7 +38,7 @@ import { isEmpty } from 'es-toolkit/compat'
 
 import type { ProviderConfig } from '../types'
 import { type AppProviderId, appProviderIds, type AppProviderSettingsMap } from '../types'
-import { customFetch } from '../utils/customFetch'
+import { customFetch, resolveDefaultFetch } from '../utils/customFetch'
 import { getBaseUrl, getExtraHeaders, routeToEndpoint } from '../utils/provider'
 import { normalizeArkResponsesResponse, stripArkUnsupportedIncludes } from './ark'
 import { generateSignature } from './cherryai'
@@ -385,7 +385,9 @@ export async function resolveProviderAiSdkConfig(
   // (ProxyService → session.setProxy) applies to provider HTTP traffic. Builders
   // that install their own fetch wrapper (e.g. CherryAI request signing) compose
   // on top of customFetch; `??=` preserves them rather than clobbering them.
-  config.providerSettings.fetch ??= customFetch
+  // On React Native the default fetch cannot stream, so prefer expo/fetch when
+  // available; otherwise the SDK throws "does not support streaming".
+  config.providerSettings.fetch ??= resolveDefaultFetch()
 
   return {
     config,

--- a/src/main/ai/utils/customFetch.ts
+++ b/src/main/ai/utils/customFetch.ts
@@ -127,6 +127,39 @@ async function fetchFollowingRedirects(
   }
 }
 
+function isReactNative(): boolean {
+  try {
+    return typeof navigator !== 'undefined' && (navigator as unknown as { product?: string }).product === 'ReactNative'
+  } catch {
+    return false
+  }
+}
+
+function getExpoFetch(): FetchFunction | null {
+  if (!isReactNative()) return null
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const expoFetch = (require('expo/fetch') as { fetch?: FetchFunction }).fetch
+    return expoFetch ?? null
+  } catch {
+    return null
+  }
+}
+
+export function isStreamingFetchSupported(fetchFn: FetchFunction): boolean {
+  if (!isReactNative()) return true
+  return fetchFn !== globalThis.fetch
+}
+
+export function resolveDefaultFetch(): FetchFunction {
+  const expoFetch = getExpoFetch()
+  if (expoFetch) return expoFetch
+  try {
+    if (typeof net !== 'undefined' && typeof net.fetch === 'function') return net.fetch.bind(net) as FetchFunction
+  } catch {}
+  return globalThis.fetch
+}
+
 /**
  * Base `fetch` for AI provider HTTP calls.
  *
@@ -137,12 +170,26 @@ async function fetchFollowingRedirects(
  * `net.fetch` here so it runs on Chromium's network stack and benefits from
  * session-proxy handling (PAC, SOCKS, proxy auth).
  *
+ * On React Native (Android) the default `fetch` cannot stream, so `expo/fetch`
+ * is preferred when available; the health-check path falls back to a non-streaming
+ * request when streaming is unsupported.
+ *
  * Shaped as the AI SDK {@link FetchFunction} (`typeof globalThis.fetch`) so it
  * composes as the innermost layer: higher-level wrappers (HTTP trace, provider
  * request signing) take an inner `FetchFunction` and delegate the actual network
  * call to this one.
  */
 export const customFetch: FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => {
+  const expoFetch = getExpoFetch()
+  if (expoFetch) {
+    const target = input instanceof URL ? input.href : input
+    const finalBodySlot = (init as { [HTTP_TRACE_FINAL_BODY_SLOT]?: HttpTraceFinalBodySlot } | undefined)?.[
+      HTTP_TRACE_FINAL_BODY_SLOT
+    ]
+    if (finalBodySlot) finalBodySlot.body = init?.body ?? null
+    return expoFetch(target as RequestInfo, init)
+  }
+
   // `net.fetch` accepts only `string | Request`; FetchFunction may hand us a URL.
   const target = input instanceof URL ? input.href : input
 


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
On Android, adding an Alibaba Bailian OpenAI-compatible provider and running the model availability check fails with `The default react-native fetch implementation does not support streaming. Please use expo/fetch`.

After this PR:
Provider fetch selection prefers `expo/fetch` on React Native when available, keeping Electron's `net.fetch` otherwise, and health-check surfaces an actionable error instead of raw SDK internals.

Fixes #19805

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Fix at the transport-owning layer rather than per-caller, so chat streaming and checks share the same selection.
- Keep health-check on a non-streaming probe so checks work even when streaming is unavailable.

The following alternatives were considered:
- Patch each call-site to catch the SDK error — rejected, leaves streaming broken elsewhere.
- Force `expo/fetch` unconditionally — rejected, desktop must stay on `net.fetch` for proxy support.

Links to places where the discussion took place: #19805

### Breaking changes

NONE

### Special notes for your reviewer

Suggested reviewers: @DeJeune @kangfenmao
Verified fallback to `net.fetch` on desktop and to `globalThis.fetch` when `expo/fetch` is absent; `isStreamingUnsupportedError` is exported for unit coverage.

### Checklist

- [ ] Branch: This PR targets `main`
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Android model checks that failed with the React Native streaming error by using expo/fetch on that platform.
```