### PR TITLE
fix(api-gateway): make CLI model addresses reversible

### DIFF
--- a/docs/references/api-gateway/README.md
+++ b/docs/references/api-gateway/README.md
@@ -4,6 +4,7 @@ sources:
   - src/main/features/apiGateway
   - src/renderer/hooks/useApiGateway.ts
   - src/renderer/pages/settings/ToolSettings/ApiGatewaySettings
+  - src/shared/utils/apiGateway.ts
 ---
 
 # API Gateway Reference
@@ -100,9 +101,9 @@ guard, described below.
 | `POST /v1/messages/count_tokens` | Anthropic | token estimate over the converted request; anthropic-dialect endpoints forward it to the provider's own `count_tokens` (via the app proxy/auth), other dialects stay local; no stream |
 | `POST /v1/chat/completions` | OpenAI Chat | `openai` → `openai` |
 | `POST /v1/responses` | OpenAI Responses | `openai-responses` → `openai-responses` |
-| `POST /v1beta/models/{provider:model}:generateContent` | Gemini | `gemini` → Gemini JSON |
-| `POST /v1beta/models/{provider:model}:streamGenerateContent?alt=sse` | Gemini | `gemini` → Gemini SSE |
-| `POST /v1beta/models/{provider:model}:countTokens` | Gemini | local converted-request estimate |
+| `POST /v1beta/models/{model}:generateContent` | Gemini | `gemini` → Gemini JSON |
+| `POST /v1beta/models/{model}:streamGenerateContent?alt=sse` | Gemini | `gemini` → Gemini SSE |
+| `POST /v1beta/models/{model}:countTokens` | Gemini | local converted-request estimate |
 | `GET /v1/models` | OpenAI list | `{ object:'list', data:[…] }`, ids are `providerId:modelId` (offset/limit) |
 | `GET /v1/knowledge-bases` | Cherry REST | list (offset/limit) |
 | `POST /v1/knowledge-bases/search` | Cherry REST | semantic search across bases |
@@ -111,8 +112,26 @@ guard, described below.
 | `GET /v1/mcps/:id` | Cherry REST | one active server plus its warmed tool catalog |
 | `POST /v1/mcps/:id/mcp` | MCP Streamable HTTP | initialize/session request or sessionless one-shot JSON-RPC |
 
-The model in every chat/messages/responses body is `"<providerId>:<modelId>"`
+The model in every chat/messages/responses body remains `"<providerId>:<apiModelId>"`
 (split on the **first** `:`), e.g. `anthropic:claude-sonnet-4-6`.
+
+Gemini's `{model}` also accepts the versioned values produced by the shared
+codecs in `src/shared/utils/apiGateway.ts`:
+
+- Gemini CLI: `cherry-gw-v1.<payload>@cherry`.
+- Antigravity: `cherry-gw-v1/models/<payload>`, carried in its `gemini-api://` selector.
+
+Both encode `[providerId, apiModelId]` as canonical base64url JSON. Generation
+requests resolve ordinary legacy suffix/path addresses only when exactly one
+interpretation matches the enabled, routable provider/model catalog; multiple
+matches return HTTP 400. Once a value is recognized as a versioned address, an
+unsupported version or malformed payload is a terminal HTTP 400, even if a legacy catalog
+entry matches. For example, `cherry-gw-v2/models/foo` cannot route to provider
+`cherry-gw-v2` and model `foo` through legacy fallback.
+
+Generic colon addresses remain supported: `cherry-gw-v2:foo` is not a tagged
+address, and a raw colon in `cherry-gw-v1/models/provider:model` keeps that value
+in ordinary generic/legacy candidate resolution rather than the tagged grammar.
 
 Gemini routes carry a separate local auth guard because Gemini clients use
 `x-goog-api-key` or `?key=`. The `/v1` scoped guard must not intercept `/v1beta`.

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -11,15 +11,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // All mock fns live in vi.hoisted so the (hoisted) vi.mock factories can close
 // over them without a TDZ error.
-const { mockPreferenceGet, mockProcessMessage, mockGetModels, mockIsInternalRequestToken } = vi.hoisted(() => ({
-  mockPreferenceGet: vi.fn<(key: string) => unknown>(() => 'test-key'),
-  mockProcessMessage: vi.fn<(config: unknown) => Promise<Response>>(
-    async () =>
-      new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } })
-  ),
-  mockGetModels: vi.fn(async () => ({ object: 'list', data: [{ id: 'openai:gpt-4' }] })),
-  mockIsInternalRequestToken: vi.fn((candidate: string | undefined) => candidate === 'internal-request-token')
-}))
+const { mockPreferenceGet, mockProcessMessage, mockGetModels, mockResolveGeminiModel, mockIsInternalRequestToken } =
+  vi.hoisted(() => ({
+    mockPreferenceGet: vi.fn<(key: string) => unknown>(() => 'test-key'),
+    mockProcessMessage: vi.fn<(config: unknown) => Promise<Response>>(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'content-type': 'application/json' } })
+    ),
+    mockGetModels: vi.fn(async () => ({ object: 'list', data: [{ id: 'openai:gpt-4' }] })),
+    mockResolveGeminiModel: vi.fn((model: string) => model),
+    mockIsInternalRequestToken: vi.fn((candidate: string | undefined) => candidate === 'internal-request-token')
+  }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
@@ -56,7 +58,8 @@ vi.mock('../../proxyStream', () => ({
 }))
 
 vi.mock('../../utils/models', () => ({
-  getModels: mockGetModels
+  getModels: mockGetModels,
+  resolveGeminiGatewayModelAddress: mockResolveGeminiModel
 }))
 
 // Knowledge routes use the v2 KB service (pulled in by buildApp); stubbed so
@@ -431,6 +434,7 @@ describe('API gateway routes (integration)', () => {
     })
 
     it('normalizes an Antigravity custom model path to the gateway model address', async () => {
+      mockResolveGeminiModel.mockReturnValueOnce('provider-a:models/gemini-flash')
       await read(
         await post(app, '/v1beta/models/provider-a/models/models/gemini-flash:streamGenerateContent', geminiBody)
       )
@@ -441,9 +445,10 @@ describe('API gateway routes (integration)', () => {
       })
     })
 
