### PR TITLE
fix(gateway): route CherryIN Gemini models to google endpoint to enable built-in tool + function calling

### DIFF
--- a/src/main/ai/provider/__tests__/cherryinGeminiRouting.regression.test.ts
+++ b/src/main/ai/provider/__tests__/cherryinGeminiRouting.regression.test.ts
@@ -1,0 +1,54 @@
+import { ENDPOINT_TYPE } from '@shared/data/types/model'
+import { describe, expect, it } from 'vitest'
+import { makeModel, makeProvider } from '../../__tests__/fixtures'
+import { resolveEffectiveEndpoint } from '../endpoint'
+import { resolveGatewayChatRoute } from '@shared/data/presets/gatewayChatRouting'
+
+describe('REGRESSION: cherryin gemini routing for built-in tools + function calling', () => {
+  const cherryin = makeProvider({
+    id: 'cherryin',
+    defaultChatEndpoint: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+    endpointConfigs: {
+      [ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS]: { baseUrl: 'https://open.cherryin.net', adapterFamily: 'cherryin' },
+      [ENDPOINT_TYPE.ANTHROPIC_MESSAGES]: { baseUrl: 'https://open.cherryin.net', adapterFamily: 'cherryin' },
+      [ENDPOINT_TYPE.OPENAI_RESPONSES]: { baseUrl: 'https://open.cherryin.net', adapterFamily: 'cherryin' },
+      [ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT]: { baseUrl: 'https://open.cherryin.net', adapterFamily: 'cherryin' }
+    }
+  })
+
+  it('gateway route resolves gemini-3.5-flash to google endpoint', () => {
+    const model = makeModel({
+      id: 'cherryin::gemini-3.5-flash',
+      providerId: 'cherryin',
+      apiModelId: 'gemini-3.5-flash'
+    })
+    const route = resolveGatewayChatRoute(cherryin as any, model as any)
+    expect(route).toEqual({ endpointType: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT, providerOptionsKey: 'google' })
+  })
+
+  it('effective endpoint for cherryin gemini without endpointTypes is google, not openai-chat', () => {
+    const model = makeModel({
+      id: 'cherryin::gemini-3.5-flash',
+      providerId: 'cherryin',
+      apiModelId: 'gemini-3.5-flash'
+    }) as any
+    // intentionally no endpointTypes to mimic cherryin.listModels missing supported_endpoint_types
+    delete (model as any).endpointTypes
+    const { endpointType, providerOptionsKey } = resolveEffectiveEndpoint(cherryin as any, model as any)
+    expect(endpointType).toBe(ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT)
+    expect(providerOptionsKey).toBe('google')
+  })
+
+  it('still routes claude models to anthropic and gpt to openai via cherryin', () => {
+    const claude = makeModel({
+      id: 'cherryin::claude-sonnet-4-5',
+      providerId: 'cherryin',
+      apiModelId: 'claude-sonnet-4-5'
+    })
+    expect(resolveGatewayChatRoute(cherryin as any, claude as any)?.endpointType).toBe(ENDPOINT_TYPE.ANTHROPIC_MESSAGES)
+    const gpt = makeModel({ id: 'cherryin::gpt-4o', providerId: 'cherryin', apiModelId: 'gpt-4o' })
+    const gptRoute = resolveGatewayChatRoute(cherryin as any, gpt as any)
+    expect(gptRoute?.endpointType).toBe(ENDPOINT_TYPE.OPENAI_RESPONSES)
+    expect(gptRoute?.providerOptionsKey).toBe('openai')
+  })
+})

--- a/src/main/ai/provider/__tests__/cherryinGeminiRouting.regression.test.ts
+++ b/src/main/ai/provider/__tests__/cherryinGeminiRouting.regression.test.ts
@@ -1,8 +1,9 @@
+import { resolveGatewayChatRoute } from '@shared/data/presets/gatewayChatRouting'
 import { ENDPOINT_TYPE } from '@shared/data/types/model'
 import { describe, expect, it } from 'vitest'
+
 import { makeModel, makeProvider } from '../../__tests__/fixtures'
 import { resolveEffectiveEndpoint } from '../endpoint'
