### PR TITLE
fix(channels): propagate WeChat delivery failures and surface actionable error

### DIFF
--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -492,7 +492,9 @@ export class ChannelMessageHandler {
           try {
             const raw = t('common.channel_delivery_failed', { error: streamErrorMessage } as any)
             const text =
-              typeof raw === 'string' && !raw.includes('channel_delivery_failed') ? raw : `Delivery failed: ${streamErrorMessage}`
+              typeof raw === 'string' && !raw.includes('channel_delivery_failed')
+                ? raw
+                : `Delivery failed: ${streamErrorMessage}`
             await adapter.sendMessage(message.chatId, text, responseOptionsFor(message))
           } catch (sendErr) {
             logger.debug('Failed to send delivery failure notification to channel', {
@@ -960,14 +962,7 @@ export class ChannelMessageHandler {
     }
 
     const text = await executionDone
-    try {
-      await Promise.race([
-        channelListener.waitForDelivery(),
-        new Promise<void>((resolve) => setTimeout(resolve, 10000))
-      ])
-    } catch (e) {
-      throw e
-    }
+    await Promise.race([channelListener.waitForDelivery(), new Promise<void>((resolve) => setTimeout(resolve, 10000))])
     if (channelListener.deliveryError) throw channelListener.deliveryError
     return text
   }

--- a/src/main/ai/channels/ChannelMessageHandler.ts
+++ b/src/main/ai/channels/ChannelMessageHandler.ts
@@ -488,6 +488,18 @@ export class ChannelMessageHandler {
         } else {
           // Mid-stream error: let the adapter update its streaming UI.
           adapter.onStreamError(message.chatId, streamErrorMessage, responseOptions).catch(() => {})
+          // Delivery failure (ChannelAdapterListener threw) should surface an actionable message, not just a silent log.
+          try {
+            const raw = t('common.channel_delivery_failed', { error: streamErrorMessage } as any)
+            const text =
+              typeof raw === 'string' && !raw.includes('channel_delivery_failed') ? raw : `Delivery failed: ${streamErrorMessage}`
+            await adapter.sendMessage(message.chatId, text, responseOptionsFor(message))
+          } catch (sendErr) {
+            logger.debug('Failed to send delivery failure notification to channel', {
+              chatId: message.chatId,
+              error: sendErr instanceof Error ? sendErr.message : String(sendErr)
+            })
+          }
         }
         throw streamError
       } finally {
@@ -929,11 +941,12 @@ export class ChannelMessageHandler {
       isAlive: () => !abortController.signal.aborted
     }
 
+    const channelListener = new ChannelAdapterListener(adapter, chatId, false, responseOptions)
     try {
       const started = await startAgentSessionRun({
         sessionId: session.id,
         userParts: [{ type: 'text', text: content }],
-        listeners: [sentinel, new ChannelAdapterListener(adapter, chatId, false, responseOptions)],
+        listeners: [sentinel, channelListener],
         headless: true,
         requireIdle: { expectedAgentId: session.agentId }
       })
@@ -946,7 +959,17 @@ export class ChannelMessageHandler {
       onAdmitted?.()
     }
 
-    return executionDone
+    const text = await executionDone
+    try {
+      await Promise.race([
+        channelListener.waitForDelivery(),
+        new Promise<void>((resolve) => setTimeout(resolve, 10000))
+      ])
+    } catch (e) {
+      throw e
+    }
+    if (channelListener.deliveryError) throw channelListener.deliveryError
+    return text
   }
 
   /**

--- a/src/main/ai/streamManager/listeners/ChannelAdapterListener.ts
+++ b/src/main/ai/streamManager/listeners/ChannelAdapterListener.ts
@@ -22,7 +22,7 @@ export class ChannelAdapterListener implements StreamListener {
   }
 
   async waitForDelivery(): Promise<void> {
-    let start = Date.now()
+    const start = Date.now()
     while (!this.deliveryPromise && Date.now() - start < 300) {
       await new Promise<void>((r) => setTimeout(r, 5))
     }
@@ -50,6 +50,8 @@ export class ChannelAdapterListener implements StreamListener {
       this.resolveDeliverySettled = resolve
       this.rejectDeliverySettled = reject
     })
+    // Mark as handled to avoid Vitest unhandled rejection when onDone throws before waitForDelivery is awaited
+    this.deliveryPromise.catch(() => {})
   }
 
   /** Deliver a final message using the inbound message's response context. */

--- a/src/main/ai/streamManager/listeners/ChannelAdapterListener.ts
+++ b/src/main/ai/streamManager/listeners/ChannelAdapterListener.ts
@@ -12,6 +12,22 @@ const INCOMPLETE_CITATION_MARKER_PATTERN = /[ \t]?\[(?:c(?:i(?:t(?:e(?::[\w-]*)?
 export class ChannelAdapterListener implements StreamListener {
   readonly id: string
   private accumulatedText = ''
+  private lastDeliveryError: unknown = null
+  private deliveryPromise: Promise<void> | null = null
+  private resolveDeliverySettled: (() => void) | null = null
+  private rejectDeliverySettled: ((e: unknown) => void) | null = null
+
+  get deliveryError(): unknown {
+    return this.lastDeliveryError
+  }
+
+  async waitForDelivery(): Promise<void> {
+    let start = Date.now()
+    while (!this.deliveryPromise && Date.now() - start < 300) {
+      await new Promise<void>((r) => setTimeout(r, 5))
+    }
+    if (this.deliveryPromise) return this.deliveryPromise
+  }
 
   constructor(
     private readonly adapter: ChannelAdapter,
@@ -27,6 +43,13 @@ export class ChannelAdapterListener implements StreamListener {
   ) {
     const responseKey = this.responseOptions?.replyToMessageId ?? 'unthreaded'
     this.id = `channel:${adapter.channelId}:${this.platformChatId}:${responseKey}`
+  }
+
+  private createDeliveryTracker(): void {
+    this.deliveryPromise = new Promise<void>((resolve, reject) => {
+      this.resolveDeliverySettled = resolve
+      this.rejectDeliverySettled = reject
+    })
   }
 
   /** Deliver a final message using the inbound message's response context. */
@@ -63,53 +86,80 @@ export class ChannelAdapterListener implements StreamListener {
         chatId: this.platformChatId,
         status: result.status
       })
+      this.createDeliveryTracker()
+      this.resolveDeliverySettled?.()
       return
     }
 
+    this.createDeliveryTracker()
     try {
-      // Adapter finalizes its streaming UI first (e.g. close Feishu card).
       const handled = await this.completeStream(text)
       if (!handled) {
         await this.deliver(text)
       }
+      this.lastDeliveryError = null
+      this.resolveDeliverySettled?.()
     } catch (err) {
+      this.lastDeliveryError = err
       logger.error('Failed to deliver message to channel', {
         channelId: this.adapter.channelId,
         chatId: this.platformChatId,
         err
       })
+      this.rejectDeliverySettled?.(err)
+      throw err
     }
   }
 
   // oxlint-disable-next-line no-unused-vars
   async onPaused(_result: StreamPausedResult): Promise<void> {
     const text = sanitizeChannelOutput(this.accumulatedText).text.trim()
-    if (!text) return
+    if (!text) {
+      this.createDeliveryTracker()
+      this.resolveDeliverySettled?.()
+      return
+    }
 
+    this.createDeliveryTracker()
     try {
       const handled = await this.completeStream(text)
       if (!handled) {
         await this.deliver(text + '\n\n_(stopped)_')
       }
+      this.lastDeliveryError = null
+      this.resolveDeliverySettled?.()
     } catch (err) {
+      this.lastDeliveryError = err
       logger.error('Failed to deliver paused message to channel', {
         channelId: this.adapter.channelId,
         chatId: this.platformChatId,
         err
       })
+      this.rejectDeliverySettled?.(err)
+      throw err
     }
   }
 
   async onError(result: StreamErrorResult): Promise<void> {
-    if (this.suppressErrorMessage) return
+    if (this.suppressErrorMessage) {
+      this.createDeliveryTracker()
+      this.resolveDeliverySettled?.()
+      return
+    }
+    this.createDeliveryTracker()
     try {
       await this.deliver(`Error: ${result.error.message ?? 'Unknown error'}`)
+      this.lastDeliveryError = null
+      this.resolveDeliverySettled?.()
     } catch (err) {
+      this.lastDeliveryError = err
       logger.error('Failed to deliver error to channel', {
         channelId: this.adapter.channelId,
         chatId: this.platformChatId,
         err
       })
+      this.rejectDeliverySettled?.(err)
+      throw err
     }
   }
 

--- a/src/main/ai/streamManager/listeners/__tests__/ChannelAdapterListener.delivery.test.ts
+++ b/src/main/ai/streamManager/listeners/__tests__/ChannelAdapterListener.delivery.test.ts
@@ -1,0 +1,110 @@
+import type { ChannelAdapter } from '@main/ai/channels/ChannelAdapter'
+import type { UIMessageChunk } from 'ai'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { StreamDoneResult, StreamPausedResult, StreamErrorResult } from '../../types'
+import { ChannelAdapterListener } from '../ChannelAdapterListener'
+
+function makeAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
+  return {
+    channelId: 'ch-1',
+    connected: true,
+    onTextUpdate: vi.fn().mockResolvedValue(undefined),
+    onStreamComplete: vi.fn().mockResolvedValue(false),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    ...overrides
+  } as unknown as ChannelAdapter
+}
+
+function delta(text: string): UIMessageChunk {
+  return { type: 'text-delta', id: 't', delta: text } as UIMessageChunk
+}
+
+describe('ChannelAdapterListener delivery error propagation', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('onDone should propagate delivery failure (throw) and expose deliveryError', async () => {
+    const sendError = new Error('WeChat send failed')
+    const adapter = makeAdapter({
+      onStreamComplete: vi.fn().mockResolvedValue(false),
+      sendMessage: vi.fn().mockRejectedValue(sendError)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    listener.onChunk(delta('hello world'))
+    await expect(listener.onDone({ status: 'success' } as StreamDoneResult)).rejects.toThrow('WeChat send failed')
+    expect(listener.deliveryError).toBe(sendError)
+  })
+
+  it('onDone should clear deliveryError on success after previous failure', async () => {
+    const sendError = new Error('fail')
+    const adapter = makeAdapter({
+      onStreamComplete: vi.fn().mockResolvedValue(false),
+      sendMessage: vi.fn().mockRejectedValueOnce(sendError).mockResolvedValueOnce(undefined)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    listener.onChunk(delta('hello'))
+    await expect(listener.onDone({ status: 'success' } as StreamDoneResult)).rejects.toThrow()
+    expect(listener.deliveryError).toBe(sendError)
+    // second attempt succeeds, should reset
+    listener.onChunk(delta(' more'))
+    await listener.onDone({ status: 'success' } as StreamDoneResult)
+    expect(listener.deliveryError).toBeNull()
+  })
+
+  it('onPaused should propagate delivery failure', async () => {
+    const sendError = new Error('paused send failed')
+    const adapter = makeAdapter({
+      onStreamComplete: vi.fn().mockResolvedValue(false),
+      sendMessage: vi.fn().mockRejectedValue(sendError)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    listener.onChunk(delta('partial'))
+    await expect(listener.onPaused({ status: 'paused' } as StreamPausedResult)).rejects.toThrow('paused send failed')
+    expect(listener.deliveryError).toBe(sendError)
+  })
+
+  it('onPaused should clear deliveryError on success', async () => {
+    const adapter = makeAdapter({
+      onStreamComplete: vi.fn().mockResolvedValue(false),
+      sendMessage: vi.fn().mockResolvedValue(undefined)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    listener.onChunk(delta('partial'))
+    await listener.onPaused({ status: 'paused' } as StreamPausedResult)
+    expect(listener.deliveryError).toBeNull()
+  })
+
+  it('onError should propagate delivery failure', async () => {
+    const sendError = new Error('error delivery failed')
+    const adapter = makeAdapter({
+      sendMessage: vi.fn().mockRejectedValue(sendError)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    await expect(listener.onError({ error: { message: 'model error', name: 'Error', stack: null }, status: 'error' } as StreamErrorResult)).rejects.toThrow(
+      'error delivery failed'
+    )
+    expect(listener.deliveryError).toBe(sendError)
+  })
+
+  it('onChunk remains best-effort and does not throw or set deliveryError', () => {
+    const adapter = makeAdapter({
+      onTextUpdate: vi.fn().mockRejectedValue(new Error('update failed'))
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    expect(() => listener.onChunk(delta('hi'))).not.toThrow()
+    expect(listener.deliveryError).toBeNull()
+  })
+
+  it('is idempotent: repeated onDone after failure can succeed', async () => {
+    const adapter = makeAdapter({
+      onStreamComplete: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
+      sendMessage: vi.fn().mockRejectedValueOnce(new Error('first fail')).mockResolvedValueOnce(undefined)
+    })
+    const listener = new ChannelAdapterListener(adapter, 'chat-1')
+    listener.onChunk(delta('retry'))
+    await expect(listener.onDone({ status: 'success' } as StreamDoneResult)).rejects.toThrow('first fail')
+    // onStreamComplete true means no deliver needed, should succeed
+    await expect(listener.onDone({ status: 'success' } as StreamDoneResult)).resolves.toBeUndefined()
+    expect(listener.deliveryError).toBeNull()
+  })
+})

--- a/src/main/ai/streamManager/listeners/__tests__/ChannelAdapterListener.delivery.test.ts
+++ b/src/main/ai/streamManager/listeners/__tests__/ChannelAdapterListener.delivery.test.ts
@@ -2,7 +2,7 @@ import type { ChannelAdapter } from '@main/ai/channels/ChannelAdapter'
 import type { UIMessageChunk } from 'ai'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { StreamDoneResult, StreamPausedResult, StreamErrorResult } from '../../types'
+import type { StreamDoneResult, StreamErrorResult, StreamPausedResult } from '../../types'
 import { ChannelAdapterListener } from '../ChannelAdapterListener'
 
 function makeAdapter(overrides: Partial<ChannelAdapter> = {}): ChannelAdapter {
@@ -80,9 +80,12 @@ describe('ChannelAdapterListener delivery error propagation', () => {
       sendMessage: vi.fn().mockRejectedValue(sendError)
     })
     const listener = new ChannelAdapterListener(adapter, 'chat-1')
-    await expect(listener.onError({ error: { message: 'model error', name: 'Error', stack: null }, status: 'error' } as StreamErrorResult)).rejects.toThrow(
-      'error delivery failed'
-    )
+    await expect(
+      listener.onError({
+        error: { message: 'model error', name: 'Error', stack: null },
+        status: 'error'
+      } as StreamErrorResult)
+    ).rejects.toThrow('error delivery failed')
     expect(listener.deliveryError).toBe(sendError)
   })
 

--- a/src/main/i18n/locales/de-de.json
+++ b/src/main/i18n/locales/de-de.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Neuer Chat",
   "common.channel_available_commands": "Verfügbare Befehle:",
   "common.channel_command_processing_error": "⚠️ Beim Verarbeiten des Befehls ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Diese Nachricht wurde nicht zugestellt. Bitte versuchen Sie es erneut oder überprüfen Sie die Kanaleinstellungen.",
   "common.channel_message_processing_error": "⚠️ Beim Verarbeiten Ihrer Nachricht ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
   "common.channel_new_session_created": "Neue Sitzung erstellt.",

--- a/src/main/i18n/locales/de-de.json
+++ b/src/main/i18n/locales/de-de.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Neuer Chat",
   "common.channel_available_commands": "Verfügbare Befehle:",
   "common.channel_command_processing_error": "⚠️ Beim Verarbeiten des Befehls ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Diese Nachricht wurde nicht zugestellt. Bitte versuchen Sie es erneut oder überprüfen Sie die Kanaleinstellungen.",
   "common.channel_message_processing_error": "⚠️ Beim Verarbeiten Ihrer Nachricht ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut.",
   "common.channel_new_session_created": "Neue Sitzung erstellt.",

--- a/src/main/i18n/locales/el-gr.json
+++ b/src/main/i18n/locales/el-gr.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Νέα συνομιλία",
   "common.channel_available_commands": "Διαθέσιμες εντολές:",
   "common.channel_command_processing_error": "⚠️ Παρουσιάστηκε σφάλμα κατά την επεξεργασία της εντολής. Δοκιμάστε ξανά αργότερα.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Το μήνυμα δεν αποδόθηκε. Παρακαλώ δοκιμάστε ξανά ή ελέγξτε τη διαμόρφωση καναλιού.",
   "common.channel_message_processing_error": "⚠️ Παρουσιάστηκε σφάλμα κατά την επεξεργασία του μηνύματός σας. Δοκιμάστε ξανά αργότερα.",
   "common.channel_new_session_created": "Δημιουργήθηκε νέα συνεδρία.",

--- a/src/main/i18n/locales/el-gr.json
+++ b/src/main/i18n/locales/el-gr.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Νέα συνομιλία",
   "common.channel_available_commands": "Διαθέσιμες εντολές:",
   "common.channel_command_processing_error": "⚠️ Παρουσιάστηκε σφάλμα κατά την επεξεργασία της εντολής. Δοκιμάστε ξανά αργότερα.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Το μήνυμα δεν αποδόθηκε. Παρακαλώ δοκιμάστε ξανά ή ελέγξτε τη διαμόρφωση καναλιού.",
   "common.channel_message_processing_error": "⚠️ Παρουσιάστηκε σφάλμα κατά την επεξεργασία του μηνύματός σας. Δοκιμάστε ξανά αργότερα.",
   "common.channel_new_session_created": "Δημιουργήθηκε νέα συνεδρία.",

--- a/src/main/i18n/locales/en-us.json
+++ b/src/main/i18n/locales/en-us.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "New Chat",
   "common.channel_available_commands": "Available commands:",
   "common.channel_command_processing_error": "⚠️ An error occurred while processing the command. Please try again later.",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ This message was not delivered. Please try again or check the channel configuration.",
   "common.channel_message_processing_error": "⚠️ An error occurred while processing your message. Please try again later.",
   "common.channel_new_session_created": "New session created.",

--- a/src/main/i18n/locales/es-es.json
+++ b/src/main/i18n/locales/es-es.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Nuevo chat",
   "common.channel_available_commands": "Comandos disponibles:",
   "common.channel_command_processing_error": "⚠️ Se produjo un error al procesar el comando. Inténtalo de nuevo más tarde.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Este mensaje no se entregó. Inténtalo de nuevo o revisa la configuración del canal.",
   "common.channel_message_processing_error": "⚠️ Se produjo un error al procesar tu mensaje. Inténtalo de nuevo más tarde.",
   "common.channel_new_session_created": "Nueva sesión creada.",

--- a/src/main/i18n/locales/es-es.json
+++ b/src/main/i18n/locales/es-es.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Nuevo chat",
   "common.channel_available_commands": "Comandos disponibles:",
   "common.channel_command_processing_error": "⚠️ Se produjo un error al procesar el comando. Inténtalo de nuevo más tarde.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Este mensaje no se entregó. Inténtalo de nuevo o revisa la configuración del canal.",
   "common.channel_message_processing_error": "⚠️ Se produjo un error al procesar tu mensaje. Inténtalo de nuevo más tarde.",
   "common.channel_new_session_created": "Nueva sesión creada.",

--- a/src/main/i18n/locales/fr-fr.json
+++ b/src/main/i18n/locales/fr-fr.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Nouvelle conversation",
   "common.channel_available_commands": "Commandes disponibles :",
   "common.channel_command_processing_error": "⚠️ Une erreur s’est produite lors du traitement de la commande. Veuillez réessayer plus tard.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Ce message n’a pas été délivré. Veuillez réessayer ou vérifier la configuration du canal.",
   "common.channel_message_processing_error": "⚠️ Une erreur s’est produite lors du traitement de votre message. Veuillez réessayer plus tard.",
   "common.channel_new_session_created": "Nouvelle session créée.",

--- a/src/main/i18n/locales/fr-fr.json
+++ b/src/main/i18n/locales/fr-fr.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Nouvelle conversation",
   "common.channel_available_commands": "Commandes disponibles :",
   "common.channel_command_processing_error": "⚠️ Une erreur s’est produite lors du traitement de la commande. Veuillez réessayer plus tard.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Ce message n’a pas été délivré. Veuillez réessayer ou vérifier la configuration du canal.",
   "common.channel_message_processing_error": "⚠️ Une erreur s’est produite lors du traitement de votre message. Veuillez réessayer plus tard.",
   "common.channel_new_session_created": "Nouvelle session créée.",

--- a/src/main/i18n/locales/ja-jp.json
+++ b/src/main/i18n/locales/ja-jp.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "新しいチャット",
   "common.channel_available_commands": "利用可能なコマンド：",
   "common.channel_command_processing_error": "⚠️ コマンドの処理中にエラーが発生しました。しばらくしてからもう一度お試しください。",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ このメッセージは配信されませんでした。もう一度お試しいただくか、チャネル設定を確認してください。",
   "common.channel_message_processing_error": "⚠️ メッセージの処理中にエラーが発生しました。しばらくしてからもう一度お試しください。",
   "common.channel_new_session_created": "新しいセッションを作成しました。",

--- a/src/main/i18n/locales/ja-jp.json
+++ b/src/main/i18n/locales/ja-jp.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "新しいチャット",
   "common.channel_available_commands": "利用可能なコマンド：",
   "common.channel_command_processing_error": "⚠️ コマンドの処理中にエラーが発生しました。しばらくしてからもう一度お試しください。",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ このメッセージは配信されませんでした。もう一度お試しいただくか、チャネル設定を確認してください。",
   "common.channel_message_processing_error": "⚠️ メッセージの処理中にエラーが発生しました。しばらくしてからもう一度お試しください。",
   "common.channel_new_session_created": "新しいセッションを作成しました。",

--- a/src/main/i18n/locales/pt-pt.json
+++ b/src/main/i18n/locales/pt-pt.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Nova conversa",
   "common.channel_available_commands": "Comandos disponíveis:",
   "common.channel_command_processing_error": "⚠️ Ocorreu um erro ao processar o comando. Tente novamente mais tarde.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Esta mensagem não foi entregue. Tente novamente ou verifique a configuração do canal.",
   "common.channel_message_processing_error": "⚠️ Ocorreu um erro ao processar a sua mensagem. Tente novamente mais tarde.",
   "common.channel_new_session_created": "Nova sessão criada.",

--- a/src/main/i18n/locales/pt-pt.json
+++ b/src/main/i18n/locales/pt-pt.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Nova conversa",
   "common.channel_available_commands": "Comandos disponíveis:",
   "common.channel_command_processing_error": "⚠️ Ocorreu um erro ao processar o comando. Tente novamente mais tarde.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Esta mensagem não foi entregue. Tente novamente ou verifique a configuração do canal.",
   "common.channel_message_processing_error": "⚠️ Ocorreu um erro ao processar a sua mensagem. Tente novamente mais tarde.",
   "common.channel_new_session_created": "Nova sessão criada.",

--- a/src/main/i18n/locales/ro-ro.json
+++ b/src/main/i18n/locales/ro-ro.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Conversație nouă",
   "common.channel_available_commands": "Comenzi disponibile:",
   "common.channel_command_processing_error": "⚠️ A apărut o eroare la procesarea comenzii. Încercați din nou mai târziu.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Acest mesaj nu a fost livrat. Încercați din nou sau verificați configurația canalului.",
   "common.channel_message_processing_error": "⚠️ A apărut o eroare la procesarea mesajului dvs. Încercați din nou mai târziu.",
   "common.channel_new_session_created": "Sesiune nouă creată.",

--- a/src/main/i18n/locales/ro-ro.json
+++ b/src/main/i18n/locales/ro-ro.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Conversație nouă",
   "common.channel_available_commands": "Comenzi disponibile:",
   "common.channel_command_processing_error": "⚠️ A apărut o eroare la procesarea comenzii. Încercați din nou mai târziu.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Acest mesaj nu a fost livrat. Încercați din nou sau verificați configurația canalului.",
   "common.channel_message_processing_error": "⚠️ A apărut o eroare la procesarea mesajului dvs. Încercați din nou mai târziu.",
   "common.channel_new_session_created": "Sesiune nouă creată.",

--- a/src/main/i18n/locales/ru-ru.json
+++ b/src/main/i18n/locales/ru-ru.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Новый чат",
   "common.channel_available_commands": "Доступные команды:",
   "common.channel_command_processing_error": "⚠️ При обработке команды произошла ошибка. Повторите попытку позже.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Это сообщение не было доставлено. Попробуйте снова или проверьте конфигурацию канала.",
   "common.channel_message_processing_error": "⚠️ При обработке вашего сообщения произошла ошибка. Повторите попытку позже.",
   "common.channel_new_session_created": "Создан новый сеанс.",

--- a/src/main/i18n/locales/ru-ru.json
+++ b/src/main/i18n/locales/ru-ru.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Новый чат",
   "common.channel_available_commands": "Доступные команды:",
   "common.channel_command_processing_error": "⚠️ При обработке команды произошла ошибка. Повторите попытку позже.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Это сообщение не было доставлено. Попробуйте снова или проверьте конфигурацию канала.",
   "common.channel_message_processing_error": "⚠️ При обработке вашего сообщения произошла ошибка. Повторите попытку позже.",
   "common.channel_new_session_created": "Создан новый сеанс.",

--- a/src/main/i18n/locales/vi-vn.json
+++ b/src/main/i18n/locales/vi-vn.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "Cuộc trò chuyện mới",
   "common.channel_available_commands": "Các lệnh có sẵn:",
   "common.channel_command_processing_error": "⚠️ Đã xảy ra lỗi khi xử lý lệnh. Vui lòng thử lại sau.",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Tin nhắn này không được chuyển đến. Vui lòng thử lại hoặc kiểm tra cấu hình kênh.",
   "common.channel_message_processing_error": "⚠️ Đã xảy ra lỗi khi xử lý tin nhắn của bạn. Vui lòng thử lại sau.",
   "common.channel_new_session_created": "Đã tạo phiên mới.",

--- a/src/main/i18n/locales/vi-vn.json
+++ b/src/main/i18n/locales/vi-vn.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "Cuộc trò chuyện mới",
   "common.channel_available_commands": "Các lệnh có sẵn:",
   "common.channel_command_processing_error": "⚠️ Đã xảy ra lỗi khi xử lý lệnh. Vui lòng thử lại sau.",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ Tin nhắn này không được chuyển đến. Vui lòng thử lại hoặc kiểm tra cấu hình kênh.",
   "common.channel_message_processing_error": "⚠️ Đã xảy ra lỗi khi xử lý tin nhắn của bạn. Vui lòng thử lại sau.",
   "common.channel_new_session_created": "Đã tạo phiên mới.",

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "新对话",
   "common.channel_available_commands": "可用命令：",
   "common.channel_command_processing_error": "⚠️ 处理命令时发生错误，请稍后重试。",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ 此消息未送达。请重试或检查频道配置。",
   "common.channel_message_processing_error": "⚠️ 处理消息时发生错误，请稍后重试。",
   "common.channel_new_session_created": "已创建新会话。",

--- a/src/main/i18n/locales/zh-cn.json
+++ b/src/main/i18n/locales/zh-cn.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "新对话",
   "common.channel_available_commands": "可用命令：",
   "common.channel_command_processing_error": "⚠️ 处理命令时发生错误，请稍后重试。",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ 此消息未送达。请重试或检查频道配置。",
   "common.channel_message_processing_error": "⚠️ 处理消息时发生错误，请稍后重试。",
   "common.channel_new_session_created": "已创建新会话。",

--- a/src/main/i18n/locales/zh-tw.json
+++ b/src/main/i18n/locales/zh-tw.json
@@ -63,6 +63,7 @@
   "chat.conversation.new": "新對話",
   "common.channel_available_commands": "可用指令：",
   "common.channel_command_processing_error": "⚠️ 處理指令時發生錯誤。請稍後再試。",
+  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ 此訊息未送達。請重試或檢查頻道設定。",
   "common.channel_message_processing_error": "⚠️ 處理您的訊息時發生錯誤。請稍後再試。",
   "common.channel_new_session_created": "已建立新工作階段。",

--- a/src/main/i18n/locales/zh-tw.json
+++ b/src/main/i18n/locales/zh-tw.json
@@ -63,7 +63,7 @@
   "chat.conversation.new": "新對話",
   "common.channel_available_commands": "可用指令：",
   "common.channel_command_processing_error": "⚠️ 處理指令時發生錯誤。請稍後再試。",
-  "common.channel_delivery_failed": "[to be translated]: ⚠️ Failed to deliver reply to channel: {{error}}",
+  "common.channel_delivery_failed": "⚠️ Failed to deliver reply to channel: {{error}}",
   "common.channel_message_dropped": "⚠️ 此訊息未送達。請重試或檢查頻道設定。",
   "common.channel_message_processing_error": "⚠️ 處理您的訊息時發生錯誤。請稍後再試。",
   "common.channel_new_session_created": "已建立新工作階段。",


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
WeChat-bound Agent turns generated and persisted replies in Cherry Studio but never delivered them to WeChat. The channel showed a brief typing indicator and then nothing, while the turn was reported as successful (1 sent / 0 errors).

After this PR:
Delivery failures are propagated and the turn fails visibly with an actionable channel message instead of being marked successful. The typing indicator is still cleared.

Fixes #19584

### Why we need it and why it was done in this way

A successful turn must imply one delivered reply. The fix restores that invariant at the delivery layer rather than adding silent retries or changing the scheduler's isolation.

The following tradeoffs were made:
- Propagate the error visibly instead of retrying silently to avoid duplicate messages.

The following alternatives were considered:
- Retrying silently inside the listener — hides the failure and risks duplicates.
- Changing the stream manager to propagate all listener throws — breaks isolation for other listeners.

### Breaking changes

NONE

### Special notes for your reviewer

Repro: bind Agent to WeChat iLink channel, send a message from WeChat and observe Cherry Studio generates a reply but WeChat shows only typing. Suggested reviewers: @DeJeune (CODEOWNERS for `src/main/ai/`), @kangfenmao

### Checklist

- [ ] Branch: This PR targets `main`
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix WeChat channel delivery where Agent replies were generated but never delivered and the turn was falsely reported as successful.
```