### PR TITLE
fix(ai): cap native inline file size at 50 MB to prevent V8 OOM

### DIFF
--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -118,6 +118,7 @@ describe('materializeNativeFilePart — fileEntryId inline', () => {
     readMock.mockReset()
     fileManagerGetMetadataMock.mockReset()
     fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 1024 })
+    readMock.mockResolvedValueOnce({ content: 'QUJD', mime: 'image/png' })
     const out = await materializeNativeFilePart(
       filePart({ mediaType: '.png', providerMetadata: { cherry: { fileEntryId: 'entry-1' } } })
     )

--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -11,13 +11,13 @@ vi.mock('@logger', () => ({
 
 const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
   readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
-  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>()
 }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
   const overrides = {
-    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock },
+    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock }
   } as Parameters<typeof mockApplicationFactory>[0]
   return mockApplicationFactory(overrides)
 })

--- a/src/main/ai/messages/__tests__/fileProcessor.test.ts
+++ b/src/main/ai/messages/__tests__/fileProcessor.test.ts
@@ -9,13 +9,16 @@ vi.mock('@logger', () => ({
   loggerService: { withContext: () => ({ debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }
 }))
 
-const { readMock } = vi.hoisted(() => ({
-  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>()
+const { readMock, fileManagerGetMetadataMock } = vi.hoisted(() => ({
+  readMock: vi.fn<(id: string, options: { encoding: 'base64' }) => Promise<{ content: string; mime: string }>>(),
+  fileManagerGetMetadataMock: vi.fn<(id: string) => Promise<{ size: number }>>(),
 }))
 
 vi.mock('@application', async () => {
   const { mockApplicationFactory } = await import('@test-mocks/main/application')
-  const overrides = { FileManager: { read: readMock } } as Parameters<typeof mockApplicationFactory>[0]
+  const overrides = {
+    FileManager: { read: readMock, getMetadata: fileManagerGetMetadataMock },
+  } as Parameters<typeof mockApplicationFactory>[0]
   return mockApplicationFactory(overrides)
 })
 
@@ -113,7 +116,8 @@ describe('materializeNativeFilePart — file:// inline', () => {
 describe('materializeNativeFilePart — fileEntryId inline', () => {
   it('reads via FileManager and applies its MIME (overriding a bad hint)', async () => {
     readMock.mockReset()
-    readMock.mockResolvedValueOnce({ content: 'QUJD', mime: 'image/png' })
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 1024 })
     const out = await materializeNativeFilePart(
       filePart({ mediaType: '.png', providerMetadata: { cherry: { fileEntryId: 'entry-1' } } })
     )
@@ -124,10 +128,26 @@ describe('materializeNativeFilePart — fileEntryId inline', () => {
 
   it('drops the part when the entry is unreadable and there is no file:// rescue', async () => {
     readMock.mockReset()
-    readMock.mockRejectedValueOnce(new Error('entry not found'))
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockRejectedValueOnce(new Error('entry not found'))
     const out = await materializeNativeFilePart(
       filePart({ url: '', providerMetadata: { cherry: { fileEntryId: 'gone' } } })
     )
     expect(out).toBeNull()
+  })
+
+  it('refuses to inline a fileEntryId whose size exceeds the native cap', async () => {
+    // 50 MB cap is defined in fileProcessor.ts (NATIVE_INLINE_FILE_CAP_BYTES).
+    // The size pre-check uses getMetadata so the function refuses to allocate
+    // a base64 buffer for a file that would blow the V8 heap on inflate.
+    readMock.mockReset()
+    fileManagerGetMetadataMock.mockReset()
+    fileManagerGetMetadataMock.mockResolvedValueOnce({ size: 100 * 1_000_000 })
+    readMock.mockResolvedValueOnce({ content: 'oversized', mime: 'image/png' })
+    const out = await materializeNativeFilePart(
+      filePart({ mediaType: 'image/png', providerMetadata: { cherry: { fileEntryId: 'entry-big' } } })
+    )
+    expect(out).toBeNull()
+    expect(readMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -93,7 +93,7 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
       logger.warn('Refusing to inline oversized native file; degrading to note', {
         fileEntryId,
         size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }
@@ -102,7 +102,7 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
       fileEntryId,
-      error: error instanceof Error ? error.message : error,
+      error: error instanceof Error ? error.message : error
     })
     return null
   }
@@ -130,7 +130,7 @@ async function fileUrlToDataUrl(fileUrl: string) {
       logger.warn('Refusing to inline oversized file:// URL; degrading to note', {
         fileUrl,
         size,
-        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES
       })
       return null
     }

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,7 +16,6 @@
  */
 
 import { fileURLToPath } from 'node:url'
-
 import { application } from '@application'
 import { loggerService } from '@logger'
 import { stat, read as fsRead } from '@main/utils/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -16,9 +16,10 @@
  */
 
 import { fileURLToPath } from 'node:url'
+
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { stat, read as fsRead } from '@main/utils/file'
+import { read as fsRead, stat } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'

--- a/src/main/ai/messages/fileProcessor.ts
+++ b/src/main/ai/messages/fileProcessor.ts
@@ -19,11 +19,30 @@ import { fileURLToPath } from 'node:url'
 
 import { application } from '@application'
 import { loggerService } from '@logger'
-import { read as fsRead } from '@main/utils/file'
+import { stat, read as fsRead } from '@main/utils/file'
 import type { FileUIPart } from '@shared/data/types/message'
 import { readCherryMeta } from '@shared/data/types/uiParts'
 import { AbsoluteFilePathSchema } from '@shared/types/file'
 import mime from 'mime'
+
+/**
+ * Native inline file size cap: the largest file (bytes) that we will inline
+ * as a base64 `data:` URL in a model request. Larger files are not read;
+ * the caller degrades them to a model-visible note instead.
+ *
+ * Rationale: base64 inflates a file by ~4/3. A 238 MB PDF becomes ~317 MB
+ * of base64, and with JSON.stringify overhead the main-process V8 heap
+ * (~2 GB on an 8 GB machine) is exhausted → SIGTRAP → whole app exits.
+ * 50 MB is also the Gemini inline PDF limit, so callers cannot send larger
+ * files natively regardless.
+ *
+ * Per-modality override points exist in attachmentRouting.ts for
+ * provider-specific limits (e.g. DashScope qwen-vl ≤ 10 MB raw, which
+ * corresponds to ~13 MB inline). Until that wiring is in place, 50 MB is a
+ * safe conservative floor that prevents crashes while allowing all
+ * reasonable files through.
+ */
+export const NATIVE_INLINE_FILE_CAP_BYTES = 50 * 1_000_000 // 50 MB
 
 const logger = loggerService.withContext('ai:fileProcessor')
 
@@ -58,12 +77,32 @@ function sanitizeFilePartMediaType(part: FileUIPart): FileUIPart {
  */
 async function fileEntryIdToDataUrl(fileEntryId: string) {
   try {
-    const { content, mime } = await application.get('FileManager').read(fileEntryId, { encoding: 'base64' })
+    // Pre-stat the entry to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer; reading a >cap file would inflate it
+    // ~4/3 into the request JSON and exhaust main-process V8 heap on
+    // 8 GB machines (see #19706). Caller treats `null` as 'degrade to
+    // note', the same path used for missing / unreadable entries.
+    const fileManager = application.get('FileManager')
+    let size: number
+    try {
+      size = (await fileManager.getMetadata(fileEntryId)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn('Refusing to inline oversized native file; degrading to note', {
+        fileEntryId,
+        size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
+      return null
+    }
+    const { content, mime } = await fileManager.read(fileEntryId, { encoding: 'base64' })
     return { url: `data:${mime};base64,${content}`, mediaType: mime }
   } catch (error) {
     logger.warn('Failed to inline file from fileEntryId', {
       fileEntryId,
-      error: error instanceof Error ? error.message : error
+      error: error instanceof Error ? error.message : error,
     })
     return null
   }
@@ -77,6 +116,24 @@ async function fileEntryIdToDataUrl(fileEntryId: string) {
 async function fileUrlToDataUrl(fileUrl: string) {
   try {
     const absPath = AbsoluteFilePathSchema.parse(fileURLToPath(fileUrl))
+    // Pre-stat the file on disk to enforce NATIVE_INLINE_FILE_CAP_BYTES before
+    // allocating a base64 buffer. Uses `stat` (follows symlinks) so the size
+    // check matches what `fsRead` will actually read — a symlink-target larger
+    // than cap is caught here too.
+    let size: number
+    try {
+      size = (await stat(absPath)).size
+    } catch {
+      size = Number.POSITIVE_INFINITY
+    }
+    if (size > NATIVE_INLINE_FILE_CAP_BYTES) {
+      logger.warn('Refusing to inline oversized file:// URL; degrading to note', {
+        fileUrl,
+        size,
+        cap: NATIVE_INLINE_FILE_CAP_BYTES,
+      })
+      return null
+    }
     const { data, mime } = await fsRead(absPath, { encoding: 'base64' })
     return { url: `data:${mime};base64,${data}`, mediaType: mime }
   } catch (error) {


### PR DESCRIPTION
## TL;DR

Cap the size of files inlined as base64 `data:` URLs at 50 MB, enforced **before** the read to prevent V8 heap exhaustion and app crash (SIGTRAP) when users attach ~238 MB PDFs.

## Problem

`fileProcessor.ts` inlined every file as base64 without any size check. Base64 inflates a file by ~4/3; a 238 MB PDF becomes ~317 MB of base64, and with `JSON.stringify` overhead the main-process V8 heap (~2 GB on an 8 GB machine) is exhausted, leading to SIGTRAP and whole-app exits. This is #19706.

## Fix

Two pre-read size guards:

- **fileEntryId branch**: `FileManager.getMetadata(size)` called before `read(encoding: base64)` — prevents allocating the inflated base64 buffer for oversized files.
- **file:// URL branch**: `fs.stat(absPath)` called before `fsRead(encoding: base64)` — same guard. `stat` follows symlinks, so symlink squatting cannot bypass the cap.

On any error (missing entry, permission denied), size is treated as `Infinity` so the part is degraded to a note, matching the existing failure path.

## Test coverage

Updated `fileProcessor.test.ts` to mock `FileManager.getMetadata` and verify:
- Normal-sized files pass through unchanged
- Over-cap files return `null` **without** calling `read`
- Missing/unreadable entries degrade to `null` (existing behaviour preserved)

## References

- Closes #19706
- 50 MB matches the Gemini inline PDF limit (no larger file can be sent natively anyway)
- A `NATIVE_INLINE_FILE_CAP_BYTES` constant is exported for future per-provider override (e.g. DashScope qwen-vl ≤ 10 MB raw in `attachmentRouting.ts`)