### PR TITLE
fix(agent-runtime): inline document text for Claude Code agent attachments

### DIFF
--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -20,10 +20,6 @@ import { collectAssistantFileAttachments } from '@main/ai/messages/assistantFile
 import { collectFileAttachments, prepareChatMessages } from '@main/ai/messages/attachmentRouting'
 import { extractDocumentText, noExtractableTextNote } from '@main/ai/messages/attachmentTextExtraction'
 import { materializeNativeFilePart } from '@main/ai/messages/fileProcessor'
-import { surrogateSafeEnd } from '@main/ai/utils/textPaging'
-import { READ_FILE_PAGE_SIZE } from '@shared/ai/builtinTools'
-import { FILE_TYPE } from '@shared/types/file'
-import { getFileTypeByExt } from '@shared/utils/file'
 import {
   appendAgentAttachmentPaths,
   buildAgentUserContent,
@@ -36,9 +32,11 @@ import {
   descriptorToTool,
   listClaudeAgentToolDescriptors
 } from '@main/ai/tools/adapters/claudeCode/agentTools'
+import { surrogateSafeEnd } from '@main/ai/utils/textPaging'
 import { probeReadable } from '@main/utils/file'
 import type { AgentSessionContextUsage } from '@shared/ai/agentSessionContextUsage'
 import type { AgentSessionSlashCommand } from '@shared/ai/agentSessionSlashCommands'
+import { READ_FILE_PAGE_SIZE } from '@shared/ai/builtinTools'
 import type { Tool } from '@shared/ai/tool'
 import type { AgentPermissionMode } from '@shared/data/api/schemas/agents'
 import type { AgentSessionMessageEntity } from '@shared/data/api/schemas/agentSessionMessages'
@@ -46,8 +44,10 @@ import type { AgentSessionEntity } from '@shared/data/api/schemas/agentSessions'
 import type { CherryUIMessage, FileUIPart } from '@shared/data/types/message'
 import { parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import { readCherryMeta } from '@shared/data/types/uiParts'
+import { FILE_TYPE } from '@shared/types/file'
 import { type AbsoluteFilePath, AbsoluteFilePathSchema } from '@shared/types/file'
 import { parseDataUrl } from '@shared/utils/dataUrl'
+import { getFileTypeByExt } from '@shared/utils/file'
 import { imageExts } from '@shared/utils/file'
 import { isVisionModel } from '@shared/utils/model'
 
@@ -1245,10 +1245,13 @@ async function materializeUserContent(
     }
   }
 
-  const text = [preparedParts
-    .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
-    .map((part) => part.text)
-    .join('\n'), ...inlineDocumentTexts]
+  const text = [
+    preparedParts
+      .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
+      .map((part) => part.text)
+      .join('\n'),
+    ...inlineDocumentTexts
+  ]
     .filter(Boolean)
     .join('\n\n')
   const images: ImageBlockParam[] = []

--- a/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
+++ b/src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts
@@ -18,7 +18,12 @@ import { modelService } from '@data/services/ModelService'
 import { loggerService } from '@logger'
 import { collectAssistantFileAttachments } from '@main/ai/messages/assistantFileAttachments'
 import { collectFileAttachments, prepareChatMessages } from '@main/ai/messages/attachmentRouting'
+import { extractDocumentText, noExtractableTextNote } from '@main/ai/messages/attachmentTextExtraction'
 import { materializeNativeFilePart } from '@main/ai/messages/fileProcessor'
+import { surrogateSafeEnd } from '@main/ai/utils/textPaging'
+import { READ_FILE_PAGE_SIZE } from '@shared/ai/builtinTools'
+import { FILE_TYPE } from '@shared/types/file'
+import { getFileTypeByExt } from '@shared/utils/file'
 import {
   appendAgentAttachmentPaths,
   buildAgentUserContent,
@@ -1187,17 +1192,72 @@ async function materializeUserContent(
     preparedParts = prepared.parts
   }
 
-  const text = preparedParts
+  // Non-image first-party files (PDF, office, text) were previously sent only as
+  // absolute paths, so a model that does not call the file tool sees no content
+  // (issue #19803). Inline extracted text so visibility never depends on tool use,
+  // matching the chat pipeline's `prepareChatMessages` fallback.
+  const inlineDocumentTexts: string[] = []
+  const remainingPathParts: FileUIPart[] = []
+  for (const part of firstPartyPathParts) {
+    if (!isDocumentLikeFilePart(part)) {
+      remainingPathParts.push(part)
+      continue
+    }
+    const fileEntryId = readCherryMeta(part)?.fileEntryId
+    if (!fileEntryId) {
+      remainingPathParts.push(part)
+      continue
+    }
+    const handle = part.filename ?? 'file'
+    try {
+      const extracted = await extractDocumentText(fileEntryId)
+      if (extracted === null) {
+        logger.info('Document attachment requires binary handling, falling back to path', {
+          filename: handle,
+          fileEntryId,
+          mode: 'path-fallback'
+        })
+        remainingPathParts.push(part)
+        continue
+      }
+      const trimmed = extracted.trim()
+      const body = trimmed || noExtractableTextNote(handle)
+      const cap = READ_FILE_PAGE_SIZE
+      const capped =
+        body.length > cap
+          ? `${body.slice(0, surrogateSafeEnd(body, cap))}\n\n[Truncated ${cap}/${body.length} chars — call read_file("${handle}", offset=${cap}) for the rest.]`
+          : body
+      inlineDocumentTexts.push(`Attached file "${handle}":\n${capped}`)
+      logger.info('Document attachment inlined as text', {
+        filename: handle,
+        fileEntryId,
+        mode: 'extracted-text',
+        chars: body.length
+      })
+      if (!trimmed) remainingPathParts.push(part)
+    } catch (error) {
+      logger.warn('Document extraction failed, falling back to path', error as Error, {
+        filename: handle,
+        fileEntryId,
+        mode: 'extraction-failed'
+      })
+      remainingPathParts.push(part)
+    }
+  }
+
+  const text = [preparedParts
     .filter((part): part is { type: 'text'; text: string } => part.type === 'text')
     .map((part) => part.text)
-    .join('\n')
+    .join('\n'), ...inlineDocumentTexts]
+    .filter(Boolean)
+    .join('\n\n')
   const images: ImageBlockParam[] = []
   const fallbackParts: FileUIPart[] = []
   const unavailableParts: FileUIPart[] = []
 
   for (const part of [
     ...preparedParts.filter((part): part is FileUIPart => part.type === 'file'),
-    ...firstPartyPathParts,
+    ...remainingPathParts,
     ...externalFileParts
   ]) {
     const fileEntryId = readCherryMeta(part)?.fileEntryId
@@ -1308,6 +1368,14 @@ async function extractAttachmentPaths(
     }
   }
   return { files, unavailable }
+}
+
+function isDocumentLikeFilePart(part: FileUIPart): boolean {
+  const filename = part.filename?.toLowerCase() ?? ''
+  const ext = filename.includes('.') ? (filename.split('.').pop() ?? '') : ''
+  if (!ext) return false
+  const fileType = getFileTypeByExt(ext)
+  return fileType === FILE_TYPE.DOCUMENT || fileType === FILE_TYPE.TEXT || ext === 'pdf'
 }
 
 function isImageFilePart(part: FileUIPart): boolean {


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:
Agent conversations show a PDF attachment chip, but the Claude Code runtime sends the PDF only as a filesystem path. If the model does not call the file tool, Claude reports no attachment content was received (issue #19803).

After this PR:
First-party document attachments in the Claude Code agent flow are inlined as extracted text before the path fallback. Text is capped with the existing paging and scanned PDFs keep the path for tool access.

Fixes #19803

### Why we need it and why it was done in this way

The chat pipeline already guarantees visibility by inlining document text; the agent path only announced the path. Reusing the existing extraction keeps the fix minimal and consistent with chat.

The following tradeoffs were made:
- Inline text vs native document block: inline text works with the current SDK shape and is proven in chat.
- Keep the path for empty, binary, or extraction-failure cases to preserve the tool-readable handle.

The following alternatives were considered:
- Make native PDF support dynamic and emit a native document block.
- Block sending at the composer with a pre-send check.

### Breaking changes

NONE

### Special notes for your reviewer

Reviewers: @DeJeune @eeee0717 (CODEOWNERS for `src/main/ai/`). Focus file: `src/main/ai/runtime/claudeCode/ClaudeCodeRuntimeDriver.ts`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Branch: This PR targets `main`
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix Claude Code agent PDF attachments being invisible when the model does not call the file tool.
```