-import { resolveGatewayChatRoute } from '@shared/data/presets/gatewayChatRouting'
 
 describe('REGRESSION: cherryin gemini routing for built-in tools + function calling', () => {
   const cherryin = makeProvider({
@@ -27,14 +28,14 @@ describe('REGRESSION: cherryin gemini routing for built-in tools + function call
   })
 
   it('effective endpoint for cherryin gemini without endpointTypes is google, not openai-chat', () => {
-    const model = makeModel({
+    const model: any = makeModel({
       id: 'cherryin::gemini-3.5-flash',
       providerId: 'cherryin',
       apiModelId: 'gemini-3.5-flash'
-    }) as any
+    })
     // intentionally no endpointTypes to mimic cherryin.listModels missing supported_endpoint_types
-    delete (model as any).endpointTypes
-    const { endpointType, providerOptionsKey } = resolveEffectiveEndpoint(cherryin as any, model as any)
+    delete model.endpointTypes
+    const { endpointType, providerOptionsKey } = resolveEffectiveEndpoint(cherryin, model)
     expect(endpointType).toBe(ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT)
     expect(providerOptionsKey).toBe('google')
   })

--- a/src/shared/data/presets/gatewayChatRouting.ts
+++ b/src/shared/data/presets/gatewayChatRouting.ts
@@ -105,11 +105,15 @@ export type CherryinChatFamily = 'anthropic' | 'gemini' | 'openai-responses' | '
 export function resolveCherryinChatFamily(modelId: string): CherryinChatFamily {
   const baseId = modelId.toLowerCase().split('/').pop() ?? modelId.toLowerCase()
   if (baseId.startsWith('claude')) return 'anthropic'
+  if (baseId.startsWith('imagen') && !baseId.endsWith('no-think') && !baseId.endsWith('-search') && !baseId.includes('embedding')) {
+    return 'gemini'
+  }
   if (
-    (baseId.startsWith('gemini') || baseId.startsWith('imagen')) &&
+    baseId.startsWith('gemini') &&
     !baseId.endsWith('no-think') &&
     !baseId.endsWith('-search') &&
-    !baseId.includes('embedding')
+    !baseId.includes('embedding') &&
+    !baseId.includes('image')
   ) {
     return 'gemini'
   }

--- a/src/shared/data/presets/gatewayChatRouting.ts
+++ b/src/shared/data/presets/gatewayChatRouting.ts
@@ -100,9 +100,52 @@ export function resolveDmxapiEndpointType(modelId: string): EndpointType {
   return resolveDmxapiChatRoute(modelId).endpointType
 }
 
+export type CherryinChatFamily = 'anthropic' | 'gemini' | 'openai-responses' | 'openai-chat' | 'compat'
+
+export function resolveCherryinChatFamily(modelId: string): CherryinChatFamily {
+  const baseId = modelId.toLowerCase().split('/').pop() ?? modelId.toLowerCase()
+  if (baseId.startsWith('claude')) return 'anthropic'
+  if (
+    (baseId.startsWith('gemini') || baseId.startsWith('imagen')) &&
+    !baseId.endsWith('no-think') &&
+    !baseId.endsWith('-search') &&
+    !baseId.includes('embedding')
+  ) {
+    return 'gemini'
+  }
+  if (isOpenAILLM(baseId)) return isOpenAIChatCompletionOnly(baseId) ? 'openai-chat' : 'openai-responses'
+  return 'compat'
+}
+
+const CHERRYIN_ENDPOINT: Record<CherryinChatFamily, EndpointType> = {
+  anthropic: ENDPOINT_TYPE.ANTHROPIC_MESSAGES,
+  gemini: ENDPOINT_TYPE.GOOGLE_GENERATE_CONTENT,
+  'openai-responses': ENDPOINT_TYPE.OPENAI_RESPONSES,
+  'openai-chat': ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS,
+  compat: ENDPOINT_TYPE.OPENAI_CHAT_COMPLETIONS
+}
+
+const CHERRYIN_OPTIONS_KEY: Record<CherryinChatFamily, string> = {
+  anthropic: 'anthropic',
+  gemini: 'google',
+  'openai-responses': 'openai',
+  'openai-chat': 'openai',
+  compat: 'cherryin'
+}
+
+export function resolveCherryinChatRoute(modelId: string): GatewayModelRoute {
+  const family = resolveCherryinChatFamily(modelId)
+  return { endpointType: CHERRYIN_ENDPOINT[family], providerOptionsKey: CHERRYIN_OPTIONS_KEY[family] }
+}
+
+export function resolveCherryinEndpointType(modelId: string): EndpointType {
+  return CHERRYIN_ENDPOINT[resolveCherryinChatFamily(modelId)]
+}
+
 const GATEWAY_MODEL_ROUTERS: Partial<Record<string, (modelId: string) => GatewayModelRoute>> = {
   [SystemProviderIds.aihubmix]: resolveAihubmixChatRoute,
-  [SystemProviderIds.dmxapi]: resolveDmxapiChatRoute
+  [SystemProviderIds.dmxapi]: resolveDmxapiChatRoute,
+  [SystemProviderIds.cherryin]: resolveCherryinChatRoute
 }
 
 /** Resolve a gateway's per-model wire route from data available in both main and renderer. */

--- a/src/shared/data/presets/gatewayChatRouting.ts
+++ b/src/shared/data/presets/gatewayChatRouting.ts
@@ -105,7 +105,12 @@ export type CherryinChatFamily = 'anthropic' | 'gemini' | 'openai-responses' | '
 export function resolveCherryinChatFamily(modelId: string): CherryinChatFamily {
   const baseId = modelId.toLowerCase().split('/').pop() ?? modelId.toLowerCase()
   if (baseId.startsWith('claude')) return 'anthropic'
-  if (baseId.startsWith('imagen') && !baseId.endsWith('no-think') && !baseId.endsWith('-search') && !baseId.includes('embedding')) {
+  if (
+    baseId.startsWith('imagen') &&
+    !baseId.endsWith('no-think') &&
+    !baseId.endsWith('-search') &&
+    !baseId.includes('embedding')
+  ) {
     return 'gemini'
   }
   if (


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Using a CherryIN `gemini-3.5-flash` (and any `gemini`/`imagen` model) together with built-in tools (`googleSearch` / `urlContext`) and function tools (MCP, `fs_read`, etc.) fails on `streamGenerateContent` with:

```
400 Please enable tool_config.include_server_side_tool_invocations to use Built-in tools with Function calling.
```

`GATEWAY_MODEL_ROUTERS` only handled `aihubmix`/`dmxapi`; `cherryin` fell back to `provider.defaultChatEndpoint=openai-chat-completions`, so `GoogleGenerativeAILanguageModel.prepareTools` never saw the `hasFunctionTools && hasProviderTools && usesGemini3Features` merge and never sent `toolConfig.includeServerSideToolInvocations`.

After this PR:

`gatewayChatRouting` registers a `cherryin` router (`resolveCherryinChatRoute`) that maps `gemini`/`imagen` → `google-generate-content` / `google`, `claude` → `anthropic`, `gpt`/`o*` → `openai` families and ports `modelId` via `split('/').pop()` for `google/gemini-*` gateway names. `resolveEffectiveEndpoint` now returns `google` for CherryIN Gemini models, letting upstream `@ai-sdk/google@3.0.113` emit the required `toolConfig` (non-Vertex only). Vertex keeps omitting the field.

Fixes #19788

### Why we need it and why it was done in this way

- Root cause is endpoint misrouting, not a missing SDK flag (#19364 already ships the conditional `...!isVertexProvider && {includeServerSideToolInvocations:true}` on `@ai-sdk/google@3.0.113`). Patching cherryin routing is the minimal layer that owns the invariant (gateway model → wire endpoint).
- Reused `aihubmix`'s family helpers but namespaced to `cherryin:*` so `cherryin.google` vs `google.vertex.*` detection (`provider.startsWith('google.vertex.')`) stays correct.
- Followed existing `GATEWAY_MODEL_ROUTERS` pattern; no new abstraction, no global `toolConfig` override.

The following tradeoffs were made:

- CherryIN compat models (`compat`) keep `openai-chat`/`cherryin` so non-Gemini/non-Claude traffic is unchanged.

The following alternatives were considered:

- Bumping `@ai-sdk/google` further or rewriting request bodies in a fetch wrapper — rejected: hides the routing bug and duplicates upstream logic.
- Per-model `endpointTypes` overrides in `provider-registry` — rejected as data churn when the gateway layer already has the model-id signal.

### Breaking changes

None. Only `cherryin` + `gemini`/`imagen` routes change; `aihubmix`/`dmxapi` and Vertex paths are untouched.

### Special notes for your reviewer

- Risk is scoped to `src/shared/data/presets/gatewayChatRouting.ts` and does not touch provider-registry generated data.
- Regression test `src/main/ai/provider/__tests__/cherryinGeminiRouting.regression.test.ts` asserts the gateway route and `resolveEffectiveEndpoint` for a `endpointTypes`-less `gemini-3.5-flash`.

### Checklist

- [ ] Branch: This PR targets `main`
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Documentation: A user-guide update was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [ ] Self-review: I have reviewed my own code (e.g., via `/gh-pr-review`, `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fix 400 "Please enable tool_config.include_server_side_tool_invocations" when using CherryIN Gemini 3.x models (e.g. gemini-3.5-flash) with built-in web search / URL context together with MCP or other function tools.
```