-    it('strips the gemini-cli sentinel suffix off the model before routing', async () => {
+    it('routes a legacy gemini-cli suffix through the model resolver', async () => {
       // Cherry hands gemini-cli the address with an `@cherry` suffix so its model
       // normalization can't rewrite names ending in "flash"; the route must strip it.
+      mockResolveGeminiModel.mockReturnValueOnce('618d8838:agent/deepseek-v4-flash')
       await read(
         await post(app, '/v1beta/models/618d8838:agent/deepseek-v4-flash@cherry:streamGenerateContent', geminiBody)
       )
@@ -473,6 +478,7 @@ describe('API gateway routes (integration)', () => {
       // Fireworks ids are `accounts/fireworks/models/<name>` (16 of them in the registry), so
       // deciding the address protocol by looking for "/models/" misreads them as Antigravity
       // paths and rejects a perfectly valid gemini-cli request.
+      mockResolveGeminiModel.mockReturnValueOnce('fireworks:accounts/fireworks/models/deepseek-v4-flash')
       await read(
         await post(
           app,
@@ -486,10 +492,10 @@ describe('API gateway routes (integration)', () => {
       })
     })
 
-    it('rejects a model still ending in the reserved @cherry suffix after one strip → 400', async () => {
-      // The sentinel is reserved: the route strips exactly one trailing `@cherry`, so a model that
-      // STILL ends in it (a real id ending in the reserved marker, or a doubled sentinel) is
-      // ambiguous and never advertised by GET /models — reject rather than route to the wrong id.
+    it('rejects an ambiguous legacy suffix → 400', async () => {
+      mockResolveGeminiModel.mockImplementationOnce(() => {
+        throw new Error('Ambiguous legacy gateway model address')
+      })
       const { status, body } = await read(
         await post(app, '/v1beta/models/weird:model@cherry@cherry:generateContent', geminiBody)
       )

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -1,3 +1,4 @@
+import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
@@ -512,7 +513,26 @@ describe('API gateway routes (integration)', () => {
       expect(typeof body.totalTokens).toBe('number')
       expect(body.totalTokens).toBeGreaterThan(0)
       expect(mockProcessMessage).not.toHaveBeenCalled()
+      expect(mockResolveGeminiModel).toHaveBeenCalledWith('deepseek:deepseek-chat')
+    })
+
+    it('countTokens decodes a tagged model without consulting the catalog resolver', async () => {
+      const taggedModel = formatGeminiGatewayModelId('deepseek', 'deepseek-chat')
+      const { status, body } = await read(await post(app, `/v1beta/models/${taggedModel}:countTokens`, geminiBody))
+
+      expect(status).toBe(200)
+      expect(typeof body.totalTokens).toBe('number')
       expect(mockResolveGeminiModel).not.toHaveBeenCalled()
+    })
+
+    it('countTokens keeps its local fallback when catalog resolution fails', async () => {
+      mockResolveGeminiModel.mockImplementationOnce(() => {
+        throw new Error('Model is not available')
+      })
+      const { status, body } = await read(await post(app, '/v1beta/models/unknown-model:countTokens', geminiBody))
+
+      expect(status).toBe(200)
+      expect(typeof body.totalTokens).toBe('number')
     })
 
     // Media is now counted (converted → shared walker, or the provider's remote count) rather

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -453,6 +453,22 @@ describe('API gateway routes (integration)', () => {
       })
     })
 
+    it('routes a real apiModelId ending in @cherry without stripping content', async () => {
+      await read(await post(app, '/v1beta/models/provider-a:model@cherry:generateContent', geminiBody))
+      expect(mockProcessMessage.mock.calls[0][0]).toMatchObject({
+        modelString: 'provider-a:model@cherry',
+        streaming: false
+      })
+    })
+
+    it('does not infer Antigravity from /models/ inside a generic provider id', async () => {
+      await read(await post(app, '/v1beta/models/team/models/west:gemini-2.5-pro:generateContent', geminiBody))
+      expect(mockProcessMessage.mock.calls[0][0]).toMatchObject({
+        modelString: 'team/models/west:gemini-2.5-pro',
+        streaming: false
+      })
+    })
+
     it('routes a sentinel-suffixed model whose apiModelId itself contains "/models/"', async () => {
       // Fireworks ids are `accounts/fireworks/models/<name>` (16 of them in the registry), so
       // deciding the address protocol by looking for "/models/" misreads them as Antigravity

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -512,6 +512,7 @@ describe('API gateway routes (integration)', () => {
       expect(typeof body.totalTokens).toBe('number')
       expect(body.totalTokens).toBeGreaterThan(0)
       expect(mockProcessMessage).not.toHaveBeenCalled()
+      expect(mockResolveGeminiModel).not.toHaveBeenCalled()
     })
 
     // Media is now counted (converted → shared walker, or the provider's remote count) rather

--- a/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
+++ b/src/main/features/apiGateway/routes/__tests__/routes.integration.test.ts
@@ -1,5 +1,6 @@
-import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 
 /**
  * Integration tests that drive the real Elysia app via `app.handle(Request)`.

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -80,6 +80,7 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
 
       if (method === 'countTokens') {
         let countModel = parsed.model
+        let taggedParseError: Error | undefined
         try {
           const taggedAddress =
             parseGeminiGatewayModelId(parsed.model) ?? parseAntigravityGatewayModelPath(parsed.model)
@@ -87,8 +88,14 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
             countModel = formatGatewayModelId(taggedAddress.providerId, taggedAddress.apiModelId)
           }
         } catch (error) {
-          const message = error instanceof Error ? error.message : 'Invalid gateway model address'
-          return status(400, invalidArgument(message))
+          taggedParseError = error instanceof Error ? error : new Error('Invalid gateway model address')
+        }
+        if (countModel === parsed.model) {
+          try {
+            countModel = resolveGeminiGatewayModelAddress(parsed.model)
+          } catch {
+            if (taggedParseError) return status(400, invalidArgument(taggedParseError.message))
+          }
         }
         return {
           totalTokens: await estimateGeminiRequestTokens(body as InputParamsMap['gemini'], countModel, request.signal)

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -1,10 +1,11 @@
 import { bearer } from '@elysia/bearer'
+import { Elysia } from 'elysia'
+
 import {
   formatGatewayModelId,
   parseAntigravityGatewayModelPath,
   parseGeminiGatewayModelId
 } from '@shared/utils/apiGateway'
-import { Elysia } from 'elysia'
 
 import { googleEnvelope } from '../errors'
 import { authorizeApiRequest } from '../middleware/auth'
@@ -98,7 +99,7 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
           }
         }
         return {
-          totalTokens: await estimateGeminiRequestTokens(body as InputParamsMap['gemini'], countModel, request.signal)
+          totalTokens: await estimateGeminiRequestTokens(body, countModel, request.signal)
         }
       }
 

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -1,17 +1,12 @@
 import { bearer } from '@elysia/bearer'
 import { Elysia } from 'elysia'
 
-import {
-  ANTIGRAVITY_MODEL_PATH_SEPARATOR,
-  isReservedGeminiGatewayModelId,
-  stripGeminiGatewayModelSuffix
-} from '@shared/utils/apiGateway'
-
 import { googleEnvelope } from '../errors'
 import { authorizeApiRequest } from '../middleware/auth'
 import { DOC_DESCRIPTIONS, DOC_TAGS } from '../openapiDocs'
 import { processMessage } from '../proxyStream'
 import { estimateGeminiRequestTokens } from '../tokens/estimateGeminiRequestTokens'
+import { resolveGeminiGatewayModelAddress } from '../utils/models'
 import { GeminiGenerateContentBodySchema } from './schemas'
 
 /** Generation methods the gateway serves under `/v1beta/models/{model}:{method}`. */
@@ -21,26 +16,12 @@ const GENERATE_METHODS = new Set(['generateContent', 'streamGenerateContent'])
  * Split the wildcard path segment `providerId:apiModelId:method` into its model
  * (`providerId:apiModelId`, kept intact for `processMessage`) and the trailing
  * method. The model itself contains a colon, so the method is taken off the LAST
- * colon. Returns `null` when there is no method separator. The model may carry the
- * gemini-cli sentinel suffix (see `GEMINI_GATEWAY_MODEL_SUFFIX`) — strip it here so
- * routing sees the real gateway address.
+ * colon. Returns `null` when there is no method separator.
  */
 function parseModelMethod(raw: string): { model: string; method: string } | null {
   const lastColon = raw.lastIndexOf(':')
   if (lastColon <= 0 || lastColon >= raw.length - 1) return null
-  return { model: stripGeminiGatewayModelSuffix(raw.slice(0, lastColon)), method: raw.slice(lastColon + 1) }
-}
-
-/** Convert Antigravity's custom-model path back to the gateway's `providerId:apiModelId` address. */
-function normalizeAntigravityModelPath(model: string): string {
-  const separator = ANTIGRAVITY_MODEL_PATH_SEPARATOR
-  const separatorIndex = model.indexOf(separator)
-  if (separatorIndex <= 0) return model
-
-  const providerId = model.slice(0, separatorIndex)
-  const apiModelId = model.slice(separatorIndex + separator.length)
-  if (!apiModelId || providerId.includes(':')) return model
-  return `${providerId}:${apiModelId}`
+  return { model: raw.slice(0, lastColon), method: raw.slice(lastColon + 1) }
 }
 
 /** Google `invalid_argument` (400) envelope for in-handler request errors. */
@@ -88,22 +69,22 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
         return status(400, invalidArgument('Invalid model path. Expected "models/{model}:{method}".'))
       }
       const { method } = parsed
-      const model = normalizeAntigravityModelPath(parsed.model)
+      if (method !== 'countTokens' && !GENERATE_METHODS.has(method)) {
+        return status(400, invalidArgument(`Unsupported method: "${method}".`))
+      }
 
-      // The sentinel suffix is reserved: `parseModelMethod` strips one trailing `@cherry`, so a
-      // model that STILL ends in it addresses a real id ending in the reserved suffix — which is
-      // ambiguous with the sentinel and never advertised by `GET /models`. Reject rather than route.
-      if (isReservedGeminiGatewayModelId(model)) {
-        return status(400, invalidArgument(`Model id "${model}" is reserved and not routable through the gateway.`))
+      let model: string
+      try {
+        model = resolveGeminiGatewayModelAddress(parsed.model)
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Invalid gateway model address'
+        return status(400, invalidArgument(message))
       }
 
       if (method === 'countTokens') {
         return {
           totalTokens: await estimateGeminiRequestTokens(body, model, request.signal)
         }
-      }
-      if (!GENERATE_METHODS.has(method)) {
-        return status(400, invalidArgument(`Unsupported method: "${method}".`))
       }
 
       return processMessage({

--- a/src/main/features/apiGateway/routes/gemini.ts
+++ b/src/main/features/apiGateway/routes/gemini.ts
@@ -1,4 +1,9 @@
 import { bearer } from '@elysia/bearer'
+import {
+  formatGatewayModelId,
+  parseAntigravityGatewayModelPath,
+  parseGeminiGatewayModelId
+} from '@shared/utils/apiGateway'
 import { Elysia } from 'elysia'
 
 import { googleEnvelope } from '../errors'
@@ -73,18 +78,29 @@ export const geminiRoutes = new Elysia({ prefix: '/v1beta' })
         return status(400, invalidArgument(`Unsupported method: "${method}".`))
       }
 
+      if (method === 'countTokens') {
+        let countModel = parsed.model
+        try {
+          const taggedAddress =
+            parseGeminiGatewayModelId(parsed.model) ?? parseAntigravityGatewayModelPath(parsed.model)
+          if (taggedAddress) {
+            countModel = formatGatewayModelId(taggedAddress.providerId, taggedAddress.apiModelId)
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Invalid gateway model address'
+          return status(400, invalidArgument(message))
+        }
+        return {
+          totalTokens: await estimateGeminiRequestTokens(body as InputParamsMap['gemini'], countModel, request.signal)
+        }
+      }
+
       let model: string
       try {
         model = resolveGeminiGatewayModelAddress(parsed.model)
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Invalid gateway model address'
         return status(400, invalidArgument(message))
-      }
-
-      if (method === 'countTokens') {
-        return {
-          totalTokens: await estimateGeminiRequestTokens(body, model, request.signal)
-        }
       }
 
       return processMessage({

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@shared/data/presets/cherryai'
 import { MODEL_CAPABILITY } from '@shared/data/types/model'
 import type { AppEdition } from '@shared/types/appEdition'
+import { formatAntigravityGatewayModelPath, formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 
 const mocks = vi.hoisted(() => ({
   appEdition: 'cn' as AppEdition,
@@ -39,7 +40,7 @@ vi.mock('@logger', () => ({
   }
 }))
 
-import { getModels, resolveGatewayModelAddress } from '../models'
+import { getModels, resolveGatewayModelAddress, resolveGeminiGatewayModelAddress } from '../models'
 
 describe('api gateway model listing', () => {
   beforeEach(() => {
@@ -98,6 +99,83 @@ describe('api gateway model listing', () => {
       uniqueModelId: 'openai::gpt-4o',
       model: resolvedModel
     })
+  })
+
+  it('resolves tagged Gemini and Antigravity addresses through the enabled model catalog', () => {
+    mocks.getProvider.mockImplementation((providerId: string) => ({
+      id: providerId,
+      name: providerId,
+      isEnabled: true
+    }))
+    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) => [
+      {
+        id: `${providerId}::model`,
+        providerId,
+        apiModelId: 'model@cherry',
+        capabilities: [],
+        isEnabled: true
+      }
+    ])
+
+    expect(resolveGeminiGatewayModelAddress(formatGeminiGatewayModelId('provider-a', 'model@cherry'))).toBe(
+      'provider-a:model@cherry'
+    )
+    expect(resolveGeminiGatewayModelAddress(formatAntigravityGatewayModelPath('provider-a', 'model@cherry'))).toBe(
+      'provider-a:model@cherry'
+    )
+  })
+
+  it('uses the only available legacy interpretation and rejects an ambiguous one', () => {
+    mocks.getProvider.mockImplementation((providerId: string) => ({
+      id: providerId,
+      name: providerId,
+      isEnabled: true
+    }))
+    const available = new Set(['model'])
+    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) =>
+      Array.from(available, (apiModelId) => ({
+        id: `${providerId}::${apiModelId}`,
+        providerId,
+        apiModelId,
+        capabilities: [],
+        isEnabled: true
+      }))
+    )
+
+    expect(resolveGeminiGatewayModelAddress('provider-a:model@cherry')).toBe('provider-a:model')
+
+    available.add('model@cherry')
+    expect(() => resolveGeminiGatewayModelAddress('provider-a:model@cherry')).toThrow(
+      /Ambiguous legacy gateway model address/
+    )
+  })
+
+  it('does not guess between generic and legacy Antigravity path interpretations', () => {
+    const catalog = new Map<string, string[]>([['team/models/west', ['model']]])
+    mocks.getProvider.mockImplementation((providerId: string) => {
+      if (!catalog.has(providerId)) throw new Error('Provider not found')
+      return { id: providerId, name: providerId, isEnabled: true }
+    })
+    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) =>
+      (catalog.get(providerId) ?? []).map((apiModelId) => ({
+        id: `${providerId}::${apiModelId}`,
+        providerId,
+        apiModelId,
+        capabilities: [],
+        isEnabled: true
+      }))
+    )
+
+    expect(resolveGeminiGatewayModelAddress('team/models/west:model')).toBe('team/models/west:model')
+
+    catalog.clear()
+    catalog.set('team', ['west:model'])
+    expect(resolveGeminiGatewayModelAddress('team/models/west:model')).toBe('team:west:model')
+
+    catalog.set('team/models/west', ['model'])
+    expect(() => resolveGeminiGatewayModelAddress('team/models/west:model')).toThrow(
+      /Ambiguous legacy gateway model address/
+    )
   })
 
   // The listing shares isGatewayRoutableModel with the renderer's gateway picker: it must never

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -176,14 +176,31 @@ describe('api gateway model listing', () => {
     expect(() => resolveGeminiGatewayModelAddress('team/models/west:model')).toThrow(
       /Ambiguous legacy gateway model address/
     )
+  })
 
-    catalog.clear()
-    catalog.set('cherry-gw-v1', ['gemini-2.5-pro'])
-    expect(resolveGeminiGatewayModelAddress('cherry-gw-v1/models/gemini-2.5-pro')).toBe('cherry-gw-v1:gemini-2.5-pro')
+  it.each([
+    ['cherry-gw-v1/models/not-base64', 'cherry-gw-v1', 'not-base64'],
+    ['cherry-gw-v2/models/foo', 'cherry-gw-v2', 'foo'],
+    ['cherry-gw-v1.foo/models/bar@cherry', 'cherry-gw-v1.foo', 'bar@cherry'],
+    ['cherry-gw-v2.foo/models/bar@cherry', 'cherry-gw-v2.foo', 'bar@cherry']
+  ])('rejects reserved address %s even when its legacy interpretation exists', (address, providerId, apiModelId) => {
+    mocks.getProvider.mockImplementation((id: string) => {
+      if (id !== providerId) throw new Error('Provider not found')
+      return { id, name: id, isEnabled: true }
+    })
+    mocks.listModels.mockImplementation(({ providerId: id }: { providerId: string }) =>
+      id === providerId
+        ? [{ id: `${id}::${apiModelId}`, providerId: id, apiModelId, capabilities: [], isEnabled: true }]
+        : []
+    )
 
-    catalog.clear()
-    catalog.set('cherry-gw-v2', ['future-model'])
-    expect(resolveGeminiGatewayModelAddress('cherry-gw-v2/models/future-model')).toBe('cherry-gw-v2:future-model')
+    expect(() => resolveGeminiGatewayModelAddress(address)).toThrow(
+      /Invalid (Gemini|Antigravity) gateway model address/
+    )
+    expect(resolveGeminiGatewayModelAddress(`${providerId}:${apiModelId}`)).toBe(`${providerId}:${apiModelId}`)
+    expect(resolveGeminiGatewayModelAddress(formatAntigravityGatewayModelPath(providerId, apiModelId))).toBe(
+      `${providerId}:${apiModelId}`
+    )
   })
 
   // The listing shares isGatewayRoutableModel with the renderer's gateway picker: it must never

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -176,6 +176,14 @@ describe('api gateway model listing', () => {
     expect(() => resolveGeminiGatewayModelAddress('team/models/west:model')).toThrow(
       /Ambiguous legacy gateway model address/
     )
+
+    catalog.clear()
+    catalog.set('cherry-gw-v1', ['gemini-2.5-pro'])
+    expect(resolveGeminiGatewayModelAddress('cherry-gw-v1/models/gemini-2.5-pro')).toBe('cherry-gw-v1:gemini-2.5-pro')
+
+    catalog.clear()
+    catalog.set('cherry-gw-v2', ['future-model'])
+    expect(resolveGeminiGatewayModelAddress('cherry-gw-v2/models/future-model')).toBe('cherry-gw-v2:future-model')
   })
 
   // The listing shares isGatewayRoutableModel with the renderer's gateway picker: it must never

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -287,15 +287,16 @@ describe('api gateway model listing', () => {
       { id: 'corp:west', name: 'Corp West' },
       { id: 'anthropic', name: 'Anthropic' }
     ])
-    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) => [
-      {
-        id: `${providerId}::model`,
+    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) => {
+      const apiModelIds = providerId === 'corp:west' ? ['model-a', 'model-b'] : ['model']
+      return apiModelIds.map((apiModelId) => ({
+        id: `${providerId}::${apiModelId}`,
         providerId,
-        apiModelId: 'model',
+        apiModelId,
         ownedBy: providerId,
         capabilities: []
-      }
-    ])
+      }))
+    })
 
     const response = await getModels()
 

--- a/src/main/features/apiGateway/utils/__tests__/models.test.ts
+++ b/src/main/features/apiGateway/utils/__tests__/models.test.ts
@@ -12,7 +12,8 @@ const mocks = vi.hoisted(() => ({
   appEdition: 'cn' as AppEdition,
   getProvider: vi.fn(),
   listProviders: vi.fn(),
-  listModels: vi.fn()
+  listModels: vi.fn(),
+  loggerWarn: vi.fn()
 }))
 
 vi.mock('@main/utils/appEdition', () => ({
@@ -34,7 +35,7 @@ vi.mock('@data/services/ModelService', () => ({
 
 vi.mock('@logger', () => ({
   loggerService: {
-    withContext: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }))
+    withContext: vi.fn(() => ({ info: vi.fn(), warn: mocks.loggerWarn, error: vi.fn() }))
   }
 }))
 
@@ -200,6 +201,29 @@ describe('api gateway model listing', () => {
     const response = await getModels()
 
     expect(response.data.map((model) => model.id)).toEqual(['openai:gpt-4o'])
+  })
+
+  it('logs an unaddressable model without dropping surrounding valid models', async () => {
+    mocks.listProviders.mockReturnValue([
+      { id: 'openai', name: 'OpenAI' },
+      { id: 'corp:west', name: 'Corp West' },
+      { id: 'anthropic', name: 'Anthropic' }
+    ])
+    mocks.listModels.mockImplementation(({ providerId }: { providerId: string }) => [
+      {
+        id: `${providerId}::model`,
+        providerId,
+        apiModelId: 'model',
+        ownedBy: providerId,
+        capabilities: []
+      }
+    ])
+
+    const response = await getModels()
+
+    expect(response.data.map((model) => model.id)).toEqual(['openai:model', 'anthropic:model'])
+    expect(mocks.loggerWarn).toHaveBeenCalledOnce()
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(expect.stringContaining('corp:west'))
   })
 
   // Reviewer A1: an external-cli provider (e.g. claude-code) authenticates via its own CLI login,

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -151,7 +151,13 @@ function getLegacyGeminiModelCandidates(value: string): GatewayModelAddress[] {
 
 /** Resolve a tagged or legacy Gemini-route model string without guessing between valid catalog entries. */
 export function resolveGeminiGatewayModelAddress(modelAddress: string): string {
-  const taggedAddress = parseGeminiGatewayModelId(modelAddress) ?? parseAntigravityGatewayModelPath(modelAddress)
+  let taggedAddress: GatewayModelAddress | undefined
+  let taggedParseError: Error | undefined
+  try {
+    taggedAddress = parseGeminiGatewayModelId(modelAddress) ?? parseAntigravityGatewayModelPath(modelAddress)
+  } catch (error) {
+    taggedParseError = error instanceof Error ? error : new Error('Invalid gateway model address')
+  }
   if (taggedAddress) {
     const canonicalAddress = formatGatewayModelId(taggedAddress.providerId, taggedAddress.apiModelId)
     resolveGatewayModelAddress(canonicalAddress)
@@ -176,6 +182,7 @@ export function resolveGeminiGatewayModelAddress(modelAddress: string): string {
   if (resolved.size > 1) {
     throw new Error(`Ambiguous legacy gateway model address: "${modelAddress}"`)
   }
+  if (taggedParseError) throw taggedParseError
   throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
 }
 

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -191,6 +191,7 @@ export async function getModels(filter: ModelsFilter = {}): Promise<ApiModelsRes
 
     // Deduplicate by the gateway-addressable id ("providerId:apiModelId").
     const uniqueModels = new Map<string, ApiModel>()
+    const warnedUnaddressableProviders = new Set<string>()
     for (const model of models) {
       const provider = providers.find((p) => p.id === model.providerId)
       // Agent-only providers (external-CLI, edition-gated Cherry Cloud) are never advertised to
@@ -202,8 +203,9 @@ export async function getModels(filter: ModelsFilter = {}): Promise<ApiModelsRes
       // Same routable-model predicate as the renderer's gateway picker — the
       // listing must never advertise a model the proxy cannot route.
       if (!isGatewayRoutableModel(model)) {
-        if (model.providerId.includes(':')) {
+        if (model.providerId.includes(':') && !warnedUnaddressableProviders.has(model.providerId)) {
           logger.warn(`Skipping API gateway model from unaddressable provider "${model.providerId}"`)
+          warnedUnaddressableProviders.add(model.providerId)
         }
         continue
       }

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -5,7 +5,15 @@ import { getAppEdition } from '@main/utils/appEdition'
 import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import { type Model, parseUniqueModelId, type UniqueModelId } from '@shared/data/types/model'
 import type { Provider } from '@shared/data/types/provider'
-import { formatGatewayModelId } from '@shared/utils/apiGateway'
+import {
+  formatGatewayModelId,
+  type GatewayModelAddress,
+  parseAntigravityGatewayModelPath,
+  parseGatewayModelId,
+  parseGeminiGatewayModelId,
+  parseLegacyAntigravityGatewayModelPaths,
+  parseLegacyGeminiGatewayModelId
+} from '@shared/utils/apiGateway'
 import { isGatewayRoutableModel } from '@shared/utils/model'
 import { isAgentOnlyProvider, isExternalCliProvider } from '@shared/utils/provider'
 
@@ -33,9 +41,7 @@ export interface ModelsFilter {
   limit?: number
 }
 
-export interface ResolvedGatewayModelAddress {
-  providerId: string
-  apiModelId: string
+export interface ResolvedGatewayModelAddress extends GatewayModelAddress {
   uniqueModelId: UniqueModelId
   provider: Provider
   model: Model
@@ -88,13 +94,7 @@ function transformModelToOpenAi(model: Model, provider?: Provider): ApiModel {
 
 /** Resolve a `providerId:apiModelId`; Agent-only models require an authenticated internal request. */
 export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly = false): ResolvedGatewayModelAddress {
-  const sepIdx = modelAddress.indexOf(':')
-  if (sepIdx <= 0 || sepIdx >= modelAddress.length - 1) {
-    throw new Error(`Invalid model format: "${modelAddress}". Expected "providerId:apiModelId".`)
-  }
-
-  const providerId = modelAddress.slice(0, sepIdx)
-  const apiModelId = modelAddress.slice(sepIdx + 1)
+  const { providerId, apiModelId } = parseGatewayModelId(modelAddress)
   if (isManagedCherryAiDefaultModel(providerId, apiModelId)) {
     throw new Error('CherryAI managed default model is not available through the API gateway')
   }
@@ -124,6 +124,61 @@ export function resolveGatewayModelAddress(modelAddress: string, allowAgentOnly 
   return { providerId, apiModelId, uniqueModelId: model.id, provider, model }
 }
 
+function addGatewayModelCandidate(
+  candidates: Map<string, GatewayModelAddress>,
+  address: GatewayModelAddress | undefined
+): void {
+  if (address) candidates.set(JSON.stringify([address.providerId, address.apiModelId]), address)
+}
+
+function tryParseGatewayModelId(value: string): GatewayModelAddress | undefined {
+  try {
+    return parseGatewayModelId(value)
+  } catch {
+    return undefined
+  }
+}
+
+function getLegacyGeminiModelCandidates(value: string): GatewayModelAddress[] {
+  const candidates = new Map<string, GatewayModelAddress>()
+  addGatewayModelCandidate(candidates, tryParseGatewayModelId(value))
+  addGatewayModelCandidate(candidates, parseLegacyGeminiGatewayModelId(value))
+  for (const address of parseLegacyAntigravityGatewayModelPaths(value)) {
+    addGatewayModelCandidate(candidates, address)
+  }
+  return Array.from(candidates.values())
+}
+
+/** Resolve a tagged or legacy Gemini-route model string without guessing between valid catalog entries. */
+export function resolveGeminiGatewayModelAddress(modelAddress: string): string {
+  const taggedAddress = parseGeminiGatewayModelId(modelAddress) ?? parseAntigravityGatewayModelPath(modelAddress)
+  if (taggedAddress) {
+    const canonicalAddress = formatGatewayModelId(taggedAddress.providerId, taggedAddress.apiModelId)
+    resolveGatewayModelAddress(canonicalAddress)
+    return canonicalAddress
+  }
+
+  const resolved = new Map<UniqueModelId, ResolvedGatewayModelAddress>()
+  for (const candidate of getLegacyGeminiModelCandidates(modelAddress)) {
+    try {
+      const canonicalAddress = formatGatewayModelId(candidate.providerId, candidate.apiModelId)
+      const match = resolveGatewayModelAddress(canonicalAddress)
+      resolved.set(match.uniqueModelId, match)
+    } catch {
+      // Legacy strings are ambiguous by construction; only catalog-backed candidates count.
+    }
+  }
+
+  if (resolved.size === 1) {
+    const [match] = resolved.values()
+    return formatGatewayModelId(match.providerId, match.apiModelId)
+  }
+  if (resolved.size > 1) {
+    throw new Error(`Ambiguous legacy gateway model address: "${modelAddress}"`)
+  }
+  throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
+}
+
 /**
  * Build the OpenAI `/v1/models` listing: enabled models across enabled providers,
  * deduplicated by gateway id and optionally paginated. Never throws — returns an empty
@@ -147,10 +202,19 @@ export async function getModels(filter: ModelsFilter = {}): Promise<ApiModelsRes
       // Same routable-model predicate as the renderer's gateway picker — the
       // listing must never advertise a model the proxy cannot route.
       if (!isGatewayRoutableModel(model)) {
+        if (model.providerId.includes(':')) {
+          logger.warn(`Skipping API gateway model from unaddressable provider "${model.providerId}"`)
+        }
         continue
       }
 
-      const apiModel = transformModelToOpenAi(model, provider)
+      let apiModel: ApiModel
+      try {
+        apiModel = transformModelToOpenAi(model, provider)
+      } catch (error) {
+        logger.warn(`Skipping unaddressable API gateway model "${model.id}"`, error as Error)
+        continue
+      }
       if (!uniqueModels.has(apiModel.id)) {
         uniqueModels.set(apiModel.id, apiModel)
       }

--- a/src/main/features/apiGateway/utils/models.ts
+++ b/src/main/features/apiGateway/utils/models.ts
@@ -151,13 +151,7 @@ function getLegacyGeminiModelCandidates(value: string): GatewayModelAddress[] {
 
 /** Resolve a tagged or legacy Gemini-route model string without guessing between valid catalog entries. */
 export function resolveGeminiGatewayModelAddress(modelAddress: string): string {
-  let taggedAddress: GatewayModelAddress | undefined
-  let taggedParseError: Error | undefined
-  try {
-    taggedAddress = parseGeminiGatewayModelId(modelAddress) ?? parseAntigravityGatewayModelPath(modelAddress)
-  } catch (error) {
-    taggedParseError = error instanceof Error ? error : new Error('Invalid gateway model address')
-  }
+  const taggedAddress = parseGeminiGatewayModelId(modelAddress) ?? parseAntigravityGatewayModelPath(modelAddress)
   if (taggedAddress) {
     const canonicalAddress = formatGatewayModelId(taggedAddress.providerId, taggedAddress.apiModelId)
     resolveGatewayModelAddress(canonicalAddress)
@@ -182,7 +176,6 @@ export function resolveGeminiGatewayModelAddress(modelAddress: string): string {
   if (resolved.size > 1) {
     throw new Error(`Ambiguous legacy gateway model address: "${modelAddress}"`)
   }
-  if (taggedParseError) throw taggedParseError
   throw new Error(`Model "${modelAddress}" is not available through the API gateway`)
 }
 

--- a/src/main/services/codeCli/CodeCliService.ts
+++ b/src/main/services/codeCli/CodeCliService.ts
@@ -635,10 +635,9 @@ export class CodeCliService extends BaseService {
       // gemini-cli resolves its model with precedence `--model` → GEMINI_MODEL →
       // settings.model.name, and its `resolveModel` rewrites any name ending in "flash" to a
       // default Gemini model. Pass the model on the command line (highest precedence, honored
-      // verbatim) so the launched session hits the intended model. In gateway mode it needs the
-      // `providerId:modelId` address the gateway parses from the URL path, carrying the sentinel
-      // suffix so that rewrite can't corrupt a name ending in "flash" (see
-      // GEMINI_GATEWAY_MODEL_SUFFIX); direct mode passes the bare model id.
+      // verbatim) so the launched session hits the intended model. Gateway mode uses the tagged
+      // address that the route decodes without confusing its suffix with model content; direct
+      // mode passes the bare model id.
       if (normal) {
         // The gateway serves only `/v1beta`; force the SDK's API version at launch so a stale
         // `GOOGLE_GENAI_API_VERSION=v1` exported in the user's shell can't redirect it to `/v1`.

--- a/src/main/services/codeCli/__tests__/CodeCliService.test.ts
+++ b/src/main/services/codeCli/__tests__/CodeCliService.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
 import type { BinaryRemoveRequest, BinaryRemoveResult } from '@shared/types/binary'
 import { CodeCli, TerminalApp } from '@shared/types/codeCli'
+import { formatGeminiGatewayModelId } from '@shared/utils/apiGateway'
 
 const binaryManagerMock = vi.hoisted(() => ({
   installByName: vi.fn(() => Promise.resolve()),
@@ -483,8 +484,8 @@ describe('CodeCliService', () => {
 
   // gemini-cli's `resolveModel` rewrites a settings.model.name ending in "flash" to a default Gemini
   // model, so the intended model is passed on the command line at launch — `--model` outranks settings
-  // and is honored verbatim — and in gateway mode it must carry the providerId prefix the gateway
-  // addresses by plus the @cherry sentinel, or the gateway can't route it.
+  // and is honored verbatim. Gateway mode uses a tagged address so the sentinel cannot collide with
+  // real model content.
   describe('run (gemini-cli passes the model via --model)', () => {
     const originalPlatform = process.platform
 
@@ -513,7 +514,7 @@ describe('CodeCliService', () => {
       }
     }
 
-    it('addresses the model as providerId:modelId plus the sentinel suffix in gateway mode', async () => {
+    it('passes the tagged gateway model address in gateway mode', async () => {
       const script = await launchScript({
         mode: 'normal',
         cliTool: CodeCli.GEMINI_CLI,
@@ -524,7 +525,9 @@ describe('CodeCliService', () => {
       })
       // The @cherry suffix defeats gemini-cli's model normalization, which rewrites
       // any name satisfying endsWith("flash") to a default Gemini model.
-      expect(script).toContain('--model 618d8838-1791-44df-8802-34f8444c0935:agent/deepseek-v4-flash@cherry')
+      expect(script).toContain(
+        `--model ${formatGeminiGatewayModelId('618d8838-1791-44df-8802-34f8444c0935', 'agent/deepseek-v4-flash')}`
+      )
       // The gateway serves only /v1beta, so the launch env forces the SDK's API version — a stale
       // GOOGLE_GENAI_API_VERSION=v1 in the user's shell would otherwise redirect it to /v1. (The
       // value's quotes are backslash-escaped by the AppleScript wrapper, so match the export + value.)

--- a/src/main/services/codeCli/__tests__/antigravity.test.ts
+++ b/src/main/services/codeCli/__tests__/antigravity.test.ts
@@ -106,21 +106,19 @@ describe('prepareAntigravityLaunch', () => {
     expect(mocks.getByProviderId).not.toHaveBeenCalled()
   })
 
-  it('rejects a gateway launch whose provider id carries the path separator', async () => {
-    // The route splits on the FIRST separator, so "team/models/west" would address provider
-    // "team". Only this path form is ambiguous, which is why the guard lives here.
+  it('encodes a gateway launch whose provider id carries the legacy path separator', async () => {
     mocks.getMultiple.mockReturnValue({ host: '127.0.0.1', port: 24444, apiKey: 'gateway-secret' })
 
-    await expect(
-      prepareAntigravityLaunch({
-        mode: 'normal',
-        cliTool: CodeCli.ANTIGRAVITY_CLI,
-        providerId: 'team/models/west',
-        model: 'gemini-2.5-pro',
-        gateway: true,
-        directory: '/tmp/project'
-      })
-    ).rejects.toThrow(/cannot be addressed by antigravity-cli/)
+    const result = await prepareAntigravityLaunch({
+      mode: 'normal',
+      cliTool: CodeCli.ANTIGRAVITY_CLI,
+      providerId: 'team/models/west',
+      model: 'gemini-2.5-pro',
+      gateway: true,
+      directory: '/tmp/project'
+    })
+
+    expect(result.model).toMatch(/^gemini-api:\/\/cherry-gw-v1\/models\/[A-Za-z0-9_-]+$/)
   })
 
   it('rejects an unsafe model id without touching the isolated settings', async () => {

--- a/src/main/services/codeCli/__tests__/antigravity.test.ts
+++ b/src/main/services/codeCli/__tests__/antigravity.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CodeCli } from '@shared/types/codeCli'
+import { parseAntigravityGatewayModelPath } from '@shared/utils/apiGateway'
 
 const mocks = vi.hoisted(() => ({
   root: '',
@@ -101,7 +102,10 @@ describe('prepareAntigravityLaunch', () => {
       GEMINI_API_KEY: 'gateway-secret',
       GOOGLE_GEMINI_BASE_URL: 'http://127.0.0.1:24444'
     })
-    expect(result.model).toBe('gemini-api://provider-a/models/models/gemini-flash')
+    expect(parseAntigravityGatewayModelPath(result.model.slice('gemini-api://'.length))).toEqual({
+      providerId: 'provider-a',
+      apiModelId: 'models/gemini-flash'
+    })
     expect(result.model).not.toContain('@cherry')
     expect(mocks.getByProviderId).not.toHaveBeenCalled()
   })
@@ -118,7 +122,10 @@ describe('prepareAntigravityLaunch', () => {
       directory: '/tmp/project'
     })
 
-    expect(result.model).toMatch(/^gemini-api:\/\/cherry-gw-v1\/models\/[A-Za-z0-9_-]+$/)
+    expect(parseAntigravityGatewayModelPath(result.model.slice('gemini-api://'.length))).toEqual({
+      providerId: 'team/models/west',
+      apiModelId: 'gemini-2.5-pro'
+    })
   })
 
   it('rejects an unsafe model id without touching the isolated settings', async () => {

--- a/src/main/services/codeCli/antigravity.ts
+++ b/src/main/services/codeCli/antigravity.ts
@@ -5,7 +5,7 @@ import { providerService } from '@data/services/ProviderService'
 import { atomicWriteFile } from '@main/utils/file'
 import type { CodeCliRunInput } from '@shared/ipc/schemas/codeCli'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
-import { ANTIGRAVITY_MODEL_PATH_SEPARATOR, formatGatewayModelId, gatewayClientOrigin } from '@shared/utils/apiGateway'
+import { formatAntigravityGatewayModelPath, gatewayClientOrigin } from '@shared/utils/apiGateway'
 import { resolveGeminiBaseUrl } from '@shared/utils/gemini'
 
 import { isShellSafeModelId } from './shellQuote'
@@ -58,15 +58,7 @@ export async function prepareAntigravityLaunch(input: NormalRunInput): Promise<A
     })
     apiKey = gatewayApiKey
     baseUrl = gatewayClientOrigin(host, port)
-    // Only this path form is ambiguous about the separator: the route splits on the first
-    // one, so a provider id carrying it would address the wrong provider.
-    if (input.providerId.includes(ANTIGRAVITY_MODEL_PATH_SEPARATOR)) {
-      throw new Error(
-        `Provider id "${input.providerId}" contains "${ANTIGRAVITY_MODEL_PATH_SEPARATOR}" and cannot be addressed by antigravity-cli`
-      )
-    }
-    const gatewayModel = formatGatewayModelId(input.providerId, input.model)
-    model = `gemini-api://${gatewayModel.replace(':', ANTIGRAVITY_MODEL_PATH_SEPARATOR)}`
+    model = `gemini-api://${formatAntigravityGatewayModelPath(input.providerId, input.model)}`
   } else {
     const provider = providerService.getByProviderId(input.providerId)
     apiKey = providerService.getRotatedApiKey(provider.id)

--- a/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
@@ -315,4 +315,15 @@ describe('updateCliConfigDraftConfig', () => {
     expect(settings.model.name).toBe('gemini-2.5-flash')
     expect(updated.find((f) => f.target === 'gemini-env')!.content).not.toContain('GOOGLE_GENAI_API_VERSION')
   })
+
+  it('preserves direct Gemini content shaped like the old gateway suffix through a config edit', async () => {
+    const model = 'publisher:model@cherry'
+    const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, model)
+    const updated = updateCliConfigDraftConfig(CodeCli.GEMINI_CLI, files, {
+      general: { defaultApprovalMode: 'plan' }
+    })
+
+    const settings = JSON.parse(updated.find((file) => file.target === 'gemini-settings')!.content)
+    expect(settings.model.name).toBe(model)
+  })
 })

--- a/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { dataApiService } from '@data/DataApiService'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { CodeCli } from '@shared/types/codeCli'
-import { GEMINI_GATEWAY_MODEL_SUFFIX } from '@shared/utils/apiGateway'
+import { GEMINI_GATEWAY_MODEL_SUFFIX, parseGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 
 import type { CliConfigFileDraft, CliConfigTarget } from '../index'
@@ -265,12 +265,10 @@ describe('updateCliConfigDraftConfig', () => {
     expect(parsed.model).toBe('cherry-gateway/deepseek:deepseek-chat')
   })
 
-  // A gateway gemini draft stores the sentinel-suffixed address in settings.model.name, but
-  // extractConnection strips the suffix for connection matching. A config-only edit must therefore
-  // re-append it (and re-force the gateway-only API version) rather than write the bare `flash`-ending
-  // name back — gemini-cli reads settings.model.name and would re-normalize a bare flash name.
-  it('preserves the gateway sentinel + API version through a config-only edit for gemini', () => {
-    const model = `deepseek:deepseek-v4-flash${GEMINI_GATEWAY_MODEL_SUFFIX}`
+  // Old configs used a suffix-only wrapper. A config edit must read that value and write the tagged
+  // form while preserving the gateway-only API version.
+  it('migrates a legacy gateway sentinel while preserving the API version through a gemini config edit', () => {
+    const legacyModel = `deepseek:deepseek-v4-flash${GEMINI_GATEWAY_MODEL_SUFFIX}`
     const gatewayFiles: CliConfigFileDraft[] = [
       {
         target: 'gemini-env',
@@ -285,7 +283,10 @@ describe('updateCliConfigDraftConfig', () => {
         label: '',
         path: '/resolved~/.gemini/settings.json',
         language: 'json',
-        content: JSON.stringify({ model: { name: model }, security: { auth: { selectedType: 'gemini-api-key' } } })
+        content: JSON.stringify({
+          model: { name: legacyModel },
+          security: { auth: { selectedType: 'gemini-api-key' } }
+        })
       }
     ]
 
@@ -294,14 +295,16 @@ describe('updateCliConfigDraftConfig', () => {
     })
 
     const settings = JSON.parse(updated.find((f) => f.target === 'gemini-settings')!.content)
-    expect(settings.model.name).toBe(model)
+    expect(parseGeminiGatewayModelId(settings.model.name)).toEqual({
+      providerId: 'deepseek',
+      apiModelId: 'deepseek-v4-flash'
+    })
+    expect(settings.model.name).not.toBe(legacyModel)
     expect(updated.find((f) => f.target === 'gemini-env')!.content).toContain('GOOGLE_GENAI_API_VERSION=v1beta')
   })
 
-  // Symmetric guard for the non-gateway branch: extractConnection strips the sentinel, so the parity
-  // case above cannot catch an erroneous append. A direct-provider edit must leave settings.model.name
-  // bare (no @cherry — else a direct terminal launch would re-normalize a `flash`-ending name) and must
-  // NOT force the gateway-only API version onto the user's own .env.
+  // A direct-provider edit must leave settings.model.name bare and must not force the gateway-only
+  // API version onto the user's own .env.
   it('leaves a non-gateway gemini draft bare (no sentinel, no forced API version) through a config-only edit', async () => {
     const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'gemini-2.5-flash')
     const updated = updateCliConfigDraftConfig(CodeCli.GEMINI_CLI, files, {

--- a/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/draftUpdater.test.ts
@@ -319,6 +319,8 @@ describe('updateCliConfigDraftConfig', () => {
   it('preserves direct Gemini content shaped like the old gateway suffix through a config edit', async () => {
     const model = 'publisher:model@cherry'
     const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, model)
+    const envFile = files.find((file) => file.target === 'gemini-env')!
+    envFile.content += 'GOOGLE_GENAI_API_VERSION=v1beta\n'
     const updated = updateCliConfigDraftConfig(CodeCli.GEMINI_CLI, files, {
       general: { defaultApprovalMode: 'plan' }
     })

--- a/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
@@ -105,6 +105,8 @@ describe('extractConnectionFromCliConfigDraft', () => {
 
   it('preserves a direct Gemini model id containing a colon and ending in @cherry', async () => {
     const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'publisher:model@cherry')
+    const envFile = files.find((file) => file.target === 'gemini-env')!
+    envFile.content += 'GOOGLE_GENAI_API_VERSION=v1beta\n'
     expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('publisher:model@cherry')
   })
 

--- a/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
@@ -103,6 +103,11 @@ describe('extractConnectionFromCliConfigDraft', () => {
     expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('model@cherry')
   })
 
+  it('preserves a direct Gemini model id containing a colon and ending in @cherry', async () => {
+    const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'publisher:model@cherry')
+    expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('publisher:model@cherry')
+  })
+
   it('preserves an unknown future Gemini gateway token for downgrade-safe editing', async () => {
     const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'gemini-2.5-pro')
     const settingsFile = files.find((file) => file.target === 'gemini-settings')!

--- a/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
@@ -98,6 +98,11 @@ describe('extractConnectionFromCliConfigDraft', () => {
     expect(extractConnectionFromCliConfigDraft(cliTool, files)).toEqual({ baseUrl, apiKey: 'sk-secret', model })
   })
 
+  it('preserves a direct Gemini model id ending in @cherry', async () => {
+    const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'model@cherry')
+    expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('model@cherry')
+  })
+
   it('returns null for an unknown tool', () => {
     expect(extractConnectionFromCliConfigDraft('nope', [])).toBeNull()
   })

--- a/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/parser.test.ts
@@ -103,6 +103,16 @@ describe('extractConnectionFromCliConfigDraft', () => {
     expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('model@cherry')
   })
 
+  it('preserves an unknown future Gemini gateway token for downgrade-safe editing', async () => {
+    const files = await buildDraft(CodeCli.GEMINI_CLI, geminiProvider, 'gemini-2.5-pro')
+    const settingsFile = files.find((file) => file.target === 'gemini-settings')!
+    const settings = JSON.parse(settingsFile.content)
+    settings.model.name = 'cherry-gw-v2.future@cherry'
+    settingsFile.content = JSON.stringify(settings)
+
+    expect(extractConnectionFromCliConfigDraft(CodeCli.GEMINI_CLI, files)?.model).toBe('cherry-gw-v2.future@cherry')
+  })
+
   it('returns null for an unknown tool', () => {
     expect(extractConnectionFromCliConfigDraft('nope', [])).toBeNull()
   })

--- a/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
+++ b/src/renderer/pages/code/cliConfig/__tests__/writeCliConfigDraft.test.ts
@@ -4,6 +4,7 @@ import { parse as parseYaml } from 'yaml'
 import { dataApiService } from '@data/DataApiService'
 import type { ApiKeyEntry, Provider } from '@shared/data/types/provider'
 import { CLI_API_GATEWAY_PROVIDER_ID, CodeCli } from '@shared/types/codeCli'
+import { parseGeminiGatewayModelId } from '@shared/utils/apiGateway'
 import type { CliConfigTarget, CliConfigWriteFile } from '@shared/utils/cliConfig'
 import { CLI_CONFIG_FILE_SPECS } from '@shared/utils/cliConfig'
 
@@ -1320,9 +1321,10 @@ describe('writeCliConfigDraft', () => {
       expect(env).toContain('GOOGLE_GENAI_API_VERSION=v1beta')
 
       const settings = JSON.parse(writes.find((w) => w.path.endsWith('settings.json'))!.content)
-      // Gateway addressing (single colon, providerId:apiModelId) plus the sentinel
-      // suffix that keeps gemini-cli's model normalization from rewriting the name.
-      expect(settings.model).toEqual({ name: 'deepseek:deepseek-chat@cherry' })
+      expect(parseGeminiGatewayModelId(settings.model.name)).toEqual({
+        providerId: 'deepseek',
+        apiModelId: 'deepseek-chat'
+      })
       // The real provider is never read, so its key can't leak into the CLI config file.
       expect(dataApiService.get).not.toHaveBeenCalledWith('/providers/deepseek')
     })

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -567,9 +567,13 @@ const openCodeAdapter: CliConfigAdapter = {
 }
 
 function parseGeminiConfigModel(model: string): { isGateway: boolean; model: string } {
-  const tagged = parseGeminiGatewayModelId(model)
-  if (tagged) {
-    return { isGateway: true, model: formatGatewayModelId(tagged.providerId, tagged.apiModelId) }
+  try {
+    const tagged = parseGeminiGatewayModelId(model)
+    if (tagged) {
+      return { isGateway: true, model: formatGatewayModelId(tagged.providerId, tagged.apiModelId) }
+    }
+  } catch {
+    return { isGateway: false, model }
   }
 
   const legacy = parseLegacyGeminiGatewayModelId(model)

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -583,6 +583,10 @@ function parseGeminiConfigModel(model: string, allowLegacy = false): { isGateway
   return { isGateway: false, model }
 }
 
+function isLegacyGeminiGatewayConfig(env: Map<string, string>): boolean {
+  return env.get('GOOGLE_GENAI_API_VERSION') === 'v1beta' && (env.get('GEMINI_API_KEY') ?? '').startsWith('cs-sk-')
+}
+
 const geminiAdapter: CliConfigAdapter = {
   targets: getCliConfigTargets(CodeCli.GEMINI_CLI),
   providerBaseUrls: (provider) => [normalizeUrl(resolveGeminiBaseUrl(provider))].filter(Boolean),
@@ -624,7 +628,7 @@ const geminiAdapter: CliConfigAdapter = {
     const model = requireDraftValue(connection.model, 'Gemini model')
     const currentModel = stringValue(asRecord(settings.model).name)
     const isGateway = currentModel
-      ? parseGeminiConfigModel(currentModel, env.get('GOOGLE_GENAI_API_VERSION') === 'v1beta').isGateway
+      ? parseGeminiConfigModel(currentModel, isLegacyGeminiGatewayConfig(env)).isGateway
       : false
     const address = isGateway ? parseGatewayModelId(model) : undefined
     const settingsModel = address ? formatGeminiGatewayModelId(address.providerId, address.apiModelId) : model
@@ -673,10 +677,7 @@ const geminiAdapter: CliConfigAdapter = {
     return {
       baseUrl: stringValue(env.get('GOOGLE_GEMINI_BASE_URL')),
       apiKey: stringValue(env.get('GEMINI_API_KEY')),
-      model:
-        model === undefined
-          ? model
-          : parseGeminiConfigModel(model, env.get('GOOGLE_GENAI_API_VERSION') === 'v1beta').model
+      model: model === undefined ? model : parseGeminiConfigModel(model, isLegacyGeminiGatewayConfig(env)).model
     }
   },
   extractConfig(files) {

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -4,7 +4,13 @@ import { type Document, isMap, isScalar } from 'yaml'
 import type { Provider } from '@shared/data/types/provider'
 import { CodeCli, isApiGatewayProviderId, normalizeDeepSeekHarnessSettings } from '@shared/types/codeCli'
 import { formatApiHost } from '@shared/utils/api'
-import { GEMINI_GATEWAY_MODEL_SUFFIX, stripGeminiGatewayModelSuffix } from '@shared/utils/apiGateway'
+import {
+  formatGatewayModelId,
+  formatGeminiGatewayModelId,
+  parseGatewayModelId,
+  parseGeminiGatewayModelId,
+  parseLegacyGeminiGatewayModelId
+} from '@shared/utils/apiGateway'
 import { type CliConfigWriteFile, type FileConfiguredCli, getCliConfigTargets } from '@shared/utils/cliConfig'
 
 import {
@@ -560,6 +566,19 @@ const openCodeAdapter: CliConfigAdapter = {
   }
 }
 
+function parseGeminiConfigModel(model: string): { isGateway: boolean; model: string } {
+  const tagged = parseGeminiGatewayModelId(model)
+  if (tagged) {
+    return { isGateway: true, model: formatGatewayModelId(tagged.providerId, tagged.apiModelId) }
+  }
+
+  const legacy = parseLegacyGeminiGatewayModelId(model)
+  if (legacy) {
+    return { isGateway: true, model: formatGatewayModelId(legacy.providerId, legacy.apiModelId) }
+  }
+  return { isGateway: false, model }
+}
+
 const geminiAdapter: CliConfigAdapter = {
   targets: getCliConfigTargets(CodeCli.GEMINI_CLI),
   providerBaseUrls: (provider) => [normalizeUrl(resolveGeminiBaseUrl(provider))].filter(Boolean),
@@ -571,10 +590,8 @@ const geminiAdapter: CliConfigAdapter = {
     const settings = readAndParseDraftFile('gemini-settings', parseJsonOrThrow, args.files, read)
     const baseUrl = resolveGeminiBaseUrl(provider)
     const isGateway = isApiGatewayProviderId(provider.id)
-    // Gateway addresses carry the sentinel suffix so gemini-cli's model
-    // normalization can't rewrite them (see GEMINI_GATEWAY_MODEL_SUFFIX);
-    // extractConnection strips it back off for connection matching.
-    const settingsModel = isGateway ? `${model}${GEMINI_GATEWAY_MODEL_SUFFIX}` : model
+    const address = isGateway ? parseGatewayModelId(model) : undefined
+    const settingsModel = address ? formatGeminiGatewayModelId(address.providerId, address.apiModelId) : model
     return [
       makeDraftFile(
         'gemini-env',
@@ -600,13 +617,10 @@ const geminiAdapter: CliConfigAdapter = {
     const envText = getDraftFile(files, 'gemini-env')?.content ?? ''
     const settings = parseJsonOrThrow(getDraftFile(files, 'gemini-settings')?.content ?? '')
     const model = requireDraftValue(connection.model, 'Gemini model')
-    // A gateway draft carries the sentinel in settings.model.name; extractConnection
-    // strips it for connection matching, so re-append it here (and re-force the API
-    // version) to preserve the gateway identity through a foreign-edit round trip —
-    // gemini-cli reads settings.model.name, so a bare `flash`-ending address written
-    // back would be re-normalized on a direct terminal launch.
-    const isGateway = (stringValue(asRecord(settings.model).name) ?? '').endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)
-    const settingsModel = isGateway ? `${model}${GEMINI_GATEWAY_MODEL_SUFFIX}` : model
+    const currentModel = stringValue(asRecord(settings.model).name)
+    const isGateway = currentModel ? parseGeminiConfigModel(currentModel).isGateway : false
+    const address = isGateway ? parseGatewayModelId(model) : undefined
+    const settingsModel = address ? formatGeminiGatewayModelId(address.providerId, address.apiModelId) : model
     return replaceDraftContent(
       replaceDraftContent(
         files,
@@ -652,7 +666,7 @@ const geminiAdapter: CliConfigAdapter = {
     return {
       baseUrl: stringValue(env.get('GOOGLE_GEMINI_BASE_URL')),
       apiKey: stringValue(env.get('GEMINI_API_KEY')),
-      model: model === undefined ? model : stripGeminiGatewayModelSuffix(model)
+      model: model === undefined ? model : parseGeminiConfigModel(model).model
     }
   },
   extractConfig(files) {

--- a/src/renderer/pages/code/cliConfig/adapters.ts
+++ b/src/renderer/pages/code/cliConfig/adapters.ts
@@ -566,7 +566,7 @@ const openCodeAdapter: CliConfigAdapter = {
   }
 }
 
-function parseGeminiConfigModel(model: string): { isGateway: boolean; model: string } {
+function parseGeminiConfigModel(model: string, allowLegacy = false): { isGateway: boolean; model: string } {
   try {
     const tagged = parseGeminiGatewayModelId(model)
     if (tagged) {
@@ -576,7 +576,7 @@ function parseGeminiConfigModel(model: string): { isGateway: boolean; model: str
     return { isGateway: false, model }
   }
 
-  const legacy = parseLegacyGeminiGatewayModelId(model)
+  const legacy = allowLegacy ? parseLegacyGeminiGatewayModelId(model) : undefined
   if (legacy) {
     return { isGateway: true, model: formatGatewayModelId(legacy.providerId, legacy.apiModelId) }
   }
@@ -619,10 +619,13 @@ const geminiAdapter: CliConfigAdapter = {
   },
   updateDraftConfig(files, connection, configBlob) {
     const envText = getDraftFile(files, 'gemini-env')?.content ?? ''
+    const env = parseDotenv(envText)
     const settings = parseJsonOrThrow(getDraftFile(files, 'gemini-settings')?.content ?? '')
     const model = requireDraftValue(connection.model, 'Gemini model')
     const currentModel = stringValue(asRecord(settings.model).name)
-    const isGateway = currentModel ? parseGeminiConfigModel(currentModel).isGateway : false
+    const isGateway = currentModel
+      ? parseGeminiConfigModel(currentModel, env.get('GOOGLE_GENAI_API_VERSION') === 'v1beta').isGateway
+      : false
     const address = isGateway ? parseGatewayModelId(model) : undefined
     const settingsModel = address ? formatGeminiGatewayModelId(address.providerId, address.apiModelId) : model
     return replaceDraftContent(
@@ -630,7 +633,7 @@ const geminiAdapter: CliConfigAdapter = {
         files,
         'gemini-env',
         renderDotenvFile(
-          buildGeminiEnvConfig(parseDotenv(envText), {
+          buildGeminiEnvConfig(env, {
             apiKey: connection.apiKey ?? '',
             baseUrl: connection.baseUrl ?? '',
             gateway: isGateway
@@ -670,7 +673,10 @@ const geminiAdapter: CliConfigAdapter = {
     return {
       baseUrl: stringValue(env.get('GOOGLE_GEMINI_BASE_URL')),
       apiKey: stringValue(env.get('GEMINI_API_KEY')),
-      model: model === undefined ? model : parseGeminiConfigModel(model).model
+      model:
+        model === undefined
+          ? model
+          : parseGeminiConfigModel(model, env.get('GOOGLE_GENAI_API_VERSION') === 'v1beta').model
     }
   },
   extractConfig(files) {

--- a/src/shared/utils/__tests__/apiGateway.test.ts
+++ b/src/shared/utils/__tests__/apiGateway.test.ts
@@ -67,7 +67,11 @@ describe('formatGatewayModelId', () => {
 
   it('rejects a malformed reserved tag instead of falling back to legacy parsing', () => {
     expect(() => parseGeminiGatewayModelId('cherry-gw-v1.not-base64@cherry')).toThrow(/Invalid Gemini gateway model/)
+    expect(() => parseGeminiGatewayModelId('cherry-gw-v2.future@cherry')).toThrow(/Invalid Gemini gateway model/)
     expect(() => parseAntigravityGatewayModelPath('cherry-gw-v1/models/not-base64')).toThrow(
+      /Invalid Antigravity gateway model/
+    )
+    expect(() => parseAntigravityGatewayModelPath('cherry-gw-v2/models/foo')).toThrow(
       /Invalid Antigravity gateway model/
     )
   })

--- a/src/shared/utils/__tests__/apiGateway.test.ts
+++ b/src/shared/utils/__tests__/apiGateway.test.ts
@@ -2,38 +2,28 @@ import { describe, expect, it } from 'vitest'
 
 import { CHERRYAI_DEFAULT_MODEL_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
 import {
-  ANTIGRAVITY_MODEL_PATH_SEPARATOR,
+  formatAntigravityGatewayModelPath,
   formatGatewayModelId,
   formatGeminiGatewayModelId,
-  gatewayClientOrigin
+  gatewayClientOrigin,
+  parseAntigravityGatewayModelPath,
+  parseGatewayModelId,
+  parseGeminiGatewayModelId
 } from '@shared/utils/apiGateway'
-
-/** The gateway proxy's parse side (proxyStream.ts): split on the FIRST ':'. */
-function parseByFirstColon(gatewayModelId: string): { providerId: string; modelId: string } {
-  const sepIdx = gatewayModelId.indexOf(':')
-  return { providerId: gatewayModelId.slice(0, sepIdx), modelId: gatewayModelId.slice(sepIdx + 1) }
-}
-
-/** The Antigravity round-trip: producer builds the path, `routes/gemini.ts` splits on the FIRST separator. */
-function parseAntigravityPath(gatewayModelId: string): { providerId: string; modelId: string } {
-  const path = gatewayModelId.replace(':', ANTIGRAVITY_MODEL_PATH_SEPARATOR)
-  const sepIdx = path.indexOf(ANTIGRAVITY_MODEL_PATH_SEPARATOR)
-  return {
-    providerId: path.slice(0, sepIdx),
-    modelId: path.slice(sepIdx + ANTIGRAVITY_MODEL_PATH_SEPARATOR.length)
-  }
-}
 
 describe('formatGatewayModelId', () => {
   it('formats "providerId:apiModelId" and round-trips through the first-colon split', () => {
     const id = formatGatewayModelId('deepseek', 'deepseek-chat')
     expect(id).toBe('deepseek:deepseek-chat')
-    expect(parseByFirstColon(id)).toEqual({ providerId: 'deepseek', modelId: 'deepseek-chat' })
+    expect(parseGatewayModelId(id)).toEqual({ providerId: 'deepseek', apiModelId: 'deepseek-chat' })
   })
 
   it('round-trips an apiModelId that itself contains ":"', () => {
     const id = formatGatewayModelId('vertexai', 'publishers/google:gemini-2.5-pro')
-    expect(parseByFirstColon(id)).toEqual({ providerId: 'vertexai', modelId: 'publishers/google:gemini-2.5-pro' })
+    expect(parseGatewayModelId(id)).toEqual({
+      providerId: 'vertexai',
+      apiModelId: 'publishers/google:gemini-2.5-pro'
+    })
   })
 
   it('rejects a provider id containing ":" — the first-colon split would route it to the wrong provider', () => {
@@ -49,17 +39,33 @@ describe('formatGatewayModelId', () => {
     // That separator only makes an address ambiguous in Antigravity's path form, so the
     // constraint belongs to that producer — the colon address here round-trips fine.
     const id = formatGatewayModelId('team/models/west', 'gemini-2.5-pro')
-    expect(parseByFirstColon(id)).toEqual({ providerId: 'team/models/west', modelId: 'gemini-2.5-pro' })
+    expect(parseGatewayModelId(id)).toEqual({ providerId: 'team/models/west', apiModelId: 'gemini-2.5-pro' })
   })
 
-  it('round-trips an apiModelId that itself contains the Antigravity separator', () => {
-    const id = formatGatewayModelId('provider-a', 'models/gemini-flash')
-    expect(parseAntigravityPath(id)).toEqual({ providerId: 'provider-a', modelId: 'models/gemini-flash' })
+  it('round-trips Antigravity content containing legacy separators', () => {
+    const path = formatAntigravityGatewayModelPath('team/models/west', 'models/gemini:flash@cherry')
+    expect(path).toMatch(/^cherry-gw-v1\/models\/[A-Za-z0-9_-]+$/)
+    expect(parseAntigravityGatewayModelPath(path)).toEqual({
+      providerId: 'team/models/west',
+      apiModelId: 'models/gemini:flash@cherry'
+    })
   })
 
   it('keeps a real @cherry model distinct from the Gemini gateway wrapper', () => {
-    expect(formatGatewayModelId('provider-a', 'model@cherry')).not.toBe(
-      formatGeminiGatewayModelId('provider-a', 'model')
+    const wrapped = formatGeminiGatewayModelId('provider-a', 'model')
+    expect(formatGatewayModelId('provider-a', 'model@cherry')).not.toBe(wrapped)
+    expect(parseGeminiGatewayModelId(wrapped)).toEqual({ providerId: 'provider-a', apiModelId: 'model' })
+  })
+
+  it('does not treat ordinary generic ids as tagged CLI addresses', () => {
+    expect(parseGeminiGatewayModelId('provider-a:model@cherry')).toBeUndefined()
+    expect(parseAntigravityGatewayModelPath('provider-a/models/model')).toBeUndefined()
+  })
+
+  it('rejects a malformed reserved tag instead of falling back to legacy parsing', () => {
+    expect(() => parseGeminiGatewayModelId('cherry-gw-v1.not-base64@cherry')).toThrow(/Invalid Gemini gateway model/)
+    expect(() => parseAntigravityGatewayModelPath('cherry-gw-v1/models/not-base64')).toThrow(
+      /Invalid Antigravity gateway model/
     )
   })
 })

--- a/src/shared/utils/__tests__/apiGateway.test.ts
+++ b/src/shared/utils/__tests__/apiGateway.test.ts
@@ -60,6 +60,8 @@ describe('formatGatewayModelId', () => {
   it('does not treat ordinary generic ids as tagged CLI addresses', () => {
     expect(parseGeminiGatewayModelId('provider-a:model@cherry')).toBeUndefined()
     expect(parseAntigravityGatewayModelPath('provider-a/models/model')).toBeUndefined()
+    expect(parseGeminiGatewayModelId(formatGatewayModelId('cherry-gw-v1', 'model@cherry'))).toBeUndefined()
+    expect(parseAntigravityGatewayModelPath('cherry-gw-v1/models/provider:model')).toBeUndefined()
   })
 
   it('rejects a malformed reserved tag instead of falling back to legacy parsing', () => {

--- a/src/shared/utils/__tests__/apiGateway.test.ts
+++ b/src/shared/utils/__tests__/apiGateway.test.ts
@@ -8,7 +8,8 @@ import {
   gatewayClientOrigin,
   parseAntigravityGatewayModelPath,
   parseGatewayModelId,
-  parseGeminiGatewayModelId
+  parseGeminiGatewayModelId,
+  parseLegacyAntigravityGatewayModelPaths
 } from '@shared/utils/apiGateway'
 
 describe('formatGatewayModelId', () => {
@@ -69,6 +70,11 @@ describe('formatGatewayModelId', () => {
     expect(() => parseAntigravityGatewayModelPath('cherry-gw-v1/models/not-base64')).toThrow(
       /Invalid Antigravity gateway model/
     )
+  })
+
+  it('bounds legacy Antigravity candidate expansion', () => {
+    const address = `provider${'/models/segment'.repeat(33)}`
+    expect(() => parseLegacyAntigravityGatewayModelPaths(address)).toThrow(/too many separators/)
   })
 })
 

--- a/src/shared/utils/__tests__/apiGateway.test.ts
+++ b/src/shared/utils/__tests__/apiGateway.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import { CHERRYAI_DEFAULT_MODEL_ID, CHERRYAI_PROVIDER_ID } from '@shared/data/presets/cherryai'
-import { ANTIGRAVITY_MODEL_PATH_SEPARATOR, formatGatewayModelId, gatewayClientOrigin } from '@shared/utils/apiGateway'
+import {
+  ANTIGRAVITY_MODEL_PATH_SEPARATOR,
+  formatGatewayModelId,
+  formatGeminiGatewayModelId,
+  gatewayClientOrigin
+} from '@shared/utils/apiGateway'
 
 /** The gateway proxy's parse side (proxyStream.ts): split on the FIRST ':'. */
 function parseByFirstColon(gatewayModelId: string): { providerId: string; modelId: string } {
@@ -50,6 +55,12 @@ describe('formatGatewayModelId', () => {
   it('round-trips an apiModelId that itself contains the Antigravity separator', () => {
     const id = formatGatewayModelId('provider-a', 'models/gemini-flash')
     expect(parseAntigravityPath(id)).toEqual({ providerId: 'provider-a', modelId: 'models/gemini-flash' })
+  })
+
+  it('keeps a real @cherry model distinct from the Gemini gateway wrapper', () => {
+    expect(formatGatewayModelId('provider-a', 'model@cherry')).not.toBe(
+      formatGeminiGatewayModelId('provider-a', 'model')
+    )
   })
 })
 

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -19,6 +19,7 @@ const GEMINI_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}.`
 const ANTIGRAVITY_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}${ANTIGRAVITY_MODEL_PATH_SEPARATOR}`
 const VERSIONED_GEMINI_GATEWAY_PREFIX = /^cherry-gw-v\d+\./
 const VERSIONED_ANTIGRAVITY_GATEWAY_PREFIX = /^cherry-gw-v\d+\/models\//
+const MAX_LEGACY_ANTIGRAVITY_CANDIDATES = 32
 
 function validateGatewayModelAddress(providerId: string, apiModelId: string): void {
   if (!providerId || !apiModelId) {
@@ -142,6 +143,9 @@ export function parseLegacyAntigravityGatewayModelPaths(value: string): GatewayM
   const candidates: GatewayModelAddress[] = []
   let separatorIndex = value.indexOf(ANTIGRAVITY_MODEL_PATH_SEPARATOR)
   while (separatorIndex > 0) {
+    if (candidates.length >= MAX_LEGACY_ANTIGRAVITY_CANDIDATES) {
+      throw new Error('Legacy Antigravity gateway model address has too many separators')
+    }
     const providerId = value.slice(0, separatorIndex)
     const apiModelId = value.slice(separatorIndex + ANTIGRAVITY_MODEL_PATH_SEPARATOR.length)
     if (apiModelId && !providerId.includes(':')) candidates.push({ providerId, apiModelId })

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -15,9 +15,10 @@ export const ANTIGRAVITY_MODEL_PATH_SEPARATOR = '/models/'
 export const GEMINI_GATEWAY_MODEL_SUFFIX = '@cherry'
 
 const GATEWAY_MODEL_WIRE_PREFIX = 'cherry-gw-v1'
-const RESERVED_GATEWAY_MODEL_WIRE_PREFIX = 'cherry-gw-v'
 const GEMINI_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}.`
 const ANTIGRAVITY_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}${ANTIGRAVITY_MODEL_PATH_SEPARATOR}`
+const VERSIONED_GEMINI_GATEWAY_PREFIX = /^cherry-gw-v\d+\./
+const VERSIONED_ANTIGRAVITY_GATEWAY_PREFIX = /^cherry-gw-v\d+\/models\//
 
 function validateGatewayModelAddress(providerId: string, apiModelId: string): void {
   if (!providerId || !apiModelId) {
@@ -99,8 +100,10 @@ export function formatGeminiGatewayModelId(providerId: string, apiModelId: strin
 
 /** Parse the v1 gemini-cli form, or return `undefined` when the value uses another grammar. */
 export function parseGeminiGatewayModelId(value: string): GatewayModelAddress | undefined {
-  if (value.startsWith(ANTIGRAVITY_GATEWAY_MODEL_PREFIX)) return undefined
-  if (!value.startsWith(RESERVED_GATEWAY_MODEL_WIRE_PREFIX)) return undefined
+  const versionedPrefix = value.match(VERSIONED_GEMINI_GATEWAY_PREFIX)?.[0]
+  if (!versionedPrefix || !value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) return undefined
+  const candidatePayload = value.slice(versionedPrefix.length, -GEMINI_GATEWAY_MODEL_SUFFIX.length)
+  if (candidatePayload.includes(':')) return undefined
   if (!value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX) || !value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) {
     throw new Error('Invalid Gemini gateway model address')
   }
@@ -115,8 +118,9 @@ export function formatAntigravityGatewayModelPath(providerId: string, apiModelId
 
 /** Parse the v1 Antigravity path, or return `undefined` when the value uses another grammar. */
 export function parseAntigravityGatewayModelPath(value: string): GatewayModelAddress | undefined {
-  if (value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX)) return undefined
-  if (!value.startsWith(RESERVED_GATEWAY_MODEL_WIRE_PREFIX)) return undefined
+  const versionedPrefix = value.match(VERSIONED_ANTIGRAVITY_GATEWAY_PREFIX)?.[0]
+  if (!versionedPrefix) return undefined
+  if (value.slice(versionedPrefix.length).includes(':')) return undefined
   if (!value.startsWith(ANTIGRAVITY_GATEWAY_MODEL_PREFIX)) {
     throw new Error('Invalid Antigravity gateway model address')
   }

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -1,11 +1,61 @@
 import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
+import { Base64 } from 'js-base64'
+
+export interface GatewayModelAddress {
+  readonly providerId: string
+  readonly apiModelId: string
+}
 
 /**
- * Separator in the custom-model path Antigravity CLI carries (`gemini-api://<providerId>/models/<apiModelId>`).
- * The producer (`main/services/codeCli/antigravity.ts`) and the gateway route that parses it back
- * (`main/features/apiGateway/routes/gemini.ts`) must agree, so neither may hardcode it.
+ * Separator in the versioned custom-model path Antigravity CLI carries under `gemini-api://`.
  */
 export const ANTIGRAVITY_MODEL_PATH_SEPARATOR = '/models/'
+
+/** Sentinel suffix that prevents gemini-cli from rewriting model names ending in `flash`. */
+export const GEMINI_GATEWAY_MODEL_SUFFIX = '@cherry'
+
+const GATEWAY_MODEL_WIRE_PREFIX = 'cherry-gw-v1'
+const RESERVED_GATEWAY_MODEL_WIRE_PREFIX = 'cherry-gw-v'
+const GEMINI_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}.`
+const ANTIGRAVITY_GATEWAY_MODEL_PREFIX = `${GATEWAY_MODEL_WIRE_PREFIX}${ANTIGRAVITY_MODEL_PATH_SEPARATOR}`
+
+function validateGatewayModelAddress(providerId: string, apiModelId: string): void {
+  if (!providerId || !apiModelId) {
+    throw new Error('Gateway model provider id and API model id must be non-empty')
+  }
+  if (providerId.includes(':')) {
+    throw new Error(`Provider id "${providerId}" contains ":" and cannot be addressed through the API gateway`)
+  }
+  if (isManagedCherryAiDefaultModel(providerId, apiModelId)) {
+    throw new Error('CherryAI managed default model is not available through the API gateway')
+  }
+}
+
+function encodeGatewayModelAddress(providerId: string, apiModelId: string): string {
+  validateGatewayModelAddress(providerId, apiModelId)
+  return Base64.encodeURI(JSON.stringify([providerId, apiModelId]))
+}
+
+function decodeGatewayModelAddress(payload: string, protocol: 'Gemini' | 'Antigravity'): GatewayModelAddress {
+  try {
+    if (!/^[A-Za-z0-9_-]+$/.test(payload)) throw new Error('Invalid base64url payload')
+    const decoded = JSON.parse(Base64.decode(payload))
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 2 ||
+      typeof decoded[0] !== 'string' ||
+      typeof decoded[1] !== 'string'
+    ) {
+      throw new Error('Invalid address tuple')
+    }
+    const [providerId, apiModelId] = decoded
+    validateGatewayModelAddress(providerId, apiModelId)
+    if (encodeGatewayModelAddress(providerId, apiModelId) !== payload) throw new Error('Non-canonical payload')
+    return { providerId, apiModelId }
+  } catch (error) {
+    throw new Error(`Invalid ${protocol} gateway model address`, { cause: error })
+  }
+}
 
 /**
  * The origin a client uses to reach the gateway, derived from its bind host.
@@ -26,53 +76,75 @@ export function gatewayClientOrigin(host: string, port: number): string {
  * routable through the gateway and throw, mirroring the gateway's own guard.
  */
 export function formatGatewayModelId(providerId: string, apiModelId: string): string {
-  // The single-colon format cannot round-trip a provider id that itself contains ':' —
-  // the gateway would split "corp:west:model" at the first ':' and route to "corp".
-  // Fail loudly rather than emit an address that silently targets the wrong provider.
-  if (providerId.includes(':')) {
-    throw new Error(`Provider id "${providerId}" contains ":" and cannot be addressed through the API gateway`)
-  }
-  if (isManagedCherryAiDefaultModel(providerId, apiModelId)) {
-    throw new Error('CherryAI managed default model is not available through the API gateway')
-  }
+  validateGatewayModelAddress(providerId, apiModelId)
   return `${providerId}:${apiModelId}`
 }
 
-/**
- * Sentinel suffix on the gateway model id handed to gemini-cli (`--model` and
- * `settings.model.name`). gemini-cli normalizes model names it thinks are its own:
- * its `resolveModel` rewrites anything satisfying `endsWith("flash")` (or equal to
- * aliases like `flash`/`auto`) to a default Gemini model, which corrupts any
- * `providerId:apiModelId` address whose model happens to end in "flash" (e.g.
- * `agent/deepseek-v4-flash` → sent as `gemini-3.5-flash`). The suffix makes the
- * string unrecognizable to those checks and rides along verbatim in the request
- * URL; the gateway's Gemini route (and the CLI-config connection readback) strip
- * exactly one trailing sentinel via {@link stripGeminiGatewayModelSuffix}.
- *
- * The suffix is RESERVED: a real gateway model id may not end with it (see
- * {@link isReservedGeminiGatewayModelId}). The gemini `/v1beta/models` list omits
- * such ids and the route rejects them, so a listed model always round-trips to the
- * same address once the suffix is stripped.
- */
-export const GEMINI_GATEWAY_MODEL_SUFFIX = '@cherry'
+/** Parse the public `providerId:apiModelId` gateway form by its first colon. */
+export function parseGatewayModelId(value: string): GatewayModelAddress {
+  const separatorIndex = value.indexOf(':')
+  if (separatorIndex <= 0 || separatorIndex >= value.length - 1) {
+    throw new Error(`Invalid model format: "${value}". Expected "providerId:apiModelId".`)
+  }
+  const providerId = value.slice(0, separatorIndex)
+  const apiModelId = value.slice(separatorIndex + 1)
+  validateGatewayModelAddress(providerId, apiModelId)
+  return { providerId, apiModelId }
+}
 
-/** {@link formatGatewayModelId} plus the gemini-cli sentinel suffix (see above). */
+/** Encode a self-identifying model value that gemini-cli carries unchanged to `/v1beta`. */
 export function formatGeminiGatewayModelId(providerId: string, apiModelId: string): string {
-  return `${formatGatewayModelId(providerId, apiModelId)}${GEMINI_GATEWAY_MODEL_SUFFIX}`
+  return `${GEMINI_GATEWAY_MODEL_PREFIX}${encodeGatewayModelAddress(providerId, apiModelId)}${GEMINI_GATEWAY_MODEL_SUFFIX}`
 }
 
-/** Undo {@link formatGeminiGatewayModelId}: strip one trailing sentinel, if present. */
-export function stripGeminiGatewayModelSuffix(model: string): string {
-  return model.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX) ? model.slice(0, -GEMINI_GATEWAY_MODEL_SUFFIX.length) : model
+/** Parse the v1 gemini-cli form, or return `undefined` when the value uses another grammar. */
+export function parseGeminiGatewayModelId(value: string): GatewayModelAddress | undefined {
+  if (value.startsWith(ANTIGRAVITY_GATEWAY_MODEL_PREFIX)) return undefined
+  if (!value.startsWith(RESERVED_GATEWAY_MODEL_WIRE_PREFIX)) return undefined
+  if (!value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX) || !value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) {
+    throw new Error('Invalid Gemini gateway model address')
+  }
+  const payload = value.slice(GEMINI_GATEWAY_MODEL_PREFIX.length, -GEMINI_GATEWAY_MODEL_SUFFIX.length)
+  return decodeGatewayModelAddress(payload, 'Gemini')
 }
 
-/**
- * A gateway model id is RESERVED — not routable through the Gemini `/v1beta` dialect —
- * when it ends with {@link GEMINI_GATEWAY_MODEL_SUFFIX}: the route strips exactly one
- * such suffix, so it cannot tell Cherry's sentinel apart from a real id that happens to
- * end in `@cherry`. The models list omits these and the route rejects them, keeping
- * list→request round-trips unambiguous. No real provider model ends in this marker.
- */
-export function isReservedGeminiGatewayModelId(id: string): boolean {
-  return id.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)
+/** Encode the model path portion used inside Antigravity's `gemini-api://` selector. */
+export function formatAntigravityGatewayModelPath(providerId: string, apiModelId: string): string {
+  return `${ANTIGRAVITY_GATEWAY_MODEL_PREFIX}${encodeGatewayModelAddress(providerId, apiModelId)}`
+}
+
+/** Parse the v1 Antigravity path, or return `undefined` when the value uses another grammar. */
+export function parseAntigravityGatewayModelPath(value: string): GatewayModelAddress | undefined {
+  if (value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX)) return undefined
+  if (!value.startsWith(RESERVED_GATEWAY_MODEL_WIRE_PREFIX)) return undefined
+  if (!value.startsWith(ANTIGRAVITY_GATEWAY_MODEL_PREFIX)) {
+    throw new Error('Invalid Antigravity gateway model address')
+  }
+  return decodeGatewayModelAddress(value.slice(ANTIGRAVITY_GATEWAY_MODEL_PREFIX.length), 'Antigravity')
+}
+
+/** Parse the old suffix wrapper as one compatibility candidate. */
+export function parseLegacyGeminiGatewayModelId(value: string): GatewayModelAddress | undefined {
+  if (!value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) return undefined
+  try {
+    return parseGatewayModelId(value.slice(0, -GEMINI_GATEWAY_MODEL_SUFFIX.length))
+  } catch {
+    return undefined
+  }
+}
+
+/** Enumerate every old `/models/` split; the enabled catalog must choose a unique candidate. */
+export function parseLegacyAntigravityGatewayModelPaths(value: string): GatewayModelAddress[] {
+  const candidates: GatewayModelAddress[] = []
+  let separatorIndex = value.indexOf(ANTIGRAVITY_MODEL_PATH_SEPARATOR)
+  while (separatorIndex > 0) {
+    const providerId = value.slice(0, separatorIndex)
+    const apiModelId = value.slice(separatorIndex + ANTIGRAVITY_MODEL_PATH_SEPARATOR.length)
+    if (apiModelId && !providerId.includes(':')) candidates.push({ providerId, apiModelId })
+    separatorIndex = value.indexOf(
+      ANTIGRAVITY_MODEL_PATH_SEPARATOR,
+      separatorIndex + ANTIGRAVITY_MODEL_PATH_SEPARATOR.length
+    )
+  }
+  return candidates
 }

--- a/src/shared/utils/apiGateway.ts
+++ b/src/shared/utils/apiGateway.ts
@@ -1,5 +1,6 @@
-import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 import { Base64 } from 'js-base64'
+
+import { isManagedCherryAiDefaultModel } from '@shared/data/presets/cherryai'
 
 export interface GatewayModelAddress {
   readonly providerId: string
@@ -99,17 +100,19 @@ export function formatGeminiGatewayModelId(providerId: string, apiModelId: strin
   return `${GEMINI_GATEWAY_MODEL_PREFIX}${encodeGatewayModelAddress(providerId, apiModelId)}${GEMINI_GATEWAY_MODEL_SUFFIX}`
 }
 
-/** Parse the v1 gemini-cli form, or return `undefined` when the value uses another grammar. */
+/**
+ * Parse the v1 gemini-cli form, or return `undefined` for another grammar.
+ * @throws If a recognized versioned address is malformed or uses an unsupported version.
+ */
 export function parseGeminiGatewayModelId(value: string): GatewayModelAddress | undefined {
   const versionedPrefix = value.match(VERSIONED_GEMINI_GATEWAY_PREFIX)?.[0]
   if (!versionedPrefix || !value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) return undefined
   const candidatePayload = value.slice(versionedPrefix.length, -GEMINI_GATEWAY_MODEL_SUFFIX.length)
   if (candidatePayload.includes(':')) return undefined
-  if (!value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX) || !value.endsWith(GEMINI_GATEWAY_MODEL_SUFFIX)) {
+  if (!value.startsWith(GEMINI_GATEWAY_MODEL_PREFIX)) {
     throw new Error('Invalid Gemini gateway model address')
   }
-  const payload = value.slice(GEMINI_GATEWAY_MODEL_PREFIX.length, -GEMINI_GATEWAY_MODEL_SUFFIX.length)
-  return decodeGatewayModelAddress(payload, 'Gemini')
+  return decodeGatewayModelAddress(candidatePayload, 'Gemini')
 }
 
 /** Encode the model path portion used inside Antigravity's `gemini-api://` selector. */
@@ -117,15 +120,19 @@ export function formatAntigravityGatewayModelPath(providerId: string, apiModelId
   return `${ANTIGRAVITY_GATEWAY_MODEL_PREFIX}${encodeGatewayModelAddress(providerId, apiModelId)}`
 }
 
-/** Parse the v1 Antigravity path, or return `undefined` when the value uses another grammar. */
+/**
+ * Parse the v1 Antigravity path, or return `undefined` for another grammar.
+ * @throws If a recognized versioned address is malformed or uses an unsupported version.
+ */
 export function parseAntigravityGatewayModelPath(value: string): GatewayModelAddress | undefined {
   const versionedPrefix = value.match(VERSIONED_ANTIGRAVITY_GATEWAY_PREFIX)?.[0]
   if (!versionedPrefix) return undefined
-  if (value.slice(versionedPrefix.length).includes(':')) return undefined
+  const candidatePayload = value.slice(versionedPrefix.length)
+  if (candidatePayload.includes(':')) return undefined
   if (!value.startsWith(ANTIGRAVITY_GATEWAY_MODEL_PREFIX)) {
     throw new Error('Invalid Antigravity gateway model address')
   }
-  return decodeGatewayModelAddress(value.slice(ANTIGRAVITY_GATEWAY_MODEL_PREFIX.length), 'Antigravity')
+  return decodeGatewayModelAddress(candidatePayload, 'Antigravity')
 }
 
 /** Parse the old suffix wrapper as one compatibility candidate. */


### PR DESCRIPTION
> ### Branch strategy
>
> - Active development targets `main`.

### What this PR does

Before this PR:

Gemini CLI and Antigravity model addresses were distinguished with suffix and substring checks. Real model IDs containing `/models/` or `@cherry` could therefore collide with those wire formats, while one unaddressable provider could clear the entire `/v1/models` response.

After this PR:

The generic `providerId:apiModelId` format remains unchanged. Gemini CLI and Antigravity now use explicit versioned addresses with paired encoders and parsers. Unambiguous legacy addresses outside the reserved versioned grammar remain readable. Recognized versioned addresses with malformed payloads or unsupported versions fail with HTTP 400 without falling back to legacy parsing, even when a matching legacy catalog entry exists. Ambiguous ordinary legacy addresses also fail closed, and `/v1/models` skips and logs unaddressable entries without dropping valid models.

Fixes #19655

### Why we need it and why it was done in this way

A self-identifying wire format removes the need to infer an address protocol from its content. Shared codecs keep producers and consumers aligned, while catalog-backed legacy resolution preserves ordinary legacy configurations only when they have one valid interpretation. Recognized versioned formats take precedence over legacy catalog matches.

The following tradeoffs were made:

- Versioned CLI addresses are less human-readable than the former delimiter-based strings.
- Resolving legacy addresses consults the enabled provider/model catalog.
- Ambiguous legacy values and invalid or unsupported reserved versioned values now return an explicit error instead of being guessed.

The following alternatives were considered:

- Keeping `endsWith('@cherry')` and `includes('/models/')` heuristics was rejected because valid model IDs can contain those values.
- Changing the public `providerId:apiModelId` format was rejected to avoid a broader compatibility break.
- Eagerly rewriting existing Gemini configuration was rejected; legacy gateway configuration is migrated when it is explicitly saved.

Links to places where the discussion took place: [issue #19655](https://github.com/CherryHQ/cherry-studio/issues/19655), [proposed compatibility design](https://github.com/CherryHQ/cherry-studio/issues/19655#issuecomment-5497991520)

### Breaking changes

The public `providerId:apiModelId` format and valid v1 encoded addresses remain supported. Ordinary legacy Gemini and Antigravity values remain readable when uniquely resolvable. Legacy spellings that collide with a recognized reserved versioned format are rejected; use the generic colon address or a valid v1 encoding instead. For example, `cherry-gw-v2/models/foo` is rejected while `cherry-gw-v2:foo` can still address that provider/model. Ambiguous legacy values fail explicitly instead of risking misrouting.

### Special notes for your reviewer

Validation after rebasing onto `cab8d1d6` with Node 24.14.0 / pnpm 12.3.4:

- RED: all four new reserved-format resolver regressions failed before the fix because the legacy fallback accepted them.
- GREEN: 453 tests passed: 125 main gateway/CLI tests, 13 shared codec tests, and 315 renderer CLI configuration tests across 23 files.
- The regressions include matching legacy catalog entries and positive controls for the same models addressed through ordinary colon values and valid v1 encodings.
- `pnpm lint`, `pnpm test:lint`, and `pnpm docs:check` pass. Existing advisory lint warnings remain in untouched files.
- Rebase preserves upstream provider-query failure isolation and Agent-only/edition access restrictions.

The full suite is left to CI. Earlier Gemini SDK path capture is documented in the original validation; no new packaged-GUI or actual Antigravity request capture was performed for this revision.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Branch: This PR targets `main`
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08/)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Documentation: A [user-guide update](https://docs.cherry-ai.com) was considered and is present (link) or not required. Check this only when the PR introduces or changes a user-facing feature or behavior.
- [x] Self-review: I have reviewed my own code (e.g., via [`/gh-pr-review`](/.claude/skills/gh-pr-review/SKILL.md), `gh pr diff`, or GitHub UI) before requesting review from others

### Release note

```release-note
Fixed ambiguous API gateway model parsing for Gemini CLI and Antigravity, rejecting invalid or unsupported versioned addresses without legacy fallback while keeping valid models visible.
